### PR TITLE
feat(qwen3.6): add Qwen3.6-35B-A3B MoE + fix hf download

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -229,6 +229,15 @@ const REGISTRY: Record<string, ModelEntry> = {
   // sees the local copy and skips the download).
   "qwen3.5:35b-a3b":  { repo: "", file: "qwen3.5-35b-a3b.mq4", size_gb: 18.7, min_vram_gb: 22, desc: "MoE 35B/3B-active, 115 tok/s — LOCAL ONLY (no HF repo yet)" },
 
+  // Qwen3.6 MoE (A3B) — 35B total / 3B activated, released April 2026.
+  // HF config still declares `model_type: qwen3_5_moe` so it loads through
+  // the existing A3B (arch_id=6) code path; weights differ (coding/agentic
+  // fine-tune) but architecture (256 experts top-8, hybrid DeltaNet+FA,
+  // head_dim=256 with partial_rotary=0.25, shared expert) is identical.
+  // Local-only until a pre-quantized HF repo exists; use `hipfire quantize
+  // Qwen/Qwen3.6-35B-A3B --format mq4` to produce the file.
+  "qwen3.6:35b-a3b":  { repo: "", file: "qwen3.6-35b-a3b.mq4", size_gb: 18.7, min_vram_gb: 22, desc: "MoE 35B/3B-active (coding/agent) — LOCAL ONLY, quantize Qwen/Qwen3.6-35B-A3B" },
+
   // Qwen3.5 MQ6 — 6-bit rotated, higher quality / larger file (~1.47× MQ4)
   "qwen3.5:0.8b-mq6": { repo: hfRepo("qwen3.5","0.8b"), file: "qwen3.5-0.8b.mq6",   size_gb: 0.67, min_vram_gb: 2,  desc: "MQ6, higher quality" },
   "qwen3.5:4b-mq6":   { repo: hfRepo("qwen3.5","4b"),   file: "qwen3.5-4b.mq6",     size_gb: 3.5,  min_vram_gb: 5,  desc: "MQ6, higher quality" },
@@ -259,6 +268,12 @@ const ALIASES: Record<string, string> = {
   "qwen3.5:latest": "qwen3.5:9b",
   "qwen3.5:small": "qwen3.5:0.8b",
   "qwen3.5:large": "qwen3.5:27b",
+  // Qwen3.6 only ships as 35B-A3B MoE (no dense variants) — all short tags
+  // fall through to the single entry.
+  "qwen3.6": "qwen3.6:35b-a3b",
+  "qwen3.6:latest": "qwen3.6:35b-a3b",
+  "qwen3.6:35b": "qwen3.6:35b-a3b",
+  "qwen3.6:a3b": "qwen3.6:35b-a3b",
   "qwen3": "qwen3:8b",
   "carnice": "carnice:9b",
   "qwopus": "qwopus:9b",

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1085,11 +1085,21 @@ fn resolve_model_path(input: &str) -> String {
                 }
             }
 
-            // Not in cache — try to download
-            eprintln!("Model {input} not found locally. Downloading via huggingface-cli...");
-            let status = std::process::Command::new("huggingface-cli")
-                .args(["download", input])
-                .status();
+            // Not in cache — try to download. Prefer the new `hf` CLI (huggingface_hub
+            // >= 0.30); fall back to the deprecated `huggingface-cli` so older installs
+            // still work. As of huggingface_hub 1.0, `huggingface-cli` is a no-op stub
+            // that just prints a deprecation message and exits non-zero, which broke
+            // the auto-download path when the HF cache didn't already have the model.
+            eprintln!("Model {input} not found locally. Downloading from HuggingFace...");
+            let run_download = |prog: &str| {
+                std::process::Command::new(prog)
+                    .args(["download", input])
+                    .status()
+            };
+            let mut status = run_download("hf");
+            if matches!(&status, Err(e) if e.kind() == std::io::ErrorKind::NotFound) {
+                status = run_download("huggingface-cli");
+            }
 
             match status {
                 Ok(s) if s.success() => {
@@ -1104,8 +1114,8 @@ fn resolve_model_path(input: &str) -> String {
                         }
                     }
                 }
-                Ok(s) => eprintln!("huggingface-cli download failed with status {s}"),
-                Err(e) => eprintln!("Failed to run huggingface-cli: {e}. Install with: pip install huggingface_hub"),
+                Ok(s) => eprintln!("HuggingFace download failed with status {s}"),
+                Err(e) => eprintln!("Failed to run hf/huggingface-cli: {e}. Install with: pip install -U huggingface_hub"),
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds `qwen3.6:35b-a3b` (and four aliases) to the CLI model registry. The new Qwen3.6-35B-A3B release declares `model_type: qwen3_5_moe` in its HF config and is architecturally identical to Qwen3.5-35B-A3B (256 experts top-8, hybrid DeltaNet + Full Attention at 3:1, head_dim=256 with partial_rotary_factor=0.25, shared expert), so the engine's existing `arch_id=6` path loads it without source changes. The quantizer's default `--include-vision=false` cleanly skips the multimodal tensors for a text-only `.mq4`.
- Fixes the quantizer's auto-download: `huggingface-cli` is a no-op deprecation stub in `huggingface_hub >= 1.0`, which silently broke `hipfire-quantize --input Owner/Model` on fresh systems. Now prefers the new `hf` CLI with a graceful fallback so older installs keep working.

## Verification (gfx1100 / RX 7900)

End-to-end tested with the model quantized from `Qwen/Qwen3.6-35B-A3B`:

- Output: `18,683.9 MB` `.mq4` (`34,660,433,920` params quantized, `1,291,212,016` visual/mtp skipped)
- `examples/a3b_smoke_forward`: logits finite `[-10.53, 14.73]`, `0` NaN / `0` Inf
- Prefill `~155 tok/s`, generation `~150 tok/s`
- Simple prompts produce coherent output end-to-end:
  ```
  $ infer qwen3.6-35b-a3b.mq4 "Say hello."
  <think></think>

  Hello!<|im_end|>
  ```

Known follow-up (not addressed here): complex thinking-mode prompts can enter repetitive loops. This behavior is not specific to Qwen3.6 — it reproduces the pre-existing Qwen3.5-thinking failure mode and is orthogonal to getting the model loading/running.

## Test plan

- [x] `cargo build --release -p hipfire-quantize`
- [x] `cargo build --release --features deltanet --example a3b_smoke_forward --example infer -p engine`
- [x] Quantize `Qwen/Qwen3.6-35B-A3B` → `qwen3.6-35b-a3b.mq4` (text-only)
- [x] `a3b_smoke_forward` — no NaN/Inf, sane logit range
- [x] `infer` — coherent output on simple prompt
- [ ] Repro on gfx1030 / gfx1200 cards (no access locally)
- [ ] Investigate thinking-mode loop on complex prompts (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)