### PR TITLE
dispatch(gfx12): wire WMMA kernels (issue #57)

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -73,16 +73,18 @@ fn has_dot2_f32_f16(arch: &str) -> bool {
 /// series) has WMMA in hardware too, but the existing kernels use the
 /// gfx11 builtin which AMD clang 22.x in ROCm 7.x does NOT pattern-
 /// match on gfx12 — it errors with `Cannot select: intrinsic
-/// %llvm.amdgcn.wmma.f32.16x16x16.f16` at codegen time. Adding gfx12
-/// requires a kernel-side `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12`
-/// (or equivalent) variant; not in scope yet.
-///
-/// Until that lands, gfx12 falls back to `dot2` (which it does have
-/// per `has_dot2_f32_f16`), trading WMMA peak throughput for a working
-/// kernel. See issue #54 (9070 XT crash report) and
-/// `kernels.rs:311` for the deferred RDNA4 GEMV variant.
+/// %llvm.amdgcn.wmma.f32.16x16x16.f16` at codegen time. The gfx12 sister
+/// path uses `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` and is
+/// gated by `has_wmma_f16_gfx12` below.
 fn has_wmma_f16(arch: &str) -> bool {
     arch.starts_with("gfx11")
+}
+
+/// gfx12 (RDNA4) WMMA fp16. Kernels live at
+/// `kernels/src/gemm_*_wmma.gfx12.hip` and are validated by the
+/// `test_wmma_*_gfx12` channel-test examples (issue #54, PR #56).
+fn has_wmma_f16_gfx12(arch: &str) -> bool {
+    arch.starts_with("gfx12")
 }
 
 /// Tensor stored on the GPU. Tracks shape and element type.
@@ -2372,6 +2374,9 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_qkvza_hfq4g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
+            }
             if has_wmma_f16(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
@@ -2646,6 +2651,9 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_qkv_hfq4g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+            }
             if has_wmma_f16(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
@@ -2902,7 +2910,11 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            // WMMA on gfx11+ (RDNA3/4)
+            // WMMA on gfx12 (RDNA4)
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_gate_up_hfq4g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
+            }
+            // WMMA on gfx11 (RDNA3)
             if has_wmma_f16(&self.arch) {
                 return self.gemm_gate_up_hfq4g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
@@ -5041,6 +5053,9 @@ impl Gpu {
     ) -> HipResult<()> {
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_qkvza_hfq6g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
+            }
             if has_wmma_f16(&self.arch) {
                 return self.gemm_qkvza_hfq6g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
@@ -5425,6 +5440,9 @@ impl Gpu {
     ) -> HipResult<()> {
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_qkv_hfq6g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+            }
             if has_wmma_f16(&self.arch) {
                 return self.gemm_qkv_hfq6g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
@@ -5775,6 +5793,9 @@ impl Gpu {
     ) -> HipResult<()> {
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_gate_up_hfq6g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
+            }
             if has_wmma_f16(&self.arch) {
                 return self.gemm_gate_up_hfq6g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }

--- a/tests/speed-baselines/gfx1201.txt
+++ b/tests/speed-baselines/gfx1201.txt
@@ -1,0 +1,25 @@
+# hipfire speed-gate baseline — gfx1201
+# Captured 2026-04-27 against commit fa6b885
+# Config: KV=givens4, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
+# Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
+#
+# Measurements: best-of-2 via bench_qwen35_mq4. Two prefill sizes per model:
+#   pp32  — short-context / launch-overhead regression detector
+#   pp128 — realistic prompt / GEMM-efficiency detector
+# Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
+# GROUND FLOOR — no commit may regress below these numbers.
+
+0.8b_mq4_pp32_prefill_tok_s=3043.1
+0.8b_mq4_gen_tok_s=288.1
+0.8b_mq4_pp128_prefill_tok_s=5473.4
+
+4b_mq4_pp32_prefill_tok_s=1084.0
+4b_mq4_gen_tok_s=135.1
+4b_mq4_pp128_prefill_tok_s=1486.4
+
+9b_mq4_pp32_prefill_tok_s=620.8
+9b_mq4_gen_tok_s=98.1
+9b_mq4_pp128_prefill_tok_s=782.5
+
+
+


### PR DESCRIPTION
Closes #57 (partial — see _Open follow-ups_).

Wires the six `gemm_*_wmma_gfx12` kernels merged in #56 into `dispatch.rs` ahead of the dot2 fallback for gfx12 (RDNA4). Validated on R9700 (gfx1201).

## What changed

`crates/rdna-compute/src/dispatch.rs`:
- New `has_wmma_f16_gfx12(arch)` predicate (matches `gfx12*`).
- Six call sites get the gfx12 probe inserted **above** the existing `has_wmma_f16` (gfx11-only) probe, so gfx11 behavior is unchanged:
  - `gemm_qkv_hfq4g256`, `gemm_qkv_hfq6g256`
  - `gemm_qkvza_hfq4g256`, `gemm_qkvza_hfq6g256`
  - `gemm_gate_up_hfq4g256`, `gemm_gate_up_hfq6g256`
- Doc comment on `has_wmma_f16` trimmed: the "gfx12 falls back to dot2" wording is no longer true; replaced with a cross-reference to the new predicate.

`tests/speed-baselines/gfx1201.txt`:
- New file. Captured against this branch's wired-in WMMA path so future RDNA4 contributors have a floor.

## R9700 perf delta vs dot2 fallback

Best-of-2/3, `KV=asym3`, `HIPFIRE_GRAPH=1` (4B/9B), no graph (0.8B). Same `bench_qwen35_mq4` matrix used by `speed-gate.sh`.

| Model | Workload | dot2 (current master) | WMMA (this PR) | Δ |
|---|---|---:|---:|---:|
| **0.8B** | pp32 prefill   | 2989 | 3146 | **+5.3%** |
|       | pp128 prefill | 3823 | 5494 | **+43.7%** |
|       | decode        |  283 |  288 | flat |
| **4B**  | pp32 prefill  |  723 | 1084 | **+50.0%** |
|       | pp128 prefill | 1038 | 1438 | **+38.5%** |
|       | decode        |  137 |  137 | flat |
| **9B**  | pp32 prefill  |  578 |  664 | **+14.9%** |
|       | pp128 prefill |  656 |  732 | **+11.6%** |
|       | decode        |   97 |   99 | flat |

Decode is GEMV (not GEMM), so it never goes through these kernels — flat as expected.

## Validation

- **Channel-tests** (the six `test_wmma_*_gfx12` examples from #56): 36/36 shapes pass.
- **Coherence-gate** (`./scripts/coherence-gate.sh`): all three models produce fluent, on-topic, non-looping output through the wired-in path. Sample outputs from `/tmp/coherence-20260427-112101.md`:
  - 0.8B (cap): `Paris.`
  - 4B (code): one-line `def square(n): return n * n`
  - 9B (reason): correct "9 sheep left" with brief reasoning
- **Speed-gate (gfx1201)**: `--update-baselines` captured the new floor; `--fast` re-run passes against itself.
- **Speed-gate (gfx1100)**: not run — I only have R9700. Asking a maintainer or gfx1100 contributor to confirm no regression before merge.

## Open follow-ups

The 9B prefill lead (1.12–1.15×) is below the 1.3× threshold the issue flags as a tuning signal. Likely BW-bound at that size. Levers from the issue's "If the perf number isn't satisfying" list, all out of scope here:

- Multi-row WMMA (share x-register state across R rows/warp)
- K-tile depth retune (current K2 unroll lifted from gfx11; RDNA4 cache may prefer K4)
- `__launch_bounds__` retune (`(32, 2)` lifted from gfx11; RDNA4's larger register file may want different occupancy)
- Port `s_prefetch_data` from `gemv_hfq4g256.gfx1201.hip`

The 4B/0.8B numbers are clear wins right now and decode is unaffected, so per the issue's "land first, iterate" framing this PR does the wiring and leaves tuning for a follow-up.

## Test plan

- [x] All six `test_wmma_*_gfx12` channel-tests pass on R9700
- [x] `coherence-gate.sh` passes (0.8B/4B/9B)
- [x] `speed-gate.sh --update-baselines` captures gfx1201.txt
- [x] `speed-gate.sh --fast` passes against new gfx1201 baseline
- [ ] gfx1100 `speed-gate.sh --fast` (need maintainer/contributor with RDNA3 hardware)