### PR TITLE
fix(ui): equivalent serve -d command on windows

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3700,10 +3700,11 @@ switch (cmd) {
       // Fork a detached child. `setsid` gives it its own session so Ctrl-C
       // in the parent shell doesn't reach it; `nohup` ignores SIGHUP; stdout
       // + stderr go to the log file. HIPFIRE_DETACHED prevents infinite forking.
+      const runBg = (process.platform == "win32") ? ["cmd", "/c", "start", "/b"] : ["setsid", "nohup"]
       const self = process.argv[0];
       const script = process.argv[1];
       const logFd = require("fs").openSync(SERVE_LOG_FILE, "a");
-      const child = Bun.spawn(["setsid", "nohup", self, script, "serve", String(port)], {
+      const child = Bun.spawn([...runBg, self, script, "serve", String(port)], {
         stdin: "ignore",
         stdout: logFd,
         stderr: logFd,

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3700,7 +3700,7 @@ switch (cmd) {
       // Fork a detached child. `setsid` gives it its own session so Ctrl-C
       // in the parent shell doesn't reach it; `nohup` ignores SIGHUP; stdout
       // + stderr go to the log file. HIPFIRE_DETACHED prevents infinite forking.
-      const runBg = (process.platform == "win32") ? ["cmd", "/c", "start", "/b"] : ["setsid", "nohup"]
+      const runBg = process.platform === "win32" ? ["cmd", "/c", "start", "/b"] : ["setsid", "nohup"]
       const self = process.argv[0];
       const script = process.argv[1];
       const logFd = require("fs").openSync(SERVE_LOG_FILE, "a");


### PR DESCRIPTION
Fix hipfire serve -d on windows by providing equivalent to setsid/nohup when windows detected

tested and working on my windows 10 machine

first time contributor, dont know what im doing, feel free to revise as needed



as an aside, idk if its just my machine but compile_kernels.ps1 didnt work for me until i replaced hipcc.bat in the code to hipcc.exe. the .bat was giving me `ERROR    The filename, directory name, or volume label syntax is incorrect.` but the .exe worked just fine. i believe for 6.4 and later, the .exe is the preferred way of executing it, so it might make sense to put the .exe as higher preference over the .bat?