### PR TITLE
feat(cli): CASK profile picker — TUI + CLI for VRAM-pinned eviction recipes

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2498,6 +2498,130 @@ interface FieldMeta {
 // pressed Enter on the "[per-model configs]" virtual row.
 type TuiExit = "exit" | "open_picker";
 
+// CASK profiles: curated bundles that map to concrete eviction behaviors.
+// Setting a profile rewrites the bundle in one shot.
+//
+// IMPORTANT: the daemon triggers eviction iff `cask_sidecar.is_some()`
+// (daemon.rs:798). The `cask` boolean only switches between m-fold and
+// drop-eviction; it does NOT disable eviction. Therefore the `off` profile
+// includes `cask_sidecar: ""` in its apply bundle — clearing the sidecar
+// path is the only way to actually disable eviction. Non-`off` profiles
+// leave `cask_sidecar` untouched (the user supplies the path).
+//
+// Why profiles vs raw knobs: the knobs interact non-obviously and have
+// hard-rule failure modes (m-fold + DFlash → block attractor; any sidecar
+// + A3B → confident-wrong hallucination at current R̄). A profile picker
+// collapses those into a small set of validated combinations.
+type CaskPolicyBundle = Pick<HipfireConfig, "cask" | "cask_budget" | "cask_beta" | "cask_core_frac" | "cask_fold_m">;
+type CaskProfileBundle = CaskPolicyBundle & { cask_sidecar?: string };
+interface CaskProfile {
+  label: string;
+  short: string;       // one-liner for the active row
+  desc: string;        // multi-line for the picker overlay
+  apply: CaskProfileBundle;
+  ar_only: boolean;    // true → warn if dflash_mode != off when this profile applied
+  a3b_safe: boolean;   // false → warn if applying to A3B target (per-model mode)
+}
+
+const CASK_PROFILES: Record<string, CaskProfile> = {
+  "off": {
+    label: "off",
+    short: "no eviction; clears cask_sidecar; physical_cap = max_seq",
+    desc: [
+      "No KV eviction. Physical KV buffer = max_seq tokens (full allocation).",
+      "Clears cask_sidecar — the daemon triggers eviction whenever a sidecar",
+      "path is set, regardless of the cask boolean, so clearing the path is",
+      "the only way to actually disable eviction.",
+      "",
+      "Use when:",
+      "  • Plenty of VRAM relative to context goal",
+      "  • Model is A3B (eviction is unsafe at current R̄≈0.36–0.39)",
+      "  • Quality-sensitive single-turn workloads",
+      "Only profile that's safe on 35B-A3B today.",
+    ].join("\n"),
+    apply: { cask: false, cask_budget: 512, cask_beta: 128, cask_core_frac: 0.5, cask_fold_m: 2, cask_sidecar: "" },
+    ar_only: false,
+    a3b_safe: true,
+  },
+  "balanced": {
+    label: "balanced",
+    short: "drop-eviction, budget=1024 (~165 MB KV on 27B asym3)",
+    desc: [
+      "Plain TriAttention drop-eviction at budget=1024.",
+      "physical_cap ≈ 1280 slots regardless of advertised max_seq.",
+      "Lets a 16 GB card fit dense 27B with usable long context.",
+      "Per-eviction quality cost on AR ≈ 1.7% (graceful).",
+      "m-fold OFF — no DFlash regression risk; works on AR or DFlash.",
+      "Dense models only — A3B safety not validated at this budget.",
+    ].join("\n"),
+    apply: { cask: false, cask_budget: 1024, cask_beta: 256, cask_core_frac: 0.5, cask_fold_m: 2 },
+    ar_only: false,
+    a3b_safe: false,
+  },
+  "conservative": {
+    label: "conservative",
+    short: "drop-eviction, budget=2048 (≥20 GB headroom)",
+    desc: [
+      "Plain TriAttention drop-eviction at budget=2048.",
+      "physical_cap ≈ 2304 slots. Use when you have ≥20 GB VRAM and",
+      "want predictable VRAM footprint with very long advertised contexts.",
+      "Same per-event quality cost as balanced (~1.7% on AR), but evicts",
+      "less often → fewer cumulative events, smoother quality curve.",
+      "Dense models only.",
+    ].join("\n"),
+    apply: { cask: false, cask_budget: 2048, cask_beta: 256, cask_core_frac: 0.5, cask_fold_m: 2 },
+    ar_only: false,
+    a3b_safe: false,
+  },
+  "aggressive-vram": {
+    label: "aggressive-vram",
+    short: "CASK m-fold, budget=512 (~96 MB KV on 27B asym3)",
+    desc: [
+      "CASK m-fold at the paper's frac=0.25 sweet spot (budget=512, m=2).",
+      "physical_cap ≈ 896 → ~96 MB KV on dense 27B asym3.",
+      "Pins VRAM hard — a 16 GB card fits 27B with a comfortable margin.",
+      "Validated +11 pts vs drop-eviction at this aggressive budget (paper §4).",
+      "",
+      "AR ONLY: m-fold + DFlash has a documented block-attractor regression",
+      "(feedback_cask_mfold_dflash_broken.md). Set dflash_mode=off when using",
+      "this profile. NOT for A3B at current R̄.",
+    ].join("\n"),
+    apply: { cask: true, cask_budget: 512, cask_beta: 128, cask_core_frac: 0.5, cask_fold_m: 2 },
+    ar_only: true,
+    a3b_safe: false,
+  },
+};
+
+// Maps the current effective values to a profile name. Returns "custom" if
+// no profile exactly matches — this is what `hipfire config list` shows for
+// users who hand-tuned individual knobs. Compares each key declared in the
+// profile's `apply` bundle, so `off` (which includes `cask_sidecar: ""`)
+// requires the sidecar path to actually be empty before it matches.
+function detectCaskProfile(values: Pick<HipfireConfig, keyof CaskPolicyBundle | "cask_sidecar">): string {
+  for (const [name, p] of Object.entries(CASK_PROFILES)) {
+    let matches = true;
+    for (const [k, v] of Object.entries(p.apply)) {
+      const cur = (values as any)[k];
+      if (typeof v === "number" && typeof cur === "number") {
+        if (Math.abs(cur - v) > 1e-9) { matches = false; break; }
+      } else if (cur !== v) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return name;
+  }
+  return "custom";
+}
+
+// Heuristic: does the resolved tag refer to an A3B model? Used to flag the
+// (any-eviction, A3B) hard-rule when applying a non-"off" profile in per-
+// model mode.
+function tagIsA3B(tag: string | null | undefined): boolean {
+  if (!tag) return false;
+  return /a3b/i.test(tag);
+}
+
 // Scope = null → edit global config. Scope = tag string → edit per-model
 // overlay for that tag. Per-model mode shows inherited values dimmed and
 // highlights overrides in cyan; `r` removes an override.
@@ -2515,9 +2639,20 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
   const keys = isPerModel
     ? allKeys.filter(k => (PER_MODEL_KEYS as readonly string[]).includes(k))
     : allKeys;
-  // Virtual rows (nav-only, not real config keys). Only in global mode.
-  const navKeys = isPerModel ? [] : ["__per_model__"];
+  // Virtual rows (nav-only, not real config keys). `__cask_profile__` is
+  // shown in both global and per-model modes — CASK is per-model overridable
+  // and the profile bundle is exactly what most users want to change in the
+  // per-model A3B/dense distinction. `__per_model__` is global-only.
+  const navKeys = isPerModel
+    ? ["__cask_profile__"]
+    : ["__cask_profile__", "__per_model__"];
   const totalRows = keys.length + navKeys.length;
+
+  // Inline modal state for the CASK profile picker. Open on Enter from the
+  // __cask_profile__ row; close on Enter (apply) or Esc (cancel).
+  const profileNames = Object.keys(CASK_PROFILES);
+  let profilePickerOpen = false;
+  let profilePickerSelected = 0;
 
   // Effective value for a key: override wins in per-model mode, else cfg.
   const effective = (k: keyof HipfireConfig): any =>
@@ -2746,7 +2881,42 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
     editBuffer = "";
   };
 
+  const renderProfilePicker = () => {
+    write("\x1b[H\x1b[2J");
+    write(`${C.bold}cask profile${C.reset}  ${C.dim}${isPerModel ? `per-model overlay for ${resolvedTag}` : "global config"}${C.reset}\n`);
+    write(`${C.dim}Pick a preset to set the (cask, cask_budget, cask_beta, cask_core_frac, cask_fold_m)\nbundle in one shot. cask_sidecar is preserved — set its path separately.${C.reset}\n\n`);
+
+    const a3bWarn = isPerModel && tagIsA3B(resolvedTag);
+    const dflashOn = effective("dflash_mode") !== "off";
+
+    for (let i = 0; i < profileNames.length; i++) {
+      const name = profileNames[i];
+      const p = CASK_PROFILES[name];
+      const caret = i === profilePickerSelected ? `${C.cyan}▸${C.reset}` : " ";
+      const title = `${caret} ${C.bold}${p.label.padEnd(18)}${C.reset} ${C.dim}${p.short}${C.reset}`;
+      write(`${title}\n`);
+      if (i === profilePickerSelected) {
+        for (const line of p.desc.split("\n")) write(`     ${C.dim}${line}${C.reset}\n`);
+        const warns: string[] = [];
+        if (a3bWarn && !p.a3b_safe) warns.push("⚠ A3B target — eviction unsafe at current R̄ (per feedback memory). Pick `off`.");
+        if (p.ar_only && dflashOn) warns.push("⚠ dflash_mode is ON. m-fold + DFlash has a documented attractor regression. Set dflash_mode=off first.");
+        for (const w of warns) write(`     ${C.yellow}${w}${C.reset}\n`);
+        write("\n");
+      }
+    }
+
+    write(`\n  ${C.dim}↑↓ select · enter apply · esc cancel${C.reset}\n`);
+    if (flash) {
+      write(`\n  ${flash}\n`);
+      flash = "";
+    }
+  };
+
   const render = () => {
+    if (profilePickerOpen) {
+      renderProfilePicker();
+      return;
+    }
     // Cursor home + clear screen
     write("\x1b[H\x1b[2J");
     if (isPerModel) {
@@ -2832,8 +3002,7 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       }
     }
 
-    // Virtual nav rows (global mode only). Shown as a distinct-looking row
-    // the user can Enter into.
+    // Virtual nav rows. Shown as a distinct-looking row the user can Enter into.
     for (let n = 0; n < navKeys.length; n++) {
       const rowIdx = keys.length + n;
       const nk = navKeys[n];
@@ -2848,6 +3017,28 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
         write(`\n${caret} ${C.bold}${label}${C.reset} ${val}  ${C.dim}→ enter to open model picker${C.reset}\n`);
         if (rowIdx === selected) {
           write(`${" ".repeat(3 + labelW)}${C.dim}Per-model overlays let you customize settings for a specific model (e.g. bigger max_seq for long ctx on 9B).${C.reset}\n`);
+        }
+      } else if (nk === "__cask_profile__") {
+        const profileVals = {
+          cask: effective("cask") as boolean,
+          cask_budget: effective("cask_budget") as number,
+          cask_beta: effective("cask_beta") as number,
+          cask_core_frac: effective("cask_core_frac") as number,
+          cask_fold_m: effective("cask_fold_m") as number,
+          cask_sidecar: effective("cask_sidecar") as string,
+        };
+        const active = detectCaskProfile(profileVals);
+        const sidecarSet = !!effective("cask_sidecar");
+        const label = "cask profile".padEnd(labelW);
+        const valColor = active === "custom" ? C.yellow : (active === "off" ? C.dim : C.green);
+        const val = `${valColor}${active}${C.reset}`.padEnd(14 + 20);
+        const evictHint = sidecarSet
+          ? `${C.dim}sidecar set → eviction ${effective("cask") ? "(m-fold)" : "(drop)"} active${C.reset}`
+          : `${C.dim}no sidecar — set cask_sidecar to engage${C.reset}`;
+        write(`\n${caret} ${C.bold}${label}${C.reset} ${val}  ${evictHint}\n`);
+        if (rowIdx === selected) {
+          const short = CASK_PROFILES[active]?.short ?? "hand-tuned values; not a preset";
+          write(`${" ".repeat(3 + labelW)}${C.dim}${short} — enter to open profile picker${C.reset}\n`);
         }
       }
     }
@@ -2888,6 +3079,30 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
     };
 
     const onData = (data: string) => {
+      if (profilePickerOpen) {
+        // Profile picker modal — Up/Down navigate, Enter applies, Esc cancels.
+        if (data === "\x1b[A") {
+          profilePickerSelected = (profilePickerSelected + profileNames.length - 1) % profileNames.length;
+        } else if (data === "\x1b[B") {
+          profilePickerSelected = (profilePickerSelected + 1) % profileNames.length;
+        } else if (data === "\r" || data === "\n") {
+          const name = profileNames[profilePickerSelected];
+          const p = CASK_PROFILES[name];
+          for (const k of Object.keys(p.apply) as (keyof CaskProfileBundle)[]) {
+            setValue(k, (p.apply as any)[k]);
+          }
+          profilePickerOpen = false;
+          flash = `${C.green}cask profile → ${name}${C.reset}`;
+        } else if (data === "\x1b" || data === "q" || data === "Q") {
+          profilePickerOpen = false;
+          flash = `${C.dim}cancelled${C.reset}`;
+        } else if (data === "\x03") {
+          cleanup();
+          process.exit(130);
+        }
+        render();
+        return;
+      }
       if (editing) {
         // Text/number edit mode
         if (data === "\r" || data === "\n") {
@@ -2955,9 +3170,23 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
           break;
         case "\r": case "\n": {
           if (onNavRow()) {
-            if (currentNavKey() === "__per_model__") {
+            const nk = currentNavKey();
+            if (nk === "__per_model__") {
               saveAndExit("open_picker");
               return;
+            } else if (nk === "__cask_profile__") {
+              const profileVals = {
+                cask: effective("cask") as boolean,
+                cask_budget: effective("cask_budget") as number,
+                cask_beta: effective("cask_beta") as number,
+                cask_core_frac: effective("cask_core_frac") as number,
+                cask_fold_m: effective("cask_fold_m") as number,
+                cask_sidecar: effective("cask_sidecar") as string,
+              };
+              const active = detectCaskProfile(profileVals);
+              const idx = profileNames.indexOf(active);
+              profilePickerSelected = idx >= 0 ? idx : 0;
+              profilePickerOpen = true;
             }
             break;
           }
@@ -4003,14 +4232,16 @@ depending on model size. HF downloads cache at ~/.hipfire/hf-cache/.`);
   case "config": {
     // `hipfire config`                                  → global TUI
     // `hipfire config list|get|set|reset [...]`          → global scripting
+    // `hipfire config cask-profile <name>`               → bundle setter
     // `hipfire config <model:tag>`                       → per-model TUI
     // `hipfire config <model:tag> list|get|set|reset ...` → per-model scripting
+    // `hipfire config <model:tag> cask-profile <name>`   → per-model bundle setter
     //
     // Disambiguate: first arg is a model tag if it's a known REGISTRY entry
     // (resolved) or matches the `name:tag` shape. Otherwise treat as action.
     let [firstArg, maybeKey, ...valueArgs] = rest;
     let modelScope: string | null = null;
-    if (firstArg && !["list", "get", "set", "reset"].includes(firstArg)) {
+    if (firstArg && !["list", "get", "set", "reset", "cask-profile"].includes(firstArg)) {
       // If looks like a tag, scope to that model
       const resolved = resolveModelTag(firstArg);
       if (REGISTRY[resolved] || firstArg.includes(":")) {
@@ -4170,8 +4401,71 @@ depending on model size. HF downloads cache at ~/.hipfire/hf-cache/.`);
         saveConfig({ ...CONFIG_DEFAULTS });
         console.log("All config reset to defaults");
       }
+    } else if (action === "cask-profile") {
+      // `hipfire config cask-profile` — print active + list available
+      // `hipfire config cask-profile <name>` — apply bundle to global
+      // `hipfire config <model:tag> cask-profile <name>` — apply to per-model
+      const profileName = key;
+      const effectiveCfg = modelScope ? resolveModelConfig(modelScope) : cfg;
+      const profileVals = {
+        cask: effectiveCfg.cask,
+        cask_budget: effectiveCfg.cask_budget,
+        cask_beta: effectiveCfg.cask_beta,
+        cask_core_frac: effectiveCfg.cask_core_frac,
+        cask_fold_m: effectiveCfg.cask_fold_m,
+        cask_sidecar: effectiveCfg.cask_sidecar,
+      };
+      const active = detectCaskProfile(profileVals);
+      if (!profileName) {
+        console.log(`Active CASK profile${modelScope ? ` (${modelScope})` : ""}: ${active}`);
+        console.log(`\nAvailable profiles:`);
+        for (const [n, p] of Object.entries(CASK_PROFILES)) {
+          const marker = n === active ? "▸" : " ";
+          console.log(`  ${marker} ${n.padEnd(18)} ${p.short}`);
+        }
+        console.log(`\nApply: hipfire config${modelScope ? ` ${modelScope}` : ""} cask-profile <name>`);
+        console.log(`Detail: see docs/CONFIG.md "CASK profiles" section.`);
+        break;
+      }
+      if (!CASK_PROFILES[profileName]) {
+        console.error(`Unknown CASK profile: ${profileName}`);
+        console.error(`Available: ${Object.keys(CASK_PROFILES).join(", ")}`);
+        process.exit(1);
+      }
+      const bundle = CASK_PROFILES[profileName].apply;
+      // Safety check: per-model A3B + non-`off` profile is unsafe at current R̄.
+      if (modelScope && tagIsA3B(modelScope) && profileName !== "off") {
+        console.error(`⚠ ${modelScope} is an A3B model. Eviction at current R̄≈0.36–0.39 produces`);
+        console.error(`  confident-wrong hallucinations under multi-turn (see feedback memory).`);
+        console.error(`  Refusing to apply '${profileName}'. Use cask-profile=off on A3B targets,`);
+        console.error(`  or set HIPFIRE_FORCE_A3B_EVICTION=1 to override (not recommended).`);
+        if (process.env.HIPFIRE_FORCE_A3B_EVICTION !== "1") process.exit(1);
+      }
+      if (modelScope) {
+        for (const k of Object.keys(bundle) as (keyof CaskProfileBundle)[]) {
+          writePerModel(k as PerModelKey, (bundle as any)[k]);
+        }
+        console.log(`${modelScope}: cask-profile → ${profileName}`);
+      } else {
+        for (const k of Object.keys(bundle) as (keyof CaskProfileBundle)[]) {
+          (cfg as any)[k] = (bundle as any)[k];
+        }
+        saveConfig(cfg);
+        console.log(`cask-profile → ${profileName}`);
+      }
+      const sidecarSet = !!effectiveCfg.cask_sidecar;
+      if (!sidecarSet && profileName !== "off") {
+        console.log(`note: cask_sidecar is not set. The profile is configured, but eviction`);
+        console.log(`      only engages when a sidecar path is loaded. Set with:`);
+        console.log(`      hipfire config${modelScope ? ` ${modelScope}` : ""} set cask_sidecar /path/to/<model>.triattn.bin`);
+      }
+      if (CASK_PROFILES[profileName].ar_only && effectiveCfg.dflash_mode !== "off") {
+        console.log(`warn: ${profileName} is AR-only (m-fold + DFlash has documented attractor regression).`);
+        console.log(`      dflash_mode is currently '${effectiveCfg.dflash_mode}'. Recommend:`);
+        console.log(`      hipfire config${modelScope ? ` ${modelScope}` : ""} set dflash_mode off`);
+      }
     } else {
-      console.error(`Usage: hipfire config${modelScope ? ` ${modelScope}` : ""} [list|get|set|reset]`);
+      console.error(`Usage: hipfire config${modelScope ? ` ${modelScope}` : ""} [list|get|set|reset|cask-profile]`);
     }
     break;
   }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -18,7 +18,7 @@ Edit interactively with `hipfire config` (global) or `hipfire config
 | `temperature` | 0.30 | 0.0–2.0 | 0.0 = greedy. |
 | `top_p` | 0.80 | 0.0–1.0 | Nucleus sampling. |
 | `repeat_penalty` | 1.05 | 1.0–3.0 | Default kept conservative — 1.3 causes MQ4 gibberish at low temp. |
-| `max_tokens` | 512 | 1–131072 | Per-request cap. |
+| `max_tokens` | 512 | 1–131072 | Per-request cap. Used by `hipfire run` and as the fallback for OpenAI API requests that omit `max_tokens` in the body. Bump if you see thinking-on responses truncated with `finish_reason=stop` mid-`<think>`. |
 | `max_seq` | 32768 | 512–524288 | KV cache physical capacity. |
 | `thinking` | on | on / off | Whether to keep `<think>...</think>` reasoning blocks. |
 | `max_think_tokens` | 0 | 0–32768 | 0 = no cap. Caps tokens emitted before `</think>` closes. |
@@ -58,19 +58,100 @@ mostly long-form prose.
 crossover for the current arch. `never` is the byte-exact reference;
 `always` forces FA even on short prompts.
 
-## CASK (m-folding speculative decode)
+## CASK (TriAttention KV eviction)
 
-| Key | Default | Notes |
-|---|---|---|
-| `cask` | false | Enable CASK m-folding atop DFlash. |
-| `cask_sidecar` | "" | Path to CASK sidecar tape file. Empty = disabled. |
-| `cask_budget` | 1024 | 64–65536. |
-| `cask_beta` | 0 | 0–65536. |
-| `cask_fold_m` | 1 | 1–16. |
-| `cask_core_frac` | 0.25 | 0.0–1.0. |
+CASK is the KV cache eviction system. When a `cask_sidecar` is loaded,
+the engine compacts KV against the sidecar's band-centers once active
+tokens exceed `cask_budget + cask_beta`, then re-triggers when the
+buffer fills again. This pins physical VRAM regardless of advertised
+`max_seq` — a 16 GB card can serve dense 27B with a 131k context window
+because only `cask_budget + cask_beta + 256` slots are physically
+allocated.
 
-CASK is experimental. Leave defaults unless you've read the
-DFLASH/CASK code.
+### Profiles (recommended path)
+
+The five raw knobs interact non-obviously and have hard-rule failure
+modes. Pick a profile bundle in the TUI (`hipfire config` → `cask
+profile` row) or via the CLI:
+
+```bash
+hipfire config cask-profile <name>                     # global
+hipfire config qwen3.6:27b cask-profile <name>         # per-model overlay
+hipfire config cask-profile                            # list active + available
+```
+
+| Profile | KV footprint¹ | Use when | Constraints |
+|---|---|---|---|
+| `off` | full `max_seq` | A3B models, plenty of VRAM, single-turn quality | only safe profile for 35B-a3b at current R̄ |
+| `balanced` | budget=1024, ≈165 MB on 27B | dense 27B on a 16 GB card, mixed-length workloads | dense only; AR or DFlash both safe |
+| `conservative` | budget=2048, ≈275 MB on 27B | ≥20 GB VRAM, very long advertised contexts | dense only |
+| `aggressive-vram` | budget=512, ≈96 MB on 27B | dense 27B on a 16 GB card with tight headroom; aggressive long-ctx fit | **AR only** — m-fold + DFlash has a documented attractor regression. Set `dflash_mode=off`. Not for A3B. |
+
+¹ KV footprint estimates for dense 27B with `kv_cache=asym3` (~107 KB/token).
+Scale linearly with the model's `n_layers × n_kv_heads × head_dim`.
+
+Picking a profile rewrites the policy bundle (`cask`, `cask_budget`,
+`cask_beta`, `cask_core_frac`, `cask_fold_m`) in one shot. The non-`off`
+profiles **preserve** `cask_sidecar` — set the path separately with
+`hipfire config set cask_sidecar /path/to/<model>.triattn.bin`.
+
+The `off` profile additionally **clears `cask_sidecar`**: the daemon
+triggers eviction whenever a sidecar path is set, regardless of the
+`cask` boolean (which only switches between m-fold and drop-eviction).
+Clearing the path is the only way to actually disable eviction.
+
+### Underlying knobs (advanced — prefer profiles)
+
+| Key | Default | Range | Notes |
+|---|---|---|---|
+| `cask_sidecar` | "" | path | Path to TriAttention sidecar `.bin`. Empty = eviction disabled regardless of other knobs. |
+| `cask` | false | bool | true = CASK m-folding (Kim & Gwon 2026); false = plain TriAttention drop-eviction. |
+| `cask_budget` | 512 | 64–65536 | Active token count post-eviction. Smaller = tighter VRAM, more frequent eviction events. |
+| `cask_beta` | 128 | 0–65536 | Hysteresis. Buffer needs to fill `budget + beta` before re-triggering eviction. |
+| `cask_core_frac` | 0.5 | 0.0–1.0 | Fraction of budget kept un-merged when `cask=true`. Inert otherwise. |
+| `cask_fold_m` | 2 | 1–16 | m-way merge factor for non-core slots when `cask=true`. m=2 is the validated sweet spot; m=4 over-folds. Inert when `cask=false`. |
+
+### Safety hard rules
+
+Three failure modes documented in `.claude/.../memory/`:
+
+1. **`cask=true` (m-fold) + DFlash → block-level attractor.** Engine
+   `f16eceb` 2026-04-26: 9B at `max_tokens=1500` emitted 76+ consecutive
+   reps of a 5-token block (`node.value = value\n`). Headline τ and
+   tok/s looked great; output was garbage. The single-token coherence
+   gate did not catch it. **Use `cask=false` whenever `dflash_mode != off`**
+   until the GPU-side m-fold rewrite re-passes the three-tier dflash
+   gate. Plain drop-eviction (`cask=false`) is stable on dense models
+   with DFlash.
+
+2. **Any eviction on A3B (35b-a3b-3.5 / 3.6) → confident-wrong
+   hallucination.** Multi-turn smoke 2026-04-28 (R̄=0.36 / 0.39
+   sidecars under eviction): A3B-3.5 attractor-looped "Safety Policy
+   Check" 8×, fabricated species; A3B-3.6 inverted hydrothermal-vent
+   recall to *photosynthesis*. Dense 27B-3.6 (R̄=0.610) degraded
+   gracefully. **Don't enable a sidecar on A3B targets at current
+   R̄.** The CLI refuses non-`off` profiles on per-model A3B configs
+   (override with `HIPFIRE_FORCE_A3B_EVICTION=1`, not recommended).
+
+3. **DFlash + eviction is quality-asymmetric vs AR + eviction.** 12
+   evictions cost DFlash −28% τ but AR only −1.7% per event. For
+   long-context quality-sensitive output, AR + sidecar is the
+   conservative path; DFlash + sidecar is ~3× faster wall-clock but
+   degrades harder.
+
+### CASK m-fold validation (when DFlash is off)
+
+Paper sweep (9B Q8, AR, 18 prompts):
+
+| Config | budget=full | budget=½ | budget=¼ |
+|---|---:|---:|---:|
+| TriAttention drop-eviction | 89% | 83% | 61% |
+| **CASK m=2, frac=0.5** | 89% | 83% | **72%** |
+| CASK m=4, frac=0.5 | 89% | 83% | 67% |
+
+m=2 is the sweet spot; m=4 over-folds. The +11 pts at the aggressive
+budget (¼) is what makes `aggressive-vram` viable for tight-VRAM
+configurations on AR.
 
 ## Prompt processing
 


### PR DESCRIPTION
## Summary

Adds four CASK eviction profiles (`off` / `balanced` / `conservative` / `aggressive-vram`), wired to both the `hipfire config` TUI (new virtual nav row + inline picker overlay) and a `hipfire config [tag] cask-profile <name>` CLI scripting verb.

The five raw CASK knobs interact non-obviously and have hard-rule failure modes (`cask=true` + DFlash → block attractor; any sidecar + A3B → confident-wrong hallucination at current R̄). Profiles collapse those into validated combinations with context-aware warnings.

## What it unlocks

A 16 GB user can now run dense 27B with usable long context via one command:

```bash
hipfire config set cask_sidecar ~/.hipfire/models/qwen3.6-27b.mq4.triattn.blended_v3.bin
hipfire config cask-profile balanced
```

`balanced` (budget=1024, beta=256) → physical_cap ≈ 1280 → ~165 MB KV on dense 27B asym3, regardless of advertised `max_seq=131072`. The daemon's existing `physical_cap = clamp(budget+beta+256, ...)` machinery (`daemon.rs:725`) does the VRAM pinning; this PR just makes the recipe one-shot.

## Profile cheatsheet

| Profile | Budget | KV (27B asym3) | Use when | Constraints |
|---|---:|---:|---|---|
| `off` | — | full max_seq | A3B, ≥20 GB, single-turn | only safe profile for 35b-a3b at current R̄ |
| `balanced` | 1024 | ~165 MB | 16 GB + 27B | dense only |
| `conservative` | 2048 | ~275 MB | ≥20 GB + very long ctx | dense only |
| `aggressive-vram` | 512 | ~96 MB | tight VRAM headroom | **AR only** (m-fold + DFlash regression), not A3B |

## TUI experience

`hipfire config` now shows a `cask profile` row with the active profile name + sidecar status. Enter opens an inline picker that:
- Shows full description per profile on selection
- Warns yellow on A3B targets when picking non-`off` profiles
- Warns yellow when `dflash_mode != off` and selecting `aggressive-vram` (m-fold + DFlash regression)

## CLI

```
hipfire config cask-profile                                   # list active + available
hipfire config cask-profile <name>                            # apply to global
hipfire config qwen3.6:27b cask-profile <name>                # per-model overlay
HIPFIRE_FORCE_A3B_EVICTION=1 hipfire config <a3b> cask-profile <not-off>   # escape hatch (not recommended)
```

The CLI refuses non-`off` profiles on per-model A3B configs unless the env override is set.

## Codex review

First iteration shipped with a real bug Codex caught: `off` only set `cask=false`, which switches m-fold→drop but does NOT disable eviction (daemon triggers on `cask.sidecar.is_some()`, daemon.rs:798). Fixed by including `cask_sidecar: ""` in the `off` profile's apply bundle, and rewriting `detectCaskProfile` to compare every key declared in `apply` so `off` requires `sidecar==""` to match (sidecar-set + default-policy now correctly detects as `custom`, not `off`).

Smoke confirms end-to-end:
1. Set sidecar + balanced → detected `balanced`, eviction would engage
2. Apply `off` → sidecar cleared, profile detected `off`, eviction actually disabled
3. Set sidecar + default policy → detected `custom` (not `off`)

## Doc updates

- `docs/CONFIG.md` "CASK" section rewritten profile-first. VRAM footprint table for dense 27B. Three safety hard rules with their feedback-memory provenance. Underlying-knob table moved to "advanced — prefer profiles."
- Corrected runtime-vs-doc default disagreement (docs had `budget=1024 / beta=0 / m=1 / frac=0.25`; code is `512 / 128 / 2 / 0.5`).
- `max_tokens` row clarified to note OpenAI API body-fallback semantics (#79 reporter confusion).

## Test plan

- [x] `bun cli/index.ts config cask-profile` lists active + available
- [x] Apply each of four profiles via CLI, verify each underlying knob written correctly
- [x] `off` profile clears `cask_sidecar` end-to-end
- [x] Detection returns `custom` when sidecar set + policy at default
- [x] Per-model A3B safety guard fires on non-`off` profiles
- [x] tsc strict-false passes (only pre-existing errors at lines 730/737/738)
- [ ] TUI smoke (manual) — overlay rendering, A3B per-model warning, dflash warning
- [ ] Live VRAM measurement — confirm dense 27B + balanced profile + sidecar fits in 16 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)