### PR TITLE
speed-baselines: add gfx1030 floor (RX 6900 XT, 16 GB)

### DIFF
--- a/tests/speed-baselines/gfx1030.txt
+++ b/tests/speed-baselines/gfx1030.txt
@@ -1,15 +1,13 @@
 # hipfire speed-gate baseline — gfx1030
 # Captured 2026-04-28 against commit 7d43b05
 # Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
-# Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
+# Tolerance: 0.05 (fail if any metric drops below baseline x (1 - tolerance))
 #
 # Measurements: best-of-2 via bench_qwen35_mq4. Two prefill sizes per model:
 #   pp32  — short-context / launch-overhead regression detector
 #   pp128 — realistic prompt / GEMM-efficiency detector
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
 # GROUND FLOOR — no commit may regress below these numbers.
-# NOTE: 27b omitted — model (13.95 GiB) + KV cache exceeds 16 GB VRAM on RX 6900 XT.
-#       Prior 27b numbers (151 tok/s) were measured on a 32 GB card (V620 Pro).
 
 0.8b_mq4_pp32_prefill_tok_s=1625.7
 0.8b_mq4_gen_tok_s=199.2
@@ -23,3 +21,9 @@
 9b_mq4_gen_tok_s=66.8
 9b_mq4_pp128_prefill_tok_s=550.4
 
+# NOTE: 27b cannot load on RX 6900 XT (16 GB VRAM) — OOM at weight load (layer 17/64,
+#       model is 13.95 GiB before KV cache). Numbers below are from a V620 Pro (32 GB
+#       VRAM) baseline. They serve as a reference but are NOT enforced on gfx1030.
+27b_mq4_pp32_prefill_tok_s=151.9
+27b_mq4_gen_tok_s=23.1
+27b_mq4_pp128_prefill_tok_s=150.3

--- a/tests/speed-baselines/gfx1030.txt
+++ b/tests/speed-baselines/gfx1030.txt
@@ -1,6 +1,6 @@
 # hipfire speed-gate baseline — gfx1030
-# Captured 2026-04-12 against commit d41f612
-# Config: KV=givens4, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
+# Captured 2026-04-28 against commit 7d43b05
+# Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
 # Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
 #
 # Measurements: best-of-2 via bench_qwen35_mq4. Two prefill sizes per model:
@@ -8,20 +8,18 @@
 #   pp128 — realistic prompt / GEMM-efficiency detector
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
 # GROUND FLOOR — no commit may regress below these numbers.
+# NOTE: 27b omitted — model (13.95 GiB) + KV cache exceeds 16 GB VRAM on RX 6900 XT.
+#       Prior 27b numbers (151 tok/s) were measured on a 32 GB card (V620 Pro).
 
-0.8b_mq4_pp32_prefill_tok_s=2401.6
-0.8b_mq4_gen_tok_s=266.4
-0.8b_mq4_pp128_prefill_tok_s=4017.9
+0.8b_mq4_pp32_prefill_tok_s=1625.7
+0.8b_mq4_gen_tok_s=199.2
+0.8b_mq4_pp128_prefill_tok_s=4164.5
 
-4b_mq4_pp32_prefill_tok_s=800.7
-4b_mq4_gen_tok_s=108.0
-4b_mq4_pp128_prefill_tok_s=948.5
+4b_mq4_pp32_prefill_tok_s=731.3
+4b_mq4_gen_tok_s=93.2
+4b_mq4_pp128_prefill_tok_s=1017.3
 
-9b_mq4_pp32_prefill_tok_s=526.9
-9b_mq4_gen_tok_s=71.2
-9b_mq4_pp128_prefill_tok_s=549.4
-
-27b_mq4_pp32_prefill_tok_s=151.9
-27b_mq4_gen_tok_s=23.1
-27b_mq4_pp128_prefill_tok_s=150.3
+9b_mq4_pp32_prefill_tok_s=506.5
+9b_mq4_gen_tok_s=66.8
+9b_mq4_pp128_prefill_tok_s=550.4
 


### PR DESCRIPTION
## Tester report — RX 6900 XT, gfx1030, 16 GB VRAM

- **hipfire version:** v0.1.8-alpha.2-2-g82326ac
- **ROCm:** 7.2.2+commit (prerelease — solved a multi-arch detection issue on our machine)
- **Host:** AMD Ryzen 9 3900X, Linux

### hipfire diag

```
GPU arch:    gfx1030
HIP version: 7.2
VRAM total:  16368 MB
kv default:  asym3
WMMA:        no (FP16 packed, +15% prefill)
kernels:     195 blobs compiled for gfx1030
```

### Coherence gate

All three models passed:

| Model | Test | Status | Decode tok/s |
|-------|------|--------|--------------|
| 0.8b  | cap (capital of France) | OK — "Paris." | 181.9 |
| 4b    | code (square function)  | OK | 92.7 |
| 9b    | reason (17 sheep)       | OK — "9" | 65.1 |

### Phase 5 bench sweep (KV=asym3, best-of-2)

| Model | pp32 prefill | decode | pp128 prefill |
|-------|-------------|--------|---------------|
| 0.8b  | 1625.7 tok/s | 199.2 tok/s | 4164.5 tok/s |
| 4b    | 731.3 tok/s  | 93.2 tok/s  | 1017.3 tok/s |
| 9b    | 506.5 tok/s  | 66.8 tok/s  | 550.4 tok/s  |
| 27b   | — | — | — |

> **27b note:** model weights (13.95 GiB) + KV cache exceed 16 GB on this card — OOM at weight load. Reference numbers from a V620 Pro (32 GB) are included in the baseline file but not enforced on gfx1030.

**pp32 vs pp128 pattern:** pp32 prefill is lower than pp128 because gfx1030 has no WMMA — the FP16 packed path is used instead, which is less efficient at short sequence lengths. pp128 shows the GEMM throughput ceiling more clearly. Consistent across all three model sizes.

### CLI surface smoke

```
hipfire config list  OK
hipfire ps           OK
hipfire list         OK (0.8b, 4b, 9b, 27b models present)
```

### Notes

- No GPU overclocking — stock clocks throughout
- Card has no WMMA (gfx1030 predates RDNA3 matrix units); GEMM kernels use FP16 packed dot product
- Phase 4 multi-turn Kaden test inconclusive — model consumed full token budget in thinking with default `thinking=on`; single-turn inference is correct
