### PR TITLE
bench: 9B merge_sort anchor + generalized LMX submitter

### DIFF
--- a/benchmarks/results/lmx_submit_merge_sort.py
+++ b/benchmarks/results/lmx_submit_merge_sort.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Submit a Qwen3.5 DFlash merge_sort thinking-OFF bench to localmaxxing.
+
+Generalized version of lmx_submit_27b_merge_sort.py — takes --size {9b|27b}
+(default 27b) and submits the matching `<size>-merge-sort-bench-*.json`
+with full metrics (decode tok/s + τ + accept_rate + ttft_ms + prefill_tok_s
++ peakVramGb).
+
+Usage:
+  LMX_API_KEY=... python3 lmx_submit_merge_sort.py --size 9b
+  LMX_API_KEY=... python3 lmx_submit_merge_sort.py --size 27b
+"""
+import argparse
+import json
+import os
+import subprocess
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+ROOT = Path("/home/kaden/ClaudeCode/autorocm/hipfire/.worktrees/dflash")
+BENCH_ROOT = ROOT / "benchmarks" / "results"
+PROMPT_FILE = ROOT / "benchmarks/prompts/merge_sort_thinking_off.txt"
+API_URL = "https://www.localmaxxing.com/api/benchmarks"
+
+HARDWARE = {
+    "hwClass": "DISCRETE_GPU", "gpuName": "RX 7900 XTX", "gpuCount": 1,
+    "vramGb": 24, "cpu": "AMD Ryzen 9 3900X", "ramGb": 64, "os": "Ubuntu 24.04",
+}
+
+SIZE_TO_HFID = {
+    "9b":  "Qwen/Qwen3.5-9B",
+    "27b": "Qwen/Qwen3.5-27B",
+}
+SIZE_TO_DRAFT = {
+    "9b":  "qwen35-9b-dflash-mq4.hfq",
+    "27b": "qwen35-27b-dflash.mq4",
+}
+SIZE_TO_TARGET = {
+    "9b":  "qwen3.5-9b.mq4",
+    "27b": "qwen3.5-27b.mq4",
+}
+
+
+def submit(payload, api_key):
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(API_URL, data=body, headers={
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode() if e.fp else str(e)
+    except Exception as e:
+        return 0, f"transport: {e}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--size", choices=["9b", "27b"], default="27b",
+                    help="model size (picks both bench JSON glob + LMX hfId)")
+    args = ap.parse_args()
+
+    api_key = os.environ["LMX_API_KEY"]
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    log_path = BENCH_ROOT / f"lmx-{args.size}-merge-sort-{stamp}.run.txt"
+    submits_path = BENCH_ROOT / f"lmx-{args.size}-merge-sort-{stamp}-submission.json"
+
+    candidates = sorted(BENCH_ROOT.glob(f"{args.size}-merge-sort-bench-*.json"),
+                        key=lambda p: p.stat().st_mtime, reverse=True)
+    if not candidates:
+        raise SystemExit(f"No {args.size}-merge-sort-bench-*.json found")
+    source = candidates[0]
+
+    engine_ver = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], cwd=str(ROOT), text=True).strip()
+
+    log_path.write_text("")
+    def log(msg):
+        line = f"[{time.strftime('%H:%M:%S')}] {msg}"
+        print(line, flush=True)
+        with log_path.open("a") as f:
+            f.write(line + "\n")
+
+    bench = json.loads(source.read_text())
+    median = bench["median"]
+    runs = bench["runs"]
+    all_tok_s = [r["decode_tok_s"] for r in runs]
+    prompt_md5 = bench.get("prompt_md5")
+
+    log(f"=== LMX {args.size}-3.5 merge_sort submission  engine={engine_ver} ===")
+    log(f"source: {source.name}")
+    log(f"median tok/s: {median['decode_tok_s']:.1f}  τ: {median['decode_tau']:.3f}  ttft: {median['ttft_ms']:.1f}ms")
+
+    notes = "\n".join([
+        f"hipfire @ {engine_ver} (master post-PR #51 + #52 series)",
+        f"prompt: merge_sort thinking-OFF (md5={prompt_md5})",
+        f"  chatml-wrapped + explicit empty <think></think> for thinking-off",
+        f"  prompt file: benchmarks/prompts/merge_sort_thinking_off.txt",
+        f"runs: {len(runs)} (median reported); range {bench['min_tok_s']:.1f}–{bench['max_tok_s']:.1f}",
+        f"  per-run tok/s: {all_tok_s}",
+        "decode mode: DFlash speculative (block_size=16)",
+        "kv_cache: asym3",
+        "prompt_normalize: true (default since 2026-04-26)",
+        f"τ (median): {median['decode_tau']:.3f}",
+        f"accept_rate (median): {median['decode_accept_rate']:.3f}",
+        f"prefill: {median['prefill_secs']*1000:.1f}ms ({median['prefill_tok_s']:.1f} tok/s)",
+        f"ttft (excl warmup): {median['ttft_ms']:.1f}ms = prefill + first cycle",
+        f"vram: {int(median['vram_used_mb'])} MB used / {int(median['vram_total_mb'])} MB total",
+        f"natural EOS at {int(median['decode_tokens_emitted'])} tokens — production-shape bounded code (no loop)",
+    ])
+
+    payload = {
+        "hfId": SIZE_TO_HFID[args.size],
+        "hardware": HARDWARE,
+        "engineName": "hipfire",
+        "engineVersion": f"0.1.8-alpha+{engine_ver}",
+        "backend": "rocm",
+        "quantization": "MQ4",
+        "tokSOut": median["decode_tok_s"],
+        "ttftMs": median["ttft_ms"],
+        "promptTokens": int(median["prompt_tokens"]),
+        "outputTokens": int(median["decode_tokens_emitted"]),
+        "contextLength": 4096,
+        "batchSize": 1,
+        "peakVramGb": median["vram_used_mb"] / 1024.0,
+        "notes": notes[:2000],
+        "engineFlags": {
+            "kvCache": "asym3",
+            "wmma": True,
+            "specDecoding": True,
+            "specMethod": "DFlash",
+            "specBlockSize": 16,
+            "specModel": f"hipfire-qwen3.5-{args.size}-dflash-mq4",
+            "promptNormalize": True,
+            "thinking": "off",
+            "prefillTokSPerSec": median["prefill_tok_s"],
+            "acceptRate": median["decode_accept_rate"],
+            "tau": median["decode_tau"],
+            "commandSnippet": (
+                "./target/release/examples/dflash_spec_demo "
+                f"--target {SIZE_TO_TARGET[args.size]} --draft {SIZE_TO_DRAFT[args.size]} "
+                "--prompt $(cat benchmarks/prompts/merge_sort_thinking_off.txt) "
+                "--max 256 --no-chatml --kv-mode asym3"
+            ),
+        },
+    }
+    payload = {k: v for k, v in payload.items() if v is not None}
+
+    log(f"\n=== submitting ===")
+    log(f"  hfId={payload['hfId']}  tokSOut={payload['tokSOut']:.1f}  ttftMs={payload['ttftMs']:.1f}  vramGb={payload['peakVramGb']:.2f}")
+    status, body = submit(payload, api_key)
+    log(f"  HTTP {status}")
+    log(f"  body: {body[:400]}")
+    submits_path.write_text(json.dumps({
+        "request": payload, "status": status, "response": body,
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }, indent=2))
+    log(f"\nsaved: {submits_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/speed-gate.sh
+++ b/scripts/speed-gate.sh
@@ -154,11 +154,15 @@ bench_dflash_27b_lru() {
 # Anchors the high-τ ceiling (real production-shape bounded code) since
 # the LRU max=120 anchor above is loop-edge. Echoes "tok_s tau ttft_ms"
 # or one of MISSING_*/CRASH. Best-of-3.
-bench_dflash_27b_merge_sort() {
+#
+# Generic core: takes target + draft basenames, runs the bench, returns
+# best of 3. Per-size wrappers below pin the model paths.
+_bench_dflash_merge_sort_core() {
+    local target_name="$1" draft_name="$2"
     local target draft
     for dir in "$MODELS_DIR" "$HOME/.hipfire/models"; do
-        [ -f "$dir/qwen3.5-27b.mq4" ] && [ -z "${target:-}" ] && target="$dir/qwen3.5-27b.mq4"
-        [ -f "$dir/qwen35-27b-dflash.mq4" ] && [ -z "${draft:-}" ] && draft="$dir/qwen35-27b-dflash.mq4"
+        [ -f "$dir/$target_name" ] && [ -z "${target:-}" ] && target="$dir/$target_name"
+        [ -f "$dir/$draft_name" ]  && [ -z "${draft:-}" ]  && draft="$dir/$draft_name"
     done
     [ ! -x "$DFLASH_EXE" ] && { echo "MISSING_BIN"; return; }
     [ -z "${target:-}" ] && { echo "MISSING_TARGET"; return; }
@@ -182,6 +186,14 @@ bench_dflash_27b_merge_sort() {
         fi
     done
     if [ "$best_t" = "0" ]; then echo "CRASH"; else echo "$best_t $best_tau $best_ttft"; fi
+}
+
+bench_dflash_27b_merge_sort() {
+    _bench_dflash_merge_sort_core "qwen3.5-27b.mq4" "qwen35-27b-dflash.mq4"
+}
+
+bench_dflash_9b_merge_sort() {
+    _bench_dflash_merge_sort_core "qwen3.5-9b.mq4" "qwen35-9b-dflash-mq4.hfq"
 }
 
 # Run bench_qwen35_mq4 once at a given prefill size.
@@ -341,6 +353,21 @@ if [ "$UPDATE" -eq 1 ]; then
             } >> "$tmpfile"
             ;;
     esac
+
+    printf "  9B-3.5 DFlash merge_sort   "
+    ms9_result=$(bench_dflash_9b_merge_sort)
+    case "$ms9_result" in
+        MISSING_*|CRASH) color yellow "$ms9_result"; echo "" ;;
+        *)
+            read -r mst9 mstau9 msttft9 <<< "$ms9_result"
+            printf "tok/s=%-7.1f τ=%s ttft_ms=%s\n" "$mst9" "$mstau9" "$msttft9"
+            {
+                echo "9b_3.5_dflash_merge_sort_tok_s=${mst9}"
+                echo "9b_3.5_dflash_merge_sort_tau=${mstau9}"
+                echo "9b_3.5_dflash_merge_sort_ttft_ms=${msttft9}"
+            } >> "$tmpfile"
+            ;;
+    esac
     echo "" >> "$tmpfile"
 
     mkdir -p "$(dirname "$BASELINE_FILE")"
@@ -477,6 +504,33 @@ if [ "$FAST" -eq 0 ]; then
                 skip=$((skip+1))
             else
                 check_metric "27B-3.5 DFlash merge_sort" "$ms_base" "$mst"
+                case $? in 0) pass=$((pass+1)) ;; *) fail=$((fail+1)) ;; esac
+            fi
+            ;;
+    esac
+
+    # Third DFlash anchor: 9B merge_sort (small-model high-τ ceiling).
+    ms9_result=$(bench_dflash_9b_merge_sort)
+    case "$ms9_result" in
+        MISSING_*)
+            printf "  9B-3.5 DFlash merge_sort   "
+            color yellow "SKIP"; echo " ($ms9_result)"
+            skip=$((skip+1))
+            ;;
+        CRASH)
+            printf "  9B-3.5 DFlash merge_sort   "
+            color red "CRASH"; echo
+            fail=$((fail+1))
+            ;;
+        *)
+            read -r mst9 mstau9 msttft9 <<< "$ms9_result"
+            ms9_base=$(grep -oE "^9b_3.5_dflash_merge_sort_tok_s=[0-9.]+" "$BASELINE_FILE" | cut -d= -f2)
+            if [ -z "$ms9_base" ]; then
+                printf "  9B-3.5 DFlash merge_sort   "
+                color yellow "NO BASELINE"; echo " (add with --update-baselines; observed=${mst9} τ=${mstau9} ttft=${msttft9}ms)"
+                skip=$((skip+1))
+            else
+                check_metric "9B-3.5 DFlash merge_sort" "$ms9_base" "$mst9"
                 case $? in 0) pass=$((pass+1)) ;; *) fail=$((fail+1)) ;; esac
             fi
             ;;

--- a/tests/speed-baselines/gfx1100.txt
+++ b/tests/speed-baselines/gfx1100.txt
@@ -48,3 +48,12 @@
 27b_3.5_dflash_merge_sort_tau=13.18
 27b_3.5_dflash_merge_sort_ttft_ms=160.0
 
+# 9B-3.5 DFlash merge_sort thinking-OFF @ max=256.
+# Same prompt as 27B anchor — 9B writes the same correct merge_sort but
+# 2.3× faster wallclock (575 vs 250 tok/s) at identical τ=13.08. TTFT
+# 75.5 ms (about half of 27B's 154.7) reflecting smaller prefill cost.
+# Median-of-3, ±0.84% range, deterministic.
+9b_3.5_dflash_merge_sort_tok_s=575.0
+9b_3.5_dflash_merge_sort_tau=13.08
+9b_3.5_dflash_merge_sort_ttft_ms=80.0
+


### PR DESCRIPTION
## Summary

Adds the 9B-3.5 DFlash merge_sort anchor to the speed-gate (third anchor after 27B LRU and 27B merge_sort), and generalizes the LMX submitter so future model sizes share one script via `--size {9b|27b}`.

## 9B numbers (median of 3, ±0.84%)

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| tok/s | 571.2 | 575.2 | 576.0 | **575.2** |
| τ | 13.077 | 13.077 | 13.077 | **13.077** |
| ttft_ms | 76.1 | 75.5 | 75.6 | **75.5** |

VRAM: 8268 MB used / 24560 MB total (33.7%), 184 tokens, natural EOS, correct merge_sort + helper, deterministic.

## 9B vs 27B same prompt

| | 9B | 27B | ratio |
|---|---|---|---|
| tok/s | 575.2 | 250.2 | **2.30× faster** |
| τ | 13.08 | 13.18 | ≈ |
| ttft | 75.5 ms | 154.7 ms | **49%** |
| vram | 8.07 GB | 18.29 GB | 44% |

Same correct code, less than half the wallclock. For pure code-completion workloads on local hardware, 9B is the right model.

## Files changed
- `tests/speed-baselines/gfx1100.txt` — three new baselines
- `scripts/speed-gate.sh` — refactor per-size bench into `_bench_dflash_merge_sort_core` + add `bench_dflash_9b_merge_sort` wrapper, wired into both gate-check and --update-baselines paths
- `benchmarks/results/lmx_submit_merge_sort.py` (new) — generalized submitter

## LMX submission

Submitted as `cmofzk74w0002ij042txvvkx5` (HTTP 201) with full fields populated:
- tokSOut=575.2, ttftMs=75.5, peakVramGb=8.07
- engineFlags: prefillTokSPerSec=861, acceptRate=0.872, tau=13.077, thinking=off

🤖 Generated with [Claude Code](https://claude.com/claude-code)