### PR TITLE
gfx908 / MI100 (CDNA1) bring-up: wave64 dispatch + new fused_gate_up kernel

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -88,6 +88,16 @@ fn has_wmma_f16_gfx12(arch: &str) -> bool {
     arch.starts_with("gfx12")
 }
 
+/// CDNA wave64-native arches: CDNA1 (gfx908, MI100) and CDNA3 (gfx94x,
+/// MI300X). On these, wave32 kernels (block=[32,1,1]) waste the upper 32
+/// lanes of every wave slot. The `*_wave64.hip` kernel variants pack two
+/// rows per block (one per warp) with block=[64,1,1] and halve the grid
+/// count. Adding gfx90a (CDNA2, MI200) here is a one-line change once it
+/// has been bring-up validated.
+fn has_wave64_native(arch: &str) -> bool {
+    matches!(arch, "gfx908" | "gfx940" | "gfx941" | "gfx942")
+}
+
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
     pub buf: DeviceBuffer,
@@ -2169,7 +2179,7 @@ impl Gpu {
         q_m: usize, k_m: usize, v_m: usize,
         k: usize,
     ) -> HipResult<()> {
-        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "fused_qkv_hfq4g256_wave64",
@@ -2256,7 +2266,7 @@ impl Gpu {
         // 2 rows per block, halves grid count vs wave32 kernel which wastes half
         // the wave slot. gfx908 added 2026-04-27 — kernel uses no MFMA, just
         // FMA + shfl_down within wave64.
-        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "fused_qkvza_hfq4g256_wave64",
@@ -2391,7 +2401,7 @@ impl Gpu {
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
             return self.gemm_qkvza_hfq4g256_fp16(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
         }
-        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_qkvza_hfq4g256_wave64",
@@ -2668,7 +2678,7 @@ impl Gpu {
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
             return self.gemm_qkv_hfq4g256_fp16(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
-        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_qkv_hfq4g256_wave64",
@@ -7164,7 +7174,7 @@ impl Gpu {
         y_gate: &GpuTensor, y_up: &GpuTensor,
         gate_m: usize, up_m: usize, k: usize,
     ) -> HipResult<()> {
-        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "fused_gate_up_hfq4g256_wave64",
@@ -11115,7 +11125,7 @@ impl Gpu {
                 // wavefront pressure in half on the hottest kernels. Wave32
                 // block=[32,1,1] kernels otherwise waste the upper 32 lanes
                 // of every wave slot on these wave64-native arches.
-                if matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942") {
+                if has_wave64_native(&self.arch) {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
                                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
@@ -11172,7 +11182,7 @@ impl Gpu {
                 specs.push(("fused_silu_mul_mq_rotate",
                             kernels::FUSED_SILU_MUL_MQ_ROTATE_SRC.to_string()));
                 // CDNA1 (gfx908) + CDNA3 wave64 variants — see hfq4 branch for rationale.
-                if matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942") {
+                if has_wave64_native(&self.arch) {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
                                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -38,11 +38,12 @@ fn gemv_rows_default(arch: &str) -> u32 {
     match arch {
         "gfx1100" | "gfx1101" | "gfx1102" => 1,
         "gfx1030" | "gfx1031" => 1,
-        // CDNA3 (MI300X): wave64 native. `gemv_hfq4g256_wide` uses
-        // block=[64,1,1] = exactly one wave — zero lane waste. The 32-
-        // thread multirow variants run on half a wave, so the wide
-        // kernel is the natural fit. Return rows=1 to trigger use_wide.
-        "gfx940" | "gfx941" | "gfx942" => 1,
+        // CDNA1 (MI100, gfx908) + CDNA3 (MI300X): wave64 native.
+        // `gemv_hfq4g256_wide` uses block=[64,1,1] = exactly one wave —
+        // zero lane waste. The 32-thread multirow variants run on half a
+        // wave, so the wide kernel is the natural fit. Return rows=1 to
+        // trigger use_wide.
+        "gfx908" | "gfx940" | "gfx941" | "gfx942" => 1,
         _ => 2,
     }
 }
@@ -2168,8 +2169,8 @@ impl Gpu {
         q_m: usize, k_m: usize, v_m: usize,
         k: usize,
     ) -> HipResult<()> {
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_x) = if cdna3 {
+        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "fused_qkv_hfq4g256_wave64",
                 kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC,
@@ -2251,10 +2252,12 @@ impl Gpu {
         qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
         k: usize,
     ) -> HipResult<()> {
-        // CDNA3 (MI300X / gfx94x) wave64-native path: 2 rows per block, halves
-        // grid count vs wave32 kernel which wastes half the wave slot.
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_x) = if cdna3 {
+        // CDNA1 (MI100, gfx908) + CDNA3 (MI300X / gfx94x) wave64-native path:
+        // 2 rows per block, halves grid count vs wave32 kernel which wastes half
+        // the wave slot. gfx908 added 2026-04-27 — kernel uses no MFMA, just
+        // FMA + shfl_down within wave64.
+        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "fused_qkvza_hfq4g256_wave64",
                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC,
@@ -2388,8 +2391,8 @@ impl Gpu {
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
             return self.gemm_qkvza_hfq4g256_fp16(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
         }
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna3 {
+        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_qkvza_hfq4g256_wave64",
                 kernels::GEMM_QKVZA_HFQ4G256_WAVE64_SRC,
@@ -2665,8 +2668,8 @@ impl Gpu {
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
             return self.gemm_qkv_hfq4g256_fp16(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna3 {
+        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_qkv_hfq4g256_wave64",
                 kernels::GEMM_QKV_HFQ4G256_WAVE64_SRC,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -7164,7 +7164,23 @@ impl Gpu {
         y_gate: &GpuTensor, y_up: &GpuTensor,
         gate_m: usize, up_m: usize, k: usize,
     ) -> HipResult<()> {
-        self.ensure_kernel("fused_gate_up_hfq4g256", kernels::FUSED_GATE_UP_HFQ4G256_SRC, "fused_gate_up_hfq4g256")?;
+        let cdna_wave64 = matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942");
+        let (func_name, block, grid_x) = if cdna_wave64 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_wave64",
+                kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC,
+                "fused_gate_up_hfq4g256_wave64",
+            )?;
+            let total = (gate_m + up_m) as u32;
+            ("fused_gate_up_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+        } else {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256",
+                kernels::FUSED_GATE_UP_HFQ4G256_SRC,
+                "fused_gate_up_hfq4g256",
+            )?;
+            ("fused_gate_up_hfq4g256", [32u32, 1, 1], (gate_m + up_m) as u32)
+        };
         let ag = a_gate.buf.as_ptr();
         let au = a_up.buf.as_ptr();
         let xp = x.buf.as_ptr();
@@ -7179,9 +7195,8 @@ impl Gpu {
             &yu as *const _ as *mut c_void, &gm as *const _ as *mut c_void,
             &um as *const _ as *mut c_void, &kv as *const _ as *mut c_void,
         ];
-        let total_rows = (gate_m + up_m) as u32;
         self.launch_maybe_blob(
-            "fused_gate_up_hfq4g256", [total_rows, 1, 1], [32, 1, 1], 0, &mut params,
+            func_name, [grid_x, 1, 1], block, 0, &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
                 b.push_ptr(ag); b.push_ptr(au); b.push_ptr(xp);
@@ -11096,17 +11111,18 @@ impl Gpu {
                             kernels::FUSED_QKV_HFQ4G256_SRC.to_string()));
                 specs.push(("fused_gate_up_hfq4g256",
                             kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string()));
-                // CDNA3 (MI300X / gfx94x) wave64-native variants — cut
-                // wavefront pressure in half on the three hottest kernels
-                // (30 LA fused + 40 MoE gate_up + 40 MoE down per token
-                // on A3B). Wave32 block=[32,1,1] kernels otherwise waste
-                // the upper 32 lanes of every wave slot.
-                if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942") {
+                // CDNA1 (gfx908) + CDNA3 (gfx94x) wave64-native variants — cut
+                // wavefront pressure in half on the hottest kernels. Wave32
+                // block=[32,1,1] kernels otherwise waste the upper 32 lanes
+                // of every wave slot on these wave64-native arches.
+                if matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942") {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
                                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
                     specs.push(("fused_qkv_hfq4g256_wave64",
                                 kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC.to_string()));
+                    specs.push(("fused_gate_up_hfq4g256_wave64",
+                                kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC.to_string()));
                     specs.push(("gemv_hfq4g256_moe_gate_up_indexed_wave64",
                                 kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC.to_string()));
                     specs.push(("gemv_hfq4g256_moe_down_indexed_wave64",
@@ -11155,13 +11171,15 @@ impl Gpu {
                             kernels::FUSED_RMSNORM_MQ_ROTATE_SRC.to_string()));
                 specs.push(("fused_silu_mul_mq_rotate",
                             kernels::FUSED_SILU_MUL_MQ_ROTATE_SRC.to_string()));
-                // CDNA3 wave64 variants — see hfq4 branch for rationale.
-                if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942") {
+                // CDNA1 (gfx908) + CDNA3 wave64 variants — see hfq4 branch for rationale.
+                if matches!(self.arch.as_str(), "gfx908" | "gfx940" | "gfx941" | "gfx942") {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
                                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
                     specs.push(("fused_qkv_hfq4g256_wave64",
                                 kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC.to_string()));
+                    specs.push(("fused_gate_up_hfq4g256_wave64",
+                                kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC.to_string()));
                     specs.push(("gemv_hfq4g256_moe_gate_up_indexed_wave64",
                                 kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC.to_string()));
                     specs.push(("gemv_hfq4g256_moe_down_indexed_wave64",

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -4031,8 +4031,8 @@ impl Gpu {
         y_up:   &GpuTensor,
         m: usize, k: usize,
     ) -> HipResult<()> {
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_x) = if cdna3 {
+        let cdna_wave64 = has_wave64_native(&self.arch);
+        let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_gate_up_indexed_wave64",
                 kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC,
@@ -4095,8 +4095,8 @@ impl Gpu {
         x_residual: &GpuTensor,
         m: usize, k: usize,
     ) -> HipResult<()> {
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_x) = if cdna3 {
+        let cdna_wave64 = has_wave64_native(&self.arch);
+        let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_down_indexed_wave64",
                 kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_WAVE64_SRC,
@@ -4206,8 +4206,8 @@ impl Gpu {
         y_up:   &GpuTensor,
         m: usize, k: usize, k_top: usize, batch_size: usize,
     ) -> HipResult<()> {
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna3 {
+        let cdna_wave64 = has_wave64_native(&self.arch);
+        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64",
                 kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_BATCHED_WAVE64_SRC,
@@ -4274,8 +4274,8 @@ impl Gpu {
         x_residual: &GpuTensor,
         m: usize, k: usize, k_top: usize, batch_size: usize,
     ) -> HipResult<()> {
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna3 {
+        let cdna_wave64 = has_wave64_native(&self.arch);
+        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_down_indexed_batched_wave64",
                 kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_BATCHED_WAVE64_SRC,
@@ -4379,8 +4379,8 @@ impl Gpu {
             // FP16 packed on all other RDNA: ~15% prefill improvement
             return self.gemm_hfq4g256_residual_fp16(a_raw, x, y, m, k, batch_size);
         }
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna3 {
+        let cdna_wave64 = has_wave64_native(&self.arch);
+        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_hfq4g256_residual_wave64",
                 kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_SRC,
@@ -4711,8 +4711,8 @@ impl Gpu {
             // Shadow allocation failed — fall through to the GEMV path.
         }
 
-        let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna3 {
+        let cdna_wave64 = has_wave64_native(&self.arch);
+        let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_hfq4g256_wave64",
                 kernels::GEMM_HFQ4G256_WAVE64_SRC,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -486,6 +486,11 @@ pub const ATTENTION_FLASH_SRC: &str = include_str!("../../../kernels/src/attenti
 /// Grid: [gate_m + up_m, 1, 1]. Each block processes one row from gate or up weight.
 pub const FUSED_GATE_UP_HFQ4G256_SRC: &str = include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip");
 
+/// Wave64-native counterpart to FUSED_GATE_UP_HFQ4G256_SRC for CDNA1/3.
+/// block=[64,1,1] with 2 rows per block (one per warp); grid halves from
+/// gate_m + up_m to (total + 1) / 2. Byte-exact with the wave32 base.
+pub const FUSED_GATE_UP_HFQ4G256_WAVE64_SRC: &str = include_str!("../../../kernels/src/fused_gate_up_hfq4g256_wave64.hip");
+
 
 /// INT8 co-located KV v2: [f16 scale (2B)][padding (2B)][int8 × head_dim] = 132 bytes per head.
 /// f16 scale matches Q8_0 but with one block per head. Padding for 4-byte alignment.

--- a/kernels/src/fused_gate_up_hfq4g256_wave64.hip
+++ b/kernels/src/fused_gate_up_hfq4g256_wave64.hip
@@ -1,0 +1,137 @@
+#include <hip/hip_runtime.h>
+
+// Wave64-native counterpart to fused_gate_up_hfq4g256 for wave64-native
+// archs (CDNA1/2/3 — gfx908, gfx90a, gfx94x). FFN gate+up fused GEMV;
+// hit once per FFN layer per token.
+//
+// block=[64,1,1] packs two rows per block (one per warp); grid halves from
+// gate_m + up_m to (total + 1) / 2. Each warp's 32-lane reduction is
+// byte-exact with the wave32 base kernel (lane 0 per warp writes output;
+// __shfl_down with offsets 16/8/4/2/1 stays correct because only lane 0
+// and lane 32 read the final reduction — the boundary-crossing shuffles
+// at offset=16 corrupt mid-warp lanes but those don't write).
+//
+// Per-row math is identical to fused_gate_up_hfq4g256.hip: 4-accumulator
+// group-interleaved summation with pairwise combine, same DOG/TAIL_DOG
+// macros, same 4 quads + tail group structure.
+
+extern "C" __global__ void fused_gate_up_hfq4g256_wave64(
+    const char* __restrict__ A_gate,
+    const char* __restrict__ A_up,
+    const float* __restrict__ x,
+    float* __restrict__ y_gate,
+    float* __restrict__ y_up,
+    int gate_m, int up_m, int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = gate_m + up_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* y;
+    int local_row;
+    if (gid < gate_m) {
+        A = A_gate; y = y_gate; local_row = gid;
+    } else {
+        A = A_up; y = y_up; local_row = gid - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)local_row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail  = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    // Tail groups must accumulate into acc[g % 4] — see
+    // gemv_hfq4g256.gfx1100.hip for the full bug explanation.
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[local_row] = acc;
+}

--- a/tests/speed-baselines/gfx908.txt
+++ b/tests/speed-baselines/gfx908.txt
@@ -1,5 +1,5 @@
 # hipfire speed-gate baseline — gfx908 (CDNA1, AMD Instinct MI100)
-# Captured 2026-04-27 against commit 9709964 on port/gfx908-wave64
+# Captured 2026-04-27 on port/gfx908-wave64
 # Config: KV=asym3 (matches the speed-gate's run_bench env_prefix),
 #         no HIPFIRE_GRAPH on 0.8B (gate skips it; known panic).
 #         HIPFIRE_GRAPH not enabled on 4B/9B either pending hipGraph
@@ -16,22 +16,24 @@
 # GROUND FLOOR — no commit may regress below these numbers.
 #
 # Cross-process verified across 5 fresh-process runs per metric:
-#   9B gen: master 64.38 ± 0.27 vs HEAD 65.70 ± 0.41 (range gap 0.6 tok/s)
-#   4B gen: master 75.22 ± 0.30 vs HEAD 76.16 ± 0.30 (range gap 0.6 tok/s)
-# i.e. the wave64 dispatch from #58 lifted 9B decode by +2.05%, 4B by +1.25%.
-# 0.8B and prefill columns are within within-session noise (kernels
-# exercised under wave32 fallback regardless of the new dispatch arm).
+#   9B gen: master 64.38 ± 0.27  →  HEAD 70.34 ± 0.40   +9.3%  (no range overlap)
+#   4B gen: master 75.22 ± 0.30  →  HEAD 78.88 ± 0.30   +4.9%  (no range overlap)
+# This branch enables wave64 dispatch on 4 fused projection sites + the
+# gemv decode path + adds a wave64 variant of fused_gate_up_hfq4g256.
+# 0.8B and prefill columns are within within-session noise (kernel-launch
+# overhead dominates 0.8B decode; gfx908 prefill falls to gemm_*_fp16
+# packed because gfx908 isn't in has_dot2_f32_f16 — separate lever).
 
-0.8b_mq4_pp32_prefill_tok_s=396.8
-0.8b_mq4_gen_tok_s=230.7
-0.8b_mq4_pp128_prefill_tok_s=423.4
+0.8b_mq4_pp32_prefill_tok_s=397.2
+0.8b_mq4_gen_tok_s=235.1
+0.8b_mq4_pp128_prefill_tok_s=423.5
 
 4b_mq4_pp32_prefill_tok_s=73.9
-4b_mq4_gen_tok_s=76.8
+4b_mq4_gen_tok_s=78.8
 4b_mq4_pp128_prefill_tok_s=75.7
 
 9b_mq4_pp32_prefill_tok_s=35.6
-9b_mq4_gen_tok_s=66.5
+9b_mq4_gen_tok_s=69.8
 9b_mq4_pp128_prefill_tok_s=36.0
 
 # 27b: not yet measured. MI100's 32 GiB VRAM has plenty of headroom for the

--- a/tests/speed-baselines/gfx908.txt
+++ b/tests/speed-baselines/gfx908.txt
@@ -1,0 +1,41 @@
+# hipfire speed-gate baseline — gfx908 (CDNA1, AMD Instinct MI100)
+# Captured 2026-04-27 against commit 9709964 on port/gfx908-wave64
+# Config: KV=asym3 (matches the speed-gate's run_bench env_prefix),
+#         no HIPFIRE_GRAPH on 0.8B (gate skips it; known panic).
+#         HIPFIRE_GRAPH not enabled on 4B/9B either pending hipGraph
+#         qualification on gfx908; raise this once it's measured.
+# Hardware: 2x AMD Instinct MI100 (32 GiB HBM2 each), bench pinned to GPU 0
+# ROCm 7.0.51831 / HIP 7.0 / amd-clang 20 (roc-7.0.0)
+# Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
+#
+# Measurements: best-of-2 via bench_qwen35_mq4 with HIPFIRE_KV_MODE=asym3.
+# Two prefill sizes per model:
+#   pp32  — short-context / launch-overhead regression detector
+#   pp128 — realistic prompt / GEMM-efficiency detector
+# Decode numbers are taken from the pp32 run (warmup=5 + gen=50 settles).
+# GROUND FLOOR — no commit may regress below these numbers.
+#
+# Cross-process verified across 5 fresh-process runs per metric:
+#   9B gen: master 64.38 ± 0.27 vs HEAD 65.70 ± 0.41 (range gap 0.6 tok/s)
+#   4B gen: master 75.22 ± 0.30 vs HEAD 76.16 ± 0.30 (range gap 0.6 tok/s)
+# i.e. the wave64 dispatch from #58 lifted 9B decode by +2.05%, 4B by +1.25%.
+# 0.8B and prefill columns are within within-session noise (kernels
+# exercised under wave32 fallback regardless of the new dispatch arm).
+
+0.8b_mq4_pp32_prefill_tok_s=396.8
+0.8b_mq4_gen_tok_s=230.7
+0.8b_mq4_pp128_prefill_tok_s=423.4
+
+4b_mq4_pp32_prefill_tok_s=73.9
+4b_mq4_gen_tok_s=76.8
+4b_mq4_pp128_prefill_tok_s=75.7
+
+9b_mq4_pp32_prefill_tok_s=35.6
+9b_mq4_gen_tok_s=66.5
+9b_mq4_pp128_prefill_tok_s=36.0
+
+# 27b: not yet measured. MI100's 32 GiB VRAM has plenty of headroom for the
+# 15 GiB MQ4 model, but the bundle hasn't been pulled to this rig yet.
+# Add a row when the bundle is fetched. DFlash baselines (drafted-decode) also
+# pending — drafts lookup paths in scripts/speed-gate.sh's bench_dflash_*
+# need a `qwen35-9b-dflash-mq4.hfq` (or similar) pulled here.


### PR DESCRIPTION
First pass at gfx908 (CDNA1, AMD MI100) on the existing wave64 dispatch path. Cumulative wins on `bench_qwen35_mq4` vs master, all cross-process verified across 5 fresh-process runs per metric:

| model | metric | master | HEAD | Δ |
|---|---|---:|---:|---:|
| qwen3.6:35b-a3b | decode (MoE) | 86.6 | **96.1** | **+11.0%** |
| qwen3.6:35b-a3b | pp32 prefill (MoE) | 117.3 | **131.0** | **+11.7%** |
| qwen3.5:9b | decode | 64.4 | 70.3 | +9.3% |
| qwen3.5:4b | decode | 75.2 | 78.9 | +4.9% |

Anchored against the maintainer's CDNA3 wave64 port (commit `4105035`: MI300X A3B decode 48.6 → 96 tok/s) — gfx908 hits **96.1 tok/s** with the same port. Wave-mismatch hypothesis cleanly confirmed.

Companion to #58 — bring-up artifacts (rocminfo, hipfire diag, coherence-gate "Paris.") were posted there: https://github.com/Kaden-Schutt/hipfire/issues/58#issuecomment-4326112943

## Commits

1. `perf(cdna1): gfx908 (MI100) wave64 dispatch + speed-gate baseline` — gfx908 added to the four existing non-MoE wave64 dispatch sites (`fused_qkv`, `fused_qkvza`, `gemm_qkv_batched`, `gemm_qkvza_batched`) and to `gemv_rows_default` so decode GEMV takes the wave64-friendly `gemv_hfq4g256_wide`. Lands `tests/speed-baselines/gfx908.txt`.
2. `perf(cdna1): wave64 fused_gate_up_hfq4g256` — new `kernels/src/fused_gate_up_hfq4g256_wave64.hip`, modeled on `fused_qkv_hfq4g256_wave64`. Closes the last VGPR-limited (88 / 11-of-20 waves) wave32 kernel hot on the gfx908 decode path. This commit drives the bulk of the 9B decode lift (master 64.4 → wave64-only 65.7 → +fused_gate_up_wave64 70.3).
3. `refactor(dispatch): extract has_wave64_native predicate` — replaces 7 inline `matches!()` with one helper, in line with the existing `has_wmma_f16` / `has_dot2_f32_f16` style. gfx90a (CDNA2) is a one-line add when there's hardware to validate.
4. `perf(cdna1): wave64 dispatch on MoE GEMV sites` — adds gfx908 to the four `gemv_hfq4g256_moe_*` dispatch arms + unifies two more `gemm_*_batched` sites under `has_wave64_native`. Drives the +7.5% isolated MoE decode lift (3f46514 → HEAD: 89.4 → 96.1 tok/s on qwen3.6:35b-a3b). The MoE wave64 kernels were already in the precompile spec list from commit 1; this just routes gfx908 through them at runtime.

## Hardware

2× AMD Instinct MI100 (gfx908, CDNA1), ROCm 7.0.51831 / HIP 7.0 / amd-clang 20 (roc-7.0.0). rocminfo: `Wavefront Size: 64`, 120 CU, 4 SIMDs/CU, 32 GiB HBM2.

## Validation

- `scripts/compile-kernels.sh gfx908`: 194/210 OK. The 16 fails are 15 WMMA kernels (`has_wmma_f16` is false on gfx908, never dispatched) + 1 unrelated `gemv_mq8g256` regression.
- `examples/test_kernels`: 16/16 PASS at each commit on the branch.
- `scripts/coherence-gate.sh`: PASS on `qwen3.5:0.8b` ("Paris.") and `qwen3.5:9b` ("9 are left." with reasoning).
- `scripts/speed-gate.sh` against `tests/speed-baselines/gfx908.txt`: 9/9 PASSED.
- MoE smoke: `qwen3.6:35b-a3b` (18.7 GB MQ4) loads, runs, decodes at 96.1 tok/s on gfx908 (single GPU). Pulled directly from `schuttdev/hipfire-qwen3.6-35b-a3b` HF repo since the CLI's registry doesn't list it (says LOCAL ONLY).

## Negative results documented for the next CDNA1 contributor

These two were tested empirically and saved for the historical record so the next person doesn't re-burn the hours.

### `has_dot2_f32_f16` for gfx908: regresses prefill

gfx908 hardware does support `v_dot2_f32_f16` (it inherits from gfx906 where the instruction was introduced). The dot2 GEMM kernels compile cleanly via hipcc 7.0 for gfx908. But measured:

```
0.8B pp32 prefill   -5.3%
0.8B pp128 prefill  -6.0%
4B/9B prefill       no measurable change
```

5 fresh runs each, ranges don't overlap. Likely hipcc's gfx908 codegen of `v_dot2_f32_f16` is slower than packed FP16 fma on CDNA1 silicon. **Don't re-try.**

### Hoisting wave64 batched GEMM above fp16-packed: also regresses prefill

The `gemm_*_wave64` kernels accept N>1 and exist for batched prefill, but the dispatch routes wave64 archs through `gemm_*_fp16` packed first (line 2669 etc.). Tested both paths via `HIPFIRE_FP16=0` env override (which bypasses the fp16 fast path):

| metric | wave64 batched | fp16 packed | Δ |
|---|---:|---:|---:|
| 9B pp32 prefill | 25.1 | 35.6 | **-29%** |
| 9B pp128 prefill | 25.5 | ~27 | **-7%** |

The maintainer's existing dispatch order is correct on gfx908 too — fp16-packed wins on small-batch prefill against wave64 batched. **Don't hoist.** This means the existing `gemm_*_batched` cdna_wave64 path (lines 2671/2392/2884/4382/4714) is effectively dead code on gfx908 (only reachable for batch=1, which is the GEMV path's territory). Left the dispatch arm in for arch-table consistency.

## Out of scope (deliberately deferred)

- **MFMA prefill kernels for gfx908.** Closes the bulk of the prefill gap vs gfx1100 (gfx908 currently at ~3.5% of gfx1100 prefill). I verified the toolchain works — `__builtin_amdgcn_mfma_f32_16x16x16f16` compiles cleanly via hipcc 7.0 for `--offload-arch=gfx908` (8 KB hsaco produced). The actual port is a 3-7 day project per the PR #56 bar (4 kernels + channel-tests + C-mapping verification — the silent-corruption story from `b7ac66a` applies). Better as a separate PR.
- **27B + DFlash baselines.** 27B is 15 GiB MQ4, fits the 32 GiB MI100 fine; DFlash drafts not pulled to this rig. Can land as follow-up commits.
- **`tests/speed-baselines/gfx908.txt` row for 35b-a3b.** `scripts/speed-gate.sh` hardcodes Qwen3.5 dense basenames + sizes (0.8b/4b/9b/27b). Wiring up Qwen3.6 + A3B-size into the gate is a script-side change I didn't want to bundle.
- **Channel-test for `fused_gate_up_hfq4g256_wave64`** (PR #56's bar). The kernel is structurally identical to the existing `fused_qkv_hfq4g256_wave64` — same FMA + bit_cast + `__shfl_down`, no MFMA. The 32-lane reduction inside a 64-lane wave was traced: only lane 0 / lane 32 read the final accumulator, intermediate-lane corruption from the offset-16 shuffle doesn't reach them. Coherence-gate validates correctness end-to-end on real models. Add a PR-#56-style harness if you'd prefer it before merge.

## Small things spotted on the way

- `scripts/coherence-gate.sh:40` has a hardcoded `MODELS_DIR=/home/kaden/ClaudeCode/autorocm/hipfire/models`. `${HIPFIRE_MODELS_DIR:-${HIPFIRE_DIR:-$HOME/.hipfire}/models}` would be more portable.
- `scripts/install.sh` swallows the bun-installer's "unzip is required" error via `2>/dev/null` (took some debugging on a fresh container).
- `scripts/install.sh`'s `gfx_target_version` arch-detect lacks a case for `90008` (gfx908). Falls through to the rocm-smi fallback which works, but a one-line add is cleaner.
- The CLI's remote model registry shows `qwen3.5:35b-a3b` and `qwen3.6:35b-a3b` as "LOCAL ONLY (no HF repo yet)" but `schuttdev/hipfire-qwen3.6-35b-a3b` does exist on HF (~18.7 GB). Resolve URL works for direct curl. The `qwen3.5:35b-a3b` HF repo specifically might still need publishing.

These are tiny one-liners I'm happy to land as a separate housekeeping PR if useful.
