### PR TITLE
bench: 27B merge_sort anchor + full BENCH METRICS (prefill/ttft/vram)

### DIFF
--- a/benchmarks/prompts/merge_sort_thinking_off.txt
+++ b/benchmarks/prompts/merge_sort_thinking_off.txt
@@ -1,0 +1,7 @@
+<|im_start|>user
+Write a Python merge_sort function. Only show the code, no explanation.<|im_end|>
+<|im_start|>assistant
+<think>
+
+</think>
+

--- a/crates/engine/examples/dflash_spec_demo.rs
+++ b/crates/engine/examples/dflash_spec_demo.rs
@@ -592,7 +592,10 @@ fn main() {
     // stay byte-identical to the old contiguous-range behaviour.
     draft_scratch.target_hidden_abs_positions =
         (0..prompt_tokens.len() as i32).collect();
-    eprintln!("prefill in {:.2}s", t2.elapsed().as_secs_f64());
+    let prefill_secs = t2.elapsed().as_secs_f64();
+    let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
+    eprintln!("prefill in {:.2}s ({:.1} tok/s)", prefill_secs, prefill_tok_s);
+    vram_report(&gpu.hip, "after_prefill");
 
     // ── Build FlashCASK policy (opt-in via --cask-sidecar) ──────────
     // The policy evicts target.kv_cache between spec_step cycles.
@@ -952,6 +955,11 @@ fn main() {
         .ok().and_then(|s| s.parse().ok()).unwrap_or(0.25);
 
     let t_decode = Instant::now();
+    // TTFT capture: production-realistic measure excluding DPM warmup
+    // (which inflates wall-clock by HIPFIRE_DPM_WARMUP_SECS during benches).
+    // Reported value = prefill_ms + first_cycle_ms, taken from t_decode
+    // (set AFTER warmup) plus the previously-recorded prefill_secs.
+    let mut ttft_ms: Option<f64> = None;
     while emitted.len() < max_tokens {
         if position + draft_scratch_b >= ctx_capacity {
             eprintln!("hit ctx_capacity {}; stopping", ctx_capacity);
@@ -1246,6 +1254,12 @@ fn main() {
         for (&tok, _) in step.committed.iter().skip(1).zip(0..) {
             emitted.push(tok);
         }
+        if ttft_ms.is_none() && step.committed.len() > 1 {
+            // Use t_decode (post-warmup) + prefill_secs so the reported
+            // TTFT is what a serving-mode client would actually see.
+            let first_cycle_ms = t_decode.elapsed().as_secs_f64() * 1000.0;
+            ttft_ms = Some(prefill_secs * 1000.0 + first_cycle_ms);
+        }
 
         // Loop-break cycle detector: hash trailing 32-token window, look
         // up in known-hash set. Hit = repeating block. The shift-by-cycle
@@ -1438,6 +1452,28 @@ fn main() {
     } else {
         0.0
     };
+
+    // ── BENCH METRICS (machine-parseable) ─────────────────────────────────
+    // Single source of truth for downstream submission scripts (LMX,
+    // benchmarks/results/*.py). Keep flat key=value lines so a simple regex
+    // pulls each field; do not change format without updating callers.
+    // hip.get_vram_info returns (free_bytes, total_bytes) — see line 356.
+    let (vram_free_bytes, vram_total_bytes) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+    let vram_used_mb = ((vram_total_bytes.saturating_sub(vram_free_bytes)) as f64 / (1024.0 * 1024.0)) as u64;
+    let vram_total_mb = (vram_total_bytes as f64 / (1024.0 * 1024.0)) as u64;
+    eprintln!("=== BENCH METRICS ===");
+    eprintln!("prompt_tokens: {}", prompt_tokens.len());
+    eprintln!("prefill_secs: {:.4}", prefill_secs);
+    eprintln!("prefill_tok_s: {:.2}", prefill_tok_s);
+    eprintln!("ttft_ms: {:.2}", ttft_ms.unwrap_or(0.0));
+    eprintln!("decode_tokens_emitted: {}", emitted.len());
+    eprintln!("decode_secs: {:.4}", elapsed);
+    eprintln!("decode_tok_s: {:.2}", tok_s);
+    eprintln!("decode_tau: {:.4}", stats.tau());
+    eprintln!("decode_accept_rate: {:.4}", accept_rate);
+    eprintln!("vram_used_mb: {}", vram_used_mb);
+    eprintln!("vram_total_mb: {}", vram_total_mb);
+    eprintln!("=====================");
     eprintln!("accept_rate (accepted / (cycles × (B-1))): {accept_rate:.3}");
     eprintln!(
         "histogram: {:?}",

--- a/scripts/speed-gate.sh
+++ b/scripts/speed-gate.sh
@@ -31,6 +31,7 @@ REPO_ROOT="$(pwd)"
 EXE="./target/release/examples/bench_qwen35_mq4"
 DFLASH_EXE="./target/release/examples/dflash_spec_demo"
 DFLASH_PROMPT_FILE="benchmarks/prompts/lru_cache_pep8_strict.txt"
+DFLASH_PROMPT_MERGE_SORT="benchmarks/prompts/merge_sort_thinking_off.txt"
 LOCK_SCRIPT="./scripts/gpu-lock.sh"
 
 # ── Arch detection ────────────────────────────────────────────────────────
@@ -147,6 +148,40 @@ bench_dflash_27b_lru() {
         fi
     done
     if [ "$best_t" = "0" ]; then echo "CRASH"; else echo "$best_t $best_tau"; fi
+}
+
+# DFlash high-acceptance gate — merge_sort thinking-OFF, max=256.
+# Anchors the high-τ ceiling (real production-shape bounded code) since
+# the LRU max=120 anchor above is loop-edge. Echoes "tok_s tau ttft_ms"
+# or one of MISSING_*/CRASH. Best-of-3.
+bench_dflash_27b_merge_sort() {
+    local target draft
+    for dir in "$MODELS_DIR" "$HOME/.hipfire/models"; do
+        [ -f "$dir/qwen3.5-27b.mq4" ] && [ -z "${target:-}" ] && target="$dir/qwen3.5-27b.mq4"
+        [ -f "$dir/qwen35-27b-dflash.mq4" ] && [ -z "${draft:-}" ] && draft="$dir/qwen35-27b-dflash.mq4"
+    done
+    [ ! -x "$DFLASH_EXE" ] && { echo "MISSING_BIN"; return; }
+    [ -z "${target:-}" ] && { echo "MISSING_TARGET"; return; }
+    [ -z "${draft:-}" ] && { echo "MISSING_DRAFT"; return; }
+    [ ! -f "$DFLASH_PROMPT_MERGE_SORT" ] && { echo "MISSING_PROMPT"; return; }
+    local best_t=0 best_tau=0 best_ttft=0
+    local prompt
+    prompt=$(cat "$DFLASH_PROMPT_MERGE_SORT")
+    for run in 1 2 3; do
+        local out
+        out=$(HIPFIRE_DPM_WARMUP_SECS=10 "$DFLASH_EXE" \
+            --target "$target" --draft "$draft" \
+            --prompt "$prompt" \
+            --max 256 --no-chatml --kv-mode asym3 2>&1)
+        local t tau ttft
+        t=$(echo "$out" | sed -nE 's/^decode_tok_s: ([0-9.]+).*/\1/p' | tail -1)
+        tau=$(echo "$out" | sed -nE 's/^decode_tau: ([0-9.]+).*/\1/p' | tail -1)
+        ttft=$(echo "$out" | sed -nE 's/^ttft_ms: ([0-9.]+).*/\1/p' | tail -1)
+        if [ -n "$t" ] && awk "BEGIN { exit !($t > $best_t) }"; then
+            best_t="$t"; best_tau="$tau"; best_ttft="$ttft"
+        fi
+    done
+    if [ "$best_t" = "0" ]; then echo "CRASH"; else echo "$best_t $best_tau $best_ttft"; fi
 }
 
 # Run bench_qwen35_mq4 once at a given prefill size.
@@ -291,6 +326,21 @@ if [ "$UPDATE" -eq 1 ]; then
             } >> "$tmpfile"
             ;;
     esac
+
+    printf "  27B-3.5 DFlash merge_sort  "
+    ms_result=$(bench_dflash_27b_merge_sort)
+    case "$ms_result" in
+        MISSING_*|CRASH) color yellow "$ms_result"; echo "" ;;
+        *)
+            read -r mst mstau msttft <<< "$ms_result"
+            printf "tok/s=%-7.1f τ=%s ttft_ms=%s\n" "$mst" "$mstau" "$msttft"
+            {
+                echo "27b_3.5_dflash_merge_sort_tok_s=${mst}"
+                echo "27b_3.5_dflash_merge_sort_tau=${mstau}"
+                echo "27b_3.5_dflash_merge_sort_ttft_ms=${msttft}"
+            } >> "$tmpfile"
+            ;;
+    esac
     echo "" >> "$tmpfile"
 
     mkdir -p "$(dirname "$BASELINE_FILE")"
@@ -400,6 +450,33 @@ if [ "$FAST" -eq 0 ]; then
                 skip=$((skip+1))
             else
                 check_metric "27B-3.5 DFlash LRU code" "$dflash_base" "$dt"
+                case $? in 0) pass=$((pass+1)) ;; *) fail=$((fail+1)) ;; esac
+            fi
+            ;;
+    esac
+
+    # Second DFlash anchor: merge_sort thinking-OFF (high-τ ceiling).
+    ms_result=$(bench_dflash_27b_merge_sort)
+    case "$ms_result" in
+        MISSING_*)
+            printf "  27B-3.5 DFlash merge_sort  "
+            color yellow "SKIP"; echo " ($ms_result)"
+            skip=$((skip+1))
+            ;;
+        CRASH)
+            printf "  27B-3.5 DFlash merge_sort  "
+            color red "CRASH"; echo
+            fail=$((fail+1))
+            ;;
+        *)
+            read -r mst mstau msttft <<< "$ms_result"
+            ms_base=$(grep -oE "^27b_3.5_dflash_merge_sort_tok_s=[0-9.]+" "$BASELINE_FILE" | cut -d= -f2)
+            if [ -z "$ms_base" ]; then
+                printf "  27B-3.5 DFlash merge_sort  "
+                color yellow "NO BASELINE"; echo " (add with --update-baselines; observed=${mst} τ=${mstau} ttft=${msttft}ms)"
+                skip=$((skip+1))
+            else
+                check_metric "27B-3.5 DFlash merge_sort" "$ms_base" "$mst"
                 case $? in 0) pass=$((pass+1)) ;; *) fail=$((fail+1)) ;; esac
             fi
             ;;

--- a/tests/speed-baselines/gfx1100.txt
+++ b/tests/speed-baselines/gfx1100.txt
@@ -34,3 +34,17 @@
 27b_3.5_dflash_lru_code_tok_s=199.0
 27b_3.5_dflash_lru_code_tau=10.36
 
+# DFlash high-acceptance gate — 27B-3.5 merge_sort thinking-OFF @ max=256.
+# Added 2026-04-26 (post PR #51) as a second anchor measuring the real
+# high-τ ceiling. The LRU max=120 number above is loop-edge — model is
+# still emitting class header at cap. merge_sort runs to natural EOS at
+# 157 tokens with τ=13.18, acc=0.88 — what production-shape bounded code
+# actually looks like. Median-of-3, ±0.6% range, deterministic.
+# Prompt: benchmarks/prompts/merge_sort_thinking_off.txt
+#         (md5 253c7ac50857fe6d0e10fb0d2c5e35c0, chatml-wrapped + closed
+#          <think></think> block for explicit thinking-off)
+# TTFT excludes DPM warmup (= prefill + first cycle).
+27b_3.5_dflash_merge_sort_tok_s=250.0
+27b_3.5_dflash_merge_sort_tau=13.18
+27b_3.5_dflash_merge_sort_ttft_ms=160.0
+


### PR DESCRIPTION
## Summary

Adds a second 27B-3.5 DFlash speed-gate anchor (merge_sort thinking-OFF, max=256) measuring the real high-τ ceiling alongside the existing LRU max=120 anchor. Extends dflash_spec_demo with a structured BENCH METRICS block so prefill/TTFT/VRAM are captured — previously absent from every LMX DFlash submission.

## Why

The locked-in canonical \`27b_3.5_dflash_lru_code\` baseline (199 tok/s τ=10.36) is **loop-edge** — at max=120 the model is still emitting the LRU class header, draft-target acceptance is dominated by structural Python syntax. Real production-shape code (a complete bounded function) hits **τ=13.18 at 250 tok/s**, +25% over the canonical. Two anchors give two regression detectors with different sensitivity profiles.

## What's new

### Bench metrics in dflash_spec_demo
Flat key=value block at end of run (machine-parseable, single source of truth for downstream submission scripts):
\`\`\`
=== BENCH METRICS ===
prompt_tokens: 27
prefill_secs: 0.081
prefill_tok_s: 332.0
ttft_ms: 154.7
decode_tokens_emitted: 157
decode_tok_s: 250.2
decode_tau: 13.18
decode_accept_rate: 0.879
vram_used_mb: 18728
vram_total_mb: 24560
=====================
\`\`\`

TTFT EXCLUDES the DPM warmup (\`HIPFIRE_DPM_WARMUP_SECS\`) — measured as prefill_secs + first_cycle_ms. Prior implementation included the 10s warmup making the number unusable for serving-mode reporting.

### Speed-gate second anchor
\`bench_dflash_27b_merge_sort\` parallels the existing LRU function. Wired into both \`--update-baselines\` and the main gate-check path (skipped in \`--fast\` like LRU).

### LMX submission
\`benchmarks/results/lmx_submit_27b_merge_sort.py\` — submitted as cmofyatrj0002jv04r8064iqg (HTTP 201). **First DFlash submission with full fields:** ttftMs=154.7, peakVramGb=18.29, plus engineFlags carrying prefillTokSPerSec/acceptRate/tau/thinking=off.

## Empirical (3 runs, ±0.6% deterministic)

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| tok/s | 249.6 | 251.0 | 250.2 | **250.2** |
| τ | 13.18 | 13.18 | 13.18 | **13.18** |
| ttft_ms | 157.7 | 154.8 | 154.7 | **154.7** |

Output: 157 tokens, natural EOS, correct merge_sort + helper, deterministic.

## Test plan
- [x] \`cargo build --release --features deltanet --example dflash_spec_demo\` clean
- [x] BENCH METRICS block parses cleanly in Python (single regex)
- [x] TTFT captures only prefill + first-cycle (excludes warmup)
- [x] VRAM math direction correct (\`total - free\` not \`free - total\`)
- [x] LMX submission: HTTP 201 with all fields populated
- [x] speed-gate.sh syntax valid (parses both anchors in --update-baselines and gate-check paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)