### PR TITLE
fix(gfx1151): avoid k2x32 for DFlash verify batches

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -4953,12 +4953,17 @@ impl Gpu {
         //   ksplit — K-split + atomicAdd (non-deterministic accum order)
         //   k2     — 2× K-tile pipeline (byte-exact accum order)
         //   k2x32  — 32-row block with shared X fragment per K-tile. Slower
-        //            than k2 on gfx1100, but faster on gfx1151 Strix Halo
-        //            for Qwen3.5 9B prefill (pp2048 q8: 339.7 → 351.3 tok/s).
+        //            than k2 on gfx1100, but faster on gfx1151 Strix Halo for
+        //            small-M residual projections at prefill-sized batches.
+        //            DFlash verify/lm_head runs at B<=16 and large-M draft
+        //            FFN/lm_head also prefer k2.
         //   k4     — 4× K-tile pipeline (output-mapping bug, τ=0 on dflash — debug only)
         //   wmma   — base WMMA         (output-mapping bug — debug only)
         //   wmma2  — 2-wave block, 32 rows × 16 batch (output-mapping bug — debug only)
-        let auto_variant = if matches!(self.arch.as_str(), "gfx1150" | "gfx1151") {
+        let is_gfx115x = matches!(self.arch.as_str(), "gfx1150" | "gfx1151");
+        let auto_variant = if is_gfx115x && batch_size <= 16 {
+            "k2"
+        } else if is_gfx115x && m < 8192 {
             "k2x32"
         } else if m >= 8192 {
             "k2"


### PR DESCRIPTION
## Summary

This is a minimal gfx115x dispatch selector change for HFQ4G256 residual WMMA:

- keep `k2x32` for gfx1150/gfx1151 only on small-M residual projections at prefill-sized batches
- route `batch_size <= 16` back to `k2`, which matches DFlash verify / lm_head behavior
- keep large-M draft FFN/lm_head on `k2`

Root cause: the previous gfx115x blanket selector sent all HFQ4G256 residual WMMA calls to `k2x32`. That helped one prefill-shaped case, but it also hit DFlash verify-sized batches where `k2` is faster on Strix Halo.

## Results

Hardware/software: Strix Halo (`gfx1151`), ROCm 7.2 toolbox.

Prompt-dependent DFlash benchmark:

```bash
./target/release/examples/dflash_spec_demo \
  --target /home/kotdath/omp/personal/amd-strix-halo-toolboxes/models/qwen3.5-9b.mq4 \
  --draft /home/kotdath/omp/personal/amd-strix-halo-toolboxes/models/qwen35-9b-dflash-mq4.hfq \
  --prompt "$(cat benchmarks/prompts/merge_sort_thinking_off.txt)" \
  --max 256 --no-chatml --kv-mode asym3
```

Prompt md5: `253c7ac50857fe6d0e10fb0d2c5e35c0`
Binary md5: `475fdb9d571a51a33abe0eb9351b36a7`

Before, current master with gfx115x blanket `k2x32`:

- 5-run tok/s: `126.28`, `127.17`, `127.58`, `129.37`, `130.02`
- median: `127.58 tok/s`
- best: `130.02 tok/s`
- tau: `13.1538`

After this PR:

- 5-run tok/s: `167.46`, `170.34`, `167.51`, `166.48`, `169.10`
- median: `167.51 tok/s`
- best: `170.34 tok/s`
- tau: `13.1538`
- accept rate: `0.8769`

That is about +31% versus the controlled master runs, with the same tau/acceptance shape.

Prefill spot checks after this PR, using `bench_qwen35_mq4`:

- `pp16`: about `305.5 tok/s`
- `pp64`: about `300.5 tok/s`
- `pp128`: about `981.8 tok/s`
- `pp512`: about `1121.6 tok/s`

## Open Question

`tests/speed-baselines/gfx1151.txt` contains `9b_3.5_dflash_merge_sort_tok_s=245.03`. I could not reproduce that target locally on this Strix Halo setup. I also checked reference commit `83358c6`; after warm JIT, the same benchmark shape reached only about `151 tok/s` locally.

So this PR recovers a clear regression from the current selector, but it does not reach the recorded `245 tok/s` baseline. Is that baseline from a different command shape, prompt, power/DPM state, model artifact, or should the gfx1151 DFlash baseline be revised?

## Validation

Passed:

- `git diff --check`
- `cargo build --release --features deltanet --example dflash_spec_demo --example bench_qwen35_mq4 -p engine`
- 5 fresh-process DFlash runs before/after, same prompt and command shape

Attempted but not cleanly applicable:

- `./scripts/coherence-gate-dflash.sh` skipped in this toolbox because the expected 27B target/draft were not present under the gate's model path (`/root/.hipfire/models`). Report path: `/tmp/coherence-dflash-20260428-223945.md`.
- `cargo fmt --check` / `rustfmt --check crates/rdna-compute/src/dispatch.rs` fail on pre-existing repository/file formatting drift. I did not apply formatting because it would create a large unrelated diff for a one-file selector fix.

Not run:

- `cargo clippy`