### PR TITLE
fix(cli): add missing budget_alert meta to config TUI

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2112,6 +2112,11 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       desc: "serve: seconds idle before unloading model (frees VRAM; 0 = never unload)",
       range: [0, 86400], step: 30,
     },
+    experimental_budget_alert: {
+      label: "budget_alert",
+      desc: "show VRAM budget alerts during generation",
+      options: ["true", "false"],
+    },
   };
 
   let selected = 0;


### PR DESCRIPTION
## Bug

`hipfire config` crashes with `TypeError: undefined is not an object (evaluating 'meta[k].label')` because `experimental_budget_alert` is in `CONFIG_DEFAULTS` but missing from TUI `meta` object.

## Fix

Added missing `meta` entry for `experimental_budget_alert`.