### PR TITLE
docs(mq3): ablation harness + negative result — G256/8-level breaks 9B

### DIFF
--- a/scripts/sim_mq3.py
+++ b/scripts/sim_mq3.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""sim_mq3.py — round-trip an MQ4 model file through 3-bit precision per group.
+
+Reads an existing .mq4 file, finds all MQ4-G256 (quant_type=13) tensors,
+and snaps each 4-bit nibble to the nearest of 8 levels {0,2,4,6,9,11,13,15}.
+This simulates what real 3-bit-G256 quantization would produce *as output*
+without requiring new kernels — the storage stays MQ4-format, but only 8
+distinct values appear per group, so the engine reads the file with no
+changes and the GEMV path runs unmodified.
+
+Per-group scale + min are preserved (we don't re-derive them; in real MQ3
+the scale would be range/7 not range/15, but with the same min the snap-to-
+even-grid produces identical reconstructed values either way as long as
+range and min are unchanged).
+
+Usage: scripts/sim_mq3.py <input.mq4> <output.mq4>
+"""
+import json
+import struct
+import sys
+from pathlib import Path
+
+# Snap table: q4 in [0..15] -> nearest 3-bit grid level.
+# q3 = round(q4 * 7/15); back to q4_storage = round(q3 * 15/7).
+# Result: [0, 0, 2, 2, 4, 4, 6, 6, 9, 9, 11, 11, 13, 13, 15, 15]
+SNAP_4 = [0, 0, 2, 2, 4, 4, 6, 6, 9, 9, 11, 11, 13, 13, 15, 15]
+# Byte-level LUT: each byte holds 2 nibbles; map both at once.
+SNAP_BYTE = bytes((SNAP_4[b & 0x0F] | (SNAP_4[(b >> 4) & 0x0F] << 4)) for b in range(256))
+
+QT_MQ4_G256 = 13
+GROUP_SIZE = 256
+BLOCK_BYTES = 136  # 4 (scale) + 4 (min) + 128 (nibbles)
+
+
+def parse_header_and_index(buf):
+    """Return (arch_id, n_tensors, metadata_offset, data_offset, json_end_offset, tensors).
+    Each tensor is dict with keys: name, qt, shape, group_size, data_offset, data_size."""
+    assert buf[0:4] == b"HFQM", "not an HFQ/MQ file"
+    arch_id = struct.unpack_from("<I", buf, 8)[0]
+    n_tensors = struct.unpack_from("<I", buf, 12)[0]
+    metadata_offset = struct.unpack_from("<Q", buf, 16)[0]
+    data_offset = struct.unpack_from("<Q", buf, 24)[0]
+
+    # Find end of JSON metadata by brace-matching
+    p = metadata_offset
+    depth = 0
+    in_str = False
+    esc = False
+    json_end = 0
+    while p < data_offset:
+        b = buf[p]
+        if esc:
+            esc = False
+        elif in_str and b == 0x5C:  # backslash
+            esc = True
+        elif b == 0x22:  # quote
+            in_str = not in_str
+        elif not in_str:
+            if b == 0x7B:
+                depth += 1
+            elif b == 0x7D:
+                depth -= 1
+                if depth == 0:
+                    json_end = p + 1
+                    break
+        p += 1
+    assert json_end > 0, "JSON not terminated"
+
+    # Tensor index follows metadata
+    pos = json_end
+    idx_n = struct.unpack_from("<I", buf, pos)[0]
+    assert idx_n == n_tensors, f"index count {idx_n} != header {n_tensors}"
+    pos += 4
+
+    tensors = []
+    cum = data_offset
+    for _ in range(n_tensors):
+        name_len = struct.unpack_from("<H", buf, pos)[0]
+        pos += 2
+        name = buf[pos:pos + name_len].decode("utf-8")
+        pos += name_len
+        qt = buf[pos]
+        pos += 1
+        n_dims = buf[pos]
+        pos += 1
+        shape = list(struct.unpack_from(f"<{n_dims}I", buf, pos))
+        pos += 4 * n_dims
+        group_size = struct.unpack_from("<I", buf, pos)[0]
+        pos += 4
+        data_size = struct.unpack_from("<Q", buf, pos)[0]
+        pos += 8
+        tensors.append({
+            "name": name, "qt": qt, "shape": shape,
+            "group_size": group_size,
+            "data_offset": cum, "data_size": data_size,
+        })
+        cum += data_size
+
+    return arch_id, n_tensors, metadata_offset, data_offset, json_end, tensors
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+    src_path = Path(sys.argv[1])
+    dst_path = Path(sys.argv[2])
+
+    src = src_path.read_bytes()
+    arch_id, n_tensors, metadata_offset, data_offset, json_end, tensors = parse_header_and_index(src)
+    print(f"arch_id={arch_id}  n_tensors={n_tensors}  data_offset={data_offset:#x}  total_size={len(src):,}")
+
+    # Mutate via bytes.translate(SNAP_BYTE) on each block's nibble region.
+    # bytes.translate is a single C call that applies a 256-byte LUT to a byte
+    # string — fast and standard-library only. Per block: bytes [0..8] are
+    # scale+min (preserved), bytes [8..136] are 128 nibble pairs (translated).
+    dst = bytearray(src)
+
+    mq4_count = 0
+    mutated_groups = 0
+    for t in tensors:
+        if t["qt"] != QT_MQ4_G256:
+            continue
+        mq4_count += 1
+        ds = t["data_size"]
+        do = t["data_offset"]
+        n_blocks, rem = divmod(ds, BLOCK_BYTES)
+        if rem != 0:
+            print(f"  WARN: tensor {t['name']} has data_size {ds} not a multiple of {BLOCK_BYTES} — skipping", file=sys.stderr)
+            continue
+        for b in range(n_blocks):
+            nibble_start = do + b * BLOCK_BYTES + 8
+            nibble_end = nibble_start + 128
+            # Slice → bytes (copy) → translate (C call, 8× LUT-speed) → write back
+            translated = bytes(dst[nibble_start:nibble_end]).translate(SNAP_BYTE)
+            dst[nibble_start:nibble_end] = translated
+        mutated_groups += n_blocks
+
+    print(f"mutated tensors: {mq4_count}/{n_tensors}  groups touched: {mutated_groups:,}")
+
+    dst_path.write_bytes(bytes(dst))
+    print(f"wrote {dst_path}  ({dst_path.stat().st_size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sim_mq3_eval.sh
+++ b/scripts/sim_mq3_eval.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# A/B eval: baseline MQ4 vs simulated MQ3 (round-tripped through 8 levels/group).
+# Runs the same prompts through both copies and prints decoded text side-by-side.
+set -u
+cd "$(dirname "$0")/.."
+
+EXE="./target/release/examples/daemon"
+SIM_DIR="${SIM_DIR:-/tmp/mq3-sim/models}"
+SRC_DIR="${HIPFIRE_MODELS_DIR:-$HOME/.hipfire/models}"
+OUT="${OUT:-/tmp/mq3-eval-$(date +%Y%m%d-%H%M%S).md}"
+
+if [ ! -x "$EXE" ]; then
+    echo "daemon binary not built: $EXE" >&2
+    exit 2
+fi
+
+# Test set: model basename | label | prompt | max_tokens
+TESTS=(
+    "qwen3.5-0.8b.mq4|cap-08|What is the capital of France? Answer in one short sentence.|80"
+    "qwen3.5-0.8b.mq4|reason-08|A farmer has 17 sheep. All but 9 die. How many are left?|160"
+    "qwen3.5-9b.mq4|cap-9|What is the capital of France? Answer in one short sentence.|80"
+    "qwen3.5-9b.mq4|reason-9|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|240"
+    "qwen3.5-9b.mq4|code-9|Write a one-line Python function named square that returns n*n.|180"
+)
+
+run_one() {
+    local model_path="$1" label="$2" prompt="$3" max_tok="$4"
+    local prompt_json
+    prompt_json=$(python3 -c "import sys,json; print(json.dumps(sys.argv[1]))" "$prompt")
+    local in_file="/tmp/mq3eval_in_$$.jsonl"
+    local out_file="/tmp/mq3eval_out_$$.log"
+    cat > "$in_file" <<JL
+{"type":"load","model":"$model_path","params":{"max_seq":4096}}
+{"type":"generate","id":"r1","prompt":${prompt_json},"temperature":0.0,"max_tokens":$max_tok,"repeat_penalty":1.05}
+{"type":"unload"}
+JL
+    timeout 180 "$EXE" < "$in_file" > "$out_file" 2>&1
+    local ec=$?
+    local text
+    text=$(grep -a '"type":"token"' "$out_file" | python3 -c '
+import sys, json
+print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))')
+    local n_tokens
+    n_tokens=$(grep -ac '"type":"token"' "$out_file")
+    rm -f "$in_file" "$out_file"
+    echo "ec=$ec tokens=$n_tokens"
+    echo "$text"
+}
+
+source ./scripts/gpu-lock.sh
+gpu_acquire "mq3-sim-eval" || { echo "could not acquire GPU lock" >&2; exit 2; }
+trap 'gpu_release 2>/dev/null || true' EXIT
+
+{
+    echo "# MQ3 simulation A/B"
+    echo
+    echo "Source: $SRC_DIR"
+    echo "Sim:    $SIM_DIR"
+    echo "commit: $(git rev-parse --short HEAD)"
+    echo
+
+    for entry in "${TESTS[@]}"; do
+        IFS='|' read -r model_file label prompt max_tok <<<"$entry"
+        src_path="$SRC_DIR/$model_file"
+        sim_path="$SIM_DIR/$model_file"
+        if [ ! -f "$src_path" ]; then
+            echo "## $label — SKIP (no $src_path)"
+            echo
+            continue
+        fi
+        if [ ! -f "$sim_path" ]; then
+            echo "## $label — SKIP (no $sim_path — run sim_mq3.py first)"
+            echo
+            continue
+        fi
+        echo "## $label  ($model_file)"
+        echo
+        echo "**Prompt:** \`$prompt\`"
+        echo
+        echo "### Baseline MQ4"
+        echo '```'
+        run_one "$src_path" "${label}-base" "$prompt" "$max_tok"
+        echo '```'
+        echo
+        echo "### Simulated MQ3"
+        echo '```'
+        run_one "$sim_path" "${label}-mq3" "$prompt" "$max_tok"
+        echo '```'
+        echo
+        echo "---"
+        echo
+    done
+} > "$OUT"
+
+echo "wrote $OUT"


### PR DESCRIPTION
Quality-only MQ3 ablation. Round-trips an MQ4 file through 8 levels/group via `bytes.translate`, then A/B-evals the daemon between baseline + simulated.

## Result

**Not viable at this layout.** Both 0.8B and 9B collapse to garbage on all five prompts; baseline produces fluent correct outputs.

| Test | Baseline MQ4 | Simulated MQ3 |
|---|---|---|
| 0.8B "capital of France" | `Paris.` | `\(\_\_\dots$ ---\_\`\* <\|endoftext\|>` |
| 0.8B "17 sheep" | full reasoning | `芝士` (Chinese: cheese) + im_end |
| 9B "capital of France" | full thinking + answer | `, /<\|im_end\|>` |
| 9B "17 sheep" | clean answer (9) | "in front of a bomb. This is not a text validation task..." |
| 9B `def square` | `def square(n): return n*n` | `One<\|im_end\|>` |

## Why theory misled

Synthetic math (Gaussian + FWHT) gave 4.6× MSE / 6.6 dB SNR drop — within theoretical halving-of-levels expectation. Looked OK on paper. Real models per `feedback_attention_precision.md` are non-linearly intolerant of weight noise above ~5%, and 6.6 dB SNR compounds through every layer until output collapses.

## What would actually work for sub-MQ4

Three issues with naive G=256 + 8 uniform levels:
1. G=256 too coarse — Q3_K_M uses G=16 for leading bits
2. Min-max scale wastes range on non-uniform post-FWHT distributions — need k-means clustering or asymmetric scale+zero
3. No mixed precision — Q3_K_M is 3-bit for most weights, 4-6 for sensitive layers (attention output / down_proj)

A real sub-MQ4 effort needs all three. Research-grade, multi-month, not the 1-2 week MQ3 kernel project I scoped earlier.

## Decision

Don't ship MQ3 as shaped. CASK profile work (#94) handles "27B on 16 GB" without bit loss. For 12 GB users wanting 27B: 9B-MQ4 is the clean answer; sub-MQ4 goes to backlog behind anything more impactful.

This PR ships the harness so future re-testing of alternate MQ3 designs doesn't need to re-derive the bytes.translate mutator or daemon-protocol A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)