### PR TITLE
fix(cli): SSE heartbeat during prefill — keep stream alive on big-context agent requests (#79, #85)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1298,6 +1298,27 @@ async function serve(port: number) {
           const hasTool = tools.length > 0;
           return new Response(new ReadableStream({
             async start(ctrl) {
+              // Prefill heartbeat: emit an SSE comment every 10s while no
+              // visible body bytes have been sent. The daemon's
+              // `forward_prefill_batch` is one synchronous device call per
+              // chunk and emits no events until the first sampled token, so on
+              // a 27B model with a 10–30K-token agent context (CLAUDE.md /
+              // AGENTS.md / skills / tools) the connection sits silent for 1–5
+              // minutes. OpenCode (#85) and pi-coding-agent (#79) have
+              // sub-minute first-byte/idle timeouts and abort. SSE comment
+              // lines (": …\n\n") are spec-required to be ignored by clients
+              // but keep the TCP connection — and any intermediary timer —
+              // alive. The flag is gated on actually enqueuing a visible
+              // chunk: thinking-block tokens are dropped and tool-mode tokens
+              // are buffered into `accumulated` and only flushed at `done`, so
+              // a "daemon emitted a token" signal does NOT mean the wire saw
+              // bytes — heartbeat must keep firing until the first real
+              // outgoing chunk.
+              let visibleChunkSent = false;
+              const heartbeat = setInterval(() => {
+                if (visibleChunkSent || streamCancelled) return;
+                try { ctrl.enqueue(enc.encode(": prefill\n\n")); } catch {}
+              }, 10_000);
               try {
                 let inThink = false;
                 let stripNextLeadingNl = false;
@@ -1325,8 +1346,11 @@ async function serve(port: number) {
                         id: reqId, object: "chat.completion.chunk", created, model: modelName,
                         choices: [{ index: 0, delta: { content: text }, finish_reason: null }]
                       })}\n\n`));
+                      visibleChunkSent = true;
                     }
                   } else if (msg.type === "done") {
+                    // Every path below enqueues at least the [DONE] sentinel.
+                    visibleChunkSent = true;
                     // When tools are present, parse accumulated text for tool calls
                     if (accumulated !== null) {
                       const parsed = parseToolCalls(accumulated);
@@ -1370,6 +1394,7 @@ async function serve(port: number) {
                     ctrl.close();
                     return;
                   } else if (msg.type === "error") {
+                    visibleChunkSent = true;
                     // Propagate daemon-side errors (e.g. KV-budget rejection on a
                     // giant prompt) to the client instead of masking them as a
                     // normal zero-token "stop" — otherwise clients can't tell a
@@ -1386,6 +1411,7 @@ async function serve(port: number) {
                 // Safety: if loop exits without done/error (shouldn't happen), close stream
                 try { ctrl.close(); } catch {}
               } finally {
+                clearInterval(heartbeat);
                 e.generating = false;
                 safeRelease();
               }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1334,7 +1334,31 @@ async function serve(port: number) {
                         text = text.split("</think>").slice(1).join("</think>");
                         inThink = false;
                         stripNextLeadingNl = true;
-                      } else { continue; }
+                      } else {
+                        // Stream thinking-phase tokens as `reasoning_content`
+                        // (OpenAI-compatible field, also adopted by DeepSeek and
+                        // pi-coding-agent). Two reasons to do this even though
+                        // the visible-content stripper still removes
+                        // `<think>...</think>` from the assistant message:
+                        //   1) the wire stays alive — without this, a
+                        //      thinking-heavy turn (Qwen3.5/3.6 routinely 2–8K
+                        //      thinking tokens before answering) leaves the
+                        //      content stream silent for minutes, recreating
+                        //      the same idle-timeout failure mode the prefill
+                        //      heartbeat was added to fix (#79 / #85);
+                        //   2) clients that render reasoning UI (pi, OpenCode
+                        //      with reasoning visible) get a live thinking
+                        //      view rather than nothing.
+                        // Patch contributed by @mikiadev in #79.
+                        if (text) {
+                          ctrl.enqueue(enc.encode(`data: ${JSON.stringify({
+                            id: reqId, object: "chat.completion.chunk", created, model: modelName,
+                            choices: [{ index: 0, delta: { reasoning_content: text }, finish_reason: null }]
+                          })}\n\n`));
+                          visibleChunkSent = true;
+                        }
+                        continue;
+                      }
                     }
                     text = text.replace(/<\|im_end\|>/g, "");
                     if (!text) continue;


### PR DESCRIPTION
## Summary

Two community reports (#85 OpenCode, #79 pi-coding-agent) of "model loads, memory full, then API silence" on agentic clients with large project context. Both daemons remain CPU-active during the silence — it's prefill work, not a deadlock.

The streaming `/v1/chat/completions` handler emits zero body bytes between the request and the first sampled token. With a 27B model and 10–30K tokens of agent context (CLAUDE.md / AGENTS.md / skills / tools registry) prefill is 1–5 minutes; OpenCode and pi both abort on sub-minute first-byte / idle timeouts.

## Fix

SSE comment line (`: prefill\n\n`) every 10 s while no visible body chunk has been enqueued. Spec-required to be ignored by clients but keeps TCP and any intermediary timer warm. Cleared via `clearInterval` in `finally` on done / error / cancel / exception.

Subtlety the first cut got wrong (caught at stop-time review): "daemon emitted a token" is **not** the right gate — `<think>...</think>` tokens are dropped, and tool-mode tokens are buffered into `accumulated` and only flushed at `done`. Heartbeat is gated on actually enqueuing a visible chunk to the wire, so thinking-only and tool-buffered streams keep the keep-alive going until they actually write to the client.

## Limits

Only the streaming path. Non-streaming requests still hit client response-timeout on big contexts; the structural fix there is a daemon `prefill_progress` event between eviction chunks — bigger change, separate cut.

## Test plan

- [x] `bun build --target=bun --no-bundle cli/index.ts` clean
- [ ] Local: `hipfire serve` + curl with `stream:true` and a big system prompt — verify `: prefill` lines appear every 10s during prefill, stop on first `data:` chunk
- [ ] Coherence-gate (no impact expected — streaming path only changes wire keepalive)
- [ ] Repro the OpenCode case with a long system prompt — confirm client no longer aborts during prefill

🤖 Generated with [Claude Code](https://claude.com/claude-code)