### PR TITLE
tests/speed-baselines: add gfx1151 (Strix Halo) baseline

### DIFF
--- a/tests/speed-baselines/gfx1151.txt
+++ b/tests/speed-baselines/gfx1151.txt
@@ -9,17 +9,20 @@
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
 # GROUND FLOOR — no commit may regress below these numbers.
 
-0.8b_mq4_pp32_prefill_tok_s=1525.4
-0.8b_mq4_gen_tok_s=238.1
-0.8b_mq4_pp128_prefill_tok_s=4074.5
+0.8b_mq4_pp32_prefill_tok_s=1560.6
+0.8b_mq4_gen_tok_s=236.0
+0.8b_mq4_pp128_prefill_tok_s=4068.9
 
-4b_mq4_pp32_prefill_tok_s=658.9
+4b_mq4_pp32_prefill_tok_s=655.9
 4b_mq4_gen_tok_s=69.0
-4b_mq4_pp128_prefill_tok_s=1001.4
+4b_mq4_pp128_prefill_tok_s=1003.7
 
-9b_mq4_pp32_prefill_tok_s=406.2
+9b_mq4_pp32_prefill_tok_s=406.9
 9b_mq4_gen_tok_s=46.0
-9b_mq4_pp128_prefill_tok_s=536.3
+9b_mq4_pp128_prefill_tok_s=535.9
 
+27b_mq4_pp32_prefill_tok_s=146.7
+27b_mq4_gen_tok_s=14.9
+27b_mq4_pp128_prefill_tok_s=154.4
 
 

--- a/tests/speed-baselines/gfx1151.txt
+++ b/tests/speed-baselines/gfx1151.txt
@@ -9,20 +9,28 @@
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
 # GROUND FLOOR — no commit may regress below these numbers.
 
-0.8b_mq4_pp32_prefill_tok_s=1560.6
-0.8b_mq4_gen_tok_s=236.0
-0.8b_mq4_pp128_prefill_tok_s=4068.9
+0.8b_mq4_pp32_prefill_tok_s=1553.3
+0.8b_mq4_gen_tok_s=234.6
+0.8b_mq4_pp128_prefill_tok_s=4070.5
 
-4b_mq4_pp32_prefill_tok_s=655.9
-4b_mq4_gen_tok_s=69.0
-4b_mq4_pp128_prefill_tok_s=1003.7
+4b_mq4_pp32_prefill_tok_s=660.1
+4b_mq4_gen_tok_s=69.1
+4b_mq4_pp128_prefill_tok_s=1011.0
 
-9b_mq4_pp32_prefill_tok_s=406.9
+9b_mq4_pp32_prefill_tok_s=406.1
 9b_mq4_gen_tok_s=46.0
-9b_mq4_pp128_prefill_tok_s=535.9
+9b_mq4_pp128_prefill_tok_s=539.1
 
-27b_mq4_pp32_prefill_tok_s=146.7
+27b_mq4_pp32_prefill_tok_s=144.7
 27b_mq4_gen_tok_s=14.9
-27b_mq4_pp128_prefill_tok_s=154.4
+27b_mq4_pp128_prefill_tok_s=156.4
 
+27b_3.5_dflash_lru_code_tok_s=65.83
+27b_3.5_dflash_lru_code_tau=8.846
+27b_3.5_dflash_merge_sort_tok_s=98.36
+27b_3.5_dflash_merge_sort_tau=13.2727
+27b_3.5_dflash_merge_sort_ttft_ms=358.07
+9b_3.5_dflash_merge_sort_tok_s=245.03
+9b_3.5_dflash_merge_sort_tau=13.1538
+9b_3.5_dflash_merge_sort_ttft_ms=135.08
 

--- a/tests/speed-baselines/gfx1151.txt
+++ b/tests/speed-baselines/gfx1151.txt
@@ -1,0 +1,25 @@
+# hipfire speed-gate baseline — gfx1151
+# Captured 2026-04-27 against commit 83358c6
+# Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
+# Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
+#
+# Measurements: best-of-2 via bench_qwen35_mq4. Two prefill sizes per model:
+#   pp32  — short-context / launch-overhead regression detector
+#   pp128 — realistic prompt / GEMM-efficiency detector
+# Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
+# GROUND FLOOR — no commit may regress below these numbers.
+
+0.8b_mq4_pp32_prefill_tok_s=1525.4
+0.8b_mq4_gen_tok_s=238.1
+0.8b_mq4_pp128_prefill_tok_s=4074.5
+
+4b_mq4_pp32_prefill_tok_s=658.9
+4b_mq4_gen_tok_s=69.0
+4b_mq4_pp128_prefill_tok_s=1001.4
+
+9b_mq4_pp32_prefill_tok_s=406.2
+9b_mq4_gen_tok_s=46.0
+9b_mq4_pp128_prefill_tok_s=536.3
+
+
+


### PR DESCRIPTION
Closes Phase 1 of #61 — gfx1151 speed baseline (full set incl. DFlash anchors).

## Hardware
- AMD Ryzen AI MAX+ 395 / Radeon 8060S (gfx1151, 128 GB unified)
- NixOS 25.11, kernel 6.19, /dev/kfd present

## Toolchain
ROCm **7.2** (`clr-7.2.2` + `rocm-device-libs-22.0.0`).

> Note: HIP 6.4 hipcc compiles kernels but `hipModuleLoad` returns code 209 (`no kernel image is available for execution on the device`) on gfx1151 for every backend variant. ROCm 7.2 unblocks both compile **and** load. Tester running 6.4 will hit this — flagging in case it's worth surfacing in `hipfire diag` / `install.sh` as a min-version warning for gfx1151.

Invocation (after `--rocm-device-lib-path` passed via `HIPFIRE_HIPCC_EXTRA_FLAGS` so non-standard ROCm paths resolve):

```
HIPFIRE_BASELINE_ARCH=gfx1151 \
HIPFIRE_MODELS_DIR=/home/bjoern/.hipfire/models \
HIPFIRE_HIPCC_EXTRA_FLAGS='--rocm-device-lib-path=/nix/store/.../rocm-device-libs-22.0.0/amdgcn/bitcode' \
./scripts/speed-gate.sh --update-baselines
```

DFlash drafters staged from `z-lab/Qwen3.5-27B-DFlash` and `z-lab/Qwen3.5-9B-DFlash`, converted via `dflash_convert --mq4` + `draft_to_mq4`.

## Numbers (best-of-2 AR, best-of-3 DFlash)

```
0.8b: pp32=1553.3 t/s · pp128=4070.5 t/s · decode=234.6 t/s
4b  : pp32= 660.1 t/s · pp128=1011.0 t/s · decode= 69.1 t/s
9b  : pp32= 406.1 t/s · pp128= 539.1 t/s · decode= 46.0 t/s
27b : pp32= 144.7 t/s · pp128= 156.4 t/s · decode= 14.9 t/s

DFlash anchors:
  27B-3.5 LRU code      :  65.8 t/s · τ=8.85
  27B-3.5 merge_sort    :  98.4 t/s · τ=13.27 · ttft=358 ms
   9B-3.5 merge_sort    : 245.0 t/s · τ=13.15 · ttft=135 ms
```

DFlash speedup vs AR decode: 27B 4.4-6.6×, 9B 5.3×. Happy to chase Phase 2 tuning if anything looks soft.