### PR TITLE
v0.1.2-alpha: tester issues, sampling flags, turbo KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ hipfire run qwen3.5:9b "What is the capital of France?"
 hipfire run qwen3.5:4b "Hello"
 ```
 
-## Performance (RX 5700 XT, 8GB)
+## Performance
+
+**RX 5700 XT (8GB, gfx1010):**
 
 | Model | Quant | tok/s | Notes |
 |-------|-------|-------|-------|
@@ -30,15 +32,23 @@ hipfire run qwen3.5:4b "Hello"
 | Qwen3.5-4B | HFQ6 | **53** | |
 | Qwen3.5-9B | HFQ4 | **45** | Best quality, fits 8GB |
 | Qwen3.5-9B | HFQ6 | **37** | Near-FP16 quality |
-| Qwen3.5-27B | HFQ4 | TBD | 14.3GB, needs 16GB+ VRAM |
 | Qwen3-8B | HFQ4 | **59.9** | Standard attention |
 | ollama Qwen3.5-9B | — | 4.93 | llama.cpp + ROCm (same GPU) |
+
+**RX 7900 XTX (24GB, gfx1100):** ([benchmarks by DomKo](https://github.com/Kaden-Schutt/hipfire/issues/2))
+
+| Model | Quant | tok/s | Notes |
+|-------|-------|-------|-------|
+| Qwen3.5-9B | HFQ4 | **62** | |
+| Qwen3.5-27B | HFQ4 | **25-27** | Good for simple tasks, degrades on coding |
+| Qwen3.5-27B | HFQ6 | **16-20** | Use this for complex/coding tasks |
 
 Recommended picks:
 - **Speed**: 0.8B HFQ4 (222 tok/s) — fast drafting, coding assistants
 - **Balance**: 4B HFQ4 (63 tok/s) — best quality-per-token for 8GB
 - **Quality (8GB)**: 9B HFQ4 (45 tok/s) — strongest reasoning on 8GB cards
-- **Quality (16GB+)**: 27B HFQ4 — best quality, needs 6800 XT / 7900 XTX / 9070. Benchmarks wanted!
+- **Quality (16GB)**: 27B HFQ4 (`hipfire pull qwen3.5:27b`) — good for simple tasks, degrades on coding/complex output
+- **Quality (24GB)**: 27B HFQ6 (`hipfire pull qwen3.5:27b-hfq6`) — best quality, needs 7900 XTX or similar
 
 Full benchmarks: [docs/BENCHMARKS.md](docs/BENCHMARKS.md)
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,16 @@ hipfire list -r                              # Show local + available models
 hipfire rm qwen3.5:9b                        # Delete model
 ```
 
-## API
+## API (Server Mode)
+
+`hipfire serve` starts an OpenAI-compatible HTTP server. Works with Open WebUI, SillyTavern, and any OpenAI-compatible frontend.
+
+> **Status:** Server mode works but is less tested than `hipfire run`. Multi-arch stability is the current priority. If you hit issues, try `hipfire run` first to isolate whether the problem is the server or the model.
 
 ```bash
+hipfire serve                          # Default port 11435
+hipfire serve 8080                     # Custom port
+
 curl http://localhost:11435/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"qwen3.5-4b","messages":[{"role":"user","content":"Hello"}],"stream":true}'

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -41,7 +41,7 @@ const REGISTRY: Record<string, ModelEntry> = {
   "qwen3.5:2b":    { repo: hfRepo("qwen3.5","2b"),   file: "qwen3.5-2b.q4.hfq",    size_gb: 1.2,  min_vram_gb: 2,  desc: "141 tok/s" },
   "qwen3.5:4b":    { repo: hfRepo("qwen3.5","4b"),   file: "qwen3.5-4b.q4.hfq",    size_gb: 2.1,  min_vram_gb: 4,  desc: "63 tok/s, best balance" },
   "qwen3.5:9b":    { repo: hfRepo("qwen3.5","9b"),   file: "qwen3.5-9b.q4.hfq",    size_gb: 4.5,  min_vram_gb: 6,  desc: "45 tok/s, best quality 8GB" },
-  "qwen3.5:27b":   { repo: hfRepo("qwen3.5","27b"),  file: "qwen3.5-27b.q4.hfq",   size_gb: 14.3, min_vram_gb: 16, desc: "best quality, needs 16GB+" },
+  "qwen3.5:27b":   { repo: hfRepo("qwen3.5","27b"),  file: "qwen3.5-27b.q4.hfq",   size_gb: 14.3, min_vram_gb: 16, desc: "16GB+, good for simple tasks (use -hfq6 for coding)" },
 
   // Qwen3.5 HFQ6
   "qwen3.5:0.8b-hfq6": { repo: hfRepo("qwen3.5","0.8b"), file: "qwen3.5-0.8b.hfq6.hfq", size_gb: 0.6,  min_vram_gb: 1,  desc: "210 tok/s, higher quality" },
@@ -152,6 +152,11 @@ async function pull(tag: string): Promise<string> {
     const sz = (statSync(dest).size / 1e9).toFixed(1);
     console.error(`Already downloaded: ${entry.file} (${sz}GB)`);
     return dest;
+  }
+
+  // Hint for 27B HFQ4: recommend HFQ6 for complex tasks
+  if (resolved === "qwen3.5:27b") {
+    console.error(`TIP: For coding/complex tasks, use: hipfire pull qwen3.5:27b-hfq6 (needs 24GB VRAM)`);
   }
 
   const url = downloadUrl(entry);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -82,6 +82,7 @@ function downloadUrl(entry: ModelEntry): string {
 
 class Engine {
   private proc: ReturnType<typeof spawn> | null = null;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   private lines: string[] = [];
   private buffer = "";
 
@@ -94,6 +95,7 @@ class Engine {
     if (!bin) throw new Error("daemon not found. cargo build --release --features deltanet --example daemon -p engine");
 
     this.proc = spawn([bin], { stdin: "pipe", stdout: "pipe", stderr: "inherit" });
+    this.reader = this.proc.stdout!.getReader();
   }
 
   async send(msg: object) {
@@ -103,20 +105,17 @@ class Engine {
   }
 
   async recv(): Promise<any> {
-    if (!this.proc?.stdout) throw new Error("not running");
-    const reader = this.proc.stdout.getReader();
+    if (!this.reader) throw new Error("not running");
     while (true) {
       if (this.lines.length > 0) {
-        reader.releaseLock();
         return JSON.parse(this.lines.shift()!);
       }
-      const { value, done } = await reader.read();
+      const { value, done } = await this.reader.read();
       if (done) throw new Error("daemon closed");
       this.buffer += new TextDecoder().decode(value);
       const parts = this.buffer.split("\n");
       this.buffer = parts.pop() || "";
       this.lines.push(...parts.filter(l => l.trim()));
-      reader.releaseLock();
     }
   }
 
@@ -131,6 +130,8 @@ class Engine {
 
   async stop() {
     try { await this.send({ type: "unload" }); } catch {}
+    this.reader?.releaseLock();
+    this.reader = null;
     this.proc?.kill();
   }
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -202,7 +202,7 @@ async function pull(tag: string): Promise<string> {
 
 // ─── Commands ───────────────────────────────────────────
 
-async function run(model: string, prompt: string, image?: string, temp = 0.3, maxTokens = 512, repeatPenalty = 1.3) {
+async function run(model: string, prompt: string, image?: string, temp = 0.3, maxTokens = 512, repeatPenalty = 1.3, topP = 0.8) {
   let path = findModel(model);
 
   // Auto-pull if model tag is recognized but not downloaded
@@ -238,7 +238,7 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   const genMsg: any = {
     type: "generate", id: "run", prompt,
     temperature: temp * TEMP_CORRECTION, max_tokens: maxTokens,
-    repeat_penalty: repeatPenalty,
+    repeat_penalty: repeatPenalty, top_p: topP,
   };
   if (image) {
     genMsg.image = resolve(image);
@@ -377,18 +377,41 @@ switch (cmd) {
   case "serve": await serve(parseInt(rest[0]) || DEFAULT_PORT); break;
   case "run": {
     const model = rest[0];
-    if (!model) { console.error("Usage: hipfire run <model> [--image img.png] [--repeat-penalty 1.3] [prompt]\n\nExamples:\n  hipfire run qwen3.5:9b \"Hello\"\n  hipfire run qwen3.5:4b --image photo.png \"Describe this\"\n  hipfire run qwen3.5:27b --repeat-penalty 1.5 \"Write a story\""); process.exit(1); }
-    const imgIdx = rest.indexOf("--image");
-    const image = imgIdx >= 0 ? rest[imgIdx + 1] : undefined;
-    const rpIdx = rest.indexOf("--repeat-penalty");
-    const repeatPenalty = rpIdx >= 0 ? parseFloat(rest[rpIdx + 1]) : 1.3;
-    const filtered = rest.slice(1).filter((_, i) => {
-      if (imgIdx >= 0 && (i === imgIdx - 1 || i === imgIdx)) return false;
-      if (rpIdx >= 0 && (i === rpIdx - 1 || i === rpIdx)) return false;
-      return true;
-    });
+    if (!model) { console.error("Usage: hipfire run <model> [flags] [prompt]\n\nFlags:\n  --temp <float>           Temperature (default 0.3)\n  --top-p <float>          Top-p sampling (default 0.8)\n  --repeat-penalty <float> Repeat penalty (default 1.3)\n  --max-tokens <int>       Max tokens to generate (default 512)\n  --image <path>           Image for VL models\n\nExamples:\n  hipfire run qwen3.5:9b \"Hello\"\n  hipfire run qwen3.5:9b --temp 0.7 --max-tokens 256 \"Write a poem\"\n  hipfire run qwen3.5:4b --image photo.png \"Describe this\""); process.exit(1); }
+    // Parse --key value flags
+    const flagDefs: Record<string, { default: number | string | undefined }> = {
+      "--image": { default: undefined }, "--temp": { default: 0.3 },
+      "--top-p": { default: 0.8 }, "--repeat-penalty": { default: 1.3 },
+      "--max-tokens": { default: 512 },
+    };
+    const flags: Record<string, string> = {};
+    const flagIndices = new Set<number>();
+    for (const key of Object.keys(flagDefs)) {
+      const idx = rest.indexOf(key);
+      if (idx >= 0 && idx + 1 < rest.length) {
+        const val = rest[idx + 1];
+        // Reject flag values that look like other flags
+        if (val.startsWith("--")) { console.error(`Error: ${key} requires a value, got '${val}'`); process.exit(1); }
+        // Validate numeric flags
+        if (key !== "--image" && isNaN(Number(val))) { console.error(`Error: ${key} requires a number, got '${val}'`); process.exit(1); }
+        flags[key] = val;
+        flagIndices.add(idx); flagIndices.add(idx + 1);
+      } else if (idx >= 0) {
+        console.error(`Error: ${key} requires a value`); process.exit(1);
+      }
+    }
+    const image = flags["--image"];
+    const temp = Number(flags["--temp"] ?? 0.3);
+    const topP = Number(flags["--top-p"] ?? 0.8);
+    const repeatPenalty = Number(flags["--repeat-penalty"] ?? 1.3);
+    const maxTokens = Math.floor(Number(flags["--max-tokens"] ?? 512));
+    if (temp < 0) { console.error("Error: --temp must be >= 0 (0 = greedy)"); process.exit(1); }
+    if (topP <= 0 || topP > 1) { console.error("Error: --top-p must be in (0, 1]"); process.exit(1); }
+    if (repeatPenalty < 1) { console.error("Error: --repeat-penalty must be >= 1.0"); process.exit(1); }
+    if (maxTokens < 1) { console.error("Error: --max-tokens must be >= 1"); process.exit(1); }
+    const filtered = rest.slice(1).filter((_, i) => !flagIndices.has(i + 1));
     const prompt = filtered.join(" ") || (image ? "Describe this image." : "Hello");
-    await run(model, prompt, image, undefined, undefined, repeatPenalty);
+    await run(model, prompt, image, temp, maxTokens, repeatPenalty, topP);
     break;
   }
   case "pull": {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -224,7 +224,7 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   const e = new Engine();
   await e.start();
   await e.send({ type: "ping" }); await e.recv();
-  await e.send({ type: "load", model: path });
+  await e.send({ type: "load", model: path, turbo: 4 });
   const loaded = await e.recv();
   if (loaded.type === "error") { console.error(loaded.message); process.exit(1); }
   const vlTag = loaded.vl ? " VL" : "";
@@ -289,7 +289,7 @@ async function serve(port: number) {
 
         if (current !== path) {
           if (current) { await e.send({ type: "unload" }); await e.recv(); }
-          await e.send({ type: "load", model: path }); await e.recv();
+          await e.send({ type: "load", model: path, turbo: 4 }); await e.recv();
           current = path;
         }
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -196,7 +196,7 @@ async function pull(tag: string): Promise<string> {
 
 // ─── Commands ───────────────────────────────────────────
 
-async function run(model: string, prompt: string, image?: string, temp = 0.3, maxTokens = 512) {
+async function run(model: string, prompt: string, image?: string, temp = 0.3, maxTokens = 512, repeatPenalty = 1.3) {
   let path = findModel(model);
 
   // Auto-pull if model tag is recognized but not downloaded
@@ -232,6 +232,7 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   const genMsg: any = {
     type: "generate", id: "run", prompt,
     temperature: temp * TEMP_CORRECTION, max_tokens: maxTokens,
+    repeat_penalty: repeatPenalty,
   };
   if (image) {
     genMsg.image = resolve(image);
@@ -370,12 +371,18 @@ switch (cmd) {
   case "serve": await serve(parseInt(rest[0]) || DEFAULT_PORT); break;
   case "run": {
     const model = rest[0];
-    if (!model) { console.error("Usage: hipfire run <model> [--image img.png] [prompt]\n\nExamples:\n  hipfire run qwen3.5:9b \"Hello\"\n  hipfire run qwen3.5:4b --image photo.png \"Describe this\""); process.exit(1); }
+    if (!model) { console.error("Usage: hipfire run <model> [--image img.png] [--repeat-penalty 1.3] [prompt]\n\nExamples:\n  hipfire run qwen3.5:9b \"Hello\"\n  hipfire run qwen3.5:4b --image photo.png \"Describe this\"\n  hipfire run qwen3.5:27b --repeat-penalty 1.5 \"Write a story\""); process.exit(1); }
     const imgIdx = rest.indexOf("--image");
     const image = imgIdx >= 0 ? rest[imgIdx + 1] : undefined;
-    const filtered = rest.slice(1).filter((_, i) => i !== imgIdx - 1 && i !== imgIdx);
+    const rpIdx = rest.indexOf("--repeat-penalty");
+    const repeatPenalty = rpIdx >= 0 ? parseFloat(rest[rpIdx + 1]) : 1.3;
+    const filtered = rest.slice(1).filter((_, i) => {
+      if (imgIdx >= 0 && (i === imgIdx - 1 || i === imgIdx)) return false;
+      if (rpIdx >= 0 && (i === rpIdx - 1 || i === rpIdx)) return false;
+      return true;
+    });
     const prompt = filtered.join(" ") || (image ? "Describe this image." : "Hello");
-    await run(model, prompt, image);
+    await run(model, prompt, image, undefined, undefined, repeatPenalty);
     break;
   }
   case "pull": {

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -80,8 +80,9 @@ fn main() {
 
                 let path = msg.get("model").and_then(|v| v.as_str()).unwrap_or("");
                 let max_seq = msg.get("params").and_then(|p| p.get("max_seq")).and_then(|v| v.as_u64()).unwrap_or(4096) as usize;
+                let turbo_bits = msg.get("turbo").and_then(|v| v.as_u64()).unwrap_or(4) as u8;
 
-                match load_model(path, max_seq, &mut gpu) {
+                match load_model(path, max_seq, turbo_bits, &mut gpu) {
                     Ok(m) => {
                         let arch = if m.arch_id == 5 { "qwen3_5" } else { "qwen3" };
                         let vl = m.vision_config.is_some();
@@ -150,7 +151,7 @@ fn main() {
     }
 }
 
-fn load_model(path: &str, max_seq: usize, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
+fn load_model(path: &str, max_seq: usize, turbo_bits: u8, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
     let hfq = HfqFile::open(Path::new(path)).map_err(|e| format!("{e}"))?;
     let tokenizer = engine::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .ok_or("tokenizer not found")?;
@@ -176,7 +177,13 @@ fn load_model(path: &str, max_seq: usize, gpu: &mut rdna_compute::Gpu) -> Result
         };
 
         let weights = qwen35::load_weights(&hfq, &config, gpu).map_err(|e| format!("{e}"))?;
-        let kv = llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?;
+        let kv = if turbo_bits >= 2 && turbo_bits <= 4 {
+            eprintln!("  KV cache: turbo{turbo_bits}");
+            llama::KvCache::new_gpu_turbo(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, turbo_bits).map_err(|e| format!("{e}"))?
+        } else {
+            eprintln!("  KV cache: Q8");
+            llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
+        };
         let dn = DeltaNetState::new(gpu, &config).map_err(|e| format!("{e}"))?;
         let scratch = qwen35::Qwen35Scratch::new(gpu, &config, 128).map_err(|e| format!("{e}"))?;
         Ok(LoadedModel {
@@ -191,7 +198,13 @@ fn load_model(path: &str, max_seq: usize, gpu: &mut rdna_compute::Gpu) -> Result
         // Qwen3 / LLaMA
         let config = engine::hfq::config_from_hfq(&hfq).ok_or("failed to read LLaMA config")?;
         let weights = engine::hfq::load_weights_hfq(&hfq, &config, gpu).map_err(|e| format!("{e}"))?;
-        let kv = llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?;
+        let kv = if turbo_bits >= 2 && turbo_bits <= 4 {
+            eprintln!("  KV cache: turbo{turbo_bits}");
+            llama::KvCache::new_gpu_turbo(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, turbo_bits).map_err(|e| format!("{e}"))?
+        } else {
+            eprintln!("  KV cache: Q8");
+            llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
+        };
         let scratch = llama::ForwardScratch::new(gpu, &config).map_err(|e| format!("{e}"))?;
         Ok(LoadedModel {
             arch_id: hfq.arch_id,

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -118,13 +118,14 @@ fn main() {
                 let image = msg.get("image").and_then(|v| v.as_str());
                 let temp = msg.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.3) as f32;
                 let max_tokens = msg.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(512) as usize;
+                let top_p = msg.get("top_p").and_then(|v| v.as_f64()).unwrap_or(0.8) as f32;
                 let repeat_penalty = msg.get("repeat_penalty").and_then(|v| v.as_f64()).unwrap_or(1.3) as f32;
                 let repeat_window = msg.get("repeat_window").and_then(|v| v.as_u64()).unwrap_or(128) as usize;
 
                 if image.is_some() && m.vision_config.is_some() {
-                    generate_vl(m, &mut gpu, &mut stdout, id, prompt, image.unwrap(), temp, max_tokens, repeat_penalty, repeat_window);
+                    generate_vl(m, &mut gpu, &mut stdout, id, prompt, image.unwrap(), temp, top_p, max_tokens, repeat_penalty, repeat_window);
                 } else {
-                    generate(m, &mut gpu, &mut stdout, id, prompt, temp, max_tokens, repeat_penalty, repeat_window);
+                    generate(m, &mut gpu, &mut stdout, id, prompt, temp, top_p, max_tokens, repeat_penalty, repeat_window);
                 }
             }
 
@@ -213,7 +214,7 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     gpu.drain_pool();
 }
 
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, temp: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
 
     // Build ChatML prompt
@@ -253,7 +254,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
 
         // Generate
         let mut logits = gpu.download_f32(&scratch.logits).unwrap();
-        let mut next_token = llama::sample_top_p(&logits, temp, 0.8);
+        let mut next_token = llama::sample_top_p(&logits, temp, top_p);
         let mut generated = 0;
         let mut token_history = prompt_tokens.clone();
 
@@ -272,7 +273,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             logits = gpu.download_f32(&scratch.logits).unwrap();
             llama::apply_ngram_block(&mut logits, &token_history);
             llama::apply_repeat_penalty(&mut logits, &token_history, repeat_window, repeat_penalty);
-            next_token = llama::sample_top_p(&logits, temp, 0.8);
+            next_token = llama::sample_top_p(&logits, temp, top_p);
         }
 
         let tok_s = generated as f64 / t0.elapsed().as_secs_f64();
@@ -287,7 +288,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
 
         let mut rng_state = 42u32;
         for (pos, &tok) in prompt_tokens.iter().enumerate() {
-            let (_, rng) = llama::forward_scratch(gpu, weights, config, tok, pos, kv, scratch, temp, 0.8, rng_state, 0, 1.0).unwrap();
+            let (_, rng) = llama::forward_scratch(gpu, weights, config, tok, pos, kv, scratch, temp, top_p, rng_state, 0, 1.0).unwrap();
             rng_state = rng;
         }
 
@@ -317,7 +318,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &hist_bytes).unwrap();
 
             let pos = prompt_tokens.len() + generated - 1;
-            let (tok, rng) = llama::forward_scratch(gpu, weights, config, next_token, pos, kv, scratch, temp, 0.8, rng_state, hist_slice.len(), repeat_penalty).unwrap();
+            let (tok, rng) = llama::forward_scratch(gpu, weights, config, next_token, pos, kv, scratch, temp, top_p, rng_state, hist_slice.len(), repeat_penalty).unwrap();
             next_token = tok;
             rng_state = rng;
         }
@@ -328,7 +329,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     }
 }
 
-fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, image_path: &str, temp: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize) {
+fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, image_path: &str, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let config = m.q35_config.as_ref().unwrap();
     let vision_config = m.vision_config.as_ref().unwrap();
@@ -397,7 +398,7 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
 
     // Generate
     let mut logits = gpu.download_f32(&scratch.logits).unwrap();
-    let mut next_token = llama::sample_top_p(&logits, temp, 0.8);
+    let mut next_token = llama::sample_top_p(&logits, temp, top_p);
     let mut generated = 0;
     let mut token_history = prompt_tokens.clone();
 
@@ -416,7 +417,7 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
         logits = gpu.download_f32(&scratch.logits).unwrap();
         llama::apply_ngram_block(&mut logits, &token_history);
         llama::apply_repeat_penalty(&mut logits, &token_history, repeat_window, repeat_penalty);
-        next_token = llama::sample_top_p(&logits, temp, 0.8);
+        next_token = llama::sample_top_p(&logits, temp, top_p);
     }
 
     let tok_s = generated as f64 / t0.elapsed().as_secs_f64();

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -115,11 +115,13 @@ fn main() {
                 let image = msg.get("image").and_then(|v| v.as_str());
                 let temp = msg.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.3) as f32;
                 let max_tokens = msg.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(512) as usize;
+                let repeat_penalty = msg.get("repeat_penalty").and_then(|v| v.as_f64()).unwrap_or(1.3) as f32;
+                let repeat_window = msg.get("repeat_window").and_then(|v| v.as_u64()).unwrap_or(128) as usize;
 
                 if image.is_some() && m.vision_config.is_some() {
-                    generate_vl(m, &mut gpu, &mut stdout, id, prompt, image.unwrap(), temp, max_tokens);
+                    generate_vl(m, &mut gpu, &mut stdout, id, prompt, image.unwrap(), temp, max_tokens, repeat_penalty, repeat_window);
                 } else {
-                    generate(m, &mut gpu, &mut stdout, id, prompt, temp, max_tokens);
+                    generate(m, &mut gpu, &mut stdout, id, prompt, temp, max_tokens, repeat_penalty, repeat_window);
                 }
             }
 
@@ -208,7 +210,7 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     gpu.drain_pool();
 }
 
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, temp: f32, max_tokens: usize) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, temp: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
 
     // Build ChatML prompt
@@ -265,7 +267,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             let pos = prompt_tokens.len() + generated - 1;
             qwen35::forward_scratch(gpu, weights, config, next_token, pos, kv, dn, scratch).unwrap();
             logits = gpu.download_f32(&scratch.logits).unwrap();
-            llama::apply_repeat_penalty(&mut logits, &token_history, 128, 1.3);
+            llama::apply_ngram_block(&mut logits, &token_history);
+            llama::apply_repeat_penalty(&mut logits, &token_history, repeat_window, repeat_penalty);
             next_token = llama::sample_top_p(&logits, temp, 0.8);
         }
 
@@ -303,13 +306,13 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             if next_token == config.eos_token { break; }
             if im_end_token == Some(next_token) { break; }
 
-            let hist_start = token_history.len().saturating_sub(64);
+            let hist_start = token_history.len().saturating_sub(repeat_window);
             let hist_slice = &token_history[hist_start..];
             let hist_bytes: Vec<u8> = hist_slice.iter().flat_map(|t| t.to_ne_bytes()).collect();
             gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &hist_bytes).unwrap();
 
             let pos = prompt_tokens.len() + generated - 1;
-            let (tok, rng) = llama::forward_scratch(gpu, weights, config, next_token, pos, kv, scratch, temp, 0.8, rng_state, hist_slice.len(), 1.3).unwrap();
+            let (tok, rng) = llama::forward_scratch(gpu, weights, config, next_token, pos, kv, scratch, temp, 0.8, rng_state, hist_slice.len(), repeat_penalty).unwrap();
             next_token = tok;
             rng_state = rng;
         }
@@ -320,7 +323,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     }
 }
 
-fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, image_path: &str, temp: f32, max_tokens: usize) {
+fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, image_path: &str, temp: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let config = m.q35_config.as_ref().unwrap();
     let vision_config = m.vision_config.as_ref().unwrap();
@@ -406,7 +409,8 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
         let pos = prompt_tokens.len() + generated - 1;
         qwen35::forward_scratch(gpu, weights, config, next_token, pos, kv, dn, scratch).unwrap();
         logits = gpu.download_f32(&scratch.logits).unwrap();
-        llama::apply_repeat_penalty(&mut logits, &token_history, 128, 1.3);
+        llama::apply_ngram_block(&mut logits, &token_history);
+        llama::apply_repeat_penalty(&mut logits, &token_history, repeat_window, repeat_penalty);
         next_token = llama::sample_top_p(&logits, temp, 0.8);
     }
 

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -309,7 +309,9 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             if next_token == config.eos_token { break; }
             if im_end_token == Some(next_token) { break; }
 
-            let hist_start = token_history.len().saturating_sub(repeat_window);
+            // Qwen3/LLaMA scratch repeat_buf is 64 slots — clamp window to fit
+            let rw = repeat_window.min(64);
+            let hist_start = token_history.len().saturating_sub(rw);
             let hist_slice = &token_history[hist_start..];
             let hist_bytes: Vec<u8> = hist_slice.iter().flat_map(|t| t.to_ne_bytes()).collect();
             gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &hist_bytes).unwrap();

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -94,7 +94,10 @@ fn main() {
                         model = Some(m);
                     }
                     Err(e) => {
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"load failed: {}"}}"#, e);
+                        let (vram_free, vram_total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+                        let free_mb = vram_free / (1024 * 1024);
+                        let total_mb = vram_total / (1024 * 1024);
+                        let _ = writeln!(stdout, r#"{{"type":"error","message":"load failed: {}. GPU: {} ({} MB free / {} MB total)"}}"#, e, gpu.arch, free_mb, total_mb);
                     }
                 }
                 let _ = stdout.flush();

--- a/crates/engine/examples/infer.rs
+++ b/crates/engine/examples/infer.rs
@@ -34,6 +34,9 @@ fn main() {
     let no_think = args.iter().any(|a| a == "--no-think");
     let debug_cmp = args.iter().any(|a| a == "--debug-compare");
     let use_asym = args.iter().any(|a| a == "--asym");
+    let max_tokens: usize = args.iter().position(|a| a == "--max-tokens")
+        .and_then(|i| args.get(i + 1).and_then(|v| v.parse().ok()))
+        .unwrap_or(2048);
     let turbo_bits: u8 = if args.iter().any(|a| a == "--turbo2") { 2 }
         else if args.iter().any(|a| a == "--turbo3") { 3 }
         else if args.iter().any(|a| a == "--turbo4") { 4 }
@@ -47,7 +50,7 @@ fn main() {
     for a in args.iter().skip(1) {
         if skip_next { skip_next = false; continue; }
         if a == "--no-think" || a == "--debug-compare" || a == "--turbo2" || a == "--turbo3" || a == "--turbo4" || a == "--asym" { continue; }
-        if a == "--image" { skip_next = true; continue; }
+        if a == "--image" || a == "--max-tokens" { skip_next = true; continue; }
         positional.push(a.as_str());
     }
     let model_path = positional.first().unwrap_or_else(|| {
@@ -224,7 +227,7 @@ fn main() {
     // Thinking mode
     let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
     let think_end_seq = tokenizer.encode("</think>");
-    let max_gen = 2048;
+    let max_gen = max_tokens;
     let max_think = 512;
 
     // First token

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -117,10 +117,13 @@ impl HipRuntime {
                 .or_else(|_| Library::new("amdhip64_7.dll"))
                 .or_else(|_| Library::new("amdhip64_6.dll"))
                 .or_else(|_| {
-                    // Try versioned names in HIP_PATH and runtime dir
-                    let p1v7 = format!(r"{userprofile}\.hipfire\runtime\amdhip64_7.dll");
-                    let p2v7 = format!(r"{hip_path}\bin\amdhip64_7.dll");
-                    Library::new(&p1v7).or_else(|_| Library::new(&p2v7))
+                    // Try versioned names in explicit paths (runtime dir + HIP_PATH)
+                    let rt = format!(r"{userprofile}\.hipfire\runtime");
+                    let hp = format!(r"{hip_path}\bin");
+                    Library::new(&format!(r"{rt}\amdhip64_7.dll"))
+                        .or_else(|_| Library::new(&format!(r"{rt}\amdhip64_6.dll")))
+                        .or_else(|_| Library::new(&format!(r"{hp}\amdhip64_7.dll")))
+                        .or_else(|_| Library::new(&format!(r"{hp}\amdhip64_6.dll")))
                 })
                 .map_err(|e| {
                     HipError::new(

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -110,15 +110,24 @@ impl HipRuntime {
             let hip_path = std::env::var("HIP_PATH").unwrap_or_default();
             let p1 = format!(r"{userprofile}\.hipfire\runtime\amdhip64.dll");
             let p2 = format!(r"{hip_path}\bin\amdhip64.dll");
+            // Try unversioned first, then versioned names (HIP SDK 7.x installs amdhip64_7.dll)
             Library::new(&p1)
                 .or_else(|_| Library::new(&p2))
                 .or_else(|_| Library::new("amdhip64.dll"))
+                .or_else(|_| Library::new("amdhip64_7.dll"))
+                .or_else(|_| Library::new("amdhip64_6.dll"))
+                .or_else(|_| {
+                    // Try versioned names in HIP_PATH and runtime dir
+                    let p1v7 = format!(r"{userprofile}\.hipfire\runtime\amdhip64_7.dll");
+                    let p2v7 = format!(r"{hip_path}\bin\amdhip64_7.dll");
+                    Library::new(&p1v7).or_else(|_| Library::new(&p2v7))
+                })
                 .map_err(|e| {
                     HipError::new(
                         0,
                         &format!(
                             "failed to load amdhip64.dll: {e}. \
-                             Searched: {p1}, {p2}, amdhip64.dll (PATH). \
+                             Searched: {p1}, {p2}, amdhip64.dll, amdhip64_7.dll, amdhip64_6.dll (PATH). \
                              Is ROCm/HIP installed?"
                         ),
                     )

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -68,15 +68,28 @@ From earlier benchmarks (2026-03-27):
 | turbo3 (3-bit) | 50.8 | 44.5 | 9.85x |
 | turbo4 (4-bit) | 53.6 | 51.0 | 7.5x |
 
-## Qwen3.5-27B — Awaiting Tester Benchmarks
+## Qwen3.5-27B (RX 7900 XTX, 24GB, gfx1100)
 
-27B does not fit on 8GB cards. Needs 16GB+ VRAM.
+Benchmarks by [DomKo](https://github.com/Kaden-Schutt/hipfire/issues/2). Runtime-compiled kernels, ROCm 6.4.
+
+| Model | Quant | KV Mode | tok/s | Quality |
+|-------|-------|---------|-------|---------|
+| 27B | HFQ4 | Q8 | **25.8** | Broken on coding/complex tasks |
+| 27B | HFQ4 | Turbo4 | **25.2** | Meta-reasoning loops, gibberish |
+| 27B | HFQ6 | Q8 | **16.5** | Correct |
+| 27B | HFQ6 | Turbo4 | **19.9** | Correct |
+| 9B | HFQ4 | Q8 | **62.3** | Correct |
+
+Notes:
+- **27B HFQ4 is not recommended for complex tasks.** Output degrades to gibberish on coding prompts. Use HFQ6.
+- HFQ6 + Turbo4 is faster than HFQ6 + Q8 (19.9 vs 16.5) — Turbo4 KV recommended for 27B.
+- 27B HFQ4 needs 16GB+ VRAM, HFQ6 needs 24GB.
 
 | GPU | VRAM | HFQ4 (14.3GB) | HFQ6 (21.1GB) |
 |-----|------|----------------|----------------|
 | RX 5700 XT | 8GB | Does not fit | Does not fit |
-| RX 6800 XT | 16GB | Fits — benchmark wanted | Does not fit |
-| RX 7900 XTX | 24GB | Fits — benchmark wanted | Fits — benchmark wanted |
+| RX 6800 XT | 16GB | Fits (benchmark wanted) | Does not fit |
+| RX 7900 XTX | 24GB | 25-27 tok/s | 16-20 tok/s |
 | RX 9070 | 16GB | Fits — benchmark wanted | Does not fit |
 
 To submit benchmarks, see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -15,8 +15,8 @@ The primary model family for hipfire alpha. Uses DeltaNet hybrid architecture wi
 | `qwen3.5:4b-hfq6` | qwen3.5-4b.hfq6.hfq | 3.3GB | 5GB | 53 tok/s |
 | `qwen3.5:9b` | qwen3.5-9b.q4.hfq | 4.5GB | 6GB | Best quality on 8GB, 45 tok/s |
 | `qwen3.5:9b-hfq6` | qwen3.5-9b.hfq6.hfq | 6.8GB | 8GB | 37 tok/s, near-FP16 quality |
-| `qwen3.5:27b` | qwen3.5-27b.q4.hfq | 14.3GB | 16GB | Needs 6800 XT / 7900 XTX / 9070 |
-| `qwen3.5:27b-hfq6` | qwen3.5-27b.hfq6.hfq | 21.4GB | 24GB | Needs 7900 XTX |
+| `qwen3.5:27b` | qwen3.5-27b.q4.hfq | 14.3GB | 16GB | 25-27 tok/s. Good for simple tasks, degrades on coding |
+| `qwen3.5:27b-hfq6` | qwen3.5-27b.hfq6.hfq | 21.4GB | 24GB | 16-20 tok/s. Use this for complex/coding tasks |
 
 ### Qwen3 (standard LLaMA attention)
 Earlier architecture with standard multi-head attention. head_dim=128. Supported but not the primary focus.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -397,16 +397,29 @@ if (-not (Test-Path $ConfigFile)) {
 
 # ─── PATH ────────────────────────────────────────────────
 Write-Host ""
+$NoPath = $args -contains "--no-path"
 $CurrentUserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($CurrentUserPath -notlike "*$BinDir*") {
+if ($null -eq $CurrentUserPath) { $CurrentUserPath = "" }
+
+if ($NoPath) {
+    Write-Host "Skipping PATH modification (--no-path)" -ForegroundColor Yellow
+    Write-Host "  Add manually to user PATH: $BinDir" -ForegroundColor Yellow
+} elseif ($CurrentUserPath -notlike "*$BinDir*") {
     Write-Host "hipfire bin dir is not in your user PATH." -ForegroundColor Yellow
     Write-Host "  $BinDir"
     $reply = Read-Host "Add to user PATH permanently? [Y/n]"
     if ($reply -notmatch "^[Nn]$") {
         $NewPath = "$BinDir;$CurrentUserPath"
-        [Environment]::SetEnvironmentVariable("PATH", $NewPath, "User")
-        $env:PATH = "$BinDir;$env:PATH"
-        Write-Host "  PATH updated ✓ (restart your shell to apply)" -ForegroundColor Green
+        # Safety: warn if PATH would exceed Windows limit (2047 chars)
+        if ($NewPath.Length -gt 2040) {
+            Write-Host "  WARNING: User PATH would be $($NewPath.Length) chars (limit ~2047)." -ForegroundColor Red
+            Write-Host "  Skipping to avoid PATH truncation. Add manually:" -ForegroundColor Red
+            Write-Host "    $BinDir" -ForegroundColor Yellow
+        } else {
+            [Environment]::SetEnvironmentVariable("PATH", $NewPath, "User")
+            $env:PATH = "$BinDir;$env:PATH"
+            Write-Host "  PATH updated ✓ (restart your shell to apply)" -ForegroundColor Green
+        }
     } else {
         Write-Host "  Add manually to user PATH: $BinDir" -ForegroundColor Yellow
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -77,23 +77,44 @@ if (Test-Path $HipDllDest) {
     $HipDllFound = $true
 }
 
-# Check %HIP_PATH%\bin
+# Check %HIP_PATH%\bin (unversioned and versioned)
 if (-not $HipDllFound -and $env:HIP_PATH) {
-    $candidate = Join-Path $env:HIP_PATH "bin\amdhip64.dll"
-    if (Test-Path $candidate) {
-        Write-Host "  amdhip64.dll: found at $candidate ✓" -ForegroundColor Green
-        Copy-Item $candidate $HipDllDest -Force
-        $HipDllFound = $true
+    foreach ($dllName in @("amdhip64.dll", "amdhip64_7.dll", "amdhip64_6.dll")) {
+        $candidate = Join-Path $env:HIP_PATH "bin\$dllName"
+        if (Test-Path $candidate) {
+            Write-Host "  $dllName: found at $candidate ✓" -ForegroundColor Green
+            Copy-Item $candidate $HipDllDest -Force
+            $HipDllFound = $true
+            break
+        }
     }
 }
 
-# Check standard ROCm install location
+# Check standard ROCm install locations (unversioned and versioned)
 if (-not $HipDllFound) {
-    $candidate = "C:\Program Files\AMD\ROCm\bin\amdhip64.dll"
-    if (Test-Path $candidate) {
-        Write-Host "  amdhip64.dll: found at $candidate ✓" -ForegroundColor Green
-        Copy-Item $candidate $HipDllDest -Force
-        $HipDllFound = $true
+    foreach ($dllName in @("amdhip64.dll", "amdhip64_7.dll", "amdhip64_6.dll")) {
+        # Check versioned ROCm dirs (e.g. C:\Program Files\AMD\ROCm\7.1\bin\)
+        $rocmBase = "C:\Program Files\AMD\ROCm"
+        if (Test-Path $rocmBase) {
+            foreach ($verDir in (Get-ChildItem $rocmBase -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending)) {
+                $candidate = Join-Path $verDir.FullName "bin\$dllName"
+                if (Test-Path $candidate) {
+                    Write-Host "  $dllName: found at $candidate ✓" -ForegroundColor Green
+                    Copy-Item $candidate $HipDllDest -Force
+                    $HipDllFound = $true
+                    break
+                }
+            }
+            if ($HipDllFound) { break }
+        }
+        # Also check flat layout
+        $candidate = "C:\Program Files\AMD\ROCm\bin\$dllName"
+        if (Test-Path $candidate) {
+            Write-Host "  $dllName: found at $candidate ✓" -ForegroundColor Green
+            Copy-Item $candidate $HipDllDest -Force
+            $HipDllFound = $true
+            break
+        }
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,7 +119,7 @@ done
 
 # Fallback: ask ldconfig if none of the hardcoded paths matched
 if ! $HIP_FOUND; then
-    ldconfig_hit=$(ldconfig -p 2>/dev/null | grep -m1 'libamdhip64.so ' | awk '{print $NF}')
+    ldconfig_hit=$(ldconfig -p 2>/dev/null | grep -m1 'libamdhip64.so ' | awk '{print $NF}' || true)
     if [ -n "$ldconfig_hit" ] && [ -f "$ldconfig_hit" ]; then
         echo "  libamdhip64.so: found via ldconfig at $ldconfig_hit ✓"
         HIP_FOUND=true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,7 +103,12 @@ echo ""
 echo "Checking HIP runtime..."
 HIP_FOUND=false
 HIP_LIB=""
-for lib in /opt/rocm/lib/libamdhip64.so /usr/lib/libamdhip64.so /usr/lib/x86_64-linux-gnu/libamdhip64.so; do
+for lib in /opt/rocm/lib/libamdhip64.so \
+           /opt/rocm/lib64/libamdhip64.so \
+           /usr/lib/libamdhip64.so \
+           /usr/lib64/libamdhip64.so \
+           /usr/lib/x86_64-linux-gnu/libamdhip64.so \
+           /usr/lib64/rocm/libamdhip64.so; do
     if [ -f "$lib" ]; then
         echo "  libamdhip64.so: found at $lib ✓"
         HIP_FOUND=true
@@ -111,6 +116,16 @@ for lib in /opt/rocm/lib/libamdhip64.so /usr/lib/libamdhip64.so /usr/lib/x86_64-
         break
     fi
 done
+
+# Fallback: ask ldconfig if none of the hardcoded paths matched
+if ! $HIP_FOUND; then
+    ldconfig_hit=$(ldconfig -p 2>/dev/null | grep -m1 'libamdhip64.so ' | awk '{print $NF}')
+    if [ -n "$ldconfig_hit" ] && [ -f "$ldconfig_hit" ]; then
+        echo "  libamdhip64.so: found via ldconfig at $ldconfig_hit ✓"
+        HIP_FOUND=true
+        HIP_LIB="$ldconfig_hit"
+    fi
+fi
 
 # Check HIP version matches GPU arch requirements
 if $HIP_FOUND; then


### PR DESCRIPTION
## Summary
- **repeat_penalty + ngram_block** in daemon — fixes 27B repetition loops
- **CLI sampling flags**: `--temp`, `--top-p`, `--repeat-penalty`, `--max-tokens` with validation
- **Turbo4 KV cache** wired through daemon/CLI — 9B goes from 17 to 40 tok/s
- **Windows DLL**: versioned filename fallback (`amdhip64_7.dll`, `amdhip64_6.dll`)
- **install.sh**: `/usr/lib64/` paths + ldconfig fallback (fixes openSUSE)
- **install.ps1**: PATH length guard + `--no-path` flag
- **hipfire serve**: fix ReadableStream locked crash on second request
- **infer CLI**: `--max-tokens` flag
- **Daemon errors**: include GPU arch + VRAM info
- **27B docs**: split benchmarks by GPU, recommend HFQ6 for complex tasks
- **Server mode**: documented with status note

Addresses: GitHub #2 (DomKo), Discord feedback from effectiveass + Vamned.

## Test plan
- [x] Qwen3.5-9B: 44.7 tok/s via infer, 40 tok/s via daemon — no regression
- [x] Qwen3.5-0.8B: 223.8 tok/s — no regression
- [x] Qwen3 + oversized repeat_window: no crash (clamped to 64)
- [x] `--max-tokens 8` caps output correctly
- [x] `--temp 0` greedy decoding works
- [x] Bad flag values rejected with clear errors
- [x] `cargo build --release --features deltanet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)