### PR TITLE
fix(daemon): scan body weights for MQ3/MQ2 in DFlash refusal (Codex stop-time follow-up)

### DIFF
--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -767,6 +767,33 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                 qt_desc
             ));
         }
+
+        // Defense-in-depth (Codex stop-time review 2026-04-30): even when
+        // lm_head is supported, refuse if any body weight is MQ3 (qt=17)
+        // or MQ2 (qt=18). The eligibility gate in `qwen35::forward_prefill_batch`
+        // (`is_batchable_la` excludes MQ3/MQ2) and `dflash::gemm_dispatch`
+        // (panics on non-{F16,F32,HFQ4,MQ4} dtypes) already prevent any
+        // memory-fault path, but a model with MQ3/MQ2 body + supported
+        // lm_head would pass this guard and silently fall back to per-token
+        // forward_scratch for every spec-verify cycle — providing zero
+        // DFlash speedup over AR while wasting the draft load. Refuse
+        // cleanly at load instead. Today hipfire-quantize produces uniform
+        // models so this is overwhelmingly caught by the lm_head check
+        // above; the body scan is for future mixed-precision PRD Phase 3.
+        let mq_lowbit = hfq.first_tensor_with_quant_type(17).map(|n| ("MQ3 (qt=17)", n))
+            .or_else(|| hfq.first_tensor_with_quant_type(18).map(|n| ("MQ2 (qt=18)", n)));
+        if let Some((qt_label, name)) = mq_lowbit {
+            return Err(format!(
+                "DFlash draft requested but model contains {qt_label} weight \
+                 `{name}`. No batched HFQ4 GEMM kernel exists for sub-4-bit \
+                 MQ formats, so the prefill fast-path (`forward_prefill_batch`) \
+                 falls back to per-token `forward_scratch` for every spec \
+                 verify cycle — defeating DFlash's speedup. Reload without \
+                 a draft, or use an MQ4 / HFQ4 / Q8 target. (PRD Phase 2: \
+                 add gemm_hfq3g256_batched_lmhead / gemm_hfq2g256_batched_lmhead \
+                 + the corresponding MQ3/MQ2 WMMA prefill kernels.)"
+            ));
+        }
     }
 
     // Derive physical_cap. With eviction (cask.sidecar set), the physical

--- a/crates/engine/src/hfq.rs
+++ b/crates/engine/src/hfq.rs
@@ -140,6 +140,17 @@ impl HfqFile {
     fn find_tensor(&self, name: &str) -> Option<&HfqTensorInfo> {
         self.tensor_map.get(name).map(|&i| &self.tensors[i])
     }
+
+    /// Returns the name of the first tensor whose `quant_type` matches `qt`,
+    /// or `None` if none match. Used by the daemon's DFlash-refusal guard to
+    /// detect MQ3/MQ2 body weights without iterating the index outside this
+    /// module.
+    pub fn first_tensor_with_quant_type(&self, qt: u8) -> Option<&str> {
+        self.tensors
+            .iter()
+            .find(|t| t.quant_type == qt)
+            .map(|t| t.name.as_str())
+    }
 }
 
 // ─── Config from HFQ metadata ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #106. Codex stop-time review flagged that the load-time DFlash refusal in #106 only checked the target's lm_head, leaving a path where MQ3/MQ2 body weights with a supported lm_head would silently fall back to per-token forward_scratch on every spec-verify cycle (zero speedup over AR, wasted draft load).

## Audit conclusion

**No memory-fault path exists.** Every direct HFQ4 batched kernel call site is already gated:

- `qwen35::forward_prefill_batch` — eligibility check at line 2864 uses `is_batchable_la` (excludes MQ3/MQ2) → falls back to per-token `forward_scratch` which uses `weight_gemv` (MQ3/MQ2 dispatch arms wired in #106).
- `speculative.rs` `try_batched` (line 2083) and `use_batched_gemm` (line 2606) — exclude MQ3/MQ2 → falls to per-row `weight_gemv`.
- `dflash::gemm_dispatch` (line 568) — panics with `"dflash gemm_dispatch: unsupported weight dtype"` on non-{F16,F32,HFQ4,MQ4}.
- `dflash::hfq_weight` (line 184) — panics with `"dflash: unsupported matrix quant_type"` on draft-side MQ3/MQ2.
- DDTree paths in `speculative.rs` (lines 3256, 3379) — explicit error on non-Q8/HFQ4/MQ4.

So Codex's framing "can route MQ3/MQ2 weights through HFQ4 batched kernels" is not strictly correct as a memory-safety statement — but the SPIRIT of the concern is right: silent slow-fallback is a worse UX than a clear refusal.

## Change

1. New `HfqFile::first_tensor_with_quant_type(qt: u8) -> Option<&str>` — keeps the index iteration inside the hfq module (no need to expose `tensors` field).
2. In `daemon.rs` DFlash refusal block, after the existing lm_head whitelist check, scan all tensors for `quant_type ∈ {17, 18}` (MQ3, MQ2). If found, refuse with a clear error.

Today `hipfire-quantize` produces uniform-format models, so this is overwhelmingly caught by the existing lm_head check above. The body scan is for future PRD Phase 3 mixed-precision models.

## Verification

- `cargo build --release --features deltanet --example daemon -p engine` — clean.
- Pre-commit hook (`.githooks/pre-commit`) ran coherence-gate + speed-gate, both passed.

## Files

- `crates/engine/src/hfq.rs`: +11 (new public method)
- `crates/engine/examples/daemon.rs`: +27 (defense-in-depth scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)