### PR TITLE
fix: List mq6 models downloaded

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1846,7 +1846,7 @@ function listLocal() {
     let entries: string[];
     try { entries = readdirSync(dir); } catch { continue; }
     for (const f of entries) {
-      if ((f.endsWith(".hf4") || f.endsWith(".hf6") || f.endsWith(".hfq") || f.endsWith(".mq4")) && !seen.has(f)) {
+      if ((f.endsWith(".hf4") || f.endsWith(".hf6") || f.endsWith(".hfq") || f.endsWith(".mq4") || f.endsWith(".mq6")) && !seen.has(f)) {
         seen.add(f);
         // statSync may throw on dangling symlinks or files removed mid-scan;
         // skip those individually instead of aborting the rest of the loop


### PR DESCRIPTION
Currently listing doesn't show the mq6 models downloaded. Here is the fix for it. 

There should also be a nicer way to do this(e.g. List all files, emitting errors when models are unrecognized and also listing those in progress).