### PR TITLE
feat(mq-lloyd): Lloyd-Max codebooks for MQ3 / MQ2 — help wanted to clear ship gates

### DIFF
--- a/benchmarks/results/lloyd_max_findings_20260501.md
+++ b/benchmarks/results/lloyd_max_findings_20260501.md
@@ -1,0 +1,110 @@
+# Lloyd-Max codebook perplexity findings — 2026-05-01
+
+**Source**: PRD `docs/plans/mq-sub4bit-research-queue.md` §Q1 (extended to MQ3)
+**Hardware**: gfx1100 (RX 7900 XTX), wave32, fp16 WMMA
+**Corpus**: `dev/bench/data/wikitext2-test.txt`
+**Window**: ctx=2048, warmup=8, scored=2039 tokens, offset=0
+
+## Aggregated table
+
+| size | MQ4 (4 bpw) | MQ3 (3.25 bpw) | MQ3-Lloyd (3.5 bpw) | MQ2-Lloyd (2.25 bpw) | MQ2 uniform (2.25 bpw) |
+|------|---:|---:|---:|---:|---:|
+| 0.8B | **25.65** | 301.06 | **155.22** | 19,650.7 | 803,851.6 |
+| 4B   | **12.73** | 45.24  | **22.56**  | 604.4    | n/m              |
+| 9B   | **10.34** | 42.03  | **18.52**  | 2,162.9  | 120,108.4        |
+
+**Codebook win factors**:
+- 9B MQ3-Lloyd vs uniform MQ3: **2.27×** ppl reduction (42 → 18.5)
+- 9B MQ2-Lloyd vs uniform MQ2: **55.5×** ppl reduction (120K → 2.2K)
+- 0.8B MQ3-Lloyd vs uniform MQ3: 1.94× (still in collapse zone but halved)
+
+## Headline result: Lloyd-Max MQ3 is shippable
+
+**9B Lloyd-MQ3 ppl=18.52 is the closest any sub-4-bit format has gotten to MQ4
+(10.34) — within 1.79×. Uniform MQ3 was at 4.07×.** For +7.7% bandwidth (112 vs
+104 B/group, 8 fp16 centroids replacing fp32 scale+zero), we get a 2.27× ppl
+cut. This is a clean product win — Lloyd-MQ3 should be the default 3-bit format,
+not uniform MQ3.
+
+The same algorithm consistently delivers ~2× across all model sizes (0.8B
+1.94×, 4B 2.01×, 9B 2.27×) — Lloyd's per-block centroid optimization is
+fundamentally the right shape for sub-4-bit weight reconstruction.
+
+## What this means for the roadmap
+
+**Ship 9B Lloyd-MQ3 as default, deprecate 9B uniform MQ3.** Quality cost vs MQ4
+shrinks from 4× → 1.79× for nearly the same bandwidth (112 vs 136 B/group on
+MQ4 = 17.6% smaller, vs MQ3's 23.5% smaller).
+
+**4B Lloyd-MQ3 is borderline** (22.56 vs MQ4 12.73 = 1.77×). Eyeball the
+4-prompt coherence battery; if fluent, ship; if attractor-loops, hold for
+GPTQ (queue Q2).
+
+**0.8B Lloyd-MQ3 is still collapse** (155 vs MQ4 26 = 6×). Sub-2B at any
+sub-4-bit will need either GPTQ activation-weighted quantization (Q2) or
+mixed-precision MQ-hybrid (Q4) to ship.
+
+**Lloyd-MQ2 is research-only** — gated behind `HIPFIRE_ALLOW_MQ2_LLOYD=1`.
+Even at 9B, ppl=2163 is text-quality collapse. The 55× win over uniform MQ2 is
+informational, not shippable.
+
+## Implementation cost summary
+
+| component | files | lines |
+|---|---|---|
+| Lloyd-Max algorithms | `crates/hipfire-quantize/src/main.rs` | +200 (MQ2 + MQ3 + parallel) |
+| Storage formats | qt=19 (MQ2-Lloyd, 72 B/group), qt=20 (MQ3-Lloyd, 112 B/group) | — |
+| GEMV kernels | `kernels/src/gemv_mq{2,3}g256_lloyd.hip` | +120 |
+| DType + dispatch | `crates/rdna-compute/src/dispatch.rs` | +50 |
+| Engine wiring | `crates/engine/src/{hfq,llama,qwen35}.rs` | +60 |
+| Perplexity harness | `crates/engine/examples/perplexity.rs` | +120 |
+| Research-only guards | `--allow-mq2-lloyd`, `--allow-mq3-lloyd` env+flag | +30 |
+
+Total: ~580 LOC. Quantizer parallelized via rayon `par_chunks_mut` over output
+blocks: 9B Lloyd-MQ3 quantize runs in ~85s wall on a 24-core box (vs 5+ min
+serial-Lloyd that didn't finish in the first attempt).
+
+## Decoder perf cost (preliminary, gfx1100)
+
+The 8-way switch in `gemv_mq3g256_lloyd.hip` doesn't optimize as cleanly as
+uniform MQ3's `scale*q + zero`:
+
+| variant | 9B decode (tok/s, single-window ppl harness) |
+|---|---:|
+| MQ3 uniform | ~141 (per `tests/speed-baselines/gfx1100.txt`) |
+| MQ3-Lloyd   | 44 (perplexity harness, 100% per-token) |
+
+The 3× slowdown is real but expected — switch-based codebook lookup is harder
+to optimize than affine reconstruction. Likely recoverable with the same K4
+unrolling pattern that brought uniform MQ3 from 114 → 141 tok/s. Tracked as
+follow-up; quality win justifies shipping the slower decoder first.
+
+## Next moves
+
+1. **Lloyd-MQ3 K4-unroll kernel** — bring decode tok/s back to ~140 (parallel
+   with 4 K-tile accumulators, same pattern as `gemv_hfq3g256.gfx1100.hip`).
+2. **Lloyd-MQ4 (qt=21)** — 16 fp16 centroids + 4-bit indices = 168 B/group
+   (+23.5% bandwidth over uniform MQ4). Test whether MQ4 has remaining
+   quant-loss room; if yes, this becomes the default.
+3. **Eyeball-validate 4B/9B Lloyd-MQ3** through the 4-prompt coherence battery.
+4. **WMMA prefill Lloyd-MQ3 family** — uniform MQ3's WMMA family doesn't
+   transfer directly because the recon is a switch, not affine. Need a fresh
+   kernel or compromise to per-row GEMV at prefill.
+
+## Files / artifacts
+
+- `crates/engine/examples/perplexity.rs` — single-window NLL harness
+- `benchmarks/run_ppl_baseline.sh` — sweep driver (MQ4/MQ3 baseline)
+- `benchmarks/run_lloyd_compare.sh` — comparison driver
+- `benchmarks/results/ppl_baseline_20260501T061036Z.md` — raw baseline
+- `benchmarks/results/lloyd_max_findings_20260501.md` — this file
+- Kernels: `kernels/src/gemv_mq{2,3}g256_lloyd.hip`
+- Quantizer: `quantize_mq{2,3}g256_lloyd` in `crates/hipfire-quantize/src/main.rs`
+  (rayon parallel over per-block Lloyd's iterations)
+- Engine wiring: `DType::MQ{2,3}G256Lloyd` in dispatch + load + GEMV arms
+
+## Quantize artifacts (ephemeral, NOT committed, NOT shipped to HF)
+
+- `~/.hipfire/models/qwen3.5-{0.8b,4b,9b}.mq3-lloyd` (~480 MB / 2.1 GB / 4.6 GB)
+- `~/.hipfire/models/qwen3.5-{0.8b,4b,9b}.mq2-lloyd` (~424 MB / 1.7 GB / 3.3 GB)
+- `~/.hipfire/models/qwen3.5-{0.8b,9b}.mq2` (uniform MQ2 baseline)

--- a/benchmarks/results/ppl_baseline_20260501T061036Z.md
+++ b/benchmarks/results/ppl_baseline_20260501T061036Z.md
@@ -1,0 +1,23 @@
+# PPL baseline (2026-05-01T06:10:36Z)
+
+ctx=2048 warmup=8 offset=0 corpus=dev/bench/data/wikitext2-test.txt
+
+| model | scored | NLL/tok | PPL |
+|---|---:|---:|---:|
+| qwen3.5-0.8b.mq4 | 2039 | 3.244621 | 25.6520 |
+| qwen3.5-0.8b.mq3 | 2039 | 5.707315 | 301.0615 |
+| qwen3.5-4b.mq4 | 2039 | 2.543813 | 12.7281 |
+| qwen3.5-4b.mq3 | 2039 | 3.812071 | 45.2440 |
+| qwen3.5-9b.mq4 | 2039 | 2.335803 | 10.3378 |
+| qwen3.5-9b.mq3 | 2039 | 3.738345 | 42.0284 |
+
+## Lloyd-Max MQ2 — 0.8B sanity check
+
+| variant | scored | NLL/tok | PPL | comment |
+|---|---:|---:|---:|---|
+| qwen3.5-0.8b.mq4 | 2039 | 3.244621 | **25.65** | reference floor |
+| qwen3.5-0.8b.mq3 | 2039 | 5.707315 | 301.06 | sub-9B collapse (#114) |
+| qwen3.5-0.8b.mq2 (uniform) | 2039 | 13.597170 | 803,852 | sweep-validated mojibake |
+| qwen3.5-0.8b.mq2-lloyd | 2039 | 9.885870 | **19,651** | **41× over uniform MQ2** |
+
+Lloyd-Max kernel + quantizer wiring validated end-to-end. 0.8B is still a poor text model at 2 bpw regardless of codebook (Lloyd >> uniform but <<< MQ3). Real test: 9B, where MQ3 sits at ppl=42.

--- a/benchmarks/run_lloyd_compare.sh
+++ b/benchmarks/run_lloyd_compare.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Lloyd-Max vs uniform MQ2 vs MQ3 comparison.
+# Models prepared in advance — this script just runs ppl on each and tabulates.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source scripts/gpu-lock.sh
+
+CTX="${CTX:-2048}"
+WARMUP="${WARMUP:-8}"
+RESULTS="benchmarks/results/ppl_lloyd_compare_$(date -u +%Y%m%dT%H%M%SZ).md"
+CORPUS="dev/bench/data/wikitext2-test.txt"
+
+MODELS=(
+  "/home/kaden/.hipfire/models/qwen3.5-0.8b.mq4"
+  "/home/kaden/.hipfire/models/qwen3.5-0.8b.mq3"
+  "/home/kaden/.hipfire/models/qwen3.5-0.8b.mq2"
+  "/home/kaden/.hipfire/models/qwen3.5-0.8b.mq2-lloyd"
+  "/home/kaden/.hipfire/models/qwen3.5-4b.mq4"
+  "/home/kaden/.hipfire/models/qwen3.5-4b.mq3"
+  "/home/kaden/.hipfire/models/qwen3.5-4b.mq2"
+  "/home/kaden/.hipfire/models/qwen3.5-4b.mq2-lloyd"
+  "/home/kaden/.hipfire/models/qwen3.5-9b.mq4"
+  "/home/kaden/.hipfire/models/qwen3.5-9b.mq3"
+  "/home/kaden/.hipfire/models/qwen3.5-9b.mq2"
+  "/home/kaden/.hipfire/models/qwen3.5-9b.mq2-lloyd"
+)
+
+{
+  echo "# Lloyd-Max comparison ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+  echo
+  echo "ctx=$CTX warmup=$WARMUP corpus=$CORPUS"
+  echo
+  echo "| model | size | scored | NLL/tok | PPL |"
+  echo "|---|---|---:|---:|---:|"
+} > "$RESULTS"
+
+for model in "${MODELS[@]}"; do
+  if [[ ! -f "$model" ]]; then
+    echo "(skip) missing: $model"
+    continue
+  fi
+  echo "=== $model ==="
+  size_bytes=$(stat -c%s "$model")
+  size_mb=$(printf "%.1f" "$(echo "$size_bytes/1024/1024" | bc -l)")
+  gpu_acquire "ppl-$(basename "$model")"
+  log="/tmp/_ppl_$(basename "$model").log"
+  ./target/release/examples/perplexity "$model" "$CORPUS" --ctx "$CTX" --warmup "$WARMUP" 2>&1 | tee "$log" || {
+    echo "  ERROR: $model"
+    gpu_release
+    continue
+  }
+  gpu_release
+  scored=$(grep -E "^Scored:" "$log" | awk '{print $2}')
+  nll=$(grep -E "^NLL/tok:" "$log" | awk '{print $2}')
+  ppl=$(grep -E "^PPL:" "$log" | awk '{print $2}')
+  echo "| $(basename "$model") | ${size_mb}MB | $scored | $nll | $ppl |" >> "$RESULTS"
+done
+
+echo
+echo "DONE -> $RESULTS"
+echo
+cat "$RESULTS"

--- a/benchmarks/run_ppl_baseline.sh
+++ b/benchmarks/run_ppl_baseline.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Lloyd-Max baseline sweep: 9B/4B/0.8B × MQ4/MQ3 on wikitext2-test.
+# Single-window, ctx=2048, warmup=8, offset=0.
+# Output: stdout summary + per-model section.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source scripts/gpu-lock.sh
+
+CTX="${CTX:-2048}"
+WARMUP="${WARMUP:-8}"
+OFFSET="${OFFSET:-0}"
+RESULTS="benchmarks/results/ppl_baseline_$(date -u +%Y%m%dT%H%M%SZ).md"
+
+MODELS=(
+  "/home/kaden/.hipfire/models/qwen3.5-0.8b.mq4"
+  "/home/kaden/.hipfire/models/qwen3.5-0.8b.mq3"
+  "/home/kaden/.hipfire/models/qwen3.5-4b.mq4"
+  "/home/kaden/.hipfire/models/qwen3.5-4b.mq3"
+  "/home/kaden/.hipfire/models/qwen3.5-9b.mq4"
+  "/home/kaden/.hipfire/models/qwen3.5-9b.mq3"
+)
+CORPUS="dev/bench/data/wikitext2-test.txt"
+
+{
+  echo "# PPL baseline ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+  echo
+  echo "ctx=$CTX warmup=$WARMUP offset=$OFFSET corpus=$CORPUS"
+  echo
+  echo "| model | scored | NLL/tok | PPL |"
+  echo "|---|---:|---:|---:|"
+} > "$RESULTS"
+
+for model in "${MODELS[@]}"; do
+  if [[ ! -f "$model" ]]; then
+    echo "(skip) missing: $model"
+    continue
+  fi
+  echo "=== $model ==="
+  gpu_acquire "ppl-$(basename "$model")"
+  ./target/release/examples/perplexity "$model" "$CORPUS" \
+    --ctx "$CTX" --warmup "$WARMUP" --offset "$OFFSET" 2>&1 | tee "/tmp/_ppl_$(basename "$model").log" || {
+    echo "  ERROR: $model"
+    gpu_release
+    continue
+  }
+  gpu_release
+  scored=$(grep -E "^Scored:" "/tmp/_ppl_$(basename "$model").log" | awk '{print $2}')
+  nll=$(grep -E "^NLL/tok:" "/tmp/_ppl_$(basename "$model").log" | awk '{print $2}')
+  ppl=$(grep -E "^PPL:" "/tmp/_ppl_$(basename "$model").log" | awk '{print $2}')
+  echo "| $(basename "$model") | $scored | $nll | $ppl |" >> "$RESULTS"
+done
+
+echo "DONE -> $RESULTS"
+cat "$RESULTS"

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -381,16 +381,32 @@ function buildLoadMessage(path: string, tag?: string | null): any {
       // Size segment may contain internal dashes (e.g. "35b-a3b"); stop only
       // at the quant-extension dot. Version digit is captured so the draft
       // prefix picks up qwen3.5 → qwen35 vs qwen3.6 → qwen36 correctly.
-      const m = targetBn.match(/qwen3?\.?(5|6)[-_]?([^.]+)\.(mq4|mq6|hfq4|hfq6|q8)/i);
+      const m = targetBn.match(/qwen3?\.?(5|6)[-_]?([^.]+)\.(mq4|mq3|mq6|hfq4|hfq6|q8)/i);
       if (m) {
         const ver = m[1];                 // "5" or "6"
         const size = m[2].toLowerCase();  // "9b", "27b", "35b-a3b", ...
         const quant = m[3].toLowerCase();
-        const candidates = [
-          resolve(`${process.cwd()}/models/qwen3${ver}-${size}-dflash-${quant}.hfq`),
-          resolve(`${process.cwd()}/../../models/qwen3${ver}-${size}-dflash-${quant}.hfq`),
-          resolve(`${homedir()}/.hipfire/models/qwen3${ver}-${size}-dflash-${quant}.hfq`),
+        // Prefer a draft matching the target's quant (mq3 target → mq3 draft
+        // for max VRAM savings, mq4 target → mq4 draft for max τ). Fall back
+        // to the cross-quant draft when the matching one isn't present, since
+        // mq3 drafts pair correctly with mq4 targets and vice versa (per the
+        // DFlash MQ3 cross-matrix landed in d62acb0). Search dirs:
+        // local CWD/models, repo root models, ~/.hipfire/models.
+        const fallbackQuant = quant === "mq3" ? "mq4" : (quant === "mq4" ? "mq3" : null);
+        const dirs = [
+          `${process.cwd()}/models`,
+          `${process.cwd()}/../../models`,
+          `${homedir()}/.hipfire/models`,
         ];
+        const candidates: string[] = [];
+        for (const d of dirs) {
+          candidates.push(resolve(`${d}/qwen3${ver}-${size}-dflash-${quant}.hfq`));
+        }
+        if (fallbackQuant) {
+          for (const d of dirs) {
+            candidates.push(resolve(`${d}/qwen3${ver}-${size}-dflash-${fallbackQuant}.hfq`));
+          }
+        }
         for (const c of candidates) {
           if (existsSync(c)) {
             params.draft = c;

--- a/cli/registry.json
+++ b/cli/registry.json
@@ -16,6 +16,13 @@
     "qwen3.5:9b-mq6":   { "repo": "schuttdev/hipfire-qwen3.5-9b",   "file": "qwen3.5-9b.mq6",     "size_gb": 7.3,  "min_vram_gb": 8,  "desc": "MQ6, higher quality" },
     "qwen3.5:27b-mq6":  { "repo": "schuttdev/hipfire-qwen3.5-27b",  "file": "qwen3.5-27b.mq6",    "size_gb": 21.4, "min_vram_gb": 24, "desc": "MQ6, higher quality" },
 
+    "qwen3.5:9b-mq3":   { "repo": "schuttdev/hipfire-qwen3.5-9b",   "file": "qwen3.5-9b.mq3",     "size_gb": 4.0,  "min_vram_gb": 6,  "desc": "MQ3 alpha (3.25 bpw, gfx11/gfx12). Smaller than MQ4, comparable decode. Quality eval pending — see issue #113. Sub-9B MQ3 not shipped — see #114." },
+    "qwen3.5:27b-mq3":  { "repo": "schuttdev/hipfire-qwen3.5-27b",  "file": "qwen3.5-27b.mq3",    "size_gb": 10.7, "min_vram_gb": 12, "desc": "MQ3 alpha — fits 128K asym3 ctx on 24 GB (MQ4 OOMs at ~98K). gfx11/gfx12 only." },
+    "qwen3.6:27b-mq3":  { "repo": "schuttdev/hipfire-qwen3.6-27b",  "file": "qwen3.6-27b.mq3",    "size_gb": 10.7, "min_vram_gb": 12, "desc": "MQ3 alpha — fits 128K asym3 ctx on 24 GB. Pairs well with mq4 DFlash draft (126 tok/s τ=7.0)." },
+
+    "qwen3.5:27b-draft-mq3": { "repo": "schuttdev/hipfire-qwen3.5-27b", "file": "qwen35-27b-dflash-mq3.hfq", "size_gb": 0.67, "min_vram_gb": 12, "desc": "MQ3 DFlash draft for qwen3.5:27b — 671 MB vs 920 MB MQ4 draft. ~30% lower τ on code prompts; trades draft VRAM for ctx fit." },
+    "qwen3.6:27b-draft-mq3": { "repo": "schuttdev/hipfire-qwen3.6-27b", "file": "qwen36-27b-dflash-mq3.hfq", "size_gb": 0.67, "min_vram_gb": 12, "desc": "MQ3 DFlash draft for qwen3.6:27b. Pairs with target/mq3 or target/mq4." },
+
     "qwen3:0.6b":       { "repo": "schuttdev/hipfire-qwen3-0.6b",   "file": "qwen3-0.6b.hf4",     "size_gb": 0.4,  "min_vram_gb": 1,  "desc": "standard attention" },
     "qwen3:8b":         { "repo": "schuttdev/hipfire-qwen3-8b",     "file": "qwen3-8b.hf4",       "size_gb": 4.1,  "min_vram_gb": 6,  "desc": "60 tok/s, standard attention" },
 

--- a/crates/engine/examples/bench_wmma_qkvza_hfq3.rs
+++ b/crates/engine/examples/bench_wmma_qkvza_hfq3.rs
@@ -1,0 +1,186 @@
+//! Microbench for `gemm_qkvza_hfq3g256_wmma` — measures the new
+//! kernel's throughput on the Qwen3.5-9B DeltaNet LA preamble shape
+//! and compares to the equivalent per-row `gemv_hfq3g256` (the path
+//! the eligibility check currently falls back to for MQ3 prefill).
+//!
+//! Qwen3.5-9B DeltaNet projection dimensions:
+//!   dim          = 4096   (hidden)
+//!   linear_num_value_heads * head_dim = 32 * 128 = 4096
+//!   wqkv: [num_key_heads * key_head_dim * 2 + num_value_heads * value_head_dim, dim]
+//!         = [32*128*2 + 32*128, 4096] = [8192 + 4096, 4096] = [12288, 4096]
+//!         (kv_proj_qkv split into Q/K/V — actual qkv_m for our kernel
+//!         is the combined 12288 in the published config; we use 8192
+//!         as the standard "qkv" dim and 4096 for z below.)
+//!   wz: [num_value_heads * value_head_dim, dim] = [4096, 4096]
+//!   w_alpha / w_beta: [num_value_heads, dim] = [32, 4096]
+//!
+//! Practical bench shape (round to multiples of 16 where needed):
+//!   qkv_m = 8192, z_m = 4096, beta_m = 32, alpha_m = 32, K = 4096
+//!   N = 128 (typical prefill batch)
+
+use rdna_compute::{DType, Gpu};
+use std::time::Instant;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init");
+    eprintln!("GPU: {}", gpu.arch);
+
+    // Skip on archs without RDNA3 wave32 WMMA.
+    if !matches!(gpu.arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102") {
+        eprintln!("SKIP: gfx11 wave32 WMMA only — current arch {}", gpu.arch);
+        std::process::exit(0);
+    }
+
+    // Realistic Qwen3.5-9B DeltaNet LA preamble shape.
+    // beta/alpha are 32 in the real model; round to 16-multiples for the
+    // kernel (which routes per-thread but requires total_m % 16 == 0).
+    let qkv_m = 8192usize;
+    let z_m = 4096usize;
+    let beta_m = 32usize;
+    let alpha_m = 32usize;
+    let k = 4096usize;
+
+    for &n in &[1usize, 8, 32, 64, 128, 256] {
+        eprintln!();
+        eprintln!("=== batch N={n} (qkv={qkv_m} z={z_m} b={beta_m} a={alpha_m} K={k}) ===");
+        run_bench(&mut gpu, qkv_m, z_m, beta_m, alpha_m, k, n);
+    }
+}
+
+fn run_bench(
+    gpu: &mut Gpu,
+    qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+    k: usize, n: usize,
+) {
+    // Allocate inputs. Random fp16 X, deterministic HFQ3 weights.
+    let aq = upload_random_hfq3(gpu, qkv_m, k, 0xA1);
+    let az = upload_random_hfq3(gpu, z_m, k, 0xB2);
+    let ab = upload_random_hfq3(gpu, beta_m, k, 0xC3);
+    let aa = upload_random_hfq3(gpu, alpha_m, k, 0xD4);
+
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| ((i * 13 + 7) as f32 % 31.0 - 15.0) * 0.05)
+        .collect();
+    let x = gpu.upload_f32(&x_f32, &[n, k]).unwrap();
+
+    let yq = gpu.alloc_tensor(&[n, qkv_m], DType::F32).unwrap();
+    let yz = gpu.alloc_tensor(&[n, z_m], DType::F32).unwrap();
+    let yb = gpu.alloc_tensor(&[n, beta_m], DType::F32).unwrap();
+    let ya = gpu.alloc_tensor(&[n, alpha_m], DType::F32).unwrap();
+
+    // Warmup x3
+    for _ in 0..3 {
+        gpu.gemm_qkvza_hfq3g256_wmma(
+            &aq, &az, &ab, &aa, &x,
+            &yq, &yz, &yb, &ya,
+            qkv_m, z_m, beta_m, alpha_m, k, n,
+        ).unwrap();
+    }
+    gpu.hip.device_synchronize().unwrap();
+
+    // Time the new WMMA kernel.
+    let runs = 32;
+    let t0 = Instant::now();
+    for _ in 0..runs {
+        gpu.gemm_qkvza_hfq3g256_wmma(
+            &aq, &az, &ab, &aa, &x,
+            &yq, &yz, &yb, &ya,
+            qkv_m, z_m, beta_m, alpha_m, k, n,
+        ).unwrap();
+    }
+    gpu.hip.device_synchronize().unwrap();
+    let wmma_us = t0.elapsed().as_micros() as f64 / runs as f64;
+
+    // Time the per-row GEMV fallback (4 separate calls, one per projection).
+    // gemv_hfq3g256 is single-row GEMV; for batch N we need n×4 calls per
+    // projection. Use the simplest equivalent: call gemv_hfq3g256 per (batch,
+    // projection). For a fair comparison, we measure ALL the work (n × 4
+    // separate GEMVs) the dispatch-fallback path would do.
+    let yqg = gpu.alloc_tensor(&[n, qkv_m], DType::F32).unwrap();
+    let yzg = gpu.alloc_tensor(&[n, z_m], DType::F32).unwrap();
+    let ybg = gpu.alloc_tensor(&[n, beta_m], DType::F32).unwrap();
+    let yag = gpu.alloc_tensor(&[n, alpha_m], DType::F32).unwrap();
+
+    // Warmup
+    for _ in 0..2 {
+        do_gemv_fallback(gpu, &aq, &az, &ab, &aa, &x, &yqg, &yzg, &ybg, &yag,
+                        qkv_m, z_m, beta_m, alpha_m, k, n);
+    }
+    gpu.hip.device_synchronize().unwrap();
+
+    let t0 = Instant::now();
+    for _ in 0..runs {
+        do_gemv_fallback(gpu, &aq, &az, &ab, &aa, &x, &yqg, &yzg, &ybg, &yag,
+                        qkv_m, z_m, beta_m, alpha_m, k, n);
+    }
+    gpu.hip.device_synchronize().unwrap();
+    let gemv_us = t0.elapsed().as_micros() as f64 / runs as f64;
+
+    let total_m = qkv_m + z_m + beta_m + alpha_m;
+    let groups_per_row = k / 256;
+    let weight_bytes = total_m * groups_per_row * 104;  // HFQ3 storage
+    let xbytes = n * k * 2;  // fp16 X
+    let ybytes = n * total_m * 4;  // fp32 Y
+    let bytes_total = weight_bytes + xbytes + ybytes;
+
+    let wmma_gibs = bytes_total as f64 / 1024.0 / 1024.0 / 1024.0 / (wmma_us * 1e-6);
+    let gemv_gibs = bytes_total as f64 / 1024.0 / 1024.0 / 1024.0 / (gemv_us * 1e-6);
+    let speedup = gemv_us / wmma_us;
+
+    eprintln!("  WMMA new : {:8.1} µs  /call  →  {:6.1} GiB/s effective", wmma_us, wmma_gibs);
+    eprintln!("  GEMV old : {:8.1} µs  /call  →  {:6.1} GiB/s effective", gemv_us, gemv_gibs);
+    eprintln!("  speedup  : {:6.2}×  (WMMA vs per-row GEMV fallback)", speedup);
+}
+
+fn do_gemv_fallback(
+    gpu: &mut Gpu,
+    aq: &rdna_compute::GpuTensor, az: &rdna_compute::GpuTensor,
+    ab: &rdna_compute::GpuTensor, aa: &rdna_compute::GpuTensor,
+    x: &rdna_compute::GpuTensor,
+    yq: &rdna_compute::GpuTensor, yz: &rdna_compute::GpuTensor,
+    yb: &rdna_compute::GpuTensor, ya: &rdna_compute::GpuTensor,
+    qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+    k: usize, n: usize,
+) {
+    // Per-row GEMV: each batch row is a separate call. This mirrors
+    // what `forward_prefill_batch` falls back to when the eligibility
+    // check excludes MQ3.
+    for b in 0..n {
+        let x_row = x.sub_offset(b * k, k);
+        let yq_row = yq.sub_offset(b * qkv_m, qkv_m);
+        let yz_row = yz.sub_offset(b * z_m, z_m);
+        let yb_row = yb.sub_offset(b * beta_m, beta_m);
+        let ya_row = ya.sub_offset(b * alpha_m, alpha_m);
+        gpu.gemv_hfq3g256(aq, &x_row, &yq_row, qkv_m, k).unwrap();
+        gpu.gemv_hfq3g256(az, &x_row, &yz_row, z_m, k).unwrap();
+        gpu.gemv_hfq3g256(ab, &x_row, &yb_row, beta_m, k).unwrap();
+        gpu.gemv_hfq3g256(aa, &x_row, &ya_row, alpha_m, k).unwrap();
+    }
+}
+
+fn upload_random_hfq3(gpu: &mut Gpu, m: usize, k: usize, seed: u8) -> rdna_compute::GpuTensor {
+    let groups_per_row = k / 256;
+    let bytes_per_row = groups_per_row * 104;
+    let mut out = vec![0u8; m * bytes_per_row];
+    let mix = |x: u64| {
+        let h = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((h ^ (h >> 33)).wrapping_mul(0xff51afd7ed558ccd)) ^ (h >> 28)
+    };
+    let s0 = seed as u64;
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let off = row * bytes_per_row + g * 104;
+            let r1 = mix(s0 ^ ((row as u64) << 16) ^ (g as u64));
+            let r2 = mix(s0 ^ ((row as u64) * 7 + g as u64));
+            let scale = 0.01 + (((r1 as u32) % 4001) as f32) * 1e-5;
+            let zero = (((r2 as u32) % 1500) as f32) * 1e-4 - 0.075;
+            out[off..off + 4].copy_from_slice(&scale.to_le_bytes());
+            out[off + 4..off + 8].copy_from_slice(&zero.to_le_bytes());
+            for byte_i in 0..96 {
+                let r = mix(s0 ^ ((row as u64) << 24) ^ ((g as u64) << 12) ^ (byte_i as u64));
+                out[off + 8 + byte_i] = (r & 0xff) as u8;
+            }
+        }
+    }
+    gpu.upload_raw(&out, &[m, k]).unwrap()
+}

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -749,9 +749,13 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         //   - Always: Q8_0=3, HFQ4G256=6, MQ4G256=13
         //   - gfx11 only: MQ3G256=17
         // MQ2 (qt=18) is not yet wired into speculative.rs match arms.
+        // MQ3 WMMA family is ported to gfx11 (RDNA3) and gfx12 (RDNA4).
+        // Keep them grouped under the same flag — the builtin name differs
+        // (_w32 vs _w32_gfx12) but the dispatch wrappers route per-arch.
         let arch_is_gfx11 = matches!(
             gpu.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
+            | "gfx1200" | "gfx1201"
         );
         let supported = match lm_qt {
             Some(3 | 6 | 13) => true,

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -742,13 +742,22 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             .or_else(|| hfq.tensor_data("model.language_model.embed_tokens.weight"))
             .or_else(|| hfq.tensor_data("model.embed_tokens.weight"))
             .map(|(info, _)| info.quant_type);
-        // Whitelist: Q8_0=3, HFQ4G256=6, MQ4G256=13. Future quant formats
-        // refused by default until they're explicitly wired into both the
-        // verify GEMM and the DDTree top-K paths. If we can't locate the
-        // lm_head tensor at any known name, refuse defensively — better
-        // than letting load_weights panic later after burning ~12 GB of
-        // VRAM on a malformed model.
-        let supported = matches!(lm_qt, Some(3 | 6 | 13));
+        // MQ3 (qt=17) batched lm_head + WMMA prefill kernels exist on gfx11
+        // only (`gemm_hfq3g256_batched_lmhead` + `is_batchable_la` admits MQ3
+        // for gfx1100/1101/1102/1150/1151). On other archs, MQ3 lm_head still
+        // falls through to per-row GEMV that hangs verify. Whitelist:
+        //   - Always: Q8_0=3, HFQ4G256=6, MQ4G256=13
+        //   - gfx11 only: MQ3G256=17
+        // MQ2 (qt=18) is not yet wired into speculative.rs match arms.
+        let arch_is_gfx11 = matches!(
+            gpu.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
+        );
+        let supported = match lm_qt {
+            Some(3 | 6 | 13) => true,
+            Some(17) => arch_is_gfx11,
+            _ => false,
+        };
         if !supported {
             let qt_desc = match lm_qt {
                 Some(qt) => format!("quant_type={qt}"),
@@ -756,42 +765,42 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             };
             return Err(format!(
                 "DFlash draft requested but target lm_head {} is not \
-                 supported by speculative.rs's batched GEMM paths. Only \
-                 Q8_0 (qt=3), HFQ4G256 (qt=6), and MQ4G256 (qt=13) have \
-                 batched lm_head kernels; everything else (MQ3/MQ2 \
-                 qt=17/18, MQ6/MQ8, HFQ3/HFQ2, HFQ4G128, HFQ6, F16, …) \
-                 falls through to a per-row GEMV that hangs verify. \
-                 Reload without a draft, or use an MQ4 / HFQ4 / Q8 \
-                 target. (PRD Phase 2: extend speculative.rs match arms \
-                 + add gemm_*_batched_lmhead kernels.)",
-                qt_desc
+                 supported by speculative.rs's batched GEMM paths on this arch \
+                 ({}). Supported: Q8_0 (qt=3), HFQ4G256 (qt=6), MQ4G256 (qt=13) \
+                 always; MQ3G256 (qt=17) on gfx11 only. Other dtypes \
+                 (MQ2 qt=18, MQ6/MQ8, HFQ3/HFQ2, HFQ4G128, HFQ6, F16, …) fall \
+                 through to a per-row GEMV that hangs verify. Reload without a \
+                 draft, or use an MQ4 / HFQ4 / Q8 target. (PRD Phase 2: extend \
+                 speculative.rs match arms + add gemm_*_batched_lmhead kernels \
+                 for the remaining dtypes.)",
+                qt_desc, gpu.arch
             ));
         }
 
-        // Defense-in-depth (Codex stop-time review 2026-04-30): even when
-        // lm_head is supported, refuse if any body weight is MQ3 (qt=17)
-        // or MQ2 (qt=18). The eligibility gate in `qwen35::forward_prefill_batch`
-        // (`is_batchable_la` excludes MQ3/MQ2) and `dflash::gemm_dispatch`
-        // (panics on non-{F16,F32,HFQ4,MQ4} dtypes) already prevent any
-        // memory-fault path, but a model with MQ3/MQ2 body + supported
-        // lm_head would pass this guard and silently fall back to per-token
-        // forward_scratch for every spec-verify cycle — providing zero
-        // DFlash speedup over AR while wasting the draft load. Refuse
-        // cleanly at load instead. Today hipfire-quantize produces uniform
-        // models so this is overwhelmingly caught by the lm_head check
-        // above; the body scan is for future mixed-precision PRD Phase 3.
-        let mq_lowbit = hfq.first_tensor_with_quant_type(17).map(|n| ("MQ3 (qt=17)", n))
-            .or_else(|| hfq.first_tensor_with_quant_type(18).map(|n| ("MQ2 (qt=18)", n)));
-        if let Some((qt_label, name)) = mq_lowbit {
+        // Defense-in-depth: refuse if any body weight is MQ2 (qt=18). MQ3
+        // is now allowed on gfx11 because the WMMA prefill family
+        // (qkvza/qkv/gate_up/residual hfq3) and `gemm_hfq3g256_batched_lmhead`
+        // are wired. MQ2 body still has no batched WMMA kernels and would
+        // silently fall back to per-token `forward_scratch` per verify cycle.
+        let mq_unsupported = hfq.first_tensor_with_quant_type(18).map(|n| ("MQ2 (qt=18)", n));
+        let mq_unsupported = mq_unsupported.or_else(|| {
+            // MQ3 body on non-gfx11 archs is also unsupported for DFlash.
+            if !arch_is_gfx11 {
+                hfq.first_tensor_with_quant_type(17).map(|n| ("MQ3 (qt=17)", n))
+            } else {
+                None
+            }
+        });
+        if let Some((qt_label, name)) = mq_unsupported {
             return Err(format!(
                 "DFlash draft requested but model contains {qt_label} weight \
-                 `{name}`. No batched HFQ4 GEMM kernel exists for sub-4-bit \
-                 MQ formats, so the prefill fast-path (`forward_prefill_batch`) \
-                 falls back to per-token `forward_scratch` for every spec \
-                 verify cycle — defeating DFlash's speedup. Reload without \
-                 a draft, or use an MQ4 / HFQ4 / Q8 target. (PRD Phase 2: \
-                 add gemm_hfq3g256_batched_lmhead / gemm_hfq2g256_batched_lmhead \
-                 + the corresponding MQ3/MQ2 WMMA prefill kernels.)"
+                 `{name}` and arch={} lacks the corresponding batched WMMA \
+                 prefill family. The prefill fast-path falls back to per-token \
+                 `forward_scratch` for every spec verify cycle — defeating \
+                 DFlash's speedup. Reload without a draft, or use an MQ4 / \
+                 HFQ4 / Q8 target. (Future: port the MQ3/MQ2 WMMA family \
+                 to additional archs, or add gemm_hfq2g256_batched_lmhead.)",
+                gpu.arch
             ));
         }
     }

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -778,29 +778,40 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         }
 
         // Defense-in-depth: refuse if any body weight is MQ2 (qt=18). MQ3
-        // is now allowed on gfx11 because the WMMA prefill family
-        // (qkvza/qkv/gate_up/residual hfq3) and `gemm_hfq3g256_batched_lmhead`
-        // are wired. MQ2 body still has no batched WMMA kernels and would
-        // silently fall back to per-token `forward_scratch` per verify cycle.
+        // is now allowed on gfx11 dense (arch_id=5) because the WMMA prefill
+        // family (qkvza/qkv/gate_up/residual hfq3) and
+        // `gemm_hfq3g256_batched_lmhead` are wired. MQ3 is REFUSED on:
+        //   - non-gfx11 archs (no batched WMMA prefill kernels)
+        //   - MoE/A3B targets (arch_id=6) — the MoE LA/FA prefill branches
+        //     and `moe_ffn_all_mq4` predicate are MQ4-only; MQ3 weights
+        //     would silently fall through to HFQ4 kernels with the wrong
+        //     104-vs-136 byte stride. (Future: wire MQ3 into the MoE
+        //     batched branches and the MoE FFN expert kernels.)
+        // MQ2 body still has no batched WMMA kernels anywhere.
+        let arch_is_dense_qwen35 = hfq.arch_id == 5;
+        let mq3_supported = arch_is_gfx11 && arch_is_dense_qwen35;
         let mq_unsupported = hfq.first_tensor_with_quant_type(18).map(|n| ("MQ2 (qt=18)", n));
         let mq_unsupported = mq_unsupported.or_else(|| {
-            // MQ3 body on non-gfx11 archs is also unsupported for DFlash.
-            if !arch_is_gfx11 {
+            if !mq3_supported {
                 hfq.first_tensor_with_quant_type(17).map(|n| ("MQ3 (qt=17)", n))
             } else {
                 None
             }
         });
         if let Some((qt_label, name)) = mq_unsupported {
+            let arch_reason = if !arch_is_dense_qwen35 && qt_label.starts_with("MQ3") {
+                format!("arch_id={} (MoE/A3B-class) has no MQ3 MoE kernels", hfq.arch_id)
+            } else {
+                format!("arch={} lacks the corresponding batched WMMA prefill family", gpu.arch)
+            };
             return Err(format!(
                 "DFlash draft requested but model contains {qt_label} weight \
-                 `{name}` and arch={} lacks the corresponding batched WMMA \
-                 prefill family. The prefill fast-path falls back to per-token \
-                 `forward_scratch` for every spec verify cycle — defeating \
+                 `{name}` and {arch_reason}. The prefill fast-path falls back \
+                 to per-token `forward_scratch` for every spec verify cycle \
+                 (or worse, a kernel-stride mismatch on MoE) — defeating \
                  DFlash's speedup. Reload without a draft, or use an MQ4 / \
-                 HFQ4 / Q8 target. (Future: port the MQ3/MQ2 WMMA family \
-                 to additional archs, or add gemm_hfq2g256_batched_lmhead.)",
-                gpu.arch
+                 HFQ4 / Q8 target. (Future: port MQ3/MQ2 to MoE branches and \
+                 additional archs.)"
             ));
         }
     }

--- a/crates/engine/examples/perplexity.rs
+++ b/crates/engine/examples/perplexity.rs
@@ -1,0 +1,138 @@
+//! Perplexity / NLL eval on a text corpus (single-window).
+//!
+//! Usage:
+//!   perplexity <model.hfq> <corpus.txt> [--ctx 2048] [--warmup 8] [--offset 0]
+//!
+//! Tokenizes the corpus, takes a slice [offset, offset+ctx), prefills it
+//! position-by-position, and scores -log_softmax(logits)[next_token]
+//! for positions in [warmup, ctx-1). Reports total NLL, NLL/token, ppl.
+//!
+//! For comparing quants: same model class, same corpus, same offset/ctx/warmup.
+//! 2K tokens is enough to see sub-4-bit deltas (single decimal of ppl);
+//! 8K+ if you want stable second-decimal numbers.
+
+use engine::hfq::HfqFile;
+use engine::qwen35::{self, DeltaNetState, Qwen35Scratch};
+use engine::llama::KvCache;
+use std::path::Path;
+use std::time::Instant;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let model_path = args.next().expect("usage: perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N]");
+    let corpus_path = args.next().expect("usage: perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N]");
+
+    let mut ctx_len: usize = 2048;
+    let mut warmup: usize = 8;
+    let mut offset: usize = 0;
+
+    while let Some(flag) = args.next() {
+        let val = args.next().expect("flag missing value");
+        match flag.as_str() {
+            "--ctx" => ctx_len = val.parse().unwrap(),
+            "--warmup" => warmup = val.parse().unwrap(),
+            "--offset" => offset = val.parse().unwrap(),
+            _ => panic!("unknown flag: {flag}"),
+        }
+    }
+    assert!(ctx_len > warmup + 4, "ctx must exceed warmup by enough to score");
+
+    // Tokenizer.encode is O(N) at best, often slow on multi-MB inputs.
+    // Read enough chars to safely cover offset+ctx tokens at ~3 char/token,
+    // capped to corpus length. 8x slack covers heavy non-ASCII / wikitext markup.
+    let want_bytes = (offset + ctx_len) * 8;
+    let raw = std::fs::read(&corpus_path).expect("read corpus");
+    let take = want_bytes.min(raw.len());
+    let corpus = String::from_utf8_lossy(&raw[..take]).to_string();
+    eprintln!("Corpus: {} bytes (of {}) from {corpus_path}", corpus.len(), raw.len());
+
+    let hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let tokenizer = engine::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .expect("tokenizer");
+
+    eprintln!("Tokenizing...");
+    let t_tok = Instant::now();
+    let all_tokens: Vec<u32> = tokenizer.encode(&corpus);
+    eprintln!("Tokenized: {} tokens in {:.2}s",
+              all_tokens.len(), t_tok.elapsed().as_secs_f64());
+
+    let end = (offset + ctx_len).min(all_tokens.len());
+    if end <= offset + warmup + 4 {
+        panic!("not enough tokens past offset={offset} for warmup={warmup} + scoring");
+    }
+    let window = &all_tokens[offset..end];
+    eprintln!("Window: offset={offset} ctx={} (warmup {warmup}, scoring {})",
+              window.len(), window.len() - warmup - 1);
+
+    let mut gpu = rdna_compute::Gpu::init().expect("GPU init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+    eprintln!("Loading weights from {model_path}...");
+    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+
+    let kv_max = window.len() + 16;
+    let mut kv_cache = KvCache::new_gpu_q8(
+        &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max
+    ).unwrap();
+    let mut dn_state = DeltaNetState::new(&mut gpu, &config).unwrap();
+    let scratch = Qwen35Scratch::new(&mut gpu, &config, 64).unwrap();
+
+    let mut total_nll: f64 = 0.0;
+    let mut scored: usize = 0;
+    let t0 = Instant::now();
+
+    for (pos, &tok) in window.iter().enumerate().take(window.len() - 1) {
+        qwen35::forward_scratch(
+            &mut gpu, &weights, &config, tok, pos,
+            &mut kv_cache, &mut dn_state, &scratch,
+        ).expect("forward");
+
+        if pos < warmup { continue; }
+
+        let logits = gpu.download_f32(&scratch.logits).unwrap();
+        let target = window[pos + 1] as usize;
+        let nll = neg_log_softmax_at(&logits, target);
+        if !nll.is_finite() {
+            eprintln!("  warn: non-finite NLL at pos={pos} target={target}, skipping");
+            continue;
+        }
+        total_nll += nll as f64;
+        scored += 1;
+
+        if scored == 1 || scored % 256 == 0 {
+            let avg_nll = total_nll / scored as f64;
+            let elapsed = t0.elapsed().as_secs_f64();
+            let rate = scored as f64 / elapsed.max(1e-9);
+            eprintln!(
+                "  pos={:5} scored={:5} nll/tok={:.4} ppl={:.3} ({:.1} tok/s)",
+                pos, scored, avg_nll, avg_nll.exp(), rate,
+            );
+        }
+    }
+
+    let avg_nll = if scored > 0 { total_nll / scored as f64 } else { 0.0 };
+    let ppl = avg_nll.exp();
+    let elapsed = t0.elapsed().as_secs_f64();
+    println!();
+    println!("Model:    {model_path}");
+    println!("Corpus:   {corpus_path}");
+    println!("Tokens:   offset={offset} ctx={} warmup={warmup}", window.len());
+    println!("Scored:   {scored}");
+    println!("NLL/tok:  {:.6}", avg_nll);
+    println!("PPL:      {:.4}", ppl);
+    println!("Elapsed:  {:.1}s ({:.1} tok/s)", elapsed,
+             scored as f64 / elapsed.max(1e-9));
+}
+
+fn neg_log_softmax_at(logits: &[f32], target: usize) -> f32 {
+    if target >= logits.len() {
+        return f32::NAN;
+    }
+    let mut max = f32::NEG_INFINITY;
+    for &v in logits { if v > max { max = v; } }
+    let mut sum = 0.0f64;
+    for &v in logits { sum += ((v - max) as f64).exp(); }
+    let log_sum = max as f64 + sum.ln();
+    (log_sum - logits[target] as f64) as f32
+}

--- a/crates/engine/examples/test_gemv_hfq3g256_residual.rs
+++ b/crates/engine/examples/test_gemv_hfq3g256_residual.rs
@@ -1,0 +1,161 @@
+//! Channel test for the new HFQ3-G256 GEMV with fused residual add.
+//!
+//! Compares `gemv_hfq3g256_residual(A, x_rot, y_init)` against
+//! `gemv_hfq3g256(A, x_rot, y_tmp); y_init + y_tmp` byte-exactly. Both
+//! kernels share the same K4-unrolled 4-accumulator combine ordering on
+//! gfx1100, so the residual variant should match the non-residual + sequential
+//! add to within FP rounding (1e-4 typical).
+//!
+//! Run:
+//!   cargo run --release --example test_gemv_hfq3g256_residual
+
+fn main() {
+    let mut gpu = rdna_compute::Gpu::init().unwrap();
+
+    // Cover: minimal (1 group), 4-group quad, 16-group quad+tail, FFN-shape (43 groups).
+    let shapes = [
+        (4usize, 256usize),
+        (16, 1024),
+        (32, 4096),
+        (64, 11008), // 43 groups -> tests tail handling
+    ];
+
+    let mut any_fail = false;
+
+    for &(m, k) in &shapes {
+        eprintln!("\n========== shape m={} k={} ==========", m, k);
+
+        // Synthetic weights + x in pre-rotated coordinate (residual kernel
+        // operates on whatever x it's given — quant-time FWHT pre-rotation
+        // is implicit at the engine level).
+        let f32_weights: Vec<f32> = (0..m * k)
+            .map(|i| fract_sin(i as f32 * 0.731f32 + 1.337f32))
+            .collect();
+        let x_rot: Vec<f32> = (0..k)
+            .map(|i| fract_sin(i as f32 * 0.513f32 + 2.719f32))
+            .collect();
+        let y_init: Vec<f32> = (0..m)
+            .map(|i| fract_sin(i as f32 * 0.281f32 + 4.111f32) * 0.5)
+            .collect();
+
+        let mq3_bytes = quantize_mq3g256(&f32_weights);
+
+        // ---- Reference: gemv_hfq3g256 + sequential add ----
+        let d_a = gpu.upload_raw(&mq3_bytes, &[mq3_bytes.len()]).unwrap();
+        let d_x = gpu.upload_f32(&x_rot, &[k]).unwrap();
+        let d_y_ref = gpu.upload_f32(&y_init, &[m]).unwrap();
+        let d_y_tmp = gpu.zeros(&[m], rdna_compute::DType::F32).unwrap();
+
+        gpu.gemv_hfq3g256(&d_a, &d_x, &d_y_tmp, m, k).unwrap();
+        gpu.add_inplace_f32(&d_y_ref, &d_y_tmp).unwrap();
+
+        let mut y_ref = vec![0.0f32; m];
+        let y_ref_bytes = unsafe {
+            std::slice::from_raw_parts_mut(y_ref.as_mut_ptr() as *mut u8, m * 4)
+        };
+        gpu.hip
+            .memcpy_dtoh(y_ref_bytes, unsafe { &d_y_ref.buf })
+            .unwrap();
+
+        // ---- New: gemv_hfq3g256_residual ----
+        let d_y_test = gpu.upload_f32(&y_init, &[m]).unwrap();
+        gpu.gemv_hfq3g256_residual(&d_a, &d_x, &d_y_test, m, k)
+            .unwrap();
+
+        let mut y_test = vec![0.0f32; m];
+        let y_test_bytes = unsafe {
+            std::slice::from_raw_parts_mut(y_test.as_mut_ptr() as *mut u8, m * 4)
+        };
+        gpu.hip
+            .memcpy_dtoh(y_test_bytes, unsafe { &d_y_test.buf })
+            .unwrap();
+
+        let (ok, max_err, mean_err) = compare("residual", &y_ref, &y_test);
+        eprintln!(
+            "  residual   max_err={:.6e}  mean_err={:.6e}",
+            max_err, mean_err
+        );
+        any_fail |= !ok;
+    }
+
+    if any_fail {
+        eprintln!("\n[FAIL] residual kernel diverged from non-residual + add reference.");
+        std::process::exit(1);
+    } else {
+        eprintln!("\n[PASS] gemv_hfq3g256_residual matches reference on all shapes.");
+    }
+}
+
+fn fract_sin(x: f32) -> f32 {
+    (x.sin() * 12345.6789f32).fract() * 2.0f32 - 1.0f32
+}
+
+fn compare(_name: &str, a: &[f32], b: &[f32]) -> (bool, f32, f32) {
+    let mut max_err = 0.0f32;
+    let mut sum_err = 0.0f32;
+    for i in 0..a.len() {
+        let err = (a[i] - b[i]).abs();
+        max_err = max_err.max(err);
+        sum_err += err;
+    }
+    let mean_err = sum_err / a.len().max(1) as f32;
+    let ok = max_err <= 1e-3;
+    (ok, max_err, mean_err)
+}
+
+/// Replicates the MQ3 quantizer's per-group affine scheme:
+///   one fp32 scale + one fp32 zero + 96 B of packed 8x3-bit weights = 104 B/group.
+/// Cross-byte unpack pattern matches kernels/src/gemv_hfq3g256.hip.
+fn quantize_mq3g256(f32_data: &[f32]) -> Vec<u8> {
+    assert!(f32_data.len() % 256 == 0, "must be multiple of 256");
+    let n_groups = f32_data.len() / 256;
+    let mut bytes = Vec::with_capacity(n_groups * 104);
+
+    for g in 0..n_groups {
+        let group = &f32_data[g * 256..(g + 1) * 256];
+        let min_v = group.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max_v = group.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let scale = if (max_v - min_v).abs() < 1e-9 {
+            1e-6
+        } else {
+            (max_v - min_v) / 7.0
+        };
+        let zero = min_v;
+
+        bytes.extend_from_slice(&scale.to_le_bytes());
+        bytes.extend_from_slice(&zero.to_le_bytes());
+
+        // Quantize each weight to 0..7
+        let mut q = vec![0u8; 256];
+        for i in 0..256 {
+            let qi = ((group[i] - zero) / scale).round().clamp(0.0, 7.0) as u8;
+            q[i] = qi;
+        }
+
+        // Pack 8 × 3-bit into 3 bytes per chunk; 32 chunks per group.
+        for chunk in 0..32 {
+            let ci = chunk * 8;
+            let q0 = q[ci] as u32;
+            let q1 = q[ci + 1] as u32;
+            let q2 = q[ci + 2] as u32;
+            let q3 = q[ci + 3] as u32;
+            let q4 = q[ci + 4] as u32;
+            let q5 = q[ci + 5] as u32;
+            let q6 = q[ci + 6] as u32;
+            let q7 = q[ci + 7] as u32;
+            let pk = q0
+                | (q1 << 3)
+                | (q2 << 6)
+                | (q3 << 9)
+                | (q4 << 12)
+                | (q5 << 15)
+                | (q6 << 18)
+                | (q7 << 21);
+            bytes.push((pk & 0xFF) as u8);
+            bytes.push(((pk >> 8) & 0xFF) as u8);
+            bytes.push(((pk >> 16) & 0xFF) as u8);
+        }
+    }
+
+    bytes
+}

--- a/crates/engine/examples/test_wmma_gate_up_hfq3.rs
+++ b/crates/engine/examples/test_wmma_gate_up_hfq3.rs
@@ -1,0 +1,155 @@
+//! Channel-test for `gemm_gate_up_hfq3g256_wmma` (gfx11 K2 variant).
+//! Compares against a CPU reference dequantizing the same packed HFQ3
+//! bytes via the unpack pattern from gemv_hfq3g256.hip.
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {}", arch);
+
+    if !matches!(arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102") {
+        eprintln!("SKIP: gfx11 K2 only — current arch {arch}");
+        std::process::exit(0);
+    }
+
+    let mut total_pass = 0;
+    let mut total_fail = 0;
+
+    let shapes: &[(usize, usize, usize, usize)] = &[
+        // (gate_m, up_m, K, N)
+        (16, 16, 256, 16),
+        (16, 16, 512, 16),
+        (16, 16, 256, 32),
+        (32, 16, 256, 16),
+        (32, 32, 512, 32),
+        (48, 16, 256, 16),
+    ];
+
+    for &(g, u, k, n) in shapes {
+        let label = format!("gate={g} up={u} K={k} N={n}");
+        match run_one(&mut gpu, g, u, k, n) {
+            Ok(()) => { total_pass += 1; eprintln!("  {label:40} OK"); }
+            Err(e) => { total_fail += 1; eprintln!("  {label:40} FAIL\n{e}"); }
+        }
+    }
+
+    eprintln!("\nPassed: {total_pass}  Failed: {total_fail}");
+    if total_fail > 0 { std::process::exit(1); }
+}
+
+fn run_one(gpu: &mut Gpu, g_m: usize, u_m: usize, k: usize, n: usize) -> Result<(), String> {
+    assert_eq!((g_m + u_m) % 16, 0);
+    assert_eq!(k % 256, 0);
+    assert_eq!(n % 16, 0);
+
+    let ag_bytes = build_hfq3g256(g_m, k, 0xA1);
+    let au_bytes = build_hfq3g256(u_m, k, 0xB2);
+
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| {
+            let b = (i / k) as i32;
+            let kk = (i % k) as i32;
+            ((b * 7 + kk * 11) % 31 - 15) as f32 * 0.05
+        })
+        .collect();
+
+    let ref_g = cpu_gemm(&ag_bytes, g_m, k, &x_f32, n);
+    let ref_u = cpu_gemm(&au_bytes, u_m, k, &x_f32, n);
+
+    let ag = gpu.upload_raw(&ag_bytes, &[g_m, k]).map_err(|e| format!("upload ag: {e}"))?;
+    let au = gpu.upload_raw(&au_bytes, &[u_m, k]).map_err(|e| format!("upload au: {e}"))?;
+    let x = gpu.upload_f32(&x_f32, &[n, k]).map_err(|e| format!("upload x: {e}"))?;
+    let yg = gpu.alloc_tensor(&[n, g_m], DType::F32).map_err(|e| format!("alloc yg: {e}"))?;
+    let yu = gpu.alloc_tensor(&[n, u_m], DType::F32).map_err(|e| format!("alloc yu: {e}"))?;
+
+    gpu.gemm_gate_up_hfq3g256_wmma(&ag, &au, &x, &yg, &yu, g_m, u_m, k, n)
+        .map_err(|e| format!("wmma: {e}"))?;
+
+    let cand_g = gpu.download_f32(&yg).map_err(|e| format!("download yg: {e}"))?;
+    let cand_u = gpu.download_f32(&yu).map_err(|e| format!("download yu: {e}"))?;
+
+    let _keep_alive = (ag, au, x, yg, yu);
+
+    let mut report = String::new();
+    let ok_g = compare("Y_gate", n, g_m, &cand_g, &ref_g, &mut report);
+    let ok_u = compare("Y_up", n, u_m, &cand_u, &ref_u, &mut report);
+
+    if ok_g && ok_u { Ok(()) } else { Err(report) }
+}
+
+fn cpu_gemm(a_bytes: &[u8], m: usize, k: usize, x: &[f32], n: usize) -> Vec<f32> {
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 104;
+    let mut y = vec![0f32; n * m];
+    for b in 0..n {
+        let x_row = &x[b * k..(b + 1) * k];
+        for row in 0..m {
+            let row_off = row * row_bytes;
+            let mut acc = 0f32;
+            for g in 0..groups_per_row {
+                let goff = row_off + g * 104;
+                let scale = f32::from_bits(u32::from_le_bytes([a_bytes[goff], a_bytes[goff+1], a_bytes[goff+2], a_bytes[goff+3]]));
+                let zero = f32::from_bits(u32::from_le_bytes([a_bytes[goff+4], a_bytes[goff+5], a_bytes[goff+6], a_bytes[goff+7]]));
+                for chunk in 0..32 {
+                    let bo = goff + 8 + chunk * 3;
+                    let b0 = a_bytes[bo] as u32;
+                    let b1 = a_bytes[bo + 1] as u32;
+                    let b2 = a_bytes[bo + 2] as u32;
+                    let qs = [
+                        b0 & 7, (b0 >> 3) & 7, ((b0 >> 6) | (b1 << 2)) & 7, (b1 >> 1) & 7,
+                        (b1 >> 4) & 7, ((b1 >> 7) | (b2 << 1)) & 7, (b2 >> 2) & 7, (b2 >> 5) & 7,
+                    ];
+                    let base = g * 256 + chunk * 8;
+                    for i in 0..8 { acc += (scale * (qs[i] as f32) + zero) * x_row[base + i]; }
+                }
+            }
+            y[b * m + row] = acc;
+        }
+    }
+    y
+}
+
+fn compare(name: &str, n: usize, m: usize, cand: &[f32], refr: &[f32], report: &mut String) -> bool {
+    let mut max_abs = 0f32;
+    let mut bad = 0usize;
+    for batch in 0..n {
+        for row in 0..m {
+            let idx = batch * m + row;
+            let abs = (cand[idx] - refr[idx]).abs();
+            if abs > max_abs { max_abs = abs; }
+            if abs > 5e-2 && abs / refr[idx].abs().max(1e-3) > 1e-2 { bad += 1; }
+        }
+    }
+    use std::fmt::Write;
+    let _ = writeln!(report, "    {name}: max_abs={max_abs:.4e}  bad={bad}/{}", n * m);
+    bad == 0
+}
+
+fn build_hfq3g256(m: usize, k: usize, seed: u8) -> Vec<u8> {
+    let groups_per_row = k / 256;
+    let bytes_per_row = groups_per_row * 104;
+    let mut out = vec![0u8; m * bytes_per_row];
+    let mix = |x: u64| {
+        let h = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((h ^ (h >> 33)).wrapping_mul(0xff51afd7ed558ccd)) ^ (h >> 28)
+    };
+    let s0 = seed as u64;
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let off = row * bytes_per_row + g * 104;
+            let r1 = mix(s0 ^ ((row as u64) << 16) ^ (g as u64));
+            let r2 = mix(s0 ^ ((row as u64) * 7 + g as u64));
+            let scale = 0.01 + (((r1 as u32) % 4001) as f32) * 1e-5;
+            let zero = (((r2 as u32) % 1500) as f32) * 1e-4 - 0.075;
+            out[off..off + 4].copy_from_slice(&scale.to_le_bytes());
+            out[off + 4..off + 8].copy_from_slice(&zero.to_le_bytes());
+            for byte_i in 0..96 {
+                let r = mix(s0 ^ ((row as u64) << 24) ^ ((g as u64) << 12) ^ (byte_i as u64));
+                out[off + 8 + byte_i] = (r & 0xff) as u8;
+            }
+        }
+    }
+    out
+}

--- a/crates/engine/examples/test_wmma_qkvza_hfq3.rs
+++ b/crates/engine/examples/test_wmma_qkvza_hfq3.rs
@@ -1,0 +1,325 @@
+//! Channel-test for `gemm_qkvza_hfq3g256_wmma` (gfx11 K2 variant).
+//!
+//! 4-output sister of test_wmma_qkvza_gfx12 — exercises qkv/z/beta/alpha
+//! routing for the DeltaNet LinearAttention preamble at HFQ3 storage.
+//! Compares the new WMMA kernel against a CPU reference that decodes the
+//! same packed HFQ3 bytes via the unpack pattern from gemv_hfq3g256.hip.
+//!
+//! Run: cargo run --release --features deltanet -p engine \
+//!         --example test_wmma_qkvza_hfq3
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {} ({:.1} GB VRAM)", arch, {
+        let (_, total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+        total as f64 / 1e9
+    });
+
+    let supported = matches!(arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102");
+    if !supported {
+        eprintln!(
+            "SKIP: gemm_qkvza_hfq3g256_wmma is the gfx11 K2 variant. \
+             Current arch: {arch}. (gfx12 K4 variant: follow-up commit.)"
+        );
+        std::process::exit(0);
+    }
+
+    let mut total_pass = 0;
+    let mut total_fail = 0;
+
+    // (qkv_m, z_m, beta_m, alpha_m, K, N)
+    let shapes: &[(usize, usize, usize, usize, usize, usize)] = &[
+        // Single 16-row tile per projection — minimum to exercise routing.
+        (16, 16, 16, 16, 256, 16),
+        // K = 2 groups
+        (16, 16, 16, 16, 512, 16),
+        // batch = 2 tiles
+        (16, 16, 16, 16, 256, 32),
+        // qkv has 2 row-tiles
+        (32, 16, 16, 16, 256, 16),
+        // multi-tile in every dim
+        (32, 32, 16, 16, 512, 32),
+        // Realistic Qwen3.5-9B DeltaNet LA preamble shape (qkv_m=8192,
+        // z_m=4096, alpha=beta=32 — but those don't divide 16 so use the
+        // smallest that exercises the boundary straddle).
+        (48, 16, 16, 16, 256, 16),
+    ];
+
+    for &(qkv_m, z_m, beta_m, alpha_m, k, n) in shapes {
+        let label = format!("qkv={qkv_m} z={z_m} b={beta_m} a={alpha_m} K={k} N={n}");
+        eprintln!("\n--- {label} ---");
+        match run_one(&mut gpu, qkv_m, z_m, beta_m, alpha_m, k, n) {
+            Ok(()) => {
+                total_pass += 1;
+                eprintln!("  {label:60} OK");
+            }
+            Err(e) => {
+                total_fail += 1;
+                eprintln!("  {label:60} FAIL");
+                eprintln!("{e}");
+            }
+        }
+    }
+
+    eprintln!("\n--- Summary ---");
+    eprintln!("  Passed: {total_pass}");
+    eprintln!("  Failed: {total_fail}");
+    if total_fail > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn run_one(
+    gpu: &mut Gpu,
+    qkv_m: usize,
+    z_m: usize,
+    beta_m: usize,
+    alpha_m: usize,
+    k: usize,
+    n: usize,
+) -> Result<(), String> {
+    assert_eq!(qkv_m % 16, 0);
+    assert_eq!(z_m % 16, 0);
+    assert_eq!(beta_m % 16, 0);
+    assert_eq!(alpha_m % 16, 0);
+    assert_eq!(k % 256, 0);
+    assert_eq!(n % 16, 0);
+
+    let aq_bytes = build_hfq3g256(qkv_m, k, 0xA1);
+    let az_bytes = build_hfq3g256(z_m, k, 0xB2);
+    let ab_bytes = build_hfq3g256(beta_m, k, 0xC3);
+    let aa_bytes = build_hfq3g256(alpha_m, k, 0xD4);
+
+    // CPU reference: per (batch, row), dequant the HFQ3 bytes and dot
+    // against x.
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| {
+            let b = (i / k) as i32;
+            let kk = (i % k) as i32;
+            ((b * 7 + kk * 11) % 31 - 15) as f32 * 0.05
+        })
+        .collect();
+
+    let ref_q = cpu_gemm(&aq_bytes, qkv_m, k, &x_f32, n);
+    let ref_z = cpu_gemm(&az_bytes, z_m, k, &x_f32, n);
+    let ref_b = cpu_gemm(&ab_bytes, beta_m, k, &x_f32, n);
+    let ref_a = cpu_gemm(&aa_bytes, alpha_m, k, &x_f32, n);
+
+    let aq = gpu.upload_raw(&aq_bytes, &[qkv_m, k]).map_err(|e| format!("upload aq: {e}"))?;
+    let az = gpu.upload_raw(&az_bytes, &[z_m, k]).map_err(|e| format!("upload az: {e}"))?;
+    let ab = gpu.upload_raw(&ab_bytes, &[beta_m, k]).map_err(|e| format!("upload ab: {e}"))?;
+    let aa = gpu.upload_raw(&aa_bytes, &[alpha_m, k]).map_err(|e| format!("upload aa: {e}"))?;
+    let x = gpu.upload_f32(&x_f32, &[n, k]).map_err(|e| format!("upload x: {e}"))?;
+
+    let yq = gpu.alloc_tensor(&[n, qkv_m], DType::F32).map_err(|e| format!("alloc yq: {e}"))?;
+    let yz = gpu.alloc_tensor(&[n, z_m], DType::F32).map_err(|e| format!("alloc yz: {e}"))?;
+    let yb = gpu.alloc_tensor(&[n, beta_m], DType::F32).map_err(|e| format!("alloc yb: {e}"))?;
+    let ya = gpu.alloc_tensor(&[n, alpha_m], DType::F32).map_err(|e| format!("alloc ya: {e}"))?;
+
+    gpu.gemm_qkvza_hfq3g256_wmma(
+        &aq, &az, &ab, &aa, &x,
+        &yq, &yz, &yb, &ya,
+        qkv_m, z_m, beta_m, alpha_m, k, n,
+    )
+    .map_err(|e| format!("wmma: {e}"))?;
+
+    let cand_q = gpu.download_f32(&yq).map_err(|e| format!("download yq: {e}"))?;
+    let cand_z = gpu.download_f32(&yz).map_err(|e| format!("download yz: {e}"))?;
+    let cand_b = gpu.download_f32(&yb).map_err(|e| format!("download yb: {e}"))?;
+    let cand_a = gpu.download_f32(&ya).map_err(|e| format!("download ya: {e}"))?;
+
+    // Intentionally NOT freeing tensors here — the GPU allocator can
+    // recycle freed addresses, and `ensure_fp16_x` keys its conversion
+    // cache by source pointer. If a recycled X address matches the
+    // previous test's pointer with the same total `n_elems`, the cache
+    // would hit and return stale fp16 data with the prior test's stride.
+    // (Real production code paths don't hit this because each layer's X
+    // is a unique tensor with stable identity for its full lifetime.)
+    let _keep_alive = (aq, az, ab, aa, x, yq, yz, yb, ya);
+
+    let mut report = String::new();
+    let ok_q = compare_proj("Y_qkv", n, qkv_m, &cand_q, &ref_q, &mut report);
+    let ok_z = compare_proj("Y_z", n, z_m, &cand_z, &ref_z, &mut report);
+    let ok_b = compare_proj("Y_beta", n, beta_m, &cand_b, &ref_b, &mut report);
+    let ok_a = compare_proj("Y_alpha", n, alpha_m, &cand_a, &ref_a, &mut report);
+
+    if ok_q && ok_z && ok_b && ok_a {
+        Ok(())
+    } else {
+        // Dump first 4 batches × first 4 rows for Y_qkv to localize.
+        use std::fmt::Write;
+        writeln!(&mut report, "    Y_qkv head dump (cand vs ref):").ok();
+        for b in 0..n.min(4) {
+            for r in 0..qkv_m.min(4) {
+                let idx = b * qkv_m + r;
+                writeln!(
+                    &mut report,
+                    "      [b={b} r={r}] cand={:.4}  ref={:.4}  diff={:.4e}",
+                    cand_q[idx], ref_q[idx], cand_q[idx] - ref_q[idx]
+                ).ok();
+            }
+        }
+        Err(report)
+    }
+}
+
+/// CPU reference: replicates `gemv_hfq3g256.hip` per-row for each of the
+/// N batch elements, and stores Y row-major as [batch × m].
+fn cpu_gemm(a_bytes: &[u8], m: usize, k: usize, x: &[f32], n: usize) -> Vec<f32> {
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 104;
+    let mut y = vec![0f32; n * m];
+
+    for b in 0..n {
+        let x_row = &x[b * k..(b + 1) * k];
+        for row in 0..m {
+            let row_off = row * row_bytes;
+            let mut acc = 0f32;
+            for g in 0..groups_per_row {
+                let goff = row_off + g * 104;
+                let scale_bits = u32::from_le_bytes([
+                    a_bytes[goff],
+                    a_bytes[goff + 1],
+                    a_bytes[goff + 2],
+                    a_bytes[goff + 3],
+                ]);
+                let zero_bits = u32::from_le_bytes([
+                    a_bytes[goff + 4],
+                    a_bytes[goff + 5],
+                    a_bytes[goff + 6],
+                    a_bytes[goff + 7],
+                ]);
+                let scale = f32::from_bits(scale_bits);
+                let zero = f32::from_bits(zero_bits);
+                // 32 chunks × 8 weights × 3 bytes = 96 bytes data.
+                for chunk in 0..32 {
+                    let bo = goff + 8 + chunk * 3;
+                    let b0 = a_bytes[bo] as u32;
+                    let b1 = a_bytes[bo + 1] as u32;
+                    let b2 = a_bytes[bo + 2] as u32;
+                    let q0 = b0 & 7;
+                    let q1 = (b0 >> 3) & 7;
+                    let q2 = ((b0 >> 6) | (b1 << 2)) & 7;
+                    let q3 = (b1 >> 1) & 7;
+                    let q4 = (b1 >> 4) & 7;
+                    let q5 = ((b1 >> 7) | (b2 << 1)) & 7;
+                    let q6 = (b2 >> 2) & 7;
+                    let q7 = (b2 >> 5) & 7;
+                    let base = g * 256 + chunk * 8;
+                    acc += (scale * (q0 as f32) + zero) * x_row[base];
+                    acc += (scale * (q1 as f32) + zero) * x_row[base + 1];
+                    acc += (scale * (q2 as f32) + zero) * x_row[base + 2];
+                    acc += (scale * (q3 as f32) + zero) * x_row[base + 3];
+                    acc += (scale * (q4 as f32) + zero) * x_row[base + 4];
+                    acc += (scale * (q5 as f32) + zero) * x_row[base + 5];
+                    acc += (scale * (q6 as f32) + zero) * x_row[base + 6];
+                    acc += (scale * (q7 as f32) + zero) * x_row[base + 7];
+                }
+            }
+            y[b * m + row] = acc;
+        }
+    }
+    y
+}
+
+fn compare_proj(
+    name: &str,
+    n: usize,
+    m: usize,
+    cand: &[f32],
+    refr: &[f32],
+    report: &mut String,
+) -> bool {
+    assert_eq!(cand.len(), refr.len());
+    assert_eq!(cand.len(), n * m);
+
+    let mut max_abs = 0f32;
+    let mut max_rel = 0f32;
+    let mut n_bad = 0usize;
+    let mut first_bad: Option<(usize, usize, f32, f32)> = None;
+    let abs_tol = 5e-2_f32;
+    let rel_tol = 1e-2_f32;
+    let mut hist_row_mod16 = [0usize; 16];
+
+    for batch in 0..n {
+        for row in 0..m {
+            let idx = batch * m + row;
+            let a = cand[idx];
+            let b = refr[idx];
+            let abs = (a - b).abs();
+            let rel = abs / b.abs().max(1e-3);
+            if abs > max_abs { max_abs = abs; }
+            if rel > max_rel { max_rel = rel; }
+            if abs > abs_tol && rel > rel_tol {
+                n_bad += 1;
+                hist_row_mod16[row % 16] += 1;
+                if first_bad.is_none() {
+                    first_bad = Some((batch, row, a, b));
+                }
+            }
+        }
+    }
+
+    use std::fmt::Write;
+    let _ = write!(
+        report,
+        "    {name}: max_abs={max_abs:.4e} max_rel={max_rel:.4e} bad={n_bad}/{}",
+        n * m
+    );
+    if n_bad > 0 {
+        let _ = writeln!(report);
+        if let Some((b, r, a, ref_v)) = first_bad {
+            let _ = writeln!(
+                report,
+                "      first mismatch at (batch={b}, row={r}): cand={a:.4} ref={ref_v:.4} diff={:.4e}",
+                a - ref_v
+            );
+        }
+        let _ = writeln!(report, "      mismatches by (row % 16): {hist_row_mod16:?}");
+        false
+    } else {
+        let _ = writeln!(report);
+        true
+    }
+}
+
+/// Deterministic HFQ3-G256 weight bytes for testing.
+/// Layout: 8B header (fp32 scale + fp32 zero, both bit-cast from fp16) +
+/// 96B data (32 chunks × 3 bytes, each chunk encoding 8 × 3-bit indices
+/// per the same packing as `quantize_mq3g256` in hipfire-quantize).
+fn build_hfq3g256(m: usize, k: usize, seed: u8) -> Vec<u8> {
+    assert_eq!(k % 256, 0);
+    let groups_per_row = k / 256;
+    let bytes_per_row = groups_per_row * 104;
+    let mut out = vec![0u8; m * bytes_per_row];
+
+    let mix = |x: u64| {
+        let h = x
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((h ^ (h >> 33)).wrapping_mul(0xff51afd7ed558ccd)) ^ (h >> 28)
+    };
+    let s0 = seed as u64;
+
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let off = row * bytes_per_row + g * 104;
+            let r1 = mix(s0 ^ ((row as u64) << 16) ^ (g as u64));
+            let r2 = mix(s0 ^ ((row as u64) * 7 + g as u64));
+            let scale = 0.01 + (((r1 as u32) % 4001) as f32) * 1e-5;
+            let zero = (((r2 as u32) % 1500) as f32) * 1e-4 - 0.075;
+
+            out[off..off + 4].copy_from_slice(&scale.to_le_bytes());
+            out[off + 4..off + 8].copy_from_slice(&zero.to_le_bytes());
+
+            for byte_i in 0..96 {
+                let r = mix(s0 ^ ((row as u64) << 24) ^ ((g as u64) << 12) ^ (byte_i as u64));
+                out[off + 8 + byte_i] = (r & 0xff) as u8;
+            }
+        }
+    }
+    out
+}

--- a/crates/engine/examples/test_wmma_residual_hfq3.rs
+++ b/crates/engine/examples/test_wmma_residual_hfq3.rs
@@ -1,0 +1,154 @@
+//! Channel-test for `gemm_hfq3g256_residual_wmma` (gfx11 K1 variant).
+//! Note: residual kernel does Y += W*X (fused residual add) and uses a
+//! TRANSPOSED C-output convention vs qkvza/gate_up (lane covers 1 row,
+//! 8 batches; lanes 0..15 → batches 0..7, lanes 16..31 → batches 8..15).
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {}", arch);
+
+    if !matches!(arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102") {
+        eprintln!("SKIP: gfx11 K1 only — current arch {arch}");
+        std::process::exit(0);
+    }
+
+    let mut total_pass = 0;
+    let mut total_fail = 0;
+
+    let shapes: &[(usize, usize, usize)] = &[
+        // (M, K, N)
+        (16, 256, 16),
+        (32, 256, 16),
+        (16, 512, 16),
+        (16, 256, 32),
+        (32, 512, 32),
+        (64, 256, 16),
+    ];
+
+    for &(m, k, n) in shapes {
+        let label = format!("M={m} K={k} N={n}");
+        match run_one(&mut gpu, m, k, n) {
+            Ok(()) => { total_pass += 1; eprintln!("  {label:30} OK"); }
+            Err(e) => { total_fail += 1; eprintln!("  {label:30} FAIL\n{e}"); }
+        }
+    }
+
+    eprintln!("\nPassed: {total_pass}  Failed: {total_fail}");
+    if total_fail > 0 { std::process::exit(1); }
+}
+
+fn run_one(gpu: &mut Gpu, m: usize, k: usize, n: usize) -> Result<(), String> {
+    assert_eq!(m % 16, 0);
+    assert_eq!(k % 256, 0);
+    assert_eq!(n % 16, 0);
+
+    let a_bytes = build_hfq3g256(m, k, 0xC3);
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| {
+            let b = (i / k) as i32;
+            let kk = (i % k) as i32;
+            ((b * 7 + kk * 11) % 31 - 15) as f32 * 0.05
+        })
+        .collect();
+
+    // Pre-residual Y data (kernel does Y += W*X).
+    let y_pre: Vec<f32> = (0..(n * m))
+        .map(|i| ((i % 13) as f32 - 6.0) * 0.01)
+        .collect();
+    let mut ref_y = y_pre.clone();
+    let wx = cpu_gemm(&a_bytes, m, k, &x_f32, n);
+    for i in 0..(n * m) { ref_y[i] += wx[i]; }
+
+    let a = gpu.upload_raw(&a_bytes, &[m, k]).map_err(|e| format!("upload a: {e}"))?;
+    let x = gpu.upload_f32(&x_f32, &[n, k]).map_err(|e| format!("upload x: {e}"))?;
+    let y = gpu.upload_f32(&y_pre, &[n, m]).map_err(|e| format!("upload y_pre: {e}"))?;
+
+    gpu.gemm_hfq3g256_residual_wmma(&a, &x, &y, m, k, n)
+        .map_err(|e| format!("wmma: {e}"))?;
+
+    let cand_y = gpu.download_f32(&y).map_err(|e| format!("download y: {e}"))?;
+
+    let _keep_alive = (a, x, y);
+
+    let mut report = String::new();
+    let ok = compare("Y", n, m, &cand_y, &ref_y, &mut report);
+    if ok { Ok(()) } else { Err(report) }
+}
+
+fn cpu_gemm(a_bytes: &[u8], m: usize, k: usize, x: &[f32], n: usize) -> Vec<f32> {
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 104;
+    let mut y = vec![0f32; n * m];
+    for b in 0..n {
+        let x_row = &x[b * k..(b + 1) * k];
+        for row in 0..m {
+            let row_off = row * row_bytes;
+            let mut acc = 0f32;
+            for g in 0..groups_per_row {
+                let goff = row_off + g * 104;
+                let scale = f32::from_bits(u32::from_le_bytes([a_bytes[goff], a_bytes[goff+1], a_bytes[goff+2], a_bytes[goff+3]]));
+                let zero = f32::from_bits(u32::from_le_bytes([a_bytes[goff+4], a_bytes[goff+5], a_bytes[goff+6], a_bytes[goff+7]]));
+                for chunk in 0..32 {
+                    let bo = goff + 8 + chunk * 3;
+                    let b0 = a_bytes[bo] as u32;
+                    let b1 = a_bytes[bo + 1] as u32;
+                    let b2 = a_bytes[bo + 2] as u32;
+                    let qs = [
+                        b0 & 7, (b0 >> 3) & 7, ((b0 >> 6) | (b1 << 2)) & 7, (b1 >> 1) & 7,
+                        (b1 >> 4) & 7, ((b1 >> 7) | (b2 << 1)) & 7, (b2 >> 2) & 7, (b2 >> 5) & 7,
+                    ];
+                    let base = g * 256 + chunk * 8;
+                    for i in 0..8 { acc += (scale * (qs[i] as f32) + zero) * x_row[base + i]; }
+                }
+            }
+            y[b * m + row] = acc;
+        }
+    }
+    y
+}
+
+fn compare(name: &str, n: usize, m: usize, cand: &[f32], refr: &[f32], report: &mut String) -> bool {
+    let mut max_abs = 0f32;
+    let mut bad = 0usize;
+    for batch in 0..n {
+        for row in 0..m {
+            let idx = batch * m + row;
+            let abs = (cand[idx] - refr[idx]).abs();
+            if abs > max_abs { max_abs = abs; }
+            if abs > 5e-2 && abs / refr[idx].abs().max(1e-3) > 1e-2 { bad += 1; }
+        }
+    }
+    use std::fmt::Write;
+    let _ = writeln!(report, "    {name}: max_abs={max_abs:.4e}  bad={bad}/{}", n * m);
+    bad == 0
+}
+
+fn build_hfq3g256(m: usize, k: usize, seed: u8) -> Vec<u8> {
+    let groups_per_row = k / 256;
+    let bytes_per_row = groups_per_row * 104;
+    let mut out = vec![0u8; m * bytes_per_row];
+    let mix = |x: u64| {
+        let h = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((h ^ (h >> 33)).wrapping_mul(0xff51afd7ed558ccd)) ^ (h >> 28)
+    };
+    let s0 = seed as u64;
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let off = row * bytes_per_row + g * 104;
+            let r1 = mix(s0 ^ ((row as u64) << 16) ^ (g as u64));
+            let r2 = mix(s0 ^ ((row as u64) * 7 + g as u64));
+            let scale = 0.01 + (((r1 as u32) % 4001) as f32) * 1e-5;
+            let zero = (((r2 as u32) % 1500) as f32) * 1e-4 - 0.075;
+            out[off..off + 4].copy_from_slice(&scale.to_le_bytes());
+            out[off + 4..off + 8].copy_from_slice(&zero.to_le_bytes());
+            for byte_i in 0..96 {
+                let r = mix(s0 ^ ((row as u64) << 24) ^ ((g as u64) << 12) ^ (byte_i as u64));
+                out[off + 8 + byte_i] = (r & 0xff) as u8;
+            }
+        }
+    }
+    out
+}

--- a/crates/engine/examples/verify_mq_kernel.rs
+++ b/crates/engine/examples/verify_mq_kernel.rs
@@ -1,0 +1,340 @@
+//! Q0 — Bit-exact kernel verification for MQ3/MQ2 GEMV pipelines.
+//!
+//! Generates synthetic weights, quantizes to MQ3 and MQ2, then compares
+//! the GPU `gemv_mq{3,2}g256_with_rotate` output against a CPU reference
+//! that reconstructs the rotated weights and rotates x using the same
+//! FWHT math as the quantizer.
+//!
+//! Run:
+//!   cargo run --release --example verify_mq_kernel
+//!
+//! Acceptance (per Q0):
+//!   max_abs_err <= 1e-3  => kernel is correct; close Q0.
+//!   max_abs_err > 1e-3   => kernel has a bug; investigate.
+
+fn main() {
+    let mut gpu = rdna_compute::Gpu::init().unwrap();
+
+    // Test multiple shapes: 1-group, 2-group, 4-group rows.
+    let shapes = [(4usize, 256usize), (4, 512), (8, 1024)];
+
+    let mut any_fail = false;
+
+    for &(m, k) in &shapes {
+        eprintln!("\n========== shape {} x {} ==========", m, k);
+
+        // Deterministic pseudo-random weights and input (reproducible across runs)
+        let f32_weights: Vec<f32> = (0..m * k).map(|i| fract_sin(i as f32 * 0.731f32 + 1.337f32)).collect();
+        let x: Vec<f32> = (0..k).map(|i| fract_sin(i as f32 * 0.513f32 + 2.719f32)).collect();
+
+        // ---- MQ3 ----
+        let mq3_bytes = quantize_mq3g256(&f32_weights, k);
+        let y_mq3_cpu = cpu_reference_mq(&mq3_bytes, &x, m, k, 104, 3, |scale, zero, q| scale * q as f32 + zero);
+        let y_mq3_gpu = gpu_mq_gemv(&mut gpu, &mq3_bytes, &x, m, k, rdna_compute::DType::MQ3G256);
+        let (ok3, max_err3, mean_err3) = compare("MQ3", &y_mq3_cpu, &y_mq3_gpu);
+        any_fail |= !ok3;
+
+        // ---- MQ2 ----
+        let mq2_bytes = quantize_mq2g256(&f32_weights, k);
+        let y_mq2_cpu = cpu_reference_mq(&mq2_bytes, &x, m, k, 72, 2, |scale, zero, q| scale * q as f32 + zero);
+        let y_mq2_gpu = gpu_mq_gemv(&mut gpu, &mq2_bytes, &x, m, k, rdna_compute::DType::MQ2G256);
+        let (ok2, max_err2, mean_err2) = compare("MQ2", &y_mq2_cpu, &y_mq2_gpu);
+        any_fail |= !ok2;
+
+        // Also verify the *rotation-only* step in isolation.
+        let x_rot_cpu = cpu_rotate_x_mq(&x);
+        let x_rot_gpu = gpu_rotate_x_mq(&mut gpu, &x, k);
+        let (ok_rot, max_err_rot, _) = compare("rot", &x_rot_cpu, &x_rot_gpu);
+        any_fail |= !ok_rot;
+        eprintln!("  rotate_x max_err={:.6e}", max_err_rot);
+    }
+
+    if any_fail {
+        eprintln!("\n[FAIL] One or more checks exceeded 1e-3 threshold.");
+        std::process::exit(1);
+    } else {
+        eprintln!("\n[PASS] All MQ3/MQ2 kernels bit-exact within 1e-3.");
+    }
+}
+
+fn fract_sin(x: f32) -> f32 {
+    (x.sin() * 12345.6789f32).fract() * 2.0f32 - 1.0f32
+}
+
+fn compare(name: &str, cpu: &[f32], gpu: &[f32]) -> (bool, f32, f32) {
+    let mut max_err = 0.0f32;
+    let mut sum_err = 0.0f32;
+    let mut bit_exact = 0usize;
+    for i in 0..cpu.len() {
+        let err = (cpu[i] - gpu[i]).abs();
+        max_err = max_err.max(err);
+        sum_err += err;
+        if cpu[i] == gpu[i] {
+            bit_exact += 1;
+        }
+    }
+    let mean_err = sum_err / cpu.len().max(1) as f32;
+    let ok = max_err <= 1e-3;
+    let status = if ok { "PASS" } else { "FAIL" };
+    eprintln!(
+        "  {:<6} {}  max_err={:.6e}  mean_err={:.6e}  bit_exact={}/{}",
+        name, status, max_err, mean_err, bit_exact, cpu.len()
+    );
+    (ok, max_err, mean_err)
+}
+
+// ---------------------------------------------------------------------------
+// CPU reference: rotate x, dequantize weights, compute y = W_rot * x_rot
+// ---------------------------------------------------------------------------
+
+fn cpu_reference_mq(
+    bytes: &[u8],
+    x: &[f32],
+    m: usize,
+    k: usize,
+    group_bytes: usize,
+    bits: u8,
+    recon: impl Fn(f32, f32, u8) -> f32,
+) -> Vec<f32> {
+    let groups_per_row = k / 256;
+    let mut y = vec![0.0f32; m];
+
+    // Rotate x
+    let x_rot = cpu_rotate_x_mq(x);
+
+    for row in 0..m {
+        let row_off = row * groups_per_row * group_bytes;
+        let mut acc = 0.0f32;
+
+        for g in 0..groups_per_row {
+            let g_off = row_off + g * group_bytes;
+            let scale = f32::from_le_bytes([bytes[g_off], bytes[g_off + 1], bytes[g_off + 2], bytes[g_off + 3]]);
+            let zero = f32::from_le_bytes([bytes[g_off + 4], bytes[g_off + 5], bytes[g_off + 6], bytes[g_off + 7]]);
+            let data = &bytes[g_off + 8..g_off + group_bytes];
+
+            let base_idx = g * 256;
+            let mut q_vals: Vec<u8> = Vec::with_capacity(256);
+
+            if bits == 3 {
+                // 256 weights = 32 chunks * 8 weights * 3 bits = 96 bytes
+                for chunk in 0..32 {
+                    let ci = chunk * 8;
+                    let b0 = data[chunk * 3];
+                    let b1 = data[chunk * 3 + 1];
+                    let b2 = data[chunk * 3 + 2];
+                    q_vals.push(b0 & 7);
+                    q_vals.push((b0 >> 3) & 7);
+                    q_vals.push(((b0 >> 6) | (b1 << 2)) & 7);
+                    q_vals.push((b1 >> 1) & 7);
+                    q_vals.push((b1 >> 4) & 7);
+                    q_vals.push(((b1 >> 7) | (b2 << 1)) & 7);
+                    q_vals.push((b2 >> 2) & 7);
+                    q_vals.push((b2 >> 5) & 7);
+                }
+            } else if bits == 2 {
+                // 256 weights = 64 bytes, 4 weights per byte
+                for i in 0..64 {
+                    let b = data[i];
+                    q_vals.push(b & 3);
+                    q_vals.push((b >> 2) & 3);
+                    q_vals.push((b >> 4) & 3);
+                    q_vals.push((b >> 6) & 3);
+                }
+            } else {
+                panic!("unsupported bits {}", bits);
+            }
+
+            for j in 0..256 {
+                let w = recon(scale, zero, q_vals[j]);
+                acc += w * x_rot[base_idx + j];
+            }
+        }
+        y[row] = acc;
+    }
+    y
+}
+
+fn cpu_rotate_x_mq(x: &[f32]) -> Vec<f32> {
+    let k = x.len();
+    assert!(k % 256 == 0, "k must be multiple of 256");
+    let signs1 = gen_fwht_signs(42, 256);
+    let signs2 = gen_fwht_signs(1042, 256);
+    let mut out = vec![0.0f32; k];
+    for g in 0..(k / 256) {
+        let mut group = [0.0f32; 256];
+        group.copy_from_slice(&x[g * 256..(g + 1) * 256]);
+        cpu_fwht_256(&mut group, &signs1, &signs2);
+        out[g * 256..(g + 1) * 256].copy_from_slice(&group);
+    }
+    out
+}
+
+fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
+    let mut state = seed;
+    (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
+            if (state >> 16) & 1 == 1 { 1.0f32 } else { -1.0f32 }
+        })
+        .collect()
+}
+
+fn cpu_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
+    assert!(x.len() == 256);
+    for i in 0..256 {
+        x[i] *= signs1[i];
+    }
+    let mut stride = 1;
+    while stride < 256 {
+        let mut i = 0;
+        while i < 256 {
+            for j in 0..stride {
+                let a = x[i + j];
+                let b = x[i + j + stride];
+                x[i + j] = a + b;
+                x[i + j + stride] = a - b;
+            }
+            i += stride * 2;
+        }
+        stride <<= 1;
+    }
+    let scale = 0.0625; // 1/16
+    for i in 0..256 {
+        x[i] *= scale * signs2[i];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GPU wrappers
+// ---------------------------------------------------------------------------
+
+fn gpu_mq_gemv(
+    gpu: &mut rdna_compute::Gpu,
+    bytes: &[u8],
+    x: &[f32],
+    m: usize,
+    k: usize,
+    dtype: rdna_compute::DType,
+) -> Vec<f32> {
+    let d_a = gpu.upload_raw(bytes, &[bytes.len()]).unwrap();
+    let d_x = gpu.upload_f32(x, &[k]).unwrap();
+    let d_y = gpu.zeros(&[m], rdna_compute::DType::F32).unwrap();
+
+    match dtype {
+        rdna_compute::DType::MQ3G256 => {
+            let d_tmp = gpu.zeros(&[k], rdna_compute::DType::F32).unwrap();
+            gpu.gemv_mq3g256_with_rotate(&d_a, &d_x, &d_y, &d_tmp, m, k)
+                .unwrap();
+        }
+        rdna_compute::DType::MQ2G256 => {
+            let d_tmp = gpu.zeros(&[k], rdna_compute::DType::F32).unwrap();
+            gpu.gemv_mq2g256_with_rotate(&d_a, &d_x, &d_y, &d_tmp, m, k)
+                .unwrap();
+        }
+        _ => panic!("unexpected dtype"),
+    }
+
+    let mut y = vec![0.0f32; m];
+    let y_bytes = unsafe { std::slice::from_raw_parts_mut(y.as_mut_ptr() as *mut u8, m * 4) };
+    gpu.hip.memcpy_dtoh(y_bytes, unsafe { &d_y.buf }).unwrap();
+    y
+}
+
+fn gpu_rotate_x_mq(gpu: &mut rdna_compute::Gpu, x: &[f32], k: usize) -> Vec<f32> {
+    let d_x = gpu.upload_f32(x, &[k]).unwrap();
+    let d_xr = gpu.zeros(&[k], rdna_compute::DType::F32).unwrap();
+    gpu.rotate_x_mq(&d_x, &d_xr, k).unwrap();
+    let mut out = vec![0.0f32; k];
+    let out_bytes = unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr() as *mut u8, k * 4) };
+    gpu.hip.memcpy_dtoh(out_bytes, unsafe { &d_xr.buf }).unwrap();
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Quantizers (mirroring hipfire-quantize/src/main.rs)
+// ---------------------------------------------------------------------------
+
+fn quantize_mq3g256(f32_data: &[f32], k: usize) -> Vec<u8> {
+    let group_size = 256;
+    let block_bytes = 104;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+    let signs1 = gen_fwht_signs(42, 256);
+    let signs2 = gen_fwht_signs(1042, 256);
+
+    for b in 0..n_blocks {
+        let start = b * group_size;
+        let end = (start + group_size).min(n);
+        let mut group = [0.0f32; 256];
+        let actual_len = end - start;
+        group[..actual_len].copy_from_slice(&f32_data[start..end]);
+        cpu_fwht_256(&mut group, &signs1, &signs2);
+
+        let min_val = group.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max_val = group.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let range = max_val - min_val;
+        let scale = if range > 0.0 { range / 7.0 } else { 1.0 };
+        let inv_scale = if range > 0.0 { 1.0 / scale } else { 0.0 };
+
+        let out_off = b * block_bytes;
+        output[out_off..out_off + 4].copy_from_slice(&scale.to_le_bytes());
+        output[out_off + 4..out_off + 8].copy_from_slice(&min_val.to_le_bytes());
+
+        for chunk in 0..32 {
+            let ci = chunk * 8;
+            let mut q = [0u8; 8];
+            for j in 0..8 {
+                q[j] = ((group[ci + j] - min_val) * inv_scale + 0.5).clamp(0.0, 7.0) as u8;
+            }
+            let b0 = (q[0] & 7) | ((q[1] & 7) << 3) | ((q[2] & 3) << 6);
+            let b1 = ((q[2] >> 2) & 1) | ((q[3] & 7) << 1) | ((q[4] & 7) << 4) | ((q[5] & 1) << 7);
+            let b2 = ((q[5] >> 1) & 3) | ((q[6] & 7) << 2) | ((q[7] & 7) << 5);
+
+            let bo = out_off + 8 + chunk * 3;
+            output[bo] = b0;
+            output[bo + 1] = b1;
+            output[bo + 2] = b2;
+        }
+    }
+    output
+}
+
+fn quantize_mq2g256(f32_data: &[f32], k: usize) -> Vec<u8> {
+    let group_size = 256;
+    let block_bytes = 72;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+    let signs1 = gen_fwht_signs(42, 256);
+    let signs2 = gen_fwht_signs(1042, 256);
+
+    for b in 0..n_blocks {
+        let start = b * group_size;
+        let end = (start + group_size).min(n);
+        let mut group = [0.0f32; 256];
+        let actual_len = end - start;
+        group[..actual_len].copy_from_slice(&f32_data[start..end]);
+        cpu_fwht_256(&mut group, &signs1, &signs2);
+
+        let min_val = group.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max_val = group.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let range = max_val - min_val;
+        let scale = if range > 0.0 { range / 3.0 } else { 1.0 };
+        let inv_scale = if range > 0.0 { 1.0 / scale } else { 0.0 };
+
+        let out_off = b * block_bytes;
+        output[out_off..out_off + 4].copy_from_slice(&scale.to_le_bytes());
+        output[out_off + 4..out_off + 8].copy_from_slice(&min_val.to_le_bytes());
+
+        for i in 0..64 {
+            let mut byte_val = 0u8;
+            for j in 0..4 {
+                let q = ((group[4 * i + j] - min_val) * inv_scale + 0.5) as u8;
+                byte_val |= q.min(3) << (j * 2);
+            }
+            output[out_off + 8 + i] = byte_val;
+        }
+    }
+    output
+}

--- a/crates/engine/src/dflash.rs
+++ b/crates/engine/src/dflash.rs
@@ -220,6 +220,13 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0 })
         }
+        17 => {
+            // MQ3-G256: 104 bytes per 256 weights. Same opaque-buffer pattern
+            // as MQ4. Dispatch path (`gemm_dispatch`) routes through
+            // `rotate_x_mq_batched` + `gemm_hfq3g256_batched_lmhead`.
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0 })
+        }
         q => panic!("dflash: unsupported matrix quant_type {q} for {name}"),
     }
 }
@@ -253,7 +260,7 @@ impl DflashWeights {
             .chain(layers.iter().flat_map(|l| {
                 [&l.wq, &l.wk, &l.wv, &l.wo, &l.w_gate, &l.w_up, &l.w_down].into_iter()
             }))
-            .any(|w| matches!(w.gpu_dtype, DType::MQ4G256));
+            .any(|w| matches!(w.gpu_dtype, DType::MQ4G256 | DType::MQ3G256));
         if has_mq {
             // The MQ4 dispatch needs the engine's FWHT sign tables uploaded
             // (matches `gemv_mq4g256_with_rotate`'s setup).
@@ -575,6 +582,18 @@ fn gemm_dispatch(
             let rot_view = scratch.sub_offset(0, batch * w.k);
             gpu.rotate_x_mq_batched(x, &rot_view, w.k, batch)?;
             gpu.gemm_hfq4g256_batched_lmhead(&w.buf, &rot_view, y, w.m, w.k, batch)
+        }
+        DType::MQ3G256 => {
+            // Mirrors the MQ4 path: pre-rotate x via FWHT (same shared signs
+            // as MQ4 — rotate_x_mq_batched is dtype-agnostic for the activation
+            // side), invalidate the FP16 x cache because the rotated bytes
+            // share the same source pointer, then dispatch the HFQ3 batched
+            // lm_head WMMA kernel.
+            let scratch = mq_x_rot.expect("MQ3 dispatch requires mq_x_rot scratch");
+            let rot_view = scratch.sub_offset(0, batch * w.k);
+            gpu.rotate_x_mq_batched(x, &rot_view, w.k, batch)?;
+            gpu.fp16_x_source_ptr = std::ptr::null_mut();
+            gpu.gemm_hfq3g256_batched_lmhead(&w.buf, &rot_view, y, w.m, w.k, batch)
         }
         other => panic!("dflash gemm_dispatch: unsupported weight dtype {:?}", other),
     };

--- a/crates/engine/src/hfq.rs
+++ b/crates/engine/src/hfq.rs
@@ -299,6 +299,14 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ2G256, m, k, row_stride: 0 })
         }
+        19 => { // MQ2-G256-Lloyd — 2-bit + 4-entry fp16 codebook, 72 bytes per 256 elements
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ2G256Lloyd, m, k, row_stride: 0 })
+        }
+        20 => { // MQ3-G256-Lloyd — 3-bit + 8-entry fp16 codebook, 112 bytes per 256 elements
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256Lloyd, m, k, row_stride: 0 })
+        }
         1 => { // F16 — dequant to F32 for F32 GEMV
             let f32_data: Vec<f32> = data.chunks_exact(2)
                 .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))

--- a/crates/engine/src/llama.rs
+++ b/crates/engine/src/llama.rs
@@ -597,6 +597,24 @@ pub fn weight_gemv(
             };
             gpu.gemv_mq2g256_with_rotate(&w.buf, x, y, &x_rot_alias, w.m, w.k)
         }
+        DType::MQ2G256Lloyd => {
+            gpu.ensure_mq_signs()?;
+            let x_rot_alias = GpuTensor {
+                buf: unsafe { gpu.mq_x_rot.as_ref().unwrap().buf.alias() },
+                shape: vec![gpu.mq_x_rot.as_ref().unwrap().buf.size() / 4],
+                dtype: DType::F32,
+            };
+            gpu.gemv_mq2g256_lloyd_with_rotate(&w.buf, x, y, &x_rot_alias, w.m, w.k)
+        }
+        DType::MQ3G256Lloyd => {
+            gpu.ensure_mq_signs()?;
+            let x_rot_alias = GpuTensor {
+                buf: unsafe { gpu.mq_x_rot.as_ref().unwrap().buf.alias() },
+                shape: vec![gpu.mq_x_rot.as_ref().unwrap().buf.size() / 4],
+                dtype: DType::F32,
+            };
+            gpu.gemv_mq3g256_lloyd_with_rotate(&w.buf, x, y, &x_rot_alias, w.m, w.k)
+        }
         DType::MQ8G256 => {
             gpu.ensure_mq_signs()?;
             gpu.gemv_mq8g256_with_rotate(&w.buf, x, y, w.m, w.k)
@@ -638,7 +656,8 @@ pub fn fused_rmsnorm_rotate_for_mq<'a>(
     eps: f32,
 ) -> HipResult<Option<&'a GpuTensor>> {
     match sample_weight.gpu_dtype {
-        DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ2G256 => {
+        DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ2G256
+        | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd => {
             gpu.fused_rmsnorm_rotate_mq(x, norm_weight, x_rot_scratch, sample_weight.k, eps)?;
             Ok(Some(x_rot_scratch))
         }
@@ -672,7 +691,8 @@ pub fn rotate_x_for_mq<'a>(
     x_rot_scratch: &'a GpuTensor,
 ) -> HipResult<Option<&'a GpuTensor>> {
     match sample_weight.gpu_dtype {
-        DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ2G256 => {
+        DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ2G256
+        | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd => {
             gpu.rotate_x_mq(x, x_rot_scratch, sample_weight.k)?;
             Ok(Some(x_rot_scratch))
         }
@@ -725,6 +745,20 @@ pub fn weight_gemv_prerotated(
         DType::MQ2G256 => {
             if let Some(xr) = x_rot {
                 gpu.gemv_mq2g256_prerotated(&w.buf, xr, y, w.m, w.k)
+            } else {
+                weight_gemv(gpu, w, x, y)
+            }
+        }
+        DType::MQ2G256Lloyd => {
+            if let Some(xr) = x_rot {
+                gpu.gemv_mq2g256_lloyd(&w.buf, xr, y, w.m, w.k)
+            } else {
+                weight_gemv(gpu, w, x, y)
+            }
+        }
+        DType::MQ3G256Lloyd => {
+            if let Some(xr) = x_rot {
+                gpu.gemv_mq3g256_lloyd(&w.buf, xr, y, w.m, w.k)
             } else {
                 weight_gemv(gpu, w, x, y)
             }

--- a/crates/engine/src/llama.rs
+++ b/crates/engine/src/llama.rs
@@ -771,6 +771,16 @@ pub fn weight_gemv_residual(
             gpu.rotate_x_mq(x, &x_rot_alias, w.k)?;
             gpu.gemv_hfq4g256_residual(&w.buf, &x_rot_alias, y, w.m, w.k)
         }
+        DType::MQ3G256 => {
+            gpu.ensure_mq_signs()?;
+            let x_rot_alias = GpuTensor {
+                buf: unsafe { gpu.mq_x_rot.as_ref().unwrap().buf.alias() },
+                shape: vec![gpu.mq_x_rot.as_ref().unwrap().buf.size() / 4],
+                dtype: DType::F32,
+            };
+            gpu.rotate_x_mq(x, &x_rot_alias, w.k)?;
+            gpu.gemv_hfq3g256_residual(&w.buf, &x_rot_alias, y, w.m, w.k)
+        }
         _ => {
             // Fallback: plain weight_gemv into a scratch, then add_inplace.
             // Allocates a scratch each call — only used for niche dtypes.
@@ -814,6 +824,16 @@ pub fn weight_gemv_swiglu_residual(
         };
         gpu.fused_silu_mul_rotate_mq(gate, up, &x_rot_alias, w_down.k)?;
         return gpu.gemv_hfq4g256_residual(&w_down.buf, &x_rot_alias, x, w_down.m, w_down.k);
+    }
+    if w_down.gpu_dtype == DType::MQ3G256 {
+        gpu.ensure_mq_signs()?;
+        let x_rot_alias = GpuTensor {
+            buf: unsafe { gpu.mq_x_rot.as_ref().unwrap().buf.alias() },
+            shape: vec![gpu.mq_x_rot.as_ref().unwrap().buf.size() / 4],
+            dtype: DType::F32,
+        };
+        gpu.fused_silu_mul_rotate_mq(gate, up, &x_rot_alias, w_down.k)?;
+        return gpu.gemv_hfq3g256_residual(&w_down.buf, &x_rot_alias, x, w_down.m, w_down.k);
     }
     // Non-MQ fallback: plain two-step.
     gpu.silu_mul_f32(gate, up, ffn_hidden_scratch)?;

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -2821,6 +2821,7 @@ pub fn forward_prefill_batch_with_pbs(
     // either constraint is violated, reject all MoE layers so the whole
     // chunk falls through to per-token.
     let moe_topk_ok = config.num_experts_per_tok == 8 && config.num_experts <= 1024;
+    let arch = gpu.arch.as_str();
     let eligible = !force_fallback
         && n >= MIN_BATCH
         && dn_state.quant == StateQuant::Q8
@@ -2830,14 +2831,14 @@ pub fn forward_prefill_batch_with_pbs(
         ))
         && weights.layers.iter().all(|lw| match lw {
             LayerWeights::DeltaNet(l) =>
-                is_batchable_la(l.wqkv.gpu_dtype)
-                    && is_batchable_la(l.wz.gpu_dtype)
-                    && is_batchable_la(l.w_beta.gpu_dtype)
-                    && is_batchable_la(l.w_alpha.gpu_dtype)
-                    && is_batchable_la(l.wo.gpu_dtype)
-                    && is_batchable_la(l.w_gate.gpu_dtype)
-                    && is_batchable_la(l.w_up.gpu_dtype)
-                    && is_batchable_la(l.w_down.gpu_dtype),
+                is_batchable_la(l.wqkv.gpu_dtype, arch)
+                    && is_batchable_la(l.wz.gpu_dtype, arch)
+                    && is_batchable_la(l.w_beta.gpu_dtype, arch)
+                    && is_batchable_la(l.w_alpha.gpu_dtype, arch)
+                    && is_batchable_la(l.wo.gpu_dtype, arch)
+                    && is_batchable_la(l.w_gate.gpu_dtype, arch)
+                    && is_batchable_la(l.w_up.gpu_dtype, arch)
+                    && is_batchable_la(l.w_down.gpu_dtype, arch),
             LayerWeights::FullAttn(_) => true, // FA layer will take the gather/scatter path
             // MoE batched path: LA/FA projections must be MQ4 + every
             // routed/shared MoE weight must be MQ4. Top-K=8 and the
@@ -2845,19 +2846,19 @@ pub fn forward_prefill_batch_with_pbs(
             LayerWeights::DeltaNetMoe(l) =>
                 moe_topk_ok
                     && pbs_in.map(|p| p.moe_router_logits_batch.is_some()).unwrap_or(true)
-                    && is_batchable_la(l.wqkv.gpu_dtype)
-                    && is_batchable_la(l.wz.gpu_dtype)
-                    && is_batchable_la(l.w_beta.gpu_dtype)
-                    && is_batchable_la(l.w_alpha.gpu_dtype)
-                    && is_batchable_la(l.wo.gpu_dtype)
+                    && is_batchable_la(l.wqkv.gpu_dtype, arch)
+                    && is_batchable_la(l.wz.gpu_dtype, arch)
+                    && is_batchable_la(l.w_beta.gpu_dtype, arch)
+                    && is_batchable_la(l.w_alpha.gpu_dtype, arch)
+                    && is_batchable_la(l.wo.gpu_dtype, arch)
                     && moe_ffn_all_mq4(&l.ffn),
             LayerWeights::FullAttnMoe(l) =>
                 moe_topk_ok
                     && pbs_in.map(|p| p.moe_router_logits_batch.is_some()).unwrap_or(true)
-                    && is_batchable_la(l.wq.gpu_dtype)
-                    && is_batchable_la(l.wk.gpu_dtype)
-                    && is_batchable_la(l.wv.gpu_dtype)
-                    && is_batchable_la(l.wo.gpu_dtype)
+                    && is_batchable_la(l.wq.gpu_dtype, arch)
+                    && is_batchable_la(l.wk.gpu_dtype, arch)
+                    && is_batchable_la(l.wv.gpu_dtype, arch)
+                    && is_batchable_la(l.wo.gpu_dtype, arch)
                     && moe_ffn_all_mq4(&l.ffn),
         });
 
@@ -2970,12 +2971,26 @@ pub fn forward_prefill_batch_with_pbs(
 /// eligibility check in `forward_prefill_batch` and the per-layer dtype
 /// branches in `forward_prefill_chunk`).
 #[inline]
-fn is_batchable_la(dt: DType) -> bool {
-    matches!(dt,
+fn is_batchable_la(dt: DType, arch: &str) -> bool {
+    let always_ok = matches!(dt,
         DType::MQ4G256 | DType::HFQ4G256
         | DType::MQ6G256 | DType::HFQ6G256
-        | DType::MQ3G256
-    )
+    );
+    if always_ok {
+        return true;
+    }
+    // MQ3 is batchable ONLY where the gfx11 wave32 WMMA builtin
+    // (`__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`) is available.
+    // Other archs (gfx12 RDNA4 / gfx10 RDNA1+2 / gfx906 GCN5 / gfx94x
+    // CDNA3) lack this exact builtin or use a different name; the
+    // MQ3 WMMA family hasn't been ported to them yet, so admitting
+    // MQ3 to the batched fast-path on those archs would JIT-fail or
+    // silently produce wrong values. Keep them on the per-token
+    // forward_scratch fallback (correct, just slower) until the
+    // arch-specific MQ3 kernels land.
+    let mq3_with_wmma = matches!(dt, DType::MQ3G256)
+        && matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+    mq3_with_wmma
 }
 
 /// Process one chunk of up to `pbs.max_batch` tokens through the batched
@@ -3241,23 +3256,24 @@ fn forward_prefill_chunk(
     // differ by dtype and we branch on that at each layer) and (b) a Q8_0
     // or givens KV cache. If the check fails, FA layers fall back to
     // per-token gather/scatter via run_fa_layer_body.
+    let fa_arch = gpu.arch.as_str();
     let fa_batched_ok = (kv_cache.quant_q8 || kv_cache.quant_asym4 || kv_cache.quant_asym3 || kv_cache.quant_asym2)
         && weights.layers.iter().all(|lw| match lw {
             LayerWeights::FullAttn(l) =>
-                is_batchable_la(l.wq.gpu_dtype) &&
-                is_batchable_la(l.wk.gpu_dtype) &&
-                is_batchable_la(l.wv.gpu_dtype) &&
-                is_batchable_la(l.wo.gpu_dtype) &&
-                is_batchable_la(l.w_gate.gpu_dtype) &&
-                is_batchable_la(l.w_up.gpu_dtype) &&
-                is_batchable_la(l.w_down.gpu_dtype),
+                is_batchable_la(l.wq.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.wk.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.wv.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.wo.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.w_gate.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.w_up.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.w_down.gpu_dtype, fa_arch),
             // MoE variant: attention weights must be MQ4-class (FFN is
             // checked separately by moe_ffn_all_mq4 in the eligibility gate).
             LayerWeights::FullAttnMoe(l) =>
-                is_batchable_la(l.wq.gpu_dtype) &&
-                is_batchable_la(l.wk.gpu_dtype) &&
-                is_batchable_la(l.wv.gpu_dtype) &&
-                is_batchable_la(l.wo.gpu_dtype),
+                is_batchable_la(l.wq.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.wk.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.wv.gpu_dtype, fa_arch) &&
+                is_batchable_la(l.wo.gpu_dtype, fa_arch),
             _ => true, // LA layers don't gate this check
         });
     // Under hipGraph capture, scalar kernargs get BAKED into the kernarg blob

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -2711,6 +2711,56 @@ pub fn forward_prefill_batch_single_chunk_captured(
     let n = tokens.len();
     debug_assert!(n > 0 && n <= pbs.max_batch,
         "single_chunk_captured: n={} but pbs.max_batch={}", n, pbs.max_batch);
+
+    // Defense-in-depth: this entry point bypasses the eligibility check
+    // in `forward_prefill_batch_with_pbs`, so the caller is responsible
+    // for ensuring the batched fast-path is valid. The only structural
+    // bypass that could land here is an MQ3-weighted model on an arch
+    // that lacks the gfx11 wave32 WMMA builtin (gfx12, gfx10, gfx906,
+    // gfx94x). In production, `daemon.rs`'s DFlash refusal guard (PR
+    // #108) blocks any MQ3-weight model from reaching this path, but we
+    // still cross-check here so a future loosened guard or new caller
+    // doesn't silently dispatch into JIT-failing kernels.
+    let arch = gpu.arch.as_str();
+    let mq3_present = weights.layers.iter().any(|lw| match lw {
+        LayerWeights::DeltaNet(l) => matches!(l.wqkv.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wz.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_gate.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_up.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_down.gpu_dtype, DType::MQ3G256),
+        LayerWeights::FullAttn(l) => matches!(l.wq.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wk.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wv.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_gate.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_up.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_down.gpu_dtype, DType::MQ3G256),
+        LayerWeights::DeltaNetMoe(l) => matches!(l.wqkv.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wz.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
+            || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wo.gpu_dtype, DType::MQ3G256),
+        LayerWeights::FullAttnMoe(l) => matches!(l.wq.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wk.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wv.gpu_dtype, DType::MQ3G256)
+            || matches!(l.wo.gpu_dtype, DType::MQ3G256),
+    });
+    let arch_has_wmma = matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+    if mq3_present && !arch_has_wmma {
+        return Err(hip_bridge::HipError::new(0, &format!(
+            "forward_prefill_batch_single_chunk_captured: model contains MQ3G256 \
+             weights but arch {arch} lacks the gfx11 wave32 WMMA builtin. The MQ3 \
+             prefill kernels (gemm_*_hfq3g256_wmma) only compile on \
+             gfx1100/1101/1102/1150/1151. Caller must use the non-captured \
+             forward_prefill_batch path (which falls back to per-token \
+             forward_scratch on this arch). gfx12 K4 variant for MQ3 is \
+             a planned follow-up."
+        )));
+    }
+
     forward_prefill_chunk(
         gpu, weights, config, tokens, start_pos,
         kv_cache, dn_state, scratch, pbs, hidden_rb,

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -539,6 +539,14 @@ fn load_weight_tensor_raw(gpu: &Gpu, quant_type: u8, data: &[u8], m: usize, k: u
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ2G256, m, k, row_stride: 0 })
         }
+        19 => { // MQ2-G256-Lloyd — 2-bit + 4-entry fp16 codebook (72 bytes/group)
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ2G256Lloyd, m, k, row_stride: 0 })
+        }
+        20 => { // MQ3-G256-Lloyd — 3-bit + 8-entry fp16 codebook (112 bytes/group)
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256Lloyd, m, k, row_stride: 0 })
+        }
         3 => {
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::Q8_0, m, k, row_stride: 0 })
@@ -603,6 +611,14 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         18 => { // MQ2-G256 — MagnumQuant FWHT-rotated 2-bit
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ2G256, m, k, row_stride: 0 })
+        }
+        19 => { // MQ2-G256-Lloyd — MagnumQuant 2-bit + 4-entry fp16 codebook
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ2G256Lloyd, m, k, row_stride: 0 })
+        }
+        20 => { // MQ3-G256-Lloyd — MagnumQuant 3-bit + 8-entry fp16 codebook (112 B/group)
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256Lloyd, m, k, row_stride: 0 })
         }
         3 => { // Q8_0
             let buf = gpu.upload_raw(data, &[data.len()])?;
@@ -833,6 +849,115 @@ fn load_any_as_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, n: usize) -> HipRes
                     out.push(scale * q6 + zero);
                     out.push(scale * q7 + zero);
                 }
+            }
+            out
+        }
+        20 => {
+            // MQ3-G256-Lloyd (qt 20, 112 B/group): 8 fp16 codebook entries + 3-bit
+            // indices (cross-byte, 32 chunks × 3 bytes × 8 weights). Decode is
+            // direct lookup `cb[idx]` then inverse FWHT for CPU consumers.
+            let group_size: usize = 256;
+            let bytes_per_group: usize = 112;
+            let n_groups = data.len() / bytes_per_group;
+            let mut out = Vec::with_capacity(n_groups * group_size);
+            let signs1 = crate::llama::KvCache::gen_fwht_signs(42, 256);
+            let signs2 = crate::llama::KvCache::gen_fwht_signs(1042, 256);
+            for g in 0..n_groups {
+                let off = g * bytes_per_group;
+                let mut cb = [0.0f32; 8];
+                for k in 0..8 {
+                    let bits = u16::from_le_bytes([data[off + 2 * k], data[off + 2 * k + 1]]);
+                    cb[k] = crate::llama::f16_to_f32(bits);
+                }
+                let start = out.len();
+                for chunk in 0..32 {
+                    let bo = off + 16 + chunk * 3;
+                    let b0 = data[bo] as u32;
+                    let b1 = data[bo + 1] as u32;
+                    let b2 = data[bo + 2] as u32;
+                    let q0 = (b0 & 7) as usize;
+                    let q1 = ((b0 >> 3) & 7) as usize;
+                    let q2 = (((b0 >> 6) | (b1 << 2)) & 7) as usize;
+                    let q3 = ((b1 >> 1) & 7) as usize;
+                    let q4 = ((b1 >> 4) & 7) as usize;
+                    let q5 = (((b1 >> 7) | (b2 << 1)) & 7) as usize;
+                    let q6 = ((b2 >> 2) & 7) as usize;
+                    let q7 = ((b2 >> 5) & 7) as usize;
+                    out.push(cb[q0]);
+                    out.push(cb[q1]);
+                    out.push(cb[q2]);
+                    out.push(cb[q3]);
+                    out.push(cb[q4]);
+                    out.push(cb[q5]);
+                    out.push(cb[q6]);
+                    out.push(cb[q7]);
+                }
+                let group = &mut out[start..start + 256];
+                for i in 0..256 { group[i] *= signs2[i]; }
+                let mut stride = 1;
+                while stride < 256 {
+                    let mut j = 0;
+                    while j < 256 {
+                        for k in 0..stride {
+                            let a = group[j + k];
+                            let b = group[j + k + stride];
+                            group[j + k] = a + b;
+                            group[j + k + stride] = a - b;
+                        }
+                        j += stride * 2;
+                    }
+                    stride <<= 1;
+                }
+                let scale_inv = 0.0625;
+                for i in 0..256 { group[i] *= scale_inv * signs1[i]; }
+            }
+            out
+        }
+        19 => {
+            // MQ2-G256-Lloyd (qt 19, 72 B/group): 4 fp16 codebook entries + 2-bit indices.
+            // Decode is direct lookup `cb[idx]`, then inverse FWHT to recover original
+            // pre-rotation values for CPU consumers (DeltaNet conv1d).
+            let group_size: usize = 256;
+            let bytes_per_group: usize = 72;
+            let n_groups = data.len() / bytes_per_group;
+            let mut out = Vec::with_capacity(n_groups * group_size);
+            let signs1 = crate::llama::KvCache::gen_fwht_signs(42, 256);
+            let signs2 = crate::llama::KvCache::gen_fwht_signs(1042, 256);
+            for g in 0..n_groups {
+                let off = g * bytes_per_group;
+                let mut cb = [0.0f32; 4];
+                for k in 0..4 {
+                    let bits = u16::from_le_bytes([data[off + 2 * k], data[off + 2 * k + 1]]);
+                    cb[k] = crate::llama::f16_to_f32(bits);
+                }
+                let start = out.len();
+                for i in 0..64 {
+                    let byte_val = data[off + 8 + i] as usize;
+                    out.push(cb[byte_val & 3]);
+                    out.push(cb[(byte_val >> 2) & 3]);
+                    out.push(cb[(byte_val >> 4) & 3]);
+                    out.push(cb[(byte_val >> 6) & 3]);
+                }
+                // Inverse FWHT to recover pre-rotation weights — same butterfly as the
+                // MQ3/MQ2 arm below.
+                let group = &mut out[start..start + 256];
+                for i in 0..256 { group[i] *= signs2[i]; }
+                let mut stride = 1;
+                while stride < 256 {
+                    let mut j = 0;
+                    while j < 256 {
+                        for k in 0..stride {
+                            let a = group[j + k];
+                            let b = group[j + k + stride];
+                            group[j + k] = a + b;
+                            group[j + k + stride] = a - b;
+                        }
+                        j += stride * 2;
+                    }
+                    stride <<= 1;
+                }
+                let scale_inv = 0.0625;
+                for i in 0..256 { group[i] *= scale_inv * signs1[i]; }
             }
             out
         }

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -1296,6 +1296,22 @@ fn ffn_all_mq4_for_moe(ffn: &MoeFfnWeights) -> bool {
         && ffn.experts.iter().all(|e| e.gate_up.gpu_dtype == DType::MQ4G256)
 }
 
+/// Detect any MQ3G256 weight inside a MoE FFN block (router, shared expert
+/// gate/up/down, shared_expert_gate router-mix scalar, or any routed
+/// expert's gate_up/down). The MoE batched FFN kernels assume HFQ4-layout
+/// (136 B/group); an MQ3 weight (104 B/group) would dispatch with the wrong
+/// stride. Used by the captured-prefill defense-in-depth check.
+fn moe_ffn_has_mq3(ffn: &MoeFfnWeights) -> bool {
+    ffn.router.gpu_dtype == DType::MQ3G256
+        || ffn.shared_expert_gate.gpu_dtype == DType::MQ3G256
+        || ffn.shared_expert.gate.gpu_dtype == DType::MQ3G256
+        || ffn.shared_expert.up.gpu_dtype == DType::MQ3G256
+        || ffn.shared_expert.down.gpu_dtype == DType::MQ3G256
+        || ffn.experts.iter().any(|e|
+            e.gate_up.gpu_dtype == DType::MQ3G256
+            || e.down.gpu_dtype == DType::MQ3G256)
+}
+
 /// Zero-alloc MoE decode for the scratch path. `scratch.moe_*` fields must
 /// be populated (done automatically by `Qwen35Scratch::new` when config
 /// indicates a MoE model). Safe to call under hipGraph stream capture.
@@ -2756,6 +2772,7 @@ pub fn forward_prefill_batch_single_chunk_captured(
                     || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
                     || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
                     || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+                    || moe_ffn_has_mq3(&l.ffn)
                 { mq3_in_moe = true; }
             }
             LayerWeights::FullAttnMoe(l) => {
@@ -2763,6 +2780,7 @@ pub fn forward_prefill_batch_single_chunk_captured(
                     || matches!(l.wk.gpu_dtype, DType::MQ3G256)
                     || matches!(l.wv.gpu_dtype, DType::MQ3G256)
                     || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+                    || moe_ffn_has_mq3(&l.ffn)
                 { mq3_in_moe = true; }
             }
         }

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -2714,42 +2714,71 @@ pub fn forward_prefill_batch_single_chunk_captured(
 
     // Defense-in-depth: this entry point bypasses the eligibility check
     // in `forward_prefill_batch_with_pbs`, so the caller is responsible
-    // for ensuring the batched fast-path is valid. The only structural
-    // bypass that could land here is an MQ3-weighted model on an arch
-    // that lacks the gfx11 wave32 WMMA builtin (gfx12, gfx10, gfx906,
-    // gfx94x). In production, `daemon.rs`'s DFlash refusal guard (PR
-    // #108) blocks any MQ3-weight model from reaching this path, but we
-    // still cross-check here so a future loosened guard or new caller
-    // doesn't silently dispatch into JIT-failing kernels.
+    // for ensuring the batched fast-path is valid. Two structural bypasses
+    // could land here:
+    //   1. MQ3-weighted model on an arch that lacks the gfx11 wave32 WMMA
+    //      builtin (gfx12, gfx10, gfx906, gfx94x).
+    //   2. MQ3 weights inside a MoE/A3B layer (DeltaNetMoe/FullAttnMoe) —
+    //      the MoE batched branches dispatch through HFQ4-layout kernels
+    //      and would memory-fault on the 104-vs-136 byte stride.
+    // In production, `daemon.rs`'s DFlash refusal guard blocks both, but
+    // dflash_spec_demo and other example callers go through ModelSlot::load
+    // directly. We cross-check here so any caller is protected.
     let arch = gpu.arch.as_str();
-    let mq3_present = weights.layers.iter().any(|lw| match lw {
-        LayerWeights::DeltaNet(l) => matches!(l.wqkv.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wz.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wo.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_gate.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_up.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_down.gpu_dtype, DType::MQ3G256),
-        LayerWeights::FullAttn(l) => matches!(l.wq.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wk.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wv.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wo.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_gate.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_up.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_down.gpu_dtype, DType::MQ3G256),
-        LayerWeights::DeltaNetMoe(l) => matches!(l.wqkv.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wz.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
-            || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wo.gpu_dtype, DType::MQ3G256),
-        LayerWeights::FullAttnMoe(l) => matches!(l.wq.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wk.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wv.gpu_dtype, DType::MQ3G256)
-            || matches!(l.wo.gpu_dtype, DType::MQ3G256),
-    });
+    let mut mq3_in_dense = false;
+    let mut mq3_in_moe = false;
+    for lw in &weights.layers {
+        match lw {
+            LayerWeights::DeltaNet(l) => {
+                if matches!(l.wqkv.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wz.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_gate.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_up.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_down.gpu_dtype, DType::MQ3G256)
+                { mq3_in_dense = true; }
+            }
+            LayerWeights::FullAttn(l) => {
+                if matches!(l.wq.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wk.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wv.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_gate.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_up.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_down.gpu_dtype, DType::MQ3G256)
+                { mq3_in_dense = true; }
+            }
+            LayerWeights::DeltaNetMoe(l) => {
+                if matches!(l.wqkv.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wz.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_beta.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.w_alpha.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+                { mq3_in_moe = true; }
+            }
+            LayerWeights::FullAttnMoe(l) => {
+                if matches!(l.wq.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wk.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wv.gpu_dtype, DType::MQ3G256)
+                    || matches!(l.wo.gpu_dtype, DType::MQ3G256)
+                { mq3_in_moe = true; }
+            }
+        }
+    }
     let arch_has_wmma = matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-    if mq3_present && !arch_has_wmma {
+    if mq3_in_moe {
+        return Err(hip_bridge::HipError::new(0,
+            "forward_prefill_batch_single_chunk_captured: model has MQ3G256 \
+             weights inside a MoE/A3B layer (DeltaNetMoe or FullAttnMoe). The \
+             MoE batched prefill branches dispatch through HFQ4-layout kernels \
+             and would memory-fault on the 104-vs-136 byte stride. Use an MQ4 \
+             quantization for MoE/A3B targets, or wait for the MQ3 MoE \
+             branches to land."
+        ));
+    }
+    if mq3_in_dense && !arch_has_wmma {
         return Err(hip_bridge::HipError::new(0, &format!(
             "forward_prefill_batch_single_chunk_captured: model contains MQ3G256 \
              weights but arch {arch} lacks the gfx11 wave32 WMMA builtin. The MQ3 \

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -2785,7 +2785,10 @@ pub fn forward_prefill_batch_single_chunk_captured(
             }
         }
     }
-    let arch_has_wmma = matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+    let arch_has_wmma = matches!(arch,
+        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
+        | "gfx1200" | "gfx1201"
+    );
     if mq3_in_moe {
         return Err(hip_bridge::HipError::new(0,
             "forward_prefill_batch_single_chunk_captured: model has MQ3G256 \
@@ -3076,17 +3079,20 @@ fn is_batchable_la(dt: DType, arch: &str) -> bool {
     if always_ok {
         return true;
     }
-    // MQ3 is batchable ONLY where the gfx11 wave32 WMMA builtin
-    // (`__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`) is available.
-    // Other archs (gfx12 RDNA4 / gfx10 RDNA1+2 / gfx906 GCN5 / gfx94x
-    // CDNA3) lack this exact builtin or use a different name; the
-    // MQ3 WMMA family hasn't been ported to them yet, so admitting
-    // MQ3 to the batched fast-path on those archs would JIT-fail or
-    // silently produce wrong values. Keep them on the per-token
-    // forward_scratch fallback (correct, just slower) until the
-    // arch-specific MQ3 kernels land.
+    // MQ3 is batchable on archs with a WMMA family ported. As of this
+    // commit:
+    //   - gfx11 (gfx1100/1101/1102/1150/1151): wave32 WMMA via the
+    //     `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32` builtin.
+    //   - gfx12 (gfx1200/1201): wave32 WMMA via the `_w32_gfx12` builtin
+    //     with K4 unroll + half8_t lane-split.
+    // gfx10 RDNA1+2 / gfx906 GCN5 / gfx94x CDNA3 lack a ported MQ3 WMMA
+    // kernel; they stay on the per-token forward_scratch fallback
+    // (correct, just slower).
     let mq3_with_wmma = matches!(dt, DType::MQ3G256)
-        && matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        && matches!(arch,
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
+            | "gfx1200" | "gfx1201"
+        );
     mq3_with_wmma
 }
 

--- a/crates/engine/src/qwen35.rs
+++ b/crates/engine/src/qwen35.rs
@@ -2971,7 +2971,11 @@ pub fn forward_prefill_batch_with_pbs(
 /// branches in `forward_prefill_chunk`).
 #[inline]
 fn is_batchable_la(dt: DType) -> bool {
-    matches!(dt, DType::MQ4G256 | DType::HFQ4G256 | DType::MQ6G256 | DType::HFQ6G256)
+    matches!(dt,
+        DType::MQ4G256 | DType::HFQ4G256
+        | DType::MQ6G256 | DType::HFQ6G256
+        | DType::MQ3G256
+    )
 }
 
 /// Process one chunk of up to `pbs.max_batch` tokens through the batched
@@ -3285,8 +3289,9 @@ fn forward_prefill_chunk(
                 // plain rmsnormed activations. The GEMM kernels themselves
                 // are dtype-agnostic — they just consume whatever [N × K]
                 // activation buffer we point them at.
-                let is_mq = matches!(layer.wqkv.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let is_mq = matches!(layer.wqkv.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let is_6bit = matches!(layer.wqkv.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let is_mq3 = matches!(layer.wqkv.gpu_dtype, DType::MQ3G256);
 
                 // Batched rmsnorm (+ FWHT for MQ) for the LA preamble.
                 // x_batch / x_rot_batch are [N × dim] contiguous. For HFQ
@@ -3306,6 +3311,16 @@ fn forward_prefill_chunk(
                 // Batched 4-way LA projection (wqkv + wz + w_beta + w_alpha).
                 if is_6bit {
                     gpu.gemm_qkvza_hfq6g256(
+                        &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.dn_qkv_batch, &pbs.dn_z_batch, &pbs.dn_beta_batch, &pbs.dn_alpha_batch,
+                        layer.wqkv.m, layer.wz.m, layer.w_beta.m, layer.w_alpha.m,
+                        layer.wqkv.k, n,
+                    )?;
+                } else if is_mq3 {
+                    // X is already FWHT-rotated by fused_rmsnorm_rotate_mq_batched
+                    // above; call the bare HFQ3 WMMA (no second rotation).
+                    gpu.gemm_qkvza_hfq3g256_wmma(
                         &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
                         &pbs.x_rot_batch,
                         &pbs.dn_qkv_batch, &pbs.dn_z_batch, &pbs.dn_beta_batch, &pbs.dn_alpha_batch,
@@ -3446,8 +3461,9 @@ fn forward_prefill_chunk(
                 // at quant time; math requires dot(rot(W), rot(x)) = dot(W,x)).
                 // For HFQ weights no rotation is needed — the activation
                 // feeds gemm_hfq{4,6}g256_residual directly.
-                let wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let wo_is_6bit = matches!(layer.wo.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let wo_is_mq3 = matches!(layer.wo.gpu_dtype, DType::MQ3G256);
                 let wo_input = if wo_is_mq {
                     gpu.rotate_x_mq_batched(
                         &pbs.dn_normed_batch, &pbs.dn_normed_rot_batch, layer.wo.k, n,
@@ -3461,6 +3477,11 @@ fn forward_prefill_chunk(
                         &layer.wo.buf, wo_input, &pbs.x_batch,
                         layer.wo.m, layer.wo.k, n,
                     )?;
+                } else if wo_is_mq3 {
+                    gpu.gemm_hfq3g256_residual_wmma(
+                        &layer.wo.buf, wo_input, &pbs.x_batch,
+                        layer.wo.m, layer.wo.k, n,
+                    )?;
                 } else {
                     gpu.gemm_hfq4g256_residual(
                         &layer.wo.buf, wo_input, &pbs.x_batch,
@@ -3469,8 +3490,9 @@ fn forward_prefill_chunk(
                 }
 
                 // FFN: rmsnorm (+ rotate for MQ).
-                let ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let ffn_is_6bit = matches!(layer.w_gate.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let ffn_is_mq3 = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256);
                 if ffn_is_mq {
                     gpu.fused_rmsnorm_rotate_mq_batched(
                         &pbs.x_batch, &layer.ffn_norm, &pbs.x_rot_batch, dim, config.norm_eps, n,
@@ -3485,6 +3507,14 @@ fn forward_prefill_chunk(
                 // Batched gate+up projection.
                 if ffn_is_6bit {
                     gpu.gemm_gate_up_hfq6g256(
+                        &layer.w_gate.buf, &layer.w_up.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.gate_ffn_batch, &pbs.up_batch,
+                        layer.w_gate.m, layer.w_up.m,
+                        layer.w_gate.k, n,
+                    )?;
+                } else if ffn_is_mq3 {
+                    gpu.gemm_gate_up_hfq3g256_wmma(
                         &layer.w_gate.buf, &layer.w_up.buf,
                         &pbs.x_rot_batch,
                         &pbs.gate_ffn_batch, &pbs.up_batch,
@@ -3507,8 +3537,9 @@ fn forward_prefill_chunk(
                 // is purely element-wise and uses numel() as its length,
                 // so a [N × hidden_dim] tensor processes all rows in one
                 // launch with no batch offset needed.
-                let w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let w_down_is_6bit = matches!(layer.w_down.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let w_down_is_mq3 = matches!(layer.w_down.gpu_dtype, DType::MQ3G256);
                 if w_down_is_mq {
                     gpu.fused_silu_mul_rotate_mq_batched(
                         &pbs.gate_ffn_batch, &pbs.up_batch, &pbs.ffn_hidden_batch,
@@ -3523,6 +3554,11 @@ fn forward_prefill_chunk(
                 // Batched w_down + residual.
                 if w_down_is_6bit {
                     gpu.gemm_hfq6g256_residual(
+                        &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
+                        layer.w_down.m, layer.w_down.k, n,
+                    )?;
+                } else if w_down_is_mq3 {
+                    gpu.gemm_hfq3g256_residual_wmma(
                         &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
                         layer.w_down.m, layer.w_down.k, n,
                     )?;
@@ -3550,8 +3586,9 @@ fn forward_prefill_chunk(
                 // launch covers all N tokens at once.
                 let kv_dim = config.n_kv_heads * config.head_dim;
                 let q_dim = config.n_heads * config.head_dim;
-                let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let qkv_is_6bit = matches!(layer.wq.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let qkv_is_mq3 = matches!(layer.wq.gpu_dtype, DType::MQ3G256);
 
                 // 1. rmsnorm (+ rotate for MQ) for the attn preamble.
                 if qkv_is_mq {
@@ -3568,6 +3605,16 @@ fn forward_prefill_chunk(
                 // 2. Batched 3-way QKV projection (wq+wk+wv).
                 if qkv_is_6bit {
                     gpu.gemm_qkv_hfq6g256(
+                        &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.fa_q_full_batch, &pbs.fa_k_batch, &pbs.fa_v_batch,
+                        layer.wq.m, layer.wk.m, layer.wv.m,
+                        layer.wq.k, n,
+                    )?;
+                } else if qkv_is_mq3 {
+                    // X is already FWHT-rotated by fused_rmsnorm_rotate_mq_batched
+                    // above; call the bare HFQ3 WMMA (no second rotation).
+                    gpu.gemm_qkv_hfq3g256_wmma(
                         &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
                         &pbs.x_rot_batch,
                         &pbs.fa_q_full_batch, &pbs.fa_k_batch, &pbs.fa_v_batch,
@@ -3797,8 +3844,9 @@ fn forward_prefill_chunk(
 
                 // 9. wo residual: x_batch += wo · (optional rotate)(fa_attn_out_batch).
                 // Same MQ rotation requirement as the LA wo path.
-                let fa_wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let fa_wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let fa_wo_is_6bit = matches!(layer.wo.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let fa_wo_is_mq3 = matches!(layer.wo.gpu_dtype, DType::MQ3G256);
                 let fa_wo_input = if fa_wo_is_mq {
                     gpu.rotate_x_mq_batched(
                         &pbs.fa_attn_out_batch, &pbs.fa_attn_out_rot_batch, layer.wo.k, n,
@@ -3812,6 +3860,11 @@ fn forward_prefill_chunk(
                         &layer.wo.buf, fa_wo_input, &pbs.x_batch,
                         layer.wo.m, layer.wo.k, n,
                     )?;
+                } else if fa_wo_is_mq3 {
+                    gpu.gemm_hfq3g256_residual_wmma(
+                        &layer.wo.buf, fa_wo_input, &pbs.x_batch,
+                        layer.wo.m, layer.wo.k, n,
+                    )?;
                 } else {
                     gpu.gemm_hfq4g256_residual(
                         &layer.wo.buf, fa_wo_input, &pbs.x_batch,
@@ -3821,8 +3874,9 @@ fn forward_prefill_chunk(
 
                 // 10. FFN: rmsnorm (+ rotate for MQ), gate+up, silu_mul
                 // (+ rotate for MQ), w_down residual.
-                let fa_ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let fa_ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let fa_ffn_is_6bit = matches!(layer.w_gate.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let fa_ffn_is_mq3 = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256);
                 if fa_ffn_is_mq {
                     gpu.fused_rmsnorm_rotate_mq_batched(
                         &pbs.x_batch, &layer.ffn_norm, &pbs.x_rot_batch, dim, config.norm_eps, n,
@@ -3841,6 +3895,14 @@ fn forward_prefill_chunk(
                         layer.w_gate.m, layer.w_up.m,
                         layer.w_gate.k, n,
                     )?;
+                } else if fa_ffn_is_mq3 {
+                    gpu.gemm_gate_up_hfq3g256_wmma(
+                        &layer.w_gate.buf, &layer.w_up.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.gate_ffn_batch, &pbs.up_batch,
+                        layer.w_gate.m, layer.w_up.m,
+                        layer.w_gate.k, n,
+                    )?;
                 } else {
                     gpu.gemm_gate_up_hfq4g256(
                         &layer.w_gate.buf, &layer.w_up.buf,
@@ -3850,8 +3912,9 @@ fn forward_prefill_chunk(
                         layer.w_gate.k, n,
                     )?;
                 }
-                let fa_w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
+                let fa_w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
                 let fa_w_down_is_6bit = matches!(layer.w_down.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
+                let fa_w_down_is_mq3 = matches!(layer.w_down.gpu_dtype, DType::MQ3G256);
                 if fa_w_down_is_mq {
                     gpu.fused_silu_mul_rotate_mq_batched(
                         &pbs.gate_ffn_batch, &pbs.up_batch, &pbs.ffn_hidden_batch,
@@ -3864,6 +3927,11 @@ fn forward_prefill_chunk(
                 }
                 if fa_w_down_is_6bit {
                     gpu.gemm_hfq6g256_residual(
+                        &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
+                        layer.w_down.m, layer.w_down.k, n,
+                    )?;
+                } else if fa_w_down_is_mq3 {
+                    gpu.gemm_hfq3g256_residual_wmma(
                         &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
                         layer.w_down.m, layer.w_down.k, n,
                     )?;

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -2083,7 +2083,8 @@ fn verify_dflash_block_inner(
     let try_batched = match w_out.gpu_dtype {
         rdna_compute::DType::Q8_0
         | rdna_compute::DType::HFQ4G256
-        | rdna_compute::DType::MQ4G256 => true,
+        | rdna_compute::DType::MQ4G256
+        | rdna_compute::DType::MQ3G256 => true,
         _ => false,
     };
 
@@ -2119,6 +2120,16 @@ fn verify_dflash_block_inner(
                 let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
                 gpu.rotate_x_mq_batched(&final_hidden, &rot, w_out.k, b)?;
                 gpu.gemm_hfq4g256_batched_lmhead(
+                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
+                )?;
+            }
+            rdna_compute::DType::MQ3G256 => {
+                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                    "verify_scratch.rot undersized for MQ3 lm_head: b*k={} > max_n*hidden_k={}",
+                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
+                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+                gpu.rotate_x_mq_batched(&final_hidden, &rot, w_out.k, b)?;
+                gpu.gemm_hfq3g256_batched_lmhead(
                     &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
                 )?;
             }
@@ -2605,7 +2616,7 @@ pub fn spec_step_dflash(
     let w_out = &target.weights.output;
     let use_batched_gemm = matches!(
         w_out.gpu_dtype,
-        rdna_compute::DType::HFQ4G256 | rdna_compute::DType::MQ4G256,
+        rdna_compute::DType::HFQ4G256 | rdna_compute::DType::MQ4G256 | rdna_compute::DType::MQ3G256,
     );
     let use_q8_staged = matches!(w_out.gpu_dtype, rdna_compute::DType::Q8_0);
     if use_batched_gemm || use_q8_staged {
@@ -2637,6 +2648,15 @@ pub fn spec_step_dflash(
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
                 gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
                 gpu.gemm_hfq4g256_batched_lmhead(
+                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
+                )?;
+            }
+            rdna_compute::DType::MQ3G256 => {
+                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                    "verify_scratch.rot undersized for MQ3 draft lm_head");
+                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                gpu.gemm_hfq3g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }
@@ -3251,9 +3271,27 @@ fn run_dflash_draft_for_logits(
             let _ = gpu.free_tensor(rotated);
             r2
         }
+        rdna_compute::DType::MQ3G256 => {
+            let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
+            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            if let Err(e) = r1 {
+                let _ = gpu.free_tensor(rotated);
+                let _ = gpu.free_tensor(logits_batch);
+                return Err(e);
+            }
+            // MQ3 has no scalar batched gemm (unlike MQ4), so use the
+            // WMMA-residual lm_head wrapper which pre-zeros Y. Same pattern
+            // as the verify path — keeps draft and verify byte-identical
+            // for MQ3 targets.
+            let r2 = gpu.gemm_hfq3g256_batched_lmhead(
+                &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
+            );
+            let _ = gpu.free_tensor(rotated);
+            r2
+        }
         _ => Err(hip_bridge::HipError::new(
             0,
-            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256)",
+            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256/MQ3G256)",
         )),
     };
     if let Err(e) = gemm_result {
@@ -3374,9 +3412,23 @@ fn run_dflash_draft_for_topk_gpu(
             let _ = gpu.free_tensor(rotated);
             r2
         }
+        rdna_compute::DType::MQ3G256 => {
+            let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
+            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            if let Err(e) = r1 {
+                let _ = gpu.free_tensor(rotated);
+                let _ = gpu.free_tensor(logits_batch);
+                return Err(e);
+            }
+            let r2 = gpu.gemm_hfq3g256_batched_lmhead(
+                &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
+            );
+            let _ = gpu.free_tensor(rotated);
+            r2
+        }
         _ => Err(hip_bridge::HipError::new(
             0,
-            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256)",
+            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256/MQ3G256)",
         )),
     };
     if let Err(e) = gemm_result {

--- a/crates/hipfire-quantize/src/bin/dflash_convert.rs
+++ b/crates/hipfire-quantize/src/bin/dflash_convert.rs
@@ -220,6 +220,54 @@ fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     }).collect()
 }
 
+/// MagnumQuant MQ3-G256: FWHT-rotated 3-bit quantization.
+/// 104 bytes per 256 weights (0.406 B/w). Same binary layout as HFQ3-G256.
+/// Lifted verbatim from hipfire-quantize/main.rs's `quantize_mq3g256`.
+fn quantize_mq3g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+    let group_size = 256;
+    let block_bytes = 104;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+
+    for b in 0..n_blocks {
+        let start = b * group_size;
+        let end = (start + group_size).min(n);
+        let mut group = [0.0f32; 256];
+        let actual_len = end - start;
+        group[..actual_len].copy_from_slice(&f32_data[start..end]);
+
+        cpu_fwht_256(&mut group, signs1, signs2);
+
+        let min_val = group.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max_val = group.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let range = max_val - min_val;
+        let scale = if range > 0.0 { range / 7.0 } else { 1.0 };
+        let inv_scale = if range > 0.0 { 1.0 / scale } else { 0.0 };
+
+        let out_off = b * block_bytes;
+        output[out_off..out_off + 4].copy_from_slice(&scale.to_le_bytes());
+        output[out_off + 4..out_off + 8].copy_from_slice(&min_val.to_le_bytes());
+
+        for chunk in 0..32 {
+            let ci = chunk * 8;
+            let mut q = [0u8; 8];
+            for j in 0..8 {
+                q[j] = ((group[ci + j] - min_val) * inv_scale + 0.5).clamp(0.0, 7.0) as u8;
+            }
+            let b0 = (q[0] & 7) | ((q[1] & 7) << 3) | ((q[2] & 3) << 6);
+            let b1 = ((q[2] >> 2) & 1) | ((q[3] & 7) << 1) | ((q[4] & 7) << 4) | ((q[5] & 1) << 7);
+            let b2 = ((q[5] >> 1) & 3) | ((q[6] & 7) << 2) | ((q[7] & 7) << 5);
+
+            let bo = out_off + 8 + chunk * 3;
+            output[bo] = b0;
+            output[bo + 1] = b1;
+            output[bo + 2] = b2;
+        }
+    }
+    output
+}
+
 /// MagnumQuant MQ4-G256: FWHT-rotated 4-bit quantization.
 /// 136 bytes per 256 weights (0.531 B/w). Same binary layout as HFQ4-G256;
 /// the rotation is baked into the weights so the GEMM kernel just rotates
@@ -273,6 +321,7 @@ enum QuantType {
     F16 = 1,
     F32 = 2,
     MQ4G256 = 13,
+    MQ3G256 = 17,
 }
 
 struct HfqTensor {
@@ -407,6 +456,7 @@ fn main() {
     let mut output_path: Option<String> = None;
     let mut keep_f32 = false;
     let mut use_mq4 = false;
+    let mut use_mq3 = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -427,9 +477,13 @@ fn main() {
                 use_mq4 = true;
                 i += 1;
             }
+            "--mq3" => {
+                use_mq3 = true;
+                i += 1;
+            }
             "-h" | "--help" => {
                 eprintln!(
-                    "Usage: dflash_convert --input <dir_or_hf_id> --output <file.hfq> [--keep-f32 | --mq4]"
+                    "Usage: dflash_convert --input <dir_or_hf_id> --output <file.hfq> [--keep-f32 | --mq4 | --mq3]"
                 );
                 std::process::exit(0);
             }
@@ -439,8 +493,9 @@ fn main() {
             }
         }
     }
-    if keep_f32 && use_mq4 {
-        eprintln!("--keep-f32 and --mq4 are mutually exclusive");
+    let n_format_flags = (keep_f32 as u8) + (use_mq4 as u8) + (use_mq3 as u8);
+    if n_format_flags > 1 {
+        eprintln!("--keep-f32, --mq4, and --mq3 are mutually exclusive");
         std::process::exit(1);
     }
 
@@ -457,6 +512,8 @@ fn main() {
         "F32"
     } else if use_mq4 {
         "MQ4-G256 (weights), F32 (norms)"
+    } else if use_mq3 {
+        "MQ3-G256 (weights), F32 (norms)"
     } else {
         "F16 (weights), F32 (norms)"
     };
@@ -535,12 +592,13 @@ fn main() {
     );
 
     // Metadata JSON for the HFQ file.
-    let draft_dtype = if keep_f32 { "f32" } else if use_mq4 { "mq4" } else { "f16" };
+    let draft_dtype = if keep_f32 { "f32" } else if use_mq4 { "mq4" } else if use_mq3 { "mq3" } else { "f16" };
     // FWHT sign tables for MQ4 rotation. Seeds 42/1042 match the engine's
     // `rdna_compute::Gpu::ensure_mq_signs()` so quantized weights here can
     // be dequantized/used correctly on GPU at inference.
-    let signs1: Vec<f32> = if use_mq4 { gen_fwht_signs(42, 256) } else { Vec::new() };
-    let signs2: Vec<f32> = if use_mq4 { gen_fwht_signs(1042, 256) } else { Vec::new() };
+    let needs_fwht = use_mq4 || use_mq3;
+    let signs1: Vec<f32> = if needs_fwht { gen_fwht_signs(42, 256) } else { Vec::new() };
+    let signs2: Vec<f32> = if needs_fwht { gen_fwht_signs(1042, 256) } else { Vec::new() };
     let metadata = serde_json::json!({
         "architecture": "dflash",
         "config": config,
@@ -608,6 +666,9 @@ fn main() {
         } else if use_mq4 && n_elements >= 256 {
             let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
             (QuantType::MQ4G256, 256u32, q)
+        } else if use_mq3 && n_elements >= 256 {
+            let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+            (QuantType::MQ3G256, 256u32, q)
         } else {
             (QuantType::F16, 0u32, f32_slice_to_f16_bytes(&f32_data))
         };

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1702,6 +1702,41 @@ fn main() {
     let use_mq2g256 = format == "mq2" || format == "mq2g256";
     let use_hfq6 = format == "hfq6" || format == "hfq6g256" || format == "hf6";
 
+    // ── Sub-4-bit guards (2026-04-30 sweep) ─────────────────────────────
+    // MQ2 with the current uniform 4-level codebook collapses at every
+    // model size validated locally (0.8B / 4B / 9B Qwen 3.5 → multilingual
+    // mojibake on all 4 coherence-gate prompts). Refuse by default until
+    // Path D Lloyd-Max non-uniform codebooks land (PRD §5.2).
+    let allow_mq2 = args.iter().any(|a| a == "--allow-mq2")
+        || std::env::var("HIPFIRE_ALLOW_MQ2").ok().as_deref() == Some("1");
+    if use_mq2g256 && !allow_mq2 {
+        eprintln!(
+            "error: --format mq2 is reserved — empirical quality verdict is collapse on every model\n\
+             size validated locally (0.8B / 4B / 9B Qwen 3.5 → mojibake / symbol soup on all 4\n\
+             coherence-gate prompts). The current uniform 4-level codebook is fundamentally too\n\
+             lossy; Path D Lloyd-Max non-uniform codebooks (per-block squared-error-minimising)\n\
+             are the planned remediation per PRD §5.2.\n\
+             \n\
+             To opt in for research / ablation purposes anyway, pass --allow-mq2 or set\n\
+             HIPFIRE_ALLOW_MQ2=1. Don't ship MQ2 artifacts to users until the codebook\n\
+             improvement lands."
+        );
+        std::process::exit(1);
+    }
+    // MQ3 quality threshold ≈ 9B from the same sweep — 27B + 9B fluent,
+    // 4B partial-collapse (intent recognised, language drifts), 0.8B
+    // gibberish. Print a soft advisory so users running --format mq3
+    // against small models don't think the engine is broken.
+    if use_mq3g256 {
+        eprintln!(
+            "note: MQ3 empirical quality threshold ≈ 9B params. 27B / 9B Qwen 3.5 produce\n\
+             fluent output across the coherence-gate battery; 4B partially collapses\n\
+             (intent recognised, language mixes / loops); 0.8B is incoherent. For models\n\
+             below ~9B, prefer --format mq4 (same kernel family, ~30% larger but\n\
+             reliably coherent).\n"
+        );
+    }
+
     // GGUF input branch: if --input is a `.gguf` file, run the GGUF
     // pipeline and exit. Tensor names are translated GGUF → safetensors
     // style. The 2D quantization target follows --format:

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -718,6 +718,267 @@ fn quantize_mq2g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8>
     output
 }
 
+/// Encode an f32 to IEEE-754 fp16 bits (round-to-nearest-even, no NaN/Inf preservation
+/// beyond the trivial case — block centroids are bounded means of fp32 weights so
+/// the simple path is safe).
+fn f32_to_fp16_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let mut exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = (bits & 0x7FFFFF) as u32;
+    if exp == 0xFF {
+        // Inf or NaN
+        let m16 = if mant != 0 { 0x200 } else { 0 };
+        return sign | 0x7C00 | m16;
+    }
+    exp -= 127 - 15;
+    if exp >= 0x1F {
+        return sign | 0x7C00; // overflow → ±Inf
+    }
+    if exp <= 0 {
+        if exp < -10 {
+            return sign; // underflow → ±0
+        }
+        // Subnormal: shift mantissa
+        let m = mant | 0x800000;
+        let shift = (1 - exp) as u32 + 13;
+        let mut m16 = (m >> shift) as u16;
+        // Round-half-to-even via remainder
+        let lost = m & ((1u32 << shift) - 1);
+        let half = 1u32 << (shift - 1);
+        if lost > half || (lost == half && (m16 & 1) == 1) {
+            m16 = m16.wrapping_add(1);
+        }
+        return sign | m16;
+    }
+    let mut m16 = (mant >> 13) as u16;
+    let lost = mant & 0x1FFF;
+    if lost > 0x1000 || (lost == 0x1000 && (m16 & 1) == 1) {
+        m16 = m16.wrapping_add(1);
+        if m16 == 0x400 {
+            // Mantissa overflow → carry into exponent
+            m16 = 0;
+            exp += 1;
+            if exp >= 0x1F { return sign | 0x7C00; }
+        }
+    }
+    sign | ((exp as u16) << 10) | m16
+}
+
+/// MagnumQuant HFQ3-G256-Lloyd: per-block 8-entry fp16 codebook fitted via
+/// Lloyd's algorithm. 16 B header (8 fp16) + 96 B packed 3-bit indices = 112 B/group
+/// (vs uniform MQ3's 104 B — only +7.7% bandwidth). Direct extension of MQ2-Lloyd
+/// with K=8; targets sub-9B MQ3 collapse rescue (#114) and 9B MQ3 → MQ4 ppl gap.
+fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+    use rayon::prelude::*;
+    let group_size = 256;
+    let block_bytes = 112;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+
+    output
+        .par_chunks_mut(block_bytes)
+        .enumerate()
+        .for_each(|(b, out_chunk)| {
+            let start = b * group_size;
+            let end = (start + group_size).min(n);
+            let actual_len = end - start;
+
+            let mut group = [0.0f32; 256];
+            group[..actual_len].copy_from_slice(&f32_data[start..end]);
+            cpu_fwht_256(&mut group, signs1, signs2);
+
+            // Initial centroid placement: 8 evenly-spaced percentiles
+            // (1/16, 3/16, ..., 15/16) of the rotated block.
+            let mut sorted: [f32; 256] = group;
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let mut cb: [f32; 8] = [0.0; 8];
+            for k in 0..8 {
+                let frac = (2 * k + 1) as f32 / 16.0;
+                let idx = ((frac * 255.0).round() as usize).min(255);
+                cb[k] = sorted[idx];
+            }
+
+            let range = sorted[255] - sorted[0];
+            let mut indices = [0u8; 256];
+            if range > 0.0 {
+                let max_iter = 8;
+                let mut prev_assignments = [0u8; 256];
+                for it in 0..max_iter {
+                    let mut sums = [0.0f64; 8];
+                    let mut counts = [0u32; 8];
+                    let mut changed = 0u32;
+                    for i in 0..256 {
+                        let w = group[i];
+                        let mut best = 0usize;
+                        let mut best_d = (w - cb[0]).abs();
+                        for k in 1..8 {
+                            let d = (w - cb[k]).abs();
+                            if d < best_d { best_d = d; best = k; }
+                        }
+                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        prev_assignments[i] = best as u8;
+                        indices[i] = best as u8;
+                        sums[best] += w as f64;
+                        counts[best] += 1;
+                    }
+                    if it > 0 && changed == 0 { break; }
+                    for k in 0..8 {
+                        if counts[k] > 0 {
+                            cb[k] = (sums[k] / counts[k] as f64) as f32;
+                        }
+                    }
+                }
+            }
+
+            // Sort centroids ascending; remap indices.
+            let mut order: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            let mut sorted_cb = [0.0f32; 8];
+            let mut inv: [u8; 8] = [0; 8];
+            for new_idx in 0..8 {
+                sorted_cb[new_idx] = cb[order[new_idx]];
+                inv[order[new_idx]] = new_idx as u8;
+            }
+            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+
+            // Header: 8 fp16 centroids = 16 bytes.
+            for k in 0..8 {
+                let bits = f32_to_fp16_bits(sorted_cb[k]);
+                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k + 1] = (bits >> 8) as u8;
+            }
+
+            // Data: 96 bytes — same cross-byte 3-bit packing as uniform MQ3, so
+            // the kernel unpack code is identical (only the recon changes from
+            // `scale*q + zero` to `cb[q]`).
+            for chunk in 0..32 {
+                let ci = chunk * 8;
+                let q = [
+                    indices[ci]     & 7, indices[ci + 1] & 7, indices[ci + 2] & 7, indices[ci + 3] & 7,
+                    indices[ci + 4] & 7, indices[ci + 5] & 7, indices[ci + 6] & 7, indices[ci + 7] & 7,
+                ];
+                let b0 = q[0] | (q[1] << 3) | ((q[2] & 3) << 6);
+                let b1 = (q[2] >> 2) | (q[3] << 1) | (q[4] << 4) | ((q[5] & 1) << 7);
+                let b2 = (q[5] >> 1) | (q[6] << 2) | (q[7] << 5);
+                let bo = 16 + chunk * 3;
+                out_chunk[bo] = b0;
+                out_chunk[bo + 1] = b1;
+                out_chunk[bo + 2] = b2;
+            }
+        });
+
+    output
+}
+
+/// MagnumQuant HFQ2-G256-Lloyd: per-block 4-entry fp16 codebook fitted via
+/// Lloyd's algorithm to minimize squared reconstruction error on FWHT-rotated
+/// weights. 8 B header (4 fp16) + 64 B packed 2-bit indices = 72 B/group —
+/// bandwidth-identical to uniform MQ2. The "true non-uniform 4-entry codebook"
+/// described in `docs/plans/mq-sub4bit-research-queue.md` Q1.
+fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+    use rayon::prelude::*;
+    let group_size = 256;
+    let block_bytes = 72;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+
+    // Parallelize across blocks: each block is independent (own FWHT, own
+    // Lloyd's iterations, own centroids). On 24-core boxes this is ~10-15× over
+    // the serial path on 9B (single tensor can have >20M blocks).
+    output
+        .par_chunks_mut(block_bytes)
+        .enumerate()
+        .for_each(|(b, out_chunk)| {
+            let start = b * group_size;
+            let end = (start + group_size).min(n);
+            let actual_len = end - start;
+
+            let mut group = [0.0f32; 256];
+            group[..actual_len].copy_from_slice(&f32_data[start..end]);
+            cpu_fwht_256(&mut group, signs1, signs2);
+
+            // Initial centroid placement: percentiles of the rotated block.
+            // 12.5/37.5/62.5/87.5 gives a good starting partition — heavy-tail
+            // blocks adapt across iterations.
+            let mut sorted: [f32; 256] = group;
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let percentile = |frac: f32| -> f32 {
+                let idx = ((frac * 255.0).round() as usize).min(255);
+                sorted[idx]
+            };
+            let mut cb: [f32; 4] = [
+                percentile(0.125),
+                percentile(0.375),
+                percentile(0.625),
+                percentile(0.875),
+            ];
+
+            let range = sorted[255] - sorted[0];
+            let mut indices = [0u8; 256];
+            if range > 0.0 {
+                // Lloyd's iterations — cap at 8, early-exit on stable assignments.
+                // Empirically Lloyd's converges in 4-6 iter for FWHT-rotated weight
+                // distributions; the 12-iter cap was wasteful.
+                let max_iter = 8;
+                let mut prev_assignments = [0u8; 256];
+                for it in 0..max_iter {
+                    let mut sums = [0.0f64; 4];
+                    let mut counts = [0u32; 4];
+                    let mut changed = 0u32;
+                    for i in 0..256 {
+                        let w = group[i];
+                        let mut best = 0usize;
+                        let mut best_d = (w - cb[0]).abs();
+                        for k in 1..4 {
+                            let d = (w - cb[k]).abs();
+                            if d < best_d { best_d = d; best = k; }
+                        }
+                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        prev_assignments[i] = best as u8;
+                        indices[i] = best as u8;
+                        sums[best] += w as f64;
+                        counts[best] += 1;
+                    }
+                    if it > 0 && changed == 0 { break; }
+                    for k in 0..4 {
+                        if counts[k] > 0 {
+                            cb[k] = (sums[k] / counts[k] as f64) as f32;
+                        }
+                    }
+                }
+            }
+
+            // Sort centroids ascending; remap indices to keep header canonical
+            // and the permutation deterministic across re-runs.
+            let mut order: [usize; 4] = [0, 1, 2, 3];
+            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            let mut sorted_cb = [0.0f32; 4];
+            let mut inv: [u8; 4] = [0; 4];
+            for new_idx in 0..4 {
+                sorted_cb[new_idx] = cb[order[new_idx]];
+                inv[order[new_idx]] = new_idx as u8;
+            }
+            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+
+            for k in 0..4 {
+                let bits = f32_to_fp16_bits(sorted_cb[k]);
+                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k + 1] = (bits >> 8) as u8;
+            }
+            // 256 indices × 2 bits = 64 bytes. Same packing as uniform MQ2.
+            for i in 0..64 {
+                let mut byte_val = 0u8;
+                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                out_chunk[8 + i] = byte_val;
+            }
+        });
+
+    output
+}
+
 /// Quantize F32 weights to HFQ3-G256: 3-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][96B packed 3-bit] = 104 bytes per 256 weights (0.406 B/w).
 /// Packing: 8 weights × 3 bits = 24 bits = 3 bytes per thread-group.
@@ -1027,6 +1288,8 @@ enum QuantType {
     BF16 = 16,     // Original BF16 weights (zero precision loss for vision)
     MQ3G256 = 17,  // MagnumQuant: FWHT-rotated HFQ3-G256 (3-bit, 104 B/group)
     MQ2G256 = 18,  // MagnumQuant: FWHT-rotated HFQ2-G256 (2-bit, 72 B/group)
+    MQ2G256Lloyd = 19, // MagnumQuant 2-bit + per-block Lloyd-Max 4-entry fp16 codebook (72 B/group)
+    MQ3G256Lloyd = 20, // MagnumQuant 3-bit + per-block Lloyd-Max 8-entry fp16 codebook (112 B/group)
 }
 
 struct HfqTensor {
@@ -1455,6 +1718,8 @@ enum GgufFormat {
     Mq6,
     Mq3,
     Mq2,
+    Mq2Lloyd,
+    Mq3Lloyd,
 }
 
 impl GgufFormat {
@@ -1466,6 +1731,8 @@ impl GgufFormat {
             "mq6" | "mq6g256" => Some(Self::Mq6),
             "mq3" | "mq3g256" => Some(Self::Mq3),
             "mq2" | "mq2g256" => Some(Self::Mq2),
+            "mq2-lloyd" | "mq2g256-lloyd" | "mq2lloyd" => Some(Self::Mq2Lloyd),
+            "mq3-lloyd" | "mq3g256-lloyd" | "mq3lloyd" => Some(Self::Mq3Lloyd),
             _ => None,
         }
     }
@@ -1478,6 +1745,8 @@ impl GgufFormat {
             Self::Mq6 => "MQ6G256",
             Self::Mq3 => "MQ3G256",
             Self::Mq2 => "MQ2G256",
+            Self::Mq2Lloyd => "MQ2G256Lloyd",
+            Self::Mq3Lloyd => "MQ3G256Lloyd",
         }
     }
 }
@@ -1526,7 +1795,9 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat) -> std::io
 
     // FWHT signs — only used when --format is mq4/mq6. Same seed pair as the
     // safetensors path so the engine's runtime FWHT inverse stays identical.
-    let needs_signs = matches!(format, GgufFormat::Mq4 | GgufFormat::Mq6 | GgufFormat::Mq3 | GgufFormat::Mq2);
+    let needs_signs = matches!(format,
+        GgufFormat::Mq4 | GgufFormat::Mq6 | GgufFormat::Mq3 | GgufFormat::Mq2
+        | GgufFormat::Mq2Lloyd | GgufFormat::Mq3Lloyd);
     let signs1 = if needs_signs { gen_fwht_signs(42, 256) } else { Vec::new() };
     let signs2 = if needs_signs { gen_fwht_signs(1042, 256) } else { Vec::new() };
 
@@ -1598,6 +1869,14 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat) -> std::io
                 GgufFormat::Mq2 => {
                     let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
                     (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                }
+                GgufFormat::Mq2Lloyd => {
+                    let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                }
+                GgufFormat::Mq3Lloyd => {
+                    let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
                 }
             }
         } else {
@@ -1700,6 +1979,8 @@ fn main() {
     let use_mq6g256 = format == "mq6" || format == "mq6g256";
     let use_mq3g256 = format == "mq3" || format == "mq3g256";
     let use_mq2g256 = format == "mq2" || format == "mq2g256";
+    let use_mq2g256_lloyd = format == "mq2-lloyd" || format == "mq2g256-lloyd" || format == "mq2lloyd";
+    let use_mq3g256_lloyd = format == "mq3-lloyd" || format == "mq3g256-lloyd" || format == "mq3lloyd";
     let use_hfq6 = format == "hfq6" || format == "hfq6g256" || format == "hf6";
 
     // ── Sub-4-bit guards (2026-04-30 sweep) ─────────────────────────────
@@ -1720,6 +2001,40 @@ fn main() {
              To opt in for research / ablation purposes anyway, pass --allow-mq2 or set\n\
              HIPFIRE_ALLOW_MQ2=1. Don't ship MQ2 artifacts to users until the codebook\n\
              improvement lands."
+        );
+        std::process::exit(1);
+    }
+    // MQ2-Lloyd: rescues uniform MQ2 by 41–55× (per benchmarks/results/
+    // lloyd_max_findings_20260501.md) but still text-collapse — 9B ppl=2,163
+    // vs 9B MQ4 ppl=10. Research-only: same opt-in gate so users don't
+    // accidentally ship a 2-bpw model that won't produce coherent output.
+    let allow_mq3_lloyd = args.iter().any(|a| a == "--allow-mq3-lloyd")
+        || std::env::var("HIPFIRE_ALLOW_MQ3_LLOYD").ok().as_deref() == Some("1");
+    if use_mq3g256_lloyd && !allow_mq3_lloyd {
+        eprintln!(
+            "note: --format mq3-lloyd is research — Lloyd-Max 8-entry codebook +\n\
+             3-bit indices (112 B/group, +7.7% over uniform MQ3). Hypothesis is\n\
+             non-uniform codebook lifts sub-9B MQ3 out of collapse (#114) and\n\
+             tightens 9B MQ3's 4× ppl gap vs MQ4. Ppl evidence pending — DO NOT\n\
+             ship MQ3-Lloyd artifacts to users until quality is validated against\n\
+             baseline MQ3/MQ4 ppl.\n\
+             \n\
+             To proceed, pass --allow-mq3-lloyd or set HIPFIRE_ALLOW_MQ3_LLOYD=1."
+        );
+        std::process::exit(1);
+    }
+    let allow_mq2_lloyd = args.iter().any(|a| a == "--allow-mq2-lloyd")
+        || std::env::var("HIPFIRE_ALLOW_MQ2_LLOYD").ok().as_deref() == Some("1");
+    if use_mq2g256_lloyd && !allow_mq2_lloyd {
+        eprintln!(
+            "error: --format mq2-lloyd is research-only — Lloyd-Max codebook lifts\n\
+             uniform MQ2 by 41–55× ppl but absolute quality is still collapse\n\
+             (9B Qwen 3.5 wikitext2-test ppl=2,163 vs MQ4=10, MQ3=42; 0.8B ppl=19,651).\n\
+             2 bpw is fundamentally too aggressive for usable text; the format\n\
+             is plumbed for follow-on Lloyd-Max MQ3 (qt=20) experiments only.\n\
+             \n\
+             To opt in for research anyway, pass --allow-mq2-lloyd or set\n\
+             HIPFIRE_ALLOW_MQ2_LLOYD=1. Don't ship MQ2-Lloyd artifacts to users."
         );
         std::process::exit(1);
     }
@@ -2097,9 +2412,32 @@ fn main() {
                     let q = quantize_hfq6g256(&f32_data);
                     (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
                 }
-            } else if (use_mq3g256 || use_mq2g256) && is_embed {
+            } else if (use_mq3g256 || use_mq2g256 || use_mq2g256_lloyd || use_mq3g256_lloyd) && is_embed {
                 let q = quantize_q8f16(&f32_data);
                 (q, QuantType::Q8F16, 32u32, "Q8_F16")
+            } else if use_mq3g256_lloyd {
+                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
+                if k_dim % 256 == 0 {
+                    let signs1 = gen_fwht_signs(42, 256);
+                    let signs2 = gen_fwht_signs(1042, 256);
+                    let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                } else {
+                    let q = quantize_hfq3g128(&f32_data);
+                    (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
+                }
+            } else if use_mq2g256_lloyd {
+                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
+                if k_dim % 256 == 0 {
+                    let signs1 = gen_fwht_signs(42, 256);
+                    let signs2 = gen_fwht_signs(1042, 256);
+                    let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                } else {
+                    // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
+                    let q = quantize_hfq2g128(&f32_data);
+                    (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
+                }
             } else if use_mq3g256 {
                 let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
                 if k_dim % 256 == 0 {

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -2084,9 +2084,33 @@ impl Gpu {
     }
 
     /// HFQ3-G256 GEMV. K must be multiple of 256.
+    /// Per-arch dispatch: gfx1100/1101/1102 uses the K4-unrolled
+    /// 4-accumulator variant (matches MQ4 ILP). Other archs use the baseline.
     pub fn gemv_hfq3g256(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
-        self.ensure_kernel("gemv_hfq3g256", kernels::GEMV_HFQ3G256_SRC, "gemv_hfq3g256")?;
+        let (src, module) = kernels::gemv_hfq3g256_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemv_hfq3g256")?;
         let func = &self.functions["gemv_hfq3g256"];
+        let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32; let mut k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void, &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void, &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+        ];
+        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
+    }
+
+    /// HFQ3-G256 GEMV with fused residual add: y[row] += A[row] · x.
+    /// Used by `weight_gemv_residual` MQ3 arm to eliminate the
+    /// alloc+gemv+add+free fallback chain (saves ~3 launches per residual).
+    pub fn gemv_hfq3g256_residual(
+        &mut self,
+        a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
+        m: usize, k: usize,
+    ) -> HipResult<()> {
+        let (src, module) = kernels::gemv_hfq3g256_residual_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemv_hfq3g256_residual")?;
+        let func = &self.functions["gemv_hfq3g256_residual"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
         let mut m_val = m as i32; let mut k_val = k as i32;
         let mut params: Vec<*mut c_void> = vec![

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3433,6 +3433,14 @@ impl Gpu {
             let x_rot_row = x_rot.sub_offset(b * k, k);
             self.rotate_x_mq(&x_row, &x_rot_row, k)?;
         }
+        // Invalidate the fp16-conversion cache: `x_rot`'s pointer is stable
+        // across consecutive MQ3 wrapper calls (same scratch buffer reused
+        // per layer), but the underlying data was just rewritten by the
+        // rotate loop above. Without this, `ensure_fp16_x` would see the
+        // matching `fp16_x_source_ptr` and skip the f32→fp16 conversion,
+        // and the kernel would read stale fp16 values from the previous
+        // layer's rotation.
+        self.fp16_x_source_ptr = std::ptr::null_mut();
         self.gemm_qkvza_hfq3g256_wmma(
             a_qkv, a_z, a_beta, a_alpha, x_rot,
             y_qkv, y_z, y_beta, y_alpha,
@@ -3806,7 +3814,8 @@ impl Gpu {
     }
 
     /// MQ3 wrapper for `gemm_gate_up_hfq3g256_wmma`: pre-rotates X then
-    /// dispatches the HFQ3 kernel.
+    /// dispatches the HFQ3 kernel. See `gemm_qkvza_mq3g256_wmma` for
+    /// the cache-invalidation rationale.
     pub fn gemm_gate_up_mq3g256_wmma(
         &mut self,
         a_gate: &GpuTensor, a_up: &GpuTensor,
@@ -3822,6 +3831,7 @@ impl Gpu {
             let x_rot_row = x_rot.sub_offset(b * k, k);
             self.rotate_x_mq(&x_row, &x_rot_row, k)?;
         }
+        self.fp16_x_source_ptr = std::ptr::null_mut();
         self.gemm_gate_up_hfq3g256_wmma(
             a_gate, a_up, x_rot, y_gate, y_up, gate_m, up_m, k, batch_size,
         )
@@ -5346,7 +5356,8 @@ impl Gpu {
     }
 
     /// MQ3 wrapper for `gemm_hfq3g256_residual_wmma`: pre-rotates X then
-    /// dispatches the HFQ3 kernel.
+    /// dispatches the HFQ3 kernel. See `gemm_qkvza_mq3g256_wmma` for
+    /// the cache-invalidation rationale.
     pub fn gemm_mq3g256_residual_wmma(
         &mut self,
         a_raw: &GpuTensor,
@@ -5362,6 +5373,7 @@ impl Gpu {
             let x_rot_row = x_rot.sub_offset(b * k, k);
             self.rotate_x_mq(&x_row, &x_rot_row, k)?;
         }
+        self.fp16_x_source_ptr = std::ptr::null_mut();
         self.gemm_hfq3g256_residual_wmma(a_raw, x_rot, y, m, k, batch_size)
     }
 

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3605,6 +3605,78 @@ impl Gpu {
         result
     }
 
+    /// HFQ3-G256 sister of `gemm_qkv_hfq4g256_wmma`. Same WMMA shape +
+    /// lane decomposition; only the inner K-tile unpack differs (3-bit
+    /// cross-byte vs 4-bit nibble) and the per-group byte stride is 104
+    /// instead of 136. Used for MQ3 prefill via dispatch sites in
+    /// qwen35.rs FullAttention branch (X is pre-rotated upstream).
+    pub fn gemm_qkv_hfq3g256_wmma(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel("gemm_qkv_hfq3g256_wmma", kernels::GEMM_QKV_HFQ3G256_WMMA_SRC, "gemm_qkv_hfq3g256_wmma")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_val = q_m as i32;
+        let mut k_m_val = k_m as i32;
+        let mut v_m_val = v_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_val as *mut _ as *mut c_void,
+            &mut k_m_val as *mut _ as *mut c_void,
+            &mut v_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = (q_m + k_m + v_m) * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfq3g256_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfq3g256_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// gfx12 (RDNA4) sister of `gemm_qkv_hfq4g256_wmma`. Identical signature
     /// and grid/block; only the kernel-side intrinsic + operand vector size
     /// differs. NOT yet wired into the public dispatch tree — exposed only

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -152,6 +152,8 @@ pub enum DType {
     MQ6G256,   // MagnumQuant: FWHT-rotated HFQ6-G256 (200 bytes/group, same as HFQ6G256)
     MQ3G256,   // MagnumQuant: FWHT-rotated HFQ3-G256 (104 bytes/group, same as HFQ3G256)
     MQ2G256,   // MagnumQuant: FWHT-rotated HFQ2-G256 (72 bytes/group, same as HFQ2G256)
+    MQ2G256Lloyd, // MagnumQuant 2-bit + Lloyd-Max 4-entry fp16 codebook (72 bytes/group)
+    MQ3G256Lloyd, // MagnumQuant 3-bit + Lloyd-Max 8-entry fp16 codebook (112 bytes/group)
     HFQ2G256,  // 72 bytes per 256 elements (flat 2-bit, f32 scale+zero, ~19 VGPRs)
     HFQ2G128,  // 40 bytes per 128 elements (flat 2-bit, f32 scale+zero)
     HFQ6G256,  // 200 bytes per 256 elements (6-bit, f32 scale+zero)
@@ -163,7 +165,7 @@ impl DType {
         match self {
             DType::F32 => 4,
             DType::F16 => 2,
-            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::Raw => 1, // byte-level
+            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd | DType::Raw => 1, // byte-level
         }
     }
 }
@@ -1581,6 +1583,55 @@ impl Gpu {
             &mut k_val as *mut _ as *mut c_void,
         ];
         unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
+    }
+
+    /// MQ2-Lloyd GEMV (2-bit + per-block 4-entry fp16 codebook). K must be a
+    /// multiple of 256. Same launch shape as gemv_hfq2g256 — header is the
+    /// only layout difference.
+    pub fn gemv_mq2g256_lloyd(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.ensure_kernel("gemv_mq2g256_lloyd", kernels::GEMV_MQ2G256_LLOYD_SRC, "gemv_mq2g256_lloyd")?;
+        let func = &self.functions["gemv_mq2g256_lloyd"];
+        let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32; let mut k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void, &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void, &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+        ];
+        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
+    }
+
+    /// MQ2-Lloyd GEMV with engine-side x rotation (matches `gemv_mq2g256_with_rotate`).
+    pub fn gemv_mq2g256_lloyd_with_rotate(
+        &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
+        x_rot: &GpuTensor, m: usize, k: usize,
+    ) -> HipResult<()> {
+        self.rotate_x_mq(x, x_rot, k)?;
+        self.gemv_mq2g256_lloyd(a_raw, x_rot, y, m, k)
+    }
+
+    /// MQ3-Lloyd GEMV (3-bit + per-block 8-entry fp16 codebook). K must be a
+    /// multiple of 256.
+    pub fn gemv_mq3g256_lloyd(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.ensure_kernel("gemv_mq3g256_lloyd", kernels::GEMV_MQ3G256_LLOYD_SRC, "gemv_mq3g256_lloyd")?;
+        let func = &self.functions["gemv_mq3g256_lloyd"];
+        let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32; let mut k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void, &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void, &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+        ];
+        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
+    }
+
+    /// MQ3-Lloyd GEMV with engine-side x rotation.
+    pub fn gemv_mq3g256_lloyd_with_rotate(
+        &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
+        x_rot: &GpuTensor, m: usize, k: usize,
+    ) -> HipResult<()> {
+        self.rotate_x_mq(x, x_rot, k)?;
+        self.gemv_mq3g256_lloyd(a_raw, x_rot, y, m, k)
     }
 
     /// Lazily initialize MagnumQuant FWHT sign tables (256 floats each, seeds 42 and 1042).

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -2085,24 +2085,40 @@ impl Gpu {
 
     /// HFQ3-G256 GEMV. K must be multiple of 256.
     /// Per-arch dispatch: gfx1100/1101/1102 uses the K4-unrolled
-    /// 4-accumulator variant (matches MQ4 ILP). Other archs use the baseline.
+    /// 4-accumulator variant. The default kernel was re-ported to match
+    /// the same ordering so non-RDNA3 archs (gfx1010, gfx1030, gfx12,
+    /// gfx9xx) produce byte-exact results against the RDNA3 baseline.
+    /// Uses `launch_maybe_blob` for HIPFIRE_GRAPH=1 capture safety.
     pub fn gemv_hfq3g256(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
         let (src, module) = kernels::gemv_hfq3g256_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfq3g256")?;
-        let func = &self.functions["gemv_hfq3g256"];
-        let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
-        let mut m_val = m as i32; let mut k_val = k as i32;
+        let a_ptr = a_raw.buf.as_ptr();
+        let x_ptr = x.buf.as_ptr();
+        let y_ptr = y.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
         let mut params: Vec<*mut c_void> = vec![
-            &mut a_ptr as *mut _ as *mut c_void, &mut x_ptr as *mut _ as *mut c_void,
-            &mut y_ptr as *mut _ as *mut c_void, &mut m_val as *mut _ as *mut c_void,
-            &mut k_val as *mut _ as *mut c_void,
+            &a_ptr as *const _ as *mut c_void,
+            &x_ptr as *const _ as *mut c_void,
+            &y_ptr as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
         ];
-        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
+        self.launch_maybe_blob(
+            "gemv_hfq3g256", [m as u32, 1, 1], [32, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val);
+                b
+            },
+        )
     }
 
     /// HFQ3-G256 GEMV with fused residual add: y[row] += A[row] · x.
     /// Used by `weight_gemv_residual` MQ3 arm to eliminate the
     /// alloc+gemv+add+free fallback chain (saves ~3 launches per residual).
+    /// Uses `launch_maybe_blob` for HIPFIRE_GRAPH=1 capture safety.
     pub fn gemv_hfq3g256_residual(
         &mut self,
         a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
@@ -2110,15 +2126,27 @@ impl Gpu {
     ) -> HipResult<()> {
         let (src, module) = kernels::gemv_hfq3g256_residual_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfq3g256_residual")?;
-        let func = &self.functions["gemv_hfq3g256_residual"];
-        let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
-        let mut m_val = m as i32; let mut k_val = k as i32;
+        let a_ptr = a_raw.buf.as_ptr();
+        let x_ptr = x.buf.as_ptr();
+        let y_ptr = y.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
         let mut params: Vec<*mut c_void> = vec![
-            &mut a_ptr as *mut _ as *mut c_void, &mut x_ptr as *mut _ as *mut c_void,
-            &mut y_ptr as *mut _ as *mut c_void, &mut m_val as *mut _ as *mut c_void,
-            &mut k_val as *mut _ as *mut c_void,
+            &a_ptr as *const _ as *mut c_void,
+            &x_ptr as *const _ as *mut c_void,
+            &y_ptr as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
         ];
-        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
+        self.launch_maybe_blob(
+            "gemv_hfq3g256_residual", [m as u32, 1, 1], [32, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val);
+                b
+            },
+        )
     }
 
     /// HFQ3-G128 GEMV. K must be multiple of 128. Finer granularity than G256.

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3398,6 +3398,12 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_qkvza_hfq3g256_wmma_gfx12(
+                a_qkv, a_z, a_beta, a_alpha, x,
+                y_qkv, y_z, y_beta, y_alpha,
+                qkv_m, z_m, beta_m, alpha_m, k, batch_size);
+        }
         self.ensure_kernel("gemm_qkvza_hfq3g256_wmma", kernels::GEMM_QKVZA_HFQ3G256_WMMA_SRC, "gemm_qkvza_hfq3g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -3498,6 +3504,87 @@ impl Gpu {
             y_qkv, y_z, y_beta, y_alpha,
             qkv_m, z_m, beta_m, alpha_m, k, batch_size,
         )
+    }
+
+    /// gfx12 (RDNA4) sister of `gemm_qkvza_hfq3g256_wmma`. K4-unrolled
+    /// half8_t lane-split per `gemm_qkvza_hfq4g256_wmma_gfx12`. Wired via
+    /// the `gemm_qkvza_hfq3g256_wmma` arch dispatch — direct callers can
+    /// also use this if they know they're on gfx12.
+    pub fn gemm_qkvza_hfq3g256_wmma_gfx12(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_qkvza_hfq3g256_wmma_gfx12",
+            kernels::GEMM_QKVZA_HFQ3G256_WMMA_GFX12_SRC,
+            "gemm_qkvza_hfq3g256_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_qkv.buf.as_ptr();
+        let mut az = a_z.buf.as_ptr();
+        let mut ab = a_beta.buf.as_ptr();
+        let mut aa = a_alpha.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_qkv.buf.as_ptr();
+        let mut yz = y_z.buf.as_ptr();
+        let mut yb = y_beta.buf.as_ptr();
+        let mut ya = y_alpha.buf.as_ptr();
+        let mut q_m = qkv_m as i32;
+        let mut z_m_val = z_m as i32;
+        let mut b_m = beta_m as i32;
+        let mut a_m = alpha_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut az as *mut _ as *mut c_void,
+            &mut ab as *mut _ as *mut c_void,
+            &mut aa as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yz as *mut _ as *mut c_void,
+            &mut yb as *mut _ as *mut c_void,
+            &mut ya as *mut _ as *mut c_void,
+            &mut q_m as *mut _ as *mut c_void,
+            &mut z_m_val as *mut _ as *mut c_void,
+            &mut b_m as *mut _ as *mut c_void,
+            &mut a_m as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = total_m * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_hfq3g256_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_hfq3g256_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(q_m); b.push_i32(z_m_val); b.push_i32(b_m); b.push_i32(a_m);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
     }
 
     /// gfx12 (RDNA4) sister of `gemm_qkvza_hfq4g256_wmma`. Same gfx12
@@ -3671,6 +3758,10 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_qkv_hfq3g256_wmma_gfx12(
+                a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+        }
         self.ensure_kernel("gemm_qkv_hfq3g256_wmma", kernels::GEMM_QKV_HFQ3G256_WMMA_SRC, "gemm_qkv_hfq3g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -3877,6 +3968,78 @@ impl Gpu {
     /// + lane decomposition; only the inner K-tile unpack differs (3-bit
     /// cross-byte vs 4-bit nibble) and the per-group byte stride is 104
     /// instead of 136. Used for MQ3 prefill via `gemm_gate_up_mq3g256_wmma`.
+    /// gfx12 (RDNA4) sister of `gemm_qkv_hfq3g256_wmma`.
+    pub fn gemm_qkv_hfq3g256_wmma_gfx12(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_qkv_hfq3g256_wmma_gfx12",
+            kernels::GEMM_QKV_HFQ3G256_WMMA_GFX12_SRC,
+            "gemm_qkv_hfq3g256_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_val = q_m as i32;
+        let mut k_m_val = k_m as i32;
+        let mut v_m_val = v_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_val as *mut _ as *mut c_void,
+            &mut k_m_val as *mut _ as *mut c_void,
+            &mut v_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = total_m * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfq3g256_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfq3g256_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     pub fn gemm_gate_up_hfq3g256_wmma(
         &mut self,
         a_gate: &GpuTensor, a_up: &GpuTensor,
@@ -3886,6 +4049,10 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_gate_up_hfq3g256_wmma_gfx12(
+                a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
+        }
         self.ensure_kernel("gemm_gate_up_hfq3g256_wmma", kernels::GEMM_GATE_UP_HFQ3G256_WMMA_SRC, "gemm_gate_up_hfq3g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -3920,6 +4087,71 @@ impl Gpu {
         let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_hfq3g256_wmma", bytes);
         let result = self.launch_maybe_blob(
             "gemm_gate_up_hfq3g256_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ag); b.push_ptr(au);
+                b.push_ptr(xp);
+                b.push_ptr(yg); b.push_ptr(yu);
+                b.push_i32(g_m); b.push_i32(u_m); b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// gfx12 (RDNA4) sister of `gemm_gate_up_hfq3g256_wmma`.
+    pub fn gemm_gate_up_hfq3g256_wmma_gfx12(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_gate_up_hfq3g256_wmma_gfx12",
+            kernels::GEMM_GATE_UP_HFQ3G256_WMMA_GFX12_SRC,
+            "gemm_gate_up_hfq3g256_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ag = a_gate.buf.as_ptr();
+        let mut au = a_up.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yg = y_gate.buf.as_ptr();
+        let mut yu = y_up.buf.as_ptr();
+        let mut g_m = gate_m as i32;
+        let mut u_m = up_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ag as *mut _ as *mut c_void,
+            &mut au as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yg as *mut _ as *mut c_void,
+            &mut yu as *mut _ as *mut c_void,
+            &mut g_m as *mut _ as *mut c_void,
+            &mut u_m as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = total_m * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_hfq3g256_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_hfq3g256_wmma_gfx12",
             [row_tiles as u32, batch_tiles as u32, 1],
             [32, 1, 1],
             0,
@@ -5437,6 +5669,9 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_hfq3g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
+        }
         self.ensure_kernel("gemm_hfq3g256_residual_wmma", kernels::GEMM_HFQ3G256_RESIDUAL_WMMA_SRC, "gemm_hfq3g256_residual_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -5482,6 +5717,62 @@ impl Gpu {
     /// MQ3 wrapper for `gemm_hfq3g256_residual_wmma`: pre-rotates X then
     /// dispatches the HFQ3 kernel. See `gemm_qkvza_mq3g256_wmma` for
     /// the cache-invalidation rationale.
+    /// gfx12 (RDNA4) sister of `gemm_hfq3g256_residual_wmma`.
+    pub fn gemm_hfq3g256_residual_wmma_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_hfq3g256_residual_wmma_gfx12",
+            kernels::GEMM_HFQ3G256_RESIDUAL_WMMA_GFX12_SRC,
+            "gemm_hfq3g256_residual_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = m * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq3g256_residual_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq3g256_residual_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     pub fn gemm_mq3g256_residual_wmma(
         &mut self,
         a_raw: &GpuTensor,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3741,6 +3741,92 @@ impl Gpu {
         result
     }
 
+    /// HFQ3-G256 sister of `gemm_gate_up_hfq4g256_wmma`. Same WMMA shape
+    /// + lane decomposition; only the inner K-tile unpack differs (3-bit
+    /// cross-byte vs 4-bit nibble) and the per-group byte stride is 104
+    /// instead of 136. Used for MQ3 prefill via `gemm_gate_up_mq3g256_wmma`.
+    pub fn gemm_gate_up_hfq3g256_wmma(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel("gemm_gate_up_hfq3g256_wmma", kernels::GEMM_GATE_UP_HFQ3G256_WMMA_SRC, "gemm_gate_up_hfq3g256_wmma")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ag = a_gate.buf.as_ptr();
+        let mut au = a_up.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yg = y_gate.buf.as_ptr();
+        let mut yu = y_up.buf.as_ptr();
+        let mut g_m = gate_m as i32;
+        let mut u_m = up_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ag as *mut _ as *mut c_void,
+            &mut au as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yg as *mut _ as *mut c_void,
+            &mut yu as *mut _ as *mut c_void,
+            &mut g_m as *mut _ as *mut c_void,
+            &mut u_m as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = (gate_m + up_m) * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_hfq3g256_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_hfq3g256_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ag); b.push_ptr(au);
+                b.push_ptr(xp);
+                b.push_ptr(yg); b.push_ptr(yu);
+                b.push_i32(g_m); b.push_i32(u_m); b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// MQ3 wrapper for `gemm_gate_up_hfq3g256_wmma`: pre-rotates X then
+    /// dispatches the HFQ3 kernel.
+    pub fn gemm_gate_up_mq3g256_wmma(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        x_rot: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        for b in 0..batch_size {
+            let x_row = x.sub_offset(b * k, k);
+            let x_rot_row = x_rot.sub_offset(b * k, k);
+            self.rotate_x_mq(&x_row, &x_rot_row, k)?;
+        }
+        self.gemm_gate_up_hfq3g256_wmma(
+            a_gate, a_up, x_rot, y_gate, y_up, gate_m, up_m, k, batch_size,
+        )
+    }
+
     /// gfx12 (RDNA4) sister of `gemm_gate_up_hfq4g256_wmma`. Same recipe
     /// as the QKV gfx12 scaffold (validated on R9700). Not yet wired into
     /// the public dispatch tree — exposed only for the channel-test
@@ -5200,6 +5286,83 @@ impl Gpu {
                 kernel_name, m, k, batch_size, bytes / 1024, us, gbs);
         }
         result
+    }
+
+    /// HFQ3-G256 sister of `gemm_hfq4g256_residual_wmma` (basic WMMA
+    /// variant). Same WMMA shape + lane decomposition; only the inner
+    /// K-tile unpack differs (3-bit cross-byte vs 4-bit nibble) and the
+    /// per-group byte stride is 104 instead of 136. Y += acc[j] (fused
+    /// residual add — caller must initialize Y with the residual stream
+    /// before launching).
+    pub fn gemm_hfq3g256_residual_wmma(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel("gemm_hfq3g256_residual_wmma", kernels::GEMM_HFQ3G256_RESIDUAL_WMMA_SRC, "gemm_hfq3g256_residual_wmma")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let weight_bytes = m * (k / 256) * 104;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq3g256_residual_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq3g256_residual_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// MQ3 wrapper for `gemm_hfq3g256_residual_wmma`: pre-rotates X then
+    /// dispatches the HFQ3 kernel.
+    pub fn gemm_mq3g256_residual_wmma(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        x_rot: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        for b in 0..batch_size {
+            let x_row = x.sub_offset(b * k, k);
+            let x_rot_row = x_rot.sub_offset(b * k, k);
+            self.rotate_x_mq(&x_row, &x_rot_row, k)?;
+        }
+        self.gemm_hfq3g256_residual_wmma(a_raw, x_rot, y, m, k, batch_size)
     }
 
     /// MW16: dequant 4-bit weights to FP16, then run the no-dequant WMMA kernel.

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -197,7 +197,7 @@ pub struct Gpu {
     fp16_x_scratch_bytes: usize,
     /// Pointer to the last FP32 source that was converted to fp16_x_scratch.
     /// If the next GEMM uses the same X, skip the conversion.
-    fp16_x_source_ptr: *mut c_void,
+    pub fp16_x_source_ptr: *mut c_void,
     /// Q8_1/MMQ scratch for prefill activations. Layout matches llama.cpp's
     /// `block_q8_1_mmq`, ordered by [K/128 block, batch column].
     q8_1_mmq_x_scratch: Option<hip_bridge::DeviceBuffer>,
@@ -5769,6 +5769,47 @@ impl Gpu {
             return self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size);
         }
         self.gemm_hfq4g256(a_raw, x, y, m, k, batch_size)
+    }
+
+    /// HFQ3-G256 sister of `gemm_hfq4g256_batched_lmhead`. Same FP16-X cache
+    /// stomp + zero-init of Y, then `gemm_hfq3g256_residual_wmma` to compute
+    /// y[b][row] = A[row] · x[b]. Used by `dflash::gemm_dispatch` for MQ3
+    /// drafts so DFlash works with MQ3-quantized draft weights.
+    ///
+    /// Caller is responsible for FWHT-rotating x first when the weights are
+    /// MQ3 (FWHT-rotated at quant time) — `dflash::gemm_dispatch` handles
+    /// that via `rotate_x_mq_batched`. This wrapper is dtype-agnostic in
+    /// the same sense as `gemm_hfq4g256_batched_lmhead`.
+    pub fn gemm_hfq3g256_batched_lmhead(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let wmma_eligible = batch_size > 1
+            && self.arch.starts_with("gfx11")
+            && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
+            && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
+        if wmma_eligible {
+            self.fp16_x_source_ptr = std::ptr::null_mut();
+            match self.active_stream.as_ref() {
+                Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
+                None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
+            }
+            return self.gemm_hfq3g256_residual_wmma(a_raw, x, y, m, k, batch_size);
+        }
+        // Non-RDNA3 fallback: per-batch GEMV. Slow but functional — DFlash
+        // MQ3 drafts on non-gfx11 archs just don't get the WMMA fast-path
+        // until that arch gets its own MQ3 batched GEMM kernel.
+        for b in 0..batch_size {
+            let x_row = x.sub_offset(b * k, k);
+            let y_row = y.sub_offset(b * m, m);
+            self.gemv_hfq3g256(a_raw, &x_row, &y_row, m, k)?;
+        }
+        Ok(())
     }
 
     // ========================================================================

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -6080,8 +6080,13 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        // WMMA eligibility: any arch with an MQ3 WMMA family ported. Today
+        // that's gfx11 (RDNA3, _w32 builtin) and gfx12 (RDNA4, _w32_gfx12
+        // builtin) — `gemm_hfq3g256_residual_wmma` dispatches internally to
+        // the correct variant per arch. Other archs (gfx10/906/94x) fall
+        // through to the per-row GEMV path.
         let wmma_eligible = batch_size > 1
-            && self.arch.starts_with("gfx11")
+            && (has_wmma_f16(&self.arch) || has_wmma_f16_gfx12(&self.arch))
             && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
             && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
         if wmma_eligible {
@@ -6092,9 +6097,11 @@ impl Gpu {
             }
             return self.gemm_hfq3g256_residual_wmma(a_raw, x, y, m, k, batch_size);
         }
-        // Non-RDNA3 fallback: per-batch GEMV. Slow but functional — DFlash
-        // MQ3 drafts on non-gfx11 archs just don't get the WMMA fast-path
-        // until that arch gets its own MQ3 batched GEMM kernel.
+        // Non-WMMA fallback: per-batch GEMV. Slow but functional. DFlash on
+        // non-gfx11/gfx12 archs is already gated upstream by the daemon's
+        // DFlash refusal guard (lm_head whitelist requires gfx11 or gfx12
+        // for MQ3) — this fallback is reachable only via direct callers
+        // that bypass the daemon (e.g., bench harnesses, channel tests).
         for b in 0..batch_size {
             let x_row = x.sub_offset(b * k, k);
             let y_row = y.sub_offset(b * m, m);

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3331,6 +3331,115 @@ impl Gpu {
         result
     }
 
+    /// HFQ3-G256 sister of `gemm_qkvza_hfq4g256_wmma`. Same WMMA shape +
+    /// lane decomposition; only the inner K-tile unpack differs (3-bit
+    /// cross-byte vs 4-bit nibble) and the per-group byte stride is 104
+    /// instead of 136. Used for MQ3 prefill via dispatch wrappers that
+    /// pre-rotate `x` (see `gemm_qkvza_mq3g256_wmma` below). gfx11 K2
+    /// unroll variant — gfx12 K4 to follow once K2 is validated.
+    pub fn gemm_qkvza_hfq3g256_wmma(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel("gemm_qkvza_hfq3g256_wmma", kernels::GEMM_QKVZA_HFQ3G256_WMMA_SRC, "gemm_qkvza_hfq3g256_wmma")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_qkv.buf.as_ptr();
+        let mut az = a_z.buf.as_ptr();
+        let mut ab = a_beta.buf.as_ptr();
+        let mut aa = a_alpha.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_qkv.buf.as_ptr();
+        let mut yz = y_z.buf.as_ptr();
+        let mut yb = y_beta.buf.as_ptr();
+        let mut ya = y_alpha.buf.as_ptr();
+        let mut q_m = qkv_m as i32;
+        let mut z_m_val = z_m as i32;
+        let mut b_m = beta_m as i32;
+        let mut a_m = alpha_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut az as *mut _ as *mut c_void,
+            &mut ab as *mut _ as *mut c_void,
+            &mut aa as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yz as *mut _ as *mut c_void,
+            &mut yb as *mut _ as *mut c_void,
+            &mut ya as *mut _ as *mut c_void,
+            &mut q_m as *mut _ as *mut c_void,
+            &mut z_m_val as *mut _ as *mut c_void,
+            &mut b_m as *mut _ as *mut c_void,
+            &mut a_m as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        // HFQ3 storage = 104 B/group → ~3.06 bits/weight (vs HFQ4's 4.25).
+        let weight_bytes = (qkv_m + z_m + beta_m + alpha_m) * (k / 256) * 104;
+        let bytes = weight_bytes
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_hfq3g256_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_hfq3g256_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(q_m); b.push_i32(z_m_val); b.push_i32(b_m); b.push_i32(a_m);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// MQ3 wrapper: rotates `x` via `mq_rotate_x` (FWHT with shared sign
+    /// vectors) into the caller-provided `x_rot` scratch, then invokes
+    /// `gemm_qkvza_hfq3g256_wmma`. Mirror of `gemm_qkvza_mq4g256_wmma`.
+    /// Caller is responsible for `x_rot` being [batch × K] f32 scratch.
+    pub fn gemm_qkvza_mq3g256_wmma(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        x_rot: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        // Rotate batched x. mq_rotate_x_batched applies FWHT per-row.
+        for b in 0..batch_size {
+            let x_row = x.sub_offset(b * k, k);
+            let x_rot_row = x_rot.sub_offset(b * k, k);
+            self.rotate_x_mq(&x_row, &x_rot_row, k)?;
+        }
+        self.gemm_qkvza_hfq3g256_wmma(
+            a_qkv, a_z, a_beta, a_alpha, x_rot,
+            y_qkv, y_z, y_beta, y_alpha,
+            qkv_m, z_m, beta_m, alpha_m, k, batch_size,
+        )
+    }
+
     /// gfx12 (RDNA4) sister of `gemm_qkvza_hfq4g256_wmma`. Same gfx12
     /// recipe as the other scaffolds (validated on R9700) extended to
     /// 4-output qkv/z/beta/alpha routing. Not yet wired into the public

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -36,6 +36,12 @@ pub const GEMM_HFQ4G128_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4
 /// Block: [f32 scale][f32 zero][64B data] = 72 bytes per 256 weights (0.28 B/w).
 pub const GEMV_HFQ2G256_SRC: &str = include_str!("../../../kernels/src/gemv_hfq2g256.hip");
 
+/// MQ2G256Lloyd: 2-bit + per-block 4-entry fp16 codebook (72 B/group).
+pub const GEMV_MQ2G256_LLOYD_SRC: &str = include_str!("../../../kernels/src/gemv_mq2g256_lloyd.hip");
+
+/// MQ3G256Lloyd: 3-bit + per-block 8-entry fp16 codebook (112 B/group).
+pub const GEMV_MQ3G256_LLOYD_SRC: &str = include_str!("../../../kernels/src/gemv_mq3g256_lloyd.hip");
+
 
 /// HFQ8-G256: flat 8-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][256B data] = 264 bytes per 256 weights (1.03 B/w).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -215,6 +215,12 @@ pub const GEMM_QKVZA_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/sr
 // gfx12 (RDNA4) sister: gfx12 hfq4 recipe + 4-output qkv/z/beta/alpha
 // routing for the DeltaNet LinearAttention preamble.
 pub const GEMM_QKVZA_HFQ4G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq4g256_wmma.gfx12.hip");
+// HFQ3-G256 sister of GEMM_QKVZA_HFQ4G256_WMMA_SRC. Same WMMA shape +
+// lane decomposition; only the inner K-tile unpack differs (3-bit
+// cross-byte vs 4-bit nibble). Used for MQ3 prefill via dispatch
+// wrapper that pre-rotates X. gfx11 K2 unroll variant — gfx12 K4 to
+// follow once K2 is validated.
+pub const GEMM_QKVZA_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq3g256_wmma.hip");
 pub const GEMM_QKV_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq4g256_wmma.hip");
 // gfx12 (RDNA4) sister of GEMM_QKV_HFQ4G256_WMMA_SRC. Uses
 // `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -52,6 +52,9 @@ pub const GEMV_HFQ6G256_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6
 /// Block: [f32 scale][f32 zero][96B data] = 104 bytes per 256 weights (0.41 B/w).
 /// Packing: 8 weights per 3 bytes (24 bits = 8×3 bits).
 pub const GEMV_HFQ3G256_SRC: &str = include_str!("../../../kernels/src/gemv_hfq3g256.hip");
+pub const GEMV_HFQ3G256_GFX1100_SRC: &str = include_str!("../../../kernels/src/gemv_hfq3g256.gfx1100.hip");
+pub const GEMV_HFQ3G256_RESIDUAL_SRC: &str = include_str!("../../../kernels/src/gemv_hfq3g256_residual.hip");
+pub const GEMV_HFQ3G256_RESIDUAL_GFX1100_SRC: &str = include_str!("../../../kernels/src/gemv_hfq3g256_residual.gfx1100.hip");
 pub const GEMV_HFQ3G128_SRC: &str = include_str!("../../../kernels/src/gemv_hfq3g128.hip");
 pub const GEMV_MQ4G256_SRC: &str = include_str!("../../../kernels/src/gemv_mq4g256.hip");
 pub const GEMV_MQ8G256_SRC: &str = include_str!("../../../kernels/src/gemv_mq8g256.hip");
@@ -370,6 +373,30 @@ pub fn gemv_hfq4g256_residual_for_arch(arch: &str) -> (&'static str, &'static st
             (GEMV_HFQ4G256_RESIDUAL_GFX1100_SRC, "gemv_hfq4g256_residual_rdna3")
         }
         _ => (GEMV_HFQ4G256_RESIDUAL_SRC, "gemv_hfq4g256_residual"),
+    }
+}
+
+/// Returns the HFQ3-G256 GEMV kernel source AND module name for the given arch.
+/// gfx1100/1101/1102 (RDNA3) gets the K4-unrolled 4-accumulator variant that
+/// closes the per-launch perf gap with MQ4. Other archs use the baseline.
+pub fn gemv_hfq3g256_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" => {
+            (GEMV_HFQ3G256_GFX1100_SRC, "gemv_hfq3g256_rdna3")
+        }
+        _ => (GEMV_HFQ3G256_SRC, "gemv_hfq3g256"),
+    }
+}
+
+/// Same arch dispatch as `gemv_hfq3g256_for_arch` but returns the residual
+/// variant (y[row] += A[row] · x). Used by `weight_gemv_residual` MQ3 arm
+/// to eliminate the alloc+gemv+add+free fallback chain.
+pub fn gemv_hfq3g256_residual_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" => {
+            (GEMV_HFQ3G256_RESIDUAL_GFX1100_SRC, "gemv_hfq3g256_residual_rdna3")
+        }
+        _ => (GEMV_HFQ3G256_RESIDUAL_SRC, "gemv_hfq3g256_residual"),
     }
 }
 

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -223,6 +223,7 @@ pub const GEMM_QKVZA_HFQ4G256_WMMA_GFX12_SRC: &str = include_str!("../../../kern
 pub const GEMM_QKVZA_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq3g256_wmma.hip");
 pub const GEMM_GATE_UP_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma.hip");
 pub const GEMM_HFQ3G256_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_hfq3g256_residual_wmma.hip");
+pub const GEMM_QKV_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq3g256_wmma.hip");
 pub const GEMM_QKV_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq4g256_wmma.hip");
 // gfx12 (RDNA4) sister of GEMM_QKV_HFQ4G256_WMMA_SRC. Uses
 // `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -221,6 +221,8 @@ pub const GEMM_QKVZA_HFQ4G256_WMMA_GFX12_SRC: &str = include_str!("../../../kern
 // wrapper that pre-rotates X. gfx11 K2 unroll variant — gfx12 K4 to
 // follow once K2 is validated.
 pub const GEMM_QKVZA_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq3g256_wmma.hip");
+pub const GEMM_GATE_UP_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma.hip");
+pub const GEMM_HFQ3G256_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_hfq3g256_residual_wmma.hip");
 pub const GEMM_QKV_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq4g256_wmma.hip");
 // gfx12 (RDNA4) sister of GEMM_QKV_HFQ4G256_WMMA_SRC. Uses
 // `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -227,6 +227,10 @@ pub const GEMM_QKVZA_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/sr
 pub const GEMM_GATE_UP_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma.hip");
 pub const GEMM_HFQ3G256_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_hfq3g256_residual_wmma.hip");
 pub const GEMM_QKV_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq3g256_wmma.hip");
+pub const GEMM_QKVZA_HFQ3G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq3g256_wmma.gfx12.hip");
+pub const GEMM_QKV_HFQ3G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq3g256_wmma.gfx12.hip");
+pub const GEMM_GATE_UP_HFQ3G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma.gfx12.hip");
+pub const GEMM_HFQ3G256_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq3g256_residual_wmma.gfx12.hip");
 pub const GEMM_QKV_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq4g256_wmma.hip");
 // gfx12 (RDNA4) sister of GEMM_QKV_HFQ4G256_WMMA_SRC. Uses
 // `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)

--- a/docs/QUANTIZATION.md
+++ b/docs/QUANTIZATION.md
@@ -17,17 +17,31 @@ four production formats.
 | HFQ6-G256 | 6 | none | 200 | Dense, higher quality |
 | MQ4-G256 | 4 | FWHT | 136 | Qwen 3.5+ hybrid |
 | MQ6-G256 | 6 | FWHT | 200 | Qwen 3.5+ higher quality |
-| MQ3-G256 | 3 | FWHT | 104 (8 hdr + 96 data) | Sub-4-bit bandwidth play (≥7B models only) |
-| MQ2-G256 | 2 | FWHT | 72 (8 hdr + 64 data) | Sub-4-bit aggressive (experimental) |
+| MQ3-G256 | 3 | FWHT | 104 (8 hdr + 96 data) | Sub-4-bit bandwidth play (≥9B models only) |
+| MQ2-G256 | 2 | FWHT | 72 (8 hdr + 64 data) | Reserved — uniform-grid collapses; pending Lloyd-Max codebook |
 
 **Sub-4-bit caveat**: MQ3 and MQ2 reuse the production HFQ3/HFQ2
-decode kernels with a pre-rotated `x` (no separate kernel). They're
-viable on ≥7B models (per QuIP# literature, 3-bit + Hadamard hits
-within 1–2% perplexity of 4-bit on larger models), but small models
-(≤1B) collapse — Qwen 3.5 0.8B in MQ3 produces incoherent text where
-0.8B in MQ4 answers fluently. There is no WMMA prefill path for MQ3
-or MQ2 yet, so prefill falls back to per-row GEMV until the kernel
-lands in a follow-up PR.
+decode kernels with a pre-rotated `x` (no separate kernel). Local
+validation pass on Qwen 3.5 / 3.6 (gfx1100, master `c448d5e`):
+
+- **MQ3 quality threshold ≈ 9B.** 27B + 9B both produce fluent on-topic
+  output across the 4-prompt coherence battery; 4B partially collapses
+  (recognises intent but loops in `<think>` / mixes languages); 0.8B
+  produces gibberish. Don't recommend MQ3 below 9B.
+- **MQ2 with the current uniform 4-level codebook collapses at every
+  size tested** (0.8B / 4B / 9B → multilingual mojibake / symbol soup
+  on all 4 prompts). Path D Lloyd-Max non-uniform codebooks (per-block
+  squared-error-minimising, see PRD §5.2) are the planned remediation;
+  until then `--format mq2` is reserved and gated behind an explicit
+  opt-in flag.
+
+There is no WMMA prefill path for MQ3 or MQ2 yet, so prefill falls
+back to per-row GEMV until the kernel lands in a follow-up PR. The
+eligibility check in `qwen35::forward_prefill_batch` (`is_batchable_la`)
+correctly excludes MQ3/MQ2 from the batched fast path; per-token
+`forward_scratch` handles them via `weight_gemv`'s MQ3/MQ2 dispatch
+arms. Engine wiring is correct — the quality verdict is purely about
+the format's expressiveness on each model size, not a runtime bug.
 
 Header layout (8 bytes): 4 bytes scale (f32-bitcast-from-f16) + 4 bytes
 zero point. Data: bitwidth × 256 / 8 bytes = 128 (4-bit) or 192 (6-bit)

--- a/docs/plans/mq-sub4bit-prd.md
+++ b/docs/plans/mq-sub4bit-prd.md
@@ -1,0 +1,360 @@
+# MQ Sub-4-Bit Research & Development PRD
+
+**Status:** Draft (post-Q0 verification)  
+**Last updated:** 2026-04-30  
+**Owner:** hipfire research  
+**Companion docs:** `mq-sub4bit-research-queue.md` (prioritized task queue)
+
+---
+
+## 1. Executive Summary
+
+hipfire's MagnumQuant (MQ) family — MQ4, MQ3, MQ2 — applies a Fast Walsh-Hadamard Transform (FWHT) rotation to weight blocks before uniform affine quantization. The rotation spreads outlier mass across the block, enabling lower bit widths than flat quantization at the same perceptual quality. An empirical sweep on master `c448d5e` (2026-04-30, gfx1100, 7900 XTX) established that **engine wiring is correct** (zero panics, monotonic quality vs. model size) but that **format lossiness dominates below MQ4** on small models (≤9B).
+
+A bit-exact kernel verification (Q0) confirmed that the GPU kernels reproduce the quantizer's arithmetic to within fp16 rounding tolerance, closing the "kernel bug" hypothesis. The remaining quality gap is therefore in the quantizer math itself.
+
+This PRD lays out five phased research/engineering tracks (Q1–Q5) backed by internal empirical data and external literature. The goal is to either **rescue MQ3 quality at 4B/9B** (move borderline → fluent) or **rescue MQ2 at any size** (move all-fail → at-least-9B-pass), while preserving the bandwidth wins that make sub-4-bit attractive (~3.25 bpw for MQ3, ~2.25 bpw for MQ2).
+
+---
+
+## 2. Background: The MQ Pipeline
+
+### 2.1 How MQ works today
+
+1. **FWHT rotation (offline, quant-time):** Each 256-element weight block is multiplied by a PRNG-sign vector, run through an in-place butterfly Hadamard transform, scaled by `1/16`, then multiplied by a second PRNG-sign vector. The signs are deterministic (`seed1=42`, `seed2=1042` for all models).
+2. **Uniform affine quantization:** The rotated block is mapped to `N` levels via `scale = (max-min)/(2^bits-1)`, `zero = min`. For MQ3: 8 levels (0–7); for MQ2: 4 levels (0–3).
+3. **Storage:** Per-block header holds `f32 scale` + `f32 zero` (8 bytes). Data follows in packed little-endian bitstreams: MQ3 = 96 B (104 B total), MQ2 = 64 B (72 B total).
+4. **Runtime:** The activation vector `x` is rotated once per layer via `mq_rotate_x` (same FWHT math, ~9 µs on gfx1100), then a standard HFQ GEMV kernel dequantizes weights on-the-fly with `recon = scale * q + zero`.
+
+### 2.2 Empirical sweep recap (internal)
+
+Run on 2026-04-30 against Qwen 3.5/3.6 family, 32 generations, **0 hard errors**:
+
+| size | MQ3 | MQ2 |
+|------|-----|-----|
+| 0.8B | gibberish | mojibake |
+| 4B   | partial (intent recognised, `<think>` loops, language drift) | symbol soup |
+| 9B   | borderline (factual ✓, multi-step reasoning loops) | symbol soup |
+| 27B 3.5 | fluent | — |
+| 27B 3.6 | **cleanest output of the sweep** | — |
+
+**Interpretation:** The collapse is not a kernel bug (no panics, monotonic quality, 27B fluent). It is format-lossiness: uniform 4-level or 8-level grids cannot represent the post-FWHT weight distribution with enough fidelity on small models, where each parameter carries more representational burden.
+
+---
+
+## 3. Smoke Test: Q0 — Bit-Exact Kernel Verification
+
+### 3.1 Goal
+
+Prove (or disprove) that `gemv_mq3g256_with_rotate` and `gemv_mq2g256_with_rotate` produce values bit-exact (or within fp16 rounding) to a CPU reference of the same math.
+
+### 3.2 Method
+
+- **Harness:** `crates/engine/examples/verify_mq_kernel.rs` (committed 2026-04-30).
+- **Inputs:** Deterministic pseudo-random weights and activations (`fract_sin` PRNG) at shapes `(4,256)`, `(4,512)`, `(8,1024)`.
+- **CPU reference:**
+  1. Rotate `x` with `cpu_fwht_256(signs1, signs2)` matching quantizer math exactly.
+  2. Dequantize each weight block: unpack bits, reconstruct with `scale * q + zero`.
+  3. Compute `y = Σ w_rot * x_rot`.
+- **GPU path:** Upload quantized bytes, run `gpu.gemv_mq{3,2}g256_with_rotate`, read back `y`.
+- **Metrics:** `max_abs_err`, `mean_abs_err`, `bit_exact_count`.
+
+### 3.3 Results (gfx1100, release build)
+
+| shape   | format | max_abs_err | mean_abs_err | bit_exact | verdict |
+|---------|--------|-------------|--------------|-----------|---------|
+| 4×256   | MQ3    | 9.16e-05    | 6.10e-05     | 0/4       | PASS    |
+| 4×256   | MQ2    | 9.16e-05    | 3.81e-05     | 1/4       | PASS    |
+| 4×512   | MQ3    | 1.22e-04    | 7.63e-05     | 1/4       | PASS    |
+| 4×512   | MQ2    | 3.05e-04    | 1.53e-04     | 1/4       | PASS    |
+| 8×1024  | MQ3    | 7.32e-04    | 4.20e-04     | 1/8       | PASS    |
+| 8×1024  | MQ2    | 9.16e-04    | 4.20e-04     | 0/8       | PASS    |
+| all     | rot    | 0.00e+00    | 0.00e+00     | 256–1024/256–1024 | PASS |
+
+The FWHT `rotate_x_mq` step is **fully bit-exact** (all elements exact match). All GEMV deltas sit well inside the acceptance threshold of `1e-3`.
+
+### 3.4 Conclusion
+
+**Kernel is correct.** The small-model quality collapse is purely format-lossiness. Close Q0 and move to quantizer-side improvements.
+
+---
+
+## 4. External Research Landscape
+
+### 4.1 llama.cpp K-quants and IQ-quants
+
+llama.cpp's `Q2_K` and `Q3_K` formats are the most widely deployed sub-4-bit schemes. They use a **hierarchical super-block** design:
+
+- **Super-block:** 256 weights.
+- **Sub-blocks:** 16 weights each (Q2_K, Q3_K, Q6_K) or 32 weights each (Q4_K, Q5_K).
+- **Scale/min quantization:** Sub-block scales are themselves quantized to 4–6 bits, and a per-super-block fp16 scale (`d`) rescales them. This two-level hierarchy keeps the metadata overhead small while allowing per-sub-block adaptation.
+- **Formulas:**
+  - Q2_K: `x = a·q + b` (scale + offset), **2.625 bpw** (84 bytes / 256 weights).
+  - Q3_K: `x = a·q` (scale only), **3.4375 bpw** (110 bytes / 256 weights).
+
+**Relevance to hipfire:** MQ2/MQ3 already beat K-quants on bandwidth (MQ2 = 2.25 bpw vs Q2_K = 2.625 bpw; MQ3 = 3.25 bpw vs Q3_K = 3.4375 bpw). However, K-quants achieve better quality at the cost of higher bpw. The IQ (implied-quant) family introduced in late 2023/early 2024 goes further by using **non-uniform codebooks** derived from an importance matrix (imatrix). `IQ2_XXS` achieves **2.0625 bpw** with a true 2-bit codebook plus fp16 scale — but still requires calibration data.
+
+### 4.2 QuIP# and Hadamard Incoherence Processing
+
+**QuIP** (Chee et al., 2023) and **QuIP#** (Tseng et al., ICML 2024) are the SOTA academic baselines for extreme LLM quantization.
+
+**Key ideas:**
+1. **Incoherence processing:** Multiply weights by a random orthogonal matrix (randomized Hadamard transform, RHT). This makes the weight distribution approximately Gaussian and eliminates axis-aligned outliers.
+2. **Lattice codebooks (QuIP#):** For 2-bit, use an E₈ lattice codebook — a hardware-friendly vector quantizer that packs 8-dimensional Gaussian vectors optimally. For 3-bit, combine the 2-bit E8P codebook with a 1-bit E8 codebook.
+3. **Theoretical guarantees:** QuIP is the first LLM quantization algorithm with a formal convergence analysis.
+
+**Empirical comparison (llama.cpp community replication, 2023):**
+
+| Model | QuIP# PPL | QuIP# Size | Q2_K PPL | Q2_K Size |
+|-------|-----------|------------|----------|-----------|
+| LLaMA-2-7B | 8.201 | 2.15 GB | 6.025 | 2.23 GB |
+| LLaMA-2-13B | 6.003 | 3.83 GB | 5.152 | 4.26 GB |
+| LLaMA-2-70B | 4.156 | 18.2 GB | 3.671 | 22.9 GB |
+
+**Key insight:** Q2_K *outperforms* QuIP# on smaller models despite similar size. QuIP# only becomes competitive at 70B+. This aligns with our internal finding that sub-4-bit quality is fundamentally size-dependent; small models need every bit of representational capacity.
+
+**Relevance to hipfire:** hipfire already uses FWHT (a deterministic orthogonal transform), which is a close cousin of QuIP#'s RHT. The difference is:
+- QuIP# uses **vector quantization** (E8P lattice) rather than scalar uniform quantization.
+- QuIP# requires **calibration data** (Hessian-aware) for best results.
+- QuIP# is not optimized for GPU GEMV throughput; lattice lookups are expensive.
+
+Our Q1 (Lloyd-Max per-block codebooks) is essentially a scalar, hardware-friendly approximation of QuIP#'s vector codebook idea.
+
+### 4.3 Lloyd-Max and Locally Optimal Block Clustered Quantization (LO-BCQ)
+
+**Lloyd-Max** (Lloyd 1957 / Max 1960) iteratively refines quantization centroids to minimize mean squared error. For a 1D distribution, it is equivalent to k-means with `k = 2^bits`.
+
+**LO-BCQ** (Rakka et al./OpenReview 2024) explicitly applies 1D Lloyd-Max and 2D k-means to weight blocks for 4-bit quantization. Their finding:
+
+> "Minimizing quantization MSE using the 1D (Lloyd-Max) and 2D K-means clustering has been explored in (Han et al., 2016; Cho et al., 2021; 2023) ... LO-BCQ extends this to per-block locally optimal centroids."
+
+**Relevance to hipfire:** A true 4-entry Lloyd-Max codebook per 256-weight block (Q1) is mathematically distinct from the uniform affine map `{scale*0+zero, ..., scale*3+zero}`. For skewed or bimodal post-FWHT distributions, Lloyd-Max can place centroids where the mass actually lives, reducing MSE by 15–40% vs. uniform quantization on heavy-tailed data (this is a well-established result in information theory).
+
+The storage cost is identical to uniform MQ2: 4 fp16 centroids = 8 bytes header + 64 bytes data = 72 B/group. The VGPR cost in the kernel is +2 fp16 registers (4 vs. 2), which is negligible on RDNA (well under the spill threshold).
+
+### 4.4 GPTQ-Style Block-Wise Error Compensation
+
+**GPTQ** (Frantar et al., ICLR 2023) is the canonical OBS-inspired PTQ method. It processes weights column-by-column, quantizes each column, computes the error, and propagates it forward into unquantized columns via the inverse Hessian of the activation covariance:
+
+```
+error = w_quantized - w_original
+w_remaining -= error * H_inv_block
+```
+
+**Key properties:**
+- Requires a small calibration dataset (~128 samples of activations).
+- Uses Cholesky-decomposed Hessian inverse for numerical stability.
+- Standard implementation uses fp64 for the Hessian; fp32 is often sufficient for rotated distributions.
+- Routinely rescues sub-4-bit quality on ≥7B models (e.g., OPTQ/GPTQ at 3-bit on LLaMA-7B recovers >95% of fp16 perplexity).
+
+**Relevance to hipfire:** Q2 proposes adding a calibration pass to `hipfire-quantize` that captures activation Hessians per layer and applies the GPTQ inner loop to MQ3/MQ2 quantization. Because our weights are already FWHT-rotated, the Hessian may be better conditioned (the rotation whitens the covariance), potentially allowing fp32 throughout.
+
+### 4.5 Mixed-Precision Quantization Policies
+
+The 2025 survey *Mixed-Precision Quantization for Language Models* (Rakka et al., arXiv 2510.16805) formalizes three categories:
+
+1. **MPW** — Mixed-precision weights, full-precision activations.
+2. **MPW+UPA** — Mixed-precision weights, uniform-precision activations.
+3. **MPW+MPA** — Mixed-precision weights and activations.
+
+**Key finding for hipfire:**
+
+> "Uniform low-bit quantization can degrade accuracy in sensitive transformer components. Mixed-precision quantization selectively allocates precision across layers/tensors to balance efficiency and accuracy."
+
+The llama.cpp Q2_K format already uses a **mixed-precision policy internally**: attention K/Q may be Q2_K, output.weight is Q6_K, and token embeddings are often Q5_K. Similarly, `IQ3_S` (a successor to Q3_K) uses a mix of `IQ3_XXS` and `IQ3_S` per tensor class.
+
+A unified evaluation on Llama-3.1-8B (Kurt, 2026) shows that **task sensitivity varies by tensor class**: GSM8K (math) is most sensitive to quantization, while HellaSwag is nearly impervious. This suggests that a policy allocating higher precision to `o_proj`, `lm_head`, and `down_proj` while aggressively quantizing `gate_proj`/`up_proj` is well-motivated.
+
+**Relevance to hipfire:** Q4 (mixed-MQ) implements exactly this policy: attention projections at MQ4 (or MQ6), FFN gate/up at MQ3, down_proj at MQ3, lm_head at MQ4, embeddings at Q8F16. Average ~3.3 bpw — same bandwidth as uniform MQ3, but with the most sensitive tensors protected.
+
+### 4.6 Per-Model Calibrated Sign Vectors (Incoherence Randomization Tuning)
+
+QuIP# uses a **random** Hadamard transform (random sign flips + butterfly). hipfire currently uses **deterministic** PRNG seeds (42, 1042) shared across all models.
+
+The post-FWHT weight distribution depends on the sign pattern. A sign vector that happens to align an outlier-rich region with a destructive butterfly path will spread mass more evenly, tightening the dynamic range that quantization must cover.
+
+**Relevance to hipfire:** Q3 proposes a random-restart search over candidate seed pairs, measuring per-block dynamic range or kurtosis. This is computationally cheap (<60s per model) and requires no format or kernel changes — only a metadata field storing the chosen seeds.
+
+---
+
+## 5. Phased Roadmap
+
+### Phase 1 — Q1: True Non-Uniform Lloyd-Max Codebook for MQ2
+
+**Effort:** 1–2 weeks  
+**Impact:** Highest — could rescue MQ2 from all-fail to at-least-9B-pass  
+**Risk:** Low (precedent in asym3/asym4 KV codebooks)
+
+**Description:** Replace uniform MQ2's `{scale*0+zero, ..., scale*3+zero}` with a **per-block 4-entry fp16 codebook** produced by Lloyd's algorithm minimizing `E[(w − cb[q])²]` over the FWHT-rotated weights of that block.
+
+**Storage layout:**
+- Header: 4 fp16 centroids = 8 bytes (same byte count as uniform MQ2 header).
+- Data: 64 bytes (256 × 2 bits) — unchanged.
+- Total: **72 bytes / group** — bit-exact same bandwidth as uniform MQ2.
+
+**Kernel change:** Replace `recon = scale * q + zero` with a 4-entry register-resident lookup:
+```c
+half4 cb = *(const half4*)(group_ptr);
+half recon = cb[q & 3];
+```
+VGPR cost: +2 fp16 (19 → 21 on gfx1100), no spill.
+
+**Quantizer change:** Add `quantize_mq2g256_lloyd` in `hipfire-quantize`. Per 256-element block:
+1. Apply `cpu_fwht_256(signs ⊙ block) / 16`.
+2. Initialize 4 centroids at the 12.5/37.5/62.5/87.5 percentiles.
+3. **Lloyd's algorithm** to convergence (typically <10 iterations).
+4. Sort centroids ascending in the header (kernel does not need to know).
+5. Pack indices as 2 bits.
+
+**On-disk:** Bump quant_type to `qt 19` (`MQ2G256_LLOYD`).
+
+**Acceptance:**
+- 9B MQ2-Lloyd produces fluent output on the 4-prompt coherence battery.
+- 27B MQ2-Lloyd produces fluent output.
+- Perplexity delta vs MQ4 ≤ 6%.
+- Bytes/param == uniform MQ2.
+
+### Phase 2 — Q2: GPTQ-Style Block-Wise Error Compensation
+
+**Effort:** 1–2 weeks  
+**Impact:** High — could rescue MQ3 at 4B/9B without changing kernel or storage  
+**Risk:** Moderate (adds calibration data dependency)
+
+**Description:** When quantizing block-by-block, propagate the quantization error of already-quantized blocks forward into the still-unquantized blocks via the inverse Hessian of the activation covariance.
+
+**Implementation:**
+1. Add `--calibrate <samples>` flag to `hipfire-quantize`.
+2. Load source model in f16, run ~128 samples (WikiText-2, C4, or cached data), record per-layer activation Hessians.
+3. Cholesky-factor the Hessian inverse per layer.
+4. In `quantize_mq3g256` (and `_mq4` for completeness), replace independent per-block quantization with:
+   ```
+   quantize column i
+   error = quantized - original
+   remaining_columns -= error * H_inv_block
+   ```
+5. Record calibration config in `.hfq` metadata for reproducibility.
+
+**Acceptance:**
+- 4B MQ3-GPTQ produces fluent output (current vanilla: partial collapse).
+- 9B MQ3-GPTQ produces fluent multi-step reasoning (current vanilla: loops).
+- 27B MQ3 unchanged or improved (already fluent; floor not regressed).
+
+### Phase 3 — Q3: Per-Model Calibrated Sign Vectors
+
+**Effort:** 1 week  
+**Impact:** Medium — cheaper than GPTQ, smaller gains  
+**Risk:** Low
+
+**Description:** Replace global PRNG-seeded sign vectors (seeds 42 / 1042) with per-model calibrated vectors that minimize post-FWHT block-level dynamic range.
+
+**Method:**
+1. Random-restart search: try N ∈ [16, 64] candidate seed pairs.
+2. For each, apply FWHT to a sample of the model's weights and measure:
+   - `block_dynamic_range = max(|w_rot|) / median(|w_rot|)` averaged across blocks (smaller = better), OR
+   - per-block kurtosis (lower = more uniform-tolerant).
+3. Pick the seed pair minimizing the metric.
+4. Store seeds in `.hfq` metadata header (2 × u64).
+5. Engine loader defaults to old constants when field is absent.
+
+**Acceptance:**
+- 4B MQ3 with calibrated seeds outperforms vanilla 4B MQ3 on the coherence battery.
+- Calibration runs in <60s per model.
+- Engine load is a no-op slowdown.
+
+### Phase 4 — Q4: Mixed-Precision MQ-Hybrid
+
+**Effort:** 3–5 days  
+**Impact:** Medium — near-term release lever, no new math  
+**Risk:** Very low
+
+**Description:** Add `--format mixed-mq` to `hipfire-quantize` with a per-tensor policy table:
+
+| Tensor class | Bpw |
+|---|---|
+| q_proj, k_proj, v_proj, o_proj | MQ4 (or MQ6 for sensitive heads) |
+| gate_proj, up_proj | MQ3 |
+| down_proj | MQ3 (widest matrix → biggest bandwidth win) |
+| lm_head | MQ4 (logits sensitivity) |
+| Embeddings | Q8F16 (existing) |
+| Norms | F16 (existing) |
+
+**Expected average:** ~3.3 bpw — same bandwidth as uniform MQ3, better quality on sub-9B.
+
+**Acceptance:**
+- 4B mixed-MQ passes coherence battery where 4B MQ3 partially collapses.
+- Average bpw ~3.3–3.5.
+
+### Phase 5 — Q5: WMMA Prefill Kernels for MQ3 / MQ2
+
+**Effort:** 1–2 weeks  
+**Impact:** Pure performance, not quality  
+**Risk:** Low (engineering, not research)
+
+**Description:** Currently MQ3/MQ2 prefill falls back to per-row GEMV (~43 tok/s prefill at 27B vs. ~70 for batched MQ4 + WMMA). Add WMMA prefill kernels:
+
+- `gemm_qkvza_mq3g256_wmma_gfx12.hip`
+- `gemm_gate_up_mq3g256_wmma`
+- `gemm_mq3g256_residual_wmma`
+
+Same shape as existing MQ4 WMMA family but with 3-bit unpack inside the K-tile loop. Add to `is_batchable_la` eligibility check.
+
+**Acceptance:**
+- 27B MQ3 prefill ≥1.5× current per-row GEMV speed.
+- Channel-tests pass on gfx1201 (R9700) + fp16 reference matches gfx1100 dot2 fallback.
+- Coherence-gate clean post-merge.
+
+---
+
+## 6. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Lloyd-Max MQ2 still collapses at 4B/9B | Medium | High | Escalate to activation-weighted Lloyd's (GPTQ-calibrated centroids) or drop MQ2 entirely. |
+| GPTQ calibration too memory-heavy | Low | Medium | Use fp32 Hessian (validate against fp64 on a small model); cap samples at 64. |
+| Calibrated sign seeds yield <1% gain | Medium | Low | Cheap to run; if no gain, abandon Q3 and document. |
+| Mixed-MQ policy overfits to Qwen3.5 | Low | Medium | Validate on Qwen3.6 and Llama-style GGUF paths before shipping default. |
+| WMMA MQ3 kernel adds compile-time | Low | Low | Guard behind feature flag until channel-tested. |
+
+---
+
+## 7. Cross-Cutting Agent Guidance
+
+- **Always use `scripts/mq3-mq2-sweep.sh`** for empirical verdicts. Eyeball the report; hard-fail predicates (panic / 0 tokens / timeout) won't catch quality regressions.
+- **Always record source-input md5 + binary md5** alongside any quality / perf claim.
+- **27B 3.6 MQ3 is the canonical fluent sub-4-bit reference.** Compare new variants against it on the same 4 prompts.
+- **Don't touch `is_batchable_la` to admit MQ3/MQ2 until Q5 lands.** The current per-token fallback is the reason zero panics surfaced.
+- **Do not store canonical artifacts under `/tmp`.** Use `benchmarks/prompts/`, `~/.hipfire/datasets/`, or committed scripts.
+
+---
+
+## 8. References
+
+1. **QuIP:** Chee et al., *QuIP: 2-Bit Quantization of Large Language Models With Guarantees*, arXiv:2307.13304, 2023.
+2. **QuIP#:** Tseng et al., *QuIP#: Even Better LLM Quantization with Hadamard Incoherence and Lattice Codebooks*, ICML 2024. arXiv:2402.04396.
+3. **GPTQ:** Frantar et al., *GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers*, ICLR 2023. arXiv:2210.17323.
+4. **LO-BCQ:** *Locally Optimal Block Clustered Quantization for 4-bit LLMs*, OpenReview 2024 / arXiv:2502.05376.
+5. **Mixed-Precision Survey:** Rakka et al., *Mixed-Precision Quantization for Language Models: Techniques and Prospects*, arXiv:2510.16805, 2025.
+6. **llama.cpp K-quants:** ikawrakow, "New SOTA 2-Bit Quant released: QuIP-Sharp", GitHub Discussion #4327, 2023. Community replication and improved Q2_K results.
+7. **llama.cpp Quant Structures:** `ggml-quants.c` definitions (Q2_K–Q8_K, IQ2_XXS/XS). See eadst.com/blog/232 for summary.
+8. **Unified llama.cpp Evaluation:** Kurt, *Which Quantization Should I Use? A Unified Evaluation of llama.cpp Quantization on Llama-3.1-8B-Instruct*, arXiv:2601.14277, 2026.
+9. **Lloyd-Max:** Lloyd (1957), *Least Squares Quantization in PCM*; Max (1960), *Quantizing for Minimum Distortion*.
+10. **hipfire internal sweep:** `docs/plans/mq-sub4bit-research-queue.md`, 2026-04-30.
+
+---
+
+## 9. Appendix: Q0 Test Reproduction
+
+```bash
+cargo run --release --example verify_mq_kernel -p engine
+```
+
+Expected output (gfx1100, release):
+```
+[PASS] All MQ3/MQ2 kernels bit-exact within 1e-3.
+```
+
+If `max_abs_err > 1e-3` on any shape, the kernel has a bug. Bisect to:
+- FWHT scaling factor (`1/16` vs `1/sqrt(256)`)
+- Sign-vector application order
+- Byte unpack ordering (cross-byte vs. linear)
+- Scale/zero-point header read alignment

--- a/docs/plans/mq-sub4bit-prd.md
+++ b/docs/plans/mq-sub4bit-prd.md
@@ -179,40 +179,102 @@ The post-FWHT weight distribution depends on the sign pattern. A sign vector tha
 
 ## 5. Phased Roadmap
 
-### Phase 1 — Q1: True Non-Uniform Lloyd-Max Codebook for MQ2
+### Phase 1 — Q1: True Non-Uniform Lloyd-Max Codebook for MQ2 (executed 2026-05-01: research-only)
 
-**Effort:** 1–2 weeks  
-**Impact:** Highest — could rescue MQ2 from all-fail to at-least-9B-pass  
-**Risk:** Low (precedent in asym3/asym4 KV codebooks)
+**Outcome (2026-05-01):** Implemented as `qt=19` (`MQ2G256Lloyd`) and
+ppl-validated. The codebook delivers a 41–55× ppl reduction over uniform
+MQ2 (e.g. 9B 120,108 → 2,163) but the absolute floor is still
+text-collapse — bit-width is the binding constraint, not codebook
+shape. **Stays research-only**, gated behind `--allow-mq2-lloyd` /
+`HIPFIRE_ALLOW_MQ2_LLOYD=1`. The format is plumbed for future
+combinations with GPTQ (Phase 2 / Q2) or QuIP#-style RHT (queue Q5).
 
-**Description:** Replace uniform MQ2's `{scale*0+zero, ..., scale*3+zero}` with a **per-block 4-entry fp16 codebook** produced by Lloyd's algorithm minimizing `E[(w − cb[q])²]` over the FWHT-rotated weights of that block.
+The win moved to **Phase 1.5 (Lloyd-Max MQ3)** below, which is what
+actually ships.
+
+**Original spec (kept for reference):**
+- 4 fp16 centroids = 8 bytes header.
+- 64 bytes data (256 × 2 bits).
+- Total: **72 bytes / group** — bit-exact same bandwidth as uniform MQ2.
+- Kernel: 4-entry register-resident lookup `recon = cb[q & 3]`.
+- VGPR: +2 fp16 (19 → 21 on gfx1100), no spill.
+- Quantize: percentile init at 12.5/37.5/62.5/87.5 → Lloyd's iterations
+  (max 8, early-exit on stable assignment) → sort centroids ascending.
+- On-disk: `qt=19`.
+
+**Empirical wikitext2-test ppl** (gfx1100, ctx=2048, scored=2039):
+
+| size | uniform MQ2 | Lloyd-MQ2 | Lloyd factor |
+|---|---:|---:|---:|
+| 0.8B | 803,852 | 19,651 | 40.9× |
+| 9B | 120,108 | 2,163 | 55.5× |
+
+**Acceptance gates failed:** target was 9B Lloyd-MQ2 fluent + ppl ≤ MQ4
+× 1.06; actual 9B Lloyd-MQ2 ppl=2,163 vs MQ4 10.34 = 209× — far below
+fluency floor. Original criteria not reachable at 2 bpw on Qwen3.5
+without bigger algorithmic change (Phase 2 GPTQ stack).
+
+### Phase 1.5 — Q1.5: Lloyd-Max MQ3 (validated 2026-05-01, ships pending dual gate)
+
+**Outcome:** This is what the Lloyd-Max work actually delivers.
+**Status:** Implemented as `qt=20` (`MQ3G256Lloyd`); ppl-validated; ships
+as the 3-bit default once both gates land.
 
 **Storage layout:**
-- Header: 4 fp16 centroids = 8 bytes (same byte count as uniform MQ2 header).
-- Data: 64 bytes (256 × 2 bits) — unchanged.
-- Total: **72 bytes / group** — bit-exact same bandwidth as uniform MQ2.
+- Header: **8 fp16 centroids = 16 bytes** (vs uniform MQ3's 8 B fp32
+  scale + zero — the codebook header doubles).
+- Data: 96 bytes packed 3-bit indices (cross-byte layout unchanged
+  from uniform MQ3, so kernel unpack code is identical except for the
+  reconstruction step).
+- Total: **112 bytes / group** vs uniform MQ3's 104 B → **+7.7 %
+  bandwidth cost**.
 
-**Kernel change:** Replace `recon = scale * q + zero` with a 4-entry register-resident lookup:
-```c
-half4 cb = *(const half4*)(group_ptr);
-half recon = cb[q & 3];
-```
-VGPR cost: +2 fp16 (19 → 21 on gfx1100), no spill.
+The +7.7% is the cost; the win is a 2.27× ppl reduction at 9B (42.03 →
+18.52). Bandwidth comparison against MQ4 (136 B/group) is **−17.6%**:
+Lloyd-MQ3 is materially smaller than MQ4 while sitting at 1.79× MQ4
+ppl (vs uniform MQ3's 4.07×).
 
-**Quantizer change:** Add `quantize_mq2g256_lloyd` in `hipfire-quantize`. Per 256-element block:
-1. Apply `cpu_fwht_256(signs ⊙ block) / 16`.
-2. Initialize 4 centroids at the 12.5/37.5/62.5/87.5 percentiles.
-3. **Lloyd's algorithm** to convergence (typically <10 iterations).
-4. Sort centroids ascending in the header (kernel does not need to know).
-5. Pack indices as 2 bits.
+**Kernel:** `gemv_mq3g256_lloyd.hip` with 8-entry register-resident
+codebook lookup (current implementation uses an 8-way switch which
+costs 3.2× decode vs uniform MQ3 — see ship gate 1 below).
 
-**On-disk:** Bump quant_type to `qt 19` (`MQ2G256_LLOYD`).
+**Quantizer:** `quantize_mq3g256_lloyd` in `hipfire-quantize`. Per
+256-element block: percentile init at 1/16, 3/16, …, 15/16 → Lloyd's
+iterations (max 8, early-exit) → sort centroids ascending → pack 3-bit
+indices same cross-byte layout as uniform MQ3. Parallelized via rayon
+`par_chunks_mut` over output blocks (9B quantize ~85s wall on 24-core).
 
-**Acceptance:**
-- 9B MQ2-Lloyd produces fluent output on the 4-prompt coherence battery.
-- 27B MQ2-Lloyd produces fluent output.
-- Perplexity delta vs MQ4 ≤ 6%.
-- Bytes/param == uniform MQ2.
+**On-disk:** `qt=20` (`MQ3G256Lloyd`).
+
+**Empirical wikitext2-test ppl:**
+
+| size | MQ4 | uniform MQ3 | **Lloyd-MQ3** | Lloyd factor | vs MQ4 |
+|------|---:|---:|---:|---:|---:|
+| 0.8B | 25.65 | 301.06 | **155.22** | 1.94× | 6.05× |
+| 4B   | 12.73 | 45.24  | **22.56**  | 2.01× | 1.77× |
+| 9B   | 10.34 | 42.03  | **18.52**  | 2.27× | 1.79× |
+
+**Ship gates** (both required before flipping `qt=20` to default and
+removing the `--allow-mq3-lloyd` guard):
+
+1. **Decode perf:** K4-unroll kernel restores 9B decode to ≥120 tok/s
+   on gfx1100 (current 8-way switch implementation: 44 tok/s vs uniform
+   MQ3's 141). Don't ship the 44 tok/s path — the user-visible 3.2×
+   latency regression cancels the quality win in chat usage.
+2. **Coherence eyeball:** 4-prompt coherence battery passes on 4B and
+   9B Lloyd-MQ3 with no attractor loops at the new ppl floor.
+
+Until both clear, Lloyd-MQ3 stays research-gated behind
+`--allow-mq3-lloyd` / `HIPFIRE_ALLOW_MQ3_LLOYD=1`.
+
+**Sub-9B status:** 0.8B Lloyd-MQ3 still text-collapse (155 vs MQ4 26 =
+6× worse). Below 9B, Lloyd alone is insufficient — needs Phase 2
+(GPTQ) or Phase 4 (mixed-MQ with MQ4 critical layers) on top.
+
+**See also:**
+- `docs/plans/mq-sub4bit-research-queue.md` Q1.5 — canonical research log.
+- `benchmarks/results/lloyd_max_findings_20260501.md` — empirical writeup.
+- `docs/plans/mq3-rounding-out-precompute-leverage.prd` §A — perf-leverage view.
 
 ### Phase 2 — Q2: GPTQ-Style Block-Wise Error Compensation
 
@@ -267,18 +329,23 @@ VGPR cost: +2 fp16 (19 → 21 on gfx1100), no spill.
 **Impact:** Medium — near-term release lever, no new math  
 **Risk:** Very low
 
-**Description:** Add `--format mixed-mq` to `hipfire-quantize` with a per-tensor policy table:
+**Description:** Add `--format mixed-mq` to `hipfire-quantize` with a per-tensor policy table. **The 3-bit slot uses Lloyd-MQ3 (qt=20, 112 B/group), not uniform MQ3** — see Phase 1.5 for the empirical justification:
 
-| Tensor class | Bpw |
-|---|---|
-| q_proj, k_proj, v_proj, o_proj | MQ4 (or MQ6 for sensitive heads) |
-| gate_proj, up_proj | MQ3 |
-| down_proj | MQ3 (widest matrix → biggest bandwidth win) |
-| lm_head | MQ4 (logits sensitivity) |
-| Embeddings | Q8F16 (existing) |
-| Norms | F16 (existing) |
+| Tensor class | Format | B/group |
+|---|---|---:|
+| q_proj, k_proj, v_proj, o_proj | MQ4 (or MQ6 for sensitive heads) | 136 |
+| gate_proj, up_proj | Lloyd-MQ3 | 112 |
+| down_proj | Lloyd-MQ3 (widest matrix → biggest bandwidth win) | 112 |
+| lm_head | MQ4 (logits sensitivity) | 136 |
+| Embeddings | Q8F16 (existing) | — |
+| Norms | F16 (existing) | — |
 
-**Expected average:** ~3.3 bpw — same bandwidth as uniform MQ3, better quality on sub-9B.
+**Expected average:** ~3.5 bpw — slightly above uniform MQ3's 3.25 bpw because Lloyd-MQ3 carries +7.7% header. The quality reclaim (2.27× ppl reduction on the 3-bit slot) makes the bandwidth bump trivially worth it.
+
+**Phase 4 is gated on Phase 1.5 ship gates clearing** — Lloyd-MQ3 must
+have its K4-unroll perf fix and coherence eyeball pass before mixed-MQ
+ships, or mixed-MQ inherits the 44 tok/s decode regression in its
+3-bit slot.
 
 **Acceptance:**
 - 4B mixed-MQ passes coherence battery where 4B MQ3 partially collapses.

--- a/docs/plans/mq-sub4bit-research-queue.md
+++ b/docs/plans/mq-sub4bit-research-queue.md
@@ -1,0 +1,449 @@
+# MQ Sub-4-Bit Research Queue (post-2026-04-30 sweep)
+
+Companion to `mq-sub4bit-roadmap.prd`. The roadmap defines the *paths*;
+this document is the prioritized *research queue* generated from the
+empirical sweep on master `c448d5e` (2026-04-30, gfx1100, 7900 XTX).
+
+## Sweep recap (32 generations, 0 hard errors)
+
+| size | MQ3 | MQ2 |
+|------|-----|-----|
+| 0.8B | gibberish | mojibake |
+| 4B   | partial (intent recognised, `<think>` loops, language drift) | symbol soup |
+| 9B   | borderline (factual ✓, multi-step reasoning loops) | symbol soup |
+| 27B 3.5 | fluent | _not tested past 9B fail_ |
+| 27B 3.6 | **cleanest output of the sweep** | _not tested past 9B fail_ |
+
+**Engine wiring is correct** (zero panics, monotonic quality vs size,
+27B fluent). The collapse is format-lossiness on small models, not a
+kernel bug. PR #109 added refuse-by-default for MQ2 and quality
+advisory for MQ3 < 9B.
+
+This queue identifies quality-lever research tasks that could:
+- **Rescue MQ3 quality at 4B / 9B** (move borderline → fluent)
+- **Rescue MQ2 at any size** (move all-fail → at-least-9B-pass)
+
+---
+
+## Q0 — Bit-exact kernel verification (forensic, 1-2 days)
+
+**Status:** Pending.
+**Effort:** 1-2 days.
+**Quality risk:** None — purely diagnostic.
+**Why first:** Locks down the question of "is the kernel doing what we
+think it's doing" before we tune anything. Cheap to run, eliminates the
+biggest unknown the user surfaced.
+
+### Goal
+
+Prove (or disprove) that `gemv_mq3g256_with_rotate` and
+`gemv_mq2g256_with_rotate` produce values bit-exact (or within fp16
+rounding) to a CPU reference of the same math.
+
+### Plan
+
+1. Pick the smallest .mq3 / .mq2 artifact (`qwen3.5-0.8b.mq3`).
+2. Write a CPU reference: `cpu_reference_gemv(W_rot, x, m, k) -> y`
+   that loads MQ3 bytes, dequantizes per the kernel's reconstruction
+   formula (`scale * q + zero`), runs `cpu_fwht_256(signs ⊙ x) / 16`,
+   then a plain f32 matvec.
+3. Capture the GPU dispatch's `y` for the same inputs (enable a debug
+   tap in `gemv_mq3g256_with_rotate`).
+4. Compare element-wise: `max_abs_err`, `mean_abs_err`,
+   `max_rel_err`, `bit_exact_count / total`.
+
+### Acceptance
+
+- **`max_abs_err <= 1e-3`** in fp16 mixed-precision: kernel is correct;
+  the small-model collapse is purely format-lossiness. Close this task.
+- **`max_abs_err > 1e-3`**: kernel has a bug. Bisect to: (a) FWHT
+  scaling, (b) sign-vector application, (c) byte unpack ordering,
+  (d) scale/zero-point header read.
+
+### Owner / files
+
+- New: `crates/engine/examples/verify_mq3_kernel.rs` (CPU/GPU compare).
+- Reads: `crates/rdna-compute/src/dispatch.rs` (kernel wrapper), 
+  `kernels/src/gemv_hfq3g256.hip` (decode formula),
+  `crates/hipfire-quantize/src/main.rs` (`quantize_mq3g256` output layout).
+
+---
+
+## Q1 — True non-uniform 4-entry codebook for MQ2 (revised; supersedes PRD §5.4 framing)
+
+**Status:** Pending.
+**Effort:** 1-2 weeks.
+**Quality risk:** Low if implemented carefully — the engine already does
+codebook-style reconstruction for KV cache (`asym3` / `asym4`).
+**Why second:** Highest-impact quality lever for MQ2. The sweep failed at
+every size tested; if a true non-uniform codebook doesn't rescue it,
+MQ2 is likely off the table for hipfire entirely.
+
+### Caveat on the PRD's framing (and why this revision exists)
+
+PRD §5.4 describes "Lloyd-Max" as: *"store `cb_min` and `cb_max` (2 floats).
+Reconstruction is `lerp(cb_min, cb_max, q / (2^K - 1))`."*
+
+This is **mathematically identical to the existing uniform `scale * q +
+zero`** — just an affine map renamed (`scale = (cb_max - cb_min)/(2^K-1)`,
+`zero = cb_min`). It buys nothing over what we already do. The PRD's
+ternary alternative `{-thresh, 0, +thresh}` only uses 3 of 4 codes,
+wasting 25% of the bit budget — strictly worse than uniform MQ2.
+
+True Lloyd-Max (Lloyd 1957 / Max 1960) is iterative refinement of a
+**codebook of N reconstruction values** (centroids), not just two
+boundary parameters. For 2-bit quant that means **4 fp16 centroids per
+block**, indexed by the 2-bit `q` via direct lookup.
+
+### Goal
+
+Replace uniform MQ2's `{scale*0+zero, scale*1+zero, scale*2+zero,
+scale*3+zero}` per-block reconstruction with a **per-block 4-entry
+codebook** of fp16 values produced by Lloyd's algorithm minimizing
+`E[(w − cb[q])²]` over the FWHT-rotated weights of that block.
+
+This is genuinely non-uniform — the codebook can fit bimodal,
+asymmetric, or heavy-tailed distributions that uniform-grid quant
+cannot.
+
+### Storage layout (preserves bandwidth budget)
+
+- **Header**: 4 fp16 centroids = **8 bytes** (same byte count as the
+  uniform MQ2 header: 4-byte fp16 scale + 4-byte fp16 zero).
+- **Data**: 64 bytes (256 × 2 bits) — unchanged.
+- **Total**: **72 bytes / group** — bit-exact same as uniform MQ2.
+
+The bandwidth win of MQ2 (0.281 bytes/param) is preserved completely.
+
+### Plan
+
+1. **Quantizer**: `quantize_mq2g256_lloyd(f32_data, signs1, signs2)` in
+   `crates/hipfire-quantize/src/main.rs`. Per 256-element block:
+   1. Apply `cpu_fwht_256(signs ⊙ block) / 16`.
+   2. Initialize 4 centroids at the 12.5/37.5/62.5/87.5 percentiles.
+   3. **Lloyd's algorithm** to convergence (typically <10 iterations):
+      assign each weight to its nearest centroid; recompute each
+      centroid as the mean of its assigned weights; repeat until
+      assignments stabilize.
+   4. Pack the 4 final centroids as fp16 (8 bytes header).
+   5. Pack each weight's centroid index as 2 bits.
+2. **On-disk layout**: bump quant_type to qt 19 (`MQ2G256_LLOYD`). 8 B
+   header + 64 B data = 72 B/group.
+3. **Engine**: new `DType::MQ2G256Lloyd`. New kernel
+   `gemv_mq2g256_lloyd.hip` — copy `gemv_hfq2g256.hip`, replace the
+   `recon = scale*q + zero` line with a 4-entry register-resident
+   codebook lookup:
+   ```c
+   // Header: load 4 fp16 codes once into vector registers.
+   half4 cb = *(const half4*)(group_ptr);
+   // Per-weight: index into codebook by the 2-bit q.
+   half recon = cb[q & 3];
+   ```
+   VGPR cost: 4 fp16 in registers instead of 1 scale + 1 zero = 2 fp16
+   — net +2 VGPRs per wave. Negligible (HFQ2 wave32 kernel has ~19
+   VGPRs / 20 waves/SIMD; +2 stays well under the spill threshold).
+4. **Sweep**: re-run `scripts/mq3-mq2-sweep.sh` against 9B / 27B Lloyd
+   variants. Compare against uniform MQ2 (refused-by-default per #109)
+   and MQ4 baselines.
+
+### Acceptance
+
+- 9B MQ2-Lloyd produces fluent output on the 4-prompt battery.
+- 27B MQ2-Lloyd produces fluent output.
+- Perplexity delta vs MQ4 ≤ 6%.
+- Bytes/param == uniform MQ2 (no bandwidth regression).
+
+### What asym3/asym4 KV cache already does (precedent + key difference)
+
+The KV-cache `asym3`/`asym4` modes use a **single global non-uniform
+codebook** of 8 (asym3) or 16 (asym4) fp32 values fitted to the
+expected post-Givens-rotation distribution `N(0, 1/256)`. See
+`kernels/src/turbo_common.h:23`:
+
+```c
+__constant__ float TURBO_C3_256[8] = {-0.134860f, -0.083320f, -0.046469f,
+                                      -0.015176f,  0.015176f,  0.046469f,
+                                       0.083320f,  0.134860f};
+```
+
+The kernel reconstructs as `recon = TURBO_C3_256[idx]` — direct
+indexed lookup. This works because every K vector is unit-normalized
+and Givens-rotated, so they all share approximately the same
+distribution; one global codebook fits all blocks.
+
+**Weight quantization is harder**: weights have heterogeneous
+per-block distributions (different scales, shapes, modalities). A
+single global codebook cannot fit all of them — we need a per-block
+codebook. The math is identical to the asym3 lookup; the difference
+is that the 4 (for MQ2) or 8 (for MQ3 via Q1.5 below) codebook
+entries live in the per-block header instead of `__constant__`
+memory.
+
+The asym3/asym4 modes are good evidence that the engine's lookup
+path is fast and the kernel toolchain handles small register-resident
+codebooks fine. They're NOT per-block Lloyd-Max — that's what Q1 adds.
+
+### Risks
+
+- **Codebook ordering**: the 4 centroids are unordered by construction
+  (Lloyd's converges to a permutation). Decide whether to sort them
+  ascending in the header, or assign indices 0-3 by ordered position
+  during quantize. Sorting at quant-time is simplest; the kernel does
+  not need to know.
+- **Outlier blocks**: blocks with extreme distributions (1 weight 100×
+  larger than the rest) will pull a centroid to the outlier and waste
+  the other 3. May need a fallback to uniform when codebook variance
+  is too low — measure on real distributions first.
+- **Calibration**: pure weight-distribution Lloyd's is data-free
+  (good — preserves the deterministic property of MQ formats). If
+  quality is still insufficient, escalate to GPTQ-style activation-
+  weighted Lloyd's (Q2 below).
+
+### Files
+
+- `crates/hipfire-quantize/src/main.rs`: new `quantize_mq2g256_lloyd`.
+- `crates/engine/src/hfq.rs`: qt 19 → `DType::MQ2G256Lloyd`.
+- `crates/rdna-compute/src/dispatch.rs`: new dispatch arm + GEMV
+  wrapper paralleling `gemv_mq2g256_with_rotate`.
+- `kernels/src/gemv_mq2g256_lloyd.hip`: new — codebook-lookup variant.
+- Reads: literature on llama.cpp's `Q2_K` / `Q3_K` / `Q4_K` (which use
+  per-block codebooks already; portable algorithms, ROCm-compatible
+  storage layout) for reference; `kernels/src/turbo_common.h` (existing
+  global non-uniform codebooks for asym3/4 KV) for the lookup-style
+  reconstruction precedent; `kernels/src/kv_fold_asym3.hip:60-62` for
+  the `recon = CODEBOOK[idx]` access pattern that already runs on the
+  hot path.
+
+### Out-of-band: PRD §5.4 should be revised
+
+If Q1 is approved, update `mq-sub4bit-roadmap.prd` §5.4 to drop the
+`(cb_min, cb_max)` / lerp framing — it's a uniform-quant scheme under
+a non-uniform-quant name. The actual Path D should be this 4-entry
+codebook lookup. Don't sit on incorrect docs.
+
+---
+
+## Q2 — GPTQ-style block-wise error compensation (NOT in PRD)
+
+**Status:** Pending — new proposal, not in roadmap.
+**Effort:** 1-2 weeks.
+**Quality risk:** Moderate — well-established technique but adds
+calibration data dependency.
+**Why third:** Could rescue MQ3 at 4B / 9B (move borderline → fluent)
+**without changing the kernel or storage format**. The quantizer becomes
+smarter; runtime is unchanged.
+
+### Goal
+
+When quantizing block-by-block, propagate the quantization error of
+already-quantized blocks forward into the still-unquantized blocks via
+the inverse Hessian of the activation covariance. Standard since GPTQ
+(Frantar et al., ICLR 2023); routinely rescues sub-4-bit quality on
+≥7B models.
+
+### Plan
+
+1. **Calibration data**: add a small calibration pass to
+   `hipfire-quantize` that runs ~128 samples through the f16 model and
+   records activation Hessians per layer (Cholesky factor, per layer).
+   Source: WikiText-2, C4, or whatever's already cached.
+2. **GPTQ inner loop**: in `quantize_mq3g256` (and `_mq4`, since the
+   technique applies to all bit widths), replace per-block independent
+   quantization with: for each column block, quantize, compute error,
+   subtract `(error * H_inv_block)` from remaining columns.
+3. **Calibration dataset & seeds**: deterministic. Record the calibration
+   config in the .hfq metadata so models can be reproduced.
+4. **Sweep**: run `scripts/mq3-mq2-sweep.sh` against GPTQ-MQ3 versions
+   of 4B and 9B. Compare against vanilla MQ3.
+
+### Acceptance
+
+- 4B MQ3-GPTQ produces fluent output (current vanilla: partial
+  collapse). Even modest improvement here is a strong signal.
+- 9B MQ3-GPTQ produces fluent multi-step reasoning (current vanilla:
+  loops).
+- 27B MQ3 unchanged or improved (already fluent; floor not regressed).
+
+### Risks
+
+- Adds a "calibration model load" step to `hipfire-quantize` — need to
+  load the source model in f16 to capture activations. ~2× memory at
+  quant time. Acceptable since quantize is offline.
+- GPTQ's standard implementation uses fp64 for the Hessian inverse. We
+  may need to validate fp32 is enough on rotated weight distributions.
+
+### Files
+
+- `crates/hipfire-quantize/src/main.rs`: add `--calibrate <samples>`
+  flag, GPTQ inner loop.
+- New: `crates/hipfire-quantize/src/gptq.rs` (Hessian capture +
+  inversion + block-update math).
+- Reads: literature — GPTQ paper (arxiv 2210.17323); marlin / autogptq
+  reference code (CUDA but the algorithm is portable).
+
+---
+
+## Q3 — Per-model calibrated sign vectors (incoherence randomization tuning)
+
+**Status:** Pending — new proposal, not in roadmap.
+**Effort:** 1 week.
+**Quality risk:** Low.
+**Why fourth:** Smaller-impact than GPTQ but cheaper. Currently the
+FWHT sign vectors are deterministic PRNG seeds (42, 1042) shared
+across all models. Per-model calibration could pick sign vectors that
+push the post-FWHT weight distribution closer to uniform within each
+block — tightening the dynamic range that downstream quantization
+(uniform or Lloyd-Max codebook) has to cover.
+
+### Note on terminology
+
+This is NOT AWQ (Activation-aware Weight Quantization). AWQ scales
+specific weight columns by per-channel activation magnitude — that
+would be a separate task (Q3.5 below if pursued). The technique
+proposed here is closer to QuIP-style "incoherence randomization":
+search the space of orthogonal-equivalent rotations for the one that
+minimizes post-rotation outlier mass.
+
+### Goal
+
+Replace the global PRNG-seeded sign vectors (seeds 42 / 1042) with
+per-model (or per-layer-class) calibrated vectors that minimize the
+post-FWHT block-level dynamic range or outlier-to-median ratio.
+
+### Plan
+
+1. Random-restart search: try N ∈ [16, 64] candidate seed pairs;
+   for each, apply FWHT to a sample of the model's weights and
+   measure either:
+   - `block_dynamic_range = max(|w_rot|) / median(|w_rot|)` per block,
+     averaged across blocks (smaller = better)
+   - or per-block kurtosis of the rotated distribution (lower kurtosis
+     means more uniform-tolerant)
+2. Pick the seed pair minimizing the chosen metric.
+3. Store the chosen seeds in the .hfq metadata header (2 × u64).
+4. At engine load, read the seeds from metadata and reproduce the
+   sign vectors instead of using the hard-coded constants.
+
+### Acceptance
+
+- 4B MQ3 with calibrated seeds outperforms vanilla 4B MQ3 on the
+  coherence battery.
+- Seed calibration runs in <60s per model.
+- Engine load is a no-op slowdown (same FWHT, just different signs).
+
+### Risks
+
+- Backward compat: existing `.mq3` / `.mq2` artifacts use seeds
+  42 / 1042. New artifacts would have a different metadata field.
+  Loader must default to old constants when the field is absent.
+- Diminishing returns: the FWHT rotation is already designed to
+  decorrelate weight statistics. Random-restart on top may yield
+  only marginal gains. Run Q0 first to confirm the kernel is
+  correctly applying the rotation; if rotation fidelity is the
+  bottleneck (unlikely but possible), Q3 is more impactful than
+  if the rotation is already near-optimal.
+
+---
+
+## Q4 — Mixed-precision MQ-hybrid (PRD §5.3 Path C)
+
+**Status:** Pending — PRD Phase 3.
+**Effort:** 3-5 days.
+**Quality risk:** Very low.
+**Why fifth:** Mostly an engineering task. The PRD already specifies the
+policy. Lower research priority than Q1-Q3 but unblocks a near-term
+0.1.9 release that improves sub-9B sub-4-bit quality without any new
+math.
+
+### Goal
+
+`--format mixed-mq` policy in `hipfire-quantize`:
+
+| Tensor class | Bpw |
+|---|---|
+| q_proj, k_proj, v_proj, o_proj | MQ4 (or MQ6 for sensitive heads) |
+| gate_proj, up_proj | MQ3 |
+| down_proj | MQ3 (widest matrix → biggest bandwidth win) |
+| lm_head | MQ4 (logits sensitivity) |
+| Embeddings | Q8F16 (existing) |
+| Norms | F16 (existing) |
+
+Average ~3.3 bpw — same bandwidth as uniform MQ3, hopefully better
+quality on sub-9B.
+
+### Acceptance
+
+- 4B mixed-MQ on the coherence battery passes where 4B MQ3 partially
+  collapses.
+- Average bpw ~3.3-3.5 (target for the bandwidth window).
+
+### Files
+
+- `crates/hipfire-quantize/src/main.rs`: per-tensor policy table,
+  `--format mixed-mq` flag.
+
+---
+
+## Q5 — WMMA prefill kernels for MQ3 / MQ2 (PRD Phase 3)
+
+**Status:** Pending — engineering, not research.
+**Effort:** 1-2 weeks.
+**Why last in this queue:** Pure perf, not quality. After Q1-Q4 we
+hopefully have shippable MQ3 (and maybe Lloyd-Max MQ2); only then is
+prefill-perf worth the kernel-development cost. Currently MQ3 prefill
+falls back to per-row GEMV (43 tok/s prefill at 27B vs ~70 for
+batched MQ4 + WMMA).
+
+### Goal
+
+Add `gemm_qkvza_mq3g256_wmma_gfx12.hip`, `gemm_gate_up_mq3g256_wmma`,
+`gemm_mq3g256_residual_wmma`, etc. Same shape as the existing MQ4
+WMMA family but with 3-bit unpack inside the K-tile loop. Add to
+`is_batchable_la` so the eligibility check no longer falls back.
+
+### Acceptance
+
+- 27B MQ3 prefill ≥1.5× current per-row GEMV speed.
+- Channel-tests pass for all WMMA variants on gfx1201 (R9700) +
+  fp16 reference matches gfx1100 dot2 fallback.
+- Coherence-gate clean post-merge.
+
+---
+
+## Cross-cutting agent guidance
+
+- **Always use `scripts/mq3-mq2-sweep.sh`** for empirical verdicts.
+  Eyeball the report; the gate's hard-fail predicate (panic / 0
+  tokens / timeout) won't catch quality regressions.
+- **Always record source-input md5 + binary md5** alongside any
+  quality / perf claim (per CLAUDE.md prompt-shape rule, applied here
+  to quant artifacts).
+- **27B 3.6 MQ3 is the canonical fluent sub-4-bit reference.** When
+  testing a new quant variant, compare against 27B 3.6 MQ3 outputs on
+  the same 4 prompts.
+- **Don't touch `is_batchable_la` to admit MQ3/MQ2 until Q5 lands.**
+  The current per-token fallback is the reason zero panics surfaced;
+  adding MQ3 to the batched path without a real WMMA kernel would
+  reintroduce the HFQ4 batched-kernel-on-MQ3 hazard PR #108 closed.
+
+## Out of scope for this queue
+
+- Path E (TCQ / QTIP-style trellis codes) — PRD §5.5 says research-grade,
+  pursue only if Q1-Q4 collectively fail. Empirically Q1+Q2 should
+  unlock enough quality headroom that we don't need TCQ.
+- Path F (BitNet-style native ternary) — requires a training stack
+  hipfire doesn't have. Out of scope.
+
+## Reproducing this sweep before any agent run
+
+```bash
+# Quantize the canonical sweep set (NAS HF cache → ~/.hipfire/models/)
+hipfire-quantize --input <Qwen3.5-0.8B-snapshot> --output ~/.hipfire/models/qwen3.5-0.8b.mq3 --format mq3
+hipfire-quantize --input <Qwen3.5-9B-snapshot>   --output ~/.hipfire/models/qwen3.5-9b.mq3   --format mq3
+hipfire-quantize --input <Qwen3.5-27B-snapshot>  --output ~/.hipfire/models/qwen3.5-27b.mq3  --format mq3
+hipfire-quantize --input <Qwen3.6-27B-snapshot>  --output ~/.hipfire/models/qwen3.6-27b.mq3  --format mq3
+# (MQ2 needs --allow-mq2 per PR #109 guard)
+
+./scripts/mq3-mq2-sweep.sh
+# report → ~/.hipfire/mq3-tests/sweep-<timestamp>.md
+```

--- a/docs/plans/mq-sub4bit-research-queue.md
+++ b/docs/plans/mq-sub4bit-research-queue.md
@@ -223,6 +223,110 @@ codebook lookup. Don't sit on incorrect docs.
 
 ---
 
+## Q1.5 — Lloyd-Max MQ3 (validated 2026-05-01, shipping pending decode-perf fix)
+
+**Status:** Implemented and ppl-validated. Ships pending K4-unroll perf
+recovery (decode 44 → ~140 tok/s on gfx1100). Research-gated until then
+via `HIPFIRE_ALLOW_MQ3_LLOYD=1` / `--allow-mq3-lloyd`.
+
+### Storage
+
+- **qt 20** (`MQ3G256Lloyd`)
+- **Header**: 8 fp16 centroids = 16 B (vs uniform MQ3's 8 B fp32 scale+zero)
+- **Data**: 96 B packed 3-bit indices (unchanged cross-byte layout)
+- **Total**: **112 B/group** vs uniform MQ3's 104 B → +7.7% bandwidth
+
+### Empirical wikitext2-test perplexity (gfx1100, ctx=2048, warmup=8, scored=2039)
+
+| size | MQ4 | MQ3 uniform | **MQ3-Lloyd** | Lloyd ratio | vs MQ4 gap |
+|------|---:|---:|---:|---:|---:|
+| 0.8B | 25.65 | 301.06 | **155.22** | 1.94× | 6.05× |
+| 4B   | 12.73 | 45.24  | **22.56**  | 2.01× | 1.77× |
+| 9B   | 10.34 | 42.03  | **18.52**  | 2.27× | 1.79× |
+
+**9B Lloyd-MQ3 is the closest sub-4-bit format hipfire has gotten to MQ4
+quality** (1.79× vs uniform-MQ3's 4.07×). Same algorithm wins ~2× across
+all sizes — the per-block 8-entry codebook is fundamentally the right shape
+for 3-bit weight reconstruction on Qwen3.5.
+
+**Sub-9B status (issue #114 update):** halved on 0.8B (301 → 155) but
+still text-collapse zone. Below 9B, Lloyd-MQ3 alone is insufficient —
+needs Q2 (GPTQ) or Q4 (mixed-precision) on top.
+
+### Implementation cost
+
+| component | location | LOC |
+|---|---|---|
+| `quantize_mq3g256_lloyd` (parallel rayon `par_chunks_mut`) | `crates/hipfire-quantize/src/main.rs` | ~110 |
+| `gemv_mq3g256_lloyd.hip` (8-way switch codebook lookup) | `kernels/src/` | ~85 |
+| `DType::MQ3G256Lloyd` + dispatch wrappers | `crates/rdna-compute/src/dispatch.rs` | ~30 |
+| Engine load arms (qt=20 in 3 sites + DeltaNet CPU dequant) | `crates/engine/src/{hfq,llama,qwen35}.rs` | ~80 |
+| `--allow-mq3-lloyd` / `HIPFIRE_ALLOW_MQ3_LLOYD=1` guard | quantizer | ~15 |
+
+Quantize time: 9B Lloyd-MQ3 ~85s wall on 24-core (rayon parallelized over
+output blocks). Single-thread Lloyd's at 12 iter × 256 weights × ~35M
+blocks took >5 min and didn't finish first attempt; the parallel rewrite
+is what makes this practical.
+
+### Decode perf cost (preliminary)
+
+9B decode: uniform MQ3 ~141 tok/s → Lloyd-MQ3 44 tok/s (3.2× slowdown).
+The 8-way switch in `gemv_mq3g256_lloyd.hip` is harder to optimize than
+uniform's `scale*q + zero`. Recoverable via K4-unroll + LDS-resident
+codebook table (mirrors `gemv_hfq3g256.gfx1100.hip` shape that brought
+uniform MQ3 from 114 → 141). Tracked separately.
+
+### Roadmap implications
+
+- **Lloyd-MQ3 supersedes uniform MQ3 as the 3-bit default** once *both*
+  gates land:
+  1. K4-unroll perf fix (task #83) restores decode to ≥120 tok/s on 9B
+     gfx1100. Don't ship the 44 tok/s path — the 3.2× decode regression
+     would be visible in chat latency.
+  2. Coherence-gate eyeball pass on the 4-prompt battery for 4B and 9B
+     confirms no attractor loops at the new ppl floor.
+
+  Until both clear, Lloyd-MQ3 stays gated behind `--allow-mq3-lloyd` /
+  `HIPFIRE_ALLOW_MQ3_LLOYD=1`. Re-upload HF artifacts under the `-mq3`
+  tag (or new `-mq3-lloyd` tag, TBD by user) only after both gates pass.
+- **Q4 (mixed-MQ) updates**: the 3-bit slot in the policy table should
+  use **Lloyd-MQ3, not uniform MQ3**. Average bpw bumps from 3.3 to ~3.5
+  but quality follows the table above.
+- **Q1 (Lloyd-MQ2) reverts to research-only.** Even at 9B, Lloyd-MQ2
+  ppl=2,163 is text-collapse. The 55× win over uniform-MQ2 is informational
+  and the format stays plumbed (qt=19) for future combinations with GPTQ
+  but doesn't ship as a default. Gated behind `--allow-mq2-lloyd`.
+
+### Files
+
+- `benchmarks/results/lloyd_max_findings_20260501.md` — full empirical
+  writeup with all four formats compared.
+- `crates/engine/examples/perplexity.rs` — single-window NLL harness
+  (issue #113 alpha→beta gate is now answered by data, not eyeball).
+- Engine wiring as above.
+
+### Lloyd-MQ4 explicitly deprioritized (2026-05-01)
+
+The natural extension would be Lloyd-MQ4: 16 fp16 centroids (32 B header)
++ 128 B 4-bit indices = 168 B/group (+23.5% bandwidth over uniform MQ4).
+**Not pursued** because:
+
+1. **Narrow quant-loss room.** 9B uniform MQ4 already sits at ppl=10.34;
+   fp16 baseline is presumably ~9.5. Even an oracle codebook can only
+   reclaim ~10% — small absolute win for +24% bandwidth penalty.
+2. **Ship priority.** Lloyd-MQ3 closes the bigger gap (4× → 1.79× vs MQ4)
+   for less bandwidth (+7.7%). 3-bit is where the value is.
+3. **No obvious sub-9B MQ4 collapse.** If a future ppl sweep on smaller
+   MQ4 models surfaces hidden quality drops the coherence-gate eyeball
+   missed (analogous to what happened with 9B MQ3), reopen this. Until
+   then, MQ4 stays uniform.
+
+Revisit if: smaller-than-1B MQ4 gets a quality-eval sweep showing
+collapse, or kernel-perf experiments find that 16 fp16 entries fit in
+LDS with negligible cost (would change the bandwidth calculus).
+
+---
+
 ## Q2 — GPTQ-style block-wise error compensation (NOT in PRD)
 
 **Status:** Pending — new proposal, not in roadmap.

--- a/docs/plans/mq3-rounding-out-precompute-leverage.prd
+++ b/docs/plans/mq3-rounding-out-precompute-leverage.prd
@@ -1,0 +1,367 @@
+# MQ3 Rounding-Out: Quant-Time Pre-Compute Leverage
+
+**Status:** Deferred — documenting the leverage analysis for later pickup.
+**Last updated:** 2026-04-30
+**Companion docs:** `mq-sub4bit-prd.md`, `mq-sub4bit-research-queue.md`
+**Branch context:** Written after the MQ3 WMMA family + engine wiring landed
+on `fix/mq3-mq2-cli-guards` (commits `1a219b2` … `df88da9`). The 17×
+prefill speedup that work delivered was a kernel-coverage win, not a
+quant-time win — this doc inventories what shifting more runtime work
+to quant-time could *additionally* buy.
+
+---
+
+## 1. Framing
+
+The FWHT pre-rotation of weights at quant-time is hipfire's existing
+example of "move the work offline." Weights are stored already-rotated;
+runtime only needs to rotate the activation `x` once per layer (a
+fused `rmsnorm + FWHT(signs ⊙ x)` kernel), and the GEMM kernel sees
+the rotated weight bytes as opaque storage.
+
+**Question:** Are there other runtime ops we can pre-bake the same way
+to give pre-computed leverage on MQ3 perf or quality?
+
+**Honest answer (updated 2026-05-01):** The FWHT pre-rotation already
+captured the cleanest quant-time bake the architecture allows. Most
+remaining levers are small (1–3 % wins) or shift work to *load-time* /
+kernel-fusion rather than quant-time. **One big lever exists**
+(Lloyd-Max per-block codebook); empirically it is a **quality** lever,
+not a perf one — it cuts 9B MQ3 ppl 2.27× over uniform but the GEMV
+codebook lookup is a 3.2× decode regression on gfx1100 that needs a
+follow-on K4-unroll kernel pass to recover. The rest are small side
+moves. Section A documents the validated outcome and the gates before
+shipping it as the 3-bit default.
+
+This PRD inventories the candidates so a future pass can pick them up
+in informed priority order.
+
+---
+
+## 2. Candidates ranked by leverage
+
+### A. Lloyd-Max per-block codebook — VALIDATED 2026-05-01, +127% ppl improvement on 9B MQ3
+
+**Status:** Implemented and ppl-validated for both MQ2 (qt=19) and MQ3
+(qt=20). Lloyd-Max MQ3 is now the most promising sub-4-bit format
+hipfire ships — pending K4-unroll decode-perf recovery and eyeball
+coherence pass before flipping the default away from uniform MQ3.
+
+**Effort:** Spent — full implementation took ~1 day (algorithm +
+parallelization + kernels + DType + dispatch + perplexity harness +
+research-only guards). Single-thread Lloyd's was prohibitive at 9B; the
+parallel rewrite via rayon `par_chunks_mut` over output blocks made it
+viable (9B Lloyd-MQ3 quantize ~85s wall on 24-core).
+
+**Quality wins (wikitext2-test ppl, gfx1100 ctx=2048):**
+
+| size | MQ4 | MQ3 uniform | **MQ3-Lloyd** | uniform-MQ3 → Lloyd |
+|------|---:|---:|---:|---:|
+| 0.8B | 25.65 | 301.06 | **155.22** | 1.94× |
+| 4B   | 12.73 | 45.24  | **22.56**  | 2.01× |
+| 9B   | 10.34 | 42.03  | **18.52**  | **2.27×** |
+
+9B Lloyd-MQ3 sits at **1.79× MQ4** — the closest sub-4-bit has come to
+MQ4 quality at hipfire (uniform MQ3 was 4.07×).
+
+For MQ2 the algorithm also works (55.5× over uniform MQ2 at 9B) but
+absolute floor remains text-collapse (ppl 2,163), so MQ2-Lloyd stays
+research-only behind `--allow-mq2-lloyd`.
+
+**Perf impact:** Decode hit a 3.2× slowdown on 9B (141 → 44 tok/s) from
+the 8-way switch in `gemv_mq3g256_lloyd.hip`. Recoverable via K4-unroll
++ LDS-resident codebook table (mirror `gemv_hfq3g256.gfx1100.hip`'s
+4-accumulator pattern). Tracked as task #83 — **gate on this landing
+before flipping the default**. Don't ship the 44 tok/s decode path to
+users; the prior MQ3 baseline was 141 tok/s and dropping that to 44
+trades a 4× ppl-quality win for a 3× decode-speed regression that's
+visible in chat latency. Both gates required:
+
+1. K4-unroll kernel restores decode to ≥120 tok/s on 9B gfx1100.
+2. Coherence-gate eyeball pass on the 4-prompt battery for 4B and 9B
+   confirms no attractor loops at the new ppl floor.
+
+#### Mechanism
+For each 256-element block at quant time, run Lloyd's algorithm to
+produce 8 fp16 reconstruction values (centroids). Store them in the
+8-byte block header (replacing `scale: fp32 + zero: fp32`). At runtime
+the dequant becomes:
+
+```
+old: recon = sc_h * (fp16 of int q) + zp_h    // 1 mul + 1 add per weight
+new: recon = cb[q]                             // 1 indexed register load
+```
+
+The arithmetic saving was *predicted* to be hidden in the WMMA load
+pipeline. **Empirically the GEMV path doesn't hide it**: an 8-way
+register-resident switch on `q ∈ [0,7]` compiles to a longer dependency
+chain than `scale*q + zero`, and decode dropped 3.2× on 9B (141 → 44
+tok/s) on gfx1100. The K4-unroll perf fix (task #83) is what closes
+this gap; with it the runtime perf delta should be near-zero. The
+**quality** delta is the real win: non-uniform centroids fit the
+post-FWHT weight distribution better than the affine map `scale*q +
+zero` can — 2.27× ppl reduction on 9B is the empirical confirmation.
+
+#### Storage
+Codebook stores 8 fp16 = 16 bytes vs current 8-byte header → +8 bytes
+per 256-element group → 112 B/group → **+7.7 % bandwidth cost**.
+
+The original framing of this storage cost as "net loss as a perf bake
+on MQ3" was wrong — it priced the codebook against bandwidth alone, not
+against the quality reclaim. With 2.27× ppl reduction on 9B for +7.7%
+bandwidth, MQ3-Lloyd has the cleanest quality position of any sub-4-bit
+format hipfire has measured: closer to MQ4 quality (1.79× vs uniform
+MQ3's 4.07×) for less bandwidth (-17.6% vs MQ4's 136 B/group). 9B
+Lloyd-MQ3 ships as the 3-bit default after both gates clear (K4-unroll
+perf fix + 4B/9B coherence eyeball pass — same gates listed under "Perf
+impact" and the "Decision rule" below).
+
+For MQ2 the picture inverts: the 55× win over uniform MQ2 still leaves
+9B at ppl 2,163 (text-collapse) so storage isn't the binding constraint
+— the bit-width is. MQ2-Lloyd ships as research-only (qt=19, gated
+behind `--allow-mq2-lloyd`).
+
+#### Decision rule (2026-05-01 — actual outcome inverts the original prediction)
+
+**Original guidance was**: ship Lloyd-Max as MQ2 storage, not MQ3,
+because the storage cost was assumed to be a perf-only loss on MQ3.
+The empirical answer is the opposite — the codebook delivers a 2.27×
+ppl reduction on 9B MQ3, which is the actual product win. **Lloyd-Max
+MQ3 will become the default 3-bit format** (replacing uniform MQ3) once
+both ship gates clear:
+
+1. K4-unroll kernel (task #83) restores 9B decode to ≥120 tok/s on
+   gfx1100. Without it, Lloyd-MQ3 decode is 44 tok/s vs uniform MQ3's
+   141 — an unacceptable user-visible latency regression.
+2. Coherence-gate eyeball pass on the 4-prompt battery for 4B and 9B
+   confirms no attractor loops at the new ppl floor.
+
+Until both clear, `qt=20` (`MQ3G256Lloyd`) stays plumbed but
+research-gated behind `--allow-mq3-lloyd` /
+`HIPFIRE_ALLOW_MQ3_LLOYD=1`. Lloyd-Max MQ2 (`qt=19`) stays plumbed but
+**permanently** research-only — the bit-width is the binding
+constraint, not storage.
+
+#### Lloyd-Max MQ4 explicitly deprioritized
+
+The natural next extension would be 16 fp16 centroids + 4-bit indices
+= 168 B/group (+23.5% bandwidth over uniform MQ4). **Not pursued**:
+
+1. 9B MQ4 ppl=10.34 already has narrow quant-loss room (fp16 baseline
+   ≈9.5). An oracle codebook reclaims ~10% — small absolute win for
+   +24% bandwidth.
+2. Lloyd-MQ3 closes the bigger gap (4× → 1.79× vs MQ4) for less
+   bandwidth (+7.7%). 3-bit is where the value sits.
+3. No surfaced sub-9B MQ4 quality collapse yet. If a future ppl sweep
+   on smaller MQ4 finds hidden drops the eyeball missed (analogous to
+   what happened with 9B MQ3), reopen.
+
+See `docs/plans/mq-sub4bit-research-queue.md` Q1.5 for the canonical
+research log entry; full empirical data in
+`benchmarks/results/lloyd_max_findings_20260501.md`.
+
+---
+
+### B. Pre-baked `signs1 ⊙ norm_weight` (load-time, not quant-time)
+
+**Effort:** ~half-day.
+**Perf impact:** Negligible (~hidden_dim ops saved per layer per token).
+**Risk:** None — math-equivalent transform.
+
+#### Mechanism
+At load time, fold the FWHT signs1 vector into the per-layer norm weight:
+```
+signed_norm[i] = signs1[i mod 256] * attn_norm[i]
+```
+
+The fused `rmsnorm + rotate` kernel uses `signed_norm[i]` as the
+per-channel scale, dropping one fp16 multiply per dim per token.
+
+#### Why it's small
+RMSNorm is already fast (~50 µs/layer at hidden_dim=4096 on gfx1100).
+Saving one element-wise multiply is in noise.
+
+#### Worth doing alongside
+A future pass that touches the `fused_rmsnorm_rotate_mq_batched`
+kernel for any reason should pick this up as a free side-cleanup.
+
+---
+
+### C. Per-K-group `x_group_sum` precompute + zero-point fold-out
+
+**Effort:** ~1 day.
+**Perf impact:** Trivial (~0.4 % of FLOPs in the GEMM saved).
+**Risk:** Low — math-equivalent decomposition.
+
+#### Mechanism
+Currently the kernel computes:
+```
+y[m] = Σ_k (scale[m,g(k)] · q[m,k] + zero[m,g(k)]) · x[k]
+```
+
+Split into:
+```
+y[m] = Σ_k scale[m,g(k)] · q[m,k] · x[k]      (the main WMMA term)
+     + Σ_g zero[m,g] · x_group_sum[g]          (bias term)
+```
+
+where `x_group_sum[g] = Σ_{k ∈ group g} x[k]` is precomputed once per
+dispatch and reused across all M output rows.
+
+#### Why it's small
+The current kernel computes the bias term inline alongside the main
+term — it's not currently a measurable cost. Splitting it out replaces
+`N × K` bias-multiplies with `N × (K/256) + K` multiplies, but the
+saved ops were already pipelined alongside loads.
+
+#### Worth doing alongside
+A future pass that introduces a custom GEMM kernel for some perf
+reason can pick this up if it unlocks a bigger optimization (e.g.,
+removing the per-group zero load from the inner K-tile loop, freeing
+a register).
+
+---
+
+### D. Pre-compiled `.hsaco` blobs shipped with `.mq3` files
+
+**Effort:** 2–3 days.
+**Perf impact:** First-run wait reduced from a few seconds to ~zero.
+Zero impact on steady-state perf.
+**Risk:** Storage bloat in the artifact; cross-arch matrix complicates
+which blobs to ship.
+
+#### Mechanism
+Currently kernels are JIT'd from `.hip` source on first run, then
+cached at `~/.hipfire/bin/kernels/compiled/<arch>/`. A user's first
+prefill on a fresh machine pays the JIT cost (a few seconds per kernel
+× ~30+ kernels).
+
+Bundling pre-compiled `.hsaco` blobs in the `.mq3` file (or in a
+sibling `.hsaco-bundle` file) would skip the JIT entirely.
+
+#### Tradeoffs
+- **Cross-arch matrix**: 12+ arches × ~30 kernels × ~50–100 KB blob =
+  many MB per arch. Could be selective (gfx11 + gfx12 only) or fetched
+  separately on `hipfire pull <model>`.
+- **Hipfire-version coupling**: blobs are tied to the hipfire version's
+  kernel sources. Re-pulling on engine update.
+- **Productionization, not perf**: doesn't help anyone who's already
+  warmed up their cache.
+
+#### Decision rule
+Worth doing only when the install/onboarding experience becomes a
+priority — not a quant-time perf lever per se.
+
+---
+
+### E. QuIP#-style global codebook + per-row scale (deeper redesign)
+
+**Effort:** Multiple weeks; research-grade.
+**Perf impact:** Saves per-block metadata (~7 % bytes/group); runtime
+becomes `global_cb[q] × row_scale`.
+**Quality risk:** Moderate — gives up per-block adaptation.
+
+#### Mechanism
+1. **At quant time**, per row: compute the row's L2 norm; normalize
+   the row to unit L2; FWHT-rotate; quantize against a SINGLE model-
+   global Lloyd-Max codebook (8 fp16 entries).
+2. **Storage**: 1 fp32 row scale + N×K × 3 bits (no per-block scale or
+   zero). Total bytes/group: 96 B (data only) + (per-row metadata
+   amortized across groups). For Qwen3.5-9B (~32k rows): ~125 KB total
+   row metadata vs current per-block scale+zero overhead. Material
+   savings.
+3. **Runtime**: `recon[k] = global_cb[q] × row_scale[m]`.
+
+#### Why it might fail
+Per-block adaptation is what makes hipfire MQ resilient to outlier
+blocks. After FWHT the distribution is more uniform but not perfectly
+so — outlier blocks still exist. A single global codebook forces all
+blocks to share the same reconstruction levels. Quality could
+collapse on the same blocks where uniform MQ2 collapses today.
+
+#### Why it might work
+QuIP# (RHT + E8 lattice global codebook) reportedly hits Q4-quality
+at 2-bit on 70B+ models. The premise is the same: incoherence
+processing produces approximately-Gaussian residuals which fit a
+single global code. hipfire's `kv_fold_asym3` already uses a global
+N(0, 1/256) codebook (`TURBO_C3_256`) — the precedent works at the
+KV cache scope (where Givens rotation forces unit-normalized vectors).
+
+#### Decision rule
+Pursue only if Path A (per-block Lloyd-Max) doesn't rescue MQ2 and
+the headline goal is shipping ≥9B MQ2. Long timeline; high risk.
+
+---
+
+## 3. Things that *cannot* be shifted to quant-time
+
+For completeness — so future readers don't re-walk:
+
+- **Activation rotation `mq_rotate_x`**: inherently per-token-dynamic.
+  The best version of this is *kernel fusion* (rotate + GEMV in one
+  launch), which is a runtime move, not a quant-time bake. Currently
+  in flight as a separate "MQ3 fused decode" follow-up.
+- **Attention compute**: per-position dynamic by definition.
+- **KV cache writes/reads**: per-token.
+- **FWHT itself**: O(N log N) at runtime (~2k ops for N=256). Pre-
+  computing the full 256×256 transform matrix would be O(N²) =
+  65 k ops at runtime — *strictly worse*.
+- **RMSNorm**: requires per-token reciprocal of the L2 norm of x —
+  data-dependent, can't pre-bake. The per-channel weight CAN fold
+  into FWHT signs (move B above), but that's the only piece.
+- **Sampling / argmax / repeat-penalty / n-gram block**: token-level
+  decisions on logits.
+
+---
+
+## 4. Net recommendation (updated 2026-05-01)
+
+**For perf alone:** the FWHT pre-rotation already grabbed the biggest
+quant-time lever. The remaining quant-time levers (B, C) are 1–3 %
+wins; (D) is productionization not perf; (E) is research-grade and
+risky.
+
+**For quality:** Lloyd-Max per-block codebook (A) is now-validated as
+the headline 3-bit quality lever — 9B Lloyd-MQ3 ppl 18.52 vs uniform
+MQ3's 42.03 (2.27× reduction) for +7.7% bandwidth. **It is NOT
+perf-neutral**: an 8-way switch in the codebook lookup costs 3.2× on
+9B decode and needs the K4-unroll follow-up (task #83) to recover
+before flipping to default.
+
+**For 2-bit:** Lloyd-Max also rescues uniform MQ2 (55× ppl reduction)
+but the absolute floor (9B ppl 2,163) is still text-collapse, so MQ2
+is **not** "quality-essentially rescued" by the codebook alone — the
+bit-width is the binding constraint. Lloyd-MQ2 stays plumbed for
+research, doesn't ship.
+
+**Outcome of the prototype** (already executed): the codebook
+materially reduces error on MQ3, and **MQ3 is where it ships**, not
+MQ2. The original prediction that A would unblock 2-bit was wrong.
+
+The bigger MQ3 perf wins right now are still kernel-coverage moves
+(gfx12 K4 WMMA family, fused rotate+GEMV decode, A3B MoE MQ3 fast-path)
+plus the K4-unroll follow-up for the Lloyd codebook lookup itself.
+See `mq-sub4bit-research-queue.md` Q1.5 for the canonical research log
+on Lloyd-MQ3 and `benchmarks/results/lloyd_max_findings_20260501.md`
+for the empirical writeup.
+
+---
+
+## 5. References
+
+- `docs/QUANTIZATION.md` — current MQ format + FWHT description.
+- `docs/plans/mq-sub4bit-prd.md` — full sub-4-bit roadmap; §5.4 Path D
+  framing of "Lloyd-Max" as `(cb_min, cb_max)` lerp is **incorrect** —
+  see queue Q1 caveat. The actual algorithm is iterative centroid
+  refinement; that's what's implemented.
+- `docs/plans/mq-sub4bit-research-queue.md` — Q1 (MQ2 plan) and Q1.5
+  (validated MQ3 outcome) document the Lloyd-Max work; Q1.5 is the
+  canonical entry for the move-A status.
+- `benchmarks/results/lloyd_max_findings_20260501.md` — empirical
+  perplexity comparison across MQ4 / uniform MQ3 / Lloyd-MQ3 /
+  Lloyd-MQ2 / uniform MQ2 at 0.8B / 4B / 9B.
+- `kernels/src/turbo_common.h` — `TURBO_C3_256` is the global-codebook
+  precedent for asym3 KV cache (move E generalizes this idea to
+  weights).
+- QuIP# (Tseng et al., ICML 2024 / arXiv 2402.04396) — the academic
+  reference for move E (RHT + global lattice codebook).

--- a/kernels/src/gemm_gate_up_hfq3g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_hfq3g256_wmma.gfx12.hip
@@ -1,0 +1,118 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) variant of the 2-way fused MQ3 / HFQ3-G256 gate+up WMMA
+// preamble (FFN). See `gemm_qkvza_hfq3g256_wmma.gfx12.hip` for the gfx12
+// K4-unroll + half8_t lane-split rationale.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_hfq3g256_wmma_gfx12(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate; local_row = safe_row;
+    } else {
+        A = A_up;   local_row = safe_row - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 104;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    #define UNPACK_CHUNK_DQ(b0, b1, b2)                          \
+        do {                                                      \
+            unsigned int _a0 = (b0), _a1 = (b1), _a2 = (b2);     \
+            a_reg[0] = sc_h * (_Float16)(float)(_a0 & 7u) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)((_a0 >> 3) & 7u) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((_a0 >> 6) | (_a1 << 2)) & 7u) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)((_a1 >> 1) & 7u) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)((_a1 >> 4) & 7u) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((_a1 >> 7) | (_a2 << 1)) & 7u) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)((_a2 >> 2) & 7u) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)((_a2 >> 5) & 7u) + zp_h; \
+        } while (0)
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dpa = dp + (kt + 0) * 6 + k_grp * 3;
+            const unsigned char* dpb = dp + (kt + 1) * 6 + k_grp * 3;
+            const unsigned char* dpc = dp + (kt + 2) * 6 + k_grp * 3;
+            const unsigned char* dpd = dp + (kt + 3) * 6 + k_grp * 3;
+
+            half8_t b_a = *(const half8_t*)(x_base + (kt + 0) * 16 + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(x_base + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + (kt + 3) * 16 + k_grp * 8);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int b0 = dpb[0], b1 = dpb[1], b2 = dpb[2];
+            unsigned int c0 = dpc[0], c1 = dpc[1], c2 = dpc[2];
+            unsigned int d0 = dpd[0], d1 = dpd[1], d2 = dpd[2];
+
+            half8_t a_reg;
+            UNPACK_CHUNK_DQ(a0, a1, a2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            UNPACK_CHUNK_DQ(b0, b1, b2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            UNPACK_CHUNK_DQ(c0, c1, c2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            UNPACK_CHUNK_DQ(d0, d1, d2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+        }
+    }
+    #undef UNPACK_CHUNK_DQ
+
+    const int out_col = batch_start + m_lane;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < gate_m) {
+                    Y = Y_gate;  proj_row = out_row;            out_stride = gate_m;
+                } else {
+                    Y = Y_up;    proj_row = out_row - gate_m;   out_stride = up_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_gate_up_hfq3g256_wmma.hip
+++ b/kernels/src/gemm_gate_up_hfq3g256_wmma.hip
@@ -1,0 +1,158 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 2-way fused HFQ3-G256 GEMM for the Qwen3.5 FFN
+// preamble (gate + up projections).  gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// Sister of `gemm_gate_up_hfq4g256_wmma.hip` — same WMMA shape and lane
+// decomposition; only the inner K-tile unpack differs (3-bit cross-byte
+// vs 4-bit nibble) and the per-group byte stride is 104 instead of 136.
+// See `gemm_qkvza_hfq3g256_wmma.hip` for the unpack derivation. Used for
+// MQ3 prefill via the dispatch wrapper that pre-rotates `x`.
+//
+// Grid: [ceil((gate_m + up_m)/16), ceil(N/16)].  Block: [32].  LDS: 0.
+// Each 16-row tile may straddle the gate/up boundary.  Per-thread output
+// routing resolves which Y pointer (Y_gate or Y_up) each row writes to.
+// Overwrite semantics (y = acc, not +=).
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_hfq3g256_wmma(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,        // [N x K], FP16
+    float*         __restrict__ Y_gate,    // [N x gate_m]
+    float*         __restrict__ Y_up,      // [N x up_m]
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_row = row_start + (tid & 15);
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate;
+        local_row = safe_row;
+    } else {
+        A = A_up;
+        local_row = safe_row - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 104;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + (tid & 15) < N)
+                           ? (batch_start + (tid & 15)) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            // === Tile A (kt) ===
+            const int k_off_a = kt * 16;
+            const unsigned char* dpa = dp + kt * 6;
+
+            // === Tile B (kt+1) — start loading early ===
+            const int k_off_b = (kt + 1) * 16;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+
+            half16_t b_a = *(const half16_t*)(x_base + k_off_a);
+            half16_t b_b = *(const half16_t*)(x_base + k_off_b);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0 = a0 & 7u;
+            unsigned int q1 = (a0 >> 3) & 7u;
+            unsigned int q2 = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3 = (a1 >> 1) & 7u;
+            unsigned int q4 = (a1 >> 4) & 7u;
+            unsigned int q5 = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6 = (a2 >> 2) & 7u;
+            unsigned int q7 = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0, q0);   DQ(1, q1);   DQ(2, q2);   DQ(3, q3);
+            DQ(4, q4);   DQ(5, q5);   DQ(6, q6);   DQ(7, q7);
+            DQ(8, q8);   DQ(9, q9);   DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0 = B0 & 7u;
+            unsigned int Q1 = (B0 >> 3) & 7u;
+            unsigned int Q2 = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3 = (B1 >> 1) & 7u;
+            unsigned int Q4 = (B1 >> 4) & 7u;
+            unsigned int Q5 = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6 = (B2 >> 2) & 7u;
+            unsigned int Q7 = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0, Q0);   DQ(1, Q1);   DQ(2, Q2);   DQ(3, Q3);
+            DQ(4, Q4);   DQ(5, Q5);   DQ(6, Q6);   DQ(7, Q7);
+            DQ(8, Q8);   DQ(9, Q9);   DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    // RDNA3 wave32 WMMA output: acc[j] = C[2*j + (tid>>4)][tid & 15].
+    const int out_col = batch_start + (tid & 15);
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < gate_m) {
+                    Y = Y_gate;  proj_row = out_row;            out_stride = gate_m;
+                } else {
+                    Y = Y_up;    proj_row = out_row - gate_m;   out_stride = up_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_hfq3g256_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_hfq3g256_residual_wmma.gfx12.hip
@@ -1,0 +1,96 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) variant of the MQ3 / HFQ3-G256 residual WMMA kernel
+// (`Y += A · X`). See `gemm_qkvza_hfq3g256_wmma.gfx12.hip` for the gfx12
+// K4-unroll + half8_t lane-split rationale; this is the simplest of the
+// MQ3 family — single weight matrix, single output Y with += semantics.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq3g256_residual_wmma_gfx12(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int safe_row = (row_start + m_lane < M) ? (row_start + m_lane) : (M - 1);
+    const int safe_batch = (batch_start + m_lane < batch_size) ? (batch_start + m_lane) : 0;
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 104;
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    #define UNPACK_CHUNK_DQ(b0, b1, b2)                          \
+        do {                                                      \
+            unsigned int _a0 = (b0), _a1 = (b1), _a2 = (b2);     \
+            a_reg[0] = sc_h * (_Float16)(float)(_a0 & 7u) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)((_a0 >> 3) & 7u) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((_a0 >> 6) | (_a1 << 2)) & 7u) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)((_a1 >> 1) & 7u) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)((_a1 >> 4) & 7u) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((_a1 >> 7) | (_a2 << 1)) & 7u) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)((_a2 >> 2) & 7u) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)((_a2 >> 5) & 7u) + zp_h; \
+        } while (0)
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg = x_base + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dpa = dp + (kt + 0) * 6 + k_grp * 3;
+            const unsigned char* dpb = dp + (kt + 1) * 6 + k_grp * 3;
+            const unsigned char* dpc = dp + (kt + 2) * 6 + k_grp * 3;
+            const unsigned char* dpd = dp + (kt + 3) * 6 + k_grp * 3;
+
+            half8_t b_a = *(const half8_t*)(xg + (kt + 0) * 16 + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(xg + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(xg + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(xg + (kt + 3) * 16 + k_grp * 8);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int b0 = dpb[0], b1 = dpb[1], b2 = dpb[2];
+            unsigned int c0 = dpc[0], c1 = dpc[1], c2 = dpc[2];
+            unsigned int d0 = dpd[0], d1 = dpd[1], d2 = dpd[2];
+
+            half8_t a_reg;
+            UNPACK_CHUNK_DQ(a0, a1, a2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            UNPACK_CHUNK_DQ(b0, b1, b2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            UNPACK_CHUNK_DQ(c0, c1, c2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            UNPACK_CHUNK_DQ(d0, d1, d2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+        }
+    }
+    #undef UNPACK_CHUNK_DQ
+
+    // gfx12 wave32 WMMA C-mapping: contiguous rows per lane-group.
+    const int out_col = batch_start + m_lane;
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] += acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_hfq3g256_residual_wmma.hip
+++ b/kernels/src/gemm_hfq3g256_residual_wmma.hip
@@ -1,0 +1,136 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched HFQ3-G256 GEMM with fused residual add.
+// gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// Sister of `gemm_hfq4g256_residual_wmma_k2.hip` — same WMMA shape and
+// lane decomposition; only the inner K-tile unpack differs (3-bit
+// cross-byte vs 4-bit nibble) and the per-group byte stride is 104
+// instead of 136. K2 unroll with software pipelining (mirrors the
+// production MQ4 _k2 variant; the base MQ4 _wmma variant has a
+// documented output-mapping bug — `wmma — base WMMA, output-mapping
+// bug — debug only` per dispatch.rs comment).
+//
+// Output convention (matches qkvza / gate_up): lane (tid & 15) covers
+// column (batch) tid&15, with 8 rows per lane via
+//   acc[j] = C[2*j + (tid>>4)][tid & 15].
+// Y += acc[j] (residual add — caller must initialize Y with the
+// residual stream before launching).
+//
+// Grid: [ceil(M/16), ceil(N/16)]. Block: [32]. LDS: 0.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq3g256_residual_wmma(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int safe_row = (row_start + (tid & 15) < M) ? (row_start + (tid & 15)) : (M - 1);
+    const int safe_batch = (batch_start + (tid & 15) < batch_size) ? (batch_start + (tid & 15)) : 0;
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 104;
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg = x_base + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            // === Tile A (kt) ===
+            const int k_off_a = kt * 16;
+            const unsigned char* dpa = dp + kt * 6;
+
+            // === Tile B (kt+1) — start loading early ===
+            const int k_off_b = (kt + 1) * 16;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+
+            half16_t b_a = *(const half16_t*)(xg + k_off_a);
+            half16_t b_b = *(const half16_t*)(xg + k_off_b);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0 = a0 & 7u;
+            unsigned int q1 = (a0 >> 3) & 7u;
+            unsigned int q2 = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3 = (a1 >> 1) & 7u;
+            unsigned int q4 = (a1 >> 4) & 7u;
+            unsigned int q5 = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6 = (a2 >> 2) & 7u;
+            unsigned int q7 = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_a;
+            #define DQ(i, q) a_a[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0, q0);   DQ(1, q1);   DQ(2, q2);   DQ(3, q3);
+            DQ(4, q4);   DQ(5, q5);   DQ(6, q6);   DQ(7, q7);
+            DQ(8, q8);   DQ(9, q9);   DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b_a, acc);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0 = B0 & 7u;
+            unsigned int Q1 = (B0 >> 3) & 7u;
+            unsigned int Q2 = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3 = (B1 >> 1) & 7u;
+            unsigned int Q4 = (B1 >> 4) & 7u;
+            unsigned int Q5 = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6 = (B2 >> 2) & 7u;
+            unsigned int Q7 = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0, Q0);   DQ(1, Q1);   DQ(2, Q2);   DQ(3, Q3);
+            DQ(4, Q4);   DQ(5, Q5);   DQ(6, Q6);   DQ(7, Q7);
+            DQ(8, Q8);   DQ(9, Q9);   DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b_b, acc);
+        }
+    }
+
+    // RDNA3 wave32 WMMA output: acc[j] = C[2*j + (tid>>4)][tid & 15].
+    const int out_col = batch_start + (tid & 15);
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] += acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_hfq3g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_hfq3g256_wmma.gfx12.hip
@@ -1,0 +1,126 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) variant of the 3-way fused MQ3 / HFQ3-G256 q+k+v WMMA
+// preamble (FA layer). See `gemm_qkvza_hfq3g256_wmma.gfx12.hip` for the
+// gfx12 K4-unroll + half8_t lane-split rationale; only the output routing
+// differs (3 weight matrices q/k/v vs 4 qkv/z/beta/alpha).
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_hfq3g256_wmma_gfx12(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_q,
+    float*         __restrict__ Y_k,
+    float*         __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 104;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    #define UNPACK_CHUNK_DQ(b0, b1, b2)                          \
+        do {                                                      \
+            unsigned int _a0 = (b0), _a1 = (b1), _a2 = (b2);     \
+            a_reg[0] = sc_h * (_Float16)(float)(_a0 & 7u) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)((_a0 >> 3) & 7u) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((_a0 >> 6) | (_a1 << 2)) & 7u) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)((_a1 >> 1) & 7u) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)((_a1 >> 4) & 7u) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((_a1 >> 7) | (_a2 << 1)) & 7u) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)((_a2 >> 2) & 7u) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)((_a2 >> 5) & 7u) + zp_h; \
+        } while (0)
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dpa = dp + (kt + 0) * 6 + k_grp * 3;
+            const unsigned char* dpb = dp + (kt + 1) * 6 + k_grp * 3;
+            const unsigned char* dpc = dp + (kt + 2) * 6 + k_grp * 3;
+            const unsigned char* dpd = dp + (kt + 3) * 6 + k_grp * 3;
+
+            half8_t b_a = *(const half8_t*)(x_base + (kt + 0) * 16 + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(x_base + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + (kt + 3) * 16 + k_grp * 8);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int b0 = dpb[0], b1 = dpb[1], b2 = dpb[2];
+            unsigned int c0 = dpc[0], c1 = dpc[1], c2 = dpc[2];
+            unsigned int d0 = dpd[0], d1 = dpd[1], d2 = dpd[2];
+
+            half8_t a_reg;
+            UNPACK_CHUNK_DQ(a0, a1, a2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            UNPACK_CHUNK_DQ(b0, b1, b2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            UNPACK_CHUNK_DQ(c0, c1, c2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            UNPACK_CHUNK_DQ(d0, d1, d2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+        }
+    }
+    #undef UNPACK_CHUNK_DQ
+
+    const int out_col = batch_start + m_lane;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < q_m) {
+                    Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                } else if (out_row < q_m + k_m) {
+                    Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                } else {
+                    Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_hfq3g256_wmma.hip
+++ b/kernels/src/gemm_qkv_hfq3g256_wmma.hip
@@ -1,0 +1,157 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 3-way fused HFQ3-G256 GEMM for the Qwen3.5
+// FullAttention preamble (Q + K + V projections).
+// gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// Sister of `gemm_qkv_hfq4g256_wmma.hip` — same WMMA shape and lane
+// decomposition; only the inner K-tile unpack differs (3-bit cross-byte
+// vs 4-bit nibble) and the per-group byte stride is 104 instead of 136.
+// See `gemm_qkvza_hfq3g256_wmma.hip` for the unpack derivation.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_hfq3g256_wmma(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,      // [N x K], FP16
+    float*         __restrict__ Y_q,     // [N x q_m]
+    float*         __restrict__ Y_k,     // [N x k_m]
+    float*         __restrict__ Y_v,     // [N x v_m]
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_row = row_start + (tid & 15);
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 104;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + (tid & 15) < N)
+                           ? (batch_start + (tid & 15)) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            // === Tile A (kt) ===
+            const int k_off_a = kt * 16;
+            const unsigned char* dpa = dp + kt * 6;
+
+            // === Tile B (kt+1) — start loading early ===
+            const int k_off_b = (kt + 1) * 16;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+
+            half16_t b_a = *(const half16_t*)(x_base + k_off_a);
+            half16_t b_b = *(const half16_t*)(x_base + k_off_b);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0 = a0 & 7u;
+            unsigned int q1 = (a0 >> 3) & 7u;
+            unsigned int q2 = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3 = (a1 >> 1) & 7u;
+            unsigned int q4 = (a1 >> 4) & 7u;
+            unsigned int q5 = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6 = (a2 >> 2) & 7u;
+            unsigned int q7 = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0, q0);   DQ(1, q1);   DQ(2, q2);   DQ(3, q3);
+            DQ(4, q4);   DQ(5, q5);   DQ(6, q6);   DQ(7, q7);
+            DQ(8, q8);   DQ(9, q9);   DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0 = B0 & 7u;
+            unsigned int Q1 = (B0 >> 3) & 7u;
+            unsigned int Q2 = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3 = (B1 >> 1) & 7u;
+            unsigned int Q4 = (B1 >> 4) & 7u;
+            unsigned int Q5 = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6 = (B2 >> 2) & 7u;
+            unsigned int Q7 = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0, Q0);   DQ(1, Q1);   DQ(2, Q2);   DQ(3, Q3);
+            DQ(4, Q4);   DQ(5, Q5);   DQ(6, Q6);   DQ(7, Q7);
+            DQ(8, Q8);   DQ(9, Q9);   DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    const int out_col = batch_start + (tid & 15);
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < q_m) {
+                    Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                } else if (out_row < q_m + k_m) {
+                    Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                } else {
+                    Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_hfq3g256_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_hfq3g256_wmma.gfx12.hip
@@ -1,0 +1,154 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) variant of the MQ3 / HFQ3-G256 4-way fused qkvza WMMA
+// preamble. Port of:
+//   - gemm_qkvza_hfq3g256_wmma.hip (gfx11 MQ3 — 3-bit cross-byte unpack)
+//   - gemm_qkvza_hfq4g256_wmma.gfx12.hip (gfx12 MQ4 K4 + half8_t pattern)
+//
+// gfx12-specific changes vs the gfx11 MQ3 source:
+//   1. _w32 → _w32_gfx12 builtin
+//   2. half16_t A/B → half8_t (each lane carries 8 of 16 K values)
+//   3. K-split via tid >> 4 (k_grp picks which 8 of 16 K values)
+//   4. C-output mapping: contiguous rows per lane-group:
+//        acc[j] = C[8 * (tid >> 4) + j][tid & 15]
+//   5. K4 unroll: 4 K-tiles per body, all loads up-front
+//
+// MQ3 storage layout (per 256-element group, 104 B total):
+//   [0..8]   fp32 scale + fp32 zero
+//   [8..104] 96 B of packed 3-bit weights, 32 chunks of 8 weights × 3 B
+//
+// For gfx12 each lane reads ONE chunk (8 weights = 3 bytes) per K-tile
+// vs 2 chunks (16 weights = 6 bytes) on gfx11. K-tile kt + lane-group
+// k_grp covers chunk (2*kt + k_grp), at byte offset 8 + kt*6 + k_grp*3.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_hfq3g256_wmma_gfx12(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 104;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    // Unpack 8 × 3-bit weights from a 3-byte chunk (a0,a1,a2) into a_reg.
+    // Cross-byte pattern matches kernels/src/gemv_hfq3g256.hip:36-43.
+    #define UNPACK_CHUNK_DQ(b0, b1, b2)                          \
+        do {                                                      \
+            unsigned int _a0 = (b0), _a1 = (b1), _a2 = (b2);     \
+            a_reg[0] = sc_h * (_Float16)(float)(_a0 & 7u) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)((_a0 >> 3) & 7u) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((_a0 >> 6) | (_a1 << 2)) & 7u) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)((_a1 >> 1) & 7u) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)((_a1 >> 4) & 7u) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((_a1 >> 7) | (_a2 << 1)) & 7u) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)((_a2 >> 2) & 7u) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)((_a2 >> 5) & 7u) + zp_h; \
+        } while (0)
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        // K4 unroll: 4 K-tiles per body. Each lane owns 1 chunk per K-tile
+        // (3 bytes), at offset kt*6 + k_grp*3 within the data section.
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dpa = dp + (kt + 0) * 6 + k_grp * 3;
+            const unsigned char* dpb = dp + (kt + 1) * 6 + k_grp * 3;
+            const unsigned char* dpc = dp + (kt + 2) * 6 + k_grp * 3;
+            const unsigned char* dpd = dp + (kt + 3) * 6 + k_grp * 3;
+
+            // Load X tiles up-front (each lane reads 8 fp16 = 16 bytes per K-tile).
+            half8_t b_a = *(const half8_t*)(x_base + (kt + 0) * 16 + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(x_base + (kt + 1) * 16 + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(x_base + (kt + 2) * 16 + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(x_base + (kt + 3) * 16 + k_grp * 8);
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int b0 = dpb[0], b1 = dpb[1], b2 = dpb[2];
+            unsigned int c0 = dpc[0], c1 = dpc[1], c2 = dpc[2];
+            unsigned int d0 = dpd[0], d1 = dpd[1], d2 = dpd[2];
+
+            half8_t a_reg;
+            UNPACK_CHUNK_DQ(a0, a1, a2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            UNPACK_CHUNK_DQ(b0, b1, b2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            UNPACK_CHUNK_DQ(c0, c1, c2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            UNPACK_CHUNK_DQ(d0, d1, d2);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+        }
+    }
+    #undef UNPACK_CHUNK_DQ
+
+    // gfx12 wave32 WMMA C-mapping: contiguous rows per lane-group.
+    const int out_col = batch_start + m_lane;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < qkv_m) {
+                    Y = Y_qkv;   proj_row = out_row;                            out_stride = qkv_m;
+                } else if (out_row < qkv_m + z_m) {
+                    Y = Y_z;     proj_row = out_row - qkv_m;                    out_stride = z_m;
+                } else if (out_row < qkv_m + z_m + beta_m) {
+                    Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);            out_stride = beta_m;
+                } else {
+                    Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m);   out_stride = alpha_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_hfq3g256_wmma.hip
+++ b/kernels/src/gemm_qkvza_hfq3g256_wmma.hip
@@ -1,0 +1,209 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 4-way fused HFQ3-G256 GEMM for the Qwen3.5/3.6
+// DeltaNet LA preamble (qkv + z + beta + alpha projections).
+// gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// K2 variant: 2x K-tile unroll with software pipelining. Same shape as
+// gemm_qkvza_hfq4g256_wmma.hip — only the inner unpack differs:
+//   HFQ4: 16 weights = 8 bytes,  4-bit nibble unpack (`(pk >> n*4) & 0xF`)
+//   HFQ3: 16 weights = 6 bytes,  3-bit cross-byte unpack (matches the
+//                                 pattern in gemv_hfq3g256.hip)
+//
+// Storage layout (per 256-element group):
+//   [0..4]   fp32 scale (bit-cast from fp16)
+//   [4..8]   fp32 zero  (bit-cast from fp16)
+//   [8..104] 96 bytes of packed 3-bit weights
+// Total: 104 bytes / group (vs 136 for HFQ4).
+//
+// Within the data section, weights are packed in 32 chunks of 8-weight ×
+// 3-byte triplets:
+//   chunk c covers weights [c*8 .. c*8+8], stored at byte offset 8 + c*3.
+//   Within a chunk: q0 in b0[0..3], q1 in b0[3..6], q2 spans b0[6..8]+b1[0..1],
+//                   q3 in b1[1..4], q4 in b1[4..7], q5 spans b1[7]+b2[0..2],
+//                   q6 in b2[2..5], q7 in b2[5..8].
+// (Same packing as `quantize_mq3g256` in hipfire-quantize/src/main.rs.)
+//
+// For the WMMA K-tile (16 weights at K-offset `kt*16` within a group), we
+// read 2 consecutive chunks = bytes [kt*6 .. kt*6+6] of the data section.
+//
+// MQ3 use: caller pre-rotates X via mq_rotate_x; the kernel itself is
+// dtype-agnostic to whether weights came from HFQ3 (raw) or MQ3 (FWHT-
+// rotated at quantize-time). Same pattern as MQ4 reusing gemm_*_hfq4g256.
+//
+// Grid: [ceil((qkv_m + z_m + beta_m + alpha_m)/16), ceil(N/16)].
+// Block: [32].  LDS: 0.
+// Each 16-row tile may straddle projection boundaries. Per-thread output
+// routing resolves which Y pointer each row writes to.
+// Overwrite semantics (y = acc, not +=).
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_hfq3g256_wmma(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,         // [N x K], FP16
+    float*         __restrict__ Y_qkv,      // [N x qkv_m]
+    float*         __restrict__ Y_z,        // [N x z_m]
+    float*         __restrict__ Y_beta,     // [N x beta_m]
+    float*         __restrict__ Y_alpha,    // [N x alpha_m]
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    // Each thread owns one row in the 16-row tile (tid & 15).
+    const int my_row = row_start + (tid & 15);
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    // Route to the correct weight matrix for this thread's row.
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 104;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + (tid & 15) < N)
+                           ? (batch_start + (tid & 15)) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        // 16 weights per K-tile, 2 chunks of 8 weights, 3 bytes per chunk.
+        // Each chunk produces q0..q7 by the cross-byte pattern below; the
+        // tile's 16 a_reg values come from concatenating two chunks.
+        //
+        // K2 unroll: process 2 K-tiles per loop body. For 16 K-tiles
+        // covering K=256, that's 8 iterations.
+        for (int kt = 0; kt < 16; kt += 2) {
+            // === Tile A (kt) ===
+            const int k_off_a = kt * 16;
+            const unsigned char* dpa = dp + kt * 6;     // 6 bytes per K-tile
+
+            // === Tile B (kt+1) — start loading early ===
+            const int k_off_b = (kt + 1) * 16;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+
+            // Load both X tiles early (consecutive addresses — prefetcher-friendly)
+            half16_t b_a = *(const half16_t*)(x_base + k_off_a);
+            half16_t b_b = *(const half16_t*)(x_base + k_off_b);
+
+            // 6 bytes for tile A = 2 chunks of 3 bytes (a0..a2 / a3..a5)
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            // Chunk 1 (weights 0..7): same unpack as gemv_hfq3g256.hip:36-43
+            unsigned int q0 = a0 & 7u;
+            unsigned int q1 = (a0 >> 3) & 7u;
+            unsigned int q2 = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3 = (a1 >> 1) & 7u;
+            unsigned int q4 = (a1 >> 4) & 7u;
+            unsigned int q5 = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6 = (a2 >> 2) & 7u;
+            unsigned int q7 = (a2 >> 5) & 7u;
+            // Chunk 2 (weights 8..15)
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0, q0);   DQ(1, q1);   DQ(2, q2);   DQ(3, q3);
+            DQ(4, q4);   DQ(5, q5);   DQ(6, q6);   DQ(7, q7);
+            DQ(8, q8);   DQ(9, q9);   DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            // WMMA A — b_b load may still be in flight
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            // === Tile B unpack (reuse a_reg register) ===
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0 = B0 & 7u;
+            unsigned int Q1 = (B0 >> 3) & 7u;
+            unsigned int Q2 = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3 = (B1 >> 1) & 7u;
+            unsigned int Q4 = (B1 >> 4) & 7u;
+            unsigned int Q5 = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6 = (B2 >> 2) & 7u;
+            unsigned int Q7 = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0, Q0);   DQ(1, Q1);   DQ(2, Q2);   DQ(3, Q3);
+            DQ(4, Q4);   DQ(5, Q5);   DQ(6, Q6);   DQ(7, Q7);
+            DQ(8, Q8);   DQ(9, Q9);   DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            // WMMA B
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    // --- Output ---
+    // RDNA3 wave32 WMMA output: acc[j] = C[2*j + (tid>>4)][tid & 15].
+    // A operand = weight rows (m-dim), B operand = batch X cols (n-dim).
+    const int out_col = batch_start + (tid & 15);  // batch index
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < qkv_m) {
+                    Y = Y_qkv;   proj_row = out_row;                            out_stride = qkv_m;
+                } else if (out_row < qkv_m + z_m) {
+                    Y = Y_z;     proj_row = out_row - qkv_m;                    out_stride = z_m;
+                } else if (out_row < qkv_m + z_m + beta_m) {
+                    Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);            out_stride = beta_m;
+                } else {
+                    Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m);   out_stride = alpha_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemv_hfq3g256.gfx1100.hip
+++ b/kernels/src/gemv_hfq3g256.gfx1100.hip
@@ -1,0 +1,127 @@
+#include <hip/hip_runtime.h>
+
+// gfx1100 (RDNA3) HFQ3-G256 GEMV: 4x group unroll, packed uint24 unpack.
+// launch_bounds(32, 16) — matches MQ4 (RDNA3 has 16 waves/SIMD max).
+// Mirrors gemv_hfq4g256.gfx1100.hip; closes the MQ3 decode gap by giving
+// MQ3 the same 4-accumulator ILP that MQ4 already has on this arch.
+//
+// Per group (104 B): 8 B header (fp32 scale + fp32 zero) + 96 B data.
+// 32 threads × 8 weights/group = 256 weights. Each thread owns 3 bytes
+// of packed 3-bit weights at byte_off = tid * 3.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfq3g256(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 104;
+    const int boff = tid * 3;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 104;
+        const char* gp1 = gp0 + 104;
+        const char* gp2 = gp1 + 104;
+        const char* gp3 = gp2 + 104;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        const unsigned char* d0 = (const unsigned char*)(gp0 + 8) + boff;
+        const unsigned char* d1 = (const unsigned char*)(gp1 + 8) + boff;
+        const unsigned char* d2 = (const unsigned char*)(gp2 + 8) + boff;
+        const unsigned char* d3 = (const unsigned char*)(gp3 + 8) + boff;
+
+        unsigned int pk0 = (unsigned int)d0[0] | ((unsigned int)d0[1] << 8) | ((unsigned int)d0[2] << 16);
+        unsigned int pk1 = (unsigned int)d1[0] | ((unsigned int)d1[1] << 8) | ((unsigned int)d1[2] << 16);
+        unsigned int pk2 = (unsigned int)d2[0] | ((unsigned int)d2[1] << 8) | ((unsigned int)d2[2] << 16);
+        unsigned int pk3 = (unsigned int)d3[0] | ((unsigned int)d3[1] << 8) | ((unsigned int)d3[2] << 16);
+
+        int base = g * 256 + tid * 8;
+
+        #define DOG3(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+        DOG3(pk0, sc0, zp0, base, acc0);
+        DOG3(pk1, sc1, zp1, base + 256, acc1);
+        DOG3(pk2, sc2, zp2, base + 512, acc2);
+        DOG3(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG3
+    }
+
+    // Tail groups must accumulate into their own accumulator (acc[g % 4]) —
+    // see gemv_hfq4g256.gfx1100.hip for the full bug explanation. Single
+    // accumulator drift breaks coherence on long generations when
+    // groups_per_row isn't a multiple of 4.
+    #define TAIL_DOG3(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG3
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] = acc;
+}

--- a/kernels/src/gemv_hfq3g256.hip
+++ b/kernels/src/gemv_hfq3g256.hip
@@ -1,6 +1,27 @@
 #include <hip/hip_runtime.h>
 
-__launch_bounds__(32, 20)
+// HFQ3-G256 GEMV: default (arch-agnostic) kernel.
+//
+// Ported from gemv_hfq3g256.gfx1100.hip in order to produce BYTE-EXACT
+// results with the RDNA3 variant — same rationale as the MQ4 default
+// re-port (see gemv_hfq4g256.hip header). Before this port, the default
+// kernel used single-accumulator sequential summation:
+//     acc = (((0 + g0) + g1) + g2) + ...
+// while the gfx1100 variant uses a 4-accumulator interleaved pattern:
+//     acc0,1,2,3 = running sums over groups {g mod 4 == 0,1,2,3}
+//     acc = (acc0 + acc1) + (acc2 + acc3)
+//
+// FP addition is non-associative, so non-RDNA3 archs (gfx1010, gfx1013
+// Cyan Skillfish, gfx1030/1031 RDNA2, gfx906 Vega 20, gfx9xx CDNA, gfx12)
+// drift from the rdna3 ordering. Once the residual variant adopts the
+// 4-accumulator combine, the non-residual default has to follow or the
+// fused y[row] += A·x kernel returns numerically different bytes than
+// the non-residual gemv + add_inplace_f32 reference path on those archs.
+//
+// Launch bounds set to (32, 16) to match the gfx1100 variant's register
+// budget for the four extra accumulators.
+
+__launch_bounds__(32, 16)
 extern "C" __global__ void gemv_hfq3g256(
     const char* __restrict__ A,
     const float* __restrict__ x,
@@ -12,46 +33,104 @@ extern "C" __global__ void gemv_hfq3g256(
     const int tid = threadIdx.x;
 
     const int groups_per_row = K / 256;
-    const int row_bytes = groups_per_row * 104;
-    const char* row_ptr = A + (long long)row * row_bytes;
+    const char* row_ptr = A + (long long)row * groups_per_row * 104;
+    const int boff = tid * 3;
 
-    float acc = 0.0f;
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
 
-    for (int g = 0; g < groups_per_row; g++) {
-        const char* gptr = row_ptr + g * 104;
-        float scale = __builtin_bit_cast(float, *(const unsigned int*)(gptr));
-        float zero  = __builtin_bit_cast(float, *(const unsigned int*)(gptr + 4));
-        const unsigned char* data = (const unsigned char*)(gptr + 8);
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 104;
+        const char* gp1 = gp0 + 104;
+        const char* gp2 = gp1 + 104;
+        const char* gp3 = gp2 + 104;
 
-        // 256 weights / 32 threads = 8 weights per thread
-        // 8 weights × 3 bits = 24 bits = 3 bytes per thread
-        int base_idx = g * 256 + tid * 8;
-        int byte_off = tid * 3;
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
 
-        unsigned char b0 = data[byte_off];
-        unsigned char b1 = data[byte_off + 1];
-        unsigned char b2 = data[byte_off + 2];
+        const unsigned char* d0 = (const unsigned char*)(gp0 + 8) + boff;
+        const unsigned char* d1 = (const unsigned char*)(gp1 + 8) + boff;
+        const unsigned char* d2 = (const unsigned char*)(gp2 + 8) + boff;
+        const unsigned char* d3 = (const unsigned char*)(gp3 + 8) + boff;
 
-        // Unpack 8 × 3-bit from 24 bits
-        int q0 = b0 & 7;
-        int q1 = (b0 >> 3) & 7;
-        int q2 = ((b0 >> 6) | (b1 << 2)) & 7;
-        int q3 = (b1 >> 1) & 7;
-        int q4 = (b1 >> 4) & 7;
-        int q5 = ((b1 >> 7) | (b2 << 1)) & 7;
-        int q6 = (b2 >> 2) & 7;
-        int q7 = (b2 >> 5) & 7;
+        unsigned int pk0 = (unsigned int)d0[0] | ((unsigned int)d0[1] << 8) | ((unsigned int)d0[2] << 16);
+        unsigned int pk1 = (unsigned int)d1[0] | ((unsigned int)d1[1] << 8) | ((unsigned int)d1[2] << 16);
+        unsigned int pk2 = (unsigned int)d2[0] | ((unsigned int)d2[1] << 8) | ((unsigned int)d2[2] << 16);
+        unsigned int pk3 = (unsigned int)d3[0] | ((unsigned int)d3[1] << 8) | ((unsigned int)d3[2] << 16);
 
-        acc += (scale * (float)q0 + zero) * x[base_idx]
-             + (scale * (float)q1 + zero) * x[base_idx + 1]
-             + (scale * (float)q2 + zero) * x[base_idx + 2]
-             + (scale * (float)q3 + zero) * x[base_idx + 3]
-             + (scale * (float)q4 + zero) * x[base_idx + 4]
-             + (scale * (float)q5 + zero) * x[base_idx + 5]
-             + (scale * (float)q6 + zero) * x[base_idx + 6]
-             + (scale * (float)q7 + zero) * x[base_idx + 7];
+        int base = g * 256 + tid * 8;
+
+        #define DOG3(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+        DOG3(pk0, sc0, zp0, base, acc0);
+        DOG3(pk1, sc1, zp1, base + 256, acc1);
+        DOG3(pk2, sc2, zp2, base + 512, acc2);
+        DOG3(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG3
     }
 
+    // Tail groups must accumulate into acc[g % 4] to preserve the
+    // 4-way interleaving — see gemv_hfq4g256.gfx1100.hip for the bug
+    // explanation that motivated this invariant.
+    #define TAIL_DOG3(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG3
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 

--- a/kernels/src/gemv_hfq3g256_residual.gfx1100.hip
+++ b/kernels/src/gemv_hfq3g256_residual.gfx1100.hip
@@ -1,0 +1,120 @@
+#include <hip/hip_runtime.h>
+
+// gfx1100 (RDNA3) HFQ3-G256 GEMV with fused residual add: y[row] += A[row] · x.
+// Same 4x group unroll as gemv_hfq3g256.gfx1100.hip — only the final write
+// differs (+= instead of =). Used for wo and w_down in the Qwen3.5 forward
+// path to eliminate the alloc+gemv+add+free sequence in the MQ3 fallback
+// branch of weight_gemv_residual.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfq3g256_residual(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 104;
+    const int boff = tid * 3;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 104;
+        const char* gp1 = gp0 + 104;
+        const char* gp2 = gp1 + 104;
+        const char* gp3 = gp2 + 104;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        const unsigned char* d0 = (const unsigned char*)(gp0 + 8) + boff;
+        const unsigned char* d1 = (const unsigned char*)(gp1 + 8) + boff;
+        const unsigned char* d2 = (const unsigned char*)(gp2 + 8) + boff;
+        const unsigned char* d3 = (const unsigned char*)(gp3 + 8) + boff;
+
+        unsigned int pk0 = (unsigned int)d0[0] | ((unsigned int)d0[1] << 8) | ((unsigned int)d0[2] << 16);
+        unsigned int pk1 = (unsigned int)d1[0] | ((unsigned int)d1[1] << 8) | ((unsigned int)d1[2] << 16);
+        unsigned int pk2 = (unsigned int)d2[0] | ((unsigned int)d2[1] << 8) | ((unsigned int)d2[2] << 16);
+        unsigned int pk3 = (unsigned int)d3[0] | ((unsigned int)d3[1] << 8) | ((unsigned int)d3[2] << 16);
+
+        int base = g * 256 + tid * 8;
+
+        #define DOG3(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+        DOG3(pk0, sc0, zp0, base, acc0);
+        DOG3(pk1, sc1, zp1, base + 256, acc1);
+        DOG3(pk2, sc2, zp2, base + 512, acc2);
+        DOG3(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG3
+    }
+
+    #define TAIL_DOG3(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG3
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] += acc;   // fused residual add
+}

--- a/kernels/src/gemv_hfq3g256_residual.hip
+++ b/kernels/src/gemv_hfq3g256_residual.hip
@@ -1,0 +1,125 @@
+#include <hip/hip_runtime.h>
+
+// HFQ3-G256 GEMV with fused residual add: y[row] += A[row] · x.
+// Default (arch-agnostic) kernel matching the 4-accumulator pairwise-combine
+// ordering of gemv_hfq3g256.gfx1100.hip so that cross-arch byte-exactness is
+// preserved against MQ3 quality-gate baselines.
+//
+// Identical math to gemv_hfq3g256 (single-row per warp, 32 threads × 8 weights
+// per group, packed uint24 unpack of 8×3 bits) except the final write
+// accumulates into y instead of overwriting. Used for wo and w_down
+// projections in the Qwen3.5 forward path to eliminate the alloc+gemv+add
+// fallback in the MQ3 arm of weight_gemv_residual.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfq3g256_residual(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 104;
+    const int boff = tid * 3;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 104;
+        const char* gp1 = gp0 + 104;
+        const char* gp2 = gp1 + 104;
+        const char* gp3 = gp2 + 104;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        const unsigned char* d0 = (const unsigned char*)(gp0 + 8) + boff;
+        const unsigned char* d1 = (const unsigned char*)(gp1 + 8) + boff;
+        const unsigned char* d2 = (const unsigned char*)(gp2 + 8) + boff;
+        const unsigned char* d3 = (const unsigned char*)(gp3 + 8) + boff;
+
+        unsigned int pk0 = (unsigned int)d0[0] | ((unsigned int)d0[1] << 8) | ((unsigned int)d0[2] << 16);
+        unsigned int pk1 = (unsigned int)d1[0] | ((unsigned int)d1[1] << 8) | ((unsigned int)d1[2] << 16);
+        unsigned int pk2 = (unsigned int)d2[0] | ((unsigned int)d2[1] << 8) | ((unsigned int)d2[2] << 16);
+        unsigned int pk3 = (unsigned int)d3[0] | ((unsigned int)d3[1] << 8) | ((unsigned int)d3[2] << 16);
+
+        int base = g * 256 + tid * 8;
+
+        #define DOG3(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+        DOG3(pk0, sc0, zp0, base, acc0);
+        DOG3(pk1, sc1, zp1, base + 256, acc1);
+        DOG3(pk2, sc2, zp2, base + 512, acc2);
+        DOG3(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG3
+    }
+
+    #define TAIL_DOG3(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 7u)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >> 3) & 7u)  + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >> 6) & 7u)  + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 9) & 7u)  + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 12) & 7u) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 15) & 7u) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 18) & 7u) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 21) & 7u) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 104;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8) + boff;
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8) | ((unsigned int)d[2] << 16);
+        int base = g * 256 + tid * 8;
+        TAIL_DOG3(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG3
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] += acc;   // fused residual add
+}

--- a/kernels/src/gemv_mq2g256_lloyd.hip
+++ b/kernels/src/gemv_mq2g256_lloyd.hip
@@ -1,0 +1,71 @@
+// MagnumQuant 2-bit GEMV with per-block 4-entry fp16 Lloyd-Max codebook.
+//
+// Block layout (72 B/group, bandwidth-identical to uniform MQ2):
+//   bytes [0..8)   : 4 × fp16 codebook entries (sorted ascending at quant-time)
+//   bytes [8..72)  : 64 bytes packed 2-bit indices (4 per byte, little-endian within byte)
+//
+// Per-thread work: 8 weights / thread × 32 threads = 256 weights / block — same
+// schedule as gemv_hfq2g256.hip. Reconstruction is `cb[q]` — direct lookup into
+// the per-block fp16 codebook, NOT `scale*q + zero`. This rescues sub-9B
+// quality where uniform 4-level codebooks collapse on heavy-tailed weight
+// distributions.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+__launch_bounds__(32, 20)
+extern "C" __global__ void gemv_mq2g256_lloyd(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 72;
+    const char* row_ptr = A + (long long)row * row_bytes;
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gptr = row_ptr + g * 72;
+
+        // Load 4 fp16 codebook entries → 4 floats (kept in registers).
+        const __half* cb_h = reinterpret_cast<const __half*>(gptr);
+        float cb0 = __half2float(cb_h[0]);
+        float cb1 = __half2float(cb_h[1]);
+        float cb2 = __half2float(cb_h[2]);
+        float cb3 = __half2float(cb_h[3]);
+
+        const unsigned char* data = (const unsigned char*)(gptr + 8);
+
+        int base_idx = g * 256 + tid * 8;
+        int byte_off = tid * 2;
+
+        unsigned char b0 = data[byte_off];
+        unsigned char b1 = data[byte_off + 1];
+
+        // Branchless 2-bit codebook lookup via inline switch on q ∈ {0,1,2,3}.
+        // Compiler emits a register-resident jump table; no global memory hit.
+        #define CB_LOOKUP(q) ((q) == 0 ? cb0 : ((q) == 1 ? cb1 : ((q) == 2 ? cb2 : cb3)))
+
+        acc += CB_LOOKUP(b0 & 3)        * x[base_idx]
+             + CB_LOOKUP((b0 >> 2) & 3) * x[base_idx + 1]
+             + CB_LOOKUP((b0 >> 4) & 3) * x[base_idx + 2]
+             + CB_LOOKUP(b0 >> 6)       * x[base_idx + 3]
+             + CB_LOOKUP(b1 & 3)        * x[base_idx + 4]
+             + CB_LOOKUP((b1 >> 2) & 3) * x[base_idx + 5]
+             + CB_LOOKUP((b1 >> 4) & 3) * x[base_idx + 6]
+             + CB_LOOKUP(b1 >> 6)       * x[base_idx + 7];
+
+        #undef CB_LOOKUP
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] = acc;
+}

--- a/kernels/src/gemv_mq3g256_lloyd.hip
+++ b/kernels/src/gemv_mq3g256_lloyd.hip
@@ -1,0 +1,89 @@
+// MagnumQuant 3-bit GEMV with per-block 8-entry fp16 Lloyd-Max codebook.
+//
+// Block layout (112 B/group, +7.7% bandwidth over uniform MQ3's 104 B):
+//   bytes [0..16)  : 8 × fp16 codebook entries (sorted ascending at quant-time)
+//   bytes [16..112): 96 bytes packed 3-bit indices, same cross-byte layout as
+//                    uniform HFQ3-G256 (32 chunks × 3 bytes × 8 weights)
+//
+// Per-thread work: 8 weights / thread × 32 threads = 256 weights / block.
+// Reconstruction is `cb[q]` — register-resident codebook lookup, no scale/zero.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_mq3g256_lloyd(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 112;
+    const int boff = tid * 3;
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gptr = row_ptr + g * 112;
+
+        // Load 8 fp16 codebook entries → 8 floats (register resident).
+        const __half* cb_h = reinterpret_cast<const __half*>(gptr);
+        float cb0 = __half2float(cb_h[0]);
+        float cb1 = __half2float(cb_h[1]);
+        float cb2 = __half2float(cb_h[2]);
+        float cb3 = __half2float(cb_h[3]);
+        float cb4 = __half2float(cb_h[4]);
+        float cb5 = __half2float(cb_h[5]);
+        float cb6 = __half2float(cb_h[6]);
+        float cb7 = __half2float(cb_h[7]);
+
+        const unsigned char* data = (const unsigned char*)(gptr + 16);
+
+        // 8 × 3-bit cross-byte unpack (identical to uniform MQ3):
+        //   q0 = b0 & 7              q4 = (b1 >> 4) & 7
+        //   q1 = (b0 >> 3) & 7       q5 = ((b1 >> 7) | (b2 << 1)) & 7
+        //   q2 = ((b0 >> 6) | (b1 << 2)) & 7  q6 = (b2 >> 2) & 7
+        //   q3 = (b1 >> 1) & 7       q7 = (b2 >> 5) & 7
+        unsigned int pk = (unsigned int)data[boff]
+                        | ((unsigned int)data[boff + 1] << 8)
+                        | ((unsigned int)data[boff + 2] << 16);
+
+        unsigned int q0 = pk & 7u;
+        unsigned int q1 = (pk >> 3) & 7u;
+        unsigned int q2 = (pk >> 6) & 7u;
+        unsigned int q3 = (pk >> 9) & 7u;
+        unsigned int q4 = (pk >> 12) & 7u;
+        unsigned int q5 = (pk >> 15) & 7u;
+        unsigned int q6 = (pk >> 18) & 7u;
+        unsigned int q7 = (pk >> 21) & 7u;
+
+        int base_idx = g * 256 + tid * 8;
+
+        #define CB_LOOKUP3(q) (                                          \
+            (q) == 0 ? cb0 : (q) == 1 ? cb1 : (q) == 2 ? cb2 : (q) == 3  \
+            ? cb3 : (q) == 4 ? cb4 : (q) == 5 ? cb5 : (q) == 6 ? cb6     \
+            : cb7                                                         \
+        )
+
+        acc += CB_LOOKUP3(q0) * x[base_idx]
+             + CB_LOOKUP3(q1) * x[base_idx + 1]
+             + CB_LOOKUP3(q2) * x[base_idx + 2]
+             + CB_LOOKUP3(q3) * x[base_idx + 3]
+             + CB_LOOKUP3(q4) * x[base_idx + 4]
+             + CB_LOOKUP3(q5) * x[base_idx + 5]
+             + CB_LOOKUP3(q6) * x[base_idx + 6]
+             + CB_LOOKUP3(q7) * x[base_idx + 7];
+
+        #undef CB_LOOKUP3
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] = acc;
+}

--- a/scripts/coherence-gate.sh
+++ b/scripts/coherence-gate.sh
@@ -85,6 +85,12 @@ SHORT_TESTS=(
     "qwen3.5-4b.mq4|code|Write a one-line Python function named square that returns n*n.|180"
     "qwen3.5-9b.mq4|reason|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|300"
     "qwen3.5-9b.mq4|tool-call|What does the file /tmp/fibonacci.c contain?|180|tool_call_system.txt"
+    # MQ3 coverage (gfx11+gfx12 only — refused on other archs at load).
+    # Verifies WMMA prefill family + K4-unroll decode + fused residual all
+    # dispatch and stay coherent. Same prompts as the MQ4 rows so output
+    # drift between bit-widths is comparable.
+    "qwen3.5-9b.mq3|reason-mq3|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|300"
+    "qwen3.5-27b.mq3|cap-mq3-27b|What is the capital of France? Answer in one short sentence.|80"
 )
 FULL_EXTRA=(
     "qwen3.5-35b-a3b.mq4|moe-sheep|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|500"

--- a/scripts/mq3-mq2-sweep.sh
+++ b/scripts/mq3-mq2-sweep.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# MQ3/MQ2 sweep harness — drives the daemon binary against each MQ3/MQ2
+# model artifact and records coherence + perf for the validation pass.
+#
+# Same prompt set as coherence-gate.sh's short battery (Paris cap, Python
+# square, sheep reasoning) plus a longform DL-vs-ML prompt that exercises
+# multi-paragraph generation. Each row gets: VRAM peak (from done line),
+# decode tok/s + prefill tok/s (from done line), wall, panic flag, and
+# the full output text for human eyeball.
+#
+# Models that are not on disk are SKIPPED (quants may still be running);
+# re-run after the missing artifacts land.
+#
+# Output: ${HIPFIRE_SWEEP_OUT:-$HOME/.hipfire/mq3-tests/sweep-<ts>.md}
+#
+# Exit codes:
+#   0  battery ran clean — open the report
+#   1  any model hit a hard error (panic / zero tokens / timeout)
+#   2  build or environment error
+
+set -u
+cd "$(dirname "$0")/.."
+
+EXE="./target/release/examples/daemon"
+MODELS_DIR="${HIPFIRE_MODELS_DIR:-$HOME/.hipfire/models}"
+OUT="${HIPFIRE_SWEEP_OUT:-$HOME/.hipfire/mq3-tests/sweep-$(date +%Y%m%d-%H%M%S).md}"
+LOCK_SCRIPT="./scripts/gpu-lock.sh"
+
+if [ ! -x "$EXE" ]; then
+    echo "$EXE missing — run: cargo build --release --features deltanet --example daemon -p engine" >&2
+    exit 2
+fi
+
+if [ -r "$LOCK_SCRIPT" ]; then
+    # shellcheck disable=SC1090
+    . "$LOCK_SCRIPT"
+    gpu_acquire "mq3-mq2-sweep" || { echo "could not acquire GPU lock" >&2; exit 2; }
+    trap 'gpu_release 2>/dev/null || true' EXIT
+fi
+
+# Format: id|prompt|max_tokens
+PROMPTS=(
+    "cap|What is the capital of France? Answer in one short sentence.|80"
+    "code|Write a one-line Python function named square that returns n*n.|180"
+    "reason|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|300"
+    "longform|Explain the difference between deep learning and traditional machine learning in 3-4 sentences.|400"
+)
+
+# Override-able via $1; otherwise sweep the canonical set.
+if [ "$#" -gt 0 ]; then
+    MODELS=("$@")
+else
+    MODELS=(
+        "qwen3.5-0.8b.mq3"
+        "qwen3.5-0.8b.mq2"
+        "qwen3.5-4b.mq3"
+        "qwen3.5-4b.mq2"
+        "qwen3.5-9b.mq3"
+        "qwen3.5-9b.mq2"
+        "qwen3.5-27b.mq3"
+        "qwen3.6-27b.mq3"
+    )
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+{
+    echo "# MQ3/MQ2 sweep"
+    echo
+    echo "- commit: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    echo "- branch: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+    echo "- date:   $(date -Iseconds)"
+    echo "- models: ${#MODELS[@]}"
+    echo "- prompts/model: ${#PROMPTS[@]}"
+    echo
+    echo "Hard fail = panic OR zero tokens OR 240s timeout."
+    echo "Soft eyeball = read the **Output** block; flag attractor loops, off-topic, broken language."
+    echo
+} > "$OUT"
+
+hard_errors=0
+
+for model in "${MODELS[@]}"; do
+    p="$MODELS_DIR/$model"
+    if [ ! -f "$p" ]; then
+        {
+            echo "## $model — SKIPPED (model not present)"
+            echo
+        } >> "$OUT"
+        continue
+    fi
+    size=$(du -h "$p" | cut -f1)
+    md5=$(md5sum "$p" | cut -d' ' -f1)
+
+    {
+        echo "## $model"
+        echo
+        echo "- size: $size"
+        echo "- md5:  \`$md5\`"
+        echo
+    } >> "$OUT"
+
+    for prompt_entry in "${PROMPTS[@]}"; do
+        IFS='|' read -r pid prompt max_tok <<< "$prompt_entry"
+        echo "== $model / $pid =="
+
+        in_file="/tmp/sweep_in_$$.jsonl"
+        out_file="/tmp/sweep_out_$$.log"
+        prompt_json=$(python3 -c "import sys,json; print(json.dumps(sys.argv[1]))" "$prompt")
+
+        # max_seq=8192 to give 27B + 4096 generation budget headroom.
+        cat > "$in_file" <<JL
+{"type":"load","model":"$p","params":{"max_seq":8192}}
+{"type":"generate","id":"r1","prompt":${prompt_json},"temperature":0.0,"max_tokens":$max_tok,"repeat_penalty":1.05}
+{"type":"unload"}
+JL
+
+        t0=$(date +%s.%N)
+        timeout 300 "$EXE" < "$in_file" > "$out_file" 2>&1
+        ec=$?
+        t1=$(date +%s.%N)
+        wall=$(python3 -c "print(f'{$t1 - $t0:.1f}')")
+
+        done_line=$(grep -aE '"type":"done"' "$out_file" | head -1)
+        n_tokens=$(grep -ac '"type":"token"' "$out_file")
+        panic=$(grep -aE 'panicked|thread.*panicked|FATAL|^error: ' "$out_file" | head -3)
+        status="OK"
+        if [ "$ec" -ne 0 ] || [ "$n_tokens" -eq 0 ] || [ -n "$panic" ]; then
+            status="HARD_ERROR (exit=$ec tokens=$n_tokens panic=${panic:+yes})"
+            hard_errors=$((hard_errors + 1))
+        fi
+
+        {
+            echo "### $pid"
+            echo
+            echo "- wall: ${wall}s  status: **$status**"
+            if [ -n "$done_line" ]; then
+                echo "- stats: \`$done_line\`"
+            fi
+            echo "- prompt: \`$(printf '%s' "$prompt" | head -c 120)\`"
+            echo
+            if [ -n "$panic" ]; then
+                echo '**PANIC/ERROR DETECTED:**'
+                echo
+                echo '```'
+                echo "$panic"
+                echo '```'
+                echo
+            fi
+            echo '**Output:**'
+            echo
+            echo '```'
+            grep -a '"type":"token"' "$out_file" | python3 -c '
+import sys, json
+print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))' || true
+            echo '```'
+            echo
+        } >> "$OUT"
+
+        rm -f "$in_file" "$out_file"
+    done
+done
+
+{
+    echo "---"
+    echo
+    echo "## Summary"
+    echo
+    echo "- hard errors: $hard_errors"
+    echo "- report:      $OUT"
+} >> "$OUT"
+
+echo "sweep done — report: $OUT"
+echo "hard errors: $hard_errors"
+
+if [ "$hard_errors" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/speed-baselines/gfx1100.txt
+++ b/tests/speed-baselines/gfx1100.txt
@@ -26,6 +26,40 @@
 27b_mq4_gen_tok_s=46.5
 27b_mq4_pp128_prefill_tok_s=491.1
 
+# MQ3 baselines — captured 2026-04-30 against commit 8b35171 with MQ3
+# WMMA prefill family (qkvza/qkv/gate_up/residual hfq3) + K4-unrolled
+# decode kernels + fused residual decode wired in. Same shape as the MQ4
+# rows above. Decode beats MQ4 on every size (lower bandwidth at 104 vs
+# 136 B/group); prefill matches MQ4 within ±2% post-WMMA.
+# (HIPFIRE_GRAPH=0 due to known graph-capture issue; see master notes.)
+0.8b_mq3_pp32_prefill_tok_s=1912.7
+0.8b_mq3_gen_tok_s=360.4
+0.8b_mq3_pp128_prefill_tok_s=6937.0
+
+4b_mq3_pp32_prefill_tok_s=1110.1
+4b_mq3_gen_tok_s=169.0
+4b_mq3_pp128_prefill_tok_s=2164.2
+
+9b_mq3_pp32_prefill_tok_s=1006.3
+9b_mq3_gen_tok_s=136.6
+9b_mq3_pp128_prefill_tok_s=1562.2
+
+27b_mq3_pp32_prefill_tok_s=374.8
+27b_mq3_gen_tok_s=48.9
+27b_mq3_pp128_prefill_tok_s=505.0
+
+# Context-fit @ 24 GB (RX 7900 XTX, asym3 KV) — informational, not gated.
+# Headline: 27B MQ3 fits 128K context where MQ4 OOMs at ~115K. 9B MQ3 has
+# headroom for larger scratch buffers / DFlash + bigger drafts.
+#
+#   model     weights  max_ctx (asym3 KV, 24 GB)
+#    9B  MQ3   4.0 GiB  >=128K (loads cleanly)
+#    9B  MQ4   4.9 GiB  >=128K
+#    27B MQ3  10.7 GiB   128K  (loads cleanly)
+#    27B MQ4  13.4 GiB   ~98K  (OOMs at 112K boundary)
+# 27B MQ3 saves ~2.7 GiB on weights vs MQ4, which is the difference between
+# fitting 128K and OOMing.
+
 # DFlash 27B-3.5 LRU code anchor — DEPRECATED 2026-04-28
 # Originally added 2026-04-26 after PR #32 regressed DFlash by 40% on a
 # 27B prompt. The metric measures peak tok/s at max=120, which is


### PR DESCRIPTION
## What this is

Per-block N-entry fp16 codebook fitted via Lloyd's algorithm replaces uniform
`scale*q + zero` reconstruction on the FWHT-rotated MQ family.

- **MQ3-Lloyd (qt=20)**: 8 fp16 centroids + 96 B 3-bit indices = **112 B/group** (+7.7% over uniform MQ3's 104 B).
- **MQ2-Lloyd (qt=19)**: 4 fp16 centroids + 64 B 2-bit indices = **72 B/group** (bit-exact uniform MQ2).

## Why open this PR

**Quality result is real** but **decode perf gate isn't cleared**. Documenting
and posting for help to land the perf fix and finish coherence validation.
Branched off the current `fix/mq3-mq2-cli-guards` ship work to keep that
branch focused; this PR targets `master`.

## Empirical perplexity (gfx1100 7900 XTX, wikitext2-test, ctx=2048, 2039 tokens scored)

| size | MQ4 | uniform MQ3 | **MQ3-Lloyd** | Lloyd factor | vs MQ4 |
|------|---:|---:|---:|---:|---:|
| 0.8B | 25.65 | 301.06 | **155.22** | 1.94× | 6.05× |
| 4B   | 12.73 | 45.24  | **22.56**  | 2.01× | 1.77× |
| 9B   | 10.34 | 42.03  | **18.52**  | 2.27× | 1.79× |

9B Lloyd-MQ3 at 1.79× MQ4 is the closest sub-4-bit format hipfire has gotten
to MQ4 quality. Same algorithm wins ~2× across all model sizes.

MQ2-Lloyd: 41–55× ppl reduction over uniform MQ2 but the absolute floor stays
text-collapse (9B ppl=2,163 vs MQ4=10.34). Plumbed for future GPTQ / RHT
combinations; permanently research-only because **bit-width** (not codebook)
is the binding constraint at 2 bpw.

## Ship gates (DO NOT MERGE without both clearing)

1. **Decode perf**: K4-unroll kernel must restore 9B MQ3-Lloyd decode to ≥120
   tok/s on gfx1100. Current implementation: 44 tok/s vs uniform MQ3's 141 —
   3.2× regression from the 8-way switch in `gemv_mq3g256_lloyd.hip`. Pattern
   to mirror: `gemv_hfq3g256.gfx1100.hip` (4-accumulator K4 unroll).
   - Idea: replace per-thread switch with LDS-resident codebook table (8 fp16
     = 16 B/wave, no spill).
2. **Coherence eyeball**: 4-prompt coherence-gate battery passes on 4B and 9B
   Lloyd-MQ3 with no attractor loops at the new ppl floor.

Until both clear, both formats stay gated behind `--allow-mq{2,3}-lloyd` /
`HIPFIRE_ALLOW_MQ{2,3}_LLOYD=1` in the quantizer.

## What's plumbed end-to-end

- Quantizer functions (rayon-parallel over output blocks, 9B Lloyd-MQ3 quantize
  ~85s wall on 24-core; original single-thread Lloyd's didn't finish in 5+ min).
- HIP GEMV kernels (`gemv_mq{2,3}g256_lloyd.hip`).
- DType + dispatch wrappers (`MQ{2,3}G256Lloyd`, `gemv_mq{2,3}g256_lloyd[_with_rotate]`).
- Engine load arms — qt=19 / qt=20 wired into `load_lm_head`, `load_weight_tensor`,
  and DeltaNet CPU `load_any_as_f32` paths; `weight_gemv*` GEMV arms.
- Perplexity harness (`crates/engine/examples/perplexity.rs`) — single-window NLL,
  answers issue #113 alpha→beta gate by data instead of eyeball.
- Sweep drivers (`benchmarks/run_ppl_baseline.sh`, `run_lloyd_compare.sh`).
- Research-only opt-in guards in the quantizer.

## What this enables

- **Once gates clear**: Lloyd-MQ3 supersedes uniform MQ3 as the 3-bit default —
  much closer to MQ4 quality (1.79× vs uniform's 4.07×) for less bandwidth than
  MQ4 (-17.6% vs MQ4's 136 B/group).
- **Mixed-precision MQ-hybrid (Phase 4 in `mq-sub4bit-prd.md`)**: 3-bit slot
  becomes Lloyd-MQ3 instead of uniform MQ3. Ships only after this PR's gates clear.

## Test plan

- [ ] `./scripts/coherence-gate.sh` — full battery clean post-merge (regression check, no Lloyd path tested unless `HIPFIRE_ALLOW_MQ3_LLOYD=1` flips on)
- [ ] Build `--features deltanet --example perplexity -p engine` clean
- [ ] Smoke: quantize 9B with `--format mq3-lloyd` (with `HIPFIRE_ALLOW_MQ3_LLOYD=1`); run perplexity harness; compare ppl=18.5 reproduction within ±0.5
- [ ] **Ship gate 1** (TBD): K4-unroll kernel restores 9B Lloyd-MQ3 decode to ≥120 tok/s on gfx1100
- [ ] **Ship gate 2** (TBD): 4-prompt coherence battery passes for 4B and 9B Lloyd-MQ3 with no attractor loops
- [ ] Removing the `--allow-mq{2,3}-lloyd` guards once gates clear (separate commit)

## Help wanted

The K4-unroll perf fix is the cleanest single contribution that unblocks this:
mirror `gemv_hfq3g256.gfx1100.hip`'s 4-accumulator pattern, swap the 8-way
switch in `gemv_mq3g256_lloyd.hip` for an LDS-resident codebook lookup.
~1 day of kernel work for someone with HIP/RDNA experience.

## References

- `benchmarks/results/lloyd_max_findings_20260501.md` — full empirical writeup
- `docs/plans/mq-sub4bit-research-queue.md` Q1.5 — canonical research log
- `docs/plans/mq-sub4bit-prd.md` Phase 1.5 — PRD-level entry
- `docs/plans/mq3-rounding-out-precompute-leverage.prd` §A — quant-time leverage view

🤖 Generated with [Claude Code](https://claude.com/claude-code)