### PR TITLE
fix(cli): allow `auto` profile on per-model A3B configs

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4559,11 +4559,11 @@ depending on model size. HF downloads cache at ~/.hipfire/hf-cache/.`);
       }
       const bundle = CASK_PROFILES[profileName].apply;
       // Safety check: per-model A3B + non-`off` profile is unsafe at current R̄.
-      if (modelScope && tagIsA3B(modelScope) && profileName !== "off") {
+      if (modelScope && tagIsA3B(modelScope) && !CASK_PROFILES[profileName].a3b_safe) {
         console.error(`⚠ ${modelScope} is an A3B model. Eviction at current R̄≈0.36–0.39 produces`);
         console.error(`  confident-wrong hallucinations under multi-turn (see feedback memory).`);
-        console.error(`  Refusing to apply '${profileName}'. Use cask-profile=off on A3B targets,`);
-        console.error(`  or set HIPFIRE_FORCE_A3B_EVICTION=1 to override (not recommended).`);
+        console.error(`  Refusing to apply '${profileName}'. Safe profiles for A3B: ${Object.entries(CASK_PROFILES).filter(([_, p]) => p.a3b_safe).map(([n]) => n).join(", ")}.`);
+        console.error(`  Override with HIPFIRE_FORCE_A3B_EVICTION=1 (not recommended).`);
         if (process.env.HIPFIRE_FORCE_A3B_EVICTION !== "1") process.exit(1);
       }
       if (modelScope) {


### PR DESCRIPTION
Codex stop-time review on #96 follow-up. The A3B safety gate hardcoded `profileName !== "off"`, but `auto` is also `a3b_safe: true` (the auto-attach discovery path filters A3B internally — buildLoadMsg's `!isA3B` precondition). On A3B targets `auto` behaves identically to `off` at runtime, so refusing it is incorrect.

Fix uses `!CASK_PROFILES[profileName].a3b_safe` instead, consulting the same source of truth as the picker overlay's warning. Error message now dynamically lists all a3b_safe profiles.

Verified: `auto` + `off` succeed on A3B; `balanced`, `conservative`, `aggressive-vram` refused with both safe profiles listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)