### PR TITLE
CLI dev tools, agent skills, dev norms + PS1 fix

### DIFF
--- a/.skills/hipfire-diag/fix-suggestions.md
+++ b/.skills/hipfire-diag/fix-suggestions.md
@@ -32,11 +32,31 @@ yay -S rocm-hip-runtime
 ./scripts/compile-kernels.sh gfx1010  # for RX 5700 XT
 ./scripts/compile-kernels.sh gfx1030  # for RX 6800 XT
 ./scripts/compile-kernels.sh gfx1100  # for RX 7900 XTX
-./scripts/compile-kernels.sh gfx1200  # for RX 9070
+./scripts/compile-kernels.sh gfx1200  # for RX 9060/9070
+./scripts/compile-kernels.sh gfx1201  # for RX 9070 XT
+
+# After compiling, generate hash files:
+./scripts/write-kernel-hashes.sh
 
 # If hipcc is NOT available:
 # Download from GitHub releases for your arch
 ```
+
+## Kernel hash files missing (INCOMPLETE in hipfire diag)
+Hash sidecar files validate pre-compiled kernels aren't stale.
+Without them, the engine recompiles via hipcc on first run (slow).
+```bash
+./scripts/write-kernel-hashes.sh
+# Or: cargo run --release -p rdna-compute --example gen_kernel_hashes
+```
+
+## All "!" output (especially gfx1100)
+Pre-compiled kernel blobs are stale — delete and let the engine recompile:
+```bash
+rm -rf ~/.hipfire/bin/kernels/compiled/gfx1100
+# Next run will recompile from correct embedded source
+```
+Or update: `hipfire update`
 
 ## Test binaries not built
 ```bash
@@ -54,7 +74,7 @@ Try a smaller model:
 - 9B needs 6GB+ VRAM
 - 8B Qwen3 needs 5GB+ VRAM
 
-Or reduce context: the `--maxgen` flag limits generation length.
+Or reduce context with `--max-tokens` flag or `--turbo4` KV cache compression.
 
 ## VRAM leak (65MB per model load)
 Update to latest version. Fixed in commit 0d1fca6:

--- a/.skills/hipfire-diag/run-diagnostics.sh
+++ b/.skills/hipfire-diag/run-diagnostics.sh
@@ -33,11 +33,12 @@ echo '  },'
 
 # 2. Pre-compiled kernels
 echo '  "kernels": {'
-for arch in gfx1010 gfx1030 gfx1100 gfx1200; do
-    count=$(ls kernels/compiled/$arch/*.hsaco 2>/dev/null | wc -l)
-    echo "    \"$arch\": $count,"
+for arch in gfx1010 gfx1030 gfx1100 gfx1200 gfx1201; do
+    hsaco=$(ls kernels/compiled/$arch/*.hsaco 2>/dev/null | wc -l)
+    hashes=$(ls kernels/compiled/$arch/*.hash 2>/dev/null | wc -l)
+    echo "    \"$arch\": {\"blobs\": $hsaco, \"hashes\": $hashes},"
 done
-echo '    "_note": "0 means kernels not compiled for that arch"'
+echo '    "_note": "blobs=pre-compiled kernels, hashes=integrity sidecar files"'
 echo '  },'
 
 # 3. Kernel tests (no model needed)

--- a/.skills/hipfire-tester/guide.md
+++ b/.skills/hipfire-tester/guide.md
@@ -60,9 +60,11 @@ target/release/hipfire-quantize \
 | 2B | ~1.1GB | ~1.6GB | Yes | Yes | Yes |
 | 4B | ~2.1GB | ~3.1GB | Yes | Yes | Yes |
 | 9B | ~4.8GB | ~7.0GB | Yes | Yes | Yes |
-| 27B | ~14.3GB | ~21.1GB | No | Yes* | Yes |
+| 27B | ~14.3GB | ~21.1GB | No | HFQ4 only | Yes |
 
-*27B HFQ6 may not fit 16GB with full KV cache — use `--turbo4` to reduce KV VRAM.
+**27B quality note:** HFQ4 produces degraded output on coding/complex tasks (gibberish).
+Use HFQ6 for 27B if you have 24GB VRAM. HFQ4 is OK for simple Q&A only.
+`hipfire pull qwen3.5:27b-hfq6` for the quality variant.
 
 ## Running Inference
 
@@ -100,9 +102,24 @@ target/release/examples/infer models/qwen3.5-4b.q4.hfq --image photo.png "Descri
 hipfire pull qwen3.5:9b         # Download model
 hipfire run qwen3.5:9b "Hello"  # Run (auto-pulls if needed)
 hipfire serve                   # OpenAI-compatible API on port 11435
-hipfire run qwen3.5:4b --image img.png "Describe this"
+hipfire diag                    # GPU diagnostics — arch, VRAM, HIP version, kernels
 hipfire list -r                 # Show local + available models
+
+# Sampling flags (v0.1.2+)
+hipfire run qwen3.5:9b --temp 0.7 --top-p 0.95 "Write a poem"
+hipfire run qwen3.5:9b --repeat-penalty 1.5 --max-tokens 256 "Explain recursion"
+hipfire run qwen3.5:4b --image img.png "Describe this"
 ```
+
+### CLI sampling flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--temp` | 0.3 | Temperature (0 = greedy) |
+| `--top-p` | 0.8 | Nucleus sampling threshold |
+| `--repeat-penalty` | 1.3 | Repeat penalty (1.0 = disabled) |
+| `--max-tokens` | 512 | Max tokens to generate |
+| `--image` | — | Image path for VL models |
 
 ### KV mode summary
 
@@ -197,8 +214,9 @@ so the maintainers can include it in the next release.
 
 ## Troubleshooting
 
-For GPU detection, driver, and ROCm runtime issues, use the hipfire-diag skill:
-- Run `.skills/hipfire-diag/run-diagnostics.sh` and share the JSON output
+For GPU detection, driver, and ROCm runtime issues:
+- Run `hipfire diag` and share the output
+- Or run `.skills/hipfire-diag/run-diagnostics.sh` for detailed JSON output
 
 ### Common tester issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,48 @@ scripts/test-kernels.sh
 3. Keep PRs focused — one logical change per PR
 4. Run `cargo fmt` and `cargo clippy` before submitting
 
+### Pre-push regression checklist
+
+Before pushing any change that touches kernels, dispatch, sampling, or the forward pass:
+
+```bash
+# 1. Build clean
+cargo build --release --features deltanet --example daemon --example infer -p engine
+
+# 2. Kernel tests (no model needed, ~30s)
+target/release/examples/test_kernels
+
+# 3. Speed regression — compare against documented baselines
+target/release/examples/infer models/qwen3.5-9b.q4.hfq --max-tokens 64 "Hello"
+# Expected: ~45 tok/s on gfx1010. Flag if >10% slower.
+
+# 4. Correctness — model should answer this correctly
+target/release/examples/infer models/qwen3.5-9b.q4.hfq --max-tokens 32 \
+  "What is the capital of France? One sentence."
+# Expected: output contains "Paris"
+
+# 5. Qwen3 path (if touching sampling or daemon)
+# Tests the non-DeltaNet code path + repeat_window clamping
+echo '{"type":"load","model":"models/qwen3-8b.q4.hfq"}' | timeout 15 target/release/examples/daemon
+```
+
+**Speed baselines (gfx1010 / RX 5700 XT):**
+
+| Model | Binary | Expected tok/s | Alarm if below |
+|-------|--------|----------------|----------------|
+| Qwen3.5-0.8B HFQ4 | infer | 220 | 180 |
+| Qwen3.5-9B HFQ4 | infer | 45 | 38 |
+| Qwen3.5-9B HFQ4 | daemon (turbo4) | 40 | 33 |
+| Qwen3-8B HFQ4 | daemon | 38 | 30 |
+
+**Multi-arch notes:**
+- We can only test gfx1010 locally. Changes to kernels, dispatch, or compilation
+  paths MUST be validated by a tester on gfx1100+ before release.
+- Kernel hash files must be regenerated after any `.hip` source change:
+  `cargo run --release -p rdna-compute --example gen_kernel_hashes`
+- Pre-compiled blobs without matching hashes are rejected at runtime (the engine
+  falls back to hipcc recompilation).
+
 ### Code style
 
 - `cargo fmt` — required, enforced in CI

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -492,6 +492,80 @@ switch (cmd) {
     console.error("hipfire updated ✓");
     break;
   }
+  case "diag": {
+    console.log("hipfire diagnostics\n");
+
+    // 1. Check daemon binary
+    const bins = [
+      resolve(__dirname, "../target/release/examples/daemon"),
+      join(HIPFIRE_DIR, "bin", "daemon"),
+    ];
+    const daemonBin = bins.find(p => existsSync(p));
+    console.log(`daemon binary: ${daemonBin ? "found" : "NOT FOUND"}`);
+    if (!daemonBin) { console.log("  Install: hipfire update\n"); process.exit(1); }
+
+    // 2. Check local models
+    const models = listLocal();
+    console.log(`local models:  ${models.length}`);
+    for (const m of models) console.log(`  ${m.name.padEnd(35)} ${m.size.padStart(6)}`);
+
+    // 3. Check pre-compiled kernels
+    const binDir = join(HIPFIRE_DIR, "bin");
+    const kernelBase = join(binDir, "kernels", "compiled");
+    const cwdKernelBase = resolve(__dirname, "../kernels/compiled");
+    const kBase = existsSync(kernelBase) ? kernelBase : existsSync(cwdKernelBase) ? cwdKernelBase : null;
+    if (kBase) {
+      const arches = readdirSync(kBase).filter(d => d.startsWith("gfx"));
+      for (const arch of arches) {
+        const dir = join(kBase, arch);
+        const hsaco = readdirSync(dir).filter(f => f.endsWith(".hsaco")).length;
+        const hashes = readdirSync(dir).filter(f => f.endsWith(".hash")).length;
+        console.log(`kernels/${arch}: ${hsaco} blobs, ${hashes} hashes${hashes < hsaco ? " (INCOMPLETE)" : ""}`);
+      }
+    } else {
+      console.log("kernels:       NOT FOUND");
+    }
+
+    // 4. Probe daemon for GPU info
+    console.log("\nProbing GPU via daemon...");
+    try {
+      const e = new Engine();
+      await e.start();
+      await e.send({ type: "ping" }); await e.recv();
+      await e.send({ type: "diag" });
+      const diag = await e.recv();
+      if (diag.type === "diag") {
+        console.log(`  GPU arch:    ${diag.arch}`);
+        console.log(`  HIP version: ${diag.hip_version}`);
+        console.log(`  VRAM free:   ${diag.vram_free_mb} MB`);
+        console.log(`  VRAM total:  ${diag.vram_total_mb} MB`);
+        console.log(`  Model:       ${diag.model_loaded ? diag.model_arch : "none loaded"}`);
+        console.log(`  Kernels:     ${diag.kernels} blobs, ${diag.kernel_hashes} hashes`);
+
+        // Recommendations
+        console.log("");
+        if (diag.vram_total_mb < 8000) {
+          console.log("TIP: <8GB VRAM — use qwen3.5:4b or qwen3.5:0.8b");
+        } else if (diag.vram_total_mb < 16000) {
+          console.log("TIP: 8-16GB VRAM — qwen3.5:9b is your best option");
+        } else {
+          console.log("TIP: 16GB+ VRAM — try qwen3.5:27b-hfq6 for best quality");
+        }
+        if (models.length === 0) {
+          console.log("TIP: No models downloaded. Run: hipfire pull qwen3.5:9b");
+        }
+      } else {
+        console.log(`  Error: ${diag.message || "unexpected response"}`);
+      }
+      await e.stop();
+    } catch (err: any) {
+      console.log(`  Failed to start daemon: ${err.message}`);
+      console.log("  Check: ROCm/HIP installed? AMD GPU visible? /dev/kfd accessible?");
+    }
+
+    console.log("\nDone.");
+    break;
+  }
   case "rm": {
     const tag = rest[0] || "";
     const resolved = resolveModelTag(tag);
@@ -512,6 +586,7 @@ switch (cmd) {
   run <model> [prompt]  Generate text (auto-pulls if needed)
   serve [port]          Start OpenAI-compatible server (default: ${DEFAULT_PORT})
   list [-r]             Show local models (-r: show available too)
+  diag                  Diagnostics — GPU, VRAM, HIP version, kernels, models
   rm <model>            Delete model
   update                Pull latest code, rebuild, update kernels
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -542,17 +542,23 @@ switch (cmd) {
         console.log(`  Model:       ${diag.model_loaded ? diag.model_arch : "none loaded"}`);
         console.log(`  Kernels:     ${diag.kernels} blobs, ${diag.kernel_hashes} hashes`);
 
-        // Recommendations
+        // Recommendations based on total VRAM
+        const vram = diag.vram_total_mb;
         console.log("");
-        if (diag.vram_total_mb < 8000) {
-          console.log("TIP: <8GB VRAM — use qwen3.5:4b or qwen3.5:0.8b");
-        } else if (diag.vram_total_mb < 16000) {
-          console.log("TIP: 8-16GB VRAM — qwen3.5:9b is your best option");
+        if (vram < 4000) {
+          console.log("TIP: <4GB VRAM — use qwen3.5:0.8b (430MB)");
+        } else if (vram < 6000) {
+          console.log("TIP: 4-6GB VRAM — use qwen3.5:4b (2.1GB)");
+        } else if (vram < 16000) {
+          console.log("TIP: 6-16GB VRAM — qwen3.5:9b (4.5GB) is your best option");
+        } else if (vram < 24000) {
+          console.log("TIP: 16-24GB VRAM — qwen3.5:27b HFQ4 (14.3GB). Note: HFQ4 degrades on complex tasks");
         } else {
-          console.log("TIP: 16GB+ VRAM — try qwen3.5:27b-hfq6 for best quality");
+          console.log("TIP: 24GB+ VRAM — qwen3.5:27b-hfq6 (21.4GB) for best quality");
         }
         if (models.length === 0) {
-          console.log("TIP: No models downloaded. Run: hipfire pull qwen3.5:9b");
+          const rec = vram < 4000 ? "qwen3.5:0.8b" : vram < 6000 ? "qwen3.5:4b" : vram < 16000 ? "qwen3.5:9b" : vram < 24000 ? "qwen3.5:27b" : "qwen3.5:27b-hfq6";
+          console.log(`TIP: No models downloaded. Run: hipfire pull ${rec}`);
         }
       } else {
         console.log(`  Error: ${diag.message || "unexpected response"}`);

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -143,6 +143,29 @@ fn main() {
                 let _ = stdout.flush();
             }
 
+            "diag" => {
+                let (vram_free, vram_total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+                let hip_ver = gpu.hip.runtime_version().unwrap_or((0, 0));
+                let has_model = model.is_some();
+                let model_arch = model.as_ref().map(|m| if m.arch_id == 5 { "qwen3_5" } else { "qwen3" }).unwrap_or("none");
+                // Count pre-compiled kernels
+                let kernel_dir = std::env::current_exe().ok()
+                    .and_then(|e| e.parent().map(|p| p.join("kernels").join("compiled").join(&gpu.arch)))
+                    .filter(|p| p.is_dir());
+                let (hsaco_count, hash_count) = kernel_dir.map(|d| {
+                    let hsaco = std::fs::read_dir(&d).map(|r| r.filter(|e| e.as_ref().ok().map(|e| e.path().extension().map(|x| x == "hsaco").unwrap_or(false)).unwrap_or(false)).count()).unwrap_or(0);
+                    let hash = std::fs::read_dir(&d).map(|r| r.filter(|e| e.as_ref().ok().map(|e| e.path().extension().map(|x| x == "hash").unwrap_or(false)).unwrap_or(false)).count()).unwrap_or(0);
+                    (hsaco, hash)
+                }).unwrap_or((0, 0));
+                let _ = writeln!(stdout,
+                    r#"{{"type":"diag","arch":"{}","hip_version":"{}.{}","vram_free_mb":{},"vram_total_mb":{},"model_loaded":{},"model_arch":"{}","kernels":{},"kernel_hashes":{}}}"#,
+                    gpu.arch, hip_ver.0, hip_ver.1,
+                    vram_free / (1024 * 1024), vram_total / (1024 * 1024),
+                    has_model, model_arch, hsaco_count, hash_count
+                );
+                let _ = stdout.flush();
+            }
+
             _ => {
                 let _ = writeln!(stdout, r#"{{"type":"error","message":"unknown type: {}"}}"#, msg_type);
                 let _ = stdout.flush();

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -82,7 +82,7 @@ if (-not $HipDllFound -and $env:HIP_PATH) {
     foreach ($dllName in @("amdhip64.dll", "amdhip64_7.dll", "amdhip64_6.dll")) {
         $candidate = Join-Path $env:HIP_PATH "bin\$dllName"
         if (Test-Path $candidate) {
-            Write-Host "  $dllName: found at $candidate ✓" -ForegroundColor Green
+            Write-Host "  ${dllName}: found at $candidate ✓" -ForegroundColor Green
             Copy-Item $candidate $HipDllDest -Force
             $HipDllFound = $true
             break
@@ -99,7 +99,7 @@ if (-not $HipDllFound) {
             foreach ($verDir in (Get-ChildItem $rocmBase -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending)) {
                 $candidate = Join-Path $verDir.FullName "bin\$dllName"
                 if (Test-Path $candidate) {
-                    Write-Host "  $dllName: found at $candidate ✓" -ForegroundColor Green
+                    Write-Host "  ${dllName}: found at $candidate ✓" -ForegroundColor Green
                     Copy-Item $candidate $HipDllDest -Force
                     $HipDllFound = $true
                     break
@@ -110,7 +110,7 @@ if (-not $HipDllFound) {
         # Also check flat layout
         $candidate = "C:\Program Files\AMD\ROCm\bin\$dllName"
         if (Test-Path $candidate) {
-            Write-Host "  $dllName: found at $candidate ✓" -ForegroundColor Green
+            Write-Host "  ${dllName}: found at $candidate ✓" -ForegroundColor Green
             Copy-Item $candidate $HipDllDest -Force
             $HipDllFound = $true
             break


### PR DESCRIPTION
## Summary
- **`hipfire diag`**: New CLI command — probes GPU, VRAM, HIP version, kernels, models. VRAM-aware model recommendations.
- **Agent skills updated**: tester guide (CLI flags, 27B quality warning, diag reference), diag skill (gfx1201, kernel hashes, stale blob fixes)
- **Dev norms**: Pre-push regression checklist + speed baselines in CONTRIBUTING.md
- **PS1 fix**: `$dllName:` → `${dllName}:` — install.ps1 was broken on ALL Windows systems

## Test plan
- [x] `bun cli/index.ts diag` outputs GPU info, VRAM, kernel counts, model recommendations
- [x] Recommendations match VRAM capacity (no 27B-hfq6 on 16GB cards)
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)