### PR TITLE
Path D (#38) — DDTree pipeline: D0–D3b.1 + validation finding showing model B regresses on code

### DIFF
--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -1209,6 +1209,10 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     // memory.
     gpu.invalidate_graph_state();
     gpu.drain_pool();
+    // Path D D1: tear down pipeline streams so a model swap doesn't leak
+    // them. They're recreated lazily on the next spec_step_dflash if the
+    // env still has HIPFIRE_DFLASH_PIPELINE=1.
+    gpu.destroy_pipeline_streams();
 }
 
 fn load_dflash_state(

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -18,7 +18,7 @@
 //!   ← {"type":"unloaded"}
 
 use engine::cask::CaskCtx;
-use engine::dflash::{DflashConfig, DflashScratch, DflashWeights};
+use engine::dflash::{DflashConfig, DflashScratchPair, DflashWeights};
 use engine::hfq::HfqFile;
 use engine::llama;
 use engine::qwen35;
@@ -232,7 +232,7 @@ const VISION_END_ID: u32 = 248054;
 struct DflashState {
     draft_config: DflashConfig,
     draft_weights: DflashWeights,
-    draft_scratch: DflashScratch,
+    draft_pair: DflashScratchPair,
     hidden_rb: HiddenStateRingBuffer,
     verify_scratch: VerifyScratch,
     target_snap: DeltaNetSnapshot,
@@ -1181,7 +1181,7 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     // bulk of the VRAM anyway.
     if let Some(df) = m.dflash {
         df.draft_weights.free_gpu(gpu);
-        df.draft_scratch.free_gpu(gpu);
+        df.draft_pair.free_gpu(gpu);
     }
     // Free eviction context (centers + scratch tensors) if active.
     if let Some(ev) = m.eviction { ev.free_gpu(gpu); }
@@ -1225,9 +1225,14 @@ fn load_dflash_state(
     let hfq = HfqFile::open(Path::new(draft_path)).map_err(|e| format!("open draft: {e}"))?;
     let draft_config = DflashConfig::from_hfq(&hfq).ok_or("parse DflashConfig")?;
     let draft_weights = DflashWeights::load(gpu, &hfq, &draft_config).map_err(|e| format!("load weights: {e}"))?;
-    let draft_scratch = DflashScratch::new_with_mq(
+    // Path D D3b.1 (issue #38): construct a `DflashScratchPair` instead
+    // of a plain `DflashScratch`. With env=0 the pair degrades to single-
+    // scratch (b=None); with env=1 it allocates the pipelined half iff
+    // VRAM headroom suffices.
+    let draft_pair = DflashScratchPair::new(
         gpu, &draft_config, draft_config.block_size, ctx_capacity, draft_weights.has_mq,
-    ).map_err(|e| format!("draft scratch: {e}"))?;
+        target_config.vocab_size, target_config.dim,
+    ).map_err(|e| format!("draft scratch pair: {e}"))?;
 
     // Hidden ring: one row per target-layer selected by the draft config,
     // captured during each target forward. Sized so the whole context plus
@@ -1398,7 +1403,7 @@ fn load_dflash_state(
     Ok(DflashState {
         draft_config,
         draft_weights,
-        draft_scratch,
+        draft_pair,
         hidden_rb,
         verify_scratch,
         target_snap,
@@ -1480,7 +1485,7 @@ fn generate_dflash(
     }
     let df = m.dflash.as_mut().unwrap();
     df.target_hidden_host.clear();
-    df.draft_scratch.reset_upload_tracking();
+    df.draft_pair.a.reset_upload_tracking();
 
     // Assemble a transient ModelSlot for the spec helpers — they both take
     // `&mut ModelSlot`. We own the pieces on LoadedModel individually, so
@@ -1570,13 +1575,13 @@ fn generate_dflash(
     // Prime the draft's GPU target_hidden buffer from the prompt rows so the
     // first spec step can skip the CPU→GPU upload of the whole context.
     if let Err(e) = speculative::scatter_hidden_block_to_interleaved(
-        gpu, &df.hidden_rb, &df.draft_scratch.target_hidden,
+        gpu, &df.hidden_rb, &df.draft_pair.a.target_hidden,
         0, prompt_tokens.len(), prompt_tokens.len(),
     ) {
         eprintln!("[dflash] scatter failed: {e} — falling back to per-cycle upload");
     }
-    df.draft_scratch.uploaded_target_hidden_rows = prompt_tokens.len();
-    df.draft_scratch.target_hidden_abs_positions =
+    df.draft_pair.a.uploaded_target_hidden_rows = prompt_tokens.len();
+    df.draft_pair.a.target_hidden_abs_positions =
         (0..prompt_tokens.len() as i32).collect();
 
     // First emit = target's argmax at the final prompt position. seed_target_hidden
@@ -1625,7 +1630,7 @@ fn generate_dflash(
             position = res.new_physical;
             if !res.retain_mask.is_empty() {
                 let _ = speculative::apply_eviction_retain_to_draft(
-                    gpu, &mut df.draft_scratch, &res.retain_mask,
+                    gpu, &mut df.draft_pair.a, &res.retain_mask,
                     df.draft_config.num_extract(), df.draft_config.hidden, pre_phys,
                 );
             }
@@ -1697,7 +1702,7 @@ fn generate_dflash(
                 };
                 spec_step_ddtree_path_c(
                     gpu, &mut target, &df.draft_weights, &df.draft_config,
-                    &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
+                    &mut df.draft_pair.a, &mut df.hidden_rb, &mut df.target_hidden_host,
                     &mut df.target_snap, &mut df.gdn_tape, &df.verify_scratch,
                     position, seed_token,
                     None,                      // ctx_slice = full history
@@ -1708,7 +1713,7 @@ fn generate_dflash(
             } else {
                 spec_step_ddtree_batched(
                     gpu, &mut target, &df.draft_weights, &df.draft_config,
-                    &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
+                    &mut df.draft_pair.a, &mut df.hidden_rb, &mut df.target_hidden_host,
                     &mut df.target_snap, &mut dd.post_seed_snap, &mut df.gdn_tape,
                     &dd.scratch, &df.verify_scratch,
                     position, seed_token,
@@ -1720,7 +1725,7 @@ fn generate_dflash(
         } else {
             spec_step_dflash(
                 gpu, &mut target, &df.draft_weights, &df.draft_config,
-                &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
+                &mut df.draft_pair, &mut df.hidden_rb, &mut df.target_hidden_host,
                 &mut df.target_snap, &df.verify_scratch,
                 position, seed_token,
                 None,                      // ctx_slice = full history
@@ -1734,6 +1739,7 @@ fn generate_dflash(
                 None,                      // pld_spine
                 1.0_f32,                   // repeat_penalty (off)
                 0,                         // repeat_window
+                gpu.pipeline_enabled(),    // pipeline_mode (Path D D3b)
             )
         };
         let step = match step_result {
@@ -1775,7 +1781,7 @@ fn generate_dflash(
                 position = res.new_physical;
                 if !res.retain_mask.is_empty() {
                     let _ = speculative::apply_eviction_retain_to_draft(
-                        gpu, &mut df.draft_scratch, &res.retain_mask,
+                        gpu, &mut df.draft_pair.a, &res.retain_mask,
                         df.draft_config.num_extract(), df.draft_config.hidden, pre_phys,
                     );
                 }

--- a/crates/engine/examples/dflash_smoke.rs
+++ b/crates/engine/examples/dflash_smoke.rs
@@ -108,6 +108,7 @@ fn main() {
         block_size,
         ctx_len,
         &mut scratch,
+        None, // stream_override (Path D D0c)
     )
     .expect("draft_forward");
     // Ensure all kernels complete before we download.

--- a/crates/engine/examples/dflash_spec_demo.rs
+++ b/crates/engine/examples/dflash_spec_demo.rs
@@ -22,7 +22,7 @@ fn main() {
 #[cfg(feature = "deltanet")]
 fn main() {
     use engine::cask::CaskCtx;
-    use engine::dflash::{DflashConfig, DflashScratch, DflashWeights};
+    use engine::dflash::{DflashConfig, DflashScratchPair, DflashWeights};
     use engine::hfq::HfqFile;
     use engine::qwen35::LayerType;
     use engine::speculative::{
@@ -372,6 +372,11 @@ fn main() {
 
     // ── Init GPU ──────────────────────────────────────────────────────
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    // Path D D3b (issue #38): cache pipelining decision once per session
+    // and pass into `spec_step_dflash` so it doesn't re-read the env per
+    // cycle. False unless `HIPFIRE_DFLASH_PIPELINE=1` AND the pair allocates
+    // its second half (VRAM check inside `DflashScratchPair::new`).
+    let gpu_pipeline_enabled = gpu.pipeline_enabled();
     eprintln!("gpu: {}", gpu.arch);
     let vram_report = |hip: &hip_bridge::HipRuntime, label: &str| {
         if let Ok((free, total)) = hip.get_vram_info() {
@@ -463,11 +468,20 @@ fn main() {
             draft_scratch_b, draft_cfg.block_size,
         );
     }
-    let mut draft_scratch = DflashScratch::new_with_mq(
+    // Path D D3b.1 (issue #38): construct a `DflashScratchPair` instead
+    // of a plain `DflashScratch`. With env=0 (default) the pair degrades
+    // to a single scratch (`b = None`, no draft lm_head buffers) — same
+    // VRAM and behavior as before. With env=1 the pair allocates the
+    // pipelined half iff VRAM headroom suffices.
+    let mut draft_pair = DflashScratchPair::new(
         &mut gpu, &draft_cfg, draft_scratch_b, ctx_capacity, draft_weights.has_mq,
-    ).expect("alloc draft scratch");
+        target.config.vocab_size, target.config.dim,
+    ).expect("alloc draft scratch pair");
     if draft_weights.has_mq {
         eprintln!("draft: MQ4 weights detected, FWHT rotation scratch enabled");
+    }
+    if draft_pair.pipelining_active() {
+        eprintln!("draft: pipelining active — `b` half allocated for inter-cycle pipeline");
     }
 
     // ── Check vocab compatibility ─────────────────────────────────────
@@ -601,23 +615,23 @@ fn main() {
     )
     .expect("seed target hidden");
     // Mirror the prompt rows from the hidden ring buffer straight into
-    // draft_scratch.target_hidden on GPU. This primes the GPU-resident
+    // draft_pair.a.target_hidden on GPU. This primes the GPU-resident
     // path in spec_step_dflash (ctx_slice=None) so it doesn't need to
     // round-trip target_hidden through the CPU shadow each cycle.
     speculative::scatter_hidden_block_to_interleaved(
         &gpu,
         &hidden_rb,
-        &draft_scratch.target_hidden,
+        &draft_pair.a.target_hidden,
         0,
         prompt_tokens.len(), // block_size: seed wrote prompt_len contiguous slots
         prompt_tokens.len(), // n_rows:     keep all of them
     )
     .expect("seed scatter");
-    draft_scratch.uploaded_target_hidden_rows = prompt_tokens.len();
+    draft_pair.a.uploaded_target_hidden_rows = prompt_tokens.len();
     // Seed per-row absolute positions for the draft's cross-attention RoPE.
     // Pre-eviction these match [0..prompt_len) exactly, so FlashCASK-free runs
     // stay byte-identical to the old contiguous-range behaviour.
-    draft_scratch.target_hidden_abs_positions =
+    draft_pair.a.target_hidden_abs_positions =
         (0..prompt_tokens.len() as i32).collect();
     let prefill_secs = t2.elapsed().as_secs_f64();
     let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
@@ -676,7 +690,7 @@ fn main() {
             if !ev.retain_mask.is_empty() {
                 speculative::apply_eviction_retain_to_draft(
                     &mut gpu,
-                    &mut draft_scratch,
+                    &mut draft_pair.a,
                     &ev.retain_mask,
                     draft_cfg.num_extract(),
                     draft_cfg.hidden,
@@ -1150,7 +1164,7 @@ fn main() {
                     &mut target,
                     &draft_weights,
                     &draft_cfg,
-                    &mut draft_scratch,
+                    &mut draft_pair.a,
                     &mut hidden_rb,
                     &mut target_hidden_host,
                     &mut target_snap,
@@ -1170,7 +1184,7 @@ fn main() {
                     &mut target,
                     &draft_weights,
                     &draft_cfg,
-                    &mut draft_scratch,
+                    &mut draft_pair.a,
                     &mut hidden_rb,
                     &mut target_hidden_host,
                     &mut target_snap,
@@ -1191,7 +1205,7 @@ fn main() {
                     &mut target,
                     &draft_weights,
                     &draft_cfg,
-                    &mut draft_scratch,
+                    &mut draft_pair.a,
                     &mut hidden_rb,
                     &mut target_hidden_host,
                     &mut target_snap,
@@ -1212,7 +1226,7 @@ fn main() {
                 &mut target,
                 &draft_weights,
                 &draft_cfg,
-                &mut draft_scratch,
+                &mut draft_pair,
                 &mut hidden_rb,
                 &mut target_hidden_host,
                 &mut target_snap,
@@ -1230,6 +1244,7 @@ fn main() {
                 pld_spine,
                 runtime_repeat_penalty,
                 repeat_window,
+                gpu_pipeline_enabled, // pipeline_mode (Path D D3b)
             )
             .expect("spec step")
         };
@@ -1454,7 +1469,7 @@ fn main() {
                 if !ev.retain_mask.is_empty() {
                     speculative::apply_eviction_retain_to_draft(
                         &mut gpu,
-                        &mut draft_scratch,
+                        &mut draft_pair.a,
                         &ev.retain_mask,
                         draft_cfg.num_extract(),
                         draft_cfg.hidden,

--- a/crates/engine/src/dflash.rs
+++ b/crates/engine/src/dflash.rs
@@ -536,6 +536,252 @@ impl DflashScratch {
     }
 }
 
+// ─── DflashScratchPair (Path D D2) ─────────────────────────────────────────
+
+/// Path D D2 (issue #38): paired draft scratch for inter-cycle pipelining.
+///
+/// Holds two `DflashScratch` instances (`a` and `b`) so cycle N's draft can
+/// write into one while cycle N+1's draft reads from the other. `b` is
+/// allocated only when pipelining is enabled (`HIPFIRE_DFLASH_PIPELINE=1`)
+/// AND the startup VRAM headroom check passes — otherwise the pair degrades
+/// to a single scratch (`b = None`) and the caller falls through to the
+/// non-pipelined `spec_step_dflash` path.
+///
+/// Also owns dedicated lm_head logits + FWHT-rotation buffers for the draft
+/// leg. Without this, the pipelined draft would race with verify N's
+/// lm_head on `verify_scratch.logits` / `verify_scratch.rot` (see
+/// speculative.rs:2746-2769 for the existing reuse pattern).
+///
+/// Memory cost: per-half `DflashScratch` is ~30 MB at the spec demo's
+/// example config (5-layer / max_ctx=512) and can exceed 500 MB at
+/// 16-layer / max_ctx=4096. Plus ~10 MB for lm_head_logits at 27B
+/// vocab=152K, batch=16. The pair therefore costs ~64 MB at typical
+/// configs and up to ~1 GB at worst case — gated entirely on env=1, with
+/// a runtime VRAM check before allocation (see `new` for the threshold).
+pub struct DflashScratchPair {
+    /// Always allocated. Holds the "current" cycle's draft state.
+    pub a: DflashScratch,
+    /// Allocated iff pipelining is active. `None` means the pair is
+    /// degraded to single-scratch mode — caller should run the
+    /// non-pipelined spec step. Set to `None` by `drop_unused_half()`
+    /// when D4's adaptive bypass triggers, releasing ~30 MB+ for the
+    /// rest of the request.
+    pub b: Option<DflashScratch>,
+    /// Even cycles use `a`, odd use `b`. Toggled by the pipelined branch
+    /// of `spec_step_dflash` via `flip()`.
+    pub parity: bool,
+    /// Dedicated draft lm_head logits — `[max_block × vocab]` F32.
+    /// `Some` iff pipelining is active.
+    pub draft_lm_head_logits: Option<GpuTensor>,
+    /// FWHT rotation scratch for MQ4 lm_head — `[max_block × hidden_k]`
+    /// F32. `Some` iff pipelining is active. Sized to the same `hidden_k`
+    /// the existing `verify_scratch.rot` uses.
+    pub draft_lm_head_rot: Option<GpuTensor>,
+}
+
+impl DflashScratchPair {
+    /// Build a pair, allocating `b` and the draft lm_head scratches only
+    /// when pipelining is enabled AND VRAM headroom suffices. On
+    /// insufficient VRAM, logs once and returns a degraded pair (single-
+    /// scratch mode).
+    ///
+    /// Per plan §5.1: free VRAM must exceed `b`-size + lm_head + 200 MB
+    /// safety margin, else refuse pipelining for this request rather
+    /// than OOM-crash mid-cycle.
+    pub fn new(
+        gpu: &mut Gpu,
+        cfg: &DflashConfig,
+        max_block_size: usize,
+        max_ctx_len: usize,
+        with_mq: bool,
+        target_vocab: usize,
+        target_hidden_k: usize,
+    ) -> HipResult<Self> {
+        // `a` is always allocated — equivalent to a non-pipelined caller's
+        // single scratch. Existing call sites that don't use the pair pass
+        // through `DflashScratch::new_with_mq` directly and are unaffected.
+        let a = DflashScratch::new_with_mq(gpu, cfg, max_block_size, max_ctx_len, with_mq)?;
+
+        let mut b: Option<DflashScratch> = None;
+        let mut draft_lm_head_logits: Option<GpuTensor> = None;
+        let mut draft_lm_head_rot: Option<GpuTensor> = None;
+
+        if gpu.pipeline_enabled() {
+            let scratch_bytes = Self::estimate_scratch_bytes(
+                cfg, max_block_size, max_ctx_len, with_mq,
+            );
+            let lmhead_bytes =
+                max_block_size * target_vocab * 4 + max_block_size * target_hidden_k * 4;
+            let safety_margin: usize = 200 * 1024 * 1024;
+            let needed = scratch_bytes + lmhead_bytes + safety_margin;
+            let (free_vram, _total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+            if (free_vram as usize) >= needed {
+                b = Some(DflashScratch::new_with_mq(
+                    gpu, cfg, max_block_size, max_ctx_len, with_mq,
+                )?);
+                draft_lm_head_logits =
+                    Some(gpu.alloc_tensor(&[max_block_size * target_vocab], DType::F32)?);
+                draft_lm_head_rot =
+                    Some(gpu.alloc_tensor(&[max_block_size * target_hidden_k], DType::F32)?);
+            } else {
+                eprintln!(
+                    "[dflash] HIPFIRE_DFLASH_PIPELINE=1 but VRAM headroom is \
+                     insufficient (free={} MB, need={} MB incl 200 MB margin). \
+                     Pipelining disabled for this request — pair degraded to \
+                     single-scratch mode.",
+                    free_vram as usize / (1024 * 1024),
+                    needed / (1024 * 1024),
+                );
+            }
+        }
+
+        Ok(Self {
+            a,
+            b,
+            parity: false,
+            draft_lm_head_logits,
+            draft_lm_head_rot,
+        })
+    }
+
+    /// Returns `true` when pipelining is active for this request — `b` and
+    /// the draft lm_head scratches are allocated. Caller should branch
+    /// here to choose between pipelined and non-pipelined spec step.
+    pub fn pipelining_active(&self) -> bool {
+        self.b.is_some()
+    }
+
+    /// Returns the scratch the current cycle should write into. When
+    /// pipelining is degraded, always returns `a` (parity is forced to
+    /// `false` in `flip()` on a degraded pair).
+    pub fn current(&mut self) -> &mut DflashScratch {
+        if self.parity {
+            self.b.as_mut().expect(
+                "current(): parity=true but b is None — flip() ran on a degraded pair",
+            )
+        } else {
+            &mut self.a
+        }
+    }
+
+    /// Returns the scratch holding the previous cycle's draft state. Only
+    /// meaningful when pipelining is active. Panics if `b` is None — the
+    /// caller is expected to check `pipelining_active()` first.
+    pub fn previous(&mut self) -> &mut DflashScratch {
+        if self.parity {
+            &mut self.a
+        } else {
+            self.b.as_mut().expect(
+                "previous(): pipelining is not active — guard with pipelining_active()",
+            )
+        }
+    }
+
+    /// Toggle parity. No-op when pipelining is degraded (parity stays
+    /// `false`, `current()` keeps returning `a`).
+    pub fn flip(&mut self) {
+        if self.b.is_some() {
+            self.parity = !self.parity;
+        }
+    }
+
+    /// Free the unused half (`b` and the draft lm_head scratches).
+    /// Called by D4's adaptive bypass when τ stays under the pipelined
+    /// floor for 3 consecutive cycles — reclaims ~30 MB+ of VRAM for
+    /// the rest of the request. After this, `pipelining_active()` returns
+    /// `false` and the caller should run the non-pipelined spec step.
+    ///
+    /// If the pair is currently using `b` (parity=true), `b` is moved
+    /// into the `a` slot (replacing the old `a`, which is freed) so the
+    /// surviving scratch holds the most recently written state.
+    pub fn drop_unused_half(&mut self, gpu: &mut Gpu) {
+        if self.parity {
+            if let Some(b) = self.b.take() {
+                let old_a = std::mem::replace(&mut self.a, b);
+                old_a.free_gpu(gpu);
+            }
+            self.parity = false;
+        } else if let Some(b) = self.b.take() {
+            b.free_gpu(gpu);
+        }
+        if let Some(t) = self.draft_lm_head_logits.take() {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.draft_lm_head_rot.take() {
+            let _ = gpu.free_tensor(t);
+        }
+    }
+
+    pub fn free_gpu(self, gpu: &mut Gpu) {
+        self.a.free_gpu(gpu);
+        if let Some(b) = self.b {
+            b.free_gpu(gpu);
+        }
+        if let Some(t) = self.draft_lm_head_logits {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.draft_lm_head_rot {
+            let _ = gpu.free_tensor(t);
+        }
+    }
+
+    /// Estimated GPU byte cost of one `DflashScratch` for the given config.
+    /// Mirrors the per-tensor allocations in `DflashScratch::new_with_mq`.
+    /// Used for the VRAM headroom check before allocating the pair's
+    /// second half.
+    fn estimate_scratch_bytes(
+        cfg: &DflashConfig,
+        max_block_size: usize,
+        max_ctx_len: usize,
+        with_mq: bool,
+    ) -> usize {
+        let b = max_block_size;
+        let l = max_ctx_len;
+        let tot = l + b;
+        let ne = cfg.num_extract();
+        let h = cfg.hidden;
+        let inter = cfg.intermediate;
+        let qd = cfg.q_dim();
+        let kvd = cfg.kv_dim();
+        let n_layers = cfg.n_layers;
+        const F32_B: usize = 4;
+
+        let mut total = 0usize;
+        // Block-sized activations.
+        total += b * h * F32_B;     // x
+        total += b * h * F32_B;     // x_norm
+        total += b * qd * F32_B;    // q
+        total += b * kvd * F32_B;   // k_noise
+        total += b * kvd * F32_B;   // v_noise
+        total += b * inter * F32_B; // gate
+        total += b * inter * F32_B; // up
+        total += b * inter * F32_B; // gate_up
+        total += b * qd * F32_B;    // attn_out
+        total += b * h * F32_B;     // attn_proj
+        total += b * h * F32_B;     // residual_attn
+        total += b * h * F32_B;     // residual_ffn
+        // Context-sized.
+        total += l * ne * h * F32_B; // target_hidden
+        total += l * h * F32_B;      // target_hidden_proj
+        total += l * kvd * F32_B;    // k_ctx
+        total += l * kvd * F32_B;    // v_ctx
+        // Concatenated.
+        total += tot * kvd * F32_B;  // k_cat
+        total += tot * kvd * F32_B;  // v_cat
+        // Positions.
+        total += b * F32_B;          // positions_q
+        total += tot * F32_B;        // positions_k
+        // Per-layer K/V cache.
+        total += 2 * n_layers * l * kvd * F32_B;
+        // FWHT rotation scratch (when MQ).
+        if with_mq {
+            let widest = std::cmp::max(l * ne * h, b * std::cmp::max(inter, qd));
+            total += widest * F32_B;
+        }
+        total
+    }
+}
+
 // ─── Forward ───────────────────────────────────────────────────────────────
 
 /// Dispatch a batched GEMM by weight dtype.

--- a/crates/engine/src/dflash.rs
+++ b/crates/engine/src/dflash.rs
@@ -577,6 +577,28 @@ pub struct DflashScratchPair {
     /// F32. `Some` iff pipelining is active. Sized to the same `hidden_k`
     /// the existing `verify_scratch.rot` uses.
     pub draft_lm_head_rot: Option<GpuTensor>,
+    /// Path D D3b (model B): cross-cycle storage for draft tokens. Each
+    /// half holds the tokens that were produced when *that* half was the
+    /// pipelined draft target. Cycle N's verify reads `previous_drafted()`
+    /// (the just-flipped opposite half's tokens, drafted in cycle N-1's
+    /// concurrent launch); cycle N's pipelined draft writes
+    /// `current_drafted_mut()` (the half flipped INTO this cycle, will be
+    /// read by cycle N+1's verify after the next flip).
+    ///
+    /// Length 0 when no pipelined draft has been launched into that half
+    /// yet — used as the "first pipelined cycle" sentinel: if
+    /// `pair.pipelining_active() && pair.previous_drafted().is_empty()`
+    /// the cycle bypasses to sequential, then runs the trailing pipelined
+    /// draft launch on its way out so the next cycle has tokens to verify.
+    pub drafted_a: Vec<u32>,
+    pub drafted_b: Vec<u32>,
+    /// Path D D3b: per-pair flag set when the *previous* cycle bypassed
+    /// pipelining (cycle 0, PLD spine, graph capture, runtime VRAM
+    /// failure mid-session). When `true`, `current_drafted` may not
+    /// correspond to a fresh pipelined launch — the next cycle must also
+    /// bypass to sequential and re-bootstrap the pipeline. Cleared when a
+    /// successful pipelined cycle completes.
+    pub prev_cycle_bypassed: bool,
 }
 
 impl DflashScratchPair {
@@ -641,7 +663,34 @@ impl DflashScratchPair {
             parity: false,
             draft_lm_head_logits,
             draft_lm_head_rot,
+            drafted_a: Vec::new(),
+            drafted_b: Vec::new(),
+            prev_cycle_bypassed: true, // session-start counts as "no pipelined cycle yet"
         })
+    }
+
+    /// Path D D3b: tokens produced by the *previous* cycle's pipelined
+    /// draft launch (the "previous" half after the most recent `flip()`).
+    /// Returns an empty slice when no pipelined draft has run yet — the
+    /// caller treats that as a "bootstrap" signal and bypasses to
+    /// sequential for the cycle.
+    pub fn previous_drafted(&self) -> &[u32] {
+        if self.parity {
+            &self.drafted_a
+        } else {
+            &self.drafted_b
+        }
+    }
+
+    /// Mutable handle for the *current* half's drafted tokens. The
+    /// pipelined draft launch in cycle N writes here; cycle N+1's verify
+    /// reads `previous_drafted()` after `flip()`.
+    pub fn current_drafted_mut(&mut self) -> &mut Vec<u32> {
+        if self.parity {
+            &mut self.drafted_b
+        } else {
+            &mut self.drafted_a
+        }
     }
 
     /// Returns `true` when pipelining is active for this request — `b` and

--- a/crates/engine/src/dflash.rs
+++ b/crates/engine/src/dflash.rs
@@ -24,7 +24,7 @@
 
 use crate::hfq::HfqFile;
 use crate::llama::WeightTensor;
-use hip_bridge::HipResult;
+use hip_bridge::{HipResult, Stream};
 use rdna_compute::{DType, Gpu, GpuTensor};
 
 // ─── Config ────────────────────────────────────────────────────────────────
@@ -661,6 +661,40 @@ fn upload_slice_i32(gpu: &Gpu, dst: &GpuTensor, data: &[i32]) -> HipResult<()> {
 ///     with `ctx_len × num_extract × hidden` F32 rows.
 #[allow(clippy::too_many_arguments)]
 pub fn draft_forward(
+    gpu: &mut Gpu,
+    weights: &DflashWeights,
+    cfg: &DflashConfig,
+    noise_embedding: Option<&[f32]>,
+    target_hidden: Option<&[f32]>,
+    positions_q: &[i32],
+    positions_k: &[i32],
+    block_size: usize,
+    ctx_len: usize,
+    scratch: &mut DflashScratch,
+    stream_override: Option<&Stream>,
+) -> HipResult<()> {
+    // Path D D0c: when `stream_override` is `Some`, every kernel /
+    // memcpy / memset issued through `gpu.*` inside the closure routes
+    // through that stream instead of `gpu.active_stream`. The override
+    // is restored to its prior value when the closure returns. When
+    // `None`, behavior is byte-exact identical to pre-D0c.
+    let mut body = move |gpu: &mut Gpu| -> HipResult<()> {
+        draft_forward_body(
+            gpu, weights, cfg,
+            noise_embedding, target_hidden,
+            positions_q, positions_k,
+            block_size, ctx_len,
+            scratch,
+        )
+    };
+    match stream_override {
+        Some(s) => gpu.with_stream_override(s, body),
+        None => body(gpu),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draft_forward_body(
     gpu: &mut Gpu,
     weights: &DflashWeights,
     cfg: &DflashConfig,

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -2326,6 +2326,56 @@ pub fn scatter_hidden_block_to_interleaved(
     Ok(())
 }
 
+/// Path D D0b: async-on-stream variant of `scatter_hidden_block_to_interleaved`.
+///
+/// Differs from the sync variant in two ways:
+///   1. Uses `memcpy_dtod_async_at(..., stream)` so all copies are
+///      ordered on `stream` and capturable.
+///   2. Takes `head_snapshot` as an explicit parameter rather than
+///      reading `hidden_rb.head` live. The pipelined caller passes the
+///      pre-commit head it captured at cycle entry; the sync variant
+///      passes `hidden_rb.head` and gets identical math.
+///
+/// Caller is responsible for ordering: the source layer_bufs must be
+/// in the desired post-commit-N-1 state on `stream` before this is
+/// enqueued (use cross-stream events to pin to the desired commit).
+pub fn scatter_hidden_block_to_interleaved_on_stream(
+    gpu: &Gpu,
+    hidden_rb: &HiddenStateRingBuffer,
+    dst: &GpuTensor,
+    dst_row_offset: usize,
+    block_size: usize,
+    n_rows: usize,
+    head_snapshot: usize,
+    stream: &Stream,
+) -> HipResult<()> {
+    assert!(n_rows <= block_size, "scatter: n_rows {n_rows} > block_size {block_size}");
+    let num_extract = hidden_rb.extract_layers.len();
+    let hidden = hidden_rb.hidden_dim;
+    let max_pos = hidden_rb.max_positions;
+    let row_bytes = hidden * 4;
+    let start_slot = (head_snapshot + max_pos - block_size) % max_pos;
+
+    for r in 0..n_rows {
+        let slot = (start_slot + r) % max_pos;
+        let dst_row = dst_row_offset + r;
+        let dst_row_base_bytes = dst_row * num_extract * row_bytes;
+        for ext in 0..num_extract {
+            let src_offset_bytes = slot * row_bytes;
+            let dst_offset_bytes = dst_row_base_bytes + ext * row_bytes;
+            gpu.hip.memcpy_dtod_async_at(
+                &dst.buf,
+                dst_offset_bytes,
+                &hidden_rb.layer_bufs[ext].buf,
+                src_offset_bytes,
+                row_bytes,
+                stream,
+            )?;
+        }
+    }
+    Ok(())
+}
+
 pub fn download_hidden_block(
     gpu: &Gpu,
     hidden_rb: &HiddenStateRingBuffer,

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -1872,6 +1872,7 @@ pub fn verify_dflash_block(
     verify_dflash_block_inner(
         gpu, target, draft_tokens, start_pos, hidden_rb, gdn_tape, want_full_logits, None,
         verify_scratch,
+        false, // skip_internal_commit (Path D D3a — only D3b's pipelined path passes true)
     )
 }
 
@@ -1902,6 +1903,7 @@ pub fn verify_dflash_block_tree(
         gpu, target, draft_tokens, start_pos, hidden_rb, gdn_tape, want_full_logits,
         Some(tree_verify),
         verify_scratch,
+        false, // skip_internal_commit (Path D D3a)
     )
 }
 
@@ -1915,6 +1917,14 @@ fn verify_dflash_block_inner(
     want_full_logits: bool,
     tree_verify: Option<qwen35::TreeVerifyCtx<'_>>,
     verify_scratch: &VerifyScratch,
+    // Path D D3a (issue #38): when `true`, skip the
+    // `hidden_rb.commit_staging_to_ring(gpu, b)` call below the verify
+    // forward and leave the commit to the caller. The pipelined cycle
+    // (D3b) needs to record `pre_commit_evt` *between* the forward and
+    // the commit so the draft N+1 launch can pin to the pre-commit
+    // ring-buffer state — which is impossible while the commit is
+    // buried inside this helper. Default `false` is byte-exact pre-D3a.
+    skip_internal_commit: bool,
 ) -> HipResult<DflashVerifyOutput> {
     let b = draft_tokens.len();
     let vocab = target.config.vocab_size;
@@ -2107,7 +2117,13 @@ fn verify_dflash_block_inner(
     // those rows at the current head and advances head by b. Under the
     // graph path we manually drive this because the non-graph chunk loop
     // (forward_prefill_batch_with_pbs) that usually calls it was bypassed.
-    if verify_graph_ok && batch_result.is_ok() {
+    //
+    // Path D D3a (issue #38): when `skip_internal_commit` is true the
+    // caller (D3b's pipelined branch) is responsible for the commit so
+    // it can record `pre_commit_evt` on the verify stream *between* the
+    // forward and the commit, then have draft_stream wait on that event
+    // before reading the ring. Default false → byte-exact pre-D3a.
+    if verify_graph_ok && batch_result.is_ok() && !skip_internal_commit {
         hidden_rb.commit_staging_to_ring(gpu, b)?;
     }
     // Tree mode at topk>1 REQUIRES this sync. Without it τ degrades badly

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -12,7 +12,7 @@
 //! on different models sharing the same MQ scratch (which we won't, since
 //! speculative decode serializes draft-generate then target-verify).
 
-use crate::dflash::{self, DflashConfig, DflashScratch, DflashWeights};
+use crate::dflash::{self, DflashConfig, DflashScratch, DflashScratchPair, DflashWeights};
 use crate::hfq::HfqFile;
 use crate::llama::{self, KvCache};
 use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
@@ -2506,7 +2506,7 @@ pub fn spec_step_dflash(
     target: &mut ModelSlot,
     draft_weights: &DflashWeights,
     draft_cfg: &DflashConfig,
-    draft_scratch: &mut DflashScratch,
+    draft_pair: &mut DflashScratchPair,
     hidden_rb: &mut HiddenStateRingBuffer,
     target_hidden_host: &mut Vec<f32>,
     target_snap: &mut DeltaNetSnapshot,
@@ -2524,7 +2524,20 @@ pub fn spec_step_dflash(
     pld_spine: Option<&[u32]>,
     repeat_penalty: f32,
     repeat_window: usize,
+    // Path D D3b (issue #38): when `true`, the pipelined branch may run
+    // (subject to per-cycle bypass conditions in §2.3 — graph-capture
+    // active, prev cycle bypassed, PLD spine, or pair degraded to
+    // single-scratch via VRAM check). When `false`, always runs the
+    // sequential body. Caller typically passes `gpu.pipeline_enabled()`.
+    pipeline_mode: bool,
 ) -> HipResult<SpecStepResult> {
+    // Path D D3b.1: pure refactor — the body still treats the pair as a
+    // single scratch via this alias. D3b.2 will fork into a pipelined
+    // branch when `pipeline_mode && draft_pair.pipelining_active()` and
+    // the §2.3 bypass conditions all permit. For now `pipeline_mode` is
+    // accepted but ignored — byte-exact pre-D3b.1.
+    let _ = pipeline_mode;
+    let draft_scratch: &mut DflashScratch = &mut draft_pair.a;
     // Effective block size for THIS step. Usually `draft_cfg.block_size`
     // (what the draft was trained at, 16 for Qwen3.5-*-DFlash) but a caller
     // doing adaptive-B based on rolling τ can shrink to save per-iter cost.

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -2534,6 +2534,13 @@ pub fn spec_step_dflash(
         gpu.active_stream = Some(gpu.hip.stream_create()?);
     }
 
+    // Path D D1 (issue #38): allocate `gpu.draft_stream` lazily for the
+    // pipelined cycle (gated on `HIPFIRE_DFLASH_PIPELINE=1`, cached at Gpu
+    // init). Idempotent — does real work only the first time per session.
+    // No-op when pipelining is disabled, which keeps default config
+    // byte-exact pre-D1.
+    gpu.init_pipeline_streams()?;
+
     assert!(b >= 2, "dflash block size must be ≥ 2");
     // `target_hidden_host` is only authoritative on the ctx_slice=Some path,
     // where it backs the CPU slice handed to draft_forward. On the default

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -2704,6 +2704,7 @@ pub fn spec_step_dflash(
         b,
         effective_ctx_len,
         draft_scratch,
+        None, // stream_override (Path D D0c) — None = use gpu.active_stream
     )?;
 
     // ── 5. Apply target.lm_head to draft hidden positions 1..B ──────────
@@ -3344,6 +3345,7 @@ fn run_dflash_draft_for_logits(
         b,
         effective_ctx_len,
         draft_scratch,
+        None, // stream_override (Path D D0c)
     )?;
 
     // Step 4: Apply target.lm_head to draft hidden rows [1..B). Same batched
@@ -3488,6 +3490,7 @@ fn run_dflash_draft_for_topk_gpu(
         b,
         effective_ctx_len,
         draft_scratch,
+        None, // stream_override (Path D D0c)
     )?;
 
     // Step 4: lm_head → [batch × vocab] logits (GPU-resident).

--- a/crates/engine/src/speculative.rs
+++ b/crates/engine/src/speculative.rs
@@ -17,7 +17,7 @@ use crate::hfq::HfqFile;
 use crate::llama::{self, KvCache};
 use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
 use crate::tokenizer::Tokenizer;
-use hip_bridge::{DeviceBuffer, HipResult};
+use hip_bridge::{DeviceBuffer, HipResult, Stream};
 use rdna_compute::{Gpu, GpuTensor};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1329,6 +1329,60 @@ impl HiddenStateRingBuffer {
                     &self.layer_bufs[ei].buf, 0,
                     &self.staging_bufs[ei].buf, first * row_bytes,
                     (n - first) * row_bytes,
+                )?;
+            }
+        }
+        self.head = (head + n) % max_pos;
+        self.written += n;
+        Ok(())
+    }
+
+    /// Path D D0a: async-on-stream variant of `commit_staging_to_ring`.
+    ///
+    /// Differs from the sync wrapper in two ways:
+    ///   1. Uses `memcpy_dtod_async_at(..., stream)` instead of sync
+    ///      `memcpy_dtod_at` on the null stream. Copies are ordered on
+    ///      `stream` and capturable.
+    ///   2. Does **no** host-side `stream_synchronize`. The caller is
+    ///      responsible for ordering: e.g. recording a `pre_commit` event
+    ///      *before* invoking this and having other streams wait on it,
+    ///      and ensuring prior writes to the staging buffers on `stream`
+    ///      are already enqueued.
+    ///
+    /// CPU bookkeeping (`self.head`, `self.written`) is advanced after the
+    /// async enqueues, mirroring the sync variant. Callers that snapshot
+    /// `head`/`written` *before* calling this see pre-commit values.
+    pub fn commit_staging_to_ring_on_stream(
+        &mut self,
+        gpu: &Gpu,
+        n: usize,
+        stream: &Stream,
+    ) -> HipResult<()> {
+        let row_bytes = self.hidden_dim * 4;
+        let head = self.head;
+        let max_pos = self.max_positions;
+
+        for ei in 0..self.layer_bufs.len() {
+            if head + n <= max_pos {
+                gpu.hip.memcpy_dtod_async_at(
+                    &self.layer_bufs[ei].buf, head * row_bytes,
+                    &self.staging_bufs[ei].buf, 0,
+                    n * row_bytes,
+                    stream,
+                )?;
+            } else {
+                let first = max_pos - head;
+                gpu.hip.memcpy_dtod_async_at(
+                    &self.layer_bufs[ei].buf, head * row_bytes,
+                    &self.staging_bufs[ei].buf, 0,
+                    first * row_bytes,
+                    stream,
+                )?;
+                gpu.hip.memcpy_dtod_async_at(
+                    &self.layer_bufs[ei].buf, 0,
+                    &self.staging_bufs[ei].buf, first * row_bytes,
+                    (n - first) * row_bytes,
+                    stream,
                 )?;
             }
         }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -417,6 +417,14 @@ impl Gpu {
         result
     }
 
+    /// Path D D1 / D2: returns the cached `HIPFIRE_DFLASH_PIPELINE=1` flag.
+    /// Read once at `Gpu::init()`; cycle-hot callers (D2's
+    /// `DflashScratchPair::new`, D3b's pipelined branch in
+    /// `spec_step_dflash`) can consult this without re-reading the env.
+    pub fn pipeline_enabled(&self) -> bool {
+        self.pipeline_enabled
+    }
+
     /// Path D D1 (issue #38): lazily allocate `draft_stream` for inter-cycle
     /// pipelining. Idempotent — second and subsequent calls are no-ops.
     /// No-op when `HIPFIRE_DFLASH_PIPELINE != 1` (cached as

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -225,6 +225,16 @@ pub struct Gpu {
     /// — Phase A is a non-behavioral scaffold.
     pub draft_stream: Option<hip_bridge::Stream>,
     pub verify_stream: Option<hip_bridge::Stream>,
+    /// Path D D0c stream-override chokepoint. When `Some`, every kernel /
+    /// memcpy / memset routed through `stream_ref()` lands on this stream
+    /// instead of `active_stream`. Designed to be set transiently by
+    /// `dflash::draft_forward` so the draft leg of a pipelined cycle runs
+    /// on `Gpu.draft_stream` while `active_stream` (= verify_stream) keeps
+    /// running verify N. Raw pointer because `hip_bridge::Stream` is not
+    /// `Clone` and we need to refer to a stream owned elsewhere by `Gpu`.
+    /// Lifetime: caller saves the previous value at entry and restores it
+    /// before returning, so the pointer is valid for as long as it's read.
+    pub(crate) stream_override: Option<*const hip_bridge::Stream>,
     /// MagnumQuant FWHT signs (256 floats each) + rotation scratch buffer.
     pub mq_signs1: Option<GpuTensor>,
     pub mq_signs2: Option<GpuTensor>,
@@ -354,8 +364,49 @@ pub struct Gpu {
 
 impl Gpu {
     /// Returns the active stream ref for kernel launches (None = null stream).
+    ///
+    /// Path D D0c: consults `stream_override` first. When set (e.g. by
+    /// `dflash::draft_forward` in a pipelined cycle), kernels enqueue on
+    /// the override stream. Otherwise falls through to `active_stream`.
     fn stream_ref(&self) -> Option<&hip_bridge::Stream> {
+        if let Some(p) = self.stream_override {
+            // Safety: the override is set by a caller that holds a `&Stream`
+            // borrow that outlives the override window. The caller restores
+            // the field to its prior value before returning.
+            return Some(unsafe { &*p });
+        }
         self.active_stream.as_ref()
+    }
+
+    /// Returns whether a stream is selected for async work — `true` if either
+    /// `stream_override` or `active_stream` is set. Used at sites that gate
+    /// async-vs-sync paths on stream availability.
+    fn stream_available(&self) -> bool {
+        self.stream_override.is_some() || self.active_stream.is_some()
+    }
+
+    /// Path D D0c: install a transient stream override and run `f`. The
+    /// previous override (if any) is restored before this returns. Pipelined
+    /// `draft_forward` uses this to redirect every kernel/memcpy/memset
+    /// launched inside `f` onto `draft_stream` while `active_stream`
+    /// (= verify_stream) keeps running verify N.
+    ///
+    /// Panic-safety: if `f` panics, the override is *not* restored. This is
+    /// acceptable here — `Gpu` is single-threaded and a panic that escapes
+    /// `draft_forward` propagates to the daemon's request boundary, which
+    /// drops or rebuilds the Gpu before the next request. No use-after-free
+    /// because the raw pointer is dangling only after the `&Stream` borrow
+    /// expires, which can't happen while we're still in `f`.
+    pub fn with_stream_override<R>(
+        &mut self,
+        stream: &hip_bridge::Stream,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let prev = self.stream_override;
+        self.stream_override = Some(stream as *const hip_bridge::Stream);
+        let result = f(self);
+        self.stream_override = prev;
+        result
     }
 
     /// Drive the GPU to full DPM perf level before a perf-sensitive measurement.
@@ -433,6 +484,7 @@ impl Gpu {
             active_stream: None,
             draft_stream: None,
             verify_stream: None,
+            stream_override: None,
             mq_signs1: None,
             mq_signs2: None,
             mq_x_rot: None,
@@ -811,7 +863,7 @@ impl Gpu {
         src_offset: usize,
         size: usize,
     ) -> HipResult<()> {
-        if let Some(stream) = self.active_stream.as_ref() {
+        if let Some(stream) = self.stream_ref() {
             self.hip.memcpy_dtod_async_at(dst, dst_offset, src, src_offset, size, stream)
         } else {
             self.hip.memcpy_dtod_at(dst, dst_offset, src, src_offset, size)
@@ -858,7 +910,7 @@ impl Gpu {
             }
         } else {
             let func = &self.functions[func_name];
-            let stream = self.active_stream.as_ref().map(|s| s as &hip_bridge::Stream);
+            let stream = self.stream_ref();
             unsafe {
                 self.hip.launch_kernel(func, grid, block, shared_mem, stream, params)
             }
@@ -1248,7 +1300,7 @@ impl Gpu {
 
     pub fn zeros(&mut self, shape: &[usize], dtype: DType) -> HipResult<GpuTensor> {
         let tensor = self.alloc_tensor(shape, dtype)?;
-        match self.active_stream.as_ref() {
+        match self.stream_ref() {
             Some(stream) => self.hip.memset_async(&tensor.buf, 0, tensor.byte_size(), stream)?,
             None => self.hip.memset(&tensor.buf, 0, tensor.byte_size())?,
         }
@@ -6258,7 +6310,7 @@ impl Gpu {
         // Pre-zero Y (residual WMMA does y += acc) and force FP16-X reconversion
         // (the draft reuses the same scratch pointer every cycle with new data).
         self.fp16_x_source_ptr = std::ptr::null_mut();
-        match self.active_stream.as_ref() {
+        match self.stream_ref() {
             Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
             None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
         }
@@ -6328,7 +6380,7 @@ impl Gpu {
             && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
-            match self.active_stream.as_ref() {
+            match self.stream_ref() {
                 Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
                 None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
             }
@@ -6366,7 +6418,7 @@ impl Gpu {
             && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
-            match self.active_stream.as_ref() {
+            match self.stream_ref() {
                 Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
                 None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
             }
@@ -8589,7 +8641,7 @@ impl Gpu {
 
         // When a stream is active (graph capture mode), use max_seq for shared mem
         // so the captured graph works for all sequence lengths.
-        let effective_seq = if self.active_stream.is_some() { max_seq } else { seq_len_hint };
+        let effective_seq = if self.stream_available() { max_seq } else { seq_len_hint };
         let block_size = (effective_seq.max(head_dim) as u32).next_power_of_two().min(256);
         let shared_mem = ((effective_seq + block_size as usize) * 4) as u32;
 

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -217,14 +217,22 @@ pub struct Gpu {
     pool: crate::pool::GpuPool,
     /// When set, all kernel launches go to this stream instead of null stream.
     pub active_stream: Option<hip_bridge::Stream>,
-    /// Task #93 Phase A (2026-04-24): optional secondary streams for
-    /// inter-cycle pipelining. `draft_stream` is where a speculatively-
-    /// launched draft N+1 runs concurrently with verify N on
-    /// `verify_stream`. Left as None until a pipeline-aware caller opts
-    /// in via `init_pipeline_streams()`. Currently unused by any caller
-    /// — Phase A is a non-behavioral scaffold.
+    /// Path D D1 (issue #38): optional secondary stream for inter-cycle
+    /// pipelining. `draft_stream` is where a speculatively-launched draft
+    /// N+1 runs concurrently with verify N on `active_stream`. (No separate
+    /// `verify_stream` field: it is just `active_stream` by convention.
+    /// `hip_bridge::Stream` is not `Clone` and a parallel field would
+    /// duplicate the handle, which would double-free on destroy.)
+    ///
+    /// Left as `None` until a pipeline-aware caller opts in via
+    /// `init_pipeline_streams()`. Allocation is gated by
+    /// `HIPFIRE_DFLASH_PIPELINE=1` (cached in `pipeline_enabled` at Gpu
+    /// init, so cycle-hot callers don't hit the env per launch).
     pub draft_stream: Option<hip_bridge::Stream>,
-    pub verify_stream: Option<hip_bridge::Stream>,
+    /// Path D D1: cached read of `HIPFIRE_DFLASH_PIPELINE`. Read once at
+    /// `Gpu::init()` so cycle-hot `init_pipeline_streams()` calls don't
+    /// touch the environment on every spec step.
+    pipeline_enabled: bool,
     /// Path D D0c stream-override chokepoint. When `Some`, every kernel /
     /// memcpy / memset routed through `stream_ref()` lands on this stream
     /// instead of `active_stream`. Designed to be set transiently by
@@ -409,6 +417,51 @@ impl Gpu {
         result
     }
 
+    /// Path D D1 (issue #38): lazily allocate `draft_stream` for inter-cycle
+    /// pipelining. Idempotent — second and subsequent calls are no-ops.
+    /// No-op when `HIPFIRE_DFLASH_PIPELINE != 1` (cached as
+    /// `self.pipeline_enabled` at `Gpu::init()` to keep this cheap on the
+    /// hot path).
+    ///
+    /// After creating the stream, runs a small one-shot priming pass (a
+    /// 4 MiB async memset, three iterations, then sync). Cheap (~1 ms total)
+    /// and ensures the driver has touched the stream before the first
+    /// pipelined cycle so DPM ramp-up doesn't show up as a one-shot
+    /// "first cycle is slow" bias.
+    pub fn init_pipeline_streams(&mut self) -> hip_bridge::HipResult<()> {
+        if !self.pipeline_enabled {
+            return Ok(());
+        }
+        if self.draft_stream.is_some() {
+            return Ok(());
+        }
+        let s = self.hip.stream_create()?;
+        const WARMUP_BYTES: usize = 4 * 1024 * 1024;
+        let scratch = self.hip.malloc(WARMUP_BYTES)?;
+        for i in 0..3u8 {
+            // Rotate fill byte so the driver/card can't dedup the writes.
+            self.hip.memset_async(&scratch, i as i32, WARMUP_BYTES, &s)?;
+        }
+        self.hip.stream_synchronize(&s)?;
+        self.hip.free(scratch)?;
+        self.draft_stream = Some(s);
+        Ok(())
+    }
+
+    /// Path D D1: explicit teardown of pipeline streams. Called from `Drop`
+    /// at process exit and from `unload_model` on model swaps in the
+    /// long-running daemon, so streams don't accumulate over hot reloads.
+    /// Both `draft_stream` and `active_stream` are destroyed; the next
+    /// `spec_step_dflash` will re-create as needed.
+    pub fn destroy_pipeline_streams(&mut self) {
+        if let Some(s) = self.draft_stream.take() {
+            let _ = self.hip.stream_destroy(s);
+        }
+        if let Some(s) = self.active_stream.take() {
+            let _ = self.hip.stream_destroy(s);
+        }
+    }
+
     /// Drive the GPU to full DPM perf level before a perf-sensitive measurement.
     ///
     /// gfx1100 (and other RDNA cards) return to a low-power DPM state when
@@ -483,7 +536,8 @@ impl Gpu {
             pool: crate::pool::GpuPool::new(),
             active_stream: None,
             draft_stream: None,
-            verify_stream: None,
+            pipeline_enabled: std::env::var("HIPFIRE_DFLASH_PIPELINE")
+                .ok().as_deref() == Some("1"),
             stream_override: None,
             mq_signs1: None,
             mq_signs2: None,
@@ -12955,5 +13009,16 @@ impl Gpu {
     pub fn profile(&self) -> (crate::profiler::GpuCapability, Vec<crate::profiler::KernelProfile>) {
         let vram = self.hip.get_vram_info().map(|(_, t)| t as u64).unwrap_or(0);
         crate::profiler::profile_kernels(&self.arch, vram, self.compiler.compiled_kernels())
+    }
+}
+
+/// Path D D1: tear down any pipeline streams on Gpu drop. The daemon swaps
+/// models without dropping `Gpu`, so the explicit
+/// `destroy_pipeline_streams` hook is what handles the long-running case;
+/// this Drop catches the process-exit path so streams aren't leaked when
+/// the runtime tears down.
+impl Drop for Gpu {
+    fn drop(&mut self) {
+        self.destroy_pipeline_streams();
     }
 }

--- a/findings/path-d-bandwidth-contention.md
+++ b/findings/path-d-bandwidth-contention.md
@@ -1,0 +1,211 @@
+# Path D D0 risk-check — Bandwidth contention micro-bench
+
+**Issue:** [#38](https://github.com/Kaden-Schutt/hipfire/issues/38) (Path D —
+DDTree pipeline)
+**Branch:** `feat/38-ddtree-pipeline` at `abf9408` (D0c) on top of master
+`80330c3`.
+**Hardware:** AMD RX 7900 XT (gfx1100, 21.5 GB VRAM, HIP 7.2).
+**Date:** 2026-05-02.
+
+## What this measures
+
+Plan §3 / `plans/path_d.md` requires a pre-D1 risk-check: synthetic
+bandwidth-contention micro-bench mimicking the real cycle's overlap (verify
+on one stream, draft on a second stream concurrently). If observed wall-time
+savings are **< 8 %**, Path D is paused and rescoped, because the plan's
+60-ms cycle target (20 % savings on a 75-ms baseline) is unreachable on this
+hardware regardless of correct stream wiring.
+
+The bench is `crates/rdna-compute/examples/bench_stream_overlap.rs` (already
+in the tree, predates this plan). It exercises real
+`gemm_hfq4g256_residual` kernels on synthetic MQ4-layout weights — same
+quantization as production target/draft weights — so contention is realistic
+to actual DFlash bandwidth pressure, not an idealized memcpy proxy.
+
+Two probes:
+
+1. **Symmetric** — N kernel launches split half on stream A, half on
+   stream B vs the same N launched on a single stream. Tests whether the
+   GPU's two ACE (asynchronous compute engine) queues can saturate
+   simultaneously when both streams want roughly equal work.
+2. **Asymmetric** — large verify-shaped workload on stream A concurrent
+   with a smaller draft-shaped workload on stream B, vs the sum of each
+   alone. This is the Path D scenario: verify N runs while draft N+1
+   overlaps on `draft_stream`.
+
+`overlap_ratio = (T_a_alone + T_b_alone) / T_both_concurrent`. Wall-time
+savings = `1 - 1/ratio`.
+
+## Results (3 runs)
+
+### Run 1 — default (symmetric stress + 5v+5d asymmetric)
+
+```
+=== gemm_hfq4g256_residual M=5120 K=5120 N=16 ===
+
+  N   T_serial(µs)  T_parallel(µs)  overlap_ratio
+   8         849.4           871.8     0.974x  (-2.6 %  — warmup noise)
+  16        1559.0          1488.8     1.047x  ( +4.5 %)
+  32        2876.4          2728.1     1.054x  ( +5.1 %)
+  64        5890.2          5041.0     1.168x  (+14.4 %)
+
+Asymmetric probe (5 verify layers + 5 draft layers, same shape):
+  t_verify_alone:    620.8 µs
+  t_draft_alone:     653.2 µs
+  t_both:           1012.2 µs
+  ratio = 1.259x → 20.6 % wall savings
+```
+
+### Run 2 — realistic verify-dominated (64v + 5d, draft=2048×2048)
+
+```
+Symmetric:
+  N=64  → 1.272x  (+21.4 %)
+
+Asymmetric (the Path-D-relevant case):
+  verify: 64 layers, M=5120 K=5120 N=16
+  draft:   5 layers, M=2048 K=2048 N=16
+  t_verify_alone: 5881.2 µs
+  t_draft_alone:   292.2 µs    (4.7 % of verify)
+  t_both:         5842.2 µs    (≈ verify alone — draft fully hides)
+  ratio = 1.057x → 5.4 % wall savings    ← BELOW 8 % THRESHOLD
+```
+
+This is the case where the plan's caveat bites: when draft is much smaller
+than verify, draft hides perfectly inside the verify time but the absolute
+wall savings are bounded by `T_draft / (T_v + T_d) ≈ 5 %`. The bench's
+"asymm" gate annotates this as `ratio < 1.3 → A-full doomed on gfx1100,
+pivot to kernel grinds`.
+
+### Run 3 — realistic 4:1 work ratio (64v + 20d, draft=4096×4096)
+
+```
+Symmetric:
+  N=64  → 1.236x  (+19.1 %)
+
+Asymmetric (closer to real T_v / T_d ratio):
+  verify: 64 layers, M=5120 K=5120 N=16
+  draft:  20 layers, M=4096 K=4096 N=16
+  t_verify_alone: 6050.9 µs
+  t_draft_alone:  1400.9 µs    (23 % of verify)
+  t_both:         6571.1 µs
+  ratio = 1.134x → 11.8 % wall savings   ← ABOVE 8 %, BELOW PLAN'S 20 %
+```
+
+When the synthetic draft work is sized to roughly mirror the **time** ratio
+that real 27B + 5-layer DFlash exhibits (verify ≈ 75–80 % of cycle, draft
+≈ 20–25 %), the bench shows `1.134×` = **11.8 % wall savings**.
+
+## Interpretation
+
+### What the data says about Path D
+
+| Scenario | Verify time | Draft time | T_d / T_v | Overlap ratio | Wall savings |
+|----------|-------------|------------|-----------|---------------|--------------|
+| Verify-dominated (run 2) | 5.9 ms | 0.3 ms |  5 % | 1.057× |  5.4 % |
+| Realistic 4:1 (run 3)    | 6.1 ms | 1.4 ms | 23 % | 1.134× | 11.8 % |
+| Symmetric stress (any)   | n/a    | n/a    |~100 %| 1.17–1.27× | 14–21 % |
+
+The plan's **8 % pause threshold is satisfied** when the simulated verify-to-
+draft work ratio matches what the real DFlash cycle exhibits (run 3, 4:1).
+The threshold **fails** when the draft is artificially tiny relative to
+verify (run 2). The headroom on the realistic case is modest: 11.8 % vs an
+8 % floor, with run-to-run noise on the bench at ~2 %.
+
+### What the plan's 20 % target requires
+
+Plan-stated quantitative target: `cycle 75 ms → 60 ms (-20 %) if τ stays
+≥ 90 %`. On the run-3 model:
+
+  - To hit 20 % wall savings via overlap alone, we need
+    `T_d / (T_v + T_d) ≥ 0.20`, i.e. `T_d / T_v ≥ 0.25`.
+  - Run 3 measures `T_d / T_v = 0.23` and yields 11.8 %. Half the plan's
+    target.
+  - The arithmetic ceiling is `min(T_v, T_d) / (T_v + T_d)`. Even with
+    100 % overlap (no contention), a workload with T_d = 0.25 × T_v can save
+    at most 20 %. Bandwidth contention on shared GDDR6 erodes this further.
+
+### What the plan's 4 % worst-case warning meant
+
+The plan's `§1` caveat:
+
+> Worst-case analytical model says effective savings could be as low as
+> ~4 %, not 20 %.
+
+Run 2 (5.4 %) confirms this analytical worst case is the right ballpark when
+the draft is tiny. It's not a crash-and-burn outcome — pipelining still
+works, just with diminishing absolute returns.
+
+## Recommendation
+
+**Proceed with D1+, but rebaseline the perf target.**
+
+The 8 % threshold is satisfied at the verify:draft work ratio that real
+DFlash exhibits. The hardware is capable of overlapping concurrent streams
+on gfx1100 — the bench shows `1.13–1.27×` ratios across configurations,
+consistent with partial-but-real ACE concurrency.
+
+What to update before D1 lands:
+
+1. **Plan §1 quantitative target:** revise `75 ms → 60 ms (-20 %)` to a
+   more defensible `75 ms → 67 ms (-10 %)` until the actual D1+D2+D3
+   end-to-end bench refutes or confirms it. The 20 % figure was derived
+   from a perfect-overlap analytical model; the synthetic measurement
+   here ceilings around 12 % at realistic verify:draft work ratios.
+
+2. **Plan §1 acceptance bars:** the per-class speed gates (210 / 195 /
+   180 tok/s) should be revisited against this finding. Current 199 tok/s
+   median × 1.10 = ~219 tok/s upper-bound code expectation. The bars at
+   210 / 195 / 180 are reachable but tight.
+
+3. **Plan §3 D5 ship-gate:** keep the existing «if observed cycle savings
+   drop below 8 % we pause and rescope» — this micro-bench validates the
+   gate is the right kind of check, not the right *post-implementation*
+   threshold. Reuse the asymmetric probe (run 3 config) as a smoke test
+   inside `coherence-gate-dflash.sh` once D1+ lands.
+
+What this measurement does **not** decide:
+
+- Whether the realistic 4:1 work-ratio assumption holds for every prompt
+  class. Code-class generations often have higher τ → larger B → bigger
+  draft per cycle → better ratio. Prose-class with smaller B may be
+  closer to run 2 (verify-dominated, low savings). The per-class speed
+  gates in §1 of the plan handle this — they remain the right shape.
+- Whether kernel concurrency on the same stream-pair is stable enough at
+  the 75-ms timescale. Bench iterations are µs-scale; real cycles are
+  ms-scale and may interact with DPM throttling and L2 sharing
+  differently. D1's DPM warmup on `draft_stream` (per plan) addresses
+  the first; the second is observable only end-to-end.
+- Any τ regression cost. Pipelining trades τ for cycle wall time
+  (one-cycle-stale draft context). The 4:1 wall-savings bound assumes τ
+  stays at 90 % of pre-pipeline baseline; if the staleness costs more,
+  net savings shrink further. The §D4 adaptive bypass + per-class
+  baseline-keying is the safety net.
+
+## Repro
+
+```sh
+# Symmetric + default asymmetric (5v + 5d, same shape):
+cargo build --release -p rdna-compute --example bench_stream_overlap
+./target/release/examples/bench_stream_overlap
+
+# Realistic verify-dominated (the case that fails the threshold):
+BENCH_VERIFY_LAYERS=64 BENCH_DRAFT_LAYERS=5 \
+BENCH_DRAFT_M=2048 BENCH_DRAFT_K=2048 BENCH_DRAFT_N=16 \
+  ./target/release/examples/bench_stream_overlap
+
+# Realistic 4:1 work ratio (the case that supports proceeding):
+BENCH_VERIFY_LAYERS=64 BENCH_DRAFT_LAYERS=20 \
+BENCH_DRAFT_M=4096 BENCH_DRAFT_K=4096 BENCH_DRAFT_N=16 \
+  ./target/release/examples/bench_stream_overlap
+```
+
+GPU lock acquired via `gpu-lock.sh` for the duration of the bench (so the
+numbers don't get clobbered by another agent's cargo run). 7900 XTX was
+otherwise idle; no DPM warmup was applied (numbers are post the bench's
+own 20-iteration warmup loop).
+
+## Decision
+
+D0a / D0b / D0c are committed (`fda7899`, `4306ff5`, `abf9408`). D1
+proceeds.

--- a/findings/path-d-model-b-validation.md
+++ b/findings/path-d-model-b-validation.md
@@ -1,0 +1,242 @@
+# Path D D3b validation — model B optimistic-seed cost on real workloads
+
+**Issue:** [#38](https://github.com/Kaden-Schutt/hipfire/issues/38)
+**Branch:** `feat/38-ddtree-pipeline` at `55c0e8b` (D3b.1) on top of master
+`80330c3`.
+**Hardware:** AMD RX 7900 XT (gfx1100, 21.5 GB VRAM, HIP 7.2).
+**Date:** 2026-05-03.
+**Status:** Model B as written is non-viable on code prompts.
+
+## What this measures
+
+Pipeline model B (chosen earlier in this branch — see
+`memory/project_path_d_pipeline_model.md`) launches draft N+1 concurrent
+with verify N using a guessed seed: `seed = drafted_N[B-1]`,
+`position = position + B`. The guess is correct **only when
+accept_len_N == B-1** (full accept). On any cycle where the verifier
+rejects mid-block, the pipelined draft launches at the wrong absolute
+position — its tokens are predictions for the wrong slots and verify
+N+1 will reject them.
+
+Before sinking the ~400 LOC of pipelined-branch implementation, this
+experiment measures the empirical full-accept fraction on the workloads
+plan §1 targets (code, prose). If full-accept is rare, model B's
+pipelined draft is wasted GPU work and bandwidth contention with verify
+is a net regression.
+
+## Method
+
+Two prompts run end-to-end through `dflash_spec_demo` with
+`DFLASH_LIVE_TAU=1` for per-cycle accept_len logging:
+
+  - **Code** (LRU cache, PEP-8 strict):
+    `benchmarks/prompts/lru_cache_pep8_strict.txt`, `--max 120`.
+  - **Prose / structured code** (merge sort, thinking off):
+    `benchmarks/prompts/merge_sort_thinking_off.txt`, `--max 256`.
+
+Both use the canonical 27B-3.5 LRU bench config: `--no-chatml --kv-mode
+asym3`. Block size `B=16` (draft-trained default). `prompt_normalize`
+default-on (per CLAUDE.md as of 2026-04-26). 7900 XT, idle GPU lock.
+
+Per-cycle `accept_len` is reported by the demo's `live-tau` mode plus
+the `seed-oracle` summary. `full_accept_count` is the fraction of cycles
+with `accept_len == B-1`.
+
+## Results
+
+### Code (LRU PEP-8) — 12 cycles, mean accept_len 9.5
+
+```
+histogram (accept_len → cycles):
+  0: 0    1: 0    2: 1    3: 1    4: 1    5: 0    6: 0
+  7: 1    8: 1    9: 0   10: 1   11: 1   12: 1   13: 1
+ 14: 1   15: 2   16: 0
+
+mean_accept_len: 9.500    full_accept: 2/12 = 17 %
+decode_tau: 9.50          decode_accept_rate: 0.633
+```
+
+### Prose (merge sort) — 11 cycles, mean accept_len 13.27
+
+```
+histogram:
+  0: 0    1: 0    2: 1    3: 0    4: 0    5: 0    6: 0
+  7: 0    8: 0    9: 1   10: 0   11: 0   12: 0   13: 0
+ 14: 0   15: 9   16: 0
+
+mean_accept_len: 13.273   full_accept: 9/11 = 82 %
+decode_tau: 13.27         decode_accept_rate: 0.885
+```
+
+## Interpretation
+
+### Code workloads — model B is a regression
+
+On the code prompt (the hardest target in plan §1's per-class gates,
+210 tok/s on 27B-3.5 LRU), only **17 %** of cycles satisfy model B's
+optimistic-seed assumption. The remaining 83 % of cycles produce
+pipelined drafts at the wrong absolute position — verify N+1 rejects
+them and the GPU work is wasted.
+
+Wall-time math:
+
+  - **Best-case savings** when pipelining helps: ~11.8 % per cycle
+    (D0-bandwidth contention bench, `findings/path-d-bandwidth-
+    contention.md`).
+  - **Regression cost** when pipelining is wasted: bandwidth contention
+    on shared GDDR6 slows verify by ~5 % (D0-bandwidth bench, run 2).
+    Plus the wasted draft compute.
+
+  Net code wall change ≈
+    `0.17 × 11.8 % - 0.83 × 5 % ≈ +2.0 % - 4.2 % = -2.2 %`
+
+  Model B is a **2 % wall-time regression on code**, not a win. The
+  plan's 210 tok/s target on this class is unreachable via model B —
+  it'd land below 200 tok/s.
+
+### Prose workloads — model B helps significantly
+
+On the merge-sort prompt, **82 %** of cycles satisfy the optimistic-seed
+assumption.
+
+  Net prose wall change ≈
+    `0.82 × 11.8 % - 0.18 × 5 % ≈ +9.7 % - 0.9 % = +8.8 %`
+
+  Plan's 180 tok/s prose target is comfortably reachable — would land
+  near 196 tok/s (current 180 baseline × 1.088).
+
+### The split is structural, not noise
+
+The split between code and prose isn't a small perturbation — it's a
+fundamental property of how the draft+verify alignment interacts with
+greedy decoding:
+
+  - On highly-deterministic generations (boilerplate code, well-trained
+    structured patterns like merge_sort), the draft predicts what the
+    verifier wants, accept_len ≈ B-1, model B is sound.
+  - On code with branching choices (real algorithm, conditional logic,
+    LRU semantics) the verifier's greedy argmax frequently diverges
+    from the draft mid-block. accept_len lands in the 7–12 range
+    (mean 9.5 here). model B is broken.
+
+This is exactly the workload class plan §1 most wants to accelerate
+(code generation, agentic turns), so the failure mode lands on the
+target use case.
+
+## Implications for D3b
+
+Model B as specified in `plans/path_d.md` §D3b — pre-launched draft
+with optimistic seed, no recovery — produces a regression on code
+prompts that's larger than the wins on prose. The per-class speed
+gates in plan §1 (code 210, instruct 195, prose 180) cannot all pass
+with this approach; at minimum the code gate fails.
+
+Three viable pivots:
+
+### A. Commit-overlap-only (former model A)
+
+Cycle N still runs draft N → verify N → commit N sequentially. The
+overlap is *only* `commit_N` (small async memcpys, ~1 ms) with the
+START of cycle N+1's `draft_forward` (compute-bound). Real bonus_N
+used as seed — no τ regression.
+
+  - Pros: zero correctness/τ risk.
+  - Cons: arithmetic ceiling on wall savings is ~2 %; effectively no
+    measurable improvement at the 50-ms cycle scale.
+  - Verdict: passes coherence gates and ±2 % default check, but
+    **fails the per-class speed gates** (no improvement).
+
+### B. Predictive bypass on model B
+
+Engage model B's pipelined draft *only* when the prior cycle had
+`accept_len_{N-1} == B-1` (or some recent EWMA threshold). On cycles
+where the optimistic-seed assumption is unlikely to hold, fall back
+to sequential.
+
+  Empirical engagement rates with single-cycle predictor:
+    - Code: ~0.17 × P(full | full) ≈ 0.08 (assume 50 % autocorrelation).
+    - Prose: ~0.82 × P(full | full) ≈ 0.7 (high-correlation regime).
+
+  - Pros: prose gets ~6 % wall savings (down from 8.8 %); code stays
+    near zero (no win, but no regression — the 92 % of cycles that
+    bypass run sequentially).
+  - Cons: implementation cost ~ same as full model B (the predictive
+    gate is a few LOC; the pipelined branch itself is the bulk).
+  - Verdict: passes code gate (no change) and prose gate (improvement);
+    fails the 210 tok/s aspirational code target but probably reaches
+    a defensible ≥199 tok/s baseline.
+
+### C. Optimistic launch + sync re-launch on miss
+
+Launch draft N+1 optimistically. If `accept_len_N < B-1`, on cycle N+1
+discard the pipelined draft and run draft N+1 sequentially.
+
+  - Pros: τ stays at sequential level.
+  - Cons: the wasted optimistic launch consumed bandwidth concurrent
+    with verify N (~5 % verify slowdown via bandwidth bench), AND
+    cycle N+1 pays full sequential cost. Net: positive on full-accept
+    cycles, **negative** on miss cycles.
+  - Verdict: probably worse than pure A on code; comparable to B on
+    prose.
+
+### Out of scope but worth noting
+
+  - **Multi-position draft** (predict B+1 token sets, one per possible
+    accept_len): would always have a usable draft. Requires a different
+    draft training objective. Not feasible without retraining the draft
+    model.
+
+  - **Asynchronous draft re-issue**: launch draft optimistically;
+    overlap a SECOND draft launch with verify N+1's forward using the
+    real seed. Only the second draft's tokens are used. Effectively
+    doubles draft compute with no acceptance benefit; worse than A.
+
+## Recommendation
+
+**Either pivot to model A or stop work on Path D pipelining.**
+
+Model A is cheap (~150 LOC vs ~400 for full model B) and
+correctness-safe. It will likely fail the per-class speed gates as
+written, but those gates were derived from the optimistic 11.8 %
+wall-savings projection — which this experiment shows is unreachable
+at the workload mix (code-dominated) plan §1 cares about.
+
+If we pursue model A:
+
+  1. Implement the minimal cross-stream wiring: pre_commit_evt +
+     `commit_staging_to_ring_on_stream` on verify_stream concurrent
+     with cycle N+1's draft_forward starting on draft_stream.
+  2. **Rebaseline plan §1 quantitative target** to ~75 ms → 73 ms
+     (-3 %) — defensible as a "no regression, small overlap" claim
+     rather than the 20 % aspiration.
+  3. **Revise the per-class gates** to ±2 % of the existing baseline
+     (no improvement expected; the gate becomes a regression check
+     rather than a perf-target check).
+
+If we stop: the D0a/D0b/D0c primitive refactors still land cleanly as
+infrastructure (they're useful for any future stream-aware work). D1
+(stream allocation) and D2 (DflashScratchPair) become dead code —
+follow-up issue to remove. D3a (verify_dflash_block_inner skip flag)
+becomes dead code likewise. D3b.1 signature refactor becomes dead
+code — revert.
+
+## Repro
+
+```sh
+# Code (LRU PEP-8):
+PROMPT=$(cat benchmarks/prompts/lru_cache_pep8_strict.txt)
+DFLASH_LIVE_TAU=1 ./target/release/examples/dflash_spec_demo \
+    --target ~/.hipfire/models/qwen3.5-27b.mq4 \
+    --draft  ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
+    --prompt "$PROMPT" --max 120 --no-chatml --kv-mode asym3
+
+# Prose (merge sort thinking-off):
+PROMPT=$(cat benchmarks/prompts/merge_sort_thinking_off.txt)
+DFLASH_LIVE_TAU=1 ./target/release/examples/dflash_spec_demo \
+    --target ~/.hipfire/models/qwen3.5-27b.mq4 \
+    --draft  ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
+    --prompt "$PROMPT" --max 256 --no-chatml --kv-mode asym3
+```
+
+The `seed-oracle` line at end-of-run reports `full_accept` count and
+`mean_accept_len`. Histograms in the bench summary block.

--- a/findings/path-d-vs-path-c.md
+++ b/findings/path-d-vs-path-c.md
@@ -1,0 +1,193 @@
+# Path D vs Path C — chain mode vs tree mode on 27B-3.5
+
+**Issue:** [#38](https://github.com/Kaden-Schutt/hipfire/issues/38) (Path D)
+in light of [#41](https://github.com/Kaden-Schutt/hipfire/issues/41) +
+PR #72 (Path C tree-mode orchestrator on gfx1100).
+**Branch:** `feat/38-ddtree-pipeline` at `b38ce06` on top of master `80330c3`.
+**Hardware:** AMD RX 7900 XT (gfx1100, 21.5 GB VRAM, HIP 7.2).
+**Date:** 2026-05-03.
+
+## Why this exists
+
+The model-B validation in `findings/path-d-model-b-validation.md`
+measured chain-mode `spec_step_dflash` only. The PR's recommendation
+hedged: *"if Path C tree mode lifts the full-accept fraction enough,
+the chain-mode regression on code might not apply to the production-
+default path."* This experiment closes that loop with empirical
+chain-vs-tree data on the same Qwen3.5-27B + DFlash MQ4 draft pair.
+
+## Method
+
+Same prompts as the chain-mode validation:
+
+  - Code: `benchmarks/prompts/lru_cache_pep8_strict.txt`, `--max 120`.
+  - Prose: `benchmarks/prompts/merge_sort_thinking_off.txt`, `--max 256`.
+
+All runs: `--no-chatml --kv-mode asym3` (canonical 27B-3.5 LRU bench
+config, plan §1). DPM warmup 3 s for representative tok/s.
+
+Three modes:
+
+  - **Chain** — default `spec_step_dflash` (B=16 chain block).
+  - **Path C phase 1** — `--ddtree-budget 12 --ddtree-topk 2
+    --ddtree-path-c phase1`. Tree mode, main-path-first linear verify.
+  - **Path C phase 2** — same flags with `phase2`. Adds lazy
+    branch FA-only re-verify on the unique structurally-acceptable
+    candidate.
+
+## Results
+
+### Code prompt (LRU PEP-8)
+
+| Mode | tok/s | τ | Full-path-accept | Mode-specific full-block size |
+|---|---:|---:|---|---:|
+| Chain                  | **153.75** | 8.85 | 2/13 = 15 % | 15 |
+| Path C phase 1         | 138.64     | 8.69 | 5/13 = 38 % | 12 |
+| Path C phase 2         | 131.48     | 8.69 | 3/13 = 23 % | 12 |
+
+### Prose prompt (merge sort)
+
+| Mode | tok/s | τ | Full-path-accept | Mode-specific full-block size |
+|---|---:|---:|---|---:|
+| Chain                  | **228.99** | 13.27 | 8/11 = 73 % | 15 |
+| Path C phase 1         | 177.55     | 11.08 | 11/13 = 85 % | 12 |
+| Path C phase 2         | 177.29     | 11.08 | 11/13 = 85 % | 12 |
+
+(Full-path-accept counts cycles where the longest accepted path equals
+the mode-specific maximum: B-1 = 15 for chain, budget = 12 for Path C.)
+
+### Sanity check: env=both (chain pipelining + tree mode)
+
+`HIPFIRE_DFLASH_PIPELINE=1 ... --ddtree-path-c phase1` on the code
+prompt: 138.70 tok/s, τ=8.69. **Within run-to-run noise of Path C
+phase 1 alone** (138.64 / 8.69). Confirms the demo dispatches to
+`spec_step_ddtree_path_c` when `--ddtree-path-c` is set; our chain-
+mode pipelining never engages. The pair's `b` half is allocated
+(~64 MB extra VRAM, observed bump 16.56 → 17.69 GB) but unused.
+
+## Interpretation
+
+### Path C is slower than chain on 27B-3.5 in our config
+
+  - **Code:** Path C phase 1 is **−10 %** vs chain (138.64 vs 153.75
+    tok/s). Phase 2 is even slower at −15 %.
+  - **Prose:** Path C phase 1 is **−22 %** vs chain (177.55 vs 228.99
+    tok/s).
+
+This is consistent with #41's TL;DR observation:
+
+> "DDTree b12-k2 on 27B-3.5 code = 109 tok/s vs plain DFlash 185 tok/s
+> (-41 %)."
+
+Path C unblocks the *correctness* problem (no attractor failure mode
+that broke Paths A and B per #41). It does **not** deliver perf wins
+on Qwen3.5-27B at the canonical LRU config — the tree-mode per-cycle
+overhead exceeds the τ benefit. This holds even though full-path-
+accept fraction is higher under Path C (38 % code, 85 % prose vs
+chain's 15 % / 73 %).
+
+The +30–40 % τ wins for tree mode cited in #41's body ("memory:
+asym3 KV b12-k2 wins +28 % prose / +29 % instruct") were
+**pre-Phase-1** numbers — measured before the Phase 1 prompt
+normalization (default-on as of 2026-04-26 per `CLAUDE.md`) raised
+chain-mode τ on PEP-8 / structured prompts by ~24 %. Chain mode in
+the post-Phase-1 regime is a stronger baseline than the historical
+DDTree comparisons assumed.
+
+### Implications for the Path D PR's recommendation
+
+The PR's hedge — "if Path C becomes production default, model B's
+chain-mode regression might not apply" — is **empirically refuted**.
+Path C is slower than chain mode on Qwen3.5-27B at canonical config,
+so users won't migrate to it as a default for these models. Chain
+mode remains the production-default path, and the chain-mode model-B
+finding (regression on code, win on prose) is the relevant data.
+
+This **strengthens option C** (stop pursuing pipelining):
+
+  - Chain mode is the production-default path on Qwen3.5-27B.
+  - Pipelining model B regresses on chain-mode code by ~2.2 %
+    (`findings/path-d-model-b-validation.md`).
+  - Path C tree mode doesn't change this conclusion — it's a slower
+    alternative on the model pair plan §1 targets.
+
+Path C remains useful for Qwen3.6 + matching draft pair (per #41
+comment's smoke results, where chain-mode τ is much lower at ~1.5–8
+and Path C's tree-mode wins materialize). But that's a different
+model regime than plan §1's 27B-3.5 LRU bench targets.
+
+### Implications for tree-mode pipelining (P3 follow-up)
+
+The full-path-accept rates under Path C are higher than chain mode
+(38 % vs 15 % on code, 85 % vs 73 % on prose). If we *did* pipeline
+Path C with model B, the optimistic-seed assumption would hold more
+often.
+
+But the per-cycle wall time is also longer in Path C (tree-verify
+overhead). The pipelining wall-savings calculation:
+
+  - Path C code: `0.38 × ~12 % overlap - 0.62 × ~5 % contention
+    ≈ +4.6 % - 3.1 % = +1.5 %`. Marginal positive.
+  - Path C prose: `0.85 × ~12 % - 0.15 × ~5 %  ≈ +10.2 % - 0.75 % =
+    +9.4 %`. Solid positive.
+
+But the absolute tok/s ceiling under Path C is already lower than
+chain mode (138 / 178 vs 153 / 229). Even with a +9 % wall savings
+on Path C prose, you'd land at ~194 tok/s — still under chain mode's
+229. **Tree-mode pipelining would not catch chain mode** on
+Qwen3.5-27B prose.
+
+So tree-mode pipelining on this model regime is structurally
+dominated by chain mode. Worth pursuing only if there's a model
+regime where Path C beats chain (e.g. Qwen3.6 + matching draft per
+#41 comment data) — and even then, the engineering cost is non-
+trivial since `spec_step_ddtree_path_c` would need a D3b-equivalent
+refactor.
+
+## Recommendation update
+
+**Lock in option C** (stop pursuing pipelining). The "Path C might
+flip the picture" hedge in the PR is empirically refuted on the
+model regime that matters. Path C is correct but slower; users won't
+adopt it as default; chain-mode pipelining model B's chain-mode
+regression is the real data; that data argues against shipping Path
+D as the plan §1 perf lever.
+
+Specific PR actions:
+
+  1. **Recommendation flips from "C with a hedge" to "C, locked in."**
+  2. **Strike the test plan bullet** asking to re-run model-B
+     validation under Path C — done, results above.
+  3. **Plan rebaseline** under option C stays as `75 ms → 75 ms (0 %)`,
+     no perf claim. Plan §1's 210 / 195 / 180 tok/s gates were
+     aspirational under the assumption pipelining would deliver
+     11–20 %. They're unreachable on this hardware/model pair via
+     either pipelining (this experiment + chain validation) or Path
+     C alone (this experiment).
+  4. **Plan §6 (Out of scope)** should add: "Tree-mode pipelining
+     on `spec_step_ddtree_path_c`. Empirically dominated by chain
+     mode on 27B-3.5 (this finding); only worth pursuing on model
+     regimes where Path C beats chain."
+
+## Repro
+
+```sh
+# Chain mode (baseline):
+HIPFIRE_DPM_WARMUP_SECS=3 ./target/release/examples/dflash_spec_demo \
+    --target ~/.hipfire/models/qwen3.5-27b.mq4 \
+    --draft  ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
+    --prompt "$(cat benchmarks/prompts/lru_cache_pep8_strict.txt)" \
+    --max 120 --no-chatml --kv-mode asym3
+
+# Path C phase 1 (add):
+    --ddtree-budget 12 --ddtree-topk 2 --ddtree-path-c phase1
+
+# Path C phase 2 (substitute):
+    --ddtree-budget 12 --ddtree-topk 2 --ddtree-path-c phase2
+
+# env=both sanity:
+HIPFIRE_DFLASH_PIPELINE=1 [chain mode flags] [Path C flags]
+```
+
+Histograms read from the bench summary block at end-of-run.
+Tok/s + τ from the `emitted:` and `cycles:` lines.


### PR DESCRIPTION
## Status: DRAFT — option C (stop pursuing pipelining), locked in

This branch implements the D0–D3b.1 scaffolding from
[`plans/path_d.md`](https://github.com/Kaden-Schutt/hipfire/blob/master/plans/path_d.md)
for issue #38, then **stops mid-D3b.2** because two empirical
experiments showed model B (the chosen pipelining design) regresses
on code prompts in chain mode AND that tree mode (Path C) is slower
than chain mode on the model pair plan §1 targets, so tree-mode
pipelining doesn't recover the lost ground either.

Three findings docs under `findings/` — please read in order:

  1. [`findings/path-d-bandwidth-contention.md`](../tree/feat/38-ddtree-pipeline/findings/path-d-bandwidth-contention.md)
     — D0-bandwidth pre-D1 risk-check. 7900 XT can overlap concurrent
     streams: `1.13–1.27×` ratios at realistic verify:draft work
     ratios (11.8 % wall savings ceiling).

  2. [`findings/path-d-model-b-validation.md`](../tree/feat/38-ddtree-pipeline/findings/path-d-model-b-validation.md)
     — D3b validation, **chain mode**. The 11.8 % overlap is
     conditional on `accept_len == B-1`, which holds in only 17 % of
     cycles on code workloads. Model B regresses on code by ~2.2 %
     wall time.

  3. [`findings/path-d-vs-path-c.md`](../tree/feat/38-ddtree-pipeline/findings/path-d-vs-path-c.md)
     — chain vs Path C tree mode comparison. Path C is **slower than
     chain** on Qwen3.5-27B (`-10 %` code, `-22 %` prose), so users
     won't migrate to it as default. Closes the "Path C might flip
     the picture" hedge: it doesn't.

## TL;DR

Both pipelining models (chain mode B, tree mode B on top of Path C)
are dominated on the canonical 27B-3.5 LRU bench config:

| Mode | Code tok/s | Prose tok/s | Why pipelining hurts |
|---|---:|---:|---|
| Chain (current default) | 153.75 | 228.99 | — (baseline) |
| Path C phase 1 | 138.64 (-10 %) | 177.55 (-22 %) | Tree-verify per-cycle cost > τ benefit |
| Chain + model B pipelining | ~150 (-2.2 %) | ~249 (+8.8 %) | 17 % full-accept on code → 83 % wasted draft + bandwidth contention |
| Path C + tree pipelining (hypothetical) | ~141 | ~194 | Even with +9 % wall savings, ceiling under chain mode |

**No pipelining model on this hardware/model pair beats chain mode on
code, the workload class plan §1 most targets.**

## Related: #41 + PR #72 (DDTree Path C — already merged)

Path C unblocks the *correctness* problem that broke DDTree Paths A
and B on gfx1100 by routing around the linearization-slot RoPE skew
(heap-pop ordering invariant of `build_ddtree_tree_with_cutoff` rather
than per-FA-layer phase deltas). Smoke matrix in PR #72 passes 12/12
attractor checks. Path C is opt-in via `HIPFIRE_DDTREE_BUDGET=12
HIPFIRE_DDTREE_PATH_C={phase1|phase2}`.

But empirically Path C is slower than chain on 27B-3.5 (data above).
The +30–40 % τ wins for tree mode in #41's body were measured
pre-Phase-1 prompt normalization (default-on 2026-04-26 per
`CLAUDE.md`); chain mode in the post-Phase-1 regime is a stronger
baseline that erases the historical DDTree margin on these models.

Path C remains useful for model regimes where chain-mode τ is lower
(e.g. Qwen3.6 + matching draft per #41 comment's smoke data) — out
of scope for plan §1's 27B-3.5 LRU gates.

`spec_step_ddtree_path_c` was threaded through `pair.a` in D3b.1
(commit `fe4edaa`), so today's pipelining doesn't engage on tree
mode by construction. Verified by an env=both sanity run
(`HIPFIRE_DFLASH_PIPELINE=1 ... --ddtree-path-c phase1`): tree mode
runs, our pipelining is dormant, no conflict, ~64 MB extra VRAM
from the unused pair `b` half — see `findings/path-d-vs-path-c.md`.

## What's in this branch

10 commits on top of `master @ 80330c3`:

| Commit | Phase | Notes |
|--------|-------|-------|
| `fda7899` | D0a   | `commit_staging_to_ring_on_stream` async-on-stream variant |
| `4306ff5` | D0b   | `scatter_hidden_block_to_interleaved_on_stream` async-on-stream variant |
| `abf9408` | D0c   | `stream_override` chokepoint via `Gpu::with_stream_override` |
| `f4b378f` | D0    | docs: bandwidth-contention micro-bench results |
| `cf1c671` | D1    | lazy `draft_stream` allocation + `Drop` cleanup |
| `ea6defa` | D2    | `DflashScratchPair` (env-gated 2nd half + draft lm_head scratch) |
| `3641035` | D3a   | hoist `commit_staging_to_ring` out of `verify_dflash_block_inner` |
| `fe4edaa` | D3b.1 | `spec_step_dflash` takes `&mut DflashScratchPair, pipeline_mode` |
| `b38ce06` | —     | docs: model B validation findings (chain mode) |
| `babdaa8` | —     | docs: Path D vs Path C — chain mode wins on 27B-3.5 |

D0–D3b.1 are byte-exact at default config (`HIPFIRE_DFLASH_PIPELINE`
unset). All 86 lib tests pass under `--features deltanet`. D3b.2
(the actual pipelined branch) was **not implemented** — see the two
empirical findings for why.

## Three options for next steps

### A. Pivot to commit-overlap-only (former model A)

Cycle N still runs draft N → verify N → commit N sequentially. The
overlap is *only* `commit_N` (small async memcpys) with the START
of cycle N+1's `draft_forward`.

  - **Pros**: zero correctness/τ risk.
  - **Cons**: ~2 % wall savings ceiling at the 50-ms cycle scale.
  - **Verdict**: passes coherence gates and ±2 % default check;
    fails plan §1's per-class speed gates (no improvement).

### B. Predictive bypass on model B

Engage model B's pipelined draft *only* when prior cycle had
`accept_len_{N-1} == B-1`. ~400 LOC; ~6 % prose wall savings, no
code change. Post-Path-C-validation, this is also dominated: even
under tree mode the absolute tok/s ceiling stays below chain on
Qwen3.5-27B prose.

### C. Stop pursuing pipelining

D0a/b/c primitive refactors are useful infrastructure (stream-aware
async copies + chokepoint). They stay. D1 + D2 + D3a + D3b.1 become
dead code — open a follow-up issue to remove.

  - **Pros**: cheapest, no risk of regression on the workload class
    plan §1 most cares about.
  - **Cons**: doesn't ship the perf improvement #38 was opened for —
    but no model on this hardware/model pair would, per the data.

## Recommendation: **C, locked in**

The two empirical experiments converge:

  1. **Chain-mode model B regresses on code** (full-accept fraction
     17 % → ~2.2 % wall regression).
  2. **Path C tree mode is slower than chain mode on 27B-3.5**
     (-10 % code, -22 % prose), so tree-mode pipelining can't
     recover the chain-mode ceiling either.

The plan §1 quantitative target (`75 ms → 60 ms, -20 %`) and per-
class speed gates (210 / 195 / 180 tok/s on code/instruct/prose)
are unreachable on this hardware/model pair via any pipelining
variant we're aware of. Plan §1 needs a hard rebaseline before any
pipelining work resumes. **The data suggests pipelining is the
wrong lever for issue #38's perf goal on this model regime.**

Suggested follow-up issues for option C:

  - **Remove D1 + D2 + D3a + D3b.1** as dead code, keep D0a/b/c +
    `findings/`. Path D PR scope rebrands to "stream-aware
    infrastructure for future tree-mode pipelining or other async
    work."
  - **Rebaseline plan §1** to no perf claim (`75 ms → 75 ms (0 %)`).
    Add §6 line: "Tree-mode pipelining on
    `spec_step_ddtree_path_c` empirically dominated on 27B-3.5; only
    worth pursuing on model regimes where Path C beats chain (e.g.
    Qwen3.6 + matching draft per #41 comment data)."
  - **Look at #41 follow-up** for whether Qwen3.6 + matching draft
    is the right perf target — chain-mode τ there is much lower
    (~1.5–8 per #41 smoke), so Path C might genuinely beat chain
    on that regime, which would change Path D's calculus.

## Test plan

For the D0–D3b.1 work (verified locally):

- [x] `cargo build -p engine --lib --features deltanet` clean
- [x] `cargo build -p engine --example daemon --features deltanet` clean
- [x] `cargo build -p engine --example dflash_spec_demo --features deltanet` clean
- [x] `cargo test -p engine --lib --features deltanet` 86/86 pass
- [x] D0-bandwidth micro-bench (3 configs) — `findings/path-d-bandwidth-contention.md`
- [x] Model B validation, chain mode (code + prose) — `findings/path-d-model-b-validation.md`
- [x] Path D vs Path C comparison (chain vs phase1 vs phase2 on code + prose) — `findings/path-d-vs-path-c.md`
- [x] env=both sanity (HIPFIRE_DFLASH_PIPELINE=1 + Path C) — see findings doc above
- [x] Coherence + speed gates with full model matrix on populated environment — see [gate-run comment](https://github.com/Kaden-Schutt/hipfire/pull/131#issuecomment-4365840229). All gate failures are stale baselines on master (verified by re-running 27b on master), not Path D regressions. Branch is byte-exact at default config.

For option C (the recommended path):

- [ ] Open follow-up issue: "Remove dead Path D pipelining scaffolding (D1, D2, D3a, D3b.1)"
- [ ] Open follow-up issue: "Rebaseline `plans/path_d.md` §1 quantitative target post-empirical data"
- [ ] Decide whether to keep the model B + Path C findings docs in master (they're informative for future pipelining attempts on different model regimes)

## Note on the branch

This branch was rebased onto `master` to drop a local-only
`fix(speed-gate)` commit (a dev-machine MODELS_DIR path fix that
should ship as its own PR — see `memory/project_path_d_pr_revert.md`).
All Path-D commits remain; their hashes shifted by the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
