### PR TITLE
docs(mq3): clarify sim_mq3.py is upper-bound, not faithful MQ3 simulation

### DIFF
--- a/scripts/sim_mq3.py
+++ b/scripts/sim_mq3.py
@@ -1,19 +1,37 @@
 #!/usr/bin/env python3
-"""sim_mq3.py — round-trip an MQ4 model file through 3-bit precision per group.
+"""sim_mq3.py — UPPER-BOUND simulation of 3-bit quantization on an MQ4 file.
 
-Reads an existing .mq4 file, finds all MQ4-G256 (quant_type=13) tensors,
-and snaps each 4-bit nibble to the nearest of 8 levels {0,2,4,6,9,11,13,15}.
-This simulates what real 3-bit-G256 quantization would produce *as output*
-without requiring new kernels — the storage stays MQ4-format, but only 8
-distinct values appear per group, so the engine reads the file with no
-changes and the GEMV path runs unmodified.
+What this script actually does:
+  Reads an existing .mq4 file, finds all MQ4-G256 (quant_type=13) tensors,
+  and snaps each 4-bit nibble (q4 in [0..15]) to the nearest of the
+  8-element subset {0, 2, 4, 6, 9, 11, 13, 15} via lookup table SNAP_4.
+  The 8 chosen indices are the closest-integer approximations of a uniform
+  8-level grid spanning [0..15]. Engine reads the file unchanged: GEMV
+  reconstructs as min + q4_sim * scale_4. Storage layout, scale, and min
+  are preserved.
 
-Per-group scale + min are preserved (we don't re-derive them; in real MQ3
-the scale would be range/7 not range/15, but with the same min the snap-to-
-even-grid produces identical reconstructed values either way as long as
-range and min are unchanged).
+LIMITATION — this is NOT a faithful simulation of real MQ3-G256:
+  Real MQ3 from f32 would compute q3 = round((w-min)*7/range) directly.
+  This simulator instead computes q3' = round(q4_orig * 7/15) — a
+  rounding-of-rounding because q4_orig is itself round((w-min)*15/range).
+  For ~12% of weights near grid boundaries the double-rounding produces a
+  different q3' than the f32-direct q3, with worst-case extra error of
+  ~14% of range vs real MQ3's ~7% intrinsic 3-bit error. The simulator
+  therefore PESSIMISTICALLY UPPER-BOUNDS the quality cost of MQ3:
+  observed degradation is always at least as bad as real MQ3 would be.
 
-Usage: scripts/sim_mq3.py <input.mq4> <output.mq4>
+  A faithful simulator would re-quantize from the original f32 / bf16
+  safetensors weights, not from already-MQ4-quantized values. That's a
+  separate larger script working on the pre-quantize input, not this one.
+  Use this harness for fast go/no-go signals only — if even the
+  upper-bound simulation produces fluent output, real MQ3 might be
+  viable; if it collapses (as it does on Qwen3.5 0.8B/9B per the
+  2026-04-30 ablation), real MQ3 might still work better but the gap
+  must be characterized by re-quantizing from f32, not by reading more
+  into this script's output.
+
+Usage: ./scripts/sim_mq3.py <input.mq4> <output.mq4>   # requires +x bit
+       python3 scripts/sim_mq3.py <input.mq4> <output.mq4>
 """
 import json
 import struct

--- a/scripts/sim_mq3_eval.sh
+++ b/scripts/sim_mq3_eval.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# A/B eval: baseline MQ4 vs simulated MQ3 (round-tripped through 8 levels/group).
+# A/B eval: baseline MQ4 vs upper-bound-simulated MQ3 (sim_mq3.py).
 # Runs the same prompts through both copies and prints decoded text side-by-side.
+#
+# IMPORTANT: the "MQ3" file produced by sim_mq3.py is a pessimistic upper bound
+# on real MQ3 quality cost — it double-rounds f32 → q4 → q3' instead of f32 → q3
+# directly. If this eval shows fluent output, real MQ3 is likely viable. If it
+# collapses, real MQ3 might still work but the gap must be characterized by
+# re-quantizing from f32 safetensors, not from this harness output. See
+# sim_mq3.py docstring for the full discussion.
 set -u
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
Codex stop-time review on #98 caught: the harness double-rounds (f32 → q4_orig → q3' → q4_sim), where real MQ3 from f32 would compute q3 directly. For ~12% of weights near grid boundaries the q4-mediated q3' differs from the f32-direct q3, producing worst-case extra error of ~14% of range vs real MQ3's intrinsic ~7%.

So the harness pessimistically upper-bounds MQ3 quality cost — observed degradation is always at least as bad as real MQ3 would be.

The 2026-04-30 ablation's catastrophic 5/5 collapse on Qwen3.5 0.8B/9B doesn't disprove MQ3 viability; it only proves *this approximation of MQ3* collapses. A faithful simulator would re-quantize from the original safetensors weights, not from already-MQ4-quantized values.

Qualitatively the conclusion still stands (don't ship MQ3 as shaped; CASK covers the same use case without bit loss; 5/5 collapse is severe enough that halving the error wouldn't recover usable quality). But the precise quantitative claim is now correctly framed as 'the upper-bound simulator collapses' not 'MQ3 is broken'.

Doc-only fix; no code changes. Updates the script docstring + eval harness header to spell out the limitation and what a faithful simulator would look like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)