### PR TITLE
fix(profiler): correct gfx1200/gfx1201 fallback CU counts (#136 part A)

### DIFF
--- a/crates/rdna-compute/src/profiler.rs
+++ b/crates/rdna-compute/src/profiler.rs
@@ -88,8 +88,8 @@ impl GpuCapability {
                 "gfx1010" => 40,   // RX 5700 XT
                 "gfx1030" => 60,   // RX 6800
                 "gfx1100" => 48,   // RX 7800 XT
-                "gfx1200" => 32,   // RX 9070
-                "gfx1201" => 32,   // RX 9070 XT
+                "gfx1200" => 56,   // RX 9070
+                "gfx1201" => 64,   // RX 9070 XT / Radeon AI PRO R9700
                 _ => 40,
             }
         });


### PR DESCRIPTION
First slice of issue #136 — fix the hardcoded fallback CU counts for RDNA4 in `crates/rdna-compute/src/profiler.rs`.

The primary `read_sysfs_cu_count()` path (KFD `simd_count / 2`) already works correctly. The hardcoded fallback in the unwrap_or_else branch had:

\`\`\`rust
\"gfx1200\" => 32,   // RX 9070
\"gfx1201\" => 32,   // RX 9070 XT
\`\`\`

Both are wrong by ~2x. Real values per AMD spec (and confirmed via KFD on hiptrx):
- gfx1200 (RX 9070): **56 CU**
- gfx1201 (RX 9070 XT, Radeon AI PRO R9700): **64 CU**

KFD on hiptrx (4× R9700) reports `simd_count: 128` per node, sysfs primary path resolves correctly to 64. The fix only matters when sysfs is unavailable (containers without `/sys/class/kfd` mounted, future SKUs not yet covered, etc.), but the fallback should still match real hardware so any occupancy-hint calculation isn't off by half.

## Test plan
- [x] `cargo check -p rdna-compute` clean
- [x] sysfs primary path (`read_sysfs_cu_count`) returns 64 for gfx1201 on hiptrx — unchanged

Hardware: hiptrx (4× Radeon AI PRO R9700, gfx1201, ROCm 7.2.2, Ubuntu 26.04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)