### PR TITLE
dispatch(gfx12 residual): wire WMMA kernel — 9B/27B prefill BW gap

### DIFF
--- a/crates/engine/examples/test_wmma_residual_gfx12.rs
+++ b/crates/engine/examples/test_wmma_residual_gfx12.rs
@@ -1,0 +1,266 @@
+//! Channel-test for the gfx12 (RDNA4) WMMA residual GEMM.
+//!
+//! Compiles `gemm_hfq4g256_residual_wmma.gfx12.hip` and compares its output
+//! against the validated dot2-fp16 reference (`gemm_hfq4g256_residual_fp16`)
+//! on identical synthetic inputs. The fp16 path is the current gfx12
+//! production fallback (gfx12 dispatch falls through to it before this PR),
+//! so any divergence from it would be a real correctness regression.
+//!
+//! What this validates:
+//!   - The kernel compiles for gfx1200 / gfx1201.
+//!   - The C-output mapping
+//!     (`acc[j] = C[8*(tid>>4) + j][tid & 15]`) is correct on silicon.
+//!   - The K-split across lane-groups (k_grp = tid >> 4) reads the
+//!     correct half of each K-tile.
+//!   - Residual-add semantics (`Y += W·X` not `Y = W·X`) match the dot2
+//!     reference.
+//!
+//! Bails with a clear message on non-gfx12 archs (this kernel uses the
+//! `_w32_gfx12` builtin which does not exist on gfx11).
+//!
+//! Run: cargo run --release --features deltanet -p engine \
+//!         --example test_wmma_residual_gfx12
+
+use rdna_compute::Gpu;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {} ({:.1} GB VRAM)", arch, {
+        let (_, total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+        total as f64 / 1e9
+    });
+
+    if !arch.starts_with("gfx12") {
+        eprintln!(
+            "SKIP: this test requires gfx12 (RDNA4). Current arch: {arch}.\n\
+             The `_w32_gfx12` WMMA builtin does not exist on gfx11."
+        );
+        std::process::exit(0);
+    }
+
+    let mut total_pass = 0;
+    let mut total_fail = 0;
+
+    // Sweep shapes that exercise the four lever points of the kernel:
+    //   - one row-tile, one batch-tile, one K-group (smallest case)
+    //   - multiple K-groups (the K accumulation loop)
+    //   - multiple batch-tiles (the second grid dim)
+    //   - multiple row-tiles (the first grid dim)
+    //   - all dims multi-tile (combined coverage)
+    //   - shape that mirrors a real 9B residual call site (intermediate=12288 → dim=4096)
+    let shapes: &[(usize, usize, usize)] = &[
+        // (M, K, N)
+        (16, 256, 16),       // minimal: 1 row-tile, 1 K-grp, 1 batch-tile
+        (16, 512, 16),       // K=2 groups: exercises K accumulation
+        (16, 256, 32),       // batch=2 tiles
+        (32, 256, 16),       // row=2 tiles
+        (32, 512, 32),       // multi-tile in every dim
+        (64, 1024, 32),      // larger but still tractable
+        (4096, 1024, 16),    // 9B-shape band: exercises real M/N ratio at small K
+    ];
+
+    for &(m, k, n) in shapes {
+        let label = format!("M={m} K={k} N={n}");
+        eprintln!("\n--- {label} ---");
+        match run_one(&mut gpu, m, k, n) {
+            Ok(()) => {
+                total_pass += 1;
+                eprintln!("  {label:50} OK");
+            }
+            Err(e) => {
+                total_fail += 1;
+                eprintln!("  {label:50} FAIL");
+                eprintln!("{e}");
+            }
+        }
+    }
+
+    eprintln!("\n--- Summary ---");
+    eprintln!("  Passed: {total_pass}");
+    eprintln!("  Failed: {total_fail}");
+    if total_fail > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn run_one(gpu: &mut Gpu, m: usize, k: usize, n: usize) -> Result<(), String> {
+    assert_eq!(m % 16, 0);
+    assert_eq!(k % 256, 0, "K must be multiple of 256 (HFQ4G256 group size)");
+    assert_eq!(n % 16, 0, "N must be multiple of 16 (WMMA batch tile)");
+
+    // ── Build synthetic HFQ4G256 weight bytes ──────────────────────────────
+    let a_bytes = build_hfq4g256(m, k, 0xD7);
+    let a = gpu
+        .upload_raw(&a_bytes, &[m, k])
+        .map_err(|e| format!("upload a: {e}"))?;
+
+    // ── X as f32 (the dispatch wrapper converts to fp16 internally) ────────
+    // Distinct values per (batch, k) to surface any row/col-swap mapping bug
+    // similar to the gfx11 6-week silent corruption (commit b7ac66a).
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| {
+            let b = (i / k) as i32;
+            let kk = (i % k) as i32;
+            ((b * 7 + kk * 11) % 31 - 15) as f32 * 0.05
+        })
+        .collect();
+    let x = gpu
+        .upload_f32(&x_f32, &[n, k])
+        .map_err(|e| format!("upload x: {e}"))?;
+
+    // ── Pre-residual Y init (the "skip connection" value Y starts at) ──────
+    // Use a non-zero pattern so the residual `+=` semantics get exercised:
+    // a kernel that overwrites instead of adding would silently match a
+    // zeros pre-init.
+    let y_init: Vec<f32> = (0..(n * m))
+        .map(|i| {
+            let b = (i / m) as i32;
+            let r = (i % m) as i32;
+            ((b * 13 + r * 17) % 23 - 11) as f32 * 0.01
+        })
+        .collect();
+
+    // ── Reference: dot2-fp16 path (current gfx12 production fallback) ──────
+    // upload_f32 allocates + initializes in one shot, so each path gets a
+    // fresh Y seeded with `y_init` (testing residual `+=` semantics).
+    let y_ref = gpu
+        .upload_f32(&y_init, &[n, m])
+        .map_err(|e| format!("upload y_ref init: {e}"))?;
+    gpu.gemm_hfq4g256_residual_fp16(&a, &x, &y_ref, m, k, n)
+        .map_err(|e| format!("dot2-fp16 residual: {e}"))?;
+    let ref_y = gpu
+        .download_f32(&y_ref)
+        .map_err(|e| format!("download y_ref: {e}"))?;
+
+    // ── Candidate: gfx12 WMMA residual ─────────────────────────────────────
+    let y_cand = gpu
+        .upload_f32(&y_init, &[n, m])
+        .map_err(|e| format!("upload y_cand init: {e}"))?;
+    gpu.gemm_hfq4g256_residual_wmma_gfx12(&a, &x, &y_cand, m, k, n)
+        .map_err(|e| format!("wmma_gfx12 residual: {e}"))?;
+    let cand_y = gpu
+        .download_f32(&y_cand)
+        .map_err(|e| format!("download y_cand: {e}"))?;
+
+    gpu.free_tensor(a).ok();
+    gpu.free_tensor(x).ok();
+    gpu.free_tensor(y_ref).ok();
+    gpu.free_tensor(y_cand).ok();
+
+    // ── Compare ────────────────────────────────────────────────────────────
+    // Tolerance: WMMA does fp16×fp16→fp32 fma; dot2 does the same algebra
+    // but with a different operation order. Differences are accumulated
+    // rounding noise. Same band as test_wmma_qkv_gfx12.
+    let mut report = String::new();
+    if compare("Y", n, m, &cand_y, &ref_y, &mut report) {
+        Ok(())
+    } else {
+        Err(report)
+    }
+}
+
+fn compare(name: &str, n: usize, m: usize, cand: &[f32], refr: &[f32], report: &mut String) -> bool {
+    assert_eq!(cand.len(), refr.len());
+    assert_eq!(cand.len(), n * m);
+
+    let mut max_abs = 0f32;
+    let mut max_rel = 0f32;
+    let mut n_bad = 0usize;
+    let mut first_bad: Option<(usize, usize, f32, f32)> = None;
+    let abs_tol = 5e-2_f32;
+    let rel_tol = 1e-2_f32;
+
+    // Per-row-mod-16 and per-batch-mod-16 mismatch histograms. A clustering
+    // in {0..7} or {8..15} on either axis points at a lane-group → output
+    // dimension mapping bug (the QKV port hit one of these during R9700
+    // bring-up — see PR #56 channel-test scaffold).
+    let mut hist_row_mod16 = [0usize; 16];
+    let mut hist_batch_mod16 = [0usize; 16];
+
+    for batch in 0..n {
+        for row in 0..m {
+            // Layout is [N × M] row-major: y[batch, row] = data[batch*M + row]
+            let idx = batch * m + row;
+            let a = cand[idx];
+            let b = refr[idx];
+            let abs = (a - b).abs();
+            let rel = abs / b.abs().max(1e-3);
+            if abs > max_abs {
+                max_abs = abs;
+            }
+            if rel > max_rel {
+                max_rel = rel;
+            }
+            if abs > abs_tol && rel > rel_tol {
+                n_bad += 1;
+                hist_row_mod16[row % 16] += 1;
+                hist_batch_mod16[batch % 16] += 1;
+                if first_bad.is_none() {
+                    first_bad = Some((batch, row, a, b));
+                }
+            }
+        }
+    }
+
+    use std::fmt::Write;
+    let _ = write!(
+        report,
+        "    {name}: max_abs={max_abs:.4e} max_rel={max_rel:.4e} bad={n_bad}/{}",
+        n * m
+    );
+    if n_bad > 0 {
+        let _ = writeln!(report);
+        if let Some((b, r, a, ref_v)) = first_bad {
+            let _ = writeln!(
+                report,
+                "      first mismatch at (batch={b}, row={r}): cand={a:.4} ref={ref_v:.4} diff={:.4e}",
+                a - ref_v
+            );
+        }
+        let _ = writeln!(report, "      mismatches by (row % 16):   {hist_row_mod16:?}");
+        let _ = writeln!(report, "      mismatches by (batch % 16): {hist_batch_mod16:?}");
+        false
+    } else {
+        let _ = writeln!(report);
+        true
+    }
+}
+
+/// Build deterministic HFQ4G256 weight bytes for an [m × k] matrix.
+/// Layout per group (256 elems): 4B f32 scale | 4B f32 zero | 128B nibbles.
+fn build_hfq4g256(m: usize, k: usize, seed: u8) -> Vec<u8> {
+    assert_eq!(k % 256, 0);
+    let groups_per_row = k / 256;
+    let bytes_per_row = groups_per_row * 136;
+    let mut out = vec![0u8; m * bytes_per_row];
+
+    let mix = |x: u64| {
+        let h = x
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((h ^ (h >> 33)).wrapping_mul(0xff51afd7ed558ccd)) ^ (h >> 28)
+    };
+
+    let s0 = seed as u64;
+
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let off = row * bytes_per_row + g * 136;
+
+            let r1 = mix(s0 ^ ((row as u64) << 16) ^ (g as u64));
+            let r2 = mix(s0 ^ ((row as u64) * 7 + g as u64));
+            let scale = 0.01 + (((r1 as u32) % 4001) as f32) * 1e-5;
+            let zero = (((r2 as u32) % 1500) as f32) * 1e-4 - 0.075;
+
+            out[off..off + 4].copy_from_slice(&scale.to_le_bytes());
+            out[off + 4..off + 8].copy_from_slice(&zero.to_le_bytes());
+
+            for byte_i in 0..128 {
+                let r = mix(s0 ^ ((row as u64) << 24) ^ ((g as u64) << 12) ^ (byte_i as u64));
+                out[off + 8 + byte_i] = (r & 0xff) as u8;
+            }
+        }
+    }
+    out
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3537,6 +3537,76 @@ impl Gpu {
         result
     }
 
+    /// gfx12 (RDNA4) sister of `gemm_hfq4g256_residual_wmma` (specifically
+    /// the `_k2` variant — the gfx11 dispatch default for M >= 8192, with
+    /// the validated C-output mapping).
+    ///
+    /// Closes the residual-GEMM gap on 9B prefill: before this kernel,
+    /// gfx12 fell through to the dot2 fp16 fallback for the residual call
+    /// site (attn-out + ffn-down), which accounted for ~42% of 9B prefill
+    /// time on R9700. The other six gfx12 WMMA kernels shipped in PR #62.
+    ///
+    /// Same recipe as the qkv / qkvza / gate_up gfx12 ports: `_w32_gfx12`
+    /// builtin, half8_t operands, K-split via `tid >> 4`, contiguous
+    /// C-row mapping (`acc[j] = C[8*(tid>>4) + j][tid & 15]`). Validated
+    /// on R9700 by the `test_wmma_residual_gfx12` channel-test against
+    /// the dot2 reference path.
+    pub fn gemm_hfq4g256_residual_wmma_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_wmma_gfx12",
+            kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_GFX12_SRC,
+            "gemm_hfq4g256_residual_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_residual_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ4-G256 GEMV with fused residual add: y[row] += A[row] · x.
     /// Same math as `gemv_hfq4g256` but the final write accumulates into `y`
     /// instead of overwriting. Used for wo / w_down projections where the
@@ -4359,6 +4429,13 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            // WMMA on gfx12 (RDNA4): K2-unroll port, validated by
+            // test_wmma_residual_gfx12 against the dot2 fp16 reference.
+            // Closes the 9B-prefill residual gap (was ~42% of GEMM time on
+            // the dot2 fallback below).
+            if has_wmma_f16_gfx12(&self.arch) {
+                return self.gemm_hfq4g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
+            }
             // WMMA on gfx11+ (RDNA3): 16×16 tiled, ~8-10× over scalar
             if self.arch.starts_with("gfx11") {
                 return self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size);

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -192,6 +192,12 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC: &str = include_str!("../../../kern
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K2X32_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_k2x32.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K4_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_k4.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit.hip");
+// gfx12 (RDNA4) sister of GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC. Same recipe
+// as the qkv / qkvza / gate_up gfx12 ports (PR #56): `_w32_gfx12` builtin,
+// half8_t operands, K-split via tid>>4, contiguous C-row mapping. Closes
+// the residual-GEMM gap on 9B prefill (42% of decode-batch GEMM time was
+// stuck on the dot2 fp16 fallback before this).
+pub const GEMM_HFQ4G256_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");

--- a/kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip
@@ -1,0 +1,132 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched HFQ4-G256 GEMM with fused residual add.
+//
+// **gfx12 (RDNA4) variant** — sister of gemm_hfq4g256_residual_wmma_k2.hip
+// (gfx11 / RDNA3). Compile with `hipcc --offload-arch=gfx1200` (or 1201).
+//
+// Differences from the gfx11 K2 kernel — same four levers as the validated
+// gfx12 QKV / QKVZA / gate_up ports (PR #56):
+//   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
+//      (gfx11 uses _w32 without the _gfx12 suffix).
+//   2. A and B operands: half8_t (8 fp16 per lane) instead of half16_t
+//      (16 fp16 per lane). Accumulator C is unchanged at float8_t.
+//   3. K dimension is split across 2 lane-groups (kABKLane=2) instead of
+//      replicated across all 32 lanes (gfx11 kABKLane=1):
+//        lane (tid >> 4) = 0  -> carries K = [0..7]  of the 16-K tile
+//        lane (tid >> 4) = 1  -> carries K = [8..15] of the 16-K tile
+//   4. C-output mapping (rows contiguous, derived from CK kCM0/kCM1PerLane
+//      swap; same pattern as the validated qkv / qkvza / gate_up gfx12 ports):
+//        gfx11: acc[j] = C[2*j + (tid>>4)][tid & 15]   (rows interleaved)
+//        gfx12: acc[j] = C[8*(tid>>4) + j][tid & 15]   (rows contiguous)
+//
+// Reference (ROCm 7.x):
+//   /opt/rocm/include/ck/utility/amd_wmma.hpp
+//   /opt/rocm/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_wmma_impl_base_traits.hpp
+//   .skills/hipfire-arch-port/wmma-matrix.md
+//
+// Source kernel pattern: gemm_hfq4g256_residual_wmma_k2.hip — chosen over
+// the base `_wmma` and `_wmma2` variants which carry known output-mapping
+// bugs (see dispatch.rs comments around `HIPFIRE_WO_WMMA_VARIANT`). The k2
+// variant is the gfx11 dispatch default for M >= 8192 (the shape band where
+// the residual GEMM dominates 9B prefill), so its mapping is exercised
+// continuously by the speed-gate.
+//
+// Grid: [ceil(M/16), ceil(N/16)]. Block: [32]. LDS: 0.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq4g256_residual_wmma_gfx12(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    // Lane decomposition (gfx12 wave32 WMMA):
+    //   m_lane = tid & 15   -> M-row within tile (A) AND N-batch within tile (B)
+    //   k_grp  = tid >> 4   -> selects which K half-tile this lane carries
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int safe_row   = (row_start   + m_lane < M)          ? (row_start   + m_lane) : (M - 1);
+    const int safe_batch = (batch_start + m_lane < batch_size) ? (batch_start + m_lane) : 0;
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 136;
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 136;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg = x_base + g * 256;
+
+        // K2 unroll: 2 K-tiles per loop body (8 iterations cover K=256).
+        for (int kt = 0; kt < 16; kt += 2) {
+            // === Tile A (kt) ===
+            const int k_off_a = kt * 16;
+            // Lane group 0 reads bytes [kt*8, kt*8+4) of the nibble area
+            // (low 8 weights of the 16-K tile); lane group 1 reads bytes
+            // [kt*8+4, kt*8+8) (high 8 weights). Each 4-byte read = 8 nibbles.
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+
+            // === Tile B (kt+1) — start loading early ===
+            const int k_off_b = (kt + 1) * 16;
+            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+
+            // Load both X tiles early (one half8_t per lane, K-offset by k_grp*8)
+            half8_t b_a = *(const half8_t*)(xg + k_off_a + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(xg + k_off_b + k_grp * 8);
+
+            // Dequant tile A (8 fp16 per lane).
+            half8_t a_reg;
+            #define DQ8(pk) \
+                a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+                a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+                a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+                a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+                a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+                a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+                a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+                a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
+            DQ8(pka);
+
+            // WMMA A — b_b load may still be in flight
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+
+            // Dequant tile B (reuse a_reg register).
+            DQ8(pkb);
+            #undef DQ8
+
+            // WMMA B
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+        }
+    }
+
+    // gfx12 wave32 WMMA output mapping (rows contiguous):
+    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
+    // A operand = weight rows (m-dim), B operand = batch X cols (n-dim).
+    // -> C row = 8*k_grp + j (M index), C col = m_lane (N=batch index).
+    // Y is [N × M] row-major: Y[batch][m] = Y[batch*M + m]. Residual semantics
+    // (overwrite-or-accumulate) handled by caller's pre-init of Y.
+    const int out_col = batch_start + m_lane;  // batch index (N)
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;  // M index
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] += acc[j];
+        }
+    }
+}

--- a/tests/speed-baselines/gfx1201.txt
+++ b/tests/speed-baselines/gfx1201.txt
@@ -1,5 +1,5 @@
 # hipfire speed-gate baseline — gfx1201
-# Captured 2026-04-27 against commit fa6b885
+# Captured 2026-04-27 against the gfx12 residual-WMMA wiring (this commit).
 # Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
 # Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
 #
@@ -8,18 +8,25 @@
 #   pp128 — realistic prompt / GEMM-efficiency detector
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
 # GROUND FLOOR — no commit may regress below these numbers.
+#
+# Prefill numbers updated by `dispatch(gfx12 residual): wire WMMA kernel`
+# (this commit). Decode + 0.8B pp32 left at the prior floor: this change
+# only routes batched residual GEMM through WMMA, so decode (GEMV-only)
+# and the 0.8B pp32 launch-overhead band aren't affected by it; the small
+# observed shifts on those metrics are within the cross-process noise
+# band and shouldn't be locked in as a new floor.
 
 0.8b_mq4_pp32_prefill_tok_s=3043.1
 0.8b_mq4_gen_tok_s=288.1
-0.8b_mq4_pp128_prefill_tok_s=5473.4
+0.8b_mq4_pp128_prefill_tok_s=6433.8
 
-4b_mq4_pp32_prefill_tok_s=1084.0
+4b_mq4_pp32_prefill_tok_s=1366.2
 4b_mq4_gen_tok_s=135.1
-4b_mq4_pp128_prefill_tok_s=1486.4
+4b_mq4_pp128_prefill_tok_s=1866.1
 
-9b_mq4_pp32_prefill_tok_s=620.8
+9b_mq4_pp32_prefill_tok_s=805.1
 9b_mq4_gen_tok_s=98.1
-9b_mq4_pp128_prefill_tok_s=782.5
+9b_mq4_pp128_prefill_tok_s=1027.4
 
 
 


### PR DESCRIPTION
# PR: Port `gemm_hfq4g256_residual` to gfx12 WMMA

This PR ports the `gemm_hfq4g256_residual` kernel (attn-out + ffn-down) to the gfx12 WMMA architecture, addressing the last major un-ported bottleneck following PR #62. 

The single un-ported kernel accounted for ~42-45% of prefill execution time in 9B/27B models. Porting this kernel achieves a ~2.1-2.3× speedup per call.

## Changes
- **Kernels**: Added `kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip`. Implements the validated `_wmma_k2` variant used in gfx11, utilizing `half8_t` operands and `_w32_gfx12` builtins with preserved K2 unroll.
- **Testing**: Added `crates/engine/examples/test_wmma_residual_gfx12.rs`. Performs a channel-test against the dot2 fp16 reference across seven shapes, specifically validating residual `+=` semantics by pre-seeding output with non-zero patterns.
- **Dispatch**: Updated `gemm_hfq4g256_residual()` to include a gfx12 dispatch branch, gated by the existing `has_wmma_f16_gfx12` predicate.

## Performance (R9700)
Significant improvements observed in prefill workloads:

| Model | Workload | Master | Branch | Δ |
| :--- | :--- | :--- | :--- | :--- |
| 0.8B | pp128 | 5473 | 6434 | +17.5% |
| 4B | pp32 | 1084 | 1366 | +26.0% |
| 4B | pp128 | 1486 | 1866 | +25.5% |
| 9B | pp32 | 620 | 805 | +29.7% |
| 9B | pp128 | 782 | 1027 | +31.3% |
| 27B | pp32 | 150.6 | 192.4 | +27.8% |
| 27B | pp128 | 218.4 | 310.9 | +42.4% |

*Decode performance remains within ±2% of baseline.*

## Validation
- **test_wmma_residual_gfx12**: 7/7 PASS.
- **coherence-gate.sh**: 0.8B / 4B / 9B coherent.
- **speed-gate.sh**: 9/9 metrics passed; baselines updated.
- **Compatibility**: gfx11 code paths remain unchanged via `gfx12*` predicate prefix-matching.

## Future Work
- Porting `gemm_hfq6g256_residual` to gfx12.
- `gemm_hfq4g256_batched_lmhead` gfx12 wiring.
- Optimization of `gate_up` (Issue #65, levers 1 & 2).

**Issue**: Addresses #65 (9B prefill tuning) via a kernel-port lever.