### PR TITLE
feat(cli): wire qwen3.6:35b-a3b to HF + drop LOCAL ONLY

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -401,9 +401,10 @@ const REGISTRY: Record<string, ModelEntry> = {
   // the existing A3B (arch_id=6) code path; weights differ (coding/agentic
   // fine-tune) but architecture (256 experts top-8, hybrid DeltaNet+FA,
   // head_dim=256 with partial_rotary=0.25, shared expert) is identical.
-  // Local-only until a pre-quantized HF repo exists; use `hipfire quantize
-  // Qwen/Qwen3.6-35B-A3B --format mq4` to produce the file.
-  "qwen3.6:35b-a3b":  { repo: "", file: "qwen3.6-35b-a3b.mq4", size_gb: 18.7, min_vram_gb: 22, desc: "MoE 35B/3B-active (coding/agent) — LOCAL ONLY, quantize Qwen/Qwen3.6-35B-A3B" },
+  // Pre-quant at schuttdev/hipfire-qwen3.6-35b-a3b; includes an Aureth-
+  // corpus Hermes sidecar (qwen3.6-35b-a3b.mq4.hermes.triattn.bin) for
+  // cask_sidecar-based KV eviction — download separately via `hf download`.
+  "qwen3.6:35b-a3b":  { repo: hfRepo("qwen3.6","35b-a3b"), file: "qwen3.6-35b-a3b.mq4", size_gb: 18.7, min_vram_gb: 22, desc: "MoE 35B/3B-active (coding/agent)" },
 
   // Qwen3.5 MQ6 — 6-bit rotated, higher quality / larger file (~1.47× MQ4)
   "qwen3.5:0.8b-mq6": { repo: hfRepo("qwen3.5","0.8b"), file: "qwen3.5-0.8b.mq6",   size_gb: 0.67, min_vram_gb: 2,  desc: "MQ6, higher quality" },


### PR DESCRIPTION
## Summary

Wires `qwen3.6:35b-a3b` to the freshly-uploaded [schuttdev/hipfire-qwen3.6-35b-a3b](https://huggingface.co/schuttdev/hipfire-qwen3.6-35b-a3b). `hipfire pull qwen3.6:35b-a3b` now resolves instead of exiting with LOCAL-ONLY guidance.

## HF repo contents

| File | Size | Purpose |
|------|------|---------|
| `qwen3.6-35b-a3b.mq4` | 18.7 GB | Main MoE model (MQ4, FWHT-rotated 4-bit) |
| `qwen3.6-35b-a3b.mq4.hermes.triattn.bin` | 983 KB | Aureth-corpus CASK sidecar for long-context eviction |
| `README.md` | — | Usage + sidecar wiring instructions |

## Why only the Hermes sidecar, not the wikitext one?

Per user directive — the standard wikitext-calibrated `<model>.mq4.triattn.bin` underperforms in practice despite the 0.1.7-alpha benchmark parity claim. Only the Aureth-corpus-trained `.hermes.triattn.bin` ships. (Memory: `feedback_wikitext_triattn_sidecar_garbage`.)

## Pull flow

```bash
hipfire pull qwen3.6:35b-a3b
hipfire run qwen3.6:35b-a3b "Write a Rust function that parses ISO-8601."
```

The sidecar is NOT auto-downloaded — existing convention is that sidecars are user-managed via `hipfire config <tag> set cask_sidecar <path>`. README on the HF repo walks through the optional wiring.

## Scope

- `qwen3.5:35b-a3b` still has `repo: ""` (LOCAL ONLY) — separate upload needed if/when desired.
- No engine changes — `arch_id=6` path already handles Qwen3.6 unchanged per the 0.1.7-alpha.3 norm-fix line (`1e01c0b`).

## Test plan

- [x] HF repo created and all 3 files uploaded
- [x] Download URL resolves (302 → CDN) — verified via `curl -sI`
- [ ] `hipfire pull qwen3.6:35b-a3b` on a fresh cache — not tested; registry wire-up is trivial and the HF repo is live

Closes (supersedes) #24.