### PR TITLE
feat(cli): auto-attach TriAttention sidecar on pull + load

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -396,6 +396,51 @@ function buildLoadMessage(path: string, tag?: string | null): any {
   // treats absent keys as "use engine defaults" so older daemons stay
   // compatible even when the CLI passes new keys.
   params.dflash_adaptive_b = resolved.dflash_adaptive_b;
+
+  // Auto-attach a TriAttention sidecar when:
+  //   (1) user hasn't manually set cask_sidecar (resolved value is empty)
+  //   (2) the loaded model file has a sidecar discoverable next to it
+  //   (3) the target is NOT A3B (R̄≈0.39 + eviction = confident-wrong
+  //       hallucination per feedback_a3b_r_not_acceptable.md)
+  //
+  // Discovery: registry entry's `triattn.file` first (manifest-driven), then
+  // glob-style fallback for `<model>.triattn*.bin` next to the weights for
+  // sidecars dropped manually.
+  let autoAttachedSidecar: string | null = null;
+  if ((!resolved.cask_sidecar || resolved.cask_sidecar.length === 0) && !isA3B) {
+    const modelDir = path.includes("/") ? path.substring(0, path.lastIndexOf("/")) : MODELS_DIR;
+    const entry = tag ? REGISTRY[resolveModelTag(tag)] : undefined;
+    if (entry?.triattn?.file) {
+      const candidate = join(modelDir, entry.triattn.file);
+      if (existsSync(candidate)) autoAttachedSidecar = candidate;
+    }
+    if (!autoAttachedSidecar) {
+      // Fallback: scan modelDir for `<basename>.triattn*.bin`. Catches
+      // hand-installed sidecars not in the registry.
+      try {
+        const baseName = basename(path);
+        const entries = readdirSync(modelDir);
+        const m = entries.find(e => e.startsWith(baseName + ".triattn") && e.endsWith(".bin"));
+        if (m) autoAttachedSidecar = join(modelDir, m);
+      } catch { /* dir read failures are fine — fall through to no auto-attach */ }
+    }
+  }
+  if (autoAttachedSidecar) {
+    params.cask_sidecar = autoAttachedSidecar;
+    // Default policy on auto-attach: drop-eviction (cask=false) at the
+    // user's configured budget — typically 512 from runtime defaults, which
+    // is the `aggressive-vram` policy minus m-fold. Safe under DFlash too.
+    // User can switch to `balanced`/`conservative` via `hipfire config
+    // cask-profile`.
+    params.cask = resolved.cask;
+    params.cask_budget = resolved.cask_budget;
+    params.cask_beta = resolved.cask_beta;
+    params.cask_core_frac = resolved.cask_core_frac;
+    params.cask_fold_m = resolved.cask_fold_m;
+    console.error(`[hipfire] TriAttention sidecar auto-attached: ${autoAttachedSidecar}`);
+    console.error(`[hipfire]   ${resolved.cask ? 'CASK m-folding' : 'drop-eviction'} budget=${resolved.cask_budget} β=${resolved.cask_beta}  (override: hipfire config cask-profile <off|balanced|conservative|aggressive-vram>)`);
+  }
+
   if (resolved.cask_sidecar && resolved.cask_sidecar.length > 0) {
     if (existsSync(resolved.cask_sidecar)) {
       params.cask_sidecar = resolved.cask_sidecar;
@@ -429,6 +474,13 @@ interface ModelEntry {
   size_gb: number;
   min_vram_gb: number;
   desc: string;
+  /// Optional published TriAttention sidecar in the same HF repo. When set,
+  /// `hipfire pull` also fetches it next to the weights, and `serve`/`run`
+  /// auto-attaches the file at startup if `cask_sidecar` is unset and the
+  /// target isn't A3B. Sidecars on A3B targets are intentionally never
+  /// auto-attached — see feedback_a3b_r_not_acceptable.md (R̄≈0.36–0.39 +
+  /// eviction = confident-wrong hallucination on multi-turn).
+  triattn?: { file: string };
 }
 
 // Registry data lives in cli/registry.json. The CLI is bundled as a single
@@ -897,6 +949,39 @@ async function pull(tag: string): Promise<string> {
 
   const sz = (statSync(dest).size / 1e9).toFixed(1);
   console.error(`  Saved: ${dest} (${sz}GB)`);
+
+  // TriAttention sidecar: fetch alongside the weights when the registry
+  // entry has one. Sidecars are tiny (≈2 MB) so we don't gate this on a
+  // flag — getting the .triattn.bin into MODELS_DIR is the prereq for the
+  // run/serve auto-attach to fire. Failures are non-fatal: weights are
+  // already on disk and runnable; the user just won't get auto-eviction.
+  if (entry.triattn?.file) {
+    const sidecarDest = join(MODELS_DIR, entry.triattn.file);
+    if (existsSync(sidecarDest)) {
+      console.error(`  TriAttention sidecar already present: ${entry.triattn.file}`);
+    } else {
+      const sidecarUrl = `${HF_BASE}/${entry.repo}/resolve/main/${entry.triattn.file}`;
+      console.error(`  Fetching TriAttention sidecar: ${entry.triattn.file}`);
+      try {
+        const sres = await fetch(sidecarUrl);
+        if (!sres.ok) {
+          console.error(`  WARN: sidecar fetch failed (${sres.status} ${sres.statusText}) — model is usable, run hipfire config cask-profile off to silence.`);
+        } else {
+          const sTmp = sidecarDest + ".tmp";
+          const sWriter = Bun.file(sTmp).writer();
+          for await (const chunk of sres.body as AsyncIterable<Uint8Array>) sWriter.write(chunk);
+          await sWriter.end();
+          const { renameSync } = await import("fs");
+          renameSync(sTmp, sidecarDest);
+          const ssz = (statSync(sidecarDest).size / 1e6).toFixed(1);
+          console.error(`  Saved: ${sidecarDest} (${ssz}MB)`);
+        }
+      } catch (e) {
+        console.error(`  WARN: sidecar fetch error: ${e} — non-fatal.`);
+      }
+    }
+  }
+
   return dest;
 }
 

--- a/cli/registry.json
+++ b/cli/registry.json
@@ -9,7 +9,7 @@
     "qwen3.5:35b-a3b":  { "repo": "", "file": "qwen3.5-35b-a3b.mq4", "size_gb": 18.7, "min_vram_gb": 22, "desc": "MoE 35B/3B-active, 115 tok/s — LOCAL ONLY (no HF repo yet)" },
     "qwen3.6:35b-a3b":  { "repo": "schuttdev/hipfire-qwen3.6-35b-a3b", "file": "qwen3.6-35b-a3b.mq4", "size_gb": 18.7, "min_vram_gb": 22, "desc": "MoE 35B/3B-active refresh, 148 tok/s" },
 
-    "qwen3.6:27b":      { "repo": "schuttdev/hipfire-qwen3.6-27b",  "file": "qwen3.6-27b.mq4",    "size_gb": 15.0, "min_vram_gb": 16, "desc": "44 tok/s AR / 185 tok/s w/ draft on code" },
+    "qwen3.6:27b":      { "repo": "schuttdev/hipfire-qwen3.6-27b",  "file": "qwen3.6-27b.mq4",    "size_gb": 15.0, "min_vram_gb": 16, "desc": "44 tok/s AR / 185 tok/s w/ draft on code", "triattn": { "file": "qwen3.6-27b.mq4.triattn.blended_v3.bin" } },
 
     "qwen3.5:0.8b-mq6": { "repo": "schuttdev/hipfire-qwen3.5-0.8b", "file": "qwen3.5-0.8b.mq6",   "size_gb": 0.67, "min_vram_gb": 2,  "desc": "MQ6, higher quality" },
     "qwen3.5:4b-mq6":   { "repo": "schuttdev/hipfire-qwen3.5-4b",   "file": "qwen3.5-4b.mq6",     "size_gb": 3.5,  "min_vram_gb": 5,  "desc": "MQ6, higher quality" },


### PR DESCRIPTION
## Summary

Closes the UX gap where the v3 sidecar shipped on HF was invisible to users:
- `hipfire pull qwen3.6:27b` now also fetches the published `.triattn.blended_v3.bin`
- `hipfire run` / `hipfire serve` auto-attach the sidecar at load time when the user hasn't manually configured one (and the target isn't A3B)

Together with PR #94 (CASK profile picker), the recipe for a 16 GB user is now: `hipfire pull qwen3.6:27b && hipfire run qwen3.6:27b "..."`. Eviction engages at the safest default automatically. No manual config step.

## Three coupled changes

1. **`ModelEntry.triattn?: { file: string }`** — optional manifest-driven sidecar pointer. Currently set on `qwen3.6:27b` only (only published v3 sidecar today). Adding more is a one-line change per model.
2. **`pull()` fetches the sidecar** after the weights land. Non-fatal on failure — the model is still runnable, user just won't get auto-eviction.
3. **`buildLoadMsg()` auto-attaches** when:
   - `cask_sidecar` is unset in resolved config (user hasn't configured one), AND
   - target is **not A3B** (per `feedback_a3b_r_not_acceptable.md` — R̄≈0.39 + eviction = confident-wrong hallucination), AND
   - a sidecar file is discoverable: registry's `triattn.file` first, then glob fallback for `<basename>.triattn*.bin` so hand-installed sidecars also work.

## What gets logged at load

```
[hipfire] TriAttention sidecar auto-attached: /home/.../qwen3.6-27b.mq4.triattn.blended_v3.bin
[hipfire]   drop-eviction budget=512 β=128  (override: hipfire config cask-profile <off|balanced|conservative|aggressive-vram>)
```

## A3B exclusion

A3B targets are intentionally never auto-attached. The hard rule is documented and shipped (#37 default-off DFlash for A3B; #94 CLI guard refusing non-`off` profiles on A3B). Users who explicitly want eviction on A3B opt in via `HIPFIRE_FORCE_A3B_EVICTION=1 hipfire config <a3b> cask-profile <not-off>`.

## Test plan

- [x] Type-check (only pre-existing errors at lines 730/737/738)
- [x] `cli/registry.json` parses with new field; `triattn` reads back correctly
- [x] `hipfire list` works (regression check on registry parsing)
- [ ] Live `hipfire pull qwen3.6:27b` on a fresh box — verifies sidecar download
- [ ] Live `hipfire run qwen3.6:27b` — verifies auto-attach log line + daemon receives `cask_sidecar`
- [ ] `hipfire run qwen3.6:35b-a3b` — verifies A3B auto-attach is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)