### PR TITLE
fix(gfx1151): restore fp16 WMMA for fused projection prefill — 9B pp3……2 214→421 tok/s

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -102,10 +102,6 @@ fn has_mmq_i8_wmma(arch: &str) -> bool {
     matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151")
 }
 
-fn prefer_dot2_hfq4_prefill(arch: &str) -> bool {
-    matches!(arch, "gfx1150" | "gfx1151")
-}
-
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
     pub buf: DeviceBuffer,
@@ -2470,7 +2466,7 @@ impl Gpu {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
+            if has_wmma_f16(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -2763,7 +2759,7 @@ impl Gpu {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
+            if has_wmma_f16(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -3038,7 +3034,7 @@ impl Gpu {
                 return self.gemm_gate_up_hfq4g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // WMMA on gfx11 (RDNA3)
-            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
+            if has_wmma_f16(&self.arch) {
                 return self.gemm_gate_up_hfq4g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).

--- a/tests/speed-baselines/gfx1151.txt
+++ b/tests/speed-baselines/gfx1151.txt
@@ -1,5 +1,5 @@
 # hipfire speed-gate baseline — gfx1151
-# Captured 2026-04-27 against commit 83358c6
+# Captured 2026-04-28 against commit 42566de
 # Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
 # Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
 #
@@ -10,20 +10,20 @@
 # GROUND FLOOR — no commit may regress below these numbers.
 
 0.8b_mq4_pp32_prefill_tok_s=1553.3
-0.8b_mq4_gen_tok_s=234.6
-0.8b_mq4_pp128_prefill_tok_s=4070.5
+0.8b_mq4_gen_tok_s=235.3
+0.8b_mq4_pp128_prefill_tok_s=4241.3
 
 4b_mq4_pp32_prefill_tok_s=660.1
 4b_mq4_gen_tok_s=69.1
-4b_mq4_pp128_prefill_tok_s=1011.0
+4b_mq4_pp128_prefill_tok_s=1031.3
 
-9b_mq4_pp32_prefill_tok_s=406.1
+9b_mq4_pp32_prefill_tok_s=419.5
 9b_mq4_gen_tok_s=46.0
 9b_mq4_pp128_prefill_tok_s=539.1
 
-27b_mq4_pp32_prefill_tok_s=144.7
+27b_mq4_pp32_prefill_tok_s=147.4
 27b_mq4_gen_tok_s=14.9
-27b_mq4_pp128_prefill_tok_s=156.4
+27b_mq4_pp128_prefill_tok_s=163.1
 
 27b_3.5_dflash_lru_code_tok_s=65.83
 27b_3.5_dflash_lru_code_tau=8.846
@@ -33,4 +33,3 @@
 9b_3.5_dflash_merge_sort_tok_s=245.03
 9b_3.5_dflash_merge_sort_tau=13.1538
 9b_3.5_dflash_merge_sort_ttft_ms=135.08
-


### PR DESCRIPTION


PR #73 (0c7d5f8) introduced `prefer_dot2_hfq4_prefill` which routed gfx1150/gfx1151 fused projection GEMMs (qkvza, qkv, gate_up) to the scalar dot2 fallback (6–8 GiB/s) instead of fp16 WMMA (25–90 GiB/s). The gfx1151 speed baseline was captured before that commit, so it caused a ~50% prefill regression that failed speed-gate.

Fix: `prefer_dot2_hfq4_prefill` now returns false unconditionally, restoring the fp16 WMMA path for all gfx11 arches including gfx1151.

Bisect baseline: 0c7d5f8 (prefer_dot2 introduced)
Candidate: this commit

9B fresh-process A/B on Strix Halo (gfx1151), KV=asym3, GRAPH=1:
  pp32  prefill: 213.7 → 421.1 tok/s (+97%)
  pp128 prefill: 239.3 → 543.9 tok/s (+127%)
  decode:        46.0  → 46.0  tok/s (0%, unchanged)

Binary md5: 25d252cb035db6154c6475e07cefb321
Speed-gate --fast: 2/2 PASSED (4B pp32 −3.2%, decode +0.0%)
Coherence-gate: 3/3 OK
Channel-test: 16/16 OK

Note: the opt-in MMQ path (HIPFIRE_MMQ=1) is faster still at large batch sizes (pp128: 885 tok/s). Auto-enabling MMQ for gfx1151 at batch_size≥64 is a candidate follow-up (separate lever per playbook).