### PR TITLE
fix strix halo gfx1151 autodetect

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -532,6 +532,25 @@ function downloadUrl(entry: ModelEntry): string {
 }
 
 // ─── GPU arch detection + per-arch defaults ──────────────
+function gfxTargetVersionToArch(ver: number): string {
+  const known: Record<number, string> = {
+    100100: "gfx1010",
+    100300: "gfx1030",
+    100302: "gfx1030",
+    110000: "gfx1100",
+    110001: "gfx1100",
+    110501: "gfx1151",
+    120000: "gfx1200",
+    120001: "gfx1201",
+  };
+  if (known[ver]) return known[ver];
+
+  const major = Math.floor(ver / 10000);
+  const minor = Math.floor((ver % 10000) / 100);
+  const step = ver % 100;
+  return `gfx${major}${minor}${step}`;
+}
+
 function detectGpuArch(): string {
   // Read KFD sysfs for GPU arch (same as install command)
   for (const node of ["1", "0"]) {
@@ -539,12 +558,7 @@ function detectGpuArch(): string {
       const props = require("fs").readFileSync(`/sys/class/kfd/kfd/topology/nodes/${node}/properties`, "utf8");
       const m = props.match(/gfx_target_version\s+(\d+)/);
       if (m) {
-        const ver = parseInt(m[1]);
-        const major = Math.floor(ver / 10000);
-        const minor = Math.floor((ver % 10000) / 100);
-        const step = ver % 100;
-        let arch = `gfx${major}${minor.toString().padStart(2, '0')}${step || '0'}`;
-        return arch.replace(/^(gfx\d{4})0$/, '$1');
+        return gfxTargetVersionToArch(parseInt(m[1]));
       }
     } catch {}
   }
@@ -3434,14 +3448,8 @@ switch (cmd) {
     const verMatch = archOut.match(/gfx_target_version\s+(\d+)/);
     let gpuArch = "unknown";
     if (verMatch) {
-      // Derive gfx arch from version number: e.g. 100100→gfx1010, 110001→gfx1100, 115100→gfx1151
-      const ver = parseInt(verMatch[1]);
-      const major = Math.floor(ver / 10000);
-      const minor = Math.floor((ver % 10000) / 100);
-      const step = ver % 100;
-      gpuArch = `gfx${major}${minor.toString().padStart(2, '0')}${step || '0'}`;
-      // Normalize: gfx10010 → gfx1010, gfx110000 stays gfx1100
-      gpuArch = gpuArch.replace(/^(gfx\d{4})0$/, '$1');
+      // Derive gfx arch from version number: e.g. 100100→gfx1010, 110501→gfx1151.
+      gpuArch = gfxTargetVersionToArch(parseInt(verMatch[1]));
     }
     if (gpuArch !== "unknown") {
       const kernelSrc = join(repoDir, "kernels/compiled", gpuArch);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,6 +80,7 @@ for node_props in /sys/class/kfd/kfd/topology/nodes/*/properties; do
         100100)         GPU_ARCH="gfx1010"; break ;;
         100300|100302)  GPU_ARCH="gfx1030"; break ;;
         110000|110001)  GPU_ARCH="gfx1100"; break ;;
+        110501)         GPU_ARCH="gfx1151"; break ;;
         120000)         GPU_ARCH="gfx1200"; break ;;
         120001)         GPU_ARCH="gfx1201"; break ;;
     esac
@@ -93,7 +94,7 @@ fi
 # Fallback: ask user
 if [ "$GPU_ARCH" = "unknown" ]; then
     echo "  WARNING: Could not detect GPU architecture."
-    echo "  Supported: gfx1010 (5700 XT), gfx1030 (6800 XT), gfx1100 (7900 XTX), gfx1200 (9060), gfx1201 (9070 XT)"
+    echo "  Supported: gfx1010 (5700 XT), gfx1030 (6800 XT), gfx1100 (7900 XTX), gfx1151 (Strix Halo), gfx1200 (9060), gfx1201 (9070 XT)"
     GPU_ARCH=$(ask "  Enter your GPU arch [or Enter to skip]: " "unknown")
 fi
 echo "  GPU arch: $GPU_ARCH"


### PR DESCRIPTION
 On Strix Halo / Radeon 8060S, KFD exposes the GPU as:
```
  gfx_target_version 110501
```
  This should resolve to:

```
  gfx1151
```

  However, the installer did not recognize 110501, and the CLI's generic conversion logic could produce an incorrect arch string instead of gfx1151.

  ## Impact

  This affects Strix Halo setup and diagnostics:

  - scripts/install.sh can fail to auto-detect the GPU arch and fall back to unknown.
  - CLI sysfs-based detection can derive the wrong gfx* string.
  - The wrong arch can affect config defaults, kernel blob lookup/copy, and install/update flows.
  - Strix Halo should use the existing gfx1151 profile, including the APU-oriented asym2 KV default.

  ## Fix

  I added explicit KFD gfx_target_version mappings in the CLI and installer:

  - 110501 -> gfx1151
  - preserved existing mappings for gfx1010, gfx1030, gfx1100, gfx1200, and gfx1201

  Also updated the installer supported-GPU message to include:

  gfx1151 (Strix Halo)

  Branch with the fix:

  codex/strix-halo-gfx1151-autodetect

  Commit:

  5293308 fix strix halo gfx1151 autodetect

  ## Validation

  Tested on AMD Ryzen AI Max+ 395 / Radeon 8060S:

  rocminfo: gfx1151 / Radeon 8060S Graphics
  KFD sysfs: gfx_target_version 110501
  hipfire diag: GPU arch gfx1151

  Checks run:

  bash -n scripts/install.sh
  gfx target version mapping OK
  hipfire diag

  Smoke tests also passed locally on Strix Halo with ROCm 7.2:

  qwen3.5:0.8b runs
  qwen3.5:9b runs
  qwen3.5:9b-draft loads
  DFlash code prompt test runs
