### PR TITLE
perf(gfx1151): auto-enable MMQ (i8 WMMA) prefill at batch_size≥128 — 9B pp128 545→890 tok/s

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -102,10 +102,6 @@ fn has_mmq_i8_wmma(arch: &str) -> bool {
     matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151")
 }
 
-fn prefer_dot2_hfq4_prefill(arch: &str) -> bool {
-    matches!(arch, "gfx1150" | "gfx1151")
-}
-
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
     pub buf: DeviceBuffer,
@@ -2470,7 +2466,7 @@ impl Gpu {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
+            if has_wmma_f16(&self.arch) {
                 return self.gemm_qkvza_hfq4g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -2763,7 +2759,7 @@ impl Gpu {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
+            if has_wmma_f16(&self.arch) {
                 return self.gemm_qkv_hfq4g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -3038,7 +3034,7 @@ impl Gpu {
                 return self.gemm_gate_up_hfq4g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // WMMA on gfx11 (RDNA3)
-            if has_wmma_f16(&self.arch) && !prefer_dot2_hfq4_prefill(&self.arch) {
+            if has_wmma_f16(&self.arch) {
                 return self.gemm_gate_up_hfq4g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -102,6 +102,19 @@ fn has_mmq_i8_wmma(arch: &str) -> bool {
     matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151")
 }
 
+/// Whether to use the MMQ (i8 WMMA) prefill path for this arch + batch size.
+/// HIPFIRE_MMQ=1 forces MMQ at any batch size. HIPFIRE_MMQ=0 disables it.
+/// Otherwise, auto-enable for gfx1150/gfx1151 at batch_size >= 128 where MMQ
+/// consistently outperforms fp16 WMMA (886 vs 543 tok/s on 9B pp128, gfx1151).
+fn use_mmq_prefill(arch: &str, batch_size: usize) -> bool {
+    if !has_mmq_i8_wmma(arch) { return false; }
+    match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
+        Some("1") => true,
+        Some("0") => false,
+        _ => matches!(arch, "gfx1150" | "gfx1151") && batch_size >= 128,
+    }
+}
+
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
     pub buf: DeviceBuffer,
@@ -2455,7 +2468,7 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            if std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1") && has_mmq_i8_wmma(&self.arch) {
+            if use_mmq_prefill(&self.arch, batch_size) {
                 let xq = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
                 let r1 = self.gemm_hfq4g256_mmq_set_prequant(a_qkv, xq, y_qkv, qkv_m, k, batch_size);
                 let r2 = if r1.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_z, xq, y_z, z_m, k, batch_size) } else { Ok(()) };
@@ -2749,7 +2762,7 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            if std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1") && has_mmq_i8_wmma(&self.arch) {
+            if use_mmq_prefill(&self.arch, batch_size) {
                 let xq = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
                 let r1 = self.gemm_hfq4g256_mmq_set_prequant(a_q, xq, y_q, q_m, k, batch_size);
                 let r2 = if r1.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_k, xq, y_k, k_m, k, batch_size) } else { Ok(()) };
@@ -3023,7 +3036,7 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            if std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1") && has_mmq_i8_wmma(&self.arch) {
+            if use_mmq_prefill(&self.arch, batch_size) {
                 let xq = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
                 let r1 = self.gemm_hfq4g256_mmq_set_prequant(a_gate, xq, y_gate, gate_m, k, batch_size);
                 let r2 = if r1.is_ok() { self.gemm_hfq4g256_mmq_set_prequant(a_up, xq, y_up, up_m, k, batch_size) } else { Ok(()) };
@@ -4555,12 +4568,12 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            // Opt-in MMQ path (RDNA3/3.5, HIPFIRE_MMQ=1 or HIPFIRE_WO_MMQ=1).
-            // Q8_1 activation quantize + i8 WMMA. ~+20% on pp≥256, larger on
-            // Strix Halo. Experimental — see PR #73 / issue #60.
-            if (std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
-                || std::env::var("HIPFIRE_MMQ").ok().as_deref() == Some("1"))
-                && has_mmq_i8_wmma(&self.arch)
+            // MMQ path (RDNA3/3.5): Q8_1 activation quantize + i8 WMMA.
+            // Auto-enabled for gfx1150/1151 at batch_size≥128; opt-in elsewhere
+            // via HIPFIRE_MMQ=1 or HIPFIRE_WO_MMQ=1. See PR #73 / issue #60.
+            if use_mmq_prefill(&self.arch, batch_size)
+                || (std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
+                    && has_mmq_i8_wmma(&self.arch))
             {
                 return self.gemm_hfq4g256_residual_mmq(a_raw, x, y, m, k, batch_size);
             }


### PR DESCRIPTION
gfx1150/gfx1151 now automatically use the MMQ (Q8_1 + i8 WMMA) prefill
path when batch_size ≥ 128, where it consistently outperforms fp16 WMMA.
Below 128 the fp16 WMMA path remains active (better at small M due to
Q8_1 quantization overhead).

Crossover data on 9B MQ4, gfx1151 (Strix Halo), KV=asym3:
  pp16:  WMMA=289 MMQ=117  → WMMA wins
  pp32:  WMMA=422 MMQ=224  → WMMA wins
  pp64:  WMMA=516 MMQ=411  → WMMA wins
  pp96:  WMMA=536 MMQ=567  → ~ crossover
  pp128: WMMA=545 MMQ=890  → MMQ +63%
  pp256: WMMA=~   MMQ=1067 → MMQ dominant

Threshold of 128 chosen conservatively (also the MMQ tile size).

Dispatch: all four fused GEMM call sites (qkvza, qkv, gate_up, residual)
now go through use_mmq_prefill(arch, batch_size) which respects:
  HIPFIRE_MMQ=1  → force MMQ at any batch size (unchanged)
  HIPFIRE_MMQ=0  → disable MMQ entirely (new kill-switch)
  default        → auto for gfx1150/1151 at batch≥128, off elsewhere

Fresh-process A/B on gfx1151, 9B pp128:
  HIPFIRE_MMQ=0: 545 tok/s (fp16 WMMA)
  default:       890 tok/s (auto MMQ) — +63%
  decode:        45.2 both  (unchanged)

Binary md5: (rebuilt after touch+clean)
Speed-gate --fast: 2/2 PASSED (4B pp32 −3.2%, decode −0.1%)
Coherence-gate: 3/3 OK
Channel-test: 16/16 OK

also includes commit from #83 