### PR TITLE
fix(cli): resolve raw filenames to registry tags for per-model config

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -515,6 +515,12 @@ function resolveModelTag(input: string): string {
   if (ALIASES[normalized]) return ALIASES[normalized];
   // Try adding "qwen3.5:" prefix
   if (REGISTRY[`qwen3.5:${normalized}`]) return `qwen3.5:${normalized}`;
+  // Reverse-resolve: if input looks like a filename (e.g. "qwen3.6-35b-a3b.mq4"),
+  // find the registry entry whose .file matches and return its tag. Without this,
+  // per-model config is silently ignored when the user passes a raw filename.
+  for (const [tag, entry] of Object.entries(REGISTRY)) {
+    if (entry.file === normalized || entry.file === input) return tag;
+  }
   return normalized;
 }
 
@@ -3594,10 +3600,11 @@ switch (cmd) {
       }
     }
     const image = flags["--image"];
-    const temp = Number(flags["--temp"] ?? cfg.temperature);
-    const topP = Number(flags["--top-p"] ?? cfg.top_p);
-    const repeatPenalty = Number(flags["--repeat-penalty"] ?? cfg.repeat_penalty);
-    const maxTokens = Math.floor(Number(flags["--max-tokens"] ?? cfg.max_tokens));
+    const runCfg = resolveModelConfig(model);
+    const temp = Number(flags["--temp"] ?? runCfg.temperature);
+    const topP = Number(flags["--top-p"] ?? runCfg.top_p);
+    const repeatPenalty = Number(flags["--repeat-penalty"] ?? runCfg.repeat_penalty);
+    const maxTokens = Math.floor(Number(flags["--max-tokens"] ?? runCfg.max_tokens));
     if (temp < 0) { console.error("Error: --temp must be >= 0 (0 = greedy)"); process.exit(1); }
     if (topP <= 0 || topP > 1) { console.error("Error: --top-p must be in (0, 1]"); process.exit(1); }
     if (repeatPenalty < 1) { console.error("Error: --repeat-penalty must be >= 1.0"); process.exit(1); }


### PR DESCRIPTION
When `hipfire run qwen3.6-35b-a3b.mq4` is invoked with a raw filename instead of a registry tag (`qwen3.6:35b-a3b`), `resolveModelTag` failed to match it — the registry keys use colons while filenames use dashes plus an extension. This caused per-model config (max_think_tokens, dflash_mode, cask_sidecar) to silently fall through to global defaults.

Consequence: Qwen 3.6 A3B ran with max_think_tokens=0 (unlimited) instead of the configured 8192, entered a <think> loop consuming all 32768 max_tokens, and the CLI's think-stripping logic produced empty visible output.

Fix:
1. resolveModelTag: add reverse-resolve pass that matches registry entries by their .file field when tag/alias lookup fails.
2. run command: use resolveModelConfig(model) for CLI flag defaults instead of the global-only cfg, so per-model temperature, top_p, repeat_penalty, and max_tokens overrides apply consistently.

Verified: `hipfire run qwen3.6-35b-a3b.mq4 "how to center a div"` now resolves to tag qwen3.6:35b-a3b, applies max_think_tokens=8192, and produces visible content (1785 tok @ 76.7 tok/s).

Related: #89 (A3B thinking-loop attractor)