### PR TITLE
docs(mq3): correct per-element variance claim — simulator is ~20% heavier, not equivalent

### DIFF
--- a/scripts/sim_mq3.py
+++ b/scripts/sim_mq3.py
@@ -25,13 +25,28 @@ NOT a strict upper bound on its quality cost:
       simulator picks q4_sim=0 → reconstructs to 0 (error 9%).
       Simulator LESS accurate than real MQ3.
 
-  Aggregate (variance / mean MSE) is approximately equivalent because the
-  MQ4 and MQ3 grids overlap closely on average. But the simulator's
-  worst-case per-weight error is ~10% of range vs real MQ3's ~7%, so the
-  simulator has heavier tail errors. For LLM coherence (which depends on
-  per-element worst-case more than averages — see
-  feedback_attention_precision.md), the simulator is biased toward
-  pessimism but NOT a strict upper bound.
+  Aggregate per-element variance is HIGHER for the simulator, not equal.
+  Real MQ3 has 8 uniform bins of width 2/14 ≈ 0.143; per-element variance
+  for uniform w is (1/14)² / 3 ≈ 1/588.
+  The simulator has 7 bins of width 4/30 ≈ 0.133 plus one outlier bin of
+  width 6/30 = 0.2 (the gap between recon=6/15 and recon=9/15 caused by
+  SNAP_4 skipping q4=7 and q4=8). Probability-weighted variance:
+    7 narrow bins × (4/30)²/12 × (4/30) + 1 wide bin × (6/30)²/12 × (6/30)
+    ≈ 1/486
+  So the simulator has ~20% higher per-element error variance than real
+  MQ3.
+
+  Worst-case per-weight error is ~10% of range for the simulator
+  (half the wide bin's width = 3/30 = 0.1) vs ~7% for real MQ3
+  (half the bin width = 1/14 = 0.071). About 40% heavier tail.
+
+  Combined: the simulator is biased pessimistic at every aggregation
+  scale — just by varying amounts. Per-weight ~50/50 either direction;
+  per-element variance ~20% heavier; worst-case ~40% heavier. For LLM
+  coherence (which depends on tail errors compounding through layers
+  per feedback_attention_precision.md), the simulator probably collapses
+  before real MQ3 would, but that's a probabilistic statement not a
+  strict ordering. NOT an upper bound on real MQ3 quality cost.
 
   Concretely: if even this approximate MQ3 produces fluent output, real
   MQ3 is very likely viable too. If this approximate MQ3 collapses (as

--- a/scripts/sim_mq3_eval.sh
+++ b/scripts/sim_mq3_eval.sh
@@ -4,11 +4,13 @@
 #
 # IMPORTANT: the "MQ3" file produced by sim_mq3.py is an APPROXIMATION of
 # real MQ3, NOT a strict upper bound on its quality cost. Per-weight error
-# vs real MQ3 can go either way (sometimes more accurate, sometimes less);
-# tail error is biased pessimistic but bulk variance is similar. If this
-# eval shows fluent output, real MQ3 is likely viable; if it collapses,
-# real MQ3 probably also fails but the gap can't be characterized from
-# this harness alone. See sim_mq3.py docstring for the full discussion.
+# vs real MQ3 can go either way; per-element variance is ~20% heavier;
+# worst-case error is ~40% heavier (because SNAP_4's 6→9 gap creates one
+# wide reconstruction bin spanning 0.4..0.6 of range vs 0.133-wide elsewhere).
+# Probabilistically biased pessimistic but not strictly worse. If this eval
+# shows fluent output, real MQ3 is likely viable; if it collapses, real
+# MQ3 probably also fails but the gap can't be characterized from this
+# harness alone. See sim_mq3.py docstring for the derivation.
 set -u
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
PR #100 said 'aggregate variance is similar between the two.' Codex stop-time review on #100 caught that's wrong, just less wrong than #99's upper-bound claim.

## Why the variance claim was wrong

The synthetic Gaussian+FWHT test in the conversation history compared *direct* 8-level quant of f32 to *direct* 16-level quant of f32. That measures real MQ3 vs MQ4 — not the simulator, which goes f32 → q4 → SNAP[q4].

## Computing the actual variance from first principles

For uniform w in [0,1] (per-group min-max approximation):

**Real MQ3** — 8 uniform bins of width 2/14:
`var ≈ (1/14)² / 3 ≈ 1/588`

**Simulator** — SNAP_4 maps {0..15} to {0,0,2,2,4,4,6,6,9,9,11,11,13,13,15,15}, producing 8 distinct reconstruction values: {0, 2/15, 4/15, 6/15, 9/15, 11/15, 13/15, 1}. Seven bins span input width 4/30, but one spans 6/30 (the gap between q4=6 → recon 0.4 and q4=9 → recon 0.6 because SNAP skips q4=7,8):
`var ≈ 7 × (4/30) × (4/30)²/12 + 1 × (6/30) × (6/30)²/12 ≈ 1/486`

Simulator has **~20% heavier per-element variance** than real MQ3.

## Combined with previously-correct claims

- Per-weight: 50/50 either way per individual weight
- Per-element variance: ~20% heavier
- Worst-case error: ~40% heavier (10% vs 7% of range)

Simulator biased pessimistic at every aggregation scale, just at varying magnitudes. The qualitative ablation conclusion still holds.

Doc-only fix; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)