### PR TITLE
fix(dflash): wire max_think_tokens through DFlash spec-decode path

### DIFF
--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -1628,6 +1628,7 @@ fn generate_dflash(
     prompt: &str,
     system_prompt: Option<&str>,
     max_tokens: usize,
+    max_think_tokens: usize,
     pflash_bypass_reason: Option<&str>,
     pflash_alpha: Option<f32>,
 ) {
@@ -1809,6 +1810,9 @@ fn generate_dflash(
     let mut position = prompt_tokens.len();
     let mut seed_token = first_token;
     let mut stats = SpecStats::new(df.block_size);
+    // max_think_tokens enforcement state (mirrors the AR path).
+    let mut think_count: usize = 0;
+    let mut prev_in_think = false;
     let mut generated = 0usize;
 
     // Post-prefill compaction (FlashCASK pattern from dflash_spec_demo).
@@ -1949,6 +1953,7 @@ fn generate_dflash(
         let committed_tail: Vec<u32> = step.committed.iter().skip(1).copied().collect();
 
         let mut hit_eos = false;
+        let mut think_cap_hit = false;
         for &tok in &committed_tail {
             if generated >= max_tokens { break; }
             emitted.push(tok);
@@ -1964,6 +1969,34 @@ fn generate_dflash(
             }
             generated += 1;
             if tok == target.config.eos_token || im_end_token == Some(tok) || tokenizer.is_terminator(tok) { hit_eos = true; break; }
+
+            // max_think_tokens enforcement (mirrors the AR path). Track
+            // <think>/<⁄think> in decoded text and count tokens inside.
+            if max_think_tokens > 0 {
+                let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
+                let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
+                let open_idx = raw_str.rfind("<think>");
+                let close_idx = raw_str.rfind("</think>");
+                let in_think = match (open_idx, close_idx) {
+                    (Some(o), Some(c)) => o > c,
+                    (Some(_), None) => true,
+                    _ => false,
+                };
+                if in_think && !prev_in_think { think_count = 0; }
+                if in_think { think_count += 1; }
+                prev_in_think = in_think;
+
+                if in_think && think_count >= max_think_tokens {
+                    // Force-close: emit </think>\n and break out of this batch.
+                    // Unlike the AR path we can't splice into the KV cache mid-
+                    // spec-cycle, so we just stream the close text and break.
+                    // The next request will start fresh.
+                    let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":"</think>\n"}}"#, id);
+                    let _ = stdout.flush();
+                    think_cap_hit = true;
+                    break;
+                }
+            }
         }
         position += step.accepted + 1;
         seed_token = step.bonus_token;
@@ -1982,7 +2015,7 @@ fn generate_dflash(
                 }
             }
         }
-        if hit_eos { break; }
+        if hit_eos || think_cap_hit { break; }
     }
 
     // Put target state back on LoadedModel so the next request sees fresh
@@ -2030,19 +2063,6 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     // effectively 0 (DFlash is greedy-only in this integration). Skip the
     // normal AR sampling setup entirely.
     if m.dflash.is_some() && temp <= 1e-6 && (m.arch_id == 5 || m.arch_id == 6) {
-        if max_think_tokens > 0 {
-            // DFlash's spec-cycle emit path doesn't yet honor max_think_tokens
-            // -- wiring close-injection through the verify loop is a separate
-            // change. Tell the operator their cap is being ignored on this
-            // path so they don't think a runaway thinking turn is a daemon
-            // hang. AR path (no draft, or temp>0) does enforce it.
-            let _ = writeln!(
-                stdout,
-                r#"{{"type":"info","id":"{}","message":"max_think_tokens={} ignored on DFlash path (only enforced on AR; set dflash_mode=off to use the AR path with the cap)"}}"#,
-                id, max_think_tokens
-            );
-            let _ = stdout.flush();
-        }
         // PFlash + DFlash decode path is not yet wired -- the DFlash spec
         // loop builds its own prompt token stream internally, so the
         // generate() PFlash block below never runs. Surface this loud so
@@ -2063,7 +2083,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                 dflash_bypass_reason = Some("dflash_decode_active");
             }
         }
-        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, dflash_bypass_reason, dflash_alpha);
+        // max_think_tokens is now enforced inside generate_dflash (it
+        // mirrors the AR path's <think>/</think> counter). The "ignored
+        // on DFlash" warning that used to live here is gone -- the cap
+        // is real on both paths now.
+        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, dflash_bypass_reason, dflash_alpha);
         // Silence unused-variable warnings for the params we didn't need.
         let _ = (top_p, repeat_penalty, repeat_window, budget_alert_at_tok, budget_alert_text, pflash_state);
         return;


### PR DESCRIPTION
## Problem

The DFlash speculative decoding path explicitly ignored `max_think_tokens`:

```
max_think_tokens=N ignored on DFlash path
(only enforced on AR; set dflash_mode=off to use the AR path with the cap)
```

Users who enabled DFlash (`dflash_mode=on`) had no way to cap thinking
tokens — the model could loop indefinitely inside `<think>` on the
spec-decode path.

This is particularly problematic for Qwen3.6-35B-A3B which has a
[documented thinking-loop issue](https://github.com/QwenLM/Qwen3.6/issues/88)
across all inference frameworks.

## Fix

Wire `max_think_tokens` through `generate_dflash()`:

1. Pass `max_think_tokens` as a parameter (was not passed before)
2. Track `<think>`/`</think>` in decoded text during the token emit loop
   (same logic as the AR path)
3. When the cap is reached, force-emit `</think>\n` and break out of the
   spec-decode batch
4. Remove the old "ignored" warning message

**Limitation:** Unlike the AR path, DFlash cannot splice tokens into the
KV cache mid-spec-cycle, so generation ends after force-close rather
than continuing with answer tokens. This still prevents infinite think
loops from consuming the entire token budget.

**Changed file:** `crates/engine/examples/daemon.rs` (35 insertions, 15 deletions)

## Proof of impact

Direct daemon test with 27b model + DFlash draft, `max_think_tokens=64`:

| Metric | Before (warning) | After (cap enforced) |
|--------|-------------------|----------------------|
| `dflash` field | true | true |
| "ignored on DFlash" warning | **present** | **absent** |
| `<think>` opened | yes | yes |
| `</think>` closed | no (loops) | **yes** (at token 65) |
| tau (acceptance rate) | — | 3.0 |

## Health checks

| Gate | Result |
|------|--------|
| `coherence-gate.sh` | 4/4 OK |
| `coherence-gate-dflash.sh` | 4/4 OK |

## Steps to reproduce

\`\`\`bash
# Build daemon
cargo build --release --example daemon --features deltanet

# Run daemon directly with DFlash + think cap
echo '{"type":"ping"}
{"type":"load","model":"~/.hipfire/models/qwen3.6-27b.mq4","params":{"max_seq":4096,"kv_mode":"asym2","draft":"~/.hipfire/models/qwen36-27b-dflash-mq4.hfq","dflash_mode":"on"}}
{"type":"generate","id":"test","prompt":"Explain quantum entanglement.","temperature":0.0,"max_tokens":512,"repeat_penalty":1.05,"top_p":0.95,"max_think_tokens":64}' \
  | ./target/release/examples/daemon 2>/dev/null \
  | grep -E '"type":"(info|done)"'

# Before this fix: info message "max_think_tokens=64 ignored on DFlash path"
# After this fix:  no warning, done message with dflash=true and </think> closed
\`\`\`