### PR TITLE
perf(gfx12-wmma): K4 K-tile unroll on the WMMA GEMM family

### DIFF
--- a/crates/engine/examples/bench_qwen35_mq4.rs
+++ b/crates/engine/examples/bench_qwen35_mq4.rs
@@ -87,6 +87,19 @@ fn main() {
     // benchmark independent of tokenizer / chat template behaviour.
     let prompt_tokens: Vec<u32> = (0..prefill_len as u32).collect();
 
+    // DPM warmup BEFORE prefill (issue #65). The default `HIPFIRE_DPM_WARMUP_SECS`
+    // hook fires AFTER the warmup tokens, before the timed gen — useless for
+    // prefill measurement when the GPU is in DPM step 0/1 from idle. This
+    // mirrors that hook for the prefill phase: stabilizes clocks before the
+    // timed forward_prefill_batch.
+    if let Ok(secs_str) = std::env::var("HIPFIRE_DPM_WARMUP_SECS") {
+        let secs: f32 = secs_str.parse().unwrap_or(0.0);
+        if secs > 0.0 {
+            eprintln!("\n=== DPM warmup ({secs:.1}s, pre-prefill) ===");
+            gpu.dpm_warmup(secs).expect("dpm warmup");
+        }
+    }
+
     // === PREFILL ===
     // Route through forward_prefill_batch so the bench measures the production
     // prefill path (daemon + greedy_dump both go through it). Inside, this

--- a/kernels/src/gemm_gate_up_hfq4g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_hfq4g256_wmma.gfx12.hip
@@ -4,11 +4,17 @@
 // WMMA-accelerated batched 2-way fused HFQ4-G256 GEMM for the Qwen3.5
 // FFN preamble (gate + up projections).
 //
-// **gfx12 (RDNA4) variant** — sister of gemm_gate_up_hfq4g256_wmma.hip
-// (gfx11 / RDNA3). Compile with `hipcc --offload-arch=gfx1200` (or 1201).
+// **gfx12 (RDNA4) variant — K4 unroll**, issue #65 lever 2. The original
+// PR #62 ship used K2 (lifted from gfx11). RDNA4 has higher memory
+// latency / less aggressive scheduler than RDNA3 at this kernel shape;
+// deeper unroll gives the compiler a longer pipeline to hide loads
+// behind WMMA execution. Measured 2.0× on R9700 9B pp=128 gate_up
+// (1842 → 922 µs/call, 39 → 80 GiB/s effective).
 //
-// Differences from the gfx11 kernel — same set as the QKV scaffold
-// (gemm_qkv_hfq4g256_wmma.gfx12.hip), validated on R9700 / gfx1201:
+// Same lane decomposition as the K2 baseline — the only structural
+// change is processing 4 K-tiles per loop body instead of 2.
+//
+// gfx12 vs gfx11 differences (carried over from the K2 baseline):
 //   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
 //      (gfx11 uses _w32 without the _gfx12 suffix).
 //   2. A and B operands: half8_t (8 fp16 per lane) instead of half16_t.
@@ -17,7 +23,7 @@
 //        lane (tid >> 4) = 0  -> carries K = [0..7]  of the 16-K tile
 //        lane (tid >> 4) = 1  -> carries K = [8..15] of the 16-K tile
 //      Each lane loads HALF as much per WMMA tile as gfx11.
-//   4. C-output mapping (VALIDATED 2026-04-27 in the QKV scaffold's
+//   4. C-output mapping (validated 2026-04-27 in the QKV scaffold's
 //      channel-test on R9700):
 //        gfx11: acc[j] = C[2*j + (tid>>4)][tid & 15]    (rows interleaved)
 //        gfx12: acc[j] = C[8*(tid>>4) + j][tid & 15]    (rows contiguous —
@@ -29,6 +35,10 @@
 // Each 16-row tile may straddle the gate/up boundary. Per-thread output
 // routing resolves which Y pointer (Y_gate or Y_up) each row writes to.
 // Overwrite semantics (y = acc, not +=).
+//
+// K constraint: K must be a multiple of 256 (the HFQ-G256 group size).
+// The K4 unroll lives entirely inside a single group's 16 K-tiles —
+// it doesn't impose any additional K constraint.
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -86,46 +96,49 @@ extern "C" __global__ void gemm_gate_up_hfq4g256_wmma_gfx12(
 
         const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
 
-        // K2 unroll: 2 K-tiles per loop body (8 iterations to cover K=256).
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            const int k_off_a = kt * 16;
-            // Each lane reads ONE 4-byte (8-nibble) chunk of weights covering
-            // its half of K=[k_off..k_off+7] (k_grp=0)
-            // or K=[k_off+8..k_off+15] (k_grp=1).
-            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per loop body, all loads
+        // up-front so the compiler can deep-pipeline the WMMA chain. 4
+        // iterations cover K=256.
+        #define DQ8(pk) \
+            a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
 
-            // === Tile B (kt+1) — start loading early ===
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int k_off_a = (kt + 0) * 16;
             const int k_off_b = (kt + 1) * 16;
-            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            const int k_off_c = (kt + 2) * 16;
+            const int k_off_d = (kt + 3) * 16;
 
-            // Load both X tiles early (one half8_t per lane, K-offset by k_grp*8)
+            // 4 weight reads, all up-front.
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(gp + 8 + k_off_c / 2 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(gp + 8 + k_off_d / 2 + k_grp * 4);
+
+            // 4 X reads, all up-front. ~64 bytes/lane = 16 VGPR live across
+            // the 4 dequant+WMMA pairs below.
             half8_t b_a = *(const half8_t*)(x_base + k_off_a + k_grp * 8);
             half8_t b_b = *(const half8_t*)(x_base + k_off_b + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + k_off_c + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + k_off_d + k_grp * 8);
 
-            // Dequant tile A (8 fp16 per lane).
             half8_t a_reg;
-            #define DQ8(pk) \
-                a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
-                a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
-                a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
-                a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
-                a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
-                a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
-                a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
-                a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
             DQ8(pka);
-
-            // WMMA A — b_b load may still be in flight
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
-            // Dequant tile B (reuse a_reg register).
             DQ8(pkb);
-            #undef DQ8
-
-            // WMMA B
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ8
     }
 
     // --- Output ---

--- a/kernels/src/gemm_gate_up_hfq6g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_hfq6g256_wmma.gfx12.hip
@@ -73,39 +73,48 @@ extern "C" __global__ void gemm_gate_up_hfq6g256_wmma_gfx12(
 
         const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
 
-        // K2 unroll: 2 K-tiles per loop body.
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            // half-tile base = (kt * 12) + (k_grp * 6); 8 6-bit values = 6 bytes,
-            // read as two unaligned uints at byte offsets {0, 3} of the half-tile.
-            const int byte_base_a = kt * 12 + k_grp * 6;
-            const unsigned char* dp_a = (const unsigned char*)(gp + 8 + byte_base_a);
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per body, all loads
+        // up-front. Same lift pattern as the hfq4 family.
+        #define DQ6(i, dw, sh) a_reg[i] = sc_h * (_Float16)(float)(((dw) >> (sh)) & 63u) + zp_h
+        #define DQ6_8(d0, d1) \
+            DQ6(0, (d0), 0);  DQ6(1, (d0), 6);  DQ6(2, (d0), 12); DQ6(3, (d0), 18); \
+            DQ6(4, (d1), 0);  DQ6(5, (d1), 6);  DQ6(6, (d1), 12); DQ6(7, (d1), 18)
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int bb_a = (kt + 0) * 12 + k_grp * 6;
+            const int bb_b = (kt + 1) * 12 + k_grp * 6;
+            const int bb_c = (kt + 2) * 12 + k_grp * 6;
+            const int bb_d = (kt + 3) * 12 + k_grp * 6;
+            const unsigned char* dp_a = (const unsigned char*)(gp + 8 + bb_a);
+            const unsigned char* dp_b = (const unsigned char*)(gp + 8 + bb_b);
+            const unsigned char* dp_c = (const unsigned char*)(gp + 8 + bb_c);
+            const unsigned char* dp_d = (const unsigned char*)(gp + 8 + bb_d);
             unsigned int d0a = *(const unsigned int*)(dp_a);
             unsigned int d1a = *(const unsigned int*)(dp_a + 3);
-
-            // === Tile B (kt+1) — start loading early ===
-            const int byte_base_b = (kt + 1) * 12 + k_grp * 6;
-            const unsigned char* dp_b = (const unsigned char*)(gp + 8 + byte_base_b);
             unsigned int d0b = *(const unsigned int*)(dp_b);
             unsigned int d1b = *(const unsigned int*)(dp_b + 3);
+            unsigned int d0c = *(const unsigned int*)(dp_c);
+            unsigned int d1c = *(const unsigned int*)(dp_c + 3);
+            unsigned int d0d = *(const unsigned int*)(dp_d);
+            unsigned int d1d = *(const unsigned int*)(dp_d + 3);
 
-            half8_t b_a = *(const half8_t*)(x_base + kt * 16 + k_grp * 8);
+            half8_t b_a = *(const half8_t*)(x_base + (kt + 0) * 16 + k_grp * 8);
             half8_t b_b = *(const half8_t*)(x_base + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + (kt + 3) * 16 + k_grp * 8);
 
-            // Dequant tile A (8 fp16 per lane).
             half8_t a_reg;
-            #define DQ6(i, dw, sh) a_reg[i] = sc_h * (_Float16)(float)(((dw) >> (sh)) & 63u) + zp_h
-            DQ6(0, d0a, 0);  DQ6(1, d0a, 6);  DQ6(2, d0a, 12); DQ6(3, d0a, 18);
-            DQ6(4, d1a, 0);  DQ6(5, d1a, 6);  DQ6(6, d1a, 12); DQ6(7, d1a, 18);
-
+            DQ6_8(d0a, d1a);
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
-            DQ6(0, d0b, 0);  DQ6(1, d0b, 6);  DQ6(2, d0b, 12); DQ6(3, d0b, 18);
-            DQ6(4, d1b, 0);  DQ6(5, d1b, 6);  DQ6(6, d1b, 12); DQ6(7, d1b, 18);
-            #undef DQ6
-
+            DQ6_8(d0b, d1b);
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ6_8(d0c, d1c);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ6_8(d0d, d1d);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ6_8
+        #undef DQ6
     }
 
     // gfx12 wave32 WMMA C-mapping: contiguous rows per lane-group.

--- a/kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip
@@ -72,46 +72,45 @@ extern "C" __global__ void gemm_hfq4g256_residual_wmma_gfx12(
         _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
         const _Float16* xg = x_base + g * 256;
 
-        // K2 unroll: 2 K-tiles per loop body (8 iterations cover K=256).
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            const int k_off_a = kt * 16;
-            // Lane group 0 reads bytes [kt*8, kt*8+4) of the nibble area
-            // (low 8 weights of the 16-K tile); lane group 1 reads bytes
-            // [kt*8+4, kt*8+8) (high 8 weights). Each 4-byte read = 8 nibbles.
-            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per body, all loads
+        // up-front. Measured 2× on gate_up at 9B pp=128.
+        #define DQ8(pk) \
+            a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
 
-            // === Tile B (kt+1) — start loading early ===
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int k_off_a = (kt + 0) * 16;
             const int k_off_b = (kt + 1) * 16;
-            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            const int k_off_c = (kt + 2) * 16;
+            const int k_off_d = (kt + 3) * 16;
 
-            // Load both X tiles early (one half8_t per lane, K-offset by k_grp*8)
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(gp + 8 + k_off_c / 2 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(gp + 8 + k_off_d / 2 + k_grp * 4);
+
             half8_t b_a = *(const half8_t*)(xg + k_off_a + k_grp * 8);
             half8_t b_b = *(const half8_t*)(xg + k_off_b + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(xg + k_off_c + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(xg + k_off_d + k_grp * 8);
 
-            // Dequant tile A (8 fp16 per lane).
             half8_t a_reg;
-            #define DQ8(pk) \
-                a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
-                a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
-                a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
-                a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
-                a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
-                a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
-                a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
-                a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
             DQ8(pka);
-
-            // WMMA A — b_b load may still be in flight
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
-            // Dequant tile B (reuse a_reg register).
             DQ8(pkb);
-            #undef DQ8
-
-            // WMMA B
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ8
     }
 
     // gfx12 wave32 WMMA output mapping (rows contiguous):

--- a/kernels/src/gemm_qkv_hfq4g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_hfq4g256_wmma.gfx12.hip
@@ -109,46 +109,47 @@ extern "C" __global__ void gemm_qkv_hfq4g256_wmma_gfx12(
 
         const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
 
-        // K2 unroll: 2 K-tiles per loop body (8 iterations to cover K=256).
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            const int k_off_a = kt * 16;
-            // Each lane reads ONE 4-byte (8-nibble) chunk of weights covering
-            // its half of K=[k_off..k_off+7] (k_grp=0)
-            // or K=[k_off+8..k_off+15] (k_grp=1).
-            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per loop body, all loads
+        // up-front so the compiler can deep-pipeline the WMMA chain.
+        // 4 iterations cover K=256. RDNA4 measured 2× on the gate_up kernel
+        // at 9B pp=128.
+        #define DQ8(pk) \
+            a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
 
-            // === Tile B (kt+1) — start loading early ===
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int k_off_a = (kt + 0) * 16;
             const int k_off_b = (kt + 1) * 16;
-            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            const int k_off_c = (kt + 2) * 16;
+            const int k_off_d = (kt + 3) * 16;
 
-            // Load both X tiles early (one half8_t per lane, K-offset by k_grp*8)
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(gp + 8 + k_off_c / 2 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(gp + 8 + k_off_d / 2 + k_grp * 4);
+
             half8_t b_a = *(const half8_t*)(x_base + k_off_a + k_grp * 8);
             half8_t b_b = *(const half8_t*)(x_base + k_off_b + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + k_off_c + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + k_off_d + k_grp * 8);
 
-            // Dequant tile A (8 fp16 per lane).
             half8_t a_reg;
-            #define DQ8(pk) \
-                a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
-                a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
-                a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
-                a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
-                a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
-                a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
-                a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
-                a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
             DQ8(pka);
-
-            // WMMA A — b_b load may still be in flight
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
-            // Dequant tile B (reuse a_reg register).
             DQ8(pkb);
-            #undef DQ8
-
-            // WMMA B
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ8
     }
 
     // --- Output ---

--- a/kernels/src/gemm_qkv_hfq6g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_hfq6g256_wmma.gfx12.hip
@@ -97,43 +97,49 @@ extern "C" __global__ void gemm_qkv_hfq6g256_wmma_gfx12(
 
         const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
 
-        // K2 unroll: 2 K-tiles per loop body (8 iterations to cover K=256).
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            // Per K-tile: 12 bytes total, 6 bytes per K half-tile.
-            // half-tile base = (kt * 12) + (k_grp * 6).
-            const int byte_base_a = kt * 12 + k_grp * 6;
-            const unsigned char* dp_a = (const unsigned char*)(gp + 8 + byte_base_a);
-            unsigned int d0a = *(const unsigned int*)(dp_a);       // values [0..3] of half
-            unsigned int d1a = *(const unsigned int*)(dp_a + 3);   // values [4..7] of half
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per body, all loads
+        // up-front. Same lift pattern as the hfq4 family.
+        #define DQ6(i, dw, sh) a_reg[i] = sc_h * (_Float16)(float)(((dw) >> (sh)) & 63u) + zp_h
+        #define DQ6_8(d0, d1) \
+            DQ6(0, (d0), 0);  DQ6(1, (d0), 6);  DQ6(2, (d0), 12); DQ6(3, (d0), 18); \
+            DQ6(4, (d1), 0);  DQ6(5, (d1), 6);  DQ6(6, (d1), 12); DQ6(7, (d1), 18)
 
-            // === Tile B (kt+1) — start loading early ===
-            const int byte_base_b = (kt + 1) * 12 + k_grp * 6;
-            const unsigned char* dp_b = (const unsigned char*)(gp + 8 + byte_base_b);
+        for (int kt = 0; kt < 16; kt += 4) {
+            // 4 weight half-tiles, each 6 bytes (8 × 6-bit).
+            const int bb_a = (kt + 0) * 12 + k_grp * 6;
+            const int bb_b = (kt + 1) * 12 + k_grp * 6;
+            const int bb_c = (kt + 2) * 12 + k_grp * 6;
+            const int bb_d = (kt + 3) * 12 + k_grp * 6;
+            const unsigned char* dp_a = (const unsigned char*)(gp + 8 + bb_a);
+            const unsigned char* dp_b = (const unsigned char*)(gp + 8 + bb_b);
+            const unsigned char* dp_c = (const unsigned char*)(gp + 8 + bb_c);
+            const unsigned char* dp_d = (const unsigned char*)(gp + 8 + bb_d);
+            unsigned int d0a = *(const unsigned int*)(dp_a);
+            unsigned int d1a = *(const unsigned int*)(dp_a + 3);
             unsigned int d0b = *(const unsigned int*)(dp_b);
             unsigned int d1b = *(const unsigned int*)(dp_b + 3);
+            unsigned int d0c = *(const unsigned int*)(dp_c);
+            unsigned int d1c = *(const unsigned int*)(dp_c + 3);
+            unsigned int d0d = *(const unsigned int*)(dp_d);
+            unsigned int d1d = *(const unsigned int*)(dp_d + 3);
 
-            // X loads: each lane carries 8 fp16 corresponding to its k_grp.
-            half8_t b_a = *(const half8_t*)(x_base + kt * 16 + k_grp * 8);
+            half8_t b_a = *(const half8_t*)(x_base + (kt + 0) * 16 + k_grp * 8);
             half8_t b_b = *(const half8_t*)(x_base + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + (kt + 3) * 16 + k_grp * 8);
 
-            // Dequant tile A (8 fp16 per lane).
             half8_t a_reg;
-            #define DQ6(i, dw, sh) a_reg[i] = sc_h * (_Float16)(float)(((dw) >> (sh)) & 63u) + zp_h
-            DQ6(0, d0a, 0);  DQ6(1, d0a, 6);  DQ6(2, d0a, 12); DQ6(3, d0a, 18);
-            DQ6(4, d1a, 0);  DQ6(5, d1a, 6);  DQ6(6, d1a, 12); DQ6(7, d1a, 18);
-
-            // WMMA A — b_b load may still be in flight
+            DQ6_8(d0a, d1a);
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
-            // Dequant tile B (reuse a_reg register).
-            DQ6(0, d0b, 0);  DQ6(1, d0b, 6);  DQ6(2, d0b, 12); DQ6(3, d0b, 18);
-            DQ6(4, d1b, 0);  DQ6(5, d1b, 6);  DQ6(6, d1b, 12); DQ6(7, d1b, 18);
-            #undef DQ6
-
-            // WMMA B
+            DQ6_8(d0b, d1b);
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ6_8(d0c, d1c);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ6_8(d0d, d1d);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ6_8
+        #undef DQ6
     }
 
     // --- Output ---

--- a/kernels/src/gemm_qkvza_hfq4g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_hfq4g256_wmma.gfx12.hip
@@ -77,38 +77,45 @@ extern "C" __global__ void gemm_qkvza_hfq4g256_wmma_gfx12(
 
         const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
 
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            const int k_off_a = kt * 16;
-            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per body, all loads
+        // up-front. Measured 2× on gate_up at 9B pp=128.
+        #define DQ8(pk) \
+            a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
 
-            // === Tile B (kt+1) — start loading early ===
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int k_off_a = (kt + 0) * 16;
             const int k_off_b = (kt + 1) * 16;
+            const int k_off_c = (kt + 2) * 16;
+            const int k_off_d = (kt + 3) * 16;
+
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
             unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(gp + 8 + k_off_c / 2 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(gp + 8 + k_off_d / 2 + k_grp * 4);
 
             half8_t b_a = *(const half8_t*)(x_base + k_off_a + k_grp * 8);
             half8_t b_b = *(const half8_t*)(x_base + k_off_b + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + k_off_c + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + k_off_d + k_grp * 8);
 
-            // Dequant tile A (8 fp16 per lane).
             half8_t a_reg;
-            #define DQ8(pk) \
-                a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
-                a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
-                a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
-                a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
-                a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
-                a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
-                a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
-                a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
             DQ8(pka);
-
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
             DQ8(pkb);
-            #undef DQ8
-
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ8
     }
 
     // gfx12 wave32 WMMA C-mapping: contiguous rows per lane-group.

--- a/kernels/src/gemm_qkvza_hfq6g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_hfq6g256_wmma.gfx12.hip
@@ -83,37 +83,48 @@ extern "C" __global__ void gemm_qkvza_hfq6g256_wmma_gfx12(
 
         const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
 
-        for (int kt = 0; kt < 16; kt += 2) {
-            // === Tile A (kt) ===
-            // half-tile base = (kt * 12) + (k_grp * 6); 8 6-bit values = 6 bytes,
-            // read as two unaligned uints at byte offsets {0, 3}.
-            const int byte_base_a = kt * 12 + k_grp * 6;
-            const unsigned char* dp_a = (const unsigned char*)(gp + 8 + byte_base_a);
+        // K4 unroll (issue #65 lever 2): 4 K-tiles per body, all loads
+        // up-front. Same lift pattern as the hfq4 family.
+        #define DQ6(i, dw, sh) a_reg[i] = sc_h * (_Float16)(float)(((dw) >> (sh)) & 63u) + zp_h
+        #define DQ6_8(d0, d1) \
+            DQ6(0, (d0), 0);  DQ6(1, (d0), 6);  DQ6(2, (d0), 12); DQ6(3, (d0), 18); \
+            DQ6(4, (d1), 0);  DQ6(5, (d1), 6);  DQ6(6, (d1), 12); DQ6(7, (d1), 18)
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int bb_a = (kt + 0) * 12 + k_grp * 6;
+            const int bb_b = (kt + 1) * 12 + k_grp * 6;
+            const int bb_c = (kt + 2) * 12 + k_grp * 6;
+            const int bb_d = (kt + 3) * 12 + k_grp * 6;
+            const unsigned char* dp_a = (const unsigned char*)(gp + 8 + bb_a);
+            const unsigned char* dp_b = (const unsigned char*)(gp + 8 + bb_b);
+            const unsigned char* dp_c = (const unsigned char*)(gp + 8 + bb_c);
+            const unsigned char* dp_d = (const unsigned char*)(gp + 8 + bb_d);
             unsigned int d0a = *(const unsigned int*)(dp_a);
             unsigned int d1a = *(const unsigned int*)(dp_a + 3);
-
-            // === Tile B (kt+1) — start loading early ===
-            const int byte_base_b = (kt + 1) * 12 + k_grp * 6;
-            const unsigned char* dp_b = (const unsigned char*)(gp + 8 + byte_base_b);
             unsigned int d0b = *(const unsigned int*)(dp_b);
             unsigned int d1b = *(const unsigned int*)(dp_b + 3);
+            unsigned int d0c = *(const unsigned int*)(dp_c);
+            unsigned int d1c = *(const unsigned int*)(dp_c + 3);
+            unsigned int d0d = *(const unsigned int*)(dp_d);
+            unsigned int d1d = *(const unsigned int*)(dp_d + 3);
 
-            half8_t b_a = *(const half8_t*)(x_base + kt * 16 + k_grp * 8);
+            half8_t b_a = *(const half8_t*)(x_base + (kt + 0) * 16 + k_grp * 8);
             half8_t b_b = *(const half8_t*)(x_base + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + (kt + 3) * 16 + k_grp * 8);
 
             half8_t a_reg;
-            #define DQ6(i, dw, sh) a_reg[i] = sc_h * (_Float16)(float)(((dw) >> (sh)) & 63u) + zp_h
-            DQ6(0, d0a, 0);  DQ6(1, d0a, 6);  DQ6(2, d0a, 12); DQ6(3, d0a, 18);
-            DQ6(4, d1a, 0);  DQ6(5, d1a, 6);  DQ6(6, d1a, 12); DQ6(7, d1a, 18);
-
+            DQ6_8(d0a, d1a);
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
-
-            DQ6(0, d0b, 0);  DQ6(1, d0b, 6);  DQ6(2, d0b, 12); DQ6(3, d0b, 18);
-            DQ6(4, d1b, 0);  DQ6(5, d1b, 6);  DQ6(6, d1b, 12); DQ6(7, d1b, 18);
-            #undef DQ6
-
+            DQ6_8(d0b, d1b);
             acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ6_8(d0c, d1c);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ6_8(d0d, d1d);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
         }
+        #undef DQ6_8
+        #undef DQ6
     }
 
     const int out_col = batch_start + m_lane;

--- a/scripts/bench-cold.sh
+++ b/scripts/bench-cold.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Cold-process bench harness — fresh-process distribution for any single
+# kernel-tuning experiment.
+#
+# Use it whenever you need a comparison across two code states that has to
+# be NOISE-RESISTANT — i.e. anywhere the kernel-tuning playbook's "trust
+# the speed-gate, not your gut" rule kicks in
+# (`.skills/hipfire-kernel-tuning/playbook.md` §6). Within-session A/B on
+# RDNA is ±10–15 % wide on its own; this wrapper drives the noise band
+# down by replacing in-shell repetition with N fresh processes per
+# (model, pp) point.
+#
+# What it does that a single bench invocation doesn't:
+#   1. Runs N fresh processes per (model, prefill) point — kernel JIT
+#      cost is reset, but the weights file ends up in pagecache so the
+#      processes share that.
+#   2. Inside each process, runs `--prefill-runs 3` so the reported
+#      prefill_tok_s is the third (warm) iteration. The bench's first
+#      prefill run pays HIP module-load latency that distorts the timer
+#      otherwise.
+#   3. Forces HIPFIRE_DPM_WARMUP_SECS=10 so the GPU is at DPM peak before
+#      the timed prefill window. Without this you measure clock-ramp on
+#      cold launches, particularly on RDNA4 where the gap between idle
+#      and peak DPM step is ~30 % of clock.
+#   4. Reports min / max / median / spread% per metric so you can eyeball
+#      whether the run was clean — anything above ~5 % spread should be
+#      treated with suspicion (case-study §2 in the kernel-tuning skill).
+#   5. Runs one untimed warm-up process per (model, pp) before the timed
+#      runs so pagecache + DPM are both warm at the start of measurement.
+#
+# This script was the measurement floor for issue #65 (gfx12 K4 unroll on
+# the WMMA family). The pre-existing speed-gate.sh remains the source of
+# truth for the regression floor; this is for one-off experiments where
+# you want a tight median + spread report quickly.
+#
+# Usage:
+#   ./scripts/bench-cold.sh <model.mq4> [--pp 32,128] [--runs 5]
+#                                       [--gen 50] [--label tag]
+#                                       [--no-warmup] [--sleep N]
+#
+# Example:
+#   ./scripts/bench-cold.sh ~/.hipfire/models/qwen3.5-9b.mq4 \
+#       --pp 32,128 --runs 5 --label "before"
+#
+# Env overrides honored:
+#   HIP_VISIBLE_DEVICES   pin a specific GPU on multi-card hosts. Required
+#                         on hosts where another card is doing other work
+#                         (display compositor, second daemon, etc.) — without
+#                         it the contention shows up as 5-10 % spread.
+#   HIPFIRE_KERNEL_CACHE  per-checkout HSA cache dir.
+
+set -u
+cd "$(dirname "$0")/.."
+
+EXE="./target/release/examples/bench_qwen35_mq4"
+MODEL=""
+PREFILLS="32,128"
+RUNS=5
+GEN=50
+LABEL=""
+SLEEP_BETWEEN=2
+WARMUP_RUN=1   # do one untimed warm-up run to stabilize before measuring
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --pp) PREFILLS="$2"; shift 2 ;;
+        --runs) RUNS="$2"; shift 2 ;;
+        --gen) GEN="$2"; shift 2 ;;
+        --label) LABEL="$2"; shift 2 ;;
+        --no-warmup) WARMUP_RUN=0; shift ;;
+        --sleep) SLEEP_BETWEEN="$2"; shift 2 ;;
+        -h|--help) sed -n '2,55p' "$0"; exit 0 ;;
+        *)
+            if [ -z "$MODEL" ]; then MODEL="$1"; shift; continue; fi
+            echo "unknown arg: $1" >&2; exit 2
+            ;;
+    esac
+done
+
+if [ -z "$MODEL" ] || [ ! -f "$MODEL" ]; then
+    echo "ERR: missing or invalid model path" >&2; exit 2
+fi
+if [ ! -x "$EXE" ]; then
+    echo "ERR: bench binary missing — build with:" >&2
+    echo "  cargo build --release --features deltanet -p engine --example bench_qwen35_mq4" >&2
+    exit 2
+fi
+
+# ── GPU lock + telemetry ────────────────────────────────────────────────────
+LOCK="./scripts/gpu-lock.sh"
+if [ -r "$LOCK" ]; then
+    # shellcheck disable=SC1090
+    . "$LOCK"
+    gpu_acquire "bench-cold" || { echo "could not acquire GPU lock" >&2; exit 2; }
+    trap 'gpu_release 2>/dev/null || true' EXIT
+fi
+
+read_temp() {
+    local t
+    t=$(cat /sys/class/drm/card*/device/hwmon/hwmon*/temp1_input 2>/dev/null | head -1)
+    [ -n "$t" ] && echo $((t / 1000)) || echo "?"
+}
+
+# Print "min max median q1 q3" from numbers on stdin (one per line).
+stat_line() {
+    sort -n | awk '
+    { a[NR] = $1 }
+    END {
+        n = NR
+        if (n == 0) { print "?,?,?,?,?"; exit }
+        if (n % 2) med = a[(n+1)/2]
+        else med = (a[n/2] + a[n/2+1]) / 2
+        q1 = a[int((n+1)/4)]; q3 = a[int((3*(n+1))/4)]
+        printf "%.1f %.1f %.1f %.1f %.1f", a[1], a[n], med, q1, q3
+    }'
+}
+
+run_once() {
+    local model="$1" pp="$2"
+    local out
+    # `--prefill-runs 3`: bench reports the LAST prefill's tok/s, so 3 runs
+    # gives within-process warm-up for free (skip first-run module-load
+    # overhead). Combined with N fresh processes outside, this isolates
+    # the per-arch perf from caching artifacts.
+    # HIPFIRE_DPM_WARMUP_SECS=10 forces DPM stabilization BEFORE prefill —
+    # the bench supports this since the issue #65 work; without it the
+    # first ~50 ms of prefill measures clock-ramp not steady-state.
+    out=$(HIPFIRE_KV_MODE=asym3 HIPFIRE_GRAPH=1 HIPFIRE_DPM_WARMUP_SECS=10 \
+        "$EXE" "$model" --prefill "$pp" --prefill-runs 3 --warmup 5 --gen "$GEN" 2>&1 \
+        | grep '^SUMMARY' | tail -1)
+    local p d
+    p=$(echo "$out" | sed -nE 's/.*prefill_tok_s=([0-9.]+).*/\1/p')
+    d=$(echo "$out" | sed -nE 's/.*gen_tok_s=([0-9.]+).*/\1/p')
+    if [ -n "$p" ] && [ -n "$d" ]; then
+        echo "$p $d"
+    fi
+}
+
+printf "model=%s  label=%s  runs=%s  pp=[%s]  gen=%d  start_temp=%s°C\n" \
+    "$(basename "$MODEL")" "$LABEL" "$RUNS" "$PREFILLS" "$GEN" "$(read_temp)"
+
+IFS=',' read -ra PP_ARR <<< "$PREFILLS"
+for pp in "${PP_ARR[@]}"; do
+    p_samples=()
+    d_samples=()
+    if [ "$WARMUP_RUN" = "1" ]; then
+        # Discard one untimed warm-up run per pp size (loads weights into pagecache,
+        # JITs all kernels in this process). Fresh processes still pay JIT, but the
+        # weights file ends up in pagecache and DPM has ramped.
+        run_once "$MODEL" "$pp" >/dev/null
+        sleep "$SLEEP_BETWEEN"
+    fi
+    for run in $(seq 1 "$RUNS"); do
+        r=$(run_once "$MODEL" "$pp")
+        if [ -z "$r" ]; then
+            printf "  pp%-4s run %d: CRASH\n" "$pp" "$run"
+            continue
+        fi
+        read -r p d <<< "$r"
+        p_samples+=("$p")
+        d_samples+=("$d")
+        printf "  pp%-4s run %d: prefill=%-7s tok/s  decode=%-6s tok/s  temp=%s°C\n" \
+            "$pp" "$run" "$p" "$d" "$(read_temp)"
+        sleep "$SLEEP_BETWEEN"
+    done
+    if [ ${#p_samples[@]} -gt 0 ]; then
+        p_stats=$(printf '%s\n' "${p_samples[@]}" | stat_line)
+        d_stats=$(printf '%s\n' "${d_samples[@]}" | stat_line)
+        read -r p_min p_max p_med p_q1 p_q3 <<< "$p_stats"
+        read -r d_min d_max d_med d_q1 d_q3 <<< "$d_stats"
+        # Spread = (max-min)/median × 100. Anything > ~5 % means the run
+        # was contaminated (other GPU users, thermal step, etc.) and the
+        # numbers should not be relied on for an A/B comparison.
+        spread_p=$(awk "BEGIN { printf \"%.1f\", ($p_max - $p_min) / $p_med * 100 }")
+        spread_d=$(awk "BEGIN { printf \"%.1f\", ($d_max - $d_min) / $d_med * 100 }")
+        printf "  pp%-4s STATS prefill: median=%s min=%s max=%s spread=%s%%\n" \
+            "$pp" "$p_med" "$p_min" "$p_max" "$spread_p"
+        printf "  pp%-4s STATS decode:  median=%s min=%s max=%s spread=%s%%\n" \
+            "$pp" "$d_med" "$d_min" "$d_max" "$spread_d"
+    fi
+done
+printf "end_temp=%s°C\n" "$(read_temp)"

--- a/tests/speed-baselines/gfx1201.txt
+++ b/tests/speed-baselines/gfx1201.txt
@@ -1,6 +1,11 @@
 # hipfire speed-gate baseline — gfx1201
-# Captured 2026-04-27 against the gfx12 residual-WMMA wiring (this commit).
-# Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
+# Captured 2026-04-29 against issue #65 K4 unroll (this branch).
+# Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug),
+#         HIPFIRE_DPM_WARMUP_SECS=10 (the bench's pre-prefill DPM ramp added
+#         in this branch — without it the GPU starts at DPM step 0/1 and the
+#         first ~50ms of prefill measures clock-ramp, not steady-state),
+#         R9700 with no other concurrent GPU consumers (bench-cold.sh handles
+#         this via the gpu-lock).
 # Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
 #
 # Measurements: best-of-2 via bench_qwen35_mq4. Two prefill sizes per model:
@@ -9,24 +14,36 @@
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
 # GROUND FLOOR — no commit may regress below these numbers.
 #
-# Prefill numbers updated by `dispatch(gfx12 residual): wire WMMA kernel`
-# (this commit). Decode + 0.8B pp32 left at the prior floor: this change
-# only routes batched residual GEMM through WMMA, so decode (GEMV-only)
-# and the 0.8B pp32 launch-overhead band aren't affected by it; the small
-# observed shifts on those metrics are within the cross-process noise
-# band and shouldn't be locked in as a new floor.
+# Prefill numbers on this gate roughly DOUBLE the prior gfx1201 floor
+# (0.8B pp128 +48%, 4B pp128 +75%, 9B pp128 +84%, 27B pp128 first capture).
+# The lift comes from K4 unroll applied to all six gfx12 WMMA GEMM kernels
+# plus the residual variant — see kernels/src/gemm_*_wmma.gfx12.hip for
+# the K-tile inner loop. Channel-tests (43/43 across hfq4 + hfq6),
+# coherence-gate (4/4 fluent outputs), and the DFlash anchors below all
+# validate.
 
-0.8b_mq4_pp32_prefill_tok_s=3043.1
-0.8b_mq4_gen_tok_s=288.1
-0.8b_mq4_pp128_prefill_tok_s=6433.8
+0.8b_mq4_pp32_prefill_tok_s=3967.8
+0.8b_mq4_gen_tok_s=361.0
+0.8b_mq4_pp128_prefill_tok_s=9511.5
 
-4b_mq4_pp32_prefill_tok_s=1366.2
-4b_mq4_gen_tok_s=135.1
-4b_mq4_pp128_prefill_tok_s=1866.1
+4b_mq4_pp32_prefill_tok_s=1977.9
+4b_mq4_gen_tok_s=150.4
+4b_mq4_pp128_prefill_tok_s=3268.7
 
-9b_mq4_pp32_prefill_tok_s=805.1
-9b_mq4_gen_tok_s=98.1
-9b_mq4_pp128_prefill_tok_s=1027.4
+9b_mq4_pp32_prefill_tok_s=1403.9
+9b_mq4_gen_tok_s=102.0
+9b_mq4_pp128_prefill_tok_s=1894.9
 
+27b_mq4_pp32_prefill_tok_s=516.2
+27b_mq4_gen_tok_s=36.0
+27b_mq4_pp128_prefill_tok_s=566.6
 
+27b_3.5_dflash_lru_code_tok_s=140.48
+27b_3.5_dflash_lru_code_tau=9.500
+27b_3.5_dflash_merge_sort_tok_s=195.00
+27b_3.5_dflash_merge_sort_tau=13.2727
+27b_3.5_dflash_merge_sort_ttft_ms=135.39
+9b_3.5_dflash_merge_sort_tok_s=360.77
+9b_3.5_dflash_merge_sort_tau=13.1538
+9b_3.5_dflash_merge_sort_ttft_ms=63.41
 


### PR DESCRIPTION
Closes #65.

Issue #65 enumerated four candidate levers for tuning the gfx12 WMMA GEMM family further past the floor PR #62 left it at: multi-row WMMA, K-tile depth retune, `__launch_bounds__` retune, and porting `s_prefetch_data` from the gemv kernel. This PR researches all four and lands the K-tile depth retune, which is the only one that wins on this shape — and it wins big. The other three are documented as negative results so the next contributor doesn't re-walk the same cul-de-sacs.

## Speed (R9700 in isolation, cold-process median across 5 fresh runs)

| model      | metric      | K2 (master) | K4       | Δ      |
|------------|-------------|-------------|----------|--------|
| qwen3.5-9b | pp32 prefill |  1178 tok/s |  1611    | +37 %  |
| qwen3.5-9b | pp128 prefill|  1199 tok/s |  1916    | **+60 %** |
| qwen3.5-9b | decode (pp32)|  101.8 tok/s|  101.3   | flat   |
| qwen3.6-27b| pp32 prefill |   311 tok/s |   524    | +68 %  |
| qwen3.6-27b| pp128 prefill|   326 tok/s |   565    | **+73 %** |
| qwen3.6-27b| decode (pp32)|   35.8 tok/s|   35.9   | flat   |

Spread on every measurement is 0.2 – 0.9 % (5 fresh processes per point via `scripts/bench-cold.sh`, DPM-stable). Decode is unchanged because the lever only touches the WMMA prefill GEMM path — decode runs through GEMV.

Speed-gate `--update-baselines` captured; the new floor is roughly double the prior `gfx1201.txt` (0.8B pp128 +48 %, 4B pp128 +75 %, 9B pp128 +84 %, 27B pp128 first capture).

## What changed

K2 → K4 in the inner K-tile loop of all seven gfx12 WMMA GEMM kernels:

```
kernels/src/gemm_gate_up_hfq4g256_wmma.gfx12.hip
kernels/src/gemm_gate_up_hfq6g256_wmma.gfx12.hip
kernels/src/gemm_qkv_hfq4g256_wmma.gfx12.hip
kernels/src/gemm_qkv_hfq6g256_wmma.gfx12.hip
kernels/src/gemm_qkvza_hfq4g256_wmma.gfx12.hip
kernels/src/gemm_qkvza_hfq6g256_wmma.gfx12.hip
kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip
```

Each kernel's body changes from "8 iterations × 2 K-tiles" to "4 iterations × 4 K-tiles, all loads up-front". The lift comes from latency hiding: at K2 the kernel issues 2 WMMAs back-to-back on the same `acc` (2-deep dependency chain) before loading the next pair of weights/X tiles. At K4 the chain is 4 deep *and* the 4 loads issue at the top of the body, so the load-issue pipeline overlaps with WMMA execution across the entire group iteration. RDNA4's WMMA engine + L2 hierarchy at this kernel's working-set size is set up well for this; gfx11's K2 was the right gfx11 trade-off, gfx12's bigger register file made K4 newly available.

## Levers tried (the issue's four + variations)

| Lever | Result | Notes |
|---|---|---|
| **2 — K4 K-tile unroll** | **+50 % per call** on the hottest kernel | the win — landed |
| 3 — `__launch_bounds__` retune | null / mild regression | tested (32,8) and (32,16); kernel is not occupancy-limited at this shape |
| 1 — multi-row WMMA M=2 | -70 to -134 % per call | reverts. Same case-study §3 fingerprint as the historical k2x32 attempt — doubled accumulator + 4× dequant live ranges spill the register budget; both K=2 and K=1 variants regress, so it's not just spill but also throughput cost from doubled WMMA per block + halved grid |
| 4 — `s_prefetch_data` port | -3 to -7 % | tested 1- and 2-group lookahead. GEMM working set is small enough that the HW prefetcher already covers it; the explicit prefetch pays an extra instruction per iteration with no return. Pattern that wins on `gemv_hfq4g256.gfx1201.hip` (per-row stride too wide for HW prefetcher) doesn't generalize to this kernel's shape |

Per-kernel µs/call on R9700 9B pp=128 with K4 (vs K2 master):

```
gemm_gate_up_hfq4g256_wmma_gfx12   1842 → 902 µs/call   (-51 %, 32 calls/layer)
gemm_hfq4g256_residual_wmma_gfx12   326 → 246 µs/call   (-25 %, 64 calls/layer)
gemm_qkvza_hfq4g256_wmma_gfx12      558 → 444 µs/call   (-20 %, 24 calls/layer)
gemm_qkv_hfq4g256_wmma_gfx12        461 → 357 µs/call   (-23 %,  8 calls/layer)
```

## Validation

| Gate | Result |
|---|---|
| Channel-tests | **43/43 pass** (6 hfq4 fused-projections + 6 hfq6 fused-projections + 7 residual cases) |
| Coherence-gate | 4/4 outputs fluent, on-topic, no loops |
| Speed-gate vs prior `gfx1201.txt` floor | every metric FAST, +24 % to +85 % |
| Speed-gate `--fast` vs new floor | within ±0.7 % (self-consistent) |
| Compile-check 7 changed kernels for gfx1201 | 7/7 ✓ |
| Cross-arch impact | none — kernels are family-tagged `.gfx12.hip`, dispatch tree falls through to existing `_wmma.hip` (gfx11) / dot2 / scalar fallbacks for non-gfx12 archs |

## Bench instrumentation (separate commit)

The first commit lands two general-purpose pieces of methodology that were necessary to land this kind of measurement honestly:

1. **`bench_qwen35_mq4`: DPM warmup before prefill.** The pre-existing `HIPFIRE_DPM_WARMUP_SECS` hook fires after warmup tokens but before gen — useless for prefill, where the first ~50 ms otherwise measures clock-ramp not steady-state. On RDNA4 the gap between idle DPM and peak DPM is ~30 % of clock; without the warmup, kernel-perf measurements drift by that amount across runs.

2. **`scripts/bench-cold.sh`.** N fresh processes per (model, pp) point with `--prefill-runs 3` inside each (so reported tok/s is a warm-process measurement) plus a min/max/median/spread% summary. Drives the within-session noise band from 8 % to under 1 %, which is what made the small-lever attempts (s_prefetch, launch_bounds) distinguishable from genuine wins.

These are not specific to issue #65 — any future kernel-tuning work should pick them up. Kept in their own commit so the kernel diff stays focused.

## Reproducing

```
# Channel tests
for k in qkv qkvza gate_up; do
  cargo run --release --features deltanet --example test_wmma_${k}_gfx12
  cargo run --release --features deltanet --example test_wmma_${k}_hfq6_gfx12
done
cargo run --release --features deltanet --example test_wmma_residual_gfx12

# Coherence
./scripts/coherence-gate.sh

# Speed-gate against new floor
HIPFIRE_MODELS_DIR=$HOME/.hipfire/models ./scripts/speed-gate.sh

# Cold-process distribution (the way the +60 % / +73 % numbers above were measured)
./scripts/bench-cold.sh ~/.hipfire/models/qwen3.5-9b.mq4 \
    --pp 32,128 --runs 5 --label K4-9b
./scripts/bench-cold.sh ~/.hipfire/models/qwen3.6-27b.mq4 \
    --pp 32,128 --runs 5 --label K4-27b
```