### PR TITLE
fix(daemon): GPU-side single-token attractor block for <tool_call> / <think> (#111)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1584,11 +1584,24 @@ async function serve(port: number) {
           const tool_calls: any[] = [];
           let repaired = 0;
           for (const m of matches) {
-            const raw = (m[1] || m[2] || "").trim();
+            let raw = (m[1] || m[2] || "").trim();
+            if (!raw) continue;
+            // MQ4 single-token attractor (#111) sometimes stacks 1-2 nested
+            // `<tool_call>` openers before the JSON body lands. The engine
+            // blocks the third+ via the unclosed-depth gate in daemon.rs,
+            // but the second still ships in the visible stream. Strip any
+            // leading nested-opener artifacts before parsing — if the
+            // first non-whitespace bytes are another `<tool_call>`,
+            // discard them and use the inner content.
+            let nestedStripped = 0;
+            while (raw.startsWith("<tool_call>")) {
+              raw = raw.slice("<tool_call>".length).trimStart();
+              nestedStripped++;
+            }
             if (!raw) continue;
             const parsed = parseOneToolCall(raw);
             if (!parsed) continue;
-            if (parsed.repaired) repaired++;
+            if (parsed.repaired || nestedStripped > 0) repaired++;
             tool_calls.push({
               id: `call_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
               type: "function",

--- a/cli/parse_tool_calls.test.ts
+++ b/cli/parse_tool_calls.test.ts
@@ -159,3 +159,54 @@ test("escaped quotes inside JSON strings are handled", () => {
   expect(r).not.toBeNull();
   expect(r!.arguments).toEqual({ path: "/tmp/x", content: 'say "hi"' });
 });
+
+// Mirror of the nested-stripping logic in parseToolCalls (cli/index.ts).
+// Keep in sync.
+function parseToolCallsBlock(raw: string) {
+  let r = raw.trim();
+  let stripped = 0;
+  while (r.startsWith("<tool_call>")) {
+    r = r.slice("<tool_call>".length).trimStart();
+    stripped++;
+  }
+  if (!r) return null;
+  const parsed = parseOneToolCall(r);
+  return parsed ? { ...parsed, nestedStripped: stripped } : null;
+}
+
+test("nested <tool_call> opener is stripped, payload still parses (#111)", () => {
+  // The shape that broke v0.1.9-alpha: model emits two stacked openers
+  // before the JSON body lands. Outer regex captures content starting
+  // with another `<tool_call>`; the parser must strip that prefix.
+  const raw = '<tool_call>\n{"name": "write", "arguments": {"path": "/tmp/x", "content": "y"}}';
+  const r = parseToolCallsBlock(raw);
+  expect(r).not.toBeNull();
+  expect(r!.name).toBe("write");
+  expect(r!.arguments).toEqual({ path: "/tmp/x", content: "y" });
+  expect(r!.nestedStripped).toBe(1);
+});
+
+test("multiple nested <tool_call> openers all get stripped (#111)", () => {
+  const raw = '<tool_call>\n<tool_call>\n<tool_call>\n{"name": "read", "arguments": {"path": "/etc"}}';
+  const r = parseToolCallsBlock(raw);
+  expect(r).not.toBeNull();
+  expect(r!.name).toBe("read");
+  expect(r!.nestedStripped).toBe(3);
+});
+
+test("no nested opener leaves payload unmodified (#111)", () => {
+  const raw = '{"name": "bash", "arguments": {"command": "ls"}}';
+  const r = parseToolCallsBlock(raw);
+  expect(r).not.toBeNull();
+  expect(r!.nestedStripped).toBe(0);
+  expect(r!.repaired).toBe(false);
+});
+
+test("nested openers with empty body returns null (no false-positive call)", () => {
+  // Pure attractor with no JSON behind the openers — must NOT emit a
+  // bogus tool call. The handler should let this fall through to the
+  // "no tool calls" path.
+  const raw = '<tool_call>\n<tool_call>\n<tool_call>';
+  const r = parseToolCallsBlock(raw);
+  expect(r).toBeNull();
+});

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -98,6 +98,41 @@ struct CaskConfig {
 ///
 /// Returns the File handle; caller MUST keep it alive for the process
 /// lifetime (on Unix, dropping it closes the fd and releases the lock).
+/// GPU-side single-token attractor block for the AR generate path (#111).
+///
+/// MQ4 quant pressure makes structured-output special tokens (`<tool_call>`,
+/// `<think>`) into self-reinforcing attractors: the model emits the same
+/// special token hundreds of times in a row, never reaching the JSON body.
+/// The CPU-side `apply_ngram_block` is not in this path (its per-token D2H
+/// + H2D would tank decode tok/s) and the GPU sampler's repeat-penalty
+/// alone doesn't break a strong single-token loop fast enough.
+///
+/// This helper is the cheapest possible surgical fix: scan the recent
+/// `window` generated tokens (CPU-side u32 comparisons over ~20 tokens);
+/// if `tok_id` appears `threshold`+ times, write a single 4-byte `-INF`
+/// into the GPU logits buffer at offset `tok_id * 4`. No D2H, no kernel
+/// change, ~5 µs only on the rare turns that trip the attractor.
+///
+/// Threshold=3 in window=20 catches any pathological loop (the bug report
+/// shows 9-100+ in a row) without harming legitimate multi-tool turns —
+/// real per-call content runs ≥10 tokens of JSON between openers.
+fn gpu_block_attractor_token(
+    gpu: &rdna_compute::Gpu,
+    logits_buf: &hip_bridge::DeviceBuffer,
+    history: &[u32],
+    tok_id: u32,
+    window: usize,
+    threshold: usize,
+) {
+    if window == 0 || threshold == 0 { return; }
+    let start = history.len().saturating_sub(window);
+    let count = history[start..].iter().filter(|&&t| t == tok_id).count();
+    if count >= threshold {
+        let bytes: [u8; 4] = f32::NEG_INFINITY.to_ne_bytes();
+        let _ = gpu.hip.memcpy_htod_offset(logits_buf, (tok_id as usize) * 4, &bytes);
+    }
+}
+
 fn acquire_daemon_lock() -> std::fs::File {
     use std::io::{Seek, Write};
 
@@ -1851,6 +1886,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     }
 
     let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    // Special-token attractor blocking (#111). Resolve the token IDs once;
+    // each is `Some` only when the tokenizer registers it as a single
+    // special token (Qwen3+ vocabs) — older vocabs return `None` and the
+    // block is silently skipped.
+    let tool_call_token = tokenizer.special_token_id("<tool_call>");
+    let think_open_token = tokenizer.special_token_id("<think>");
     let prefill_tokens = new_tokens.len();
     let t0 = Instant::now();
 
@@ -1936,6 +1977,16 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         let bytes0: Vec<u8> = scope0.iter().flat_map(|t| t.to_ne_bytes()).collect();
         if !bytes0.is_empty() {
             gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &bytes0).unwrap();
+        }
+        // #111 attractor block: empty `ngram_scope` on first sample (no
+        // generated tokens yet), so the count is always 0 and this is a
+        // no-op here. Still call it for symmetry with the loop body, in
+        // case a future change moves this block into a multi-step warmup.
+        if let Some(t) = tool_call_token {
+            gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+        }
+        if let Some(t) = think_open_token {
+            gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
         }
         let (tok0, rng0) = gpu.sample_top_p(
             &scratch.logits, &scratch.sample_buf, &scratch.repeat_buf,
@@ -2104,6 +2155,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                     if !bytes.is_empty() {
                         gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &bytes).unwrap();
                     }
+                    if let Some(t) = tool_call_token {
+                        gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+                    }
+                    if let Some(t) = think_open_token {
+                        gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+                    }
                     let (tok, rng) = gpu.sample_top_p(
                         &scratch.logits, &scratch.sample_buf, &scratch.repeat_buf,
                         vocab_size, temp, top_p, rng_state, scope.len(), repeat_penalty,
@@ -2167,6 +2224,15 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             let bytes: Vec<u8> = scope.iter().flat_map(|t| t.to_ne_bytes()).collect();
             if !bytes.is_empty() {
                 gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &bytes).unwrap();
+            }
+            // #111 attractor block — see helper docstring. Counts in 20-token
+            // window; trips at 3+ occurrences. Cheap when not tripped, ~5 µs
+            // when tripped (single 4-byte H2D into the logits buffer).
+            if let Some(t) = tool_call_token {
+                gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+            }
+            if let Some(t) = think_open_token {
+                gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
             }
             // GPU sample: reads scratch.logits (already on GPU), writes token+rng
             // to scratch.sample_buf. Blocks only on the 8-byte D2H readback.

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -98,24 +98,57 @@ struct CaskConfig {
 ///
 /// Returns the File handle; caller MUST keep it alive for the process
 /// lifetime (on Unix, dropping it closes the fd and releases the lock).
-/// GPU-side single-token attractor block for the AR generate path (#111).
+/// GPU-side attractor blockers for the AR generate path (#111).
 ///
 /// MQ4 quant pressure makes structured-output special tokens (`<tool_call>`,
 /// `<think>`) into self-reinforcing attractors: the model emits the same
-/// special token hundreds of times in a row, never reaching the JSON body.
-/// The CPU-side `apply_ngram_block` is not in this path (its per-token D2H
-/// + H2D would tank decode tok/s) and the GPU sampler's repeat-penalty
-/// alone doesn't break a strong single-token loop fast enough.
+/// special token hundreds of times in a row, never reaching the JSON body
+/// (or in stacked-opener shapes that downstream regex parsers cannot
+/// recover). The CPU-side `apply_ngram_block` is not in this path (its
+/// per-token D2H + H2D would tank decode tok/s) and the GPU sampler's
+/// repeat-penalty alone doesn't break a strong single-token loop fast
+/// enough at the user-validated `RP=1.05` floor.
 ///
-/// This helper is the cheapest possible surgical fix: scan the recent
-/// `window` generated tokens (CPU-side u32 comparisons over ~20 tokens);
-/// if `tok_id` appears `threshold`+ times, write a single 4-byte `-INF`
-/// into the GPU logits buffer at offset `tok_id * 4`. No D2H, no kernel
-/// change, ~5 µs only on the rare turns that trip the attractor.
+/// Both helpers below scan the recent `window` generated tokens
+/// (CPU-side u32 comparisons over ~20 tokens) and, when tripped, write
+/// a single 4-byte `-INF` into the GPU logits buffer at offset
+/// `open_id * 4` via `memcpy_htod_offset`. No D2H, no kernel change,
+/// ~5 µs only on turns that trip; zero cost otherwise.
 ///
-/// Threshold=3 in window=20 catches any pathological loop (the bug report
-/// shows 9-100+ in a row) without harming legitimate multi-tool turns —
-/// real per-call content runs ≥10 tokens of JSON between openers.
+/// `gpu_block_attractor_unclosed` is the right call for paired
+/// open/close special tokens (`<tool_call>` / `</tool_call>`,
+/// `<think>` / `</think>`). It blocks the next emission when there
+/// are ≥ `threshold` opens minus closes in the window — i.e. unclosed
+/// nested openers. With `threshold = 2`, the helper trips before the
+/// model can emit a third nested opener; a second opener is still
+/// possible (we can only block the *next* token), but the parser-side
+/// strip in `parseToolCalls` (#111 stopgap) recovers from a single
+/// nested opener.
+///
+/// `gpu_block_attractor_token` is the simpler fallback for unpaired
+/// tokens: trips on `count >= threshold` regardless of structure.
+fn gpu_block_attractor_unclosed(
+    gpu: &rdna_compute::Gpu,
+    logits_buf: &hip_bridge::DeviceBuffer,
+    history: &[u32],
+    open_id: u32,
+    close_id: u32,
+    window: usize,
+    threshold: usize,
+) {
+    if window == 0 || threshold == 0 { return; }
+    let start = history.len().saturating_sub(window);
+    let mut depth: i32 = 0;
+    for &t in &history[start..] {
+        if t == open_id { depth += 1; }
+        else if t == close_id && depth > 0 { depth -= 1; }
+    }
+    if depth >= threshold as i32 {
+        let bytes: [u8; 4] = f32::NEG_INFINITY.to_ne_bytes();
+        let _ = gpu.hip.memcpy_htod_offset(logits_buf, (open_id as usize) * 4, &bytes);
+    }
+}
+
 fn gpu_block_attractor_token(
     gpu: &rdna_compute::Gpu,
     logits_buf: &hip_bridge::DeviceBuffer,
@@ -1887,11 +1920,24 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
 
     let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
     // Special-token attractor blocking (#111). Resolve the token IDs once;
-    // each is `Some` only when the tokenizer registers it as a single
-    // special token (Qwen3+ vocabs) — older vocabs return `None` and the
-    // block is silently skipped.
-    let tool_call_token = tokenizer.special_token_id("<tool_call>");
-    let think_open_token = tokenizer.special_token_id("<think>");
+    // each pair is `Some` only when the tokenizer registers both opener
+    // and closer as single special tokens (Qwen3+ vocabs). Older vocabs
+    // return `None` and the block is silently skipped — no behavior
+    // change.
+    let tool_call_pair = match (
+        tokenizer.special_token_id("<tool_call>"),
+        tokenizer.special_token_id("</tool_call>"),
+    ) {
+        (Some(o), Some(c)) => Some((o, c)),
+        _ => None,
+    };
+    let think_pair = match (
+        tokenizer.special_token_id("<think>"),
+        tokenizer.special_token_id("</think>"),
+    ) {
+        (Some(o), Some(c)) => Some((o, c)),
+        _ => None,
+    };
     let prefill_tokens = new_tokens.len();
     let t0 = Instant::now();
 
@@ -1979,14 +2025,15 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &bytes0).unwrap();
         }
         // #111 attractor block: empty `ngram_scope` on first sample (no
-        // generated tokens yet), so the count is always 0 and this is a
-        // no-op here. Still call it for symmetry with the loop body, in
-        // case a future change moves this block into a multi-step warmup.
-        if let Some(t) = tool_call_token {
-            gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+        // generated tokens yet), so the unclosed-depth is always 0 and
+        // this is a no-op here. Still call it for symmetry with the
+        // loop body, in case a future change moves this block into a
+        // multi-step warmup.
+        if let Some((open, close)) = tool_call_pair {
+            gpu_block_attractor_unclosed(gpu, &scratch.logits.buf, ngram_scope, open, close, 20, 2);
         }
-        if let Some(t) = think_open_token {
-            gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+        if let Some((open, close)) = think_pair {
+            gpu_block_attractor_unclosed(gpu, &scratch.logits.buf, ngram_scope, open, close, 20, 2);
         }
         let (tok0, rng0) = gpu.sample_top_p(
             &scratch.logits, &scratch.sample_buf, &scratch.repeat_buf,
@@ -2155,11 +2202,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                     if !bytes.is_empty() {
                         gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &bytes).unwrap();
                     }
-                    if let Some(t) = tool_call_token {
-                        gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+                    if let Some((open, close)) = tool_call_pair {
+                        gpu_block_attractor_unclosed(gpu, &scratch.logits.buf, ngram_scope, open, close, 20, 2);
                     }
-                    if let Some(t) = think_open_token {
-                        gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+                    if let Some((open, close)) = think_pair {
+                        gpu_block_attractor_unclosed(gpu, &scratch.logits.buf, ngram_scope, open, close, 20, 2);
                     }
                     let (tok, rng) = gpu.sample_top_p(
                         &scratch.logits, &scratch.sample_buf, &scratch.repeat_buf,
@@ -2225,14 +2272,15 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             if !bytes.is_empty() {
                 gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &bytes).unwrap();
             }
-            // #111 attractor block — see helper docstring. Counts in 20-token
-            // window; trips at 3+ occurrences. Cheap when not tripped, ~5 µs
-            // when tripped (single 4-byte H2D into the logits buffer).
-            if let Some(t) = tool_call_token {
-                gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+            // #111 attractor block — see helper docstrings. Counts unclosed
+            // opens in a 20-token window; trips at depth ≥ 2. Cheap when
+            // not tripped, ~5 µs when tripped (single 4-byte H2D into the
+            // logits buffer).
+            if let Some((open, close)) = tool_call_pair {
+                gpu_block_attractor_unclosed(gpu, &scratch.logits.buf, ngram_scope, open, close, 20, 2);
             }
-            if let Some(t) = think_open_token {
-                gpu_block_attractor_token(gpu, &scratch.logits.buf, ngram_scope, t, 20, 3);
+            if let Some((open, close)) = think_pair {
+                gpu_block_attractor_unclosed(gpu, &scratch.logits.buf, ngram_scope, open, close, 20, 2);
             }
             // GPU sample: reads scratch.logits (already on GPU), writes token+rng
             // to scratch.sample_buf. Blocks only on the 8-byte D2H readback.

--- a/crates/engine/src/llama.rs
+++ b/crates/engine/src/llama.rs
@@ -2528,19 +2528,12 @@ pub fn apply_ngram_block(logits: &mut [f32], history: &[u32]) {
 /// Single-token attractor block for special tokens. Counts how many times
 /// `token_id` appears in the last `window` tokens of `history`; if it is
 /// at or above `threshold`, sets that token's logit to `-INF` so the
-/// next sample picks something else. Targets the specific failure mode
-/// in #111 where MQ4 quant pressure makes a structured-output token
-/// (e.g. `<tool_call>`) into a self-reinforcing attractor — the model
-/// emits the same special token hundreds of times in a row, never
-/// reaching the JSON body. The general n-gram block does not catch this
-/// pattern reliably because the surrounding tokens vary (newline, blank,
-/// repeats) so the n-gram suffix rarely matches an earlier window
-/// verbatim.
-///
-/// Why a count gate instead of a hard ban: legitimate multi-tool turns
-/// can emit 2 `<tool_call>` openers within a short stretch when the
-/// per-call content is short. Threshold=3 in window=20 lets normal
-/// multi-call flows through but breaks any actual single-token loop.
+/// next sample picks something else. Targets MQ4 single-token attractors
+/// on tokens that have no paired closer (e.g. a runaway emit of a
+/// solo special). For paired open/close tokens like `<tool_call>` /
+/// `</tool_call>`, prefer `apply_unclosed_attractor_block` — it triggers
+/// before the model can stack a second nested opener that breaks
+/// downstream regex parsers (see #111 codex review).
 pub fn apply_special_token_attractor_block(
     logits: &mut [f32],
     history: &[u32],
@@ -2555,6 +2548,42 @@ pub fn apply_special_token_attractor_block(
     let count = history[start..].iter().filter(|&&t| t == token_id).count();
     if count >= threshold {
         logits[token_id as usize] = f32::NEG_INFINITY;
+    }
+}
+
+/// Open/close-paired attractor block for structured special tokens
+/// (`<tool_call>`/`</tool_call>`, `<think>`/`</think>`).
+///
+/// Counts unclosed openers in the last `window` tokens — `opens - closes`,
+/// floored at zero. When the running depth reaches `threshold`, sets
+/// `open_id`'s logit to `-INF` so the next sample cannot stack another
+/// nested opener. With `threshold = 2`, a second consecutive opener
+/// without an intervening closer is the last one the decoder is allowed
+/// to emit; the third+ are blocked. The downstream regex parser
+/// (`parseToolCalls` in cli/index.ts) tolerates a single nested opener
+/// by stripping the leading repeat before JSON parse.
+///
+/// The depth saturates at 0 from below: a stray closer at the start of
+/// the window doesn't push depth negative and create false-allow.
+pub fn apply_unclosed_attractor_block(
+    logits: &mut [f32],
+    history: &[u32],
+    open_id: u32,
+    close_id: u32,
+    window: usize,
+    threshold: usize,
+) {
+    if (open_id as usize) >= logits.len() || threshold == 0 || window == 0 {
+        return;
+    }
+    let start = history.len().saturating_sub(window);
+    let mut depth: i32 = 0;
+    for &t in &history[start..] {
+        if t == open_id { depth += 1; }
+        else if t == close_id && depth > 0 { depth -= 1; }
+    }
+    if depth >= threshold as i32 {
+        logits[open_id as usize] = f32::NEG_INFINITY;
     }
 }
 
@@ -2887,5 +2916,57 @@ mod tests {
         // token_id past vocab size — should not panic, leave logits untouched.
         apply_special_token_attractor_block(&mut logits, &history, 999, 20, 3);
         for &v in &logits { assert!(v.is_finite()); }
+    }
+
+    #[test]
+    fn unclosed_block_below_threshold() {
+        // 1 open, 0 closes — depth=1 < threshold=2, no block.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![5, 1, 2];
+        apply_unclosed_attractor_block(&mut logits, &history, 5, 6, 20, 2);
+        assert!(logits[5].is_finite());
+    }
+
+    #[test]
+    fn unclosed_block_paired_call_passes() {
+        // Single complete call: <tool_call>{}</tool_call> = open + close.
+        // Depth ends at 0; a follow-up second open would land at 1,
+        // still below threshold=2. Don't block.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![5, 1, 2, 6, 5]; // open, body, body, close, open
+        apply_unclosed_attractor_block(&mut logits, &history, 5, 6, 20, 2);
+        assert!(logits[5].is_finite(), "second legit open after a complete call must pass");
+    }
+
+    #[test]
+    fn unclosed_block_two_stacked_opens_blocks_third() {
+        // The exact #111 attractor shape: <tool_call><tool_call>...
+        // After two consecutive opens with no close, depth = 2 = threshold,
+        // block fires (preventing the third).
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![5, 5];
+        apply_unclosed_attractor_block(&mut logits, &history, 5, 6, 20, 2);
+        assert_eq!(logits[5], f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn unclosed_block_depth_saturates_at_zero() {
+        // Stray close at start of window must not push depth negative
+        // and let an attractor through. Window: close, open, open.
+        // depth = max(0, -1) + 1 + 1 = 2 → block.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![6, 5, 5];
+        apply_unclosed_attractor_block(&mut logits, &history, 5, 6, 20, 2);
+        assert_eq!(logits[5], f32::NEG_INFINITY);
+    }
+
+    #[test]
+    fn unclosed_block_window_scoped() {
+        // 2 unclosed opens earlier in history, but the recent window=3 only
+        // sees [body, body, close]. depth = 0, allow.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![5, 5, 1, 2, 6];
+        apply_unclosed_attractor_block(&mut logits, &history, 5, 6, 3, 2);
+        assert!(logits[5].is_finite(), "older unclosed opens must not count once they leave the window");
     }
 }

--- a/crates/engine/src/llama.rs
+++ b/crates/engine/src/llama.rs
@@ -2525,6 +2525,39 @@ pub fn apply_ngram_block(logits: &mut [f32], history: &[u32]) {
     }
 }
 
+/// Single-token attractor block for special tokens. Counts how many times
+/// `token_id` appears in the last `window` tokens of `history`; if it is
+/// at or above `threshold`, sets that token's logit to `-INF` so the
+/// next sample picks something else. Targets the specific failure mode
+/// in #111 where MQ4 quant pressure makes a structured-output token
+/// (e.g. `<tool_call>`) into a self-reinforcing attractor — the model
+/// emits the same special token hundreds of times in a row, never
+/// reaching the JSON body. The general n-gram block does not catch this
+/// pattern reliably because the surrounding tokens vary (newline, blank,
+/// repeats) so the n-gram suffix rarely matches an earlier window
+/// verbatim.
+///
+/// Why a count gate instead of a hard ban: legitimate multi-tool turns
+/// can emit 2 `<tool_call>` openers within a short stretch when the
+/// per-call content is short. Threshold=3 in window=20 lets normal
+/// multi-call flows through but breaks any actual single-token loop.
+pub fn apply_special_token_attractor_block(
+    logits: &mut [f32],
+    history: &[u32],
+    token_id: u32,
+    window: usize,
+    threshold: usize,
+) {
+    if (token_id as usize) >= logits.len() || threshold == 0 || window == 0 {
+        return;
+    }
+    let start = history.len().saturating_sub(window);
+    let count = history[start..].iter().filter(|&&t| t == token_id).count();
+    if count >= threshold {
+        logits[token_id as usize] = f32::NEG_INFINITY;
+    }
+}
+
 pub fn sample_top_p(logits: &[f32], temperature: f32, top_p: f32) -> u32 {
     if temperature <= 0.0 {
         return argmax(logits);
@@ -2801,4 +2834,58 @@ fn simple_rand() -> f32 {
     s ^= s << 5;
     SAMPLER_STATE.store(s, Ordering::Relaxed);
     (s as f32) / (u32::MAX as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attractor_block_below_threshold() {
+        // 2 occurrences of token 7 in window=20, threshold=3 → no block.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![1, 2, 7, 3, 4, 7, 5];
+        apply_special_token_attractor_block(&mut logits, &history, 7, 20, 3);
+        assert!(logits[7].is_finite(), "below threshold should leave logit untouched");
+    }
+
+    #[test]
+    fn attractor_block_at_threshold() {
+        // 3 occurrences of token 5 in last 20 → block fires.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![5, 1, 5, 2, 5];
+        apply_special_token_attractor_block(&mut logits, &history, 5, 20, 3);
+        assert_eq!(logits[5], f32::NEG_INFINITY, "threshold met should -INF the logit");
+    }
+
+    #[test]
+    fn attractor_block_window_scoped() {
+        // 3 occurrences of token 9, but only 1 in the last 5 tokens (window=5,
+        // threshold=3) → no block.
+        let mut logits = vec![1.0f32; 16];
+        let history: Vec<u32> = vec![9, 9, 1, 2, 3, 4, 5, 9, 6];
+        apply_special_token_attractor_block(&mut logits, &history, 9, 5, 3);
+        assert!(logits[9].is_finite(), "older occurrences must not count");
+    }
+
+    #[test]
+    fn attractor_block_pure_repeat() {
+        // Worst case: model emits the same special token 5x in a row. Block
+        // must fire.
+        let mut logits = vec![0.5f32; 16];
+        let history: Vec<u32> = vec![11, 11, 11, 11, 11];
+        apply_special_token_attractor_block(&mut logits, &history, 11, 20, 3);
+        assert_eq!(logits[11], f32::NEG_INFINITY);
+        // Other logits untouched.
+        assert!((logits[10] - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn attractor_block_oob_token_is_noop() {
+        let mut logits = vec![1.0f32; 4];
+        let history: Vec<u32> = vec![999, 999, 999];
+        // token_id past vocab size — should not panic, leave logits untouched.
+        apply_special_token_attractor_block(&mut logits, &history, 999, 20, 3);
+        for &v in &logits { assert!(v.is_finite()); }
+    }
 }

--- a/crates/engine/src/tokenizer.rs
+++ b/crates/engine/src/tokenizer.rs
@@ -308,6 +308,15 @@ impl Tokenizer {
         id == self.eos_id || self.eot_id == Some(id)
     }
 
+    /// Look up a special token's ID by literal content. Returns `None`
+    /// when the token is not registered as a special token in this
+    /// tokenizer (e.g. an older Qwen vocab without `<tool_call>`).
+    pub fn special_token_id(&self, content: &str) -> Option<u32> {
+        self.special_tokens.iter()
+            .find(|(s, _)| s == content)
+            .map(|(_, id)| *id)
+    }
+
     /// Decode a sequence of token IDs to text.
     /// Handles both GPT-2 BPE (Ġ=space, Ċ=newline) and SentencePiece (▁=space).
     /// For GPT-2 BPE: collects all bytes first, then does UTF-8 conversion once


### PR DESCRIPTION
## Summary

Closes the second symptom of #111 reported by @Fluorax after v0.1.9-alpha shipped: under MQ4 quant pressure, `qwen3.6:27b.mq4` decodes the `<tool_call>` special token into a self-reinforcing attractor (9 to 100+ in a row, never reaching the JSON body). The defensive `parseToolCalls` repair from #120 catches malformed JSON but cannot help when the model never produces JSON.

The fix adds a tightly-scoped GPU-side block:
- Resolve `<tool_call>` and `<think>` special-token IDs once at decode start via a new `Tokenizer::special_token_id()` accessor.
- Before each `gpu.sample_top_p`, count occurrences in the last 20 *generated* tokens (never the prompt).
- If count ≥ 3, write a single 4-byte `-INF` to the GPU logits buffer at offset `tok_id × 4`. No D2H, no kernel change, ~5 µs only on the turns that trip — zero cost otherwise.

## Why this scope (not n-gram block)

- The general `apply_ngram_block` does not catch single-token attractors reliably: surrounding tokens vary (newline, blank repeats, `</think>` resumption) so the suffix rarely matches an earlier window verbatim.
- The GPU sampler's repeat penalty alone can't break the loop fast enough at the user-validated `RP=1.05` floor.
- A CPU-side per-step logits download would tank decode tok/s. The 4-byte H2D-only path keeps the GPU sample fast.

## Verification

- **5 unit tests** in `llama::tests` cover threshold-edge / window-scope / pure-repeat / out-of-vocab token cases. All pass.
- **coherence-gate green**: 6/6 prompts including the qwen3.5-9b.mq4 tool-call coverage test (47 tokens, on-shape, no false-positive block).
- The fix is silent on tokenizers without `<tool_call>` registered as a special token (older Qwen vocabs return `None` from `special_token_id()`).

## Known limitations

This is still a stopgap. The proper fix is Path C calibration retrain (#39) so the structured-output token-tail is preserved at MQ4. That remains tracked in MANUAL_REVIEW.md.

DFlash decode loop (`spec_step_dflash` in `speculative.rs`) is not yet wired to the same block — the reporter's repro is plain AR (no draft loaded). If attractor surfaces on DFlash, it lands as a follow-up.

## Test plan

- [x] cargo build --features deltanet clean
- [x] cargo test attractor_block (5/5 passing)
- [x] coherence-gate.sh green (6/6, tool-call coverage included)
- [ ] User-facing repro on Fluorax's exact prompts (left for the reporter once merged)

Reported-by: @Fluorax
Refs: #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)