### PR TITLE
Add opt-in HFQ4 MMQ prefill path

### DIFF
--- a/crates/engine/examples/bench_qwen35_mq4.rs
+++ b/crates/engine/examples/bench_qwen35_mq4.rs
@@ -4,7 +4,7 @@
 //! via an explicit warmup phase, and reports per-token latency stats plus
 //! an effective memory bandwidth estimate (weights_bytes × gen_tok/s).
 //!
-//! Usage: bench_qwen35_mq4 <model.hfq> [--prefill <N>] [--gen <N>] [--warmup <N>]
+//! Usage: bench_qwen35_mq4 <model.hfq> [--prefill <N>] [--prefill-runs <N>] [--gen <N>] [--warmup <N>]
 
 #[cfg(not(feature = "deltanet"))]
 fn main() { eprintln!("build with --features deltanet"); }
@@ -19,19 +19,21 @@ fn main() {
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: bench_qwen35_mq4 <model.hfq> [--prefill N] [--gen N] [--warmup N]");
+        eprintln!("Usage: bench_qwen35_mq4 <model.hfq> [--prefill N] [--prefill-runs N] [--gen N] [--warmup N]");
         std::process::exit(1);
     }
     let model_path = &args[1];
 
     // Defaults: 32-token prefill, 5-token warmup, 100-token bench.
     let mut prefill_len: usize = 32;
+    let mut prefill_runs: usize = 1;
     let mut gen_len: usize = 100;
     let mut warmup_len: usize = 5;
     let mut i = 2;
     while i < args.len() {
         match args[i].as_str() {
             "--prefill" => { prefill_len = args[i + 1].parse().unwrap(); i += 2; }
+            "--prefill-runs" => { prefill_runs = args[i + 1].parse::<usize>().unwrap().max(1); i += 2; }
             "--gen"     => { gen_len     = args[i + 1].parse().unwrap(); i += 2; }
             "--warmup"  => { warmup_len  = args[i + 1].parse().unwrap(); i += 2; }
             other => { eprintln!("unknown arg: {other}"); std::process::exit(1); }
@@ -40,7 +42,7 @@ fn main() {
 
     eprintln!("=== bench_qwen35_mq4 ===");
     eprintln!("Model: {model_path}");
-    eprintln!("Phases: prefill={prefill_len} warmup={warmup_len} gen={gen_len}");
+    eprintln!("Phases: prefill={prefill_len} prefill_runs={prefill_runs} warmup={warmup_len} gen={gen_len}");
 
     let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
@@ -113,34 +115,64 @@ fn main() {
         rdna_compute::profile::start();
     }
     eprintln!("\n=== prefill ({prefill_len} tokens) ===");
-    let t_prefill = Instant::now();
-    qwen35::forward_prefill_batch(
-        &mut gpu, &weights, &config, &prompt_tokens, 0,
-        &mut kv_cache, &mut dn_state, &scratch,
-        None, None, None, None,
-    ).expect("prefill forward failed");
-    gpu.hip.device_synchronize().expect("sync after prefill");
-    let prefill_ms = t_prefill.elapsed().as_secs_f64() * 1000.0;
+    let mut prefill_samples_ms = Vec::with_capacity(prefill_runs);
+    for run in 0..prefill_runs {
+        if run > 0 {
+            dn_state = DeltaNetState::new(&mut gpu, &config).unwrap();
+            kv_cache = match kv_mode.as_str() {
+                "q8" => KvCache::new_gpu_q8(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq).unwrap(),
+                "asym4" | "turbo4" => KvCache::new_gpu_asym4(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq).unwrap(),
+                "asym3" | "turbo3" | "turbo" => KvCache::new_gpu_asym3(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq).unwrap(),
+                "asym2" | "turbo2" => KvCache::new_gpu_asym2(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq).unwrap(),
+                _ => KvCache::new_gpu_q8(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq).unwrap(),
+            };
+        }
+        let t_prefill = Instant::now();
+        qwen35::forward_prefill_batch(
+            &mut gpu, &weights, &config, &prompt_tokens, 0,
+            &mut kv_cache, &mut dn_state, &scratch,
+            None, None, None, None,
+        ).expect("prefill forward failed");
+        gpu.hip.device_synchronize().expect("sync after prefill");
+        let ms = t_prefill.elapsed().as_secs_f64() * 1000.0;
+        prefill_samples_ms.push(ms);
+        if prefill_runs > 1 {
+            eprintln!("  run {:>2}: {:.1}ms  {:.1} tok/s", run + 1, ms, prefill_len as f64 / (ms / 1000.0));
+        }
+    }
+    let prefill_ms = *prefill_samples_ms.last().unwrap();
     if do_profile {
         if let Some(entries) = rdna_compute::profile::stop() {
-            let mut by_kernel: std::collections::HashMap<&str, (f64, usize)> = Default::default();
+            let mut by_kernel: std::collections::HashMap<&str, (f64, usize, usize)> = Default::default();
             for e in &entries {
-                let (time, count) = by_kernel.entry(e.kernel).or_default();
+                let (time, count, bytes) = by_kernel.entry(e.kernel).or_default();
                 *time += e.time_us;
                 *count += 1;
+                *bytes += e.bytes;
             }
             eprintln!("\n=== PROFILE ({} launches, {:.1}ms wall) ===", entries.len(), prefill_ms);
             let mut kerns: Vec<_> = by_kernel.iter().collect();
             kerns.sort_by(|a, b| b.1.0.partial_cmp(&a.1.0).unwrap());
-            let total_us: f64 = kerns.iter().map(|(_, (t, _))| t).sum();
-            for (kern, (us, n)) in &kerns {
-                eprintln!("  {kern:45} {n:5}x  {:.1}ms  ({:.0}µs/call)  {:.1}%",
-                    us / 1000.0, us / *n as f64, us / total_us * 100.0);
+            let total_us: f64 = kerns.iter().map(|(_, (t, _, _))| t).sum();
+            for (kern, (us, n, bytes)) in &kerns {
+                let gib_s = if *us > 0.0 {
+                    (*bytes as f64 / (1024.0 * 1024.0 * 1024.0)) / (*us / 1_000_000.0)
+                } else {
+                    0.0
+                };
+                eprintln!("  {kern:45} {n:5}x  {:.1}ms  ({:.0}µs/call)  {:.1}%  {:.1} GiB/s",
+                    us / 1000.0, us / *n as f64, us / total_us * 100.0, gib_s);
             }
             eprintln!("  {:45} {:5}   {:.1}ms", "TOTAL (serialized)", "", total_us / 1000.0);
         }
     }
     let prefill_tok_s = prefill_len as f64 / (prefill_ms / 1000.0);
+    if prefill_samples_ms.len() > 1 {
+        let mut sorted_prefill = prefill_samples_ms.clone();
+        sorted_prefill.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let median_ms = sorted_prefill[sorted_prefill.len() / 2];
+        eprintln!("  median: {median_ms:.1}ms  {:.1} tok/s", prefill_len as f64 / (median_ms / 1000.0));
+    }
     eprintln!("  total: {prefill_ms:.1}ms");
     eprintln!("  tok/s: {prefill_tok_s:.1}");
     eprintln!("  NOTE: first prefill run includes kernel JIT compile cost");
@@ -200,6 +232,13 @@ fn main() {
     let mut sorted = per_token_ms.clone();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let n = sorted.len();
+    if n == 0 {
+        eprintln!("  total: {gen_total_ms:.1}ms over 0 tokens");
+        eprintln!("  tok/s (gen): 0.0");
+        eprintln!();
+        eprintln!("SUMMARY  gen_tok_s=0.0  bw_gib_s=0.0  prefill_tok_s={prefill_tok_s:.1}  avg_ms=0.00  p50_ms=0.00");
+        return;
+    }
     let sum: f64 = sorted.iter().sum();
     let avg_ms = sum / n as f64;
     let min_ms = sorted[0];

--- a/crates/engine/examples/test_hfq4g256QA.rs
+++ b/crates/engine/examples/test_hfq4g256QA.rs
@@ -85,8 +85,63 @@ fn run() -> Result<String, Outcome> {
     gpu.free_tensor(d_y).map_err(|e| Outcome::Fail(format!("free y failed: {e}")))?;
     gpu.free_tensor(d_out).map_err(|e| Outcome::Fail(format!("free out failed: {e}")))?;
 
+    let mmq_result = if supports_mmq_i8_wmma(&gpu.arch) {
+        let mmq_m = 128usize;
+        let mmq_n = 128usize;
+        let mmq_k = 256usize;
+        let mut mmq_w = vec![0.0f32; mmq_m * mmq_k];
+        for row in 0..mmq_m {
+            for col in 0..mmq_k {
+                mmq_w[row * mmq_k + col] = (row as f32 * 0.007) - 0.5 + (col as f32 * 0.003).sin();
+            }
+        }
+        let mut mmq_x = vec![0.0f32; mmq_n * mmq_k];
+        for n in 0..mmq_n {
+            for col in 0..mmq_k {
+                mmq_x[n * mmq_k + col] = ((n * 17 + col * 13) as f32 * 0.01).sin();
+            }
+        }
+        let mmq_q = quantize_hfq4g256(&mmq_w);
+        let mut mmq_ref = vec![0.0f32; mmq_n * mmq_m];
+        for n in 0..mmq_n {
+            for row in 0..mmq_m {
+                let off = row * 136;
+                let scale = f32::from_le_bytes([mmq_q[off], mmq_q[off + 1], mmq_q[off + 2], mmq_q[off + 3]]);
+                let zero = f32::from_le_bytes([mmq_q[off + 4], mmq_q[off + 5], mmq_q[off + 6], mmq_q[off + 7]]);
+                let mut acc = 0.0f32;
+                for col in 0..mmq_k {
+                    let byte_idx = col / 2;
+                    let nibble = if col % 2 == 0 { mmq_q[off + 8 + byte_idx] & 0xF } else { mmq_q[off + 8 + byte_idx] >> 4 };
+                    acc += (scale * nibble as f32 + zero) * mmq_x[n * mmq_k + col];
+                }
+                mmq_ref[n * mmq_m + row] = acc;
+            }
+        }
+
+        let d_mmq_a = gpu.upload_raw(&mmq_q, &[mmq_q.len()]).map_err(|e| Outcome::Fail(format!("upload mmq A failed: {e}")))?;
+        let d_mmq_x = gpu.upload_f32(&mmq_x, &[mmq_n * mmq_k]).map_err(|e| Outcome::Fail(format!("upload mmq X failed: {e}")))?;
+        let d_mmq_y = gpu.zeros(&[mmq_n * mmq_m], rdna_compute::DType::F32).map_err(|e| Outcome::Fail(format!("alloc mmq Y failed: {e}")))?;
+        gpu.gemm_hfq4g256_residual_mmq(&d_mmq_a, &d_mmq_x, &d_mmq_y, mmq_m, mmq_k, mmq_n)
+            .map_err(|e| Outcome::Fail(format!("gemm_hfq4g256_residual_mmq failed: {e}")))?;
+        let mmq_gpu = gpu.download_f32(&d_mmq_y).map_err(|e| Outcome::Fail(format!("download mmq Y failed: {e}")))?;
+        let max_mmq_err = mmq_gpu.iter().zip(&mmq_ref).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
+        if max_mmq_err > 0.5 {
+            return Err(Outcome::Fail(format!("MMQ residual mismatch too large: {max_mmq_err:.6} gpu0={} ref0={}", mmq_gpu[0], mmq_ref[0])));
+        }
+        gpu.free_tensor(d_mmq_a).map_err(|e| Outcome::Fail(format!("free mmq A failed: {e}")))?;
+        gpu.free_tensor(d_mmq_x).map_err(|e| Outcome::Fail(format!("free mmq X failed: {e}")))?;
+        gpu.free_tensor(d_mmq_y).map_err(|e| Outcome::Fail(format!("free mmq Y failed: {e}")))?;
+        format!("mmq_err={max_mmq_err:.6}")
+    } else {
+        format!("mmq_skipped_arch={}", gpu.arch)
+    };
+
     let max_ref_err = y_cpu_dequant.iter().zip(&y_ref).map(|(a, b)| (a - b).abs()).fold(0.0f32, f32::max);
-    Ok(format!("gpu_cpu_err={max_gpu_cpu_err:.6} quant_ref_err={max_ref_err:.6}"))
+    Ok(format!("gpu_cpu_err={max_gpu_cpu_err:.6} quant_ref_err={max_ref_err:.6} {mmq_result}"))
+}
+
+fn supports_mmq_i8_wmma(arch: &str) -> bool {
+    matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151")
 }
 
 fn quantize_hfq4g256(f32_data: &[f32]) -> Vec<u8> {

--- a/crates/engine/examples/test_inferenceQA.rs
+++ b/crates/engine/examples/test_inferenceQA.rs
@@ -37,6 +37,12 @@ use std::time::{Duration, Instant};
 const SKIP_EXIT: u8 = 10;
 #[cfg(feature = "deltanet")]
 const QWEN_GGUF_FALLBACK: &str = "/home/kaden/llama.cpp/models/Qwen3-0.6B-Q8_0.gguf";
+#[cfg(feature = "deltanet")]
+const PREFILL_MEAN_LOGIT_TOL: f64 = 0.15;
+#[cfg(feature = "deltanet")]
+const PREFILL_ASYM2_MEAN_LOGIT_TOL: f64 = 0.25;
+#[cfg(feature = "deltanet")]
+const PREFILL_SELECTED_LOGIT_TOL: f32 = 1.0;
 
 #[cfg(feature = "deltanet")]
 struct CaseDef {
@@ -53,6 +59,7 @@ const CASES: &[CaseDef] = &[
     CaseDef { name: "chatml_single_tokens", timeout: Duration::from_secs(10) },
     CaseDef { name: "givens4_cache_allocates", timeout: Duration::from_secs(20) },
     CaseDef { name: "givens4_forward_no_hang", timeout: Duration::from_secs(20) },
+    CaseDef { name: "prefill_batch_matches_sequential", timeout: Duration::from_secs(120) },
     CaseDef { name: "decode_speed_sanity", timeout: Duration::from_secs(35) },
     CaseDef { name: "vram_leak_signal", timeout: Duration::from_secs(20) },
 ];
@@ -236,6 +243,7 @@ fn run_case(case_name: &str, model_path: Option<&Path>) -> ExitCode {
             "chatml_single_tokens" => chatml_single_tokens(&mut ctx),
             "givens4_cache_allocates" => givens4_cache_allocates(&mut ctx),
             "givens4_forward_no_hang" => givens4_forward_no_hang(&mut ctx),
+            "prefill_batch_matches_sequential" => prefill_batch_matches_sequential(&mut ctx),
             "decode_speed_sanity" => decode_speed_sanity(&mut ctx),
             "vram_leak_signal" => vram_leak_signal(&mut ctx),
             other => CaseOutcome::Fail(format!("unknown case: {other}")),
@@ -359,6 +367,88 @@ fn ensure(cond: bool, msg: impl Into<String>) -> Result<(), String> {
     } else {
         Err(msg.into())
     }
+}
+
+#[cfg(feature = "deltanet")]
+fn logit_diff_stats(a: &[f32], b: &[f32]) -> (f32, f64) {
+    let mut max_diff = 0.0f32;
+    let mut sum_diff = 0.0f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        let diff = (x - y).abs();
+        max_diff = max_diff.max(diff);
+        sum_diff += diff as f64;
+    }
+    (max_diff, sum_diff / a.len().max(1) as f64)
+}
+
+#[cfg(feature = "deltanet")]
+fn prefill_mean_logit_tol(mode: &str) -> f64 {
+    match mode {
+        // The rotated 2-bit K cache is intentionally the lossiest KV mode.
+        // Keep top-token and selected-logit checks strict, but allow a wider
+        // full-vocab mean drift than q8/asym3/asym4.
+        "asym2" | "turbo2" => PREFILL_ASYM2_MEAN_LOGIT_TOL,
+        _ => PREFILL_MEAN_LOGIT_TOL,
+    }
+}
+
+#[cfg(feature = "deltanet")]
+fn prompt_processing_tokens(ctx: &Context) -> Result<Vec<u32>, String> {
+    let prompt = "\
+Write a Python function that returns the length of the longest substring without repeating characters.
+
+
+Use a sliding window and include a small doctest.";
+    let seed = ctx.tokenizer.encode(prompt);
+    ensure(!seed.is_empty(), "prompt encoded to zero tokens")?;
+
+    let mut tokens = seed.clone();
+    while tokens.len() < 40 {
+        tokens.extend(seed.iter().copied());
+    }
+    tokens.truncate(40);
+    Ok(tokens)
+}
+
+#[cfg(feature = "deltanet")]
+fn kv_cache_for_mode(
+    gpu: &mut rdna_compute::Gpu,
+    config: &qwen35::Qwen35Config,
+    mode: &str,
+    seq_len: usize,
+) -> Result<llama::KvCache, String> {
+    match mode {
+        "q8" => llama::KvCache::new_gpu_q8(
+            gpu,
+            config.n_layers,
+            config.n_kv_heads,
+            config.head_dim,
+            seq_len,
+        ),
+        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4(
+            gpu,
+            config.n_layers,
+            config.n_kv_heads,
+            config.head_dim,
+            seq_len,
+        ),
+        "asym3" | "turbo3" | "turbo" => llama::KvCache::new_gpu_asym3(
+            gpu,
+            config.n_layers,
+            config.n_kv_heads,
+            config.head_dim,
+            seq_len,
+        ),
+        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2(
+            gpu,
+            config.n_layers,
+            config.n_kv_heads,
+            config.head_dim,
+            seq_len,
+        ),
+        other => return Err(format!("unknown KV mode: {other}")),
+    }
+    .map_err(|e| e.to_string())
 }
 
 #[cfg(feature = "deltanet")]
@@ -502,6 +592,104 @@ fn givens4_forward_no_hang(ctx: &mut Context) -> CaseOutcome {
                 .map_err(|e: hip_bridge::HipError| e.to_string())?;
         }
         Ok(format!("{} tokens in {}ms", tokens.len(), t0.elapsed().as_millis()))
+    })() {
+        Ok(msg) => CaseOutcome::Pass(msg),
+        Err(err) => CaseOutcome::Fail(err),
+    }
+}
+
+#[cfg(feature = "deltanet")]
+fn prefill_batch_matches_sequential(ctx: &mut Context) -> CaseOutcome {
+    match (|| -> Result<String, String> {
+        let tokens = prompt_processing_tokens(ctx)?;
+        let lengths = [2usize, 7, 17, 33];
+        let kv_modes = env::var("HIPFIRE_QA_KV_MODES")
+            .unwrap_or_else(|_| "q8,asym4,asym3,asym2".to_string());
+        let kv_modes: Vec<&str> = kv_modes
+            .split(',')
+            .map(str::trim)
+            .filter(|mode| !mode.is_empty())
+            .collect();
+        ensure(!kv_modes.is_empty(), "HIPFIRE_QA_KV_MODES produced zero modes")?;
+        let mut summaries = Vec::new();
+
+        for mode in kv_modes {
+            for &n in &lengths {
+                ensure(n <= tokens.len(), format!("test length {n} exceeds prompt length {}", tokens.len()))?;
+                let kv_seq_len = (n + 8).max(128);
+                let mut kv_seq = kv_cache_for_mode(&mut ctx.gpu, &ctx.config, mode, kv_seq_len)?;
+                let mut kv_batch = kv_cache_for_mode(&mut ctx.gpu, &ctx.config, mode, kv_seq_len)?;
+                let mut dn_seq = DeltaNetState::new(&mut ctx.gpu, &ctx.config)
+                    .map_err(|e: hip_bridge::HipError| e.to_string())?;
+                let mut dn_batch = DeltaNetState::new(&mut ctx.gpu, &ctx.config)
+                    .map_err(|e: hip_bridge::HipError| e.to_string())?;
+                let scratch = qwen35::Qwen35Scratch::new_with_kv_max(&mut ctx.gpu, &ctx.config, 64, kv_seq_len)
+                    .map_err(|e: hip_bridge::HipError| e.to_string())?;
+
+                for (pos, &tok) in tokens[..n].iter().enumerate() {
+                    qwen35::forward_scratch(&mut ctx.gpu, &ctx.weights, &ctx.config, tok, pos, &mut kv_seq, &mut dn_seq, &scratch)
+                        .map_err(|e: hip_bridge::HipError| e.to_string())?;
+                }
+                let seq_logits = ctx.gpu.download_f32(&scratch.logits).map_err(|e| e.to_string())?;
+
+                qwen35::forward_prefill_batch(
+                    &mut ctx.gpu,
+                    &ctx.weights,
+                    &ctx.config,
+                    &tokens[..n],
+                    0,
+                    &mut kv_batch,
+                    &mut dn_batch,
+                    &scratch,
+                    None,
+                    None,
+                    None,
+                    None,
+                ).map_err(|e: hip_bridge::HipError| e.to_string())?;
+                let batch_logits = ctx.gpu.download_f32(&scratch.logits).map_err(|e| e.to_string())?;
+
+                let seq_top = llama::argmax(&seq_logits);
+                let batch_top = llama::argmax(&batch_logits);
+                let (max_diff, mean_diff) = logit_diff_stats(&seq_logits, &batch_logits);
+                let selected_diff = (seq_logits[seq_top as usize] - batch_logits[seq_top as usize]).abs();
+                let mean_tol = prefill_mean_logit_tol(mode);
+                ensure(
+                    seq_top == batch_top,
+                    format!("prefill top token diverged at mode={mode} n={n}: sequential={seq_top} batch={batch_top} max_diff={max_diff:.6} mean_diff={mean_diff:.6} selected_diff={selected_diff:.6}"),
+                )?;
+                ensure(
+                    mean_diff < mean_tol && selected_diff < PREFILL_SELECTED_LOGIT_TOL,
+                    format!("prefill logits drift too high at mode={mode} n={n}: max_diff={max_diff:.6} mean_diff={mean_diff:.6} mean_tol={mean_tol:.3} selected_diff={selected_diff:.6}"),
+                )?;
+
+                let next = seq_top;
+                qwen35::forward_scratch(&mut ctx.gpu, &ctx.weights, &ctx.config, next, n, &mut kv_seq, &mut dn_seq, &scratch)
+                    .map_err(|e: hip_bridge::HipError| e.to_string())?;
+                let seq_next_logits = ctx.gpu.download_f32(&scratch.logits).map_err(|e| e.to_string())?;
+                qwen35::forward_scratch(&mut ctx.gpu, &ctx.weights, &ctx.config, next, n, &mut kv_batch, &mut dn_batch, &scratch)
+                    .map_err(|e: hip_bridge::HipError| e.to_string())?;
+                let batch_next_logits = ctx.gpu.download_f32(&scratch.logits).map_err(|e| e.to_string())?;
+
+                let seq_next_top = llama::argmax(&seq_next_logits);
+                let batch_next_top = llama::argmax(&batch_next_logits);
+                let (next_max_diff, next_mean_diff) = logit_diff_stats(&seq_next_logits, &batch_next_logits);
+                let next_selected_diff = (seq_next_logits[seq_next_top as usize] - batch_next_logits[seq_next_top as usize]).abs();
+                ensure(
+                    seq_next_top == batch_next_top,
+                    format!("post-prefill decode top token diverged at mode={mode} n={n}: sequential={seq_next_top} batch={batch_next_top} max_diff={next_max_diff:.6} mean_diff={next_mean_diff:.6} selected_diff={next_selected_diff:.6}"),
+                )?;
+                ensure(
+                    next_mean_diff < mean_tol && next_selected_diff < PREFILL_SELECTED_LOGIT_TOL,
+                    format!("post-prefill decode logits drift too high at mode={mode} n={n}: max_diff={next_max_diff:.6} mean_diff={next_mean_diff:.6} mean_tol={mean_tol:.3} selected_diff={next_selected_diff:.6}"),
+                )?;
+
+                summaries.push(format!(
+                    "{mode}/n={n} prefill(max={max_diff:.4},mean={mean_diff:.5},sel={selected_diff:.4}) next(max={next_max_diff:.4},mean={next_mean_diff:.5},sel={next_selected_diff:.4})"
+                ));
+            }
+        }
+
+        Ok(summaries.join("; "))
     })() {
         Ok(msg) => CaseOutcome::Pass(msg),
         Err(err) => CaseOutcome::Fail(err),

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -2032,6 +2032,10 @@ pub struct Qwen35Scratch {
     /// can stay in a graph-capturable stream).
     pub moe_topk_indices:  Option<GpuTensor>,   // [k] i32 stored as f32 alias
     pub moe_topk_weights:  Option<GpuTensor>,   // [k] f32
+
+    // Optional long-prefill scratch. Default is None to preserve VRAM
+    // footprint; set HIPFIRE_PREFILL_REUSE_PBS=1 to allocate and reuse it.
+    pub prefill_batch: Option<PrefillBatchScratch>,
 }
 
 impl Qwen35Scratch {
@@ -2118,6 +2122,7 @@ impl Qwen35Scratch {
             moe_rot_batch:     None,
             moe_topk_indices:  None,
             moe_topk_weights:  None,
+            prefill_batch:     None,
         })
         .and_then(|mut s| {
             // Allocate MoE scratch only for MoE configs. Done after the
@@ -2152,6 +2157,14 @@ impl Qwen35Scratch {
                 // error). Idempotent if already computed.
                 gpu.ensure_mq_signs()?;
             }
+            if std::env::var("HIPFIRE_PREFILL_REUSE_PBS").ok().as_deref() == Some("1") {
+                let max_batch = std::env::var("HIPFIRE_PREFILL_MAX_BATCH")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .filter(|&v| v >= 2)
+                    .unwrap_or(PREFILL_MAX_BATCH);
+                s.prefill_batch = Some(PrefillBatchScratch::new(gpu, config, max_batch)?);
+            }
             Ok(s)
         })
     }
@@ -2177,6 +2190,9 @@ impl Qwen35Scratch {
                    self.moe_gate_batch, self.moe_up_batch, self.moe_rot_batch,
                    self.moe_topk_indices, self.moe_topk_weights] {
             if let Some(buf) = t { let _ = gpu.free_tensor(buf); }
+        }
+        if let Some(pbs) = self.prefill_batch {
+            pbs.free_gpu(gpu);
         }
     }
 }
@@ -2609,7 +2625,7 @@ pub fn forward_prefill_batch(
 ) -> HipResult<()> {
     forward_prefill_batch_with_pbs(
         gpu, weights, config, tokens, start_pos, kv_cache, dn_state, scratch,
-        hidden_rb, per_token_hidden_out, gdn_tape, tree_verify, None,
+        hidden_rb, per_token_hidden_out, gdn_tape, tree_verify, scratch.prefill_batch.as_ref(),
     )
 }
 
@@ -2654,7 +2670,11 @@ pub fn forward_prefill_batch_with_pbs(
     //
     // Exposed via PREFILL_MAX_BATCH so callers sizing `HiddenStateRingBuffer`
     // staging can match the chunk upper bound.
-    const MAX_BATCH: usize = PREFILL_MAX_BATCH;
+    let max_batch: usize = std::env::var("HIPFIRE_PREFILL_MAX_BATCH")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&v| v >= MIN_BATCH)
+        .unwrap_or(PREFILL_MAX_BATCH);
 
     let n = tokens.len();
     if n == 0 {
@@ -2770,9 +2790,9 @@ pub fn forward_prefill_batch_with_pbs(
     // is extra work for a case we don't need.
     if tree_verify.is_some() {
         assert!(
-            n <= MAX_BATCH,
-            "tree-verify tokens {} exceeds MAX_BATCH {}; tree budget must fit",
-            n, MAX_BATCH,
+            n <= max_batch,
+            "tree-verify tokens {} exceeds max_batch {}; tree budget must fit",
+            n, max_batch,
         );
     }
 
@@ -2784,19 +2804,12 @@ pub fn forward_prefill_batch_with_pbs(
     // same. The chunk size is `pbs.max_batch` so a caller-owned scratch sized
     // to e.g. `block_size` or `1 + tree_budget` keeps DFlash verify in one
     // chunk without the full 256-row MAX_BATCH footprint.
-    if let Some(p) = pbs_in {
-        debug_assert!(
-            n <= p.max_batch,
-            "caller-owned PrefillBatchScratch max_batch {} < tokens {}",
-            p.max_batch, n,
-        );
-    }
     let mut own_pbs: Option<PrefillBatchScratch> = None;
     let result = (|| -> HipResult<()> {
         let pbs: &PrefillBatchScratch = match pbs_in {
             Some(p) => p,
             None => {
-                own_pbs = Some(PrefillBatchScratch::new(gpu, config, MAX_BATCH)?);
+                own_pbs = Some(PrefillBatchScratch::new(gpu, config, max_batch)?);
                 own_pbs.as_ref().unwrap()
             }
         };

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -98,6 +98,14 @@ fn has_wave64_native(arch: &str) -> bool {
     matches!(arch, "gfx908" | "gfx940" | "gfx941" | "gfx942")
 }
 
+fn has_mmq_i8_wmma(arch: &str) -> bool {
+    matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151")
+}
+
+fn prefer_dot2_hfq4_prefill(arch: &str) -> bool {
+    matches!(arch, "gfx1150" | "gfx1151")
+}
+
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
     pub buf: DeviceBuffer,
@@ -191,6 +199,10 @@ pub struct Gpu {
     /// Pointer to the last FP32 source that was converted to fp16_x_scratch.
     /// If the next GEMM uses the same X, skip the conversion.
     fp16_x_source_ptr: *mut c_void,
+    /// Q8_1/MMQ scratch for prefill activations. Layout matches llama.cpp's
+    /// `block_q8_1_mmq`, ordered by [K/128 block, batch column].
+    q8_1_mmq_x_scratch: Option<hip_bridge::DeviceBuffer>,
+    q8_1_mmq_x_scratch_bytes: usize,
 
     // ── hipGraph capture state ────────────────────────────────────────────
     /// When true, dispatch methods use the blob launch path (graph-capture-safe).
@@ -372,6 +384,8 @@ impl Gpu {
             fp16_x_scratch: None,
             fp16_x_scratch_bytes: 0,
             fp16_x_source_ptr: std::ptr::null_mut(),
+            q8_1_mmq_x_scratch: None,
+            q8_1_mmq_x_scratch_bytes: 0,
             capture_mode: false,
             force_blob_path: std::env::var("HIPFIRE_BLOB_FORCE").ok().as_deref() == Some("1"),
             capture_blobs: Vec::new(),
@@ -887,6 +901,64 @@ impl Gpu {
         }
 
         Ok(self.fp16_x_scratch.as_ref().unwrap().as_ptr())
+    }
+
+    /// Ensure prefill activations are quantized into a llama.cpp-style
+    /// `block_q8_1_mmq` layout. The scratch is ordered by [K/128 block, batch]
+    /// so a 128-column batch tile is contiguous for each K tile.
+    fn ensure_q8_1_mmq_x(&mut self, x: &GpuTensor, batch_size: usize, k: usize) -> HipResult<*mut c_void> {
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mmq",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+            "quantize_q8_1_mmq_ds4",
+        )?;
+
+        let blocks_k = (k + 127) / 128;
+        let block_q8_1_mmq_bytes = 144usize;
+        let needed = blocks_k * batch_size * block_q8_1_mmq_bytes;
+        if self.q8_1_mmq_x_scratch_bytes < needed {
+            self.q8_1_mmq_x_scratch = Some(self.hip.malloc(needed)?);
+            self.q8_1_mmq_x_scratch_bytes = needed;
+        }
+
+        let src_ptr = x.buf.as_ptr();
+        // Unlike the FP16 helper, the same scratch pointer is reused for many
+        // different hidden states during prefill. Pointer equality is therefore
+        // not a safe freshness test. Higher-level fused MMQ callers quantize
+        // once and reuse the returned pointer across sibling projections.
+        let must_convert = true;
+        if must_convert {
+            let out_ptr = self.q8_1_mmq_x_scratch.as_ref().unwrap().as_ptr();
+            let mut xp = src_ptr;
+            let mut yp = out_ptr;
+            let mut k_val = k as i32;
+            let mut n_val = batch_size as i32;
+            let mut params: Vec<*mut c_void> = vec![
+                &mut xp as *mut _ as *mut c_void,
+                &mut yp as *mut _ as *mut c_void,
+                &mut k_val as *mut _ as *mut c_void,
+                &mut n_val as *mut _ as *mut c_void,
+            ];
+            let grid_x = ((k + 1023) / 1024) as u32;
+            let grid_y = batch_size as u32;
+            self.launch_maybe_blob(
+                "quantize_q8_1_mmq_ds4",
+                [grid_x, grid_y, 1],
+                [256, 1, 1],
+                0,
+                &mut params,
+                || {
+                    let mut b = hip_bridge::KernargBlob::new();
+                    b.push_ptr(src_ptr);
+                    b.push_ptr(out_ptr);
+                    b.push_i32(k_val);
+                    b.push_i32(n_val);
+                    b
+                },
+            )?;
+        }
+
+        Ok(self.q8_1_mmq_x_scratch.as_ref().unwrap().as_ptr())
     }
 
     /// Ensure an FP16 shadow of `w_mq4` (HFQ4-G256 format, [M × K]) exists in
@@ -2387,10 +2459,18 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1") && has_mmq_i8_wmma(&self.arch) {
+                let xq = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+                let r1 = self.gemm_hfq4g256_mmq_set_prequant(a_qkv, xq, y_qkv, qkv_m, k, batch_size);
+                let r2 = if r1.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_z, xq, y_z, z_m, k, batch_size) } else { Ok(()) };
+                let r3 = if r2.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_beta, xq, y_beta, beta_m, k, batch_size) } else { Ok(()) };
+                let r4 = if r3.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_alpha, xq, y_alpha, alpha_m, k, batch_size) } else { Ok(()) };
+                return r1.and(r2).and(r3).and(r4);
+            }
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -2613,11 +2693,20 @@ impl Gpu {
         let batch_tiles = { const BATCH_TILE: usize = 8; (batch_size + BATCH_TILE - 1) / BATCH_TILE };
         let total_m = (qkv_m + z_m + beta_m + alpha_m) as u32;
 
-        unsafe {
+        let bytes = crate::profile::gemv_hfq4g256_bytes(qkv_m, k)
+                  + crate::profile::gemv_hfq4g256_bytes(z_m, k)
+                  + crate::profile::gemv_hfq4g256_bytes(beta_m, k)
+                  + crate::profile::gemv_hfq4g256_bytes(alpha_m, k)
+                  + batch_size * k * 2
+                  + batch_size * (qkv_m + z_m + beta_m + alpha_m) * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_hfq4g256_dot2", bytes);
+        let result = unsafe {
             self.hip.launch_kernel(
                 func, [total_m, batch_tiles as u32, 1], [32, 1, 1], 0, self.stream_ref(), &mut params,
             )
-        }
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
     }
 
     /// Batched 3-way fused HFQ4-G256 GEMM for the FA preamble.
@@ -2664,10 +2753,17 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1") && has_mmq_i8_wmma(&self.arch) {
+                let xq = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+                let r1 = self.gemm_hfq4g256_mmq_set_prequant(a_q, xq, y_q, q_m, k, batch_size);
+                let r2 = if r1.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_k, xq, y_k, k_m, k, batch_size) } else { Ok(()) };
+                let r3 = if r2.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_v, xq, y_v, v_m, k, batch_size) } else { Ok(()) };
+                return r1.and(r2).and(r3);
+            }
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -2868,11 +2964,19 @@ impl Gpu {
         let batch_tiles = { const BATCH_TILE: usize = 8; (batch_size + BATCH_TILE - 1) / BATCH_TILE };
         let total_m = (q_m + k_m + v_m) as u32;
 
-        unsafe {
+        let bytes = crate::profile::gemv_hfq4g256_bytes(q_m, k)
+                  + crate::profile::gemv_hfq4g256_bytes(k_m, k)
+                  + crate::profile::gemv_hfq4g256_bytes(v_m, k)
+                  + batch_size * k * 2
+                  + batch_size * (q_m + k_m + v_m) * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfq4g256_dot2", bytes);
+        let result = unsafe {
             self.hip.launch_kernel(
                 func, [total_m, batch_tiles as u32, 1], [32, 1, 1], 0, self.stream_ref(), &mut params,
             )
-        }
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
     }
 
     /// Batched 2-way fused HFQ4-G256 GEMM for the FFN preamble (gate + up).
@@ -2923,12 +3027,18 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1") && has_mmq_i8_wmma(&self.arch) {
+                let xq = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+                let r1 = self.gemm_hfq4g256_mmq_set_prequant(a_gate, xq, y_gate, gate_m, k, batch_size);
+                let r2 = if r1.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_up, xq, y_up, up_m, k, batch_size) } else { Ok(()) };
+                return r1.and(r2);
+            }
             // WMMA on gfx12 (RDNA4)
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_gate_up_hfq4g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // WMMA on gfx11 (RDNA3)
-            if has_wmma_f16(&self.arch) {
+            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
                 return self.gemm_gate_up_hfq4g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -3029,11 +3139,18 @@ impl Gpu {
         let batch_tiles = { const BATCH_TILE: usize = 8; (batch_size + BATCH_TILE - 1) / BATCH_TILE };
         let total_m = (gate_m + up_m) as u32;
 
-        unsafe {
+        let bytes = crate::profile::gemv_hfq4g256_bytes(gate_m, k)
+                  + crate::profile::gemv_hfq4g256_bytes(up_m, k)
+                  + batch_size * k * 2
+                  + batch_size * (gate_m + up_m) * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_hfq4g256_dot2", bytes);
+        let result = unsafe {
             self.hip.launch_kernel(
                 func, [total_m, batch_tiles as u32, 1], [32, 1, 1], 0, self.stream_ref(), &mut params,
             )
-        }
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
     }
 
     /// FP16-packed batched 2-way fused HFQ4-G256 GEMM (gate + up).
@@ -4372,6 +4489,12 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+            if (std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
+                || std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1"))
+                && has_mmq_i8_wmma(&self.arch)
+            {
+                return self.gemm_hfq4g256_residual_mmq(a_raw, x, y, m, k, batch_size);
+            }
             // WMMA on gfx11+ (RDNA3): 16×16 tiled, ~8-10× over scalar
             if self.arch.starts_with("gfx11") {
                 return self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size);
@@ -4490,6 +4613,222 @@ impl Gpu {
         result
     }
 
+    /// Experimental llama.cpp-style MMQ residual GEMM for HFQ4-G256.
+    /// Opt-in only via `HIPFIRE_WO_MMQ=1` while the tiled path is validated.
+    pub fn gemm_hfq4g256_residual_mmq(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+        let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
+            "gemm_hfq4g256_residual_mmq_full_add"
+        } else {
+            "gemm_hfq4g256_residual_mmq"
+        };
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mmq",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+            kernel_name,
+        )?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut xq_ptr = x_q8_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut add_val = 1i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut xq_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+            &mut add_val as *mut _ as *mut c_void,
+        ];
+
+        const MMQ_X: usize = 128;
+        const MMQ_Y: usize = 128;
+        const MMQ_TILE_Y_K: usize = 36;
+        const MMQ_TILE_X_K: usize = 76;
+        let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
+        let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
+        let shared_mem = ((MMQ_X * MMQ_TILE_Y_K + MMQ_Y * MMQ_TILE_X_K) * std::mem::size_of::<i32>()) as u32;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_residual_mmq", bytes);
+        let result = self.launch_maybe_blob(
+            kernel_name,
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 8, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr);
+                b.push_ptr(xq_ptr);
+                b.push_ptr(y_ptr);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b.push_i32(add_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_hfq4g256_mmq_set(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+        let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
+            "gemm_hfq4g256_residual_mmq_full_set"
+        } else {
+            "gemm_hfq4g256_residual_mmq"
+        };
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mmq",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+            kernel_name,
+        )?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut xq_ptr = x_q8_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut add_val = 0i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut xq_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+            &mut add_val as *mut _ as *mut c_void,
+        ];
+
+        const MMQ_X: usize = 128;
+        const MMQ_Y: usize = 128;
+        const MMQ_TILE_Y_K: usize = 36;
+        const MMQ_TILE_X_K: usize = 76;
+        let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
+        let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
+        let shared_mem = ((MMQ_X * MMQ_TILE_Y_K + MMQ_Y * MMQ_TILE_X_K) * std::mem::size_of::<i32>()) as u32;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k
+            + batch_size * m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_mmq_set", bytes);
+        let result = self.launch_maybe_blob(
+            kernel_name,
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 8, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr);
+                b.push_ptr(xq_ptr);
+                b.push_ptr(y_ptr);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b.push_i32(add_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    fn gemm_hfq4g256_mmq_set_prequant(
+        &mut self,
+        a_raw: &GpuTensor,
+        x_q8_ptr: *mut c_void,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
+            "gemm_hfq4g256_residual_mmq_full_set"
+        } else {
+            "gemm_hfq4g256_residual_mmq"
+        };
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mmq",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+            kernel_name,
+        )?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut xq_ptr = x_q8_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut add_val = 0i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut xq_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+            &mut add_val as *mut _ as *mut c_void,
+        ];
+
+        const MMQ_X: usize = 128;
+        const MMQ_Y: usize = 128;
+        const MMQ_TILE_Y_K: usize = 36;
+        const MMQ_TILE_X_K: usize = 76;
+        let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
+        let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
+        let shared_mem = ((MMQ_X * MMQ_TILE_Y_K + MMQ_Y * MMQ_TILE_X_K) * std::mem::size_of::<i32>()) as u32;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_mmq_set", bytes);
+        let result = self.launch_maybe_blob(
+            kernel_name,
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 8, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr);
+                b.push_ptr(xq_ptr);
+                b.push_ptr(y_ptr);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b.push_i32(add_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// WMMA-accelerated batched HFQ4-G256 GEMM with residual add.
     /// gfx1100+ only. 16×16 output tiles via wave32 WMMA.
     /// Converts X to FP16, then uses __builtin_amdgcn_wmma_f32_16x16x16_f16_w32.
@@ -4523,15 +4862,19 @@ impl Gpu {
         // auto selection (applies to every call, both target and draft).
         //   ksplit — K-split + atomicAdd (non-deterministic accum order)
         //   k2     — 2× K-tile pipeline (byte-exact accum order)
-        //   k2x32  — 32-row block with shared X fragment per K-tile; measured
-        //            46% slower than k2 at M=248320 on 7900 XTX (1564µs → 2287µs,
-        //            450→310 GB/s). Likely register pressure / occupancy loss
-        //            from the doubled accumulator + 4× dequant path. Kept opt-in
-        //            for future revisit (needs LDS-staged B share + reg budget).
+        //   k2x32  — 32-row block with shared X fragment per K-tile. Slower
+        //            than k2 on gfx1100, but faster on gfx1151 Strix Halo
+        //            for Qwen3.5 9B prefill (pp2048 q8: 339.7 → 351.3 tok/s).
         //   k4     — 4× K-tile pipeline (output-mapping bug, τ=0 on dflash — debug only)
         //   wmma   — base WMMA         (output-mapping bug — debug only)
         //   wmma2  — 2-wave block, 32 rows × 16 batch (output-mapping bug — debug only)
-        let auto_variant = if m >= 8192 { "k2" } else { "ksplit" };
+        let auto_variant = if matches!(self.arch.as_str(), "gfx1150" | "gfx1151") {
+            "k2x32"
+        } else if m >= 8192 {
+            "k2"
+        } else {
+            "ksplit"
+        };
         let variant_override = std::env::var("HIPFIRE_WO_WMMA_VARIANT").ok();
         let variant = variant_override.as_deref().unwrap_or(auto_variant);
         let (kernel_name, kernel_src, block_size, row_step, k_splits) = match variant {

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -192,6 +192,7 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC: &str = include_str!("../../../kern
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K2X32_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_k2x32.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K4_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_k4.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_MMQ_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mmq.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");
@@ -989,4 +990,3 @@ pub const REPEAT_INTERLEAVE_QK_SRC: &str = include_str!("../../../kernels/src/re
 
 /// Batched repeat-interleave Q and K key heads up to value heads count.
 pub const REPEAT_INTERLEAVE_QK_BATCHED_SRC: &str = include_str!("../../../kernels/src/repeat_interleave_qk_batched.hip");
-

--- a/docs/perf-checkpoints/2026-04-27-mmq-prefill-experiment-report.md
+++ b/docs/perf-checkpoints/2026-04-27-mmq-prefill-experiment-report.md
@@ -1,0 +1,400 @@
+# 2026-04-27 MMQ Prefill Experiment Report
+
+Scope: Qwen3.5 9B, HFQ4/MQ4 target, Q8 KV cache, Strix Halo / gfx1151,
+ROCm 7.2 toolbox `llama-rocm-7.2`.
+
+This report summarizes the prefill investigation that moved hipfire from the
+initial Q8 prefill baseline to a llama.cpp-style MMQ path and then past the
+1000 tok/s target for pp2048.
+
+## Baseline and Target
+
+The reference comparison was llama.cpp on the same Strix Halo machine:
+
+```bash
+llama-bench \
+  -m /home/kotdath/omp/personal/amd-strix-halo-toolboxes/models/Qwen3.5-9B-Q4_K_M.gguf \
+  -ngl 99 -p 2048 -n 1 -r 3 -ctk q8_0 -ctv q8_0 -fa 1
+```
+
+Measured llama.cpp prompt-processing reference:
+
+| Prompt tokens | Prefill tok/s |
+| ---: | ---: |
+| 2048 | 1076.08 +/- 3.87 |
+| 4096 | 1043.52 +/- 7.44 |
+
+Hipfire started far below that when using Q8 KV:
+
+| Stage | pp2048 prefill tok/s |
+| --- | ---: |
+| Original gfx1151 path | ~233 |
+| gfx1151 dot2/k2x32 routing | ~354 |
+| Experimental MMQ baseline | ~813-814 |
+| MMQ full-tile fast path | ~1029-1065 |
+| Full-tile loader/writeback specialization | ~1053-1125 |
+
+## What Was Changed
+
+### 1. gfx1151 prefill routing
+
+The first safe improvement was to avoid the old WMMA prefill GEMM path for
+gfx1150/gfx1151 and route QKV/QKVZA/gate-up to the dot2 path instead. The
+residual GEMM selected the existing `k2x32` WMMA variant only on gfx1150/gfx1151.
+
+Why: direct A/B tests showed the existing WMMA path was slower on Strix Halo,
+while comments in the source indicated `k2x32` was not generally better on
+gfx1100. This kept the change scoped to gfx1150/gfx1151.
+
+Result: pp2048 improved from roughly `233 tok/s` to roughly `354 tok/s`.
+
+### 2. Reusable prefill scratch
+
+`Qwen35Scratch` gained optional reusable `PrefillBatchScratch`, enabled by:
+
+```bash
+HIPFIRE_PREFILL_REUSE_PBS=1
+HIPFIRE_PREFILL_MAX_BATCH=2048
+```
+
+Why: the MMQ experiment needs stable, reusable large-batch buffers so pp2048 can
+run as one batch instead of being split into smaller chunks.
+
+Result: this did not solve the main gap by itself; it made the later MMQ path
+measurable and usable from the existing prefill entry point.
+
+### 3. Experimental HFQ4 MMQ path
+
+An opt-in `HIPFIRE_MMQ=1` path was added for gfx1100/gfx1101/gfx1102/gfx1103
+and gfx1150/gfx1151. It follows the llama.cpp MMQ structure:
+
+- quantize activations into a Q8_1/MMQ layout;
+- use 128 batch columns x 128 output rows per workgroup;
+- stage activations and HFQ4 weights in LDS;
+- use RDNA3/RDNA3.5 i8 WMMA for the dot product;
+- apply HFQ4 scale/zero correction during accumulation.
+
+Why: profiling showed hipfire was GEMM-bound, while llama.cpp uses MMQ for
+quantized prompt processing. Experiments with Q8 activations outside MMQ were
+slow, so the useful part was not "Q8 activations" alone; it was the row/batch
+tiling algorithm.
+
+Result, fresh-process pp2048:
+
+| Run | Prefill tok/s |
+| ---: | ---: |
+| 1 | 813.9 |
+| 2 | 814.1 |
+| 3 | 812.5 |
+
+### 4. Full-tile MMQ fast path
+
+The current best commit is:
+
+```text
+81c588e Add MMQ full-tile prefill fast path
+```
+
+It adds a separate `gemm_hfq4g256_residual_mmq_full` kernel and dispatches to it
+only when both dimensions are exact 128-wide MMQ tiles:
+
+```text
+m % 128 == 0 && batch_size % 128 == 0
+```
+
+All tail shapes remain on the checked generic MMQ kernel.
+
+Why: a temporary global no-check kernel passed the standalone 128x128 QA case
+but caused a GPU memory fault in the real Qwen3.5 forward. That proved tail
+forms exist in production. The final version keeps the optimization only where
+it is mathematically safe.
+
+Result, fresh-process pp2048:
+
+| Run | Prefill ms | Prefill tok/s |
+| ---: | ---: | ---: |
+| 1 | 1989.8 | 1029.2 |
+| 2 | 1974.7 | 1037.1 |
+| 3 | 1923.8 | 1064.6 |
+
+### 5. Full-tile loader and writeback specialization
+
+The follow-up experiment kept the same safety split between full-tile and
+generic-tail kernels, then specialized two remaining pieces inside the full
+path:
+
+- `load_hfq4_tile<true>` removes the row clamp for full tiles;
+- `gemm_hfq4g256_residual_mmq_full_{set,add}` removes the runtime set/add
+  branch in full-tile writeback.
+
+The generic kernel remains checked and is still used for non-128 batch or row
+shapes.
+
+Result, fresh-process pp2048:
+
+| Run | Prefill tok/s |
+| ---: | ---: |
+| 1 | 1073.6 |
+| 2 | 1095.2 |
+| 3 | 1116.9 |
+| 4 | 1125.0 |
+| 5 | 1125.4 |
+| 6 | 1077.0 |
+| 7 | 1053.2 |
+
+Additional shape checks:
+
+| Prompt tokens | Prefill tok/s |
+| ---: | ---: |
+| 4096 | 997.9, 1002.9 |
+| 1937 | 753.5 |
+
+Follow-up `HIPFIRE_PREFILL_MAX_BATCH=4096` checks:
+
+| Prompt tokens | Prefill tok/s |
+| ---: | ---: |
+| 2048 | 1166.3, 1143.6 |
+| 4096 | 1040.9, 1016.8 |
+| 8192 | 727.3 |
+
+One larger-batch check was also run:
+
+| Prompt tokens | `HIPFIRE_PREFILL_MAX_BATCH` | Prefill tok/s |
+| ---: | ---: | ---: |
+| 8192 | 8192 | 715.8 |
+
+The pp2048 result is now at or above the measured llama.cpp reference in most
+fresh-process runs. The pp4096 result reaches the 1000 tok/s target, and the
+larger 4096-token prefill chunk improves the long-prompt result. This remains
+an opt-in setting for now because the larger reusable prefill scratch is a
+poor default for smaller VRAM AMD cards. The pp8192 check suggests 4096 is a
+better current cap than 8192 on this machine.
+
+Profile delta, serialized kernel timers:
+
+| Kernel group | Before full-tile | After full-tile |
+| --- | ---: | ---: |
+| `gemm_hfq4g256_mmq_set` | 1409.1 ms | 936.4 ms |
+| `gemm_hfq4g256_residual_mmq` | 722.6 ms | 445.0 ms |
+| Total serialized | 2629.1 ms | 1898.0 ms |
+
+## Negative Experiments
+
+These were tested and not kept:
+
+- MMQ `set`/`add` split entrypoints: regressed to about `764 tok/s`.
+- `MMQ_X=64`: passed QA but regressed to about `688 tok/s`.
+- `MMQ_Y=64`: broke QA with the current writeback layout.
+- Full HFQ4 prepack into MMQ-ready shadow: correct but slower, about
+  `654-668 tok/s`.
+- Single-thread-per-row metadata fill: correct but slightly slower,
+  about `804 tok/s`.
+- `__launch_bounds__(..., 1)`: regressed to about `755 tok/s`.
+- `HIPFIRE_ROCBLAS_ALL_ARCHS=1` FP16-shadow path on RDNA: about `239 tok/s`.
+- Global no-check MMQ kernel: unsafe; caused a GPU memory fault in real forward.
+- Removing the second-128-block guard from the full kernel regressed pp2048 to
+  about `1072 tok/s`, so that simplification was rejected.
+
+## Correctness and Safety Checks
+
+Checks performed after the full-tile path:
+
+```text
+HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617
+```
+
+After the loader/writeback specialization:
+
+```text
+HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617
+```
+
+Prompt-processing correctness was then added to the inference QA harness as:
+
+```bash
+HIPFIRE_VERIFY_GRAPH=0 HIPFIRE_MMQ=1 \
+  target/release/examples/test_inferenceQA \
+  --model ~/.hipfire/models/qwen3.5-9b.mq4 \
+  --qa-case prefill_batch_matches_sequential
+```
+
+The case compares `forward_prefill_batch` against token-by-token
+`forward_scratch` at lengths 2, 7, 17, and 33. It checks:
+
+- final prefill greedy token matches;
+- final prefill selected-logit drift is below tolerance;
+- one additional decode step from the post-prefill KV/DeltaNet state also
+  matches.
+
+Result with MMQ enabled:
+
+```text
+QA PASS prefill_batch_matches_sequential:
+n=2  prefill(max=0.5607,mean=0.08337,sel=0.1198) next(max=0.2369,mean=0.03658,sel=0.0159)
+n=7  prefill(max=0.2964,mean=0.04197,sel=0.0080) next(max=0.2075,mean=0.03194,sel=0.0160)
+n=17 prefill(max=0.5449,mean=0.08397,sel=0.0264) next(max=0.4400,mean=0.05932,sel=0.0410)
+n=33 prefill(max=0.8963,mean=0.09999,sel=0.0601) next(max=0.8364,mean=0.08171,sel=0.0146)
+```
+
+The same case also passed with:
+
+```text
+HIPFIRE_PREFILL_REUSE_PBS=1 HIPFIRE_PREFILL_MAX_BATCH=2048
+```
+
+Short generation smokes after the same change:
+
+- AR baseline Fibonacci prompt: coherent text, `47.26 tok/s`.
+- DFlash Fibonacci prompt: coherent text, `decode_tau=1.6000`,
+  `decode_tok_s=13.58`.
+
+Tail-shape smoke:
+
+```text
+--prefill 1937: completed without GPU fault, 733.0 tok/s
+```
+
+Short generation smokes:
+
+- AR baseline Fibonacci prompt: coherent text, `43.59 tok/s`.
+- DFlash Fibonacci prompt: coherent text, `decode_tau=1.4615`,
+  `decode_tok_s=12.90`.
+
+Canonical DFlash coherence gate:
+
+```text
+coherence-gate-dflash: 27B models not present, skipping (no hard error)
+report: /tmp/coherence-dflash-20260427-211326.md
+```
+
+This means the mandatory gate was invoked, but it did not run its 27B cases
+because the expected 27B target/draft files were not present locally.
+
+## MR Validation Addendum
+
+After rebasing the final diff onto upstream `603c267`, the MR branch was
+validated again on Strix Halo / gfx1151 in the ROCm 7.2 toolbox.
+
+Build and binary identity:
+
+```text
+cargo build --release --features deltanet --example test_hfq4g256QA --example test_inferenceQA --example bench_qwen35_mq4 -p engine
+
+md5sum target/release/examples/bench_qwen35_mq4
+7505b5121044d70847b826f3d084898d
+```
+
+HFQ4/MMQ channel QA:
+
+```text
+HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617
+```
+
+Prefill and KV-cache correctness QA:
+
+- command was run with `HIPFIRE_PREFILL_REUSE_PBS=1` and
+  `HIPFIRE_PREFILL_MAX_BATCH=2048`;
+- one run used default dispatch (`HIPFIRE_MMQ` unset);
+- one run used the new path (`HIPFIRE_MMQ=1`);
+- each run covered `q8`, `asym4`, `asym3`, and `asym2`;
+- each mode compared batched prefill against sequential forward for
+  `n=2,7,17,33`;
+- for each comparison it checked:
+  - the final prefill top token matches;
+  - selected-logit drift stays below the threshold;
+  - the next decode step after prefill also matches top token and selected-logit
+    tolerance.
+
+Both default and MMQ runs passed. This is a behavioral KV-cache validation: if
+batched prefill wrote K/V slots incorrectly, the immediately following decode
+step would diverge from the sequential reference.
+
+Before/after prefill matrix, same branch with `HIPFIRE_MMQ` unset vs enabled,
+`--prefill-runs 3`, median tok/s:
+
+| KV mode | pp | MMQ off | MMQ on | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| q8 | 256 | 363.1 | 1127.6 | 3.11x |
+| q8 | 512 | 352.0 | 1179.8 | 3.35x |
+| q8 | 1024 | 328.9 | 1222.7 | 3.72x |
+| q8 | 2048 | 318.2 | 1168.5 | 3.67x |
+| asym4 | 256 | 368.6 | 1108.8 | 3.01x |
+| asym4 | 512 | 360.7 | 1173.3 | 3.25x |
+| asym4 | 1024 | 333.9 | 1223.0 | 3.66x |
+| asym4 | 2048 | 312.3 | 1151.7 | 3.69x |
+| asym3 | 256 | 361.4 | 1124.5 | 3.11x |
+| asym3 | 512 | 359.8 | 1187.3 | 3.30x |
+| asym3 | 1024 | 329.9 | 1259.1 | 3.82x |
+| asym3 | 2048 | 314.1 | 1216.5 | 3.87x |
+| asym2 | 256 | 374.0 | 1116.2 | 2.98x |
+| asym2 | 512 | 356.6 | 1173.2 | 3.29x |
+| asym2 | 1024 | 340.1 | 1208.5 | 3.55x |
+| asym2 | 2048 | 311.4 | 1142.9 | 3.67x |
+
+Kernel compile/hash checks:
+
+- `./scripts/write-kernel-hashes.sh` completed.
+- An isolated compile check for the new
+  `gemm_hfq4g256_residual_mmq.hip` source passed for
+  `gfx1010`, `gfx1030`, `gfx1100`, `gfx1200`, and `gfx1201`.
+- The full `./scripts/compile-kernels.sh gfx1010 gfx1030 gfx1100 gfx1200
+  gfx1201` matrix was invoked, but it still fails on pre-existing unrelated
+  kernels in the current upstream matrix (`57 failed`). The new MMQ source no
+  longer blocks non-RDNA3 targets; unsupported targets compile stub entry
+  points and dispatch never selects the MMQ path there.
+
+## How Scientific Is This?
+
+The core causal claim is reasonably supported:
+
+- The comparison used the same machine, same ROCm toolbox, same Q8 KV mode, and
+  the same pp2048 prompt-processing shape.
+- The main result was reproduced in three fresh processes, which matters because
+  same-process measurements showed DPM/thermal drift.
+- Profiling before and after shows the improvement lands exactly in the MMQ GEMM
+  kernels that were changed.
+- Negative controls ruled out several plausible but wrong causes: final logits,
+  KV mode, rocBLAS, plain Q8 activations, graph capture, prepacking, and simple
+  launch-bound tuning.
+- The unsafe global no-check variant was rejected after a real GPU fault, and
+  the kept version is guarded by exact full-tile predicates.
+
+The experiment is not fully publication-grade:
+
+- It uses one Strix Halo system and one main 9B model.
+- The hipfire target is HFQ4/MQ4 while llama.cpp uses Q4_K_M GGUF, so this is a
+  practical systems comparison, not a bit-identical format comparison.
+- The canonical 27B DFlash coherence gate could not run because the 27B files
+  were absent.
+- The prompt-processing command uses synthetic token IDs for hipfire's focused
+  bench, while llama.cpp's `llama-bench` uses its own benchmark harness.
+- The new prompt-processing correctness QA uses a short real tokenizer prompt
+  and validates batched-vs-sequential equivalence, but it is still not a full
+  long-context semantic equivalence proof.
+- No power/clock pinning was enforced; fresh-process medians reduce this risk
+  but do not eliminate it.
+- The latest pp2048 runs range from `1053` to `1125 tok/s`; that is an
+  engineering win, but the spread means it should be reported as a range rather
+  than a single exact number.
+
+Practical conclusion: the result is strong enough for engineering decisions and
+future optimization work, but should be described as an experimentally
+reproduced local Strix Halo result, not as a universal AMD performance claim.
+
+## Current Conclusion
+
+The low hipfire prefill speed was primarily a GEMM algorithm issue. Moving the
+hot HFQ4 prefill projections to a llama.cpp-style MMQ tiled algorithm closed
+most of the gap, and the full-tile fast path brought pp2048 above 1000 tok/s on
+gfx1151. The follow-up full-tile specializations bring pp2048 into the same
+range as the local llama.cpp reference. Using a 4096-token prefill chunk also
+brings pp4096 above 1000 tok/s on this Strix Halo system, while pp8192 still
+drops to roughly 720 tok/s.
+
+Remaining work should focus on:
+
+- reducing MMQ overhead for tail shapes;
+- checking pp4096 and longer contexts after the full-tile path;
+- comparing exact model/format effects more carefully;
+- running the 27B coherence gate once the required files are available;
+- keeping the path opt-in until more AMD targets have been checked.

--- a/docs/perf-checkpoints/2026-04-27-strix-halo-q8-prefill.md
+++ b/docs/perf-checkpoints/2026-04-27-strix-halo-q8-prefill.md
@@ -1,0 +1,388 @@
+# 2026-04-27 Strix Halo Q8 Prefill
+
+Hardware: Radeon 8060S / gfx1151, ROCm 7.2, toolbox `llama-rocm-7.2`.
+
+Models:
+
+- llama.cpp: `/home/kotdath/omp/personal/amd-strix-halo-toolboxes/models/Qwen3.5-9B-Q4_K_M.gguf`
+- hipfire target: `~/.hipfire/models/qwen3.5-9b.mq4`
+- hipfire draft: `~/.hipfire/models/qwen35-9b-dflash-mq4.hfq`
+- hipfire target converted from the Unsloth GGUF:
+  `/home/kotdath/omp/personal/amd-strix-halo-toolboxes/models/qwen3.5-9b-unsloth.hf4`
+
+Binaries:
+
+- `bench_qwen35_mq4`: `7cd9a6b059dc4d05b78ffb504470c680`
+- `dflash_spec_demo`: `8df7bd8dc9d8f716a79fab8f7c95f825`
+- `lru_cache_pep8_strict.txt`: `df5dedc8040ce70ba55080c4548e6024`
+
+## llama.cpp Q8_0 KV
+
+Command pattern:
+
+```bash
+llama-bench -m /home/kotdath/omp/personal/amd-strix-halo-toolboxes/models/Qwen3.5-9B-Q4_K_M.gguf \
+  -ngl 99 -p <N> -n 1 -r 3 -ctk q8_0 -ctv q8_0 -fa 1
+```
+
+`-fa 1` is required for `-ctv q8_0`; without it llama.cpp fails context creation.
+
+| Prompt tokens | Prefill tok/s | Gen tok/s |
+| ---: | ---: | ---: |
+| 2048 | 1076.08 +/- 3.87 | 33.70 +/- 0.42 |
+| 4096 | 1043.52 +/- 7.44 | 33.66 +/- 0.42 |
+
+## hipfire Q8 KV
+
+Command pattern:
+
+```bash
+HIPFIRE_KV_MODE=q8 ./target/release/examples/bench_qwen35_mq4 \
+  ~/.hipfire/models/qwen3.5-9b.mq4 --prefill <N> --prefill-runs 3 --warmup 0 --gen 1
+```
+
+Before the gfx1151 routing change, q8 pp2048 measured `233.0 tok/s` median.
+
+After routing gfx1150/gfx1151 away from WMMA prefill GEMM and onto dot2:
+
+| Prompt tokens | Run tok/s | Median tok/s | Gen tok/s |
+| ---: | --- | ---: | ---: |
+| 2048 | 322.1, 320.5, 323.5 | 322.1 | 42.4 |
+| 4096 | 307.1, 306.3, 302.5 | 306.3 | 38.0 |
+
+After additionally selecting the existing residual `k2x32` WMMA variant on
+gfx1150/gfx1151 only:
+
+| Prompt tokens | Variant | Run tok/s | Median tok/s | Gen tok/s |
+| ---: | --- | --- | ---: | ---: |
+| 2048 | `k2` override | 340.6, 343.0, 337.2, 340.5, 336.7 | 340.5 | 38.0 |
+| 2048 | auto `k2x32` | 360.1, 357.4, 357.4, 356.4, 355.7 | 357.4 | 39.1 |
+
+This is a small but repeatable +5% over the same-binary `k2` baseline.
+
+Re-check after the negative experiments were reverted:
+
+| Prompt tokens | Run tok/s | Median tok/s | Gen tok/s |
+| ---: | --- | ---: | ---: |
+| 2048 | 355.8, 354.2, 354.0 | 354.2 | 42.8 |
+
+Changing `HIPFIRE_PREFILL_MAX_BATCH` did not materially move pp2048:
+
+| Max batch | Prefill tok/s |
+| ---: | ---: |
+| 64 | 361.5 |
+| 128 | 356.3 |
+| 192 | 358.9 |
+| 256 | 357.2 |
+| 384 | 359.0 |
+| 512 | 351.6 |
+| 1024 | 304.5 |
+| 2048 | 306.8 |
+
+The larger 1024/2048-token chunks regress instead of converging toward
+llama.cpp, so the gap is not caused by hipfire's default chunk size being too
+small.
+
+## Model Artifact Check
+
+The Unsloth GGUF was converted into hipfire `hf4` format and benchmarked with
+the same Q8 KV prefill command. The result was `357.8 tok/s` median and `43.5`
+gen tok/s, matching the native hipfire `.mq4` within noise. This rules out the
+final Unsloth/GGUF model artifact as the cause of the 3x prefill gap; the gap
+is in the hipfire execution format/kernels.
+
+## Negative Experiments
+
+These were tested and not kept:
+
+- `HIPFIRE_ROCBLAS_ALL_ARCHS=1 HIPFIRE_ROCBLAS_MIN_BATCH=1`: `106.3 tok/s`
+  prefill, much slower than the custom kernels on gfx1151.
+- `BATCH_TILE=16` for dot2 qkv/qkvza/gate_up: regressed to about `223 tok/s`.
+- `PREFILL_MAX_BATCH=512`: about `352 tok/s`, no useful gain over 256 and
+  higher scratch footprint.
+- `HIPFIRE_GRAPH=1`: about `348 tok/s`, so launch overhead is not the main
+  limiter.
+- `HIPFIRE_WMMA=1`: about `241 tok/s`; the old WMMA prefill path remains worse
+  on gfx1151.
+- 32x2 thread-block grouping for `gemm_gate_up_hfq4g256_dot2`: compiled and ran
+  after fixing launch bounds, but measured about `354 tok/s`, i.e. no useful
+  improvement over the simpler dot2 kernel.
+- `HIPFIRE_WMMA=1` re-check after the residual routing change: about `225 tok/s`;
+  gate/up WMMA alone was roughly 18 ms/call vs about 11 ms/call for dot2.
+- Gate/up WMMA x32, modeled after the residual `k2x32` variant: about
+  `235.5 tok/s`; still much slower than dot2.
+- Gate/up dot2 with `BATCH_TILE=16` only: about `239 tok/s`; more batch rows per
+  workgroup increased register pressure enough to lose badly.
+- Gate/up dot2 multi-wave/LDS weight-sharing experiment: about `264.7 tok/s`;
+  sharing did not compensate for occupancy and scheduling costs.
+- `HIPFIRE_ROCBLAS_ALL_ARCHS=1 HIPFIRE_ROCBLAS_MIN_BATCH=1 ROCBLAS_USE_HIPBLASLT=1`:
+  about `294 tok/s`; RDNA rocBLAS/hipBLASLt was still slower than the custom
+  kernels for this format.
+- Gate/up Q8-activation integer-dot experiment: compiled with `sudot4` on
+  gfx1151 but measured about `309 tok/s`. Simple per-call Q8 activation
+  quantization without MMQ-style row/batch tiling is a regression.
+- Gate/up dot2 `BATCH_TILE=4`: the first apparent `~378 tok/s` result was an
+  invalid host/kernel tile mismatch. The corrected implementation measured
+  about `294 tok/s`, so it was reverted.
+- Gate/up dot2 `__launch_bounds__(32, 16)`: measured `360.8 tok/s` median vs
+  `359.7 tok/s` for the default `__launch_bounds__(32, 8)` in the same A/B
+  session. This is measurement noise, not a useful tuning point.
+- `HIPFIRE_MW16=1` residual path with per-call HFQ4->FP16 dequant: regressed to
+  `~72-108 tok/s`. Dequantizing every prefill call is too expensive.
+- Cached FP16-shadow residual MW16 prototype: reusing dequantized residual
+  weights still measured only `~178 tok/s`, slower than the existing residual
+  `k2x32` WMMA path on gfx1151.
+- Skipping final prefill logits (temporary `HIPFIRE_PREFILL_SKIP_LOGITS=1`) only
+  moved pp2048 to `~363 tok/s`. This matters for apples-to-apples methodology
+  because llama.cpp's `llama-bench` calls `llama_batch_get_one(...)` with
+  `logits=nullptr`, but it does not explain the gap.
+- Gate/up Q8 activation prototype (`HIPFIRE_GATE_UP_Q8X=1`) quantized the
+  activation matrix once per gate/up call and used gfx1151 integer dot
+  instructions, but stayed in hipfire's row-wise work decomposition. It
+  measured `~189.5 tok/s`, much slower than the dot2 baseline. This confirms
+  that the llama.cpp-like win is not "Q8 activations" alone; it requires the
+  MMQ row/batch tiling layout.
+- Extending the existing `HIPFIRE_ROCBLAS_ALL_ARCHS=1` experiment so gate/up
+  also used the FP16-shadow rocBLAS path measured `~348.2 tok/s` with
+  `ROCBLAS_USE_HIPBLASLT=1`, still below the current dot2/k2x32 path. rocBLAS
+  FP16 shadows are not a useful RDNA/Strix Halo bypass for this model.
+- Gate/up via two calls to the existing residual `k2x32` WMMA kernel after
+  zero-filling the output buffers measured `~312.4 tok/s`. The wider residual
+  row tile is not a drop-in replacement for fused gate/up; the extra launches,
+  memset, and separate output traffic outweigh the tiling benefit.
+- Gate/up Q8 activation with a 4-row workgroup tile (`HIPFIRE_GATE_UP_Q8R4=1`)
+  measured `~297.7 tok/s` and was also only approximate math. Reusing a small
+  X tile across four rows was not enough; the quantization overhead and
+  row-wise HFQ4 format still lose to the current dot2 path.
+- Existing decode-style Q4_K kernels are not the missing piece. The
+  `bench_hfq4g128` microbench on gfx1151 measured HFQ4 faster than Q4K for
+  single-vector GEMV shapes, e.g. `4096x4096`: HFQ4 `15.4 us` vs Q4K
+  `32.6 us`, and `12288x4096`: HFQ4 `50.3 us` vs Q4K `97.9 us`. The llama.cpp
+  advantage is the batched MMQ algorithm, not the raw Q4_K format alone.
+
+## DFlash Smoke
+
+Prompt: `benchmarks/prompts/lru_cache_pep8_strict.txt` (`231` tokens), `--ctx 2048 --kv-mode q8 --no-adaptive-b --no-chatml`.
+
+| Mode | Prefill tok/s | Decode tok/s | Notes |
+| --- | ---: | ---: | --- |
+| AR baseline | 358.9 | 47.84 | target-only greedy |
+| DFlash | 359.0 | 92.65 | tau 8.75, accept rate 0.583 |
+
+## Experimental MMQ Port
+
+Commit under test: `c5a28ca` plus local MMQ changes.
+
+Binaries:
+
+- `bench_qwen35_mq4`: `5fcafd6c8719275046caa10e629140c4`
+- `dflash_spec_demo`: `fef1598678742ee1153b12ffd9c7a76a`
+- `test_hfq4g256QA`: `15139ebc102703ebd5ffeb871655d79a`
+
+New opt-in flags:
+
+- `HIPFIRE_MMQ=1`: routes gfx1100/gfx1101/gfx1102/gfx1103/gfx1150/gfx1151
+  HFQ4 prefill GEMMs through an experimental llama.cpp-style MMQ path.
+- `HIPFIRE_PREFILL_REUSE_PBS=1`: allocates a reusable `PrefillBatchScratch`
+  in `Qwen35Scratch`.
+- `HIPFIRE_PREFILL_MAX_BATCH=2048`: lets the regular `forward_prefill_batch`
+  process pp2048 as one chunk instead of eight 256-token chunks.
+
+Command:
+
+```bash
+HIPFIRE_VERIFY_GRAPH=0 HIPFIRE_MMQ=1 \
+HIPFIRE_PREFILL_REUSE_PBS=1 HIPFIRE_PREFILL_MAX_BATCH=2048 \
+target/release/examples/bench_qwen35_mq4 \
+  ~/.hipfire/models/qwen3.5-9b.mq4 \
+  --prefill 2048 --prefill-runs 1 --gen 0 --warmup 0
+```
+
+Fresh-process pp2048 results:
+
+| Run | Prefill ms | Prefill tok/s |
+| ---: | ---: | ---: |
+| 1 | 2516.2 | 813.9 |
+| 2 | 2515.6 | 814.1 |
+| 3 | 2520.6 | 812.5 |
+
+Same-process 5-run result with the same env showed DPM/thermal drift:
+`813.5, 815.0, 797.5, 793.3, 792.4 tok/s`. Per the project playbook,
+fresh-process runs are the fairer number for this bench class.
+
+Kernel QA:
+
+```text
+HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617
+```
+
+Short 9B DFlash sanity with `HIPFIRE_MMQ=1` produced coherent Fibonacci
+text, `decode_tau=3.6522`, `decode_tok_s=24.98`. The canonical
+`coherence-gate-dflash.sh` was invoked with the same MMQ env, but skipped
+because the expected 27B files (`qwen3.5-27b.mq4` and
+`qwen35-27b-dflash.mq4`) were not present in `~/.hipfire/models`.
+
+## MMQ Full-Tile Fast Path
+
+Commit under test: local changes after `d77f1ec`.
+
+Binaries:
+
+- `bench_qwen35_mq4`: `e466040940b12e46c73bf00504294b41`
+- `dflash_spec_demo`: `7f87da798bc93cff8bd3cbb8ddff6351`
+- `test_hfq4g256QA`: `c07383316121d12bc43824db8fea9bee`
+
+The next bottleneck was the generic MMQ kernel's tail handling. A temporary
+no-check kernel proved unsafe globally: it passed the standalone 128x128 QA
+case, but the real Qwen3.5 forward hit smaller/tail MMQ shapes and faulted.
+The kept version therefore adds a separate `gemm_hfq4g256_residual_mmq_full`
+entrypoint and dispatches to it only when both `m` and `batch_size` are exact
+128-wide tiles. All other shapes stay on the checked generic kernel.
+
+Fresh-process pp2048 results with the same command/env as above:
+
+| Run | Prefill ms | Prefill tok/s |
+| ---: | ---: | ---: |
+| 1 | 1989.8 | 1029.2 |
+| 2 | 1974.7 | 1037.1 |
+| 3 | 1923.8 | 1064.6 |
+
+Tail-shape smoke (`--prefill 1937`) completed without a GPU fault and measured
+`733.0 tok/s`, confirming that non-128 batch sizes route through the safe
+generic path.
+
+Profile delta, pp2048, serialized kernel timers:
+
+| Kernel group | Before full-tile | After full-tile |
+| --- | ---: | ---: |
+| `gemm_hfq4g256_mmq_set` | 1409.1 ms | 936.4 ms |
+| `gemm_hfq4g256_residual_mmq` | 722.6 ms | 445.0 ms |
+| Total serialized | 2629.1 ms | 1898.0 ms |
+
+Correctness/smoke:
+
+- `HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617`
+- AR baseline short Fibonacci prompt produced coherent text at `43.59 tok/s`.
+- DFlash short Fibonacci prompt produced coherent text, `decode_tau=1.4615`,
+  `decode_tok_s=12.90`.
+
+Additional negative experiments after the MMQ baseline:
+
+- MMQ `set`/`add` split entrypoints regressed to about `764 tok/s`; the uniform
+  runtime branch was not the limiter.
+- `MMQ_X=64` with adjusted row mapping passed QA but regressed to about
+  `688 tok/s`.
+- `MMQ_Y=64` broke QA with the current writeback layout.
+- Full HFQ4 prepack into an MMQ-ready shadow was correct but slower
+  (`~654-668 tok/s`), likely due the larger global-memory footprint and less
+  favorable cache behavior.
+- Single-thread-per-row metadata fill was correct but slightly slower
+  (`~804 tok/s`), so duplicated metadata loads were not material.
+- `__launch_bounds__(..., 1)` regressed to about `755 tok/s`; keeping two
+  resident blocks is better on gfx1151.
+- `HIPFIRE_ROCBLAS_ALL_ARCHS=1` with FP16 shadows measured only `~239 tok/s`
+  on the second run, so rocBLAS is still not a useful RDNA bypass here.
+
+## MMQ Full-Tile Specialization Follow-Up
+
+Commit under test: local changes after `947eef8`.
+
+Binaries:
+
+- `bench_qwen35_mq4`: `d926b1e1a6cc25cd498eda390f2fbe65`
+- `dflash_spec_demo`: `3840178c5e166c0ec42a2a7ce5e7a744`
+- `test_hfq4g256QA`: `2fec248d246697539f0831ee0854f32d`
+
+Two full-tile-only refinements were added:
+
+- `load_hfq4_tile<true>` removes the row clamp inside the full-tile kernel;
+  the generic kernel still uses `load_hfq4_tile<false>`.
+- `gemm_hfq4g256_residual_mmq_full_{set,add}` specialize the full-tile
+  writeback for set vs residual-add. The checked generic tail kernel remains
+  unchanged.
+
+Fresh-process results:
+
+| Prompt tokens | Run tok/s |
+| ---: | --- |
+| 2048 | 1073.6, 1095.2, 1116.9, 1125.0, 1125.4, 1077.0, 1053.2 |
+| 4096 | 997.9, 1002.9 |
+| 1937 | 753.5 |
+
+The pp2048 runs vary with the same DPM/thermal sensitivity seen earlier, but
+the post-specialization range is consistently around or above the llama.cpp
+pp2048 reference measured earlier in the same investigation (`1076.08 +/- 3.87`
+tok/s). The pp4096 result also reaches the 1000 tok/s target once, but is still
+too close to the threshold to claim a stable win over llama.cpp's
+`1043.52 +/- 7.44` pp4096 reference.
+
+Correctness:
+
+```text
+HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617
+```
+
+Short generation smokes after the same change:
+
+- AR baseline Fibonacci prompt: coherent text, `47.26 tok/s`.
+- DFlash Fibonacci prompt: coherent text, `decode_tau=1.6000`,
+  `decode_tok_s=13.58`.
+
+Additional negative experiment:
+
+- Removing the second-128-block `if` from the full kernel regressed pp2048 to
+  about `1072 tok/s`, so the compiler prefers the guarded version despite the
+  condition being effectively always true for the tested HFQ4 shapes.
+
+## Interpretation
+
+Q8 KV does not explain the prefill gap: llama.cpp stays around 1.0k tok/s with
+Q8_0 KV, while hipfire stays GEMM-bound. Profiling after the gfx1151 routing
+fix shows the remaining prefill time is dominated by 4-bit GEMM:
+
+- `gemm_gate_up_hfq4g256_dot2`: ~49%
+- `gemm_hfq4g256_residual_wmma_k2x32`: ~27%
+- `gemm_qkvza_hfq4g256_dot2`: ~13%
+- `gemm_qkv_hfq4g256_dot2`: ~3.5%
+
+The gap also does not appear to be DPM/power-state driven. During the same
+session, sysfs reported `power_dpm_force_performance_level=auto` and
+`sclk=775Mhz`, but llama.cpp still measured `1069.93 tok/s` for pp2048. That
+keeps the comparison valid: llama.cpp is fast in the same observed state where
+hipfire is about `354-357 tok/s`.
+
+The structural difference is the GEMM algorithm. llama.cpp's HIP/CUDA backend
+routes quantized prompt processing through MMQ: it quantizes the activation
+matrix into a `q8_1` layout and tiles both the batch dimension and the weight
+rows. The experimental hipfire MMQ port confirms this diagnosis: moving the
+hot HFQ4 prefill GEMMs from row-wise dot2/WMMA kernels to 128x128 Q8_1/HFQ4
+MMQ tiling lifts pp2048 from ~354 tok/s to ~813 tok/s on gfx1151.
+
+Two details from llama.cpp matter for a faithful port:
+
+- `tools/llama-bench/llama-bench.cpp::test_prompt` uses
+  `llama_batch_get_one(tokens.data(), n_tokens)`.
+- `src/llama-batch.cpp::llama_batch_get_one` sets `logits = nullptr`, so the
+  prompt-processing number is not dominated by final logits. Hipfire's
+  temporary no-logits test confirmed this is not the main gap.
+
+The MMQ path then routes through `ggml_cuda_mul_mat_q`, first quantizing the
+activation matrix with `quantize_mmq_q8_1_cuda`, then launching
+`mul_mat_q_case<GGML_TYPE_Q4_K>`. For AMD, llama.cpp uses `mmq_y=128`,
+`MMQ_ITER_K=256`, and Q4_K/Q8_1 vector-dot helpers with
+`VDR_Q4_K_Q8_1_MMQ=8`. That design reuses the activation tile across many
+weight rows; the experimental hipfire MMQ path ports that same structural
+idea to HFQ4-G256 storage.
+
+The measured safe improvements before the MMQ port were:
+
+1. Avoid the current WMMA prefill qkv/qkvza/gate_up path on gfx1150/gfx1151 and
+   route those kernels to dot2.
+2. Use residual `k2x32` only on gfx1150/gfx1151, where it is faster than `k2`;
+   keep gfx1100 and other AMD targets on the previous auto path because the
+   source comment records `k2x32` as slower on gfx1100.
+
+The remaining gap to llama.cpp is now much smaller but still visible
+(~813 tok/s vs ~1076 tok/s pp2048). The next work should focus on reducing
+MMQ kernel overhead and closing format-specific gaps versus llama.cpp's Q4_K
+implementation, not KV-cache tuning.

--- a/kernels/src/gemm_hfq4g256_residual_mmq.hip
+++ b/kernels/src/gemm_hfq4g256_residual_mmq.hip
@@ -1,0 +1,504 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+#include <math.h>
+
+// Experimental HFQ4-G256 MMQ residual GEMM for RDNA3/RDNA3.5.
+//
+// This mirrors the important parts of llama.cpp's AMD MMQ path:
+// - pre-quantize the activation matrix into block_q8_1_mmq DS4 layout
+// - process 128 output rows x 128 batch columns per workgroup
+// - stage both HFQ4 weights and Q8_1 activations in LDS
+// - use i8 WMMA for the dot product and apply HFQ4 scale/zero via Q8_1
+//   scale/sum correction.
+
+#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__)
+#define HIPFIRE_RDNA3 1
+#else
+#define HIPFIRE_RDNA3 0
+#endif
+
+#define MMQ_X 128
+#define MMQ_Y 128
+#define MMQ_NWARPS 8
+#define WARP_SIZE 32
+#define QK8_1 32
+#define QI8_1 8
+#define MMQ_TILE_NE_K 32
+#define MMQ_TILE_Y_K 36
+#define MMQ_TILE_X_K 76
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+#if !HIPFIRE_RDNA3
+
+extern "C" __global__ void quantize_q8_1_mmq_ds4(
+    const float*,
+    block_q8_1_mmq*,
+    int,
+    int
+) {}
+
+extern "C" __global__ void gemm_hfq4g256_residual_mmq(
+    const char*,
+    const block_q8_1_mmq*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
+extern "C" __global__ void gemm_hfq4g256_residual_mmq_full_add(
+    const char*,
+    const block_q8_1_mmq*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
+extern "C" __global__ void gemm_hfq4g256_residual_mmq_full_set(
+    const char*,
+    const block_q8_1_mmq*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
+#else
+
+template <int nbytes>
+static __device__ __forceinline__ void memcpy_aligned(void* __restrict__ dst, const void* __restrict__ src) {
+    if constexpr (nbytes == 16) {
+        ((int4*)dst)[0] = ((const int4*)src)[0];
+    } else if constexpr (nbytes == 8) {
+        ((int2*)dst)[0] = ((const int2*)src)[0];
+    } else if constexpr (nbytes == 4) {
+        ((int*)dst)[0] = ((const int*)src)[0];
+    }
+}
+
+enum data_layout {
+    DATA_LAYOUT_I_MAJOR = 0,
+    DATA_LAYOUT_J_MAJOR = 10,
+    DATA_LAYOUT_I_MAJOR_MIRRORED = 20,
+};
+
+template <int I_, int J_, typename T, data_layout dl = DATA_LAYOUT_I_MAJOR>
+struct tile {};
+
+template <int I_, int J_, typename T>
+struct tile<I_, J_, T, DATA_LAYOUT_I_MAJOR> {
+    static constexpr int I = I_;
+    static constexpr int J = J_;
+    static constexpr int ne = I * J / 32;
+    T x[ne] = {0};
+
+    static __device__ __forceinline__ int get_i(const int) {
+        return threadIdx.x % 16;
+    }
+
+    static __device__ __forceinline__ int get_j(const int l) {
+#if HIPFIRE_RDNA3
+        if constexpr (I == 16 && J == 16) {
+            return 2 * l + (threadIdx.x / 16);
+        } else {
+            return l;
+        }
+#else
+        return ne * (threadIdx.x / 16) + l;
+#endif
+    }
+};
+
+template <int I_, int J_, typename T>
+struct tile<I_, J_, T, DATA_LAYOUT_J_MAJOR> {
+    static constexpr int I = I_;
+    static constexpr int J = J_;
+    static constexpr int ne = tile<I_, J_, T, DATA_LAYOUT_I_MAJOR>::ne;
+    T x[ne] = {0};
+
+    static __device__ __forceinline__ int get_i(const int l) {
+        return tile<I_, J_, T, DATA_LAYOUT_I_MAJOR>::get_j(l);
+    }
+
+    static __device__ __forceinline__ int get_j(const int l) {
+        return tile<I_, J_, T, DATA_LAYOUT_I_MAJOR>::get_i(l);
+    }
+};
+
+template <int I_, int J_, typename T>
+struct tile<I_, J_, T, DATA_LAYOUT_I_MAJOR_MIRRORED> {
+    static constexpr int I = I_;
+    static constexpr int J = J_;
+    static constexpr int ne = I * J / 32 * 2;
+    T x[ne] = {0};
+
+    static __device__ __forceinline__ int get_i(const int) {
+        return threadIdx.x % 16;
+    }
+
+    static __device__ __forceinline__ int get_j(const int l) {
+        return l;
+    }
+};
+
+template <typename T, data_layout dl>
+static __device__ __forceinline__ void load_ldmatrix_16x8(tile<16, 8, T, dl>& t, const T* __restrict__ xs0, const int stride) {
+#if HIPFIRE_RDNA3
+    static_assert(dl == DATA_LAYOUT_I_MAJOR_MIRRORED, "bad layout");
+    static_assert(sizeof(t.x) == 32, "bad mirrored tile size");
+    memcpy_aligned<16>(t.x + 0, xs0 + t.get_i(0) * stride + 0);
+    memcpy_aligned<16>(t.x + 4, xs0 + t.get_i(0) * stride + 4);
+#else
+    static_assert(dl == DATA_LAYOUT_I_MAJOR, "bad layout");
+    static_assert(sizeof(t.x) == 16, "bad tile size");
+    memcpy_aligned<16>(t.x, xs0 + t.get_i(0) * stride + t.get_j(0));
+#endif
+}
+
+template <data_layout dl_d, data_layout dl_ab>
+static __device__ __forceinline__ void mma_i8(
+    tile<16, 16, int, dl_d>& D,
+    const tile<16, 8, int, dl_ab>& A,
+    const tile<16, 8, int, dl_ab>& B
+) {
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+    using int32x4_t = __attribute__((__vector_size__(4 * sizeof(int)))) int;
+    int32x8_t* acc = (int32x8_t*)D.x;
+    const int32x4_t* a_vec = (const int32x4_t*)A.x;
+    const int32x4_t* b_vec = (const int32x4_t*)B.x;
+    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a_vec[0], true, b_vec[0], acc[0], true);
+    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a_vec[1], true, b_vec[1], acc[0], true);
+}
+
+extern "C" __global__ void quantize_q8_1_mmq_ds4(
+    const float* __restrict__ X,
+    block_q8_1_mmq* __restrict__ Y,
+    int K,
+    int N
+) {
+    const int token = blockIdx.y;
+    const int i0 = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
+    if (token >= N || i0 >= K) return;
+
+    const float4 xi = (i0 + 3 < K)
+        ? *(const float4*)(X + (long long)token * K + i0)
+        : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    float amax = fmaxf(fmaxf(fabsf(xi.x), fabsf(xi.y)), fmaxf(fabsf(xi.z), fabsf(xi.w)));
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        amax = fmaxf(amax, __shfl_xor(amax, offset, WARP_SIZE));
+    }
+
+    float sum = xi.x + xi.y + xi.z + xi.w;
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        sum += __shfl_xor(sum, offset, WARP_SIZE);
+    }
+
+    const float d = amax > 1.0e-20f ? amax / 127.0f : 0.0f;
+    const float id = d > 0.0f ? 1.0f / d : 0.0f;
+    char4 q;
+    q.x = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.x * id)));
+    q.y = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.y * id)));
+    q.z = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.z * id)));
+    q.w = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.w * id)));
+
+    const int kblock = i0 / 128;
+    const int iqs = i0 & 127;
+    block_q8_1_mmq* out = Y + (long long)kblock * N + token;
+    ((char4*)out->qs)[iqs / 4] = q;
+
+    if ((iqs & 31) == 0) {
+        out->ds4[iqs / 32] = make_half2((_Float16)d, (_Float16)sum);
+    }
+}
+
+template <bool FULL>
+static __device__ __forceinline__ void load_hfq4_tile(
+    const char* __restrict__ A,
+    int* __restrict__ tile_x,
+    int row0,
+    int kb,
+    int M,
+    int groups_per_row
+) {
+    int* x_qs = tile_x;
+    half2* x_dm = (half2*)(x_qs + 2 * MMQ_TILE_NE_K);
+
+    constexpr int threads_per_row = 32;
+    constexpr int rows_per_warp = 1;
+    const int txi = threadIdx.x;
+
+    for (int i0 = 0; i0 < MMQ_Y; i0 += rows_per_warp * MMQ_NWARPS) {
+        const int i = i0 + threadIdx.y;
+        const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+        const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
+        const unsigned int qs0 = *(const unsigned int*)(gp + 8 + txi * 4);
+
+        const unsigned int q0 = (qs0 >>  0) & 0xFu;
+        const unsigned int q1 = (qs0 >>  4) & 0xFu;
+        const unsigned int q2 = (qs0 >>  8) & 0xFu;
+        const unsigned int q3 = (qs0 >> 12) & 0xFu;
+        const unsigned int q4 = (qs0 >> 16) & 0xFu;
+        const unsigned int q5 = (qs0 >> 20) & 0xFu;
+        const unsigned int q6 = (qs0 >> 24) & 0xFu;
+        const unsigned int q7 = (qs0 >> 28) & 0xFu;
+        x_qs[i * MMQ_TILE_X_K + 2 * txi + 0] = q0 | (q1 << 8) | (q2 << 16) | (q3 << 24);
+        x_qs[i * MMQ_TILE_X_K + 2 * txi + 1] = q4 | (q5 << 8) | (q6 << 16) | (q7 << 24);
+    }
+
+    constexpr int rows_per_warp_meta = 16;
+    for (int i0 = 0; i0 < MMQ_Y; i0 += MMQ_NWARPS * rows_per_warp_meta) {
+        const int i = i0 + threadIdx.y * rows_per_warp_meta + threadIdx.x / 2;
+        if (i < MMQ_Y) {
+            const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+            const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
+            const float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+            const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+            const int ksc = threadIdx.x & 1;
+            const half2 dm = make_half2((_Float16)sc, (_Float16)zp);
+            #pragma unroll
+            for (int l = 0; l < 4; ++l) {
+                x_dm[i * MMQ_TILE_X_K + 4 * ksc + l] = dm;
+            }
+        }
+    }
+}
+
+static __device__ __forceinline__ void vec_dot_q8_1_q8_1_mma(
+    const int* __restrict__ x,
+    const int* __restrict__ y,
+    float* __restrict__ sum,
+    int k00
+) {
+    using tile_A = tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED>;
+    using tile_B = tile<16, 8, int, DATA_LAYOUT_I_MAJOR_MIRRORED>;
+    using tile_C = tile<16, 16, int, DATA_LAYOUT_J_MAJOR>;
+
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C::I;
+
+    y += (threadIdx.y % ntx) * (tile_C::J * MMQ_TILE_Y_K);
+
+    const int* x_qs = x;
+    const half2* x_dm = (const half2*)(x_qs + 2 * MMQ_TILE_NE_K);
+    const int* y_qs = y + 4;
+    const half2* y_dm = (const half2*)y;
+
+    const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+
+    for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_1) {
+        const int k0 = k00 + k01;
+        tile_A A_frag[ntx];
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            load_ldmatrix_16x8(A_frag[n], x_qs + (i0 + n * tile_A::I) * MMQ_TILE_X_K + k0, MMQ_TILE_X_K);
+        }
+
+        #pragma unroll
+        for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C::J) {
+            tile_B B_frag;
+            load_ldmatrix_16x8(B_frag, y_qs + j0 * MMQ_TILE_Y_K + k01, MMQ_TILE_Y_K);
+            const int j = j0 + tile_C::get_j(0);
+            const float2 dsB = __half22float2(y_dm[j * MMQ_TILE_Y_K + k01 / QI8_1]);
+
+            #pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+                tile_C C_frag;
+                mma_i8(C_frag, A_frag[n], B_frag);
+
+                #pragma unroll
+                for (int l = 0; l < tile_C::ne; ++l) {
+                    const int i = i0 + n * tile_A::I + tile_C::get_i(l);
+                    const float2 dmA = __half22float2(x_dm[i * MMQ_TILE_X_K + k0 / QI8_1]);
+                    sum[(j0 / tile_C::J + n) * tile_C::ne + l] += dmA.x * dsB.x * (float)C_frag.x[l];
+                    sum[(j0 / tile_C::J + n) * tile_C::ne + l] += dmA.y * dsB.y;
+                }
+            }
+        }
+    }
+}
+
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_mmq(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int add
+) {
+    const int row0 = blockIdx.x * MMQ_Y;
+    const int col0 = blockIdx.y * MMQ_X;
+    if (row0 >= M || col0 >= N) return;
+
+    const int groups_per_row = K / 256;
+    const int blocks128 = K / 128;
+
+    extern __shared__ int smem[];
+    int* tile_y = smem;
+    int* tile_x = tile_y + MMQ_X * MMQ_TILE_Y_K;
+
+    float sum[MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)] = {0.0f};
+
+    for (int kb = 0; kb < groups_per_row; ++kb) {
+        load_hfq4_tile<false>(A, tile_x, row0, kb, M, groups_per_row);
+
+        const int* by0 = (const int*)(Xq + (long long)(2 * kb) * N + col0);
+        for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += MMQ_NWARPS * WARP_SIZE) {
+            const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+            const int j = l / MMQ_TILE_Y_K;
+            tile_y[l] = (col0 + j < N) ? by0[l] : 0;
+        }
+        __syncthreads();
+        vec_dot_q8_1_q8_1_mma(tile_x, tile_y, sum, 0);
+        __syncthreads();
+
+        if (2 * kb + 1 < blocks128) {
+            const int* by1 = (const int*)(Xq + (long long)(2 * kb + 1) * N + col0);
+            for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += MMQ_NWARPS * WARP_SIZE) {
+                const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+                const int j = l / MMQ_TILE_Y_K;
+                tile_y[l] = (col0 + j < N) ? by1[l] : 0;
+            }
+            __syncthreads();
+            vec_dot_q8_1_q8_1_mma(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+        }
+    }
+
+    using tile_C = tile<16, 16, int, DATA_LAYOUT_J_MAJOR>;
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C::I;
+    const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C::J) {
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            #pragma unroll
+            for (int l = 0; l < tile_C::ne; ++l) {
+                const int j = j0 + (threadIdx.y % ntx) * tile_C::J + tile_C::get_j(l);
+                const int i = i0 + n * tile_C::I + tile_C::get_i(l);
+                if (row0 + i < M && col0 + j < N) {
+                    float* yp = Y + (long long)(col0 + j) * M + (row0 + i);
+                    const float v = sum[(j0 / tile_C::J + n) * tile_C::ne + l];
+                    if (add) {
+                        *yp += v;
+                    } else {
+                        *yp = v;
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <bool ADD>
+static __device__ __forceinline__ void gemm_hfq4g256_residual_mmq_full_body(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N
+) {
+    const int row0 = blockIdx.x * MMQ_Y;
+    const int col0 = blockIdx.y * MMQ_X;
+
+    const int groups_per_row = K / 256;
+    const int blocks128 = K / 128;
+
+    extern __shared__ int smem[];
+    int* tile_y = smem;
+    int* tile_x = tile_y + MMQ_X * MMQ_TILE_Y_K;
+
+    float sum[MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)] = {0.0f};
+
+    for (int kb = 0; kb < groups_per_row; ++kb) {
+        load_hfq4_tile<true>(A, tile_x, row0, kb, M, groups_per_row);
+
+        const int* by0 = (const int*)(Xq + (long long)(2 * kb) * N + col0);
+        for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += MMQ_NWARPS * WARP_SIZE) {
+            const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+            tile_y[l] = by0[l];
+        }
+        __syncthreads();
+        vec_dot_q8_1_q8_1_mma(tile_x, tile_y, sum, 0);
+        __syncthreads();
+
+        if (2 * kb + 1 < blocks128) {
+            const int* by1 = (const int*)(Xq + (long long)(2 * kb + 1) * N + col0);
+            for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += MMQ_NWARPS * WARP_SIZE) {
+                const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+                tile_y[l] = by1[l];
+            }
+            __syncthreads();
+            vec_dot_q8_1_q8_1_mma(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+        }
+    }
+
+    using tile_C = tile<16, 16, int, DATA_LAYOUT_J_MAJOR>;
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C::I;
+    const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C::J) {
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            #pragma unroll
+            for (int l = 0; l < tile_C::ne; ++l) {
+                const int j = j0 + (threadIdx.y % ntx) * tile_C::J + tile_C::get_j(l);
+                const int i = i0 + n * tile_C::I + tile_C::get_i(l);
+                float* yp = Y + (long long)(col0 + j) * M + (row0 + i);
+                const float v = sum[(j0 / tile_C::J + n) * tile_C::ne + l];
+                if constexpr (ADD) {
+                    *yp += v;
+                } else {
+                    *yp = v;
+                }
+            }
+        }
+    }
+}
+
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_mmq_full_add(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int
+) {
+    gemm_hfq4g256_residual_mmq_full_body<true>(A, Xq, Y, M, K, N);
+}
+
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_mmq_full_set(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int
+) {
+    gemm_hfq4g256_residual_mmq_full_body<false>(A, Xq, Y, M, K, N);
+}
+
+#endif


### PR DESCRIPTION
## Summary

  Adds an opt-in HFQ4-G256 MMQ prefill path for RDNA3/RDNA3.5, currently gated behind `HIPFIRE_MMQ=1`.

  This targets the Strix Halo / gfx1151 prefill bottleneck seen with Qwen3.5 9B HFQ4/MQ4. The new path pre-quantizes prefill activations into a Q8_1 MMQ layout and uses i8 WMMA over 128x128 output/batch tiles,
  similar in shape to llama.cpp's AMD MMQ prompt-processing path.

  This is intentionally **not enabled by default**. I am not fully confident yet that the algorithm is correct enough to ship broadly, so this PR keeps it experimental and architecture-gated.

  ## Scope

  The fast path is only selected when:

  - `HIPFIRE_MMQ=1`
  - GPU arch is one of:
    - `gfx1100`
    - `gfx1101`
    - `gfx1102`
    - `gfx1103`
    - `gfx1150`
    - `gfx1151`

  Unsupported architectures compile stub entry points for the new kernel, but dispatch does not select the MMQ path there.

  This may be worth experimenting with on other AMD architectures later, but I did not want to silently change behavior outside the RDNA3/RDNA3.5 family in this PR.

  ## Why

  The Strix Halo prefill investigation showed that hipfire was much slower than llama.cpp on prompt processing. The main issue appears to be the HFQ4 prefill GEMM algorithm rather than KV cache mode alone.

  The productive experiment was moving the hot HFQ4 prefill projections toward a llama.cpp-style MMQ shape:

  - Q8_1 activation tiles
  - LDS staging
  - 128 batch columns x 128 output rows per workgroup
  - i8 WMMA accumulation
  - HFQ4 scale/zero correction during accumulation

  Other attempted paths were either neutral or regressions and are not included here.

  ## What Changed

  - Adds `kernels/src/gemm_hfq4g256_residual_mmq.hip`.
  - Adds Q8_1/MMQ activation quantization scratch for prefill.
  - Wires the MMQ path into HFQ4 residual, QKV, QKVZA, and gate/up prefill calls.
  - Keeps the path opt-in via `HIPFIRE_MMQ=1`.
  - Keeps Strix Halo on the existing dot2 HFQ4 prefill path unless MMQ is explicitly enabled.
  - Adds reusable prefill scratch behind:
    - `HIPFIRE_PREFILL_REUSE_PBS=1`
    - `HIPFIRE_PREFILL_MAX_BATCH=<N>`
  - Extends `test_inferenceQA` with stronger batched prefill vs sequential correctness checks across KV cache modes.
  - Adds experiment and validation notes under `docs/perf-checkpoints/`.

  ## Correctness Validation

  The new QA compares batched prefill against sequential token-by-token forward pass.

  It checks:

  - final prefill top token matches;
  - selected-logit drift stays within tolerance;
  - the next decode step after prefill also matches top token and selected-logit tolerance.

  That last check is intended to validate KV cache behavior: if batched prefill writes K/V slots incorrectly, the following decode step should diverge from the sequential reference.

  Validated on Strix Halo `gfx1151`, ROCm 7.2 toolbox, Qwen3.5 9B HFQ4/MQ4:

  ```text
  HIPFIRE_VERIFY_GRAPH=0 HIPFIRE_PREFILL_REUSE_PBS=1 HIPFIRE_PREFILL_MAX_BATCH=2048 \
  target/release/examples/test_inferenceQA \
    --model /home/kotdath/.hipfire/models/qwen3.5-9b.mq4 \
    --qa-case prefill_batch_matches_sequential

  Passed with HIPFIRE_MMQ unset.

  HIPFIRE_VERIFY_GRAPH=0 HIPFIRE_MMQ=1 HIPFIRE_PREFILL_REUSE_PBS=1 HIPFIRE_PREFILL_MAX_BATCH=2048 \
  target/release/examples/test_inferenceQA \
    --model /home/kotdath/.hipfire/models/qwen3.5-9b.mq4 \
    --qa-case prefill_batch_matches_sequential

  Passed with HIPFIRE_MMQ=1.

  Covered KV cache modes:

  - q8
  - asym4
  - asym3
  - asym2

  Covered prompt lengths inside QA:

  - n=2
  - n=7
  - n=17
  - n=33

  ## Performance

  Measured on Strix Halo gfx1151, ROCm 7.2 toolbox, qwen3.5-9b.mq4.

  Settings:

  - HIPFIRE_VERIFY_GRAPH=0
  - HIPFIRE_PREFILL_REUSE_PBS=1
  - HIPFIRE_PREFILL_MAX_BATCH=2048
  - --prefill-runs 3
  - values are median prefill tok/s
  - baseline is the same branch with HIPFIRE_MMQ unset

  | KV mode | pp | MMQ off | MMQ on | Speedup |
  |---|---:|---:|---:|---:|
  | q8 | 256 | 363.1 | 1127.6 | 3.11x |
  | q8 | 512 | 352.0 | 1179.8 | 3.35x |
  | q8 | 1024 | 328.9 | 1222.7 | 3.72x |
  | q8 | 2048 | 318.2 | 1168.5 | 3.67x |
  | asym4 | 256 | 368.6 | 1108.8 | 3.01x |
  | asym4 | 512 | 360.7 | 1173.3 | 3.25x |
  | asym4 | 1024 | 333.9 | 1223.0 | 3.66x |
  | asym4 | 2048 | 312.3 | 1151.7 | 3.69x |
  | asym3 | 256 | 361.4 | 1124.5 | 3.11x |
  | asym3 | 512 | 359.8 | 1187.3 | 3.30x |
  | asym3 | 1024 | 329.9 | 1259.1 | 3.82x |
  | asym3 | 2048 | 314.1 | 1216.5 | 3.87x |
  | asym2 | 256 | 374.0 | 1116.2 | 2.98x |
  | asym2 | 512 | 356.6 | 1173.2 | 3.29x |
  | asym2 | 1024 | 340.1 | 1208.5 | 3.55x |
  | asym2 | 2048 | 311.4 | 1142.9 | 3.67x |

  The gain is consistent across q8/asym KV cache modes. At longer prefill sizes (pp=1024..2048), this moves prefill from roughly 311-340 tok/s to 1143-1259 tok/s.

  A later single pp2048 smoke after the final kernel-source stub change produced:

  prefill_tok_s=1184.5

  ## Additional Checks

  Build:

  cargo build --release --features deltanet \
    --example test_hfq4g256QA \
    --example test_inferenceQA \
    --example bench_qwen35_mq4 \
    -p engine

  HFQ4/MMQ channel QA:

  HFQ4G256 QA PASS: gpu_cpu_err=0.000366 quant_ref_err=0.000000 mmq_err=0.040617

  Binary md5:

  7505b5121044d70847b826f3d084898d  target/release/examples/bench_qwen35_mq4

  Kernel checks:

  ./scripts/write-kernel-hashes.sh

  Completed successfully.

  Isolated compile check for the new kernel passed for:

  - gfx1010
  - gfx1030
  - gfx1100
  - gfx1200
  - gfx1201

  The full kernel matrix was also invoked:

  ./scripts/compile-kernels.sh gfx1010 gfx1030 gfx1100 gfx1200 gfx1201

  It still fails on pre-existing unrelated kernels in current upstream:

  998/1055 compiled, 57 failed

  The new MMQ source no longer blocks non-RDNA3 targets; unsupported targets compile stub entry points and dispatch does not select the MMQ path there.

  ## Caveats

  - This was validated on one Strix Halo / gfx1151 system.
  - The algorithm is experimental and not enabled by default.
  - I am not yet fully confident that this is the final/canonical MMQ implementation.
  - Correctness is validated behaviorally through batched-vs-sequential logits and post-prefill decode parity, not by byte-comparing raw KV buffers.
  - Other AMD architectures may benefit from a similar approach, but this PR intentionally avoids changing their runtime behavior.
  - cargo clippy was not available in my environment.
  - cargo fmt --all --check reports broad pre-existing formatting diffs across the repository, so this PR avoids reformatting unrelated files.
