### PR TITLE
feat(cli): hipfire chat — interactive TUI (closes #63)

### DIFF
--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -507,15 +507,32 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
 
           if (text.includes("\n")) {
             const parts = incompleteLine.split("\n");
-            // Commit all complete lines: print the unwritten suffix first, then
-            // re-render with markdown styling. We're switching from "raw tail"
-            // to "rendered committed" so we use \r + clear-EOL for the first
-            // committed line only.
+            const cols = stdout.columns ?? 80;
             for (let i = 0; i < parts.length - 1; i++) {
               const p = parts[i]!;
               if (i === 0) {
-                // First commit needs to clear the raw tail and re-emit styled.
-                w("\r\x1b[K" + md(p) + "\n");
+                // First commit: the raw tail is already on screen. Decide
+                // whether to re-emit with markdown styling.
+                //
+                // Re-emitting via `\r\x1b[K` only clears the CURRENT visual
+                // row — if the raw tail soft-wrapped onto multiple terminal
+                // rows, the rows above stay, and the re-emitted line then
+                // wraps again, producing visible duplication. So we only
+                // re-emit when the line fits on a single visual row.
+                const rendered = md(p);
+                const wrapped = p.length >= cols;
+                if (rendered === p) {
+                  // No markdown transform happened — just terminate the line.
+                  w("\n");
+                } else if (wrapped) {
+                  // Markdown changed the line, but it's wrapped. Skip the
+                  // re-emit to avoid the duplication bug; user sees raw
+                  // delimiters. Acceptable for Phase 1.
+                  w("\n");
+                } else {
+                  // Single visual row, has markdown — safe to re-emit styled.
+                  w("\r\x1b[K" + rendered + "\n");
+                }
               } else {
                 w(md(p) + "\n");
               }
@@ -550,10 +567,17 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
 
     if (spinInterval) { clearInterval(spinInterval); spinInterval = null; }
 
-    // Flush the trailing incomplete line: re-render with markdown so any
-    // closing delimiters that arrived in the final chunk get styled.
+    // Flush the trailing incomplete line. Same wrap-aware re-emit logic as
+    // the per-chunk commit path: only re-emit styled if the line fits on a
+    // single visual row, otherwise just terminate.
     if (incompleteLine && !firstChunk) {
-      w("\r\x1b[K" + md(incompleteLine) + "\n");
+      const rendered = md(incompleteLine);
+      const cols = stdout.columns ?? 80;
+      if (rendered === incompleteLine || incompleteLine.length >= cols) {
+        w("\n");
+      } else {
+        w("\r\x1b[K" + rendered + "\n");
+      }
       state.committedLines.push(incompleteLine);
     }
 

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -4,6 +4,7 @@ import {
   graphemes, sanitizePaste, estimateTokens,
   computeTokPerSec, trimTokenWindow,
   trimMessages, renderMarkdown,
+  detectFenceLine, renderFenceOpen, renderFenceClose,
   feedPasteParser, type PasteParserState,
   historyUp, historyDown, historySubmit, type HistoryState,
   type ChatMessage,
@@ -438,6 +439,11 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     let incompleteLineWritten = 0;  // chars of incompleteLine already on screen
     let fullResponse = "";
     let firstChunk = true;
+    // Tracks whether we're inside a ```fence```. Streaming line-by-line, the
+    // full-block fence regex in renderMarkdown can never match — we detect
+    // the open/close lines explicitly and style them per-line.
+    let inFence = false;
+    const fenceWidth = Math.min(60, stdout.columns ?? 60);
 
     // ASCII spinner — works on every terminal, including older xterm and the
     // plain Linux console (braille pattern chars don't render there).
@@ -510,31 +516,50 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
             const cols = stdout.columns ?? 80;
             for (let i = 0; i < parts.length - 1; i++) {
               const p = parts[i]!;
-              if (i === 0) {
-                // First commit: the raw tail is already on screen. Decide
-                // whether to re-emit with markdown styling.
-                //
-                // Re-emitting via `\r\x1b[K` only clears the CURRENT visual
-                // row — if the raw tail soft-wrapped onto multiple terminal
-                // rows, the rows above stay, and the re-emitted line then
-                // wraps again, producing visible duplication. So we only
-                // re-emit when the line fits on a single visual row.
+              const fence = detectFenceLine(p, inFence);
+
+              // Decide what string to write for this committed line.
+              // - Fence open: dim rule + [lang] label
+              // - Fence close: dim rule
+              // - Inside fence: raw text (no markdown rendering applied)
+              // - Outside fence: markdown-rendered, with the wrap-aware
+              //   re-emit guard (don't \r\x1b[K a soft-wrapped line)
+              let toEmit: string;
+              let needsClearTail: boolean;
+              if (fence.isFenceOpen) {
+                toEmit = renderFenceOpen(fence.lang, fenceWidth);
+                needsClearTail = true;
+                inFence = true;
+              } else if (fence.isFenceClose) {
+                toEmit = renderFenceClose(fenceWidth);
+                needsClearTail = true;
+                inFence = false;
+              } else if (inFence) {
+                // Inside a code block: don't apply markdown to body lines.
+                toEmit = p;
+                needsClearTail = false;
+              } else {
                 const rendered = md(p);
                 const wrapped = p.length >= cols;
-                if (rendered === p) {
-                  // No markdown transform happened — just terminate the line.
-                  w("\n");
-                } else if (wrapped) {
-                  // Markdown changed the line, but it's wrapped. Skip the
-                  // re-emit to avoid the duplication bug; user sees raw
-                  // delimiters. Acceptable for Phase 1.
-                  w("\n");
+                if (rendered === p || wrapped) {
+                  toEmit = p;
+                  needsClearTail = false;
                 } else {
-                  // Single visual row, has markdown — safe to re-emit styled.
-                  w("\r\x1b[K" + rendered + "\n");
+                  toEmit = rendered;
+                  needsClearTail = true;
                 }
+              }
+
+              if (i === 0 && needsClearTail) {
+                // First commit and we need to redraw — clear the raw tail
+                // first. Safe only when the toEmit fits on one visual row,
+                // which we've already gated on above.
+                w("\r\x1b[K" + toEmit + "\n");
+              } else if (i === 0) {
+                // Tail is already on screen as raw text; just terminate it.
+                w("\n");
               } else {
-                w(md(p) + "\n");
+                w(toEmit + "\n");
               }
               state.committedLines.push(p);
             }
@@ -567,16 +592,40 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
 
     if (spinInterval) { clearInterval(spinInterval); spinInterval = null; }
 
-    // Flush the trailing incomplete line. Same wrap-aware re-emit logic as
-    // the per-chunk commit path: only re-emit styled if the line fits on a
-    // single visual row, otherwise just terminate.
+    // Flush the trailing incomplete line. Apply the same fence-aware
+    // commit logic as the per-chunk path: detect fence open/close, skip
+    // markdown inside fences, wrap-aware re-emit otherwise.
     if (incompleteLine && !firstChunk) {
-      const rendered = md(incompleteLine);
       const cols = stdout.columns ?? 80;
-      if (rendered === incompleteLine || incompleteLine.length >= cols) {
-        w("\n");
+      const fence = detectFenceLine(incompleteLine, inFence);
+      let toEmit: string;
+      let needsClearTail: boolean;
+      if (fence.isFenceOpen) {
+        toEmit = renderFenceOpen(fence.lang, fenceWidth);
+        needsClearTail = true;
+        inFence = true;
+      } else if (fence.isFenceClose) {
+        toEmit = renderFenceClose(fenceWidth);
+        needsClearTail = true;
+        inFence = false;
+      } else if (inFence) {
+        toEmit = incompleteLine;
+        needsClearTail = false;
       } else {
-        w("\r\x1b[K" + rendered + "\n");
+        const rendered = md(incompleteLine);
+        const wrapped = incompleteLine.length >= cols;
+        if (rendered === incompleteLine || wrapped) {
+          toEmit = incompleteLine;
+          needsClearTail = false;
+        } else {
+          toEmit = rendered;
+          needsClearTail = true;
+        }
+      }
+      if (needsClearTail) {
+        w("\r\x1b[K" + toEmit + "\n");
+      } else {
+        w("\n");
       }
       state.committedLines.push(incompleteLine);
     }

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -504,7 +504,10 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
           }
 
           if (firstChunk) {
-            w("\r\x1b[K");
+            // Dim "Assistant:" role prefix so a copy-pasted transcript
+            // shows roles unambiguously (matches the bright "You:" on
+            // the user side).
+            w("\r\x1b[K\x1b[2mAssistant:\x1b[0m ");
             firstChunk = false;
           }
 

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -1,18 +1,19 @@
 import type { HipfireConfig } from "./index.ts";
 import { findModel, resolveModelTag, isServeUp } from "./index.ts";
-
-interface ChatMessage {
-  role: "user" | "assistant" | "system";
-  content: string;
-}
+import {
+  graphemes, sanitizePaste, estimateTokens,
+  computeTokPerSec, trimTokenWindow,
+  trimMessages, renderMarkdown,
+  feedPasteParser, type PasteParserState,
+  historyUp, historyDown, historySubmit, type HistoryState,
+  type ChatMessage,
+} from "./chat_pure.ts";
 
 interface ChatState {
   messages: ChatMessage[];
   inputBuf: string;
   inputCursor: number;            // grapheme index, not code-unit index
-  inputDraft: string | null;      // saved draft when navigating history
-  inputHistory: string[];
-  historyIndex: number;
+  history: HistoryState;          // input history with draft preservation
   streaming: boolean;
   committedLines: string[];
   tokPerSec: number;
@@ -21,39 +22,13 @@ interface ChatState {
   modelTag: string;
   daemonPid: number | null;
   daemonPort: number;
-  pasteMode: boolean;
-  pasteBuf: string;
+  paste: PasteParserState;        // bracketed-paste accumulator
   escBuf: string;
   tokenTimes: number[];
   totalTokens: number;
   thinking: boolean;
   ctxLimit: number;
   cleanedUp: boolean;
-}
-
-// Grapheme-aware split. Falls back to Array.from for runtimes without Intl.Segmenter.
-const SEGMENTER: any = (typeof (globalThis as any).Intl !== "undefined" && (Intl as any).Segmenter)
-  ? new (Intl as any).Segmenter(undefined, { granularity: "grapheme" })
-  : null;
-
-function graphemes(s: string): string[] {
-  if (!s) return [];
-  if (SEGMENTER) {
-    const out: string[] = [];
-    for (const seg of SEGMENTER.segment(s)) out.push(seg.segment);
-    return out;
-  }
-  return Array.from(s);
-}
-
-function sanitizePaste(s: string): string {
-  // Strip control bytes < 0x20 except \n and \t.
-  let out = "";
-  for (let i = 0; i < s.length; i++) {
-    const c = s.charCodeAt(i);
-    if (c >= 32 || c === 0x0a || c === 0x09) out += s[i];
-  }
-  return out;
 }
 
 export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
@@ -78,9 +53,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     messages: [],
     inputBuf: "",
     inputCursor: 0,
-    inputDraft: null,
-    inputHistory: [],
-    historyIndex: 0,
+    history: { history: [], index: 0, draft: null },
     streaming: false,
     committedLines: [],
     tokPerSec: 0,
@@ -89,8 +62,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     modelTag,
     daemonPid: null,
     daemonPort: cfg.port,
-    pasteMode: false,
-    pasteBuf: "",
+    paste: { inPaste: false, buf: "" },
     escBuf: "",
     tokenTimes: [],
     totalTokens: 0,
@@ -208,17 +180,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
   // final flush of the response. Never to the streaming tail — partial markdown
   // delimiters cause flicker as styling pops in/out.
 
-  function renderMarkdown(text: string): string {
-    text = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_m: string, lang: string, code: string) => {
-      const border = "\x1b[2m" + "─".repeat(Math.min(60, stdout.columns ?? 60)) + "\x1b[0m";
-      const label = lang ? `\x1b[2m[${lang}]\x1b[0m` : "\x1b[2m[code]\x1b[0m";
-      return `\n${border}\n${label}\n${code}\n${border}`;
-    });
-    text = text.replace(/`([^`]+)`/g, (_m: string, code: string) => `\x1b[7m${code}\x1b[0m`);
-    text = text.replace(/\*\*([^*]+)\*\*/g, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
-    text = text.replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, (_m: string, inner: string) => `\x1b[3m${inner}\x1b[0m`);
-    return text;
-  }
+  const md = (text: string): string => renderMarkdown(text, Math.min(60, stdout.columns ?? 60));
 
   // ─── Input line rendering ───────────────────────────────
   // Uses real terminal cursor (\x1b[?25h + position reporting) instead of
@@ -315,20 +277,10 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
       }
 
       case "trim": {
-        // Trim only enough to fall under target % of REAL context limit,
-        // preserving any leading system message.
         const targetPct = args[0] ? parseFloat(args[0]) / 100 : 0.5;
-        const target = state.ctxLimit * (Number.isFinite(targetPct) ? targetPct : 0.5);
-        let used = state.messages.reduce((s, m) => s + estimateTokens(m.content), 0);
-        let dropped = 0;
-        // Find first non-system message; preserve system at index 0 if present.
-        const firstIdx = (state.messages[0]?.role === "system") ? 1 : 0;
-        while (used > target && state.messages.length > firstIdx + 1) {
-          const removed = state.messages.splice(firstIdx, 1)[0]!;
-          used -= estimateTokens(removed.content);
-          dropped++;
-        }
-        w(`\nTrimmed ${dropped} message(s); ${state.messages.length} remain (~${used} tok).\n\n`);
+        const result = trimMessages(state.messages, state.ctxLimit, targetPct);
+        state.messages = result.kept;
+        w(`\nTrimmed ${result.dropped} message(s); ${state.messages.length} remain (~${result.remainingTokens} tok).\n\n`);
         break;
       }
 
@@ -370,8 +322,8 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
 
     state.inputBuf = "";
     state.inputCursor = 0;
-    state.inputDraft = null;
-    state.historyIndex = state.inputHistory.length;
+    // Reset history navigation cursor to the bottom; clear any saved draft.
+    state.history = { ...state.history, index: state.history.history.length, draft: null };
     renderInputLine();
   }
 
@@ -385,18 +337,8 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     const now = Date.now();
     for (let i = 0; i < tokAdded; i++) state.tokenTimes.push(now);
     state.totalTokens += tokAdded;
-    const cutoff = now - 2000;
-    while (state.tokenTimes.length > 0 && (state.tokenTimes[0] ?? 0) < cutoff) {
-      state.tokenTimes.shift();
-    }
-    if (state.tokenTimes.length >= 2) {
-      const span = ((state.tokenTimes[state.tokenTimes.length - 1] ?? 0) - (state.tokenTimes[0] ?? 0)) / 1000;
-      if (span > 0) state.tokPerSec = state.tokenTimes.length / span;
-    }
-  }
-
-  function estimateTokens(text: string): number {
-    return Math.ceil(text.length / 3.5);
+    trimTokenWindow(state.tokenTimes, now);
+    state.tokPerSec = computeTokPerSec(state.tokenTimes);
   }
 
   function checkContextOverflow() {
@@ -563,9 +505,9 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
               const p = parts[i]!;
               if (i === 0) {
                 // First commit needs to clear the raw tail and re-emit styled.
-                w("\r\x1b[K" + renderMarkdown(p) + "\n");
+                w("\r\x1b[K" + md(p) + "\n");
               } else {
-                w(renderMarkdown(p) + "\n");
+                w(md(p) + "\n");
               }
               state.committedLines.push(p);
             }
@@ -601,7 +543,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     // Flush the trailing incomplete line: re-render with markdown so any
     // closing delimiters that arrived in the final chunk get styled.
     if (incompleteLine && !firstChunk) {
-      w("\r\x1b[K" + renderMarkdown(incompleteLine) + "\n");
+      w("\r\x1b[K" + md(incompleteLine) + "\n");
       state.committedLines.push(incompleteLine);
     }
 
@@ -625,9 +567,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     const msg = state.inputBuf.trim();
     if (!msg) return;
 
-    state.inputHistory.push(state.inputBuf);
-    state.historyIndex = state.inputHistory.length;
-    state.inputDraft = null;
+    state.history = historySubmit(state.history, state.inputBuf);
     state.inputBuf = "";
     state.inputCursor = 0;
 
@@ -693,25 +633,19 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
       return;
     }
 
-    // Bracketed paste start.
-    if (chunk.startsWith("\x1b[200~")) {
-      state.pasteMode = true;
-      state.pasteBuf = sanitizePaste(chunk.slice(6).replace(/\r\n?/g, "\n"));
-      return;
-    }
-
-    if (state.pasteMode) {
-      const endIdx = chunk.indexOf("\x1b[201~");
-      if (endIdx !== -1) {
-        state.pasteBuf += sanitizePaste(chunk.slice(0, endIdx).replace(/\r\n?/g, "\n"));
-        insertText(state.pasteBuf);
-        state.pasteMode = false;
-        state.pasteBuf = "";
+    // Bracketed paste — pure state-machine in chat_pure.ts handles all the
+    // start/end-marker-split-across-chunks and CRLF-normalization edge cases.
+    {
+      const r = feedPasteParser(state.paste, chunk);
+      state.paste = r.state;
+      if (r.paste !== null) {
+        insertText(r.paste);
         renderInputLine();
-      } else {
-        state.pasteBuf += sanitizePaste(chunk.replace(/\r\n?/g, "\n"));
+        return;
       }
-      return;
+      if (r.passthrough === null) return;          // still mid-paste, swallow
+      // Otherwise fall through to keystroke handling with r.passthrough.
+      chunk = r.passthrough;
     }
 
     switch (chunk) {
@@ -747,8 +681,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
           if (state.inputBuf.length > 0) {
             state.inputBuf = "";
             state.inputCursor = 0;
-            state.inputDraft = null;
-            state.historyIndex = state.inputHistory.length;
+            state.history = { ...state.history, index: state.history.history.length, draft: null };
             w("^C\n");
             renderInputLine();
           }
@@ -796,30 +729,26 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
         break;
 
       case "\x1b[A": // Up arrow — history back
-        if (!state.streaming && state.historyIndex > 0) {
-          // Save in-progress draft on first up-arrow.
-          if (state.historyIndex === state.inputHistory.length && state.inputDraft === null) {
-            state.inputDraft = state.inputBuf;
+        if (!state.streaming) {
+          const r = historyUp(state.history, state.inputBuf);
+          if (r.buffer !== state.inputBuf || r.state !== state.history) {
+            state.history = r.state;
+            state.inputBuf = r.buffer;
+            state.inputCursor = bufferGraphemeLength();
+            renderInputLine();
           }
-          state.historyIndex--;
-          state.inputBuf = state.inputHistory[state.historyIndex] ?? "";
-          state.inputCursor = bufferGraphemeLength();
-          renderInputLine();
         }
         break;
 
       case "\x1b[B": // Down arrow — history forward
-        if (!state.streaming && state.historyIndex < state.inputHistory.length) {
-          state.historyIndex++;
-          if (state.historyIndex === state.inputHistory.length) {
-            // Restore the in-progress draft (if any).
-            state.inputBuf = state.inputDraft ?? "";
-            state.inputDraft = null;
-          } else {
-            state.inputBuf = state.inputHistory[state.historyIndex] ?? "";
+        if (!state.streaming) {
+          const r = historyDown(state.history, state.inputBuf);
+          if (r.buffer !== state.inputBuf || r.state !== state.history) {
+            state.history = r.state;
+            state.inputBuf = r.buffer;
+            state.inputCursor = bufferGraphemeLength();
+            renderInputLine();
           }
-          state.inputCursor = bufferGraphemeLength();
-          renderInputLine();
         }
         break;
 

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -49,6 +49,16 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
 
   const modelTag = resolveModelTag(tag);
 
+  // Chat-shaped floor for max_tokens. The global default (cli/index.ts:148) is
+  // 512, tuned for one-shot `hipfire run` invocations; in chat that truncates
+  // mid-sentence with no user-visible warning. Floor only — a deliberate
+  // higher value from `hipfire config set max_tokens` or mid-session
+  // `/set max_tokens N` still wins.
+  const CHAT_MIN_MAX_TOKENS = 8192;
+  if (cfg.max_tokens < CHAT_MIN_MAX_TOKENS) {
+    cfg.max_tokens = CHAT_MIN_MAX_TOKENS;
+  }
+
   const state: ChatState = {
     messages: [],
     inputBuf: "",

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -1,0 +1,894 @@
+import type { HipfireConfig } from "./index.ts";
+import { findModel, resolveModelTag, isServeUp } from "./index.ts";
+
+interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+interface ChatState {
+  messages: ChatMessage[];
+  inputBuf: string;
+  inputCursor: number;            // grapheme index, not code-unit index
+  inputDraft: string | null;      // saved draft when navigating history
+  inputHistory: string[];
+  historyIndex: number;
+  streaming: boolean;
+  committedLines: string[];
+  tokPerSec: number;
+  abortController: AbortController | null;
+  lastAbortTime: number | null;
+  modelTag: string;
+  daemonPid: number | null;
+  daemonPort: number;
+  pasteMode: boolean;
+  pasteBuf: string;
+  escBuf: string;
+  tokenTimes: number[];
+  totalTokens: number;
+  thinking: boolean;
+  ctxLimit: number;
+  cleanedUp: boolean;
+}
+
+// Grapheme-aware split. Falls back to Array.from for runtimes without Intl.Segmenter.
+const SEGMENTER: any = (typeof (globalThis as any).Intl !== "undefined" && (Intl as any).Segmenter)
+  ? new (Intl as any).Segmenter(undefined, { granularity: "grapheme" })
+  : null;
+
+function graphemes(s: string): string[] {
+  if (!s) return [];
+  if (SEGMENTER) {
+    const out: string[] = [];
+    for (const seg of SEGMENTER.segment(s)) out.push(seg.segment);
+    return out;
+  }
+  return Array.from(s);
+}
+
+function sanitizePaste(s: string): string {
+  // Strip control bytes < 0x20 except \n and \t.
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 32 || c === 0x0a || c === 0x09) out += s[i];
+  }
+  return out;
+}
+
+export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
+  const stdin = process.stdin;
+  const stdout = process.stdout;
+
+  if (!stdout.isTTY || !stdin.isTTY) {
+    console.error("Error: hipfire chat requires an interactive terminal (TTY).");
+    process.exit(1);
+  }
+
+  const modelPath = findModel(tag);
+  if (!modelPath) {
+    console.error(`Model not found: ${tag}`);
+    console.error("Run 'hipfire list' to see available models, or 'hipfire pull <tag>' to download.");
+    process.exit(1);
+  }
+
+  const modelTag = resolveModelTag(tag);
+
+  const state: ChatState = {
+    messages: [],
+    inputBuf: "",
+    inputCursor: 0,
+    inputDraft: null,
+    inputHistory: [],
+    historyIndex: 0,
+    streaming: false,
+    committedLines: [],
+    tokPerSec: 0,
+    abortController: null,
+    lastAbortTime: null,
+    modelTag,
+    daemonPid: null,
+    daemonPort: cfg.port,
+    pasteMode: false,
+    pasteBuf: "",
+    escBuf: "",
+    tokenTimes: [],
+    totalTokens: 0,
+    thinking: false,
+    // Real context limit comes from cfg.max_seq (registry-resolved per model).
+    ctxLimit: cfg.max_seq && cfg.max_seq > 0 ? cfg.max_seq : 32768,
+    cleanedUp: false,
+  };
+
+  const w = (text: string) => stdout.write(text);
+  const we = (text: string) => process.stderr.write(text);
+
+  // ─── Daemon management ──────────────────────────────────
+
+  const existingServe = await isServeUp(cfg.port);
+  if (existingServe) {
+    state.daemonPort = cfg.port;
+    we(`[hipfire] Using existing serve on port ${cfg.port}\n`);
+  } else {
+    state.daemonPort = cfg.port;
+    we(`[hipfire] Starting serve on port ${state.daemonPort}...\n`);
+
+    const proc = Bun.spawn(
+      [process.argv[0], process.argv[1], "serve", String(state.daemonPort)],
+      {
+        stdout: "pipe",
+        // Pipe instead of inherit so daemon log lines don't bleed into the chat UI.
+        // Drained to /dev/null below; tail -f ~/.hipfire/serve.log if you want them.
+        stderr: "pipe",
+        // Suppress the daemon's PID-file write so it doesn't clobber a long-lived
+        // `hipfire serve -d`. The chat session owns this daemon's lifecycle directly
+        // via state.daemonPid; `hipfire stop` should not touch it.
+        env: { ...process.env, HIPFIRE_NO_PID_FILE: "1" },
+      },
+    );
+    state.daemonPid = proc.pid ?? null;
+
+    // Drain stderr/stdout to avoid buffer backpressure (and prevent UI bleed).
+    if (proc.stderr) {
+      const reader = (proc.stderr as ReadableStream).getReader();
+      (async () => { try { while (true) { const { done } = await reader.read(); if (done) break; } } catch {} })();
+    }
+    if (proc.stdout) {
+      const reader = (proc.stdout as ReadableStream).getReader();
+      (async () => { try { while (true) { const { done } = await reader.read(); if (done) break; } } catch {} })();
+    }
+
+    const spin = ["|", "/", "-", "\\"];
+    const deadline = Date.now() + 120_000;
+    let si = 0;
+    while (Date.now() < deadline) {
+      await new Promise<void>(r => setTimeout(r, 500));
+      if (await isServeUp(state.daemonPort)) break;
+      si = (si + 1) % 4;
+      we(`\r  Waiting for serve... ${spin[si]}       `);
+    }
+    we("\r\x1b[K");
+
+    if (!await isServeUp(state.daemonPort)) {
+      we("Daemon failed to start within 120s. Check logs.\n");
+      if (state.daemonPid) {
+        try { process.kill(state.daemonPid, "SIGTERM"); } catch {}
+      }
+      process.exit(1);
+    }
+    we(`[hipfire] Serve ready on port ${state.daemonPort}\n`);
+  }
+
+  // ─── Raw mode setup ─────────────────────────────────────
+
+  stdin.setRawMode!(true);
+  stdin.resume();
+  stdin.setEncoding("utf8");
+  w("\x1b[?2004h"); // Bracketed paste
+
+  // Handler for SIGWINCH; intentionally a no-op since we don't manage scrollback,
+  // but registered so we can deregister it cleanly on exit (and so we don't
+  // inherit any default behavior from the parent shell).
+  const onResize = () => {};
+  process.stdout.on("resize", onResize);
+
+  // ─── Cleanup (idempotent, runnable from finally OR signal handler) ─────────
+
+  const cleanup = () => {
+    if (state.cleanedUp) return;
+    state.cleanedUp = true;
+    if (state.abortController) {
+      try { state.abortController.abort(); } catch {}
+    }
+    if (state.daemonPid) {
+      try { process.kill(state.daemonPid, "SIGTERM"); } catch {}
+    }
+    // Restore terminal: leave raw mode FIRST, then disable bracketed paste —
+    // matches xterm spec ordering and avoids stuck mode on exotic terminals.
+    try { stdin.setRawMode!(false); } catch {}
+    try { stdin.pause(); } catch {}
+    try { stdin.removeAllListeners("data"); } catch {}
+    try { stdin.removeAllListeners("close"); } catch {}
+    try { stdout.write("\x1b[?2004l"); } catch {}
+    try { stdout.write("\x1b[?25h"); } catch {}  // ensure cursor visible
+    try { process.stdout.off("resize", onResize); } catch {}
+  };
+
+  const onSignal = (signo: string) => {
+    cleanup();
+    try { stdout.write(`\n[chat] received ${signo}, exiting.\n`); } catch {}
+    process.exit(0);
+  };
+  process.on("SIGINT", () => onSignal("SIGINT"));
+  process.on("SIGTERM", () => onSignal("SIGTERM"));
+  process.on("SIGHUP", () => onSignal("SIGHUP"));
+
+  // ─── Markdown rendering ─────────────────────────────────
+  // Applied only to COMMITTED lines (full lines that ended with \n) and to the
+  // final flush of the response. Never to the streaming tail — partial markdown
+  // delimiters cause flicker as styling pops in/out.
+
+  function renderMarkdown(text: string): string {
+    text = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_m: string, lang: string, code: string) => {
+      const border = "\x1b[2m" + "─".repeat(Math.min(60, stdout.columns ?? 60)) + "\x1b[0m";
+      const label = lang ? `\x1b[2m[${lang}]\x1b[0m` : "\x1b[2m[code]\x1b[0m";
+      return `\n${border}\n${label}\n${code}\n${border}`;
+    });
+    text = text.replace(/`([^`]+)`/g, (_m: string, code: string) => `\x1b[7m${code}\x1b[0m`);
+    text = text.replace(/\*\*([^*]+)\*\*/g, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
+    text = text.replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, (_m: string, inner: string) => `\x1b[3m${inner}\x1b[0m`);
+    return text;
+  }
+
+  // ─── Input line rendering ───────────────────────────────
+  // Uses real terminal cursor (\x1b[?25h + position reporting) instead of
+  // inverse-video — respects user's cursor-shape preferences and works on
+  // light themes.
+
+  function renderInputLine() {
+    const lines = state.inputBuf.split("\n");
+    const curLineRaw = lines[lines.length - 1] || "";
+    const curLineGraphemes = graphemes(curLineRaw);
+
+    // Where in the (multi-line) buffer does the current line start? Find by
+    // counting graphemes per logical line.
+    let cursorInLine = state.inputCursor;
+    for (let i = 0; i < lines.length - 1; i++) {
+      cursorInLine -= graphemes(lines[i]!).length + 1; // +1 for the \n
+    }
+    cursorInLine = Math.max(0, Math.min(cursorInLine, curLineGraphemes.length));
+
+    // Hide cursor while we redraw, then show + position at the end.
+    w("\x1b[?25l");
+    w("\r\x1b[K");
+    w("\x1b[1;36m>\x1b[0m ");
+
+    let prefixGraphemes = 2; // "> "
+    if (lines.length > 1) {
+      const indicator = `[${lines.length} lines] `;
+      w(`\x1b[2m${indicator}\x1b[0m`);
+      prefixGraphemes += indicator.length;
+    }
+
+    w(curLineGraphemes.join(""));
+
+    // Move terminal cursor to logical position.
+    // Note: this assumes 1-column-wide graphemes for cursor positioning.
+    // CJK/emoji wide-glyph cursor positioning is handled by the terminal's
+    // own width tracking when we use cursor-back from end-of-line.
+    const back = curLineGraphemes.length - cursorInLine;
+    if (back > 0) w(`\x1b[${back}D`);
+    w("\x1b[?25h");
+  }
+
+  // ─── Slash commands ─────────────────────────────────────
+
+  function handleSlashCommand() {
+    const trimmed = state.inputBuf.trimStart();
+    const parts = trimmed.slice(1).split(/\s+/);
+    const cmd = parts[0];
+    const args = parts.slice(1);
+
+    switch (cmd) {
+      case "help":
+      case "?":
+        w(`\n\x1b[1mAvailable commands:\x1b[0m
+  /help, /?          Show this help
+  /clear             Clear conversation history
+  /stats             Show model stats (tok/s, context usage)
+  /trim [pct]        Drop oldest user/assistant turns (default trim to 50% ctx)
+  /set <key> <val>   Adjust temperature, top_p, max_tokens for this session
+  /exit, /quit       Exit chat
+
+\x1b[1mKeybindings:\x1b[0m
+  CTRL+O             Insert newline (multi-line input)
+  CTRL+C             Abort stream (press twice from idle to exit)
+  CTRL+L             Clear screen
+  CTRL+D             Exit (when input empty)
+  Up/Down            Navigate input history (drafts preserved)
+  Left/Right         Move cursor
+  Home/End           Jump to start/end of line
+  Backspace/Delete   Delete characters
+\n`);
+        break;
+
+      case "clear":
+        state.messages = [];
+        state.committedLines = [];
+        state.totalTokens = 0;
+        state.tokenTimes = [];
+        state.tokPerSec = 0;
+        state.lastAbortTime = null;
+        w("\x1b[2J\x1b[H");
+        w(`Chat cleared. Model: ${state.modelTag}\n\n`);
+        break;
+
+      case "stats": {
+        const used = state.messages.reduce((s, m) => s + estimateTokens(m.content), 0);
+        const pct = state.ctxLimit > 0 ? (used / state.ctxLimit) * 100 : 0;
+        w(`\n  Model:     ${state.modelTag}\n`);
+        w(`  Messages:  ${state.messages.length}\n`);
+        w(`  Tokens:    ~${used} / ${state.ctxLimit} (${pct.toFixed(0)}%)\n`);
+        w(`  Tok/s:     ${state.tokPerSec.toFixed(1)} (last turn)\n`);
+        w(`  Total tok: ${state.totalTokens} this session\n\n`);
+        break;
+      }
+
+      case "trim": {
+        // Trim only enough to fall under target % of REAL context limit,
+        // preserving any leading system message.
+        const targetPct = args[0] ? parseFloat(args[0]) / 100 : 0.5;
+        const target = state.ctxLimit * (Number.isFinite(targetPct) ? targetPct : 0.5);
+        let used = state.messages.reduce((s, m) => s + estimateTokens(m.content), 0);
+        let dropped = 0;
+        // Find first non-system message; preserve system at index 0 if present.
+        const firstIdx = (state.messages[0]?.role === "system") ? 1 : 0;
+        while (used > target && state.messages.length > firstIdx + 1) {
+          const removed = state.messages.splice(firstIdx, 1)[0]!;
+          used -= estimateTokens(removed.content);
+          dropped++;
+        }
+        w(`\nTrimmed ${dropped} message(s); ${state.messages.length} remain (~${used} tok).\n\n`);
+        break;
+      }
+
+      case "set": {
+        const key = args[0];
+        const val = args[1];
+        if (!key || val === undefined) {
+          w("\nUsage: /set <temperature|top_p|max_tokens|repeat_penalty> <value>\n\n");
+          break;
+        }
+        const num = Number(val);
+        if (!Number.isFinite(num)) {
+          w(`\nInvalid value: ${val} (expected a number)\n\n`);
+          break;
+        }
+        switch (key) {
+          case "temperature":
+          case "temp":
+            cfg.temperature = num; w(`\nSet temperature=${num} for this session.\n\n`); break;
+          case "top_p":
+            cfg.top_p = num; w(`\nSet top_p=${num} for this session.\n\n`); break;
+          case "max_tokens":
+            cfg.max_tokens = Math.round(num); w(`\nSet max_tokens=${Math.round(num)} for this session.\n\n`); break;
+          case "repeat_penalty":
+            cfg.repeat_penalty = num; w(`\nSet repeat_penalty=${num} for this session.\n\n`); break;
+          default:
+            w(`\nUnknown key: ${key}. Try: temperature, top_p, max_tokens, repeat_penalty\n\n`);
+        }
+        break;
+      }
+
+      case "exit":
+      case "quit":
+        throw new Error("User exit");
+
+      default:
+        w(`\nUnknown command: /${cmd}. Type /help for available commands.\n\n`);
+    }
+
+    state.inputBuf = "";
+    state.inputCursor = 0;
+    state.inputDraft = null;
+    state.historyIndex = state.inputHistory.length;
+    renderInputLine();
+  }
+
+  // ─── Token tracking ─────────────────────────────────────
+  // Character-based heuristic. SSE chunks are NOT one token each — count by
+  // estimated tokens (chars / 3.5) instead. Window is per-turn (reset by
+  // streamResponse) so the rate reflects the current generation, not session avg.
+
+  function updateTokPerSec(charsAdded: number) {
+    const tokAdded = Math.max(1, Math.round(charsAdded / 3.5));
+    const now = Date.now();
+    for (let i = 0; i < tokAdded; i++) state.tokenTimes.push(now);
+    state.totalTokens += tokAdded;
+    const cutoff = now - 2000;
+    while (state.tokenTimes.length > 0 && (state.tokenTimes[0] ?? 0) < cutoff) {
+      state.tokenTimes.shift();
+    }
+    if (state.tokenTimes.length >= 2) {
+      const span = ((state.tokenTimes[state.tokenTimes.length - 1] ?? 0) - (state.tokenTimes[0] ?? 0)) / 1000;
+      if (span > 0) state.tokPerSec = state.tokenTimes.length / span;
+    }
+  }
+
+  function estimateTokens(text: string): number {
+    return Math.ceil(text.length / 3.5);
+  }
+
+  function checkContextOverflow() {
+    const totalTokens = state.messages.reduce((s, m) => s + estimateTokens(m.content), 0);
+    const pct = state.ctxLimit > 0 ? (totalTokens / state.ctxLimit) * 100 : 0;
+    if (pct > 80) {
+      w(`\n\x1b[33m[WARNING: Context ~${pct.toFixed(0)}% full (${totalTokens}/${state.ctxLimit}). Type /trim to drop old messages.]\x1b[0m\n`);
+    }
+  }
+
+  // ─── SSE stream consumer ────────────────────────────────
+  // Append-only on the live tail: we track how much of the current incomplete
+  // line has been written and only emit the new bytes. No \r + clear-EOL +
+  // re-render every token. Markdown rendering is deferred to commit-time
+  // (i.e. when we hit \n) so partial backticks/asterisks don't pop styling.
+
+  async function streamResponse(userMessage: string): Promise<void> {
+    state.messages.push({ role: "user", content: userMessage });
+    checkContextOverflow();
+
+    state.streaming = true;
+    state.abortController = new AbortController();
+    state.committedLines = [];
+    state.thinking = false;
+
+    // Per-turn rate window: clear stale entries from previous turns.
+    state.tokenTimes = [];
+    state.tokPerSec = 0;
+
+    const body: Record<string, unknown> = {
+      model: state.modelTag,
+      stream: true,
+      messages: state.messages.map(m => ({ role: m.role, content: m.content })),
+      temperature: cfg.temperature,
+      max_tokens: cfg.max_tokens,
+      repeat_penalty: cfg.repeat_penalty,
+      top_p: cfg.top_p,
+    };
+
+    w("\n");
+
+    let resp: Response;
+    try {
+      resp = await fetch(
+        `http://127.0.0.1:${state.daemonPort}/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal: state.abortController.signal,
+        },
+      );
+    } catch (err: any) {
+      if (err.name === "AbortError") {
+        w("[Stream aborted]\n");
+      } else {
+        w(`\x1b[31m[ERROR: Daemon disconnected. ${err.message ?? err}]\x1b[0m\n`);
+        w("Restart chat to reconnect.\n");
+      }
+      state.streaming = false;
+      state.abortController = null;
+      renderInputLine();
+      return;
+    }
+
+    if (!resp.ok) {
+      const txt = await resp.text().catch(() => "");
+      w(`\x1b[31m[ERROR: HTTP ${resp.status}: ${txt.slice(0, 200)}]\x1b[0m\n`);
+      state.streaming = false;
+      state.abortController = null;
+      renderInputLine();
+      return;
+    }
+
+    if (!resp.body) {
+      w("\x1b[31m[ERROR: No response body]\x1b[0m\n");
+      state.streaming = false;
+      state.abortController = null;
+      renderInputLine();
+      return;
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let incompleteLine = "";
+    let incompleteLineWritten = 0;  // chars of incompleteLine already on screen
+    let fullResponse = "";
+    let firstChunk = true;
+
+    // ASCII spinner — works on every terminal, including older xterm and the
+    // plain Linux console (braille pattern chars don't render there).
+    const spinChars = ["|", "/", "-", "\\"];
+    let spinInterval: ReturnType<typeof setInterval> | null = setInterval(() => {
+      if (firstChunk) {
+        const label = state.thinking ? "thinking..." : "generating...";
+        w(`\r  ${spinChars[Math.floor(Date.now() / 80) % spinChars.length]} ${label}\x1b[K`);
+      }
+    }, 80);
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6);
+          if (data === "[DONE]") { buffer = ""; break; }
+
+          let chunk: any;
+          try { chunk = JSON.parse(data); }
+          catch (e: any) {
+            we(`\x1b[2m[SSE parse: ${(e?.message ?? "error").slice(0, 60)}]\x1b[0m`);
+            continue;
+          }
+
+          if (chunk.error) {
+            w(`\n\x1b[31m[hipfire] ${chunk.error.message || "server error"}\x1b[0m\n`);
+            continue;
+          }
+
+          const delta = chunk.choices?.[0]?.delta ?? {};
+
+          if (delta.reasoning_content && !delta.content) {
+            if (!state.thinking) {
+              state.thinking = true;
+              if (firstChunk) {
+                w("\r\x1b[K");
+                firstChunk = false;
+              }
+              w("\x1b[2m[thinking]\x1b[0m");
+            }
+            continue;
+          }
+
+          let text: string = delta.content ?? "";
+          if (!text) continue;
+
+          if (state.thinking) {
+            state.thinking = false;
+            w("\r\x1b[K");
+          }
+
+          if (firstChunk) {
+            w("\r\x1b[K");
+            firstChunk = false;
+          }
+
+          fullResponse += text;
+          incompleteLine += text;
+
+          if (text.includes("\n")) {
+            const parts = incompleteLine.split("\n");
+            // Commit all complete lines: print the unwritten suffix first, then
+            // re-render with markdown styling. We're switching from "raw tail"
+            // to "rendered committed" so we use \r + clear-EOL for the first
+            // committed line only.
+            for (let i = 0; i < parts.length - 1; i++) {
+              const p = parts[i]!;
+              if (i === 0) {
+                // First commit needs to clear the raw tail and re-emit styled.
+                w("\r\x1b[K" + renderMarkdown(p) + "\n");
+              } else {
+                w(renderMarkdown(p) + "\n");
+              }
+              state.committedLines.push(p);
+            }
+            incompleteLine = parts[parts.length - 1] ?? "";
+            incompleteLineWritten = 0;
+            // Print the (unstyled) tail for the next incomplete line.
+            if (incompleteLine.length > 0) {
+              w(incompleteLine);
+              incompleteLineWritten = incompleteLine.length;
+            }
+          } else {
+            // Append-only: write only the new bytes since the last paint.
+            // No \r, no clear-EOL, no full re-render. Markdown is unstyled
+            // here on purpose — it will be re-rendered when the line commits.
+            if (incompleteLine.length > incompleteLineWritten) {
+              w(incompleteLine.slice(incompleteLineWritten));
+              incompleteLineWritten = incompleteLine.length;
+            }
+          }
+
+          updateTokPerSec(text.length);
+        }
+      }
+    } catch (err: any) {
+      if (err.name === "AbortError") {
+        if (!firstChunk) w("\n");
+        w("[Stream aborted]\n");
+      }
+    }
+
+    if (spinInterval) { clearInterval(spinInterval); spinInterval = null; }
+
+    // Flush the trailing incomplete line: re-render with markdown so any
+    // closing delimiters that arrived in the final chunk get styled.
+    if (incompleteLine && !firstChunk) {
+      w("\r\x1b[K" + renderMarkdown(incompleteLine) + "\n");
+      state.committedLines.push(incompleteLine);
+    }
+
+    if (state.tokPerSec > 0 && state.totalTokens > 0) {
+      we(`\x1b[2m  ${state.tokPerSec.toFixed(0)} tok/s\x1b[0m`);
+    }
+
+    if (fullResponse) {
+      state.messages.push({ role: "assistant", content: fullResponse });
+    }
+
+    state.streaming = false;
+    state.abortController = null;
+    w("\n");
+    renderInputLine();
+  }
+
+  // ─── Submit handler ─────────────────────────────────────
+
+  function handleSubmit() {
+    const msg = state.inputBuf.trim();
+    if (!msg) return;
+
+    state.inputHistory.push(state.inputBuf);
+    state.historyIndex = state.inputHistory.length;
+    state.inputDraft = null;
+    state.inputBuf = "";
+    state.inputCursor = 0;
+
+    w("\r\x1b[K");
+    w(`\x1b[1;33mYou:\x1b[0m ${msg}\n`);
+
+    streamResponse(msg).catch((err: any) => {
+      w(`\x1b[31mError: ${err.message ?? err}\x1b[0m\n`);
+      state.streaming = false;
+      state.abortController = null;
+      renderInputLine();
+    });
+  }
+
+  // ─── Input mutation helpers (grapheme-cursor aware) ─────────────────────
+
+  function insertText(text: string) {
+    if (!text) return;
+    const g = graphemes(state.inputBuf);
+    const left = g.slice(0, state.inputCursor).join("");
+    const right = g.slice(state.inputCursor).join("");
+    state.inputBuf = left + text + right;
+    state.inputCursor += graphemes(text).length;
+  }
+
+  function deleteBackward() {
+    if (state.inputCursor === 0) return;
+    const g = graphemes(state.inputBuf);
+    g.splice(state.inputCursor - 1, 1);
+    state.inputBuf = g.join("");
+    state.inputCursor--;
+  }
+
+  function deleteForward() {
+    const g = graphemes(state.inputBuf);
+    if (state.inputCursor >= g.length) return;
+    g.splice(state.inputCursor, 1);
+    state.inputBuf = g.join("");
+  }
+
+  function bufferGraphemeLength(): number {
+    return graphemes(state.inputBuf).length;
+  }
+
+  function isAtNewline(offset: number): boolean {
+    const g = graphemes(state.inputBuf);
+    return g[offset] === "\n";
+  }
+
+  // ─── Raw input handler ──────────────────────────────────
+
+  function handleInput(chunk: string) {
+    if (state.escBuf) {
+      chunk = state.escBuf + chunk;
+      state.escBuf = "";
+    }
+
+    // Buffer lone ESC and wait for next chunk. Don't try to be clever about
+    // partial CSI sequences — \x1b[? would have been wrongly classified as
+    // "complete" by the prior digit-only regex.
+    if (chunk === "\x1b") {
+      state.escBuf = chunk;
+      return;
+    }
+
+    // Bracketed paste start.
+    if (chunk.startsWith("\x1b[200~")) {
+      state.pasteMode = true;
+      state.pasteBuf = sanitizePaste(chunk.slice(6).replace(/\r\n?/g, "\n"));
+      return;
+    }
+
+    if (state.pasteMode) {
+      const endIdx = chunk.indexOf("\x1b[201~");
+      if (endIdx !== -1) {
+        state.pasteBuf += sanitizePaste(chunk.slice(0, endIdx).replace(/\r\n?/g, "\n"));
+        insertText(state.pasteBuf);
+        state.pasteMode = false;
+        state.pasteBuf = "";
+        renderInputLine();
+      } else {
+        state.pasteBuf += sanitizePaste(chunk.replace(/\r\n?/g, "\n"));
+      }
+      return;
+    }
+
+    switch (chunk) {
+      case "\x0f": // CTRL+O — explicit newline
+        if (!state.streaming) {
+          insertText("\n");
+          renderInputLine();
+        }
+        break;
+
+      case "\r":
+        if (!state.streaming && state.inputBuf.trim()) {
+          if (state.inputBuf.trimStart().startsWith("/")) {
+            handleSlashCommand();
+          } else {
+            handleSubmit();
+          }
+        }
+        break;
+
+      case "\x03": { // CTRL+C
+        const now = Date.now();
+        if (state.streaming) {
+          state.abortController?.abort();
+          state.lastAbortTime = now;
+        } else if (state.lastAbortTime && now - state.lastAbortTime < 1000) {
+          throw new Error("User interrupt");
+        } else {
+          // First idle Ctrl+C: silently arm the second-hit timer. No nag.
+          // Discoverability is via /help, not via inline message.
+          state.lastAbortTime = now;
+          // If the user had partial input, clear it (bash semantics).
+          if (state.inputBuf.length > 0) {
+            state.inputBuf = "";
+            state.inputCursor = 0;
+            state.inputDraft = null;
+            state.historyIndex = state.inputHistory.length;
+            w("^C\n");
+            renderInputLine();
+          }
+        }
+        break;
+      }
+
+      case "\x04": // CTRL+D
+        if (!state.streaming && state.inputBuf === "") {
+          throw new Error("User exit");
+        }
+        break;
+
+      case "\x0c": // CTRL+L
+        if (!state.streaming) {
+          w("\x1b[2J\x1b[H");
+          renderInputLine();
+        }
+        break;
+
+      case "\x7f":
+      case "\b":
+        if (!state.streaming && state.inputCursor > 0) {
+          deleteBackward();
+          renderInputLine();
+        }
+        break;
+
+      case "\x1b[D": // Left arrow
+        if (!state.streaming && state.inputCursor > 0) {
+          if (!isAtNewline(state.inputCursor - 1)) {
+            state.inputCursor--;
+            renderInputLine();
+          }
+        }
+        break;
+
+      case "\x1b[C": // Right arrow
+        if (!state.streaming && state.inputCursor < bufferGraphemeLength()) {
+          if (!isAtNewline(state.inputCursor)) {
+            state.inputCursor++;
+            renderInputLine();
+          }
+        }
+        break;
+
+      case "\x1b[A": // Up arrow — history back
+        if (!state.streaming && state.historyIndex > 0) {
+          // Save in-progress draft on first up-arrow.
+          if (state.historyIndex === state.inputHistory.length && state.inputDraft === null) {
+            state.inputDraft = state.inputBuf;
+          }
+          state.historyIndex--;
+          state.inputBuf = state.inputHistory[state.historyIndex] ?? "";
+          state.inputCursor = bufferGraphemeLength();
+          renderInputLine();
+        }
+        break;
+
+      case "\x1b[B": // Down arrow — history forward
+        if (!state.streaming && state.historyIndex < state.inputHistory.length) {
+          state.historyIndex++;
+          if (state.historyIndex === state.inputHistory.length) {
+            // Restore the in-progress draft (if any).
+            state.inputBuf = state.inputDraft ?? "";
+            state.inputDraft = null;
+          } else {
+            state.inputBuf = state.inputHistory[state.historyIndex] ?? "";
+          }
+          state.inputCursor = bufferGraphemeLength();
+          renderInputLine();
+        }
+        break;
+
+      case "\x1b[H": // Home
+        if (!state.streaming) {
+          // Move to start of current logical line.
+          const g = graphemes(state.inputBuf);
+          let i = state.inputCursor;
+          while (i > 0 && g[i - 1] !== "\n") i--;
+          state.inputCursor = i;
+          renderInputLine();
+        }
+        break;
+
+      case "\x1b[F": // End
+        if (!state.streaming) {
+          const g = graphemes(state.inputBuf);
+          let i = state.inputCursor;
+          while (i < g.length && g[i] !== "\n") i++;
+          state.inputCursor = i;
+          renderInputLine();
+        }
+        break;
+
+      case "\x1b[3~": // Delete
+        if (!state.streaming && state.inputCursor < bufferGraphemeLength()) {
+          deleteForward();
+          renderInputLine();
+        }
+        break;
+
+      default:
+        if (!state.streaming && chunk.length > 0 && chunk.charCodeAt(0) >= 32) {
+          if (chunk.startsWith("\x1b")) break;
+          insertText(chunk);
+          renderInputLine();
+        }
+        break;
+    }
+  }
+
+  // ─── Main loop ──────────────────────────────────────────
+
+  try {
+    w(`\x1b[1mhipfire chat\x1b[0m — ${state.modelTag}\n`);
+    w("Type /help for commands. CTRL+O for multi-line input.\n\n");
+    renderInputLine();
+
+    await new Promise<void>((resolve, reject) => {
+      stdin.on("data", (data: string) => {
+        try {
+          handleInput(data);
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      stdin.on("close", () => {
+        reject(new Error("User exit"));
+      });
+    });
+  } catch (err: any) {
+    if (err.message === "User exit" || err.message === "User interrupt") {
+      w("\nExiting...\n");
+    } else {
+      w(`\n\x1b[31mError: ${err.message ?? err}\x1b[0m\n`);
+    }
+  } finally {
+    cleanup();
+    w("\n");
+  }
+}

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -3,7 +3,7 @@ import { findModel, resolveModelTag, isServeUp } from "./index.ts";
 import {
   graphemes, sanitizePaste, estimateTokens,
   computeTokPerSec, trimTokenWindow,
-  trimMessages, renderMarkdown,
+  trimMessages, renderMarkdown, stripAnsi,
   detectFenceLine, renderFenceOpen, renderFenceClose,
   feedPasteParser, type PasteParserState,
   historyUp, historyDown, historySubmit, type HistoryState,
@@ -32,7 +32,11 @@ interface ChatState {
   cleanedUp: boolean;
 }
 
-export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
+export interface ChatTuiOptions {
+  noColor?: boolean;  // explicit --no-color flag from CLI
+}
+
+export async function chatTui(tag: string, cfg: HipfireConfig, opts: ChatTuiOptions = {}): Promise<void> {
   const stdin = process.stdin;
   const stdout = process.stdout;
 
@@ -83,8 +87,23 @@ export async function chatTui(tag: string, cfg: HipfireConfig): Promise<void> {
     cleanedUp: false,
   };
 
-  const w = (text: string) => stdout.write(text);
-  const we = (text: string) => process.stderr.write(text);
+  // NO_COLOR support: https://no-color.org. Strips SGR + OSC 8 hyperlinks
+  // at write-time so the per-site styling code stays untouched. Also auto-
+  // disables when stdout/stderr aren't TTYs (already gated above for stdin
+  // but redundancy is cheap). Honors:
+  //   - explicit --no-color flag (opts.noColor)
+  //   - NO_COLOR env var (any non-empty value, per the spec)
+  //   - CLICOLOR=0 (de-facto-standard fallback)
+  const colorOff = opts.noColor === true
+    || (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "")
+    || process.env.CLICOLOR === "0";
+
+  const w = colorOff
+    ? (text: string) => stdout.write(stripAnsi(text))
+    : (text: string) => stdout.write(text);
+  const we = colorOff
+    ? (text: string) => process.stderr.write(stripAnsi(text))
+    : (text: string) => process.stderr.write(text);
 
   // ─── Daemon management ──────────────────────────────────
 

--- a/cli/chat_pure.test.ts
+++ b/cli/chat_pure.test.ts
@@ -1,0 +1,456 @@
+// Bun-native tests for cli/chat_pure.ts.
+//
+// Direct import: chat_pure.ts is a side-effect-free module (no top-level
+// console writes, no fs/spawn). Unlike parse_tool_calls.test.ts, we don't
+// need to duplicate the SUT.
+//
+// Run: bun test cli/chat_pure.test.ts
+
+import { test, expect, describe } from "bun:test";
+import {
+  graphemes,
+  sanitizePaste,
+  estimateTokens,
+  computeTokPerSec,
+  trimTokenWindow,
+  trimMessages,
+  renderMarkdown,
+  feedPasteParser,
+  historyUp,
+  historyDown,
+  historySubmit,
+} from "./chat_pure.ts";
+
+// ─── graphemes ──────────────────────────────────────────────────────────────
+
+describe("graphemes", () => {
+  test("empty string returns empty array", () => {
+    expect(graphemes("")).toEqual([]);
+  });
+
+  test("ASCII splits one char per grapheme", () => {
+    expect(graphemes("hello")).toEqual(["h", "e", "l", "l", "o"]);
+  });
+
+  test("non-BMP emoji is one grapheme, not two surrogates", () => {
+    // 😀 is U+1F600, which is a 2-code-unit surrogate pair in UTF-16.
+    // Naive str[i] would return half-pairs; graphemes() must coalesce.
+    const g = graphemes("a😀b");
+    expect(g.length).toBe(3);
+    expect(g[1]).toBe("😀");
+  });
+
+  test("CJK characters are one grapheme each", () => {
+    const g = graphemes("你好");
+    expect(g.length).toBe(2);
+    expect(g[0]).toBe("你");
+    expect(g[1]).toBe("好");
+  });
+
+  test("ZWJ-joined family emoji is a single grapheme (Intl.Segmenter only)", () => {
+    // 👨‍👩‍👧 — man + ZWJ + woman + ZWJ + girl. Renders as one glyph.
+    // Array.from() fallback would return 5 elements; Intl.Segmenter returns 1.
+    const fam = "👨‍👩‍👧";
+    const g = graphemes(fam);
+    if ((globalThis as any).Intl?.Segmenter) {
+      expect(g.length).toBe(1);
+      expect(g[0]).toBe(fam);
+    } else {
+      // Fallback path — at least confirm it doesn't blow up.
+      expect(g.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("combining marks attach to base character", () => {
+    // 'e' + combining acute → "é" as one grapheme.
+    const s = "é";
+    const g = graphemes(s);
+    if ((globalThis as any).Intl?.Segmenter) {
+      expect(g.length).toBe(1);
+    }
+  });
+});
+
+// ─── sanitizePaste ──────────────────────────────────────────────────────────
+
+describe("sanitizePaste", () => {
+  test("pure ASCII passes through", () => {
+    expect(sanitizePaste("hello world")).toBe("hello world");
+  });
+
+  test("preserves \\n and \\t", () => {
+    expect(sanitizePaste("a\nb\tc")).toBe("a\nb\tc");
+  });
+
+  test("strips NUL byte", () => {
+    expect(sanitizePaste("a\x00b")).toBe("ab");
+  });
+
+  test("strips BEL", () => {
+    expect(sanitizePaste("a\x07b")).toBe("ab");
+  });
+
+  test("strips embedded ANSI escape sequences (the actual bug it fixes)", () => {
+    // If a user pastes `\x1b[31mred\x1b[0m`, the ESC bytes must not survive
+    // into inputBuf — otherwise they'd be sent to the model verbatim.
+    expect(sanitizePaste("a\x1b[31mred\x1b[0mb")).toBe("a[31mred[0mb");
+  });
+
+  test("preserves Unicode (multi-byte chars are >= 0x20)", () => {
+    expect(sanitizePaste("hello 你好 😀")).toBe("hello 你好 😀");
+  });
+});
+
+// ─── estimateTokens ─────────────────────────────────────────────────────────
+
+describe("estimateTokens", () => {
+  test("empty string returns 0", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  test("short string rounds up", () => {
+    // "hi" = 2 chars / 3.5 = 0.57 → ceil = 1
+    expect(estimateTokens("hi")).toBe(1);
+  });
+
+  test("scales linearly with length", () => {
+    // 35 chars / 3.5 = 10
+    expect(estimateTokens("a".repeat(35))).toBe(10);
+  });
+});
+
+// ─── computeTokPerSec / trimTokenWindow ────────────────────────────────────
+
+describe("computeTokPerSec", () => {
+  test("empty array returns 0", () => {
+    expect(computeTokPerSec([])).toBe(0);
+  });
+
+  test("single sample returns 0 (no time span)", () => {
+    expect(computeTokPerSec([1000])).toBe(0);
+  });
+
+  test("two samples 1s apart yields 2 tok/s", () => {
+    expect(computeTokPerSec([0, 1000])).toBe(2);
+  });
+
+  test("ten samples over 1s yields 10 tok/s", () => {
+    const times = Array.from({ length: 10 }, (_, i) => i * 100);
+    // span = 900ms = 0.9s, count = 10, rate = 10/0.9 ≈ 11.1
+    expect(computeTokPerSec(times)).toBeCloseTo(10 / 0.9, 1);
+  });
+
+  test("zero-span samples (all at same time) return 0", () => {
+    expect(computeTokPerSec([500, 500, 500])).toBe(0);
+  });
+});
+
+describe("trimTokenWindow", () => {
+  test("removes entries older than windowMs", () => {
+    const now = 10_000;
+    const times = [5000, 7000, 8500, 9000];
+    trimTokenWindow(times, now, 2000); // cutoff = 8000
+    expect(times).toEqual([8500, 9000]);
+  });
+
+  test("keeps everything if all in window", () => {
+    const now = 10_000;
+    const times = [9000, 9500, 9999];
+    trimTokenWindow(times, now, 2000);
+    expect(times).toEqual([9000, 9500, 9999]);
+  });
+
+  test("handles empty array", () => {
+    const times: number[] = [];
+    trimTokenWindow(times, 10_000, 2000);
+    expect(times).toEqual([]);
+  });
+
+  test("default window is 2000ms", () => {
+    const now = 5000;
+    const times = [2000, 3500, 4500];
+    trimTokenWindow(times, now); // default cutoff = 3000
+    expect(times).toEqual([3500, 4500]);
+  });
+
+  test("per-turn reset use case: stale entries from previous turn cleared", () => {
+    // Regression: GLM-5 finding M2 (session-cumulative tok/s).
+    // After a 30s gap between turns, all old entries must be evicted.
+    const times = [1000, 1200, 1400]; // turn 1
+    const now = 31_400; // 30s later
+    trimTokenWindow(times, now, 2000);
+    expect(times).toEqual([]);
+  });
+});
+
+// ─── trimMessages ───────────────────────────────────────────────────────────
+
+describe("trimMessages", () => {
+  test("no trim needed when under target", () => {
+    const msgs = [
+      { role: "user" as const, content: "short" },
+      { role: "assistant" as const, content: "ok" },
+    ];
+    const r = trimMessages(msgs, 32768, 0.5);
+    expect(r.dropped).toBe(0);
+    expect(r.kept.length).toBe(2);
+  });
+
+  test("preserves leading system message (regression: original /trim ate it)", () => {
+    const big = "x".repeat(100_000); // ~28571 tokens, exceeds half of 32768
+    const msgs = [
+      { role: "system" as const, content: "you are helpful" },
+      { role: "user" as const, content: big },
+      { role: "user" as const, content: big },
+      { role: "user" as const, content: "latest" },
+    ];
+    const r = trimMessages(msgs, 32768, 0.5);
+    expect(r.kept[0]?.role).toBe("system");
+    expect(r.kept[0]?.content).toBe("you are helpful");
+    // Should have dropped at least one of the big user messages.
+    expect(r.dropped).toBeGreaterThan(0);
+  });
+
+  test("system message NOT at index 0 is treated like a normal message", () => {
+    const big = "x".repeat(100_000);
+    const msgs = [
+      { role: "user" as const, content: big },
+      { role: "system" as const, content: "mid-conversation system msg" },
+      { role: "user" as const, content: "latest" },
+    ];
+    const r = trimMessages(msgs, 32768, 0.5);
+    // The leading user message is dropped; the system msg in middle has no special protection.
+    expect(r.kept[0]?.role).not.toBe("user");
+  });
+
+  test("always keeps at least one message after the system slot", () => {
+    const huge = "x".repeat(1_000_000); // way over any sane limit
+    const msgs = [
+      { role: "system" as const, content: "sys" },
+      { role: "user" as const, content: huge },
+    ];
+    const r = trimMessages(msgs, 1024, 0.5);
+    // Must not drop the only non-system message (would leave conversation with only system).
+    expect(r.kept.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("custom targetPct trims more aggressively", () => {
+    const msgs = Array.from({ length: 20 }, (_, i) => ({
+      role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+      content: "x".repeat(1000),
+    }));
+    const lenient = trimMessages(msgs, 1000, 0.9);
+    const strict = trimMessages(msgs, 1000, 0.1);
+    expect(strict.dropped).toBeGreaterThan(lenient.dropped);
+  });
+
+  test("invalid targetPct (NaN) falls back to 0.5", () => {
+    const msgs = Array.from({ length: 10 }, () => ({
+      role: "user" as const, content: "x".repeat(100),
+    }));
+    const r = trimMessages(msgs, 200, NaN);
+    // Should behave as 0.5; not infinite-loop or pass through unchanged.
+    expect(r.dropped).toBeGreaterThan(0);
+  });
+});
+
+// ─── renderMarkdown ─────────────────────────────────────────────────────────
+
+describe("renderMarkdown", () => {
+  test("plain text passes through unchanged", () => {
+    expect(renderMarkdown("hello world")).toBe("hello world");
+  });
+
+  test("inline code is wrapped in inverse-video SGR", () => {
+    expect(renderMarkdown("call `foo()` here")).toBe("call \x1b[7mfoo()\x1b[0m here");
+  });
+
+  test("bold is wrapped in bold SGR", () => {
+    expect(renderMarkdown("**bold**")).toBe("\x1b[1mbold\x1b[0m");
+  });
+
+  test("italic single-asterisk wrapped in italic SGR", () => {
+    expect(renderMarkdown("*em*")).toBe("\x1b[3mem\x1b[0m");
+  });
+
+  test("double asterisk does NOT match italic (must stay bold)", () => {
+    // Regression: italic regex with negative lookbehind/ahead must skip **.
+    const out = renderMarkdown("**foo**");
+    expect(out).toBe("\x1b[1mfoo\x1b[0m");
+    // No italic SGR injected.
+    expect(out).not.toContain("\x1b[3m");
+  });
+
+  test("fenced code block with language label", () => {
+    const out = renderMarkdown("```python\nprint(1)\n```", 10);
+    expect(out).toContain("[python]");
+    expect(out).toContain("print(1)");
+    expect(out).toContain("─".repeat(10));
+  });
+
+  test("fenced code block without language label", () => {
+    const out = renderMarkdown("```\nraw\n```", 10);
+    expect(out).toContain("[code]");
+    expect(out).toContain("raw");
+  });
+
+  test("fenceWidth controls border length", () => {
+    const out = renderMarkdown("```\nx\n```", 5);
+    expect(out).toContain("─".repeat(5));
+    expect(out).not.toContain("─".repeat(6));
+  });
+
+  test("incomplete fence (no closing) is left raw — important for streaming", () => {
+    // Per finding #6: streaming tail with unclosed ``` must not transform.
+    // The renderer is only ever called on COMMITTED lines, so this is the
+    // contract: no closing fence → no transform → no flicker on commit.
+    const out = renderMarkdown("```python\nprint(1)");
+    expect(out).toBe("```python\nprint(1)");
+  });
+
+  test("incomplete inline code is left raw", () => {
+    expect(renderMarkdown("call `foo here")).toBe("call `foo here");
+  });
+
+  test("multiple inline codes on one line", () => {
+    const out = renderMarkdown("`a` and `b`");
+    expect(out).toBe("\x1b[7ma\x1b[0m and \x1b[7mb\x1b[0m");
+  });
+});
+
+// ─── feedPasteParser ────────────────────────────────────────────────────────
+
+describe("feedPasteParser (bracketed paste state machine)", () => {
+  const initial = { inPaste: false, buf: "" };
+
+  test("non-paste input passes through", () => {
+    const r = feedPasteParser(initial, "hello");
+    expect(r.passthrough).toBe("hello");
+    expect(r.paste).toBeNull();
+    expect(r.state.inPaste).toBe(false);
+  });
+
+  test("complete paste in single chunk extracts content", () => {
+    const r = feedPasteParser(initial, "\x1b[200~hello world\x1b[201~");
+    expect(r.paste).toBe("hello world");
+    expect(r.passthrough).toBeNull();
+    expect(r.state.inPaste).toBe(false);
+  });
+
+  test("paste split across two chunks: start-only", () => {
+    const r1 = feedPasteParser(initial, "\x1b[200~part1");
+    expect(r1.paste).toBeNull();
+    expect(r1.state.inPaste).toBe(true);
+    expect(r1.state.buf).toBe("part1");
+
+    const r2 = feedPasteParser(r1.state, "part2\x1b[201~");
+    expect(r2.paste).toBe("part1part2");
+    expect(r2.state.inPaste).toBe(false);
+  });
+
+  test("paste split across three chunks (mid-content)", () => {
+    let st = initial;
+    let acc = "";
+    for (const chunk of ["\x1b[200~aaa", "bbb", "ccc\x1b[201~"]) {
+      const r = feedPasteParser(st, chunk);
+      st = r.state;
+      if (r.paste !== null) acc = r.paste;
+    }
+    expect(acc).toBe("aaabbbccc");
+  });
+
+  test("CRLF is normalized to LF", () => {
+    const r = feedPasteParser(initial, "\x1b[200~line1\r\nline2\x1b[201~");
+    expect(r.paste).toBe("line1\nline2");
+  });
+
+  test("embedded control bytes are sanitized", () => {
+    const r = feedPasteParser(initial, "\x1b[200~a\x07b\x00c\x1b[201~");
+    expect(r.paste).toBe("abc");
+  });
+
+  test("non-paste chunk while in-paste is buffered, not passed through", () => {
+    const mid = { inPaste: true, buf: "x" };
+    const r = feedPasteParser(mid, "y");
+    expect(r.passthrough).toBeNull();
+    expect(r.paste).toBeNull();
+    expect(r.state.buf).toBe("xy");
+  });
+
+  test("paste containing tabs preserves them", () => {
+    const r = feedPasteParser(initial, "\x1b[200~a\tb\x1b[201~");
+    expect(r.paste).toBe("a\tb");
+  });
+});
+
+// ─── history navigation ────────────────────────────────────────────────────
+
+describe("history navigation with draft preservation", () => {
+  const empty = { history: [], index: 0, draft: null };
+
+  test("up-arrow on empty history is a no-op", () => {
+    const r = historyUp(empty, "typed");
+    expect(r.buffer).toBe("typed");
+    expect(r.state).toBe(empty); // unchanged
+  });
+
+  test("up-arrow recalls last entry, saves draft", () => {
+    const st = historySubmit(empty, "first");
+    // st.index is now 1, history.length is 1, so index === length means "at draft slot".
+    const r = historyUp(st, "in-progress draft");
+    expect(r.buffer).toBe("first");
+    expect(r.state.draft).toBe("in-progress draft");
+    expect(r.state.index).toBe(0);
+  });
+
+  test("down-arrow back to bottom restores the draft (regression: original lost it)", () => {
+    let st = historySubmit(empty, "old");
+    const upR = historyUp(st, "my draft");
+    st = upR.state;
+    const downR = historyDown(st, upR.buffer);
+    expect(downR.buffer).toBe("my draft");
+    expect(downR.state.draft).toBeNull();
+    expect(downR.state.index).toBe(st.history.length);
+  });
+
+  test("up-arrow at oldest entry stays put", () => {
+    let st = historySubmit(empty, "a");
+    st = historySubmit(st, "b");
+    const r1 = historyUp(st, "");
+    const r2 = historyUp(r1.state, r1.buffer);
+    const r3 = historyUp(r2.state, r2.buffer);
+    expect(r3.state.index).toBe(0);
+    expect(r3.buffer).toBe("a");
+    // Already at oldest; further up is a no-op.
+    const r4 = historyUp(r3.state, r3.buffer);
+    expect(r4.state).toBe(r3.state);
+  });
+
+  test("down-arrow at bottom is a no-op", () => {
+    const st = historySubmit(empty, "a");
+    const r = historyDown(st, "draft");
+    expect(r.state).toBe(st);
+    expect(r.buffer).toBe("draft");
+  });
+
+  test("submit appends to history and resets navigation", () => {
+    let st = historySubmit(empty, "first");
+    st = historySubmit(st, "second");
+    expect(st.history).toEqual(["first", "second"]);
+    expect(st.index).toBe(2);
+    expect(st.draft).toBeNull();
+  });
+
+  test("draft is preserved across multiple ups but cleared on submit", () => {
+    let st = historySubmit(empty, "a");
+    st = historySubmit(st, "b");
+    // Type some draft, then up twice
+    let r = historyUp(st, "my draft");
+    expect(r.state.draft).toBe("my draft");
+    r = historyUp(r.state, r.buffer);
+    expect(r.state.draft).toBe("my draft"); // still preserved
+    // Submit clears it
+    const after = historySubmit(r.state, "submitted");
+    expect(after.draft).toBeNull();
+  });
+});

--- a/cli/chat_pure.test.ts
+++ b/cli/chat_pure.test.ts
@@ -15,6 +15,7 @@ import {
   trimTokenWindow,
   trimMessages,
   renderMarkdown,
+  stripAnsi,
   detectFenceLine,
   renderFenceOpen,
   renderFenceClose,
@@ -254,6 +255,74 @@ describe("trimMessages", () => {
     const r = trimMessages(msgs, 200, NaN);
     // Should behave as 0.5; not infinite-loop or pass through unchanged.
     expect(r.dropped).toBeGreaterThan(0);
+  });
+});
+
+// ─── stripAnsi (NO_COLOR support) ───────────────────────────────────────────
+
+describe("stripAnsi", () => {
+  test("plain text passes through unchanged", () => {
+    expect(stripAnsi("hello world")).toBe("hello world");
+  });
+
+  test("empty string", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+
+  test("strips simple SGR (bold)", () => {
+    expect(stripAnsi("\x1b[1mbold\x1b[0m")).toBe("bold");
+  });
+
+  test("strips compound SGR (bold+cyan)", () => {
+    expect(stripAnsi("\x1b[1;36mtitle\x1b[0m")).toBe("title");
+  });
+
+  test("strips reverse video", () => {
+    expect(stripAnsi("\x1b[7mfoo()\x1b[0m")).toBe("foo()");
+  });
+
+  test("strips dim + italic", () => {
+    expect(stripAnsi("\x1b[2m>\x1b[0m \x1b[3mquoted\x1b[0m")).toBe("> quoted");
+  });
+
+  test("strips OSC 8 hyperlink (ST = ESC \\)", () => {
+    const link = "\x1b]8;;https://example.com\x1b\\\x1b[4mlabel\x1b[0m\x1b]8;;\x1b\\";
+    expect(stripAnsi(link)).toBe("label");
+  });
+
+  test("strips OSC 8 hyperlink with BEL terminator", () => {
+    const link = "\x1b]8;;https://example.com\x07\x1b[4mlabel\x1b[0m\x1b]8;;\x07";
+    expect(stripAnsi(link)).toBe("label");
+  });
+
+  test("strips clear-to-EOL CSI", () => {
+    expect(stripAnsi("foo\x1b[K")).toBe("foo");
+  });
+
+  test("strips cursor positioning CSI", () => {
+    expect(stripAnsi("\x1b[2J\x1b[Hhello")).toBe("hello");
+  });
+
+  test("strips private-mode set/reset (e.g. cursor hide)", () => {
+    expect(stripAnsi("\x1b[?25lhello\x1b[?25h")).toBe("hello");
+  });
+
+  test("preserves Unicode and tabs/newlines", () => {
+    expect(stripAnsi("\x1b[1m你好\x1b[0m\n\t😀")).toBe("你好\n\t😀");
+  });
+
+  test("strips full markdown-rendered output (real-world fragment)", () => {
+    // Render a fragment then verify stripping yields the source text minus
+    // the rendered transformations.
+    const rendered = renderMarkdown("**bold** and `code`");
+    expect(stripAnsi(rendered)).toBe("bold and code");
+  });
+
+  test("strips a complete markdown link (OSC 8 + underline + dim parens)", () => {
+    const rendered = renderMarkdown("[docs](https://example.com)");
+    const stripped = stripAnsi(rendered);
+    // What survives: the visible text + space + raw URL in parens.
+    expect(stripped).toBe("docs (https://example.com)");
   });
 });
 

--- a/cli/chat_pure.test.ts
+++ b/cli/chat_pure.test.ts
@@ -15,6 +15,9 @@ import {
   trimTokenWindow,
   trimMessages,
   renderMarkdown,
+  detectFenceLine,
+  renderFenceOpen,
+  renderFenceClose,
   feedPasteParser,
   historyUp,
   historyDown,
@@ -315,6 +318,106 @@ describe("renderMarkdown", () => {
   test("multiple inline codes on one line", () => {
     const out = renderMarkdown("`a` and `b`");
     expect(out).toBe("\x1b[7ma\x1b[0m and \x1b[7mb\x1b[0m");
+  });
+
+  test("# heading is bold + cyan", () => {
+    expect(renderMarkdown("# Top")).toBe("\x1b[1;36mTop\x1b[0m");
+  });
+
+  test("## heading is bold", () => {
+    expect(renderMarkdown("## Section")).toBe("\x1b[1mSection\x1b[0m");
+  });
+
+  test("### heading is dim-bold", () => {
+    expect(renderMarkdown("### Sub")).toBe("\x1b[1;2mSub\x1b[0m");
+  });
+
+  test("heading regex anchored to start of line — '#' mid-text untouched", () => {
+    expect(renderMarkdown("not a # heading")).toBe("not a # heading");
+  });
+
+  test("heading without space after # is not transformed", () => {
+    // `#tag` is a hashtag, not a heading.
+    expect(renderMarkdown("#nothashtag")).toBe("#nothashtag");
+  });
+
+  test("heading with inline code styles both", () => {
+    const out = renderMarkdown("## Use `foo()` here");
+    // The ## regex captures the full line content; inline code regex then
+    // applies inside the bold-wrapped span.
+    expect(out).toContain("\x1b[7mfoo()\x1b[0m");
+    expect(out).toContain("\x1b[1m");
+  });
+});
+
+// ─── detectFenceLine + renderFence{Open,Close} ──────────────────────────────
+
+describe("detectFenceLine", () => {
+  test("plain text outside fence is not detected", () => {
+    const r = detectFenceLine("hello world", false);
+    expect(r.isFenceOpen).toBe(false);
+    expect(r.isFenceClose).toBe(false);
+  });
+
+  test("```python opens a fence with language", () => {
+    const r = detectFenceLine("```python", false);
+    expect(r.isFenceOpen).toBe(true);
+    expect(r.isFenceClose).toBe(false);
+    expect(r.lang).toBe("python");
+  });
+
+  test("``` (no lang) opens with empty lang", () => {
+    const r = detectFenceLine("```", false);
+    expect(r.isFenceOpen).toBe(true);
+    expect(r.lang).toBe("");
+  });
+
+  test("``` while inside fence closes it", () => {
+    const r = detectFenceLine("```", true);
+    expect(r.isFenceClose).toBe(true);
+    expect(r.isFenceOpen).toBe(false);
+  });
+
+  test("```rust while inside fence still treated as close (no nesting)", () => {
+    const r = detectFenceLine("```rust", true);
+    expect(r.isFenceClose).toBe(true);
+    expect(r.isFenceOpen).toBe(false);
+  });
+
+  test("indented ``` opens a fence (LLMs sometimes indent)", () => {
+    const r = detectFenceLine("    ```typescript", false);
+    expect(r.isFenceOpen).toBe(true);
+    expect(r.lang).toBe("typescript");
+  });
+
+  test("body line that starts with backtick but not ``` is not a fence", () => {
+    const r = detectFenceLine("`single backtick line", false);
+    expect(r.isFenceOpen).toBe(false);
+    expect(r.isFenceClose).toBe(false);
+  });
+});
+
+describe("renderFenceOpen / renderFenceClose", () => {
+  test("renderFenceOpen with language emits border + label", () => {
+    const out = renderFenceOpen("python", 10);
+    expect(out).toContain("[python]");
+    expect(out).toContain("─".repeat(10));
+  });
+
+  test("renderFenceOpen without language uses [code]", () => {
+    const out = renderFenceOpen("", 10);
+    expect(out).toContain("[code]");
+  });
+
+  test("renderFenceClose emits just the dim border", () => {
+    const out = renderFenceClose(10);
+    expect(out).toContain("─".repeat(10));
+    expect(out).toContain("\x1b[2m");
+  });
+
+  test("fenceWidth controls border length", () => {
+    expect(renderFenceOpen("py", 5)).toContain("─".repeat(5));
+    expect(renderFenceOpen("py", 5)).not.toContain("─".repeat(6));
   });
 });
 

--- a/cli/chat_pure.test.ts
+++ b/cli/chat_pure.test.ts
@@ -348,6 +348,87 @@ describe("renderMarkdown", () => {
     expect(out).toContain("\x1b[7mfoo()\x1b[0m");
     expect(out).toContain("\x1b[1m");
   });
+
+  test("bullet list with - dims the bullet, replaces with •", () => {
+    const out = renderMarkdown("- item one");
+    expect(out).toBe("\x1b[2m•\x1b[0m item one");
+  });
+
+  test("bullet list with * dims the bullet", () => {
+    const out = renderMarkdown("* item two");
+    expect(out).toBe("\x1b[2m•\x1b[0m item two");
+  });
+
+  test("bullet list preserves indentation (nested lists)", () => {
+    const out = renderMarkdown("  - nested");
+    expect(out).toBe("  \x1b[2m•\x1b[0m nested");
+  });
+
+  test("dash mid-text is NOT a bullet", () => {
+    expect(renderMarkdown("a - b - c")).toBe("a - b - c");
+  });
+
+  test("numbered list dims the number + period", () => {
+    const out = renderMarkdown("1. first");
+    expect(out).toBe("\x1b[2m1.\x1b[0m first");
+  });
+
+  test("numbered list with multi-digit number", () => {
+    const out = renderMarkdown("12. twelfth");
+    expect(out).toBe("\x1b[2m12.\x1b[0m twelfth");
+  });
+
+  test("numbered list preserves indentation", () => {
+    const out = renderMarkdown("  3. nested item");
+    expect(out).toBe("  \x1b[2m3.\x1b[0m nested item");
+  });
+
+  test("digit + period mid-text is NOT a numbered list", () => {
+    expect(renderMarkdown("see fig 3.5 above")).toBe("see fig 3.5 above");
+  });
+
+  test("block quote dims the > and italicizes the body", () => {
+    const out = renderMarkdown("> a quote");
+    expect(out).toBe("\x1b[2m>\x1b[0m \x1b[3ma quote\x1b[0m");
+  });
+
+  test("> mid-text is NOT a block quote", () => {
+    expect(renderMarkdown("a > b")).toBe("a > b");
+  });
+
+  test("markdown link emits OSC 8 hyperlink + underline + dim raw URL", () => {
+    const out = renderMarkdown("see [docs](https://example.com)");
+    expect(out).toContain("\x1b]8;;https://example.com\x1b\\");
+    expect(out).toContain("\x1b[4mdocs\x1b[0m");
+    expect(out).toContain("(https://example.com)");
+  });
+
+  test("bare URL gets OSC 8 + underline", () => {
+    const out = renderMarkdown("visit https://example.com today");
+    expect(out).toContain("\x1b]8;;https://example.com\x1b\\");
+    expect(out).toContain("\x1b[4mhttps://example.com\x1b[0m");
+  });
+
+  test("bare URL stops at trailing whitespace, not at fragment chars", () => {
+    const out = renderMarkdown("https://example.com/path?q=1#frag end");
+    // Must include the full URL with query + fragment, but stop before " end"
+    expect(out).toContain("\x1b[4mhttps://example.com/path?q=1#frag\x1b[0m");
+    expect(out).toContain(" end");
+  });
+
+  test("URL inside markdown link is NOT double-wrapped as bare URL", () => {
+    // The [..](..) regex runs first; the bare-URL regex's negative lookbehind
+    // for `(` and `[` skips URLs that follow `(`.
+    const out = renderMarkdown("[label](https://example.com)");
+    // Should contain exactly one OSC 8 open marker for the URL.
+    const matches = out.match(/\x1b\]8;;https:\/\/example\.com\x1b\\/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  test("file:// URL is supported", () => {
+    const out = renderMarkdown("see file:///tmp/log.txt for details");
+    expect(out).toContain("\x1b]8;;file:///tmp/log.txt\x1b\\");
+  });
 });
 
 // ─── detectFenceLine + renderFence{Open,Close} ──────────────────────────────

--- a/cli/chat_pure.ts
+++ b/cli/chat_pure.ts
@@ -97,6 +97,35 @@ export function trimMessages(
   return { kept: out, dropped, remainingTokens: used };
 }
 
+// ─── ANSI stripping (NO_COLOR support) ──────────────────────────────────────
+//
+// Removes SGR (\x1b[...m), OSC 8 hyperlinks (\x1b]8;...\x1b\\text\x1b]8;;\x1b\\),
+// and other CSI/private-mode sequences so output remains readable when colors
+// are disabled. Honors https://no-color.org — set NO_COLOR=1 in the environment
+// or pass --no-color on the command line.
+//
+// We sanitize at write-time rather than gating each SGR call site, so all
+// current and future styling code stays unchanged and the same kill-switch
+// applies to everything (including OSC 8 hyperlinks emitted by markdown links).
+//
+// OSC 8 format is: ESC ] 8 ; params ; URI ST text ESC ] 8 ; ; ST
+// where ST (string terminator) is either ESC \ (BEL also accepted in spec).
+// We collapse the wrapping markers and keep the visible text.
+
+const SGR_RE = /\x1b\[[0-9;?]*[A-Za-z]/g;          // ESC [ params final-byte (any CSI)
+const OSC8_OPEN_RE = /\x1b\]8;[^\x07\x1b]*(?:\x1b\\|\x07)/g; // ESC ] 8 ; ... ST
+const OSC8_CLOSE_RE = /\x1b\]8;;(?:\x1b\\|\x07)/g;
+const OSC_GENERIC_RE = /\x1b\][^\x07\x1b]*(?:\x1b\\|\x07)/g; // any other OSC
+
+export function stripAnsi(s: string): string {
+  if (!s) return s;
+  return s
+    .replace(OSC8_CLOSE_RE, "")    // close before open (close is more specific)
+    .replace(OSC8_OPEN_RE, "")
+    .replace(OSC_GENERIC_RE, "")
+    .replace(SGR_RE, "");
+}
+
 // ─── Markdown rendering ─────────────────────────────────────────────────────
 
 // Phase 1 markdown: fenced code blocks, inline code, bold, italic. ANSI SGR
@@ -123,17 +152,20 @@ export function renderMarkdown(text: string, fenceWidth: number = 60): string {
   text = text.replace(/^(\s*)[-*] +(.+)$/gm, (_m: string, indent: string, inner: string) => `${indent}\x1b[2m•\x1b[0m ${inner}`);
   // Numbered lists: `1. foo`, `12. bar` → dim the digits + dot.
   text = text.replace(/^(\s*)(\d+\.) +(.+)$/gm, (_m: string, indent: string, num: string, inner: string) => `${indent}\x1b[2m${num}\x1b[0m ${inner}`);
+  // Bare URLs (http/https/file) — underline + OSC 8 hyperlink. Done BEFORE
+  // markdown-link replacement so the URL inside [text](url) is protected by
+  // the negative lookbehind on `(` and `[`. Stops at whitespace or trailing
+  // bracket-style punctuation.
+  text = text.replace(/(?<![(\[])\b(https?:\/\/[^\s)\]]+|file:\/\/[^\s)\]]+)/g, (_m: string, url: string) =>
+    `\x1b]8;;${url}\x1b\\\x1b[4m${url}\x1b[0m\x1b]8;;\x1b\\`,
+  );
   // Markdown links: [text](url) → underline text, dim parens with raw URL.
   // OSC 8 hyperlink: `\x1b]8;;url\x1b\\text\x1b]8;;\x1b\\` makes text
   // clickable in iTerm2/kitty/Wezterm/modern xterm; degrades to underline
-  // in non-supporting terminals.
+  // in non-supporting terminals. Inner URL is wrapped raw (not via OSC 8)
+  // to avoid double-wrapping when the visible text is shown in parens.
   text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m: string, label: string, url: string) =>
     `\x1b]8;;${url}\x1b\\\x1b[4m${label}\x1b[0m\x1b]8;;\x1b\\ \x1b[2m(${url})\x1b[0m`,
-  );
-  // Bare URLs (http/https/file) not already inside [..](..) — underline +
-  // OSC 8 hyperlink. Stops at whitespace or common trailing punctuation.
-  text = text.replace(/(?<![(\[])\b(https?:\/\/[^\s)\]]+|file:\/\/[^\s)\]]+)/g, (_m: string, url: string) =>
-    `\x1b]8;;${url}\x1b\\\x1b[4m${url}\x1b[0m\x1b]8;;\x1b\\`,
   );
   text = text.replace(/`([^`]+)`/g, (_m: string, code: string) => `\x1b[7m${code}\x1b[0m`);
   text = text.replace(/\*\*([^*]+)\*\*/g, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);

--- a/cli/chat_pure.ts
+++ b/cli/chat_pure.ts
@@ -1,0 +1,221 @@
+// Pure helpers for cli/chat.ts. Lifted to a side-effect-free module so they can
+// be unit-tested directly without loading the full CLI module graph (which has
+// top-level side effects from `cli/index.ts`).
+//
+// Run tests: `bun test cli/chat_pure.test.ts`
+
+// ─── Grapheme handling ──────────────────────────────────────────────────────
+
+const SEGMENTER: any = (typeof (globalThis as any).Intl !== "undefined" && (Intl as any).Segmenter)
+  ? new (Intl as any).Segmenter(undefined, { granularity: "grapheme" })
+  : null;
+
+export function graphemes(s: string): string[] {
+  if (!s) return [];
+  if (SEGMENTER) {
+    const out: string[] = [];
+    for (const seg of SEGMENTER.segment(s)) out.push(seg.segment);
+    return out;
+  }
+  return Array.from(s);
+}
+
+// ─── Paste sanitization ─────────────────────────────────────────────────────
+
+// Strip control bytes < 0x20 except \n (LF) and \t (TAB). Prevents pasted ANSI
+// escape sequences from being interpreted by downstream renderers and prevents
+// stray BEL/NUL/etc. from corrupting the input buffer.
+export function sanitizePaste(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 32 || c === 0x0a || c === 0x09) out += s[i];
+  }
+  return out;
+}
+
+// ─── Token estimation ───────────────────────────────────────────────────────
+
+// Rough English+code heuristic. Real tokenization happens server-side; this is
+// only used for client-side context-fill warnings and tok/s display.
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 3.5);
+}
+
+// ─── Tok/s sliding-window math ──────────────────────────────────────────────
+
+// Pure sliding-window rate calculator. `times` is a list of token-arrival
+// timestamps (ms); the caller is responsible for trimming entries older than
+// `windowMs` before calling. Returns 0 for fewer than 2 samples.
+export function computeTokPerSec(times: number[]): number {
+  if (times.length < 2) return 0;
+  const span = ((times[times.length - 1] ?? 0) - (times[0] ?? 0)) / 1000;
+  if (span <= 0) return 0;
+  return times.length / span;
+}
+
+// Trim out-of-window entries from `times` in place. Returns the modified array.
+export function trimTokenWindow(times: number[], now: number, windowMs: number = 2000): number[] {
+  const cutoff = now - windowMs;
+  while (times.length > 0 && (times[0] ?? 0) < cutoff) {
+    times.shift();
+  }
+  return times;
+}
+
+// ─── /trim logic ────────────────────────────────────────────────────────────
+
+export interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+export interface TrimResult {
+  kept: ChatMessage[];
+  dropped: number;
+  remainingTokens: number;
+}
+
+// Drop oldest user/assistant turns until the conversation fits under
+// `targetPct` of `ctxLimit`. Always preserves a leading system message if
+// present at index 0. Always keeps at least one message after the system slot.
+export function trimMessages(
+  messages: ChatMessage[],
+  ctxLimit: number,
+  targetPct: number = 0.5,
+): TrimResult {
+  const out = [...messages];
+  const target = ctxLimit * (Number.isFinite(targetPct) && targetPct > 0 ? targetPct : 0.5);
+  let used = out.reduce((s, m) => s + estimateTokens(m.content), 0);
+  let dropped = 0;
+  const firstIdx = (out[0]?.role === "system") ? 1 : 0;
+  while (used > target && out.length > firstIdx + 1) {
+    const removed = out.splice(firstIdx, 1)[0]!;
+    used -= estimateTokens(removed.content);
+    dropped++;
+  }
+  return { kept: out, dropped, remainingTokens: used };
+}
+
+// ─── Markdown rendering ─────────────────────────────────────────────────────
+
+// Phase 1 markdown: fenced code blocks, inline code, bold, italic. ANSI SGR
+// codes only; no syntax highlighting. Render at commit-time only — never on
+// the streaming tail (partial delimiters cause styling pop-in).
+//
+// `fenceWidth` controls the horizontal-rule width above/below code fences;
+// callers pass `Math.min(60, stdout.columns)` when rendering to a TTY.
+export function renderMarkdown(text: string, fenceWidth: number = 60): string {
+  text = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_m: string, lang: string, code: string) => {
+    const border = "\x1b[2m" + "─".repeat(Math.max(1, fenceWidth)) + "\x1b[0m";
+    const label = lang ? `\x1b[2m[${lang}]\x1b[0m` : "\x1b[2m[code]\x1b[0m";
+    return `\n${border}\n${label}\n${code}\n${border}`;
+  });
+  text = text.replace(/`([^`]+)`/g, (_m: string, code: string) => `\x1b[7m${code}\x1b[0m`);
+  text = text.replace(/\*\*([^*]+)\*\*/g, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
+  text = text.replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, (_m: string, inner: string) => `\x1b[3m${inner}\x1b[0m`);
+  return text;
+}
+
+// ─── Bracketed paste state machine ──────────────────────────────────────────
+//
+// Bracketed paste arrives as: `\x1b[200~ ...content... \x1b[201~`. Both
+// markers may be split across stdin chunks. This is a pure transducer: feed
+// it stdin chunks, get back either { paste: string } when a complete paste is
+// assembled, or { keystroke: string } for normal input. State persists across
+// calls via the returned object.
+
+export interface PasteParserState {
+  inPaste: boolean;
+  buf: string;
+}
+
+export interface PasteParseResult {
+  state: PasteParserState;
+  paste: string | null;       // non-null when a complete paste was assembled
+  passthrough: string | null; // non-null for non-paste input to be handled normally
+}
+
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+
+export function feedPasteParser(state: PasteParserState, chunk: string): PasteParseResult {
+  if (!state.inPaste) {
+    if (chunk.startsWith(PASTE_START)) {
+      const rest = chunk.slice(PASTE_START.length);
+      const endIdx = rest.indexOf(PASTE_END);
+      if (endIdx !== -1) {
+        // Whole paste arrived in one chunk.
+        const paste = sanitizePaste(rest.slice(0, endIdx).replace(/\r\n?/g, "\n"));
+        return { state: { inPaste: false, buf: "" }, paste, passthrough: null };
+      }
+      return {
+        state: { inPaste: true, buf: sanitizePaste(rest.replace(/\r\n?/g, "\n")) },
+        paste: null,
+        passthrough: null,
+      };
+    }
+    return { state, paste: null, passthrough: chunk };
+  }
+
+  // In paste mode: keep accumulating until we see PASTE_END.
+  const endIdx = chunk.indexOf(PASTE_END);
+  if (endIdx !== -1) {
+    const paste = state.buf + sanitizePaste(chunk.slice(0, endIdx).replace(/\r\n?/g, "\n"));
+    return { state: { inPaste: false, buf: "" }, paste, passthrough: null };
+  }
+  return {
+    state: { inPaste: true, buf: state.buf + sanitizePaste(chunk.replace(/\r\n?/g, "\n")) },
+    paste: null,
+    passthrough: null,
+  };
+}
+
+// ─── Input history with draft preservation ─────────────────────────────────
+//
+// readline-style history navigation. Saves the in-progress draft on first
+// up-arrow, restores it when the user navigates back past the most recent
+// entry with down-arrow. Pure state machine; caller owns rendering.
+
+export interface HistoryState {
+  history: string[];
+  index: number;          // points at history entry to restore; == history.length means "draft"
+  draft: string | null;   // saved in-progress buffer
+}
+
+export function historyUp(state: HistoryState, currentBuffer: string): { state: HistoryState; buffer: string } {
+  if (state.index === 0 || state.history.length === 0) {
+    return { state, buffer: currentBuffer };
+  }
+  const draft = (state.index === state.history.length && state.draft === null) ? currentBuffer : state.draft;
+  const newIndex = state.index - 1;
+  return {
+    state: { history: state.history, index: newIndex, draft },
+    buffer: state.history[newIndex] ?? "",
+  };
+}
+
+export function historyDown(state: HistoryState, currentBuffer: string): { state: HistoryState; buffer: string } {
+  if (state.index >= state.history.length) {
+    return { state, buffer: currentBuffer };
+  }
+  const newIndex = state.index + 1;
+  if (newIndex === state.history.length) {
+    return {
+      state: { history: state.history, index: newIndex, draft: null },
+      buffer: state.draft ?? "",
+    };
+  }
+  return {
+    state: { history: state.history, index: newIndex, draft: state.draft },
+    buffer: state.history[newIndex] ?? "",
+  };
+}
+
+export function historySubmit(state: HistoryState, submitted: string): HistoryState {
+  return {
+    history: [...state.history, submitted],
+    index: state.history.length + 1,
+    draft: null,
+  };
+}

--- a/cli/chat_pure.ts
+++ b/cli/chat_pure.ts
@@ -116,6 +116,25 @@ export function renderMarkdown(text: string, fenceWidth: number = 60): string {
   text = text.replace(/^### +(.+)$/gm, (_m: string, inner: string) => `\x1b[1;2m${inner}\x1b[0m`);
   text = text.replace(/^## +(.+)$/gm, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
   text = text.replace(/^# +(.+)$/gm, (_m: string, inner: string) => `\x1b[1;36m${inner}\x1b[0m`);
+  // Block quotes: `> body` → dim `>`, italic body. Anchored to start-of-line.
+  text = text.replace(/^> +(.+)$/gm, (_m: string, inner: string) => `\x1b[2m>\x1b[0m \x1b[3m${inner}\x1b[0m`);
+  // Bullet lists: `- item` or `* item` (with leading whitespace) → `• item`
+  // with the bullet dimmed. Indentation preserved. Anchored to line start.
+  text = text.replace(/^(\s*)[-*] +(.+)$/gm, (_m: string, indent: string, inner: string) => `${indent}\x1b[2m•\x1b[0m ${inner}`);
+  // Numbered lists: `1. foo`, `12. bar` → dim the digits + dot.
+  text = text.replace(/^(\s*)(\d+\.) +(.+)$/gm, (_m: string, indent: string, num: string, inner: string) => `${indent}\x1b[2m${num}\x1b[0m ${inner}`);
+  // Markdown links: [text](url) → underline text, dim parens with raw URL.
+  // OSC 8 hyperlink: `\x1b]8;;url\x1b\\text\x1b]8;;\x1b\\` makes text
+  // clickable in iTerm2/kitty/Wezterm/modern xterm; degrades to underline
+  // in non-supporting terminals.
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m: string, label: string, url: string) =>
+    `\x1b]8;;${url}\x1b\\\x1b[4m${label}\x1b[0m\x1b]8;;\x1b\\ \x1b[2m(${url})\x1b[0m`,
+  );
+  // Bare URLs (http/https/file) not already inside [..](..) — underline +
+  // OSC 8 hyperlink. Stops at whitespace or common trailing punctuation.
+  text = text.replace(/(?<![(\[])\b(https?:\/\/[^\s)\]]+|file:\/\/[^\s)\]]+)/g, (_m: string, url: string) =>
+    `\x1b]8;;${url}\x1b\\\x1b[4m${url}\x1b[0m\x1b]8;;\x1b\\`,
+  );
   text = text.replace(/`([^`]+)`/g, (_m: string, code: string) => `\x1b[7m${code}\x1b[0m`);
   text = text.replace(/\*\*([^*]+)\*\*/g, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
   text = text.replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, (_m: string, inner: string) => `\x1b[3m${inner}\x1b[0m`);

--- a/cli/chat_pure.ts
+++ b/cli/chat_pure.ts
@@ -111,10 +111,56 @@ export function renderMarkdown(text: string, fenceWidth: number = 60): string {
     const label = lang ? `\x1b[2m[${lang}]\x1b[0m` : "\x1b[2m[code]\x1b[0m";
     return `\n${border}\n${label}\n${code}\n${border}`;
   });
+  // Headings: # / ## / ### at start of line. Bold + bright cyan for #, bold
+  // for ##, dim-bold for ###. Whole line gets the styling so wrap looks ok.
+  text = text.replace(/^### +(.+)$/gm, (_m: string, inner: string) => `\x1b[1;2m${inner}\x1b[0m`);
+  text = text.replace(/^## +(.+)$/gm, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
+  text = text.replace(/^# +(.+)$/gm, (_m: string, inner: string) => `\x1b[1;36m${inner}\x1b[0m`);
   text = text.replace(/`([^`]+)`/g, (_m: string, code: string) => `\x1b[7m${code}\x1b[0m`);
   text = text.replace(/\*\*([^*]+)\*\*/g, (_m: string, inner: string) => `\x1b[1m${inner}\x1b[0m`);
   text = text.replace(/(?<!\*)\*(?!\*)([^*]+)\*(?!\*)/g, (_m: string, inner: string) => `\x1b[3m${inner}\x1b[0m`);
   return text;
+}
+
+// ─── Streaming-friendly code-fence detection ────────────────────────────────
+//
+// Detects the open/close lines of a fenced code block (` ```python `, ` ``` `)
+// during line-by-line streaming. The full `renderMarkdown` regex needs the
+// whole fence in one pass, which doesn't work when each committed line is
+// rendered independently. This helper lets the streaming path style fence
+// boundaries per-line without buffering the whole code block.
+
+export interface FenceLineInfo {
+  isFenceOpen: boolean;   // line is the opening ```lang
+  isFenceClose: boolean;  // line is the closing ```
+  lang: string;           // language tag from the open fence (empty if none)
+}
+
+export function detectFenceLine(line: string, currentlyInFence: boolean): FenceLineInfo {
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith("```")) {
+    return { isFenceOpen: false, isFenceClose: false, lang: "" };
+  }
+  if (currentlyInFence) {
+    // Inside a fence, ``` always closes (we don't try to handle ` ```lang `
+    // mid-fence as a nested open — markdown doesn't support nesting either)
+    return { isFenceOpen: false, isFenceClose: true, lang: "" };
+  }
+  // Outside a fence: ` ```python ` opens, language is whatever follows the ticks
+  const lang = trimmed.slice(3).trim().split(/\s+/)[0] ?? "";
+  return { isFenceOpen: true, isFenceClose: false, lang };
+}
+
+// Render a fence-open line as a dim rule + language label.
+export function renderFenceOpen(lang: string, fenceWidth: number = 60): string {
+  const border = "\x1b[2m" + "─".repeat(Math.max(1, fenceWidth)) + "\x1b[0m";
+  const label = lang ? `\x1b[2m[${lang}]\x1b[0m` : "\x1b[2m[code]\x1b[0m";
+  return `${border}\n${label}`;
+}
+
+// Render a fence-close line as a dim rule.
+export function renderFenceClose(fenceWidth: number = 60): string {
+  return "\x1b[2m" + "─".repeat(Math.max(1, fenceWidth)) + "\x1b[0m";
 }
 
 // ─── Bracketed paste state machine ──────────────────────────────────────────

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3846,13 +3846,15 @@ switch (cmd) {
     break;
   }
   case "chat": {
-    const chatTag = rest[0];
+    const chatArgs = rest.filter(a => !a.startsWith("--"));
+    const chatFlags = new Set(rest.filter(a => a.startsWith("--")));
+    const chatTag = chatArgs[0];
     if (!chatTag) {
-      console.error("Usage: hipfire chat <tag>  (e.g. hipfire chat qwen3.5:9b)");
+      console.error("Usage: hipfire chat <tag> [--no-color]  (e.g. hipfire chat qwen3.5:9b)");
       process.exit(1);
     }
     const { chatTui } = await import("./chat.ts");
-    await chatTui(chatTag, cfg);
+    await chatTui(chatTag, cfg, { noColor: chatFlags.has("--no-color") });
     break;
   }
   case "pull": {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -20,7 +20,7 @@ const TEMP_CORRECTION = 0.82;
 mkdirSync(MODELS_DIR, { recursive: true });
 
 // ─── Persistent config ─────────────────────────────────
-interface HipfireConfig {
+export interface HipfireConfig {
   kv_cache: string;       // "auto" (per-arch default), "q8", "asym4", "asym3", "asym2"
   flash_mode: string;     // "auto" (ctx-gated), "always", "never" — only affects Q8 path
   default_model: string;  // model tag for serve pre-warm, e.g. "qwen3.5:9b"
@@ -587,7 +587,7 @@ import registryData from "./registry.json" with { type: "json" };
 const REGISTRY: Record<string, ModelEntry> = registryData.models as Record<string, ModelEntry>;
 const ALIASES: Record<string, string>    = registryData.aliases as Record<string, string>;
 
-function resolveModelTag(input: string): string {
+export function resolveModelTag(input: string): string {
   // Backward compat: old hfq4/hfq6 tags → hf4/hf6
   const normalized = input.replace(/-hfq(\d)/, "-hf$1").replace(/\.hfq$/, ".hf4");
   // Direct registry match
@@ -767,7 +767,7 @@ function readServePid(): number | null {
 }
 
 // Cheap liveness probe: 500ms health check. Used by `run` to decide HTTP vs local spawn.
-async function isServeUp(port: number): Promise<boolean> {
+export async function isServeUp(port: number): Promise<boolean> {
   try {
     const ctl = AbortSignal.timeout(500);
     const r = await fetch(`http://127.0.0.1:${port}/health`, { signal: ctl });
@@ -1189,10 +1189,18 @@ async function serve(port: number) {
   applyConfigEnv(cfg);
   // Write the PID so `hipfire stop` / `hipfire ps` / `hipfire run` can find us.
   // Cleanup on normal exit; stale PID on crash is tolerated (isPidAlive catches it).
-  try {
-    require("fs").writeFileSync(SERVE_PID_FILE, String(process.pid));
-  } catch {}
-  const cleanupPid = () => { try { require("fs").unlinkSync(SERVE_PID_FILE); } catch {} };
+  // HIPFIRE_NO_PID_FILE=1 suppresses the write — used by `hipfire chat` when it
+  // spawns an ephemeral daemon, so it doesn't clobber a long-lived `serve -d`.
+  const ownsPidFile = !process.env.HIPFIRE_NO_PID_FILE;
+  if (ownsPidFile) {
+    try {
+      require("fs").writeFileSync(SERVE_PID_FILE, String(process.pid));
+    } catch {}
+  }
+  const cleanupPid = () => {
+    if (!ownsPidFile) return;
+    try { require("fs").unlinkSync(SERVE_PID_FILE); } catch {}
+  };
   process.on("exit", cleanupPid);
   process.on("SIGTERM", () => { cleanupPid(); process.exit(0); });
   process.on("SIGINT", () => { cleanupPid(); process.exit(0); });
@@ -2151,7 +2159,7 @@ function loadUserAliases(): Record<string, UserAlias> {
   } catch { return {}; }
 }
 
-function findModel(name: string): string | null {
+export function findModel(name: string): string | null {
   // Direct file path
   if (existsSync(name)) return resolve(name);
 
@@ -3835,6 +3843,16 @@ switch (cmd) {
     const filtered = rest.slice(1).filter((_, i) => !flagIndices.has(i + 1));
     const prompt = filtered.join(" ") || (image ? "Describe this image." : "Hello");
     await run(model, prompt, image, temp, maxTokens, repeatPenalty, topP);
+    break;
+  }
+  case "chat": {
+    const chatTag = rest[0];
+    if (!chatTag) {
+      console.error("Usage: hipfire chat <tag>  (e.g. hipfire chat qwen3.5:9b)");
+      process.exit(1);
+    }
+    const { chatTui } = await import("./chat.ts");
+    await chatTui(chatTag, cfg);
     break;
   }
   case "pull": {

--- a/docs/CHAT.md
+++ b/docs/CHAT.md
@@ -1,0 +1,52 @@
+# `hipfire chat` — Interactive Chat TUI
+
+## Usage
+
+```
+hipfire chat <model-tag>
+```
+
+Example:
+```
+hipfire chat qwen3.5:9b
+```
+
+Requires a running `hipfire serve` or auto-spawns a dedicated daemon.
+
+## Keybindings
+
+| Key | Action |
+|-----|--------|
+| CTRL+O | Insert newline (multi-line input) |
+| Enter | Submit message |
+| CTRL+C | Abort stream (press twice to exit) |
+| CTRL+L | Clear screen |
+| CTRL+D | Exit (when input empty) |
+| Up / Down | Navigate input history |
+| Left / Right | Move cursor |
+| Home / End | Jump to start / end of line |
+| Backspace / Delete | Delete characters |
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/help`, `/?` | Show help |
+| `/clear` | Clear conversation history |
+| `/stats` | Show model stats |
+| `/trim` | Drop old messages to free context |
+| `/exit`, `/quit` | Exit chat |
+
+## Features
+
+- **Multi-line input:** Use CTRL+O to insert newlines. Bracketed paste works automatically.
+- **Markdown rendering:** Code blocks, inline code, bold, and italic are rendered with ANSI styling.
+- **Streaming:** See tokens appear in real-time. Abort with CTRL+C.
+- **Input history:** Use up/down arrows to recall previous messages.
+- **Context awareness:** Warning when approaching the model's context limit.
+
+## Daemon Lifecycle
+
+`hipfire chat` reuses a running `hipfire serve` if one is detected on the
+configured port. Otherwise it spawns a dedicated daemon and tears it down on
+exit.

--- a/docs/CHAT.md
+++ b/docs/CHAT.md
@@ -45,6 +45,21 @@ Requires a running `hipfire serve` or auto-spawns a dedicated daemon.
 - **Input history:** Use up/down arrows to recall previous messages.
 - **Context awareness:** Warning when approaching the model's context limit.
 
+## Color output
+
+Colors and OSC 8 hyperlinks track your terminal palette automatically (we
+use 16-color ANSI throughout, no truecolor). To disable styling entirely:
+
+| Trigger | Effect |
+|---|---|
+| `hipfire chat <tag> --no-color` | One-shot: this session only |
+| `NO_COLOR=1 hipfire chat <tag>` | Honors the [no-color.org](https://no-color.org) standard |
+| `CLICOLOR=0 hipfire chat <tag>` | De-facto-standard fallback also honored |
+
+When disabled, all SGR (bold/dim/italic/color) and OSC 8 hyperlink
+sequences are stripped at write-time — markdown still renders to
+plain text but loses styling.
+
 ## Daemon Lifecycle
 
 `hipfire chat` reuses a running `hipfire serve` if one is detected on the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,6 +17,7 @@ flag-level detail; this page is the index.
 | Command | Purpose |
 |---|---|
 | `hipfire run <tag\|path> [prompt...]` | Generate. Auto-pulls if missing. Routes through the running `serve` daemon if one is up; otherwise spawns a one-shot daemon. |
+| `hipfire chat <tag>` | Interactive TUI chat with streaming, markdown, multi-line input. Reuses running serve or spawns a dedicated daemon. |
 | `hipfire serve [port] [-d]` | Start the OpenAI-compatible HTTP server. `-d` detaches into the background and writes a pid file. Default port `11435`. |
 | `hipfire stop` | Graceful shutdown of the background daemon. |
 | `hipfire bench <tag>` | Measure prefill + decode tok/s on a fixed prompt set. |

--- a/plans/tui-phase-2.md
+++ b/plans/tui-phase-2.md
@@ -1,0 +1,219 @@
+# Phase 2 TODOs for `hipfire chat`
+
+Collected during Phase 1 implementation + adversarial review (`tui_rev_claude.md`).
+Phase 1 shipped in PR #129 (closes #63). This document tracks what was
+*intentionally* deferred so it doesn't get lost.
+
+Source map for each item: A=adversarial review (numbered finding), I=user
+session-testing report, D=design discussion. Keep this when triaging — the
+finding numbers point at concrete bug analysis in `tui_rev_claude.md`.
+
+---
+
+## Renderer / styling
+
+### Markdown features (deferred from "what styling makes sense" discussion)
+
+- **Bullet lists** [D] — `- item` / `* item` → `• item` with dim leading
+  marker. ~3 LOC regex. High frequency in LLM output.
+- **Numbered lists** [D] — `1. foo` → dim the digits. ~3 LOC.
+- **Block quotes** [D] — `> quoted` → dim the `>`, italic the body. ~5 LOC.
+- **Strikethrough** [D] — `~~text~~` → `\x1b[9m...\x1b[0m`. ~3 LOC. Rare.
+- **Horizontal rules** [D] — line of `---` / `***` / `___` → dim full-width
+  rule. ~3 LOC.
+- **Links** [D] — `[text](url)` → underline text, dim parens; with OSC 8
+  hyperlink (`\x1b]8;;url\x1b\\text\x1b]8;;\x1b\\`) for terminals that
+  support it (iTerm2, kitty, Wezterm, modern xterm) and raw-link fallback.
+  ~10 LOC.
+- **`Assistant:` role prefix** [D] — current output has no role marker on
+  assistant turns; only `You:` is shown for user input. Adding a dim
+  `Assistant:` prefix on the first chunk makes transcript copy-paste
+  parseable. ~5 LOC.
+- **Auto-detect raw URLs** [D] — `https://...` not in markdown link form →
+  underline + OSC 8. ~10 LOC.
+- **Auto-detect file:line refs** [D] — `cli/chat.ts:447` → underline (and
+  OSC 8 to `file://` if absolute). Useful for code-focused chat where
+  models cite source locations. ~15 LOC.
+
+### Markdown features (bigger lifts)
+
+- **Syntax highlighting in code fences** [D] — currently fence body emits
+  raw. Lightweight tokenizer for Python/TS/Rust/JSON would cover ~80% of
+  LLM output. Hand-rolled per-language is ~80 LOC each; library
+  (cli-highlight, prism in pure JS) ~50 KB. **Highest user-perceived
+  quality bump.** All competitors (opencode, aider, parllama) do this.
+- **Tables** [D] — `| col | col |` parsed and rendered with column
+  alignment. Multi-line construct → needs the same buffering architecture
+  as fenced blocks (see "Buffer-then-render" below). ~50 LOC + state.
+- **Nested SGR fix** [D] — bold-then-inline-code currently breaks because
+  inline code's `\x1b[0m` resets the outer bold. Need a style-stack in
+  `renderMarkdown` that re-applies outer styles after inner closes.
+  ~20-30 LOC, makes `**use \`foo()\` here**` actually bold throughout.
+
+### Renderer architecture changes
+
+- **Wrapped-line styling** [A #6, I] — currently lines longer than terminal
+  width skip the markdown re-emit (Phase 1 ships them as raw text). Proper
+  fix: count visual rows = `ceil(unicode_width(line) / cols)`, walk up
+  with `\x1b[<n>F` per row, clear each, then re-emit styled. Needs
+  Unicode width handling (CJK = 2, emoji = 2, ZWJ sequences variable).
+  ~50 LOC.
+- **Buffer-then-render for multi-line constructs** [D] — fenced blocks
+  currently styled per-line via `detectFenceLine`. For tables (and any
+  future multi-line construct) we need an accumulator: buffer lines until
+  the construct closes, then render the whole block with proper alignment
+  / box-drawing. Affects `streamResponse` SSE consumer. Trade-off: no
+  output during accumulation, which is bad UX for long blocks.
+
+---
+
+## Input / interaction
+
+- **Type-ahead during streaming** [A #2] — current code locks all input
+  while a stream is in flight. Most modern chat tools allow typing the
+  next prompt while the model is still answering. After the per-line
+  rendering changes from Phase 1, the path is clear: `\x1b[s` save cursor
+  before tail repaint, `\x1b[u` restore after, input prompt lives on a
+  separate line below. ~20 LOC.
+- **Backpressure on stdout.write** [A #25, GLM-5 M1] — `process.stdout.write()`
+  returns false when the internal buffer is full; current code ignores
+  this. On slow links (SSH, serial) this could drop bytes. Fix: await
+  drain event when write returns false. Requires making writes async,
+  larger refactor. Defer until field reports.
+- **CSI parser state machine** [A #14, GLM-5 H3] — `escBuf` currently
+  buffers only lone `\x1b`. Most LSP / private-mode CSI sequences arrive
+  in one chunk on Linux, but exotic terminals might split mid-sequence.
+  Replace ad-hoc handling with a proper CSI parser (state machine over
+  `\x1b [ params; final-byte`). ~40 LOC.
+- **Reasoning + content interleaving** [A #24, Gemini #5] — current
+  `[thinking]` indicator only fires when `delta.reasoning_content` is
+  present *and* `delta.content` is absent. If a future model interleaves
+  them, the indicator clobbers the content. Need a state machine that
+  tracks transitions and re-emits `[thinking]` when reasoning resumes.
+
+---
+
+## Daemon / lifecycle
+
+- **Daemon ownership ambiguity** [A #20] — when chat-A spawns an
+  ephemeral daemon and chat-B (in another terminal) detects + reuses it,
+  chat-B doesn't track ownership. If chat-A exits before chat-B, the
+  daemon dies underneath chat-B. Fix: lock-file coordination or
+  reference-counting in `~/.hipfire/`. ~30 LOC.
+- **Spawn engine directly, skip HTTP layer** [GLM-5 C1 alternative] — the
+  cleanest fix for the original PID-file collision (Phase 1 used the
+  env-var gate workaround). Bypassing `serve()` and talking to the
+  Engine via IPC would also save ~5ms per request. Bigger refactor —
+  share more code with `runLocal`.
+
+---
+
+## Slash commands / config
+
+- **`/model` switch mid-session** [out-of-scope-Phase-1] — currently
+  bound to one model for the session. Adding `/model qwen3.5:27b` would
+  request the daemon to swap. Daemon already supports load/unload.
+  ~30 LOC + UI for "loading…" feedback.
+- **`/save` and `/load` for session persistence** [plan §"Out of Scope"]
+  — write `messages` array to `~/.hipfire/sessions/<timestamp>.json`,
+  load on demand. Useful for resuming a debugging conversation across
+  days. ~50 LOC.
+- **`/edit` to edit prior turns** [plan §"Out of Scope"] — opens `$EDITOR`
+  on the last user message, re-submits on save. Useful for refining a
+  prompt without retyping. ~40 LOC + temp-file dance.
+- **`/system <text>`** — set or update the system prompt mid-session. ~5 LOC.
+- **`/regen`** — regenerate the last assistant turn (drop it, re-stream
+  from the same user message). ~10 LOC.
+- **`/copy` and `/copy <n>`** — copy last assistant turn (or turn `n`)
+  to clipboard via OSC 52. Cross-platform, no `xclip`/`pbcopy` shell-out
+  needed. ~15 LOC.
+
+---
+
+## Telemetry / accuracy
+
+- **Daemon-reported tok/s** [A #3, all-three-reviews] — Phase 1 uses a
+  character-based heuristic (`chars / 3.5`). Real fix: have the daemon
+  emit `usage.completion_tokens` in the SSE stream (currently only in
+  the non-streaming path at `cli/index.ts:1909`). Requires daemon-side
+  change to track per-chunk token count and emit it in the final
+  `[DONE]`-adjacent chunk. Cross-cutting with `runViaHttp` which has
+  the same chunk-as-token bug at `cli/index.ts:856`.
+- **Per-token latency display** — `time-to-first-token` and
+  `inter-token-latency-p50` for the last turn. Useful for the "feels
+  slow" debugging path. ~20 LOC, hook into the existing `tokenTimes`
+  buffer.
+
+---
+
+## Test coverage
+
+- **Integration test for `streamResponse` against a fake daemon** [D] —
+  Phase 1 tests cover the 8 pure helpers in `chat_pure.ts` (74 tests).
+  The `streamResponse` consumer itself isn't tested — needs a mock
+  fetch that emits canned SSE chunks. Would catch regressions in
+  fence-detection, wrap-aware re-emit, abort handling. ~80 LOC of test
+  scaffolding.
+- **Snapshot test for `renderInputLine` output** [D] — pure formatter
+  function once lifted, but currently tied to `stdout.write` calls.
+  Worth lifting if we add more multi-line input features.
+- **Fuzz test for `feedPasteParser`** [D] — randomized chunking of
+  paste content with start/end markers split at every byte boundary.
+  Phase 1 has hand-picked split cases; fuzzing would find off-by-ones.
+  ~30 LOC.
+
+---
+
+## Documentation
+
+- **`docs/CHAT.md` examples** — add screenshots / asciinema cast of a
+  real chat session showing markdown rendering, slash commands, paste.
+- **`docs/CHAT.md` keybinding cheatsheet card** — terminal-printable
+  one-pager that users can `cat` while learning.
+
+---
+
+## Already-fixed-but-fragile (revisit if anything regresses)
+
+These are Phase 1 fixes that solved the symptom but left the underlying
+mechanism somewhat fragile. Worth a re-look if related bugs surface:
+
+- **PID-file collision** [A #4 / GLM-5 C1] — fixed via
+  `HIPFIRE_NO_PID_FILE=1` env gate. Cleaner solution: spawn engine
+  directly (see "Daemon" section).
+- **Soft-wrap duplication** [A wrap fix, I] — fixed by skipping markdown
+  re-emit on wrapped lines. User loses styling on those lines. Proper
+  fix is the multi-row clear (see "Wrapped-line styling" above).
+- **Fence body unstyled** [I, intentional] — fence body lines emit raw
+  to keep code readable. Real fix is syntax highlighting (see
+  "Syntax highlighting" above).
+
+---
+
+## Won't-fix / explicit non-goals
+
+For the record, these were considered and rejected for Phase 2 too:
+
+- **Vim keybindings (j/k scroll)** — native terminal scrollback handles
+  this; we don't manage our own scroll buffer.
+- **Mouse support in chat area** — terminal natively supports mouse
+  selection / copy on the rendered output. Adding mouse handlers
+  would conflict with that.
+- **Cross-vendor compute backend** — out of scope per CLAUDE.md
+  (issue #44 closed). hipfire is HIP/ROCm-direct; chat surface
+  inherits this constraint.
+
+---
+
+## Effort estimate
+
+Quick-win batch (bullets, numbered lists, block quotes, role prefix,
+auto-link with OSC 8): **~30 LOC, 1-2 hours**. Recommended for a
+follow-up PR right after #129 lands.
+
+Medium batch (syntax highlighting, type-ahead, daemon-reported tok/s,
+nested SGR): **~250 LOC, 1-2 days**.
+
+Large batch (tables, wrapped-line styling with Unicode width,
+spawn-engine-directly refactor): **~500 LOC, 3-5 days**. Worth
+deferring until the chat surface has soak time and more user input.


### PR DESCRIPTION
## Summary

Phase 1 MVP of `hipfire chat` — interactive multi-turn TUI with streaming tokens, multi-line input, basic markdown rendering, slash commands, and clean daemon lifecycle. Closes #63.

- New file `cli/chat.ts` (separate from the 4889-line `cli/index.ts` monolith); dispatched lazily via `import("./chat.ts")`
- Pure helpers extracted to `cli/chat_pure.ts` with **57 unit tests** (all green)
- Reuses an existing `hipfire serve` if one is up; otherwise spawns a dedicated daemon and tears it down on exit
- Architecture follows the revised plan in `plans/tui.md` (no alternate screen, no custom word wrap, native scrollback, committed-lines + append-only live tail rendering)

## Features

- **Multi-line input:** `CTRL+O` inserts a newline; bracketed paste handles multi-line clipboards automatically (CRLF normalized to LF, control bytes sanitized)
- **Markdown:** fenced code blocks, inline code, bold, italic — rendered with ANSI SGR at commit-time (no flicker on streaming tail)
- **Slash commands:** `/help`, `/clear`, `/stats`, `/trim [pct]`, `/set <key> <val>`, `/exit`
- **Input history:** up/down arrows recall previous messages; in-progress drafts are preserved across navigation
- **Two-hit Ctrl+C:** first hit aborts an in-flight stream; second within 1s exits
- **Context-overflow warning:** at 80% of `cfg.max_seq` (per-model, registry-resolved)
- **Reasoning models:** `[thinking]` indicator while `delta.reasoning_content` arrives without `delta.content`

## Critical fixes from adversarial review (`tui_rev_claude.md`)

Three independent reviews (Claude, Gemini, GLM-5) flagged 27 issues across the implementation; the fixes that landed before merge:

- **PID-file collision (GLM-5):** chat-spawned daemon previously clobbered `~/.hipfire/serve.pid`, breaking `hipfire stop` for any user with a backgrounded `serve -d`. Fixed by gating the PID write on `HIPFIRE_NO_PID_FILE=1`, which `chat` now sets when spawning its ephemeral daemon
- **tok/s wrong by 3-5×** (3-way consensus): was counting SSE chunks, now estimates from `delta.content` length
- **Context limit hardcoded 4096** (3-way consensus): now uses `cfg.max_seq` (32k+ for shipped models)
- **Renderer was full-line repaint per token, not append-only** (Claude): now tracks `incompleteLineWritten`, only emits new bytes; markdown deferred to commit so partial backticks/asterisks don't flicker
- **Multi-byte cursor desync** (Claude): all input cursor math now grapheme-aware via `Intl.Segmenter` (handles CJK, emoji, ZWJ family glyphs, combining marks)
- **History eats in-progress draft** (Claude): up-arrow now saves the current buffer; full down-arrow restores it
- **Daemon stderr bled into chat UI** (Claude): now piped + drained
- **No SIGINT/SIGTERM/SIGHUP handlers** (Claude, GLM-5): cleanup is now idempotent and runnable from both `finally` and signal paths
- **`escBuf` accumulator too narrow** (Claude, GLM-5): simplified to buffer only lone `\x1b`
- **Per-turn tok/s reset** (GLM-5): `tokenTimes` cleared at the start of each `streamResponse` so rates reflect the current generation
- **Silent SSE parse errors** (GLM-5): now logged to stderr in dim text
- **`/trim` ate system messages** (Claude): now preserves leading system message and uses real ctx limit

## Test plan

- [x] `bun test cli/chat_pure.test.ts` — 57/57 pass, 91 expect calls (~50ms)
- [x] `bun test cli/parse_tool_calls.test.ts` — 14/14 pass (no regression)
- [x] `bun build cli/chat.ts` — clean
- [x] `bun build cli/index.ts` — clean
- [x] `bun cli/index.ts chat` — dispatch prints usage correctly
- [ ] Manual smoke test: 5-turn conversation with streaming, multi-line input, paste, history navigation with draft preservation, `/trim 30`, `/set temp 0.5`, `/stats`, two-hit Ctrl+C
- [ ] Verify `hipfire serve -d` (backgrounded) survives a `hipfire chat` lifecycle (regression test for PID-file collision fix)

## Files

- `cli/chat.ts` — TUI implementation (~620 lines after refactor)
- `cli/chat_pure.ts` — side-effect-free helpers (~220 lines)
- `cli/chat_pure.test.ts` — 57 unit tests
- `cli/index.ts` — `case "chat"` dispatch + `HIPFIRE_NO_PID_FILE` gate in `serve()` + 3 export changes
- `docs/CHAT.md` — usage docs
- `docs/CLI.md` — chat row added to inference table

## Commits

1. `0045ecf` feat(cli): hipfire chat — interactive TUI (closes #63)
2. `c6d5421` test(cli): extract chat helpers to chat_pure.ts + 57 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)