### PR TITLE
v0.1.7-alpha.2 hotfix — config TUI crash + A3B DFlash default-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Per-model config (via `hipfire config` or `~/.hipfire/per_model_config.json`):
 
 ```
 dflash_adaptive_b   boolean   default true     # τ-window trip-wire block shrink
+dflash_mode         enum      default auto     # on | off | auto (A3B-aware)
 cask_sidecar        string    default ""       # path to a .triattn.bin
 cask                boolean   default false    # enable m-folding (on top of sidecar)
 cask_budget         int       default 512
@@ -71,6 +72,19 @@ The daemon protocol accepts all of these in the `load` message's `params` object
 `cask_sidecar` is accepted and logged today; the generate-loop integration
 lands in 0.1.7 stable (current serve users run DFlash without eviction —
 use `dflash_spec_demo` directly for the `--cask-sidecar` path).
+
+### Post-alpha fixes (land in v0.1.7 stable)
+
+- **`dflash_mode` gate** — A3B DFlash silently routed every temp=0 request
+  through DFlash in the alpha; a 7900 XTX sweep showed it's 2-5× slower than
+  plain AR on code/prose (A3B draft rejects most drafted tokens — τ≈1.0-1.5
+  — and the cycle overhead dwarfs the AR win). New per-model config key
+  `dflash_mode: on | off | auto`. `auto` keeps dense-on, flips A3B off
+  unless a `cask_sidecar` is configured (long-ctx A3B on 24 GB consumer
+  cards needs eviction for correctness, and that combo wins on τ too).
+  Daemon-side belt-and-suspenders: `dflash_mode=off` skips draft load even
+  when a draft path is supplied. Also fixes the draft-discovery regex so
+  A3B targets pick up `qwen3{N}-35b-a3b-dflash-*.hfq` under `on`/`auto+sidecar`.
 
 ### Pending for v0.1.7 stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## v0.1.7-alpha.2 (2026-04-18)
+
+Hotfix release for three user-visible regressions in v0.1.7-alpha. No
+behavior changes beyond the fixes listed — intended as a drop-in
+replacement for anyone running v0.1.7-alpha.
+
+### Fixes
+
+- **`hipfire config` TUI crash** (`TypeError: undefined is not an object
+  (evaluating 'meta[k].label')`). The v0.1.7-alpha release added 8 new
+  config keys (`experimental_budget_alert`, `dflash_adaptive_b`,
+  `cask_sidecar`, `cask`, `cask_budget`, `cask_beta`, `cask_core_frac`,
+  `cask_fold_m`) to `CONFIG_DEFAULTS` without matching entries in the
+  TUI's `meta` field descriptor table, so every interactive `hipfire
+  config` invocation on a real TTY threw on first render. Non-interactive
+  `hipfire config list|get|set` flows were unaffected. Added full meta
+  entries + boolean option round-tripping in `cycleOption` / `commitEdit`.
+- **A3B DFlash default-on perf regression** (2-5× slower than plain AR on
+  code/prose). A3B drafts reject most tokens (τ≈1.0-1.5 outside math),
+  and the spec cycle overhead dominates the AR win. New `dflash_mode`
+  per-model config key: `on | off | auto`. `auto` keeps dense targets
+  running DFlash as before and flips A3B off unless a `cask_sidecar` is
+  configured (A3B long-context on 24 GB consumer cards needs eviction to
+  fit). Daemon-side belt-and-suspenders: `dflash_mode=off` skips draft
+  load outright even when a draft path is supplied.
+- **`hipfire config set dflash_mode <value>` → "Unknown key"**. The
+  dflash_mode key was not in the released alpha's validKeys list. Ships
+  as part of the same commit as the default-off gate above.
+
+### Upgrade path
+
+```
+curl -fsSL https://raw.githubusercontent.com/Kaden-Schutt/hipfire/master/install.sh | bash
+# or: hipfire update
+```
+
+No config migration needed — `~/.hipfire/config.json` written by
+v0.1.7-alpha remains compatible. If you want to explicitly disable
+DFlash on A3B (defaults to auto-off now anyway), either edit config.json
+or run:
+
+```
+hipfire config set dflash_mode off
+hipfire config qwen3.5:35b-a3b set dflash_mode off   # per-model override
+```
+
+Full v0.1.7 stable release (rocBLAS MFMA on MI300X, hipGraph+MoE fix,
+full Hermes agent validation) tracking on `dflash` branch.
+
 ## v0.1.7-alpha (2026-04-18)
 
 Pre-release tag cutting the dflash branch against master. Gated to full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "engine"
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 dependencies = [
  "byteorder",
  "hip-bridge",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "hip-bridge"
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 dependencies = [
  "libloading",
  "thiserror",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "hipfire-quantize"
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 dependencies = [
  "byteorder",
  "memmap2",
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "hsa-bridge"
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 dependencies = [
  "hip-bridge",
  "libloading",
@@ -285,14 +285,14 @@ dependencies = [
 
 [[package]]
 name = "rdna-compute"
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 dependencies = [
  "hip-bridge",
 ]
 
 [[package]]
 name = "redline"
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 dependencies = [
  "libc",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7-alpha"
+version = "0.1.7-alpha.2"
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ hipfire run  qwen3.5:9b "What is the capital of France?"
 hipfire serve -d       # background daemon on port 11435 (OpenAI API compatible)
 ```
 
-Current release: **v0.1.7-alpha** — FlashTriAttn long-ctx speculative decoding (+42% tok/s on 9B), CASK m-folding KV eviction, Qwen3.6-35B-A3B MoE support, MI300X wave64 port. See [CHANGELOG.md](CHANGELOG.md). Previous: **v0.1.6 "deltacut"**.
+Current release: **v0.1.7-alpha.2** — hotfix for `hipfire config` TUI crash + A3B DFlash default-off. FlashTriAttn long-ctx speculative decoding (+42% tok/s on 9B), CASK m-folding KV eviction, Qwen3.6-35B-A3B MoE support, MI300X wave64 port. See [CHANGELOG.md](CHANGELOG.md). Previous: **v0.1.6 "deltacut"**.
 
 ## Why
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -50,6 +50,18 @@ interface HipfireConfig {
   // this to true restores the demo's behavior for `hipfire serve` users.
   dflash_adaptive_b: boolean;
 
+  // `dflash_mode`:
+  //   "on"   → always attempt draft auto-discovery / honor HIPFIRE_DFLASH_DRAFT
+  //   "off"  → never load the draft; temp=0 falls back to AR
+  //   "auto" → dense Qwen3.5 → on; A3B (MoE) targets → off
+  //
+  // Rationale: A3B DFlash is a NET LOSS vs AR on non-math prompts on
+  // 7900 XTX (τ≈1.0-1.5, 2-5× slower than AR on code/prose). Only math
+  // shows DFlash-positive τ. Default-off for A3B prevents the silent
+  // slowdown when a user serves an A3B target with an auto-discovered
+  // draft. Override per-model with `hipfire config set dflash_mode on`.
+  dflash_mode: "on" | "off" | "auto";
+
   // ── TriAttention / CASK KV eviction (0.1.7-alpha) ─────────────────────
   // `cask_sidecar` is a .triattn.bin path. Empty string = eviction disabled.
   // When set, the engine compacts KV against the sidecar's band-centers
@@ -88,6 +100,7 @@ const CONFIG_DEFAULTS: HipfireConfig = {
   idle_timeout: 300,
   experimental_budget_alert: false,
   dflash_adaptive_b: true,
+  dflash_mode: "auto",
   cask_sidecar: "",
   cask: false,
   cask_budget: 512,
@@ -112,6 +125,7 @@ function validateConfigValue(key: string, value: any): boolean {
     case "default_model": return typeof value === "string" && value.trim().length > 0;
     case "experimental_budget_alert": return typeof value === "boolean";
     case "dflash_adaptive_b": return typeof value === "boolean";
+    case "dflash_mode": return ["on", "off", "auto"].includes(value);
     case "cask_sidecar": return typeof value === "string";  // "" = disabled
     case "cask": return typeof value === "boolean";
     case "cask_budget": return typeof value === "number" && Number.isInteger(value) && value >= 64 && value <= 65536;
@@ -157,7 +171,8 @@ const PER_MODEL_CONFIG_PATH = join(HIPFIRE_DIR, "per_model_config.json");
 const PER_MODEL_KEYS = [
   "kv_cache", "flash_mode", "temperature", "top_p",
   "repeat_penalty", "max_tokens", "max_seq", "thinking", "max_think_tokens",
-  "dflash_adaptive_b", "cask_sidecar", "cask",
+  "dflash_adaptive_b", "dflash_mode",
+  "cask_sidecar", "cask",
   "cask_budget", "cask_beta", "cask_core_frac", "cask_fold_m",
 ] as const;
 type PerModelKey = typeof PER_MODEL_KEYS[number];
@@ -267,26 +282,56 @@ function buildLoadMessage(path: string, tag?: string | null): any {
   //
   // If the draft file is missing the daemon logs a warning and falls back
   // to AR (no client-visible error).
-  const explicit = process.env.HIPFIRE_DFLASH_DRAFT;
-  if (explicit !== undefined) {
-    if (explicit.length > 0) params.draft = explicit;
-    // empty-string → explicit opt-out; leave draft unset
+  //
+  // `dflash_mode` gate (0.1.7 stable): the user's per-model / global config
+  // decides whether to bother. "off" skips load entirely — saves 3-4 GB
+  // VRAM for the draft weights when DFlash would net-regress anyway. "auto"
+  // gates A3B (MoE) targets off by default because their drafts reject
+  // most tokens on non-math prompts (τ≈1.0-1.5) and DFlash becomes 2-5×
+  // slower than plain AR. Exception: an A3B target *with* a TriAttention
+  // sidecar configured stays DFlash-on under auto, because long-ctx A3B on
+  // 24 GB consumer cards OOMs without eviction — the DFlash+sidecar combo
+  // is correctness-required there, and that combo does win on τ as well.
+  // Override per-model with `dflash_mode=on/off` to bypass the heuristic.
+  const targetBn = basename(path);
+  const isA3B = /a3b/i.test(targetBn);
+  const hasSidecar = !!(resolved.cask_sidecar && resolved.cask_sidecar.length > 0 && existsSync(resolved.cask_sidecar));
+  const mode = resolved.dflash_mode;
+  params.dflash_mode = mode;
+  const autoOn = !isA3B || hasSidecar;
+  const dflashAllowed = mode === "on" || (mode === "auto" && autoOn);
+  if (!dflashAllowed) {
+    if (mode === "auto" && isA3B) {
+      const hint = tag ? `config set-model ${tag} dflash_mode on` : `config set dflash_mode on`;
+      console.error(`[hipfire] DFlash disabled for A3B target (dflash_mode=auto, no sidecar). Override with 'hipfire ${hint}'.`);
+    } else if (mode === "off") {
+      console.error(`[hipfire] DFlash disabled (dflash_mode=off).`);
+    }
   } else {
-    const bn = basename(path);
-    const m = bn.match(/qwen3?\.?5[-_]?([^.\-_]+)\.(mq4|mq6|hfq4|hfq6|q8)/i);
-    if (m) {
-      const size = m[1].toLowerCase();
-      const quant = m[2].toLowerCase();
-      const candidates = [
-        resolve(`${process.cwd()}/models/qwen35-${size}-dflash-${quant}.hfq`),
-        resolve(`${process.cwd()}/../../models/qwen35-${size}-dflash-${quant}.hfq`),
-        resolve(`${homedir()}/.hipfire/models/qwen35-${size}-dflash-${quant}.hfq`),
-      ];
-      for (const c of candidates) {
-        if (existsSync(c)) {
-          params.draft = c;
-          console.error(`[hipfire] DFlash draft detected: ${c}`);
-          break;
+    const explicit = process.env.HIPFIRE_DFLASH_DRAFT;
+    if (explicit !== undefined) {
+      if (explicit.length > 0) params.draft = explicit;
+      // empty-string → explicit opt-out; leave draft unset
+    } else {
+      // Size segment may contain internal dashes (e.g. "35b-a3b"); stop only
+      // at the quant-extension dot. Version digit is captured so the draft
+      // prefix picks up qwen3.5 → qwen35 vs qwen3.6 → qwen36 correctly.
+      const m = targetBn.match(/qwen3?\.?(5|6)[-_]?([^.]+)\.(mq4|mq6|hfq4|hfq6|q8)/i);
+      if (m) {
+        const ver = m[1];                 // "5" or "6"
+        const size = m[2].toLowerCase();  // "9b", "27b", "35b-a3b", ...
+        const quant = m[3].toLowerCase();
+        const candidates = [
+          resolve(`${process.cwd()}/models/qwen3${ver}-${size}-dflash-${quant}.hfq`),
+          resolve(`${process.cwd()}/../../models/qwen3${ver}-${size}-dflash-${quant}.hfq`),
+          resolve(`${homedir()}/.hipfire/models/qwen3${ver}-${size}-dflash-${quant}.hfq`),
+        ];
+        for (const c of candidates) {
+          if (existsSync(c)) {
+            params.draft = c;
+            console.error(`[hipfire] DFlash draft detected: ${c}`);
+            break;
+          }
         }
       }
     }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2302,6 +2302,50 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       desc: "serve: seconds idle before unloading model (frees VRAM; 0 = never unload)",
       range: [0, 86400], step: 30,
     },
+    experimental_budget_alert: {
+      label: "experimental_budget_alert",
+      desc: "show a one-line warning on startup when an experimental feature is enabled",
+      options: ["true", "false"],
+    },
+    dflash_adaptive_b: {
+      label: "dflash_adaptive_b",
+      desc: "DFlash draft length picker adapts B per-block based on acceptance history",
+      options: ["true", "false"],
+    },
+    dflash_mode: {
+      label: "dflash_mode",
+      desc: "DFlash speculative decoding: on = always, off = disable, auto = arch+model aware",
+      options: ["auto", "on", "off"],
+    },
+    cask_sidecar: {
+      label: "cask_sidecar",
+      desc: "path to CASK sidecar .bin (empty = disabled; enables KV cache pruning)",
+    },
+    cask: {
+      label: "cask",
+      desc: "enable CASK KV eviction when a sidecar is loaded",
+      options: ["true", "false"],
+    },
+    cask_budget: {
+      label: "cask_budget",
+      desc: "CASK keep budget (tokens retained per layer under eviction)",
+      range: [64, 65536], step: 64,
+    },
+    cask_beta: {
+      label: "cask_beta",
+      desc: "CASK recent-window bias — tokens newer than this are always kept",
+      range: [0, 65536], step: 64,
+    },
+    cask_core_frac: {
+      label: "cask_core_frac",
+      desc: "CASK core-aware m-folding fraction (0 = disabled, 1 = full)",
+      range: [0, 1], step: 0.05, decimals: 2,
+    },
+    cask_fold_m: {
+      label: "cask_fold_m",
+      desc: "CASK m-fold factor (1 = no folding, 2+ = fold m heads into one)",
+      range: [1, 16], step: 1,
+    },
   };
 
   let selected = 0;
@@ -2359,7 +2403,11 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
     let idx = m.options.indexOf(cur);
     if (idx < 0) idx = 0;
     const next = m.options[(idx + dir + m.options.length) % m.options.length];
-    setValue(k, next);
+    // Booleans live as true/false in config but render as "true"/"false" in meta.
+    // Convert back so validateConfigValue + saveConfig see the right type.
+    const defaultVal = CONFIG_DEFAULTS[k];
+    const finalVal = typeof defaultVal === "boolean" ? next === "true" : next;
+    setValue(k, finalVal);
   };
 
   const nudge = (k: keyof HipfireConfig, dir: number) => {
@@ -2376,7 +2424,13 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
   const commitEdit = () => {
     const k = keys[selected];
     const defaultVal = CONFIG_DEFAULTS[k];
-    const parsed = typeof defaultVal === "number" ? Number(editBuffer) : editBuffer;
+    let parsed: any;
+    if (typeof defaultVal === "number") parsed = Number(editBuffer);
+    else if (typeof defaultVal === "boolean") {
+      if (editBuffer === "true") parsed = true;
+      else if (editBuffer === "false") parsed = false;
+      else parsed = editBuffer; // will fail validation, user sees red flash
+    } else parsed = editBuffer;
     if (editBuffer.length > 0 && validateConfigValue(k as string, parsed as any)) {
       const m = meta[k];
       const finalVal = typeof parsed === "number" && m.decimals !== undefined

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -224,8 +224,24 @@ fn main() {
                 // through `spec_step_dflash` for the 1.7-2.5× speedup on the
                 // 27B target. Non-matching archs / missing draft file are
                 // logged but don't fail the load.
-                let draft_path = msg.get("params").and_then(|p| p.get("draft")).and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty()).map(|s| s.to_string());
+                //
+                // `dflash_mode=off` is a hard daemon-side override: even if a
+                // draft path was passed, skip the load. CLI-side gating is the
+                // primary path (saves the wire round-trip for the draft path
+                // string), but this guard makes the flag durable when the
+                // daemon is driven by a non-hipfire-CLI client.
+                let dflash_mode = msg.get("params").and_then(|p| p.get("dflash_mode"))
+                    .and_then(|v| v.as_str()).unwrap_or("auto");
+                let raw_draft = msg.get("params").and_then(|p| p.get("draft")).and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty());
+                let draft_path = if dflash_mode == "off" {
+                    if raw_draft.is_some() {
+                        eprintln!("[hipfire-daemon] dflash_mode=off — skipping draft load ({})", raw_draft.unwrap());
+                    }
+                    None
+                } else {
+                    raw_draft.map(|s| s.to_string())
+                };
                 let kv_mode_override = msg.get("params").and_then(|p| p.get("kv_mode")).and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty()).map(|s| s.to_string());
 


### PR DESCRIPTION
Hotfix branch cut from `origin/master` (= v0.1.7-alpha tag). 4 commits:

- `fc31bd2` fix(dflash): gate A3B DFlash default-off via dflash_mode config
- `064458f` docs(changelog): document dflash_mode gate as post-alpha fix
- `0c77934` fix(cli): config TUI crashes on missing meta for new 0.1.7 keys
- `f3fd666` chore(release): v0.1.7-alpha.2 hotfix

## Regressions addressed

1. `hipfire config` TUI crashes with `TypeError: undefined is not an object` on any real TTY because `meta` was not extended when 9 new config keys were added. Non-TUI flows (`config list|get|set`) were unaffected.
2. A3B DFlash is default-on in 0.1.7-alpha and 2–5× slower than plain AR on code/prose because A3B drafts mostly reject. New `dflash_mode` per-model key (`on | off | auto`) gates it; `auto` flips A3B off unless a `cask_sidecar` is configured.
3. `hipfire config set dflash_mode` returned "Unknown key" in the released alpha — same commit adds it to `validKeys`.

Not included: Gemma4 work or the SPM-BPE tokenizer fix on master — those changes are post-alpha and the tokenizer regression they guard against wasn't present in released v0.1.7-alpha.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `bun run cli/index.ts config` under PTY renders all 21 keys with no TypeError (verified on gfx1100)
- [x] `rocblas_sanity` example still PASSes byte-exact on gfx1100 (not touched by this PR, re-ran anyway)
- [ ] User smoke: `hipfire config`, `hipfire config set dflash_mode off`, `hipfire run qwen3.5:35b-a3b 'hi'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)