### PR TITLE
gfx1151: require ROCm 7.2+ (RDNA 3.5 segfaults on <7.2)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3584,6 +3584,13 @@ switch (cmd) {
         if (diag.type === "diag") {
           console.log(`  GPU arch:    ${diag.arch}`);
           console.log(`  HIP version: ${diag.hip_version}`);
+          if ((diag.arch === "gfx1150" || diag.arch === "gfx1151") && diag.hip_version) {
+            const [maj, min] = diag.hip_version.split(".").map(Number);
+            if (maj < 7 || (maj === 7 && min < 2)) {
+              console.log(`  WARNING: ${diag.arch} requires ROCm 7.2+. Current: ${diag.hip_version}`);
+              console.log(`           ROCm <7.2 segfaults on hipMalloc for RDNA 3.5.`);
+            }
+          }
           console.log(`  VRAM free:   ${diag.vram_free_mb} MB`);
           console.log(`  VRAM total:  ${diag.vram_total_mb} MB`);
 

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -355,6 +355,7 @@ impl Gpu {
         let (hip_major, hip_minor) = hip.runtime_version().unwrap_or((0, 0));
         let (min_major, min_minor) = match arch.as_str() {
             "gfx1200" | "gfx1201" => (6, 4), // RDNA4 needs ROCm 6.4+
+            "gfx1150" | "gfx1151" => (7, 2), // RDNA3.5 (Strix) needs ROCm 7.2+
             "gfx1100" | "gfx1101" | "gfx1102" => (5, 5), // RDNA3 needs ROCm 5.5+
             _ => (5, 0),
         };

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -180,6 +180,7 @@ if $HIP_FOUND; then
         MIN_MAJOR=5; MIN_MINOR=0
         case "$GPU_ARCH" in
             gfx1200|gfx1201) MIN_MAJOR=6; MIN_MINOR=4 ;;
+            gfx1150|gfx1151) MIN_MAJOR=7; MIN_MINOR=2 ;;
             gfx1100|gfx1101) MIN_MAJOR=5; MIN_MINOR=5 ;;
         esac
 


### PR DESCRIPTION
Empirically verified via Docker containers on Strix Halo (gfx1151):
- ROCm 6.4.1: segfault on hipMalloc
- ROCm 7.0.2: segfault on hipMalloc
- ROCm 7.1.0: segfault on hipMalloc
- ROCm 7.2.0: ALL PASS (memtest + vector_add kernel)

Add gfx1150/gfx1151 minimum version (7.2) to:
- scripts/install.sh: version gate case block
- crates/rdna-compute/src/dispatch.rs: runtime version warning
- cli/index.ts: hipfire diag live probe warning