### PR TITLE
feat(gcn5): add gfx906 bring-up path

### DIFF
--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -276,7 +276,7 @@ fn main() {
             // Arch is unknown until Gpu::init; use a broad mkdir for the common arches
             // we support so the probe picks one up. The real arch check after init
             // will log the active dir.
-            for arch in ["gfx1010", "gfx1013", "gfx1030", "gfx1031", "gfx1100", "gfx1101", "gfx1102", "gfx1151", "gfx1200", "gfx1201"] {
+            for arch in ["gfx906", "gfx1010", "gfx1013", "gfx1030", "gfx1031", "gfx1100", "gfx1101", "gfx1102", "gfx1151", "gfx1200", "gfx1201"] {
                 let _ = std::fs::create_dir_all(exe_dir.join("kernels").join("compiled").join(arch));
             }
         }

--- a/crates/rdna-compute/examples/gen_kernel_hashes.rs
+++ b/crates/rdna-compute/examples/gen_kernel_hashes.rs
@@ -59,7 +59,7 @@ fn main() {
     kernel_sources.sort_by(|a, b| a.0.cmp(&b.0));
     rdna2_variant_sources.sort_by(|a, b| a.0.cmp(&b.0));
 
-    let archs = ["gfx1010", "gfx1030", "gfx1100", "gfx1200", "gfx1201"];
+    let archs = ["gfx906", "gfx1010", "gfx1030", "gfx1100", "gfx1200", "gfx1201"];
 
     let mut written = 0;
     let mut skipped = 0;

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -38,12 +38,13 @@ fn gemv_rows_default(arch: &str) -> u32 {
     match arch {
         "gfx1100" | "gfx1101" | "gfx1102" => 1,
         "gfx1030" | "gfx1031" => 1,
-        // CDNA1 (MI100, gfx908) + CDNA3 (MI300X): wave64 native.
+        // Vega 20 / GCN5 (gfx906), CDNA1 (MI100, gfx908), and CDNA3
+        // (MI300X): wave64 native.
         // `gemv_hfq4g256_wide` uses block=[64,1,1] = exactly one wave —
         // zero lane waste. The 32-thread multirow variants run on half a
         // wave, so the wide kernel is the natural fit. Return rows=1 to
         // trigger use_wide.
-        "gfx908" | "gfx940" | "gfx941" | "gfx942" => 1,
+        "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942" => 1,
         _ => 2,
     }
 }
@@ -88,14 +89,14 @@ fn has_wmma_f16_gfx12(arch: &str) -> bool {
     arch.starts_with("gfx12")
 }
 
-/// CDNA wave64-native arches: CDNA1 (gfx908, MI100) and CDNA3 (gfx94x,
-/// MI300X). On these, wave32 kernels (block=[32,1,1]) waste the upper 32
-/// lanes of every wave slot. The `*_wave64.hip` kernel variants pack two
-/// rows per block (one per warp) with block=[64,1,1] and halve the grid
-/// count. Adding gfx90a (CDNA2, MI200) here is a one-line change once it
-/// has been bring-up validated.
+/// Wave64-native arches: Vega 20 / GCN5 (gfx906), CDNA1 (gfx908, MI100),
+/// and CDNA3 (gfx94x, MI300X). On these, wave32 kernels (block=[32,1,1])
+/// waste the upper 32 lanes of every wave slot. The `*_wave64.hip` kernel
+/// variants pack two rows per block (one per warp) with block=[64,1,1] and
+/// halve the grid count. Adding gfx90a (CDNA2, MI200) here is a one-line
+/// change once it has been bring-up validated.
 fn has_wave64_native(arch: &str) -> bool {
-    matches!(arch, "gfx908" | "gfx940" | "gfx941" | "gfx942")
+    matches!(arch, "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942")
 }
 
 fn has_mmq_i8_wmma(arch: &str) -> bool {
@@ -2331,10 +2332,10 @@ impl Gpu {
         qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
         k: usize,
     ) -> HipResult<()> {
-        // CDNA1 (MI100, gfx908) + CDNA3 (MI300X / gfx94x) wave64-native path:
+        // gfx906/gfx908/gfx94x wave64-native path:
         // 2 rows per block, halves grid count vs wave32 kernel which wastes half
-        // the wave slot. gfx908 added 2026-04-27 — kernel uses no MFMA, just
-        // FMA + shfl_down within wave64.
+        // the wave slot. This kernel uses no MFMA, just FMA + shfl_down within
+        // wave64, so it is safe for Vega 20 as well as CDNA.
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
@@ -11595,7 +11596,7 @@ impl Gpu {
                             kernels::FUSED_QKV_HFQ4G256_SRC.to_string()));
                 specs.push(("fused_gate_up_hfq4g256",
                             kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string()));
-                // CDNA1 (gfx908) + CDNA3 (gfx94x) wave64-native variants — cut
+                // gfx906/gfx908/gfx94x wave64-native variants — cut
                 // wavefront pressure in half on the hottest kernels. Wave32
                 // block=[32,1,1] kernels otherwise waste the upper 32 lanes
                 // of every wave slot on these wave64-native arches.
@@ -11655,7 +11656,7 @@ impl Gpu {
                             kernels::FUSED_RMSNORM_MQ_ROTATE_SRC.to_string()));
                 specs.push(("fused_silu_mul_mq_rotate",
                             kernels::FUSED_SILU_MUL_MQ_ROTATE_SRC.to_string()));
-                // CDNA1 (gfx908) + CDNA3 wave64 variants — see hfq4 branch for rationale.
+                // gfx906/gfx908/gfx94x wave64 variants — see hfq4 branch for rationale.
                 if has_wave64_native(&self.arch) {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
@@ -11800,6 +11801,18 @@ impl Gpu {
                     "gemv_hfq4g256_residual_multirow_r2",
                     "gemv_hfq4g256_residual_multirow_r4",
                     "gemv_hfq4g256_residual_multirow_r8",
+                ],
+                "gemv_hfq4g256_moe_gate_up_indexed_wave64" => vec![
+                    "gemv_hfq4g256_moe_gate_up_k8_indexed_wave64",
+                ],
+                "gemv_hfq4g256_moe_down_indexed_wave64" => vec![
+                    "gemv_hfq4g256_moe_down_residual_scaled_k8_indexed_wave64",
+                ],
+                "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64" => vec![
+                    "gemv_hfq4g256_moe_gate_up_k8_indexed_batched_wave64",
+                ],
+                "gemv_hfq4g256_moe_down_indexed_batched_wave64" => vec![
+                    "gemv_hfq4g256_moe_down_residual_scaled_k8_indexed_batched_wave64",
                 ],
                 other => vec![other],
             };

--- a/crates/rdna-compute/src/profiler.rs
+++ b/crates/rdna-compute/src/profiler.rs
@@ -36,6 +36,12 @@ struct ArchSpec {
 
 fn arch_spec(arch: &str) -> ArchSpec {
     match arch {
+        // Vega 20 / GCN5
+        "gfx906" => ArchSpec {
+            generation: "GCN5", simds_per_cu: 4, max_waves_per_simd: 10,
+            vgprs_per_simd: 1024, lds_per_cu: 65536,
+            l2_cache_mb: 4.0, infinity_cache_mb: 0.0, default_bus_width: 4096,
+        },
         // RDNA1
         "gfx1010" | "gfx1011" | "gfx1012" => ArchSpec {
             generation: "RDNA1", simds_per_cu: 2, max_waves_per_simd: 20,
@@ -78,6 +84,7 @@ impl GpuCapability {
         let cu_count = read_sysfs_cu_count().unwrap_or_else(|| {
             // Fallback: common defaults per arch
             match arch {
+                "gfx906" => 60,   // Vega 20 / Radeon VII / MI50 class
                 "gfx1010" => 40,   // RX 5700 XT
                 "gfx1030" => 60,   // RX 6800
                 "gfx1100" => 48,   // RX 7800 XT
@@ -97,6 +104,7 @@ impl GpuCapability {
         // GDDR6 data rate = clock * 2 (DDR) * 8 (prefetch) = 16x multiplier.
         // Peak BW = mem_clock * 16 * bus_width / 8 (bits→bytes) / 1000 (MHz→GHz)
         let gddr_multiplier: f32 = match spec.generation {
+            "GCN5" => 2.0,                         // HBM2 DDR
             "RDNA1" | "RDNA2" | "RDNA3" => 16.0, // GDDR6
             "RDNA4" => 16.0,                       // GDDR6 (9070 series)
             _ => 16.0,

--- a/crates/redline/src/device.rs
+++ b/crates/redline/src/device.rs
@@ -78,7 +78,15 @@ impl Device {
         // Map family_id + asic_id to gfx arch string
         // family 143 (AMDGPU_FAMILY_NV) covers both RDNA1 and RDNA2
         let gfx_arch = match gpu_info.family_id {
-            141 => "gfx900",  // AMDGPU_FAMILY_AI (Vega)
+            141 => {
+                // AMDGPU_FAMILY_AI covers Vega 10/20. Vega 20 devices report
+                // gfx906 through ROCm and use the same wave64 execution model
+                // as the hipfire runtime port.
+                match gpu_info.chip_external_rev {
+                    0x3c | 0x3d | 0x3e | 0x3f => "gfx906",
+                    _ => "gfx900",
+                }
+            },
             142 => "gfx902",  // AMDGPU_FAMILY_RV (Raven Ridge)
             143 => {
                 // AMDGPU_FAMILY_NV: distinguish by asic_id

--- a/scripts/_detect-gpu.sh
+++ b/scripts/_detect-gpu.sh
@@ -28,7 +28,27 @@ if [ -z "${HIPFIRE_DETECTED_ARCH:-}" ]; then
             [ -n "$HIPFIRE_DETECTED_ARCH" ] && break
         fi
     done
+    if [ -z "${HIPFIRE_DETECTED_ARCH:-}" ]; then
+        for node_props in /sys/class/kfd/kfd/topology/nodes/*/properties; do
+            [ -f "$node_props" ] || continue
+            ver=$(awk '/gfx_target_version/ {print $2; exit}' "$node_props" 2>/dev/null || true)
+            case "$ver" in
+                90006)          HIPFIRE_DETECTED_ARCH="gfx906";  break ;;
+                90008)          HIPFIRE_DETECTED_ARCH="gfx908";  break ;;
+                100100)         HIPFIRE_DETECTED_ARCH="gfx1010"; break ;;
+                100300|100302)  HIPFIRE_DETECTED_ARCH="gfx1030"; break ;;
+                110000|110001)  HIPFIRE_DETECTED_ARCH="gfx1100"; break ;;
+                110501)         HIPFIRE_DETECTED_ARCH="gfx1151"; break ;;
+                120000)         HIPFIRE_DETECTED_ARCH="gfx1200"; break ;;
+                120001)         HIPFIRE_DETECTED_ARCH="gfx1201"; break ;;
+            esac
+        done
+    fi
+    if [ -z "${HIPFIRE_DETECTED_ARCH:-}" ] && command -v rocminfo >/dev/null 2>&1; then
+        HIPFIRE_DETECTED_ARCH="$({ rocminfo 2>/dev/null | awk '/^  Name:/ && $2 ~ /^gfx/ {print $2; exit}'; } || true)"
+    fi
     case "${HSA_OVERRIDE_GFX_VERSION:-}" in
+        9.0.6|9.0) HIPFIRE_DETECTED_ARCH="gfx906" ;;
         10.1.0|10.1) HIPFIRE_DETECTED_ARCH="gfx1010" ;;
         10.3.0|10.3) HIPFIRE_DETECTED_ARCH="gfx1030" ;;
         11.0.0|11.0) HIPFIRE_DETECTED_ARCH="gfx1100" ;;
@@ -38,8 +58,8 @@ fi
 # ── Marketing name ("Radeon RX 7900 XTX") ──────────────────────
 if [ -z "${HIPFIRE_DETECTED_NAME:-}" ]; then
     if command -v rocminfo >/dev/null 2>&1; then
-        HIPFIRE_DETECTED_NAME="$(rocminfo 2>/dev/null \
-            | awk '/^  Name:/{n=$2} /^  Marketing Name:/{$1=""; $2=""; sub(/^[ \t]+/,""); if (n ~ /^gfx/) {print; exit}}')"
+        HIPFIRE_DETECTED_NAME="$({ rocminfo 2>/dev/null \
+            | awk '/^  Name:/{n=$2} /^  Marketing Name:/{$1=""; $2=""; sub(/^[ \t]+/,""); if (n ~ /^gfx/) {print; exit}}'; } || true)"
     fi
     [ -z "$HIPFIRE_DETECTED_NAME" ] && HIPFIRE_DETECTED_NAME="Unknown GPU"
 fi
@@ -50,11 +70,11 @@ if [ -z "${HIPFIRE_DETECTED_VRAM_GB:-}" ]; then
     # GPU agent's GLOBAL pool is the VRAM. We grep "Size:" lines under
     # the first gfx-named agent.
     if command -v rocminfo >/dev/null 2>&1; then
-        HIPFIRE_DETECTED_VRAM_GB="$(rocminfo 2>/dev/null \
+        HIPFIRE_DETECTED_VRAM_GB="$({ rocminfo 2>/dev/null \
             | awk '
                 /^  Name:/                { in_gpu = ($2 ~ /^gfx/) }
                 in_gpu && /^      Size:/  { size_kb = $2; print int(size_kb/1024/1024); exit }
-            ')"
+            '; } || true)"
     fi
     [ -z "$HIPFIRE_DETECTED_VRAM_GB" ] && HIPFIRE_DETECTED_VRAM_GB="?"
 fi

--- a/scripts/coherence-gate-dflash.sh
+++ b/scripts/coherence-gate-dflash.sh
@@ -49,7 +49,11 @@ EXE="./target/release/examples/dflash_spec_demo"
 MODELS_DIR="${HIPFIRE_MODELS_DIR:-$HOME/.hipfire/models}"
 TARGET_27B="$MODELS_DIR/qwen3.5-27b.mq4"
 DRAFT_27B="$MODELS_DIR/qwen35-27b-dflash.mq4"
+if [ ! -f "$DRAFT_27B" ] && [ -f "$MODELS_DIR/qwen35-27b-dflash-mq4.hfq" ]; then
+    DRAFT_27B="$MODELS_DIR/qwen35-27b-dflash-mq4.hfq"
+fi
 OUT="${HIPFIRE_COHERENCE_OUT:-/tmp/coherence-dflash-$(date +%Y%m%d-%H%M%S).md}"
+CASE_TIMEOUT="${HIPFIRE_COHERENCE_TIMEOUT:-240}"
 LOCK_SCRIPT="./scripts/gpu-lock.sh"
 
 # ── Rebuild dflash_spec_demo if any relevant source is newer ──────────────
@@ -236,7 +240,7 @@ for entry in "${tests[@]}"; do
     echo "== $label =="
     out_file="/tmp/cohdf_out_$$.log"
     t0=$(date +%s.%N)
-    timeout 240 "$EXE" \
+    timeout "$CASE_TIMEOUT" "$EXE" \
         --target "$TARGET_27B" --draft "$DRAFT_27B" \
         --prompt "$prompt" --max "$max_tok" --ctx 2048 \
         --kv-mode asym3 --no-chatml \

--- a/scripts/compile-kernels.sh
+++ b/scripts/compile-kernels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Pre-compile all HIP kernels for target GPU architectures.
 # Usage: ./scripts/compile-kernels.sh [arch1 arch2 ...]
-# Default: gfx1010 gfx1030 gfx1100 gfx1200
+# Default: gfx906 gfx1010 gfx1030 gfx1100 gfx1200
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -12,7 +12,7 @@ OUT_BASE="$SCRIPT_DIR/kernels/compiled"
 if [ $# -gt 0 ]; then
     ARCHS=("$@")
 else
-    ARCHS=(gfx1010 gfx1030 gfx1100 gfx1200 gfx1201)
+    ARCHS=(gfx906 gfx1010 gfx1030 gfx1100 gfx1200 gfx1201)
 fi
 
 echo "=== hipfire kernel compiler ==="
@@ -49,6 +49,19 @@ for arch in "${ARCHS[@]}"; do
         fi
 
         name=$(basename "$src" .hip)
+
+        # gfx906 (Vega 20 / GCN5) is wave64-native but predates the RDNA3/4
+        # WMMA builtins and the dot8 instruction used by MQ8. These kernels
+        # are not dispatched on gfx906, so don't make packaging fail on blobs
+        # this arch cannot legally compile.
+        if [ "$arch" = "gfx906" ]; then
+            case "$name" in
+                *_wmma*|gemv_mq8g256)
+                    echo "  - $name SKIP (unsupported ISA on gfx906)"
+                    continue
+                    ;;
+            esac
+        fi
 
         # Variant precedence:
         #   1. ${name}.${arch}.hip          (chip-specific, e.g. .gfx1100.)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,6 +102,7 @@ for node_props in /sys/class/kfd/kfd/topology/nodes/*/properties; do
     [ -f "$node_props" ] || continue
     ver=$(grep -oP 'gfx_target_version\s+\K\d+' "$node_props" 2>/dev/null || true)
     case "$ver" in
+        90006)          GPU_ARCH="gfx906";  break ;;
         90008)          GPU_ARCH="gfx908";  break ;;
         100100)         GPU_ARCH="gfx1010"; break ;;
         100300|100302)  GPU_ARCH="gfx1030"; break ;;
@@ -120,7 +121,7 @@ fi
 # Fallback: ask user
 if [ "$GPU_ARCH" = "unknown" ]; then
     echo "  WARNING: Could not detect GPU architecture."
-    echo "  Supported: gfx908 (MI100), gfx1010 (5700 XT), gfx1030 (6800 XT), gfx1100 (7900 XTX), gfx1151 (Strix Halo), gfx1200 (R9700), gfx1201 (9070 XT)"
+    echo "  Supported: gfx906 (Vega 20), gfx908 (MI100), gfx1010 (5700 XT), gfx1030 (6800 XT), gfx1100 (7900 XTX), gfx1151 (Strix Halo), gfx1200 (R9700), gfx1201 (9070 XT)"
     GPU_ARCH=$(ask "  Enter your GPU arch [or Enter to skip]: " "unknown")
 fi
 echo "  GPU arch: $GPU_ARCH"

--- a/scripts/speed-gate.sh
+++ b/scripts/speed-gate.sh
@@ -47,8 +47,28 @@ else
             if [ -n "$BASELINE_ARCH" ]; then break; fi
         fi
     done
+    if [ -z "$BASELINE_ARCH" ]; then
+        for node_props in /sys/class/kfd/kfd/topology/nodes/*/properties; do
+            [ -f "$node_props" ] || continue
+            ver=$(awk '/gfx_target_version/ {print $2; exit}' "$node_props" 2>/dev/null || true)
+            case "$ver" in
+                90006)          BASELINE_ARCH="gfx906";  break ;;
+                90008)          BASELINE_ARCH="gfx908";  break ;;
+                100100)         BASELINE_ARCH="gfx1010"; break ;;
+                100300|100302)  BASELINE_ARCH="gfx1030"; break ;;
+                110000|110001)  BASELINE_ARCH="gfx1100"; break ;;
+                110501)         BASELINE_ARCH="gfx1151"; break ;;
+                120000)         BASELINE_ARCH="gfx1200"; break ;;
+                120001)         BASELINE_ARCH="gfx1201"; break ;;
+            esac
+        done
+    fi
+    if [ -z "$BASELINE_ARCH" ] && command -v rocminfo >/dev/null 2>&1; then
+        BASELINE_ARCH="$(rocminfo 2>/dev/null | awk '/^  Name:/ && $2 ~ /^gfx/ {print $2; exit}')"
+    fi
 fi
 case "${HSA_OVERRIDE_GFX_VERSION:-}" in
+    9.0.6|9.0) BASELINE_ARCH="gfx906" ;;
     10.1.0|10.1) BASELINE_ARCH="gfx1010" ;;
     10.3.0|10.3) BASELINE_ARCH="gfx1030" ;;
     11.0.0|11.0) BASELINE_ARCH="gfx1100" ;;

--- a/scripts/test-kernels.sh
+++ b/scripts/test-kernels.sh
@@ -15,7 +15,15 @@ ARCH="${1:-${HIPFIRE_DETECTED_ARCH:-gfx1100}}"
 echo "=== hipfire kernel test harness (${ARCH}) ==="
 
 # Build the test binary
-cargo build --release --features deltanet --example test_kernels -p engine 2>&1 | tail -2
+BUILD_LOG=$(mktemp)
+if cargo build --release --features deltanet --example test_kernels -p engine >"$BUILD_LOG" 2>&1; then
+    tail -2 "$BUILD_LOG"
+else
+    tail -40 "$BUILD_LOG"
+    rm -f "$BUILD_LOG"
+    exit 1
+fi
+rm -f "$BUILD_LOG"
 
 echo ""
 echo "Running kernel tests..."


### PR DESCRIPTION
Map gfx906 through device detection, install scripts, profiler metadata, and kernel precompile setup. Route gfx906 through the wave64 GEMV path and skip WMMA/MQ8 blobs that Vega 20 cannot compile.

Also give the DFlash coherence gate the current 27B draft filename I could download and make its per-case timeout configurable for slower gfx906 runs, cause my MI50 is incredibly slow.

Validation:

- ./scripts/compile-kernels.sh gfx906 (196/196 compiled)

- bash ./scripts/test-kernelsQA.sh gfx906 (16 passed)

- bash ./scripts/test-kernels.sh gfx906 (16 passed)

- cargo run --release --features deltanet -p engine --example daemon -- --precompile

- cargo check -p rdna-compute

- ./scripts/coherence-gate.sh

- HIPFIRE_COHERENCE_TIMEOUT=600 ./scripts/coherence-gate-dflash.sh

I used the port arch skill with some extra prodding to do this work, validated it on my local 1x MI50 machine.

With the `--full` coherence check (not dflash version), the MoE did fall into a loop, and one of the smaller models didn't finish its thinking block, so I'm not positive where to go from here with that. I've attached the coherence check output for reference. I'd be very happy for some pointers, I'm quite new at LLM backends.

I've also attached the dflash coherence check, which I think went a bit wonky too, with some repetition and odd caps. 


[coherence-20260429-224602.md](https://github.com/user-attachments/files/27219021/coherence-20260429-224602.md)

[coherence-dflash-20260429-223341.md](https://github.com/user-attachments/files/27219022/coherence-dflash-20260429-223341.md)