### PR TITLE
fix(compiler): Further fix for windows paths in hipcc compiler

### DIFF
--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -9,6 +9,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 /// Copy .hsaco and .hash files from the persistent install location (cold)
 /// into the tmpfs hot path. Used once at KernelCompiler startup to seed the
 /// hot path after reboot (when /tmp gets cleared) without forcing a full
@@ -243,7 +246,8 @@ impl KernelCompiler {
         // 8.3 alias. Subprocess approach avoids pulling in a winapi crate dep
         // for this single call site.
         let out = Command::new("cmd")
-            .args(["/c", &format!("for %A in (\"{}\") do @echo %~sA", p)])
+            .raw_arg("/c")
+            .raw_arg(&format!("for %A in (\"{}\") do @echo %~sA", p))
             .output();
         match out {
             Ok(o) if o.status.success() => {


### PR DESCRIPTION
I had used the workaround previously mentioned in https://github.com/Kaden-Schutt/hipfire/issues/82 of creating a copy of the rocm path and using that as my HIP_PATH but seeing a patch for the issue I tried it again with the canonical C:\Program Files\... path, but it still wasn't working. Apparently the problem is with `cmd` not respecting `\"` escapes in the `args` function, and after applying the suggested fix using the Windows' specific `raw_arg` function I can confirm the compilation process now works fine for me on Windows.

I figure if I can help out a little on the windows bugs you will have more time to look at the more important improvements...