### PR TITLE
feat(iu4-cal): runtime activation calibration recovers gfx12 iu4 layer-0 quality (full-model needs outlier extraction)

### DIFF
--- a/crates/engine/examples/calibrate_iu4_activations.rs
+++ b/crates/engine/examples/calibrate_iu4_activations.rs
@@ -318,6 +318,12 @@ fn real_main() {
         let hs = hists.lock().unwrap();
         for (&sid, h) in hs.iter() {
             let s = match strategy.as_str() {
+                "center" => {
+                    // No s_a scaling — preshift is `(x - mu)` only. Math
+                    // is exact (no group-bake approximation), but Q4_1
+                    // dynamic-range pressure is unchanged from raw iu4.
+                    vec![1.0f32; h.n_channels()]
+                }
                 "mean" => h.mean_abs(),
                 _ => h.percentile_abs(99.0),
             };

--- a/crates/engine/examples/calibrate_iu4_activations.rs
+++ b/crates/engine/examples/calibrate_iu4_activations.rs
@@ -1,0 +1,613 @@
+//! Offline activation calibration for the gfx12 iu4 K=32 GEMM path.
+//!
+//! Runs FP16 forward over a small calibration corpus, snoops per-channel
+//! activation distributions at every `gemm_hfq4g256_residual` call site,
+//! and writes a `<model>.iu4cal` sidecar that the engine auto-loads at
+//! model load time when `HIPFIRE_GFX12_IU4_CALIBRATED=1`.
+//!
+//! Sidecar contents (per call site, in dispatch-counter order):
+//!   - `mu_a[k]`    per-input-channel activation mean
+//!   - `s_a[k]`     per-input-channel activation scale (default 99-pctile-abs)
+//!   - `w_mu_bias[m]` precomputed `W·mu_a` so the runtime can add it to the
+//!                    GEMM output and recover `y = W·x` exactly (modulo
+//!                    Q4_1 quant of the centered activation).
+//!
+//! Math:
+//!   y = W·x = (W·diag(s)) · ((x - mu)/s) + W·mu
+//!
+//! At inference time:
+//!   1. preshift kernel:  x_centered[t][c] = (x[t][c] - mu[c]) * inv_s[c]
+//!   2. existing Q4_1 quant on x_centered
+//!   3. existing iu4 GEMM with weight whose per-K=256-group scale was
+//!      multiplied by `s_group[g]` at sidecar-load time
+//!   4. broadcast-add `w_mu_bias[m]` to the GEMM output column
+//!
+//! The bias is computed CPU-side here by dequantizing the HFQ4 weight
+//! row-by-row and dotting with the calibration `mu_a`. ~512 MB of CPU work
+//! for a 27B model — slow but offline-only. Output sidecar is ~32 MB FP16.
+//!
+//! Usage:
+//!   HIPFIRE_MODELS_DIR=$HOME/.hipfire/models \
+//!     cargo run --release --features deltanet -p engine \
+//!     --example calibrate_iu4_activations -- \
+//!     --model $HOME/.hipfire/models/qwen3.5-9b.mq4
+//!
+//! Optional flags:
+//!   --corpus <dir>         additional prompts; defaults to the embedded
+//!                          coherence-style corpus
+//!   --strategy {p99,mean}  s_a estimation strategy (default p99)
+//!   --max-tokens <n>       cap per-prompt token budget (default 256)
+//!   --out <path>           sidecar output; defaults to <model>.iu4cal
+//!
+//! Local note: this binary uses FP16 forward only — runs anywhere hipfire
+//! runs (gfx1100, gfx1201, etc.). Test gfx1201 calibrated dispatch on
+//! hiptrx; capture a calibration here and ship it with the model.
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("calibrate_iu4_activations requires --features deltanet");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    real_main();
+}
+
+#[cfg(feature = "deltanet")]
+fn real_main() {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    use engine::hfq::HfqFile;
+    use engine::quant::iu4_calibration::{
+        CenteredHistogram, Iu4CalSite, Iu4Calibration, MeanAccumulator, f32_vec_to_f16,
+    };
+    use engine::qwen35::{
+        self, DeltaNetState, LayerWeights, Qwen35Config, Qwen35Scratch, Qwen35Weights,
+    };
+    use engine::llama::{self, KvCache, f16_to_f32};
+    use rdna_compute::Gpu;
+
+    // ── argv parse ──────────────────────────────────────────────────────
+    let args: Vec<String> = std::env::args().collect();
+    let mut model_path: Option<String> = None;
+    let mut corpus_dir: Option<String> = None;
+    let mut strategy: String = "p99".to_string();
+    let mut max_tokens: usize = 256;
+    let mut out_path: Option<String> = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--model" => {
+                model_path = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--corpus" => {
+                corpus_dir = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--strategy" => {
+                strategy = args.get(i + 1).cloned().unwrap_or_else(|| "p99".into());
+                i += 2;
+            }
+            "--max-tokens" => {
+                max_tokens = args.get(i + 1).and_then(|v| v.parse().ok()).unwrap_or(256);
+                i += 2;
+            }
+            "--out" => {
+                out_path = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "Usage: calibrate_iu4_activations --model <path> [--corpus <dir>] \
+                     [--strategy p99|mean] [--max-tokens 256] [--out <path>]"
+                );
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("unknown arg: {}", args[i]);
+                std::process::exit(2);
+            }
+        }
+    }
+    let Some(model_path) = model_path else {
+        eprintln!("--model is required (path to .mq4 / .hfq HFQ4-G256 model)");
+        std::process::exit(2);
+    };
+    let out_path = out_path.unwrap_or_else(|| format!("{model_path}.iu4cal"));
+
+    eprintln!("[calibrate-iu4] model:    {model_path}");
+    eprintln!("[calibrate-iu4] strategy: {strategy}");
+    eprintln!("[calibrate-iu4] out:      {out_path}");
+
+    // ── corpus ──────────────────────────────────────────────────────────
+    let mut prompts: Vec<String> = embedded_corpus();
+    if let Some(dir) = corpus_dir.as_ref() {
+        match std::fs::read_dir(dir) {
+            Ok(entries) => {
+                for ent in entries.flatten() {
+                    let p = ent.path();
+                    if p.extension().and_then(|s| s.to_str()) == Some("txt") {
+                        if let Ok(s) = std::fs::read_to_string(&p) {
+                            prompts.push(s);
+                        }
+                    }
+                }
+            }
+            Err(e) => eprintln!("[calibrate-iu4] failed to read corpus dir {dir}: {e}"),
+        }
+    }
+    eprintln!("[calibrate-iu4] {} corpus prompts", prompts.len());
+
+    // ── load model ──────────────────────────────────────────────────────
+    let hfq = HfqFile::open(std::path::Path::new(&model_path))
+        .expect("open model");
+    let config = qwen35::config_from_hfq(&hfq).expect("read qwen35 config");
+    eprintln!("[calibrate-iu4] config: dim={} layers={} arch_id={} n_heads={} n_kv_heads={} hidden_dim={}",
+        config.dim, config.n_layers, hfq.arch_id, config.n_heads, config.n_kv_heads, config.hidden_dim);
+    let mut gpu = Gpu::init().expect("gpu init");
+    eprintln!("[calibrate-iu4] gpu: {}", gpu.arch);
+    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    eprintln!("[calibrate-iu4] loaded {} layers", weights.layers.len());
+
+    // ── tokenizer ───────────────────────────────────────────────────────
+    let tokenizer = engine::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .expect("tokenizer");
+
+    // ── KV / state / scratch ────────────────────────────────────────────
+    // Use the BATCHED prefill scratch so each prompt fires through
+    // gemm_hfq4g256_residual (which is what the calibration capture hook
+    // is attached to). Per-token forward_scratch goes through
+    // gemv_hfq4g256_residual instead and would not capture activation
+    // statistics.
+    let kv_seq = max_tokens.max(512);
+    let mut kv_cache = KvCache::new_gpu_q8(
+        &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq,
+    ).expect("kv cache alloc");
+    let mut dn_state = DeltaNetState::new(&mut gpu, &config).expect("dn state alloc");
+    // Force PrefillBatchScratch allocation by pretending HIPFIRE_PREFILL_REUSE_PBS
+    // is set for the scratch builder. We use a per-prompt batch cap of
+    // max_tokens — small enough not to OOM, large enough to do each prompt
+    // in one prefill chunk.
+    std::env::set_var("HIPFIRE_PREFILL_REUSE_PBS", "1");
+    let pbs_max = max_tokens.max(64).min(qwen35::PREFILL_MAX_BATCH);
+    std::env::set_var("HIPFIRE_PREFILL_MAX_BATCH", pbs_max.to_string());
+    let scratch = Qwen35Scratch::new(&mut gpu, &config, pbs_max)
+        .expect("scratch alloc");
+
+    // ── shared capture state ────────────────────────────────────────────
+    // Per-site MeanAccumulator and CenteredHistogram. Sites are discovered
+    // dynamically in the first forward pass (we don't know the dispatch
+    // call order a priori, just the count).
+    //
+    // The capture protocol is two-pass:
+    //   Pass A: accumulate `sum` and `count` per site → mu = sum/count
+    //   Pass B: with mu fixed, accumulate per-channel histogram of |x-mu|
+    //           → s_a from p99-abs (or mean-abs)
+    //
+    // We record per-site (n_channels, n_output_rows) at first-touch in
+    // pass A so pass B can construct CenteredHistograms with the right
+    // shape.
+    #[derive(Default, Clone)]
+    struct SiteShape {
+        n_channels: usize,
+        n_output_rows: usize,
+        layer_idx: u32,
+        proj_id: u32,
+    }
+    let shapes: Arc<Mutex<HashMap<usize, SiteShape>>> = Arc::new(Mutex::new(HashMap::new()));
+    let mean_accs: Arc<Mutex<HashMap<usize, MeanAccumulator>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+
+    // ── Pass A: accumulate per-channel sum/count ────────────────────────
+    eprintln!("[calibrate-iu4] === pass A: per-channel mean ===");
+    {
+        let shapes_a = shapes.clone();
+        let mean_accs_a = mean_accs.clone();
+        let hook = Box::new(move |site_id: usize, x: &[f32], n: usize, k: usize, m: usize| {
+            let mut sh = shapes_a.lock().unwrap();
+            let entry = sh.entry(site_id).or_insert_with(|| SiteShape {
+                n_channels: k,
+                n_output_rows: m,
+                // Layer + proj inferred from site_id assuming Qwen3.5
+                // dense (wo and w_down are exactly 2 sites per layer);
+                // sites alternate (0=wo of layer 0, 1=w_down of layer 0,
+                // 2=wo of layer 1, ...). Storing as informational metadata.
+                layer_idx: (site_id / 2) as u32,
+                proj_id: (site_id % 2) as u32,
+            });
+            entry.n_channels = k;
+            entry.n_output_rows = m;
+            drop(sh);
+            let mut accs = mean_accs_a.lock().unwrap();
+            let acc = accs
+                .entry(site_id)
+                .or_insert_with(|| MeanAccumulator::new(k));
+            acc.add_batch(x, n);
+        });
+        gpu.set_iu4_capture_hook(Some(hook));
+    }
+    let mut total_tokens_pass_a = 0usize;
+    for (idx, prompt) in prompts.iter().enumerate() {
+        let toks = tokenize_for_chat(&tokenizer, prompt, max_tokens);
+        if toks.is_empty() {
+            continue;
+        }
+        eprintln!(
+            "[calibrate-iu4] pass A prompt {}/{} ({} tokens)",
+            idx + 1,
+            prompts.len(),
+            toks.len()
+        );
+        gpu.reset_iu4_dispatch_counter();
+        // Process each prompt as a fresh sequence (pos starts at 0). The
+        // KV slots at pos 0..n get overwritten before attention reads
+        // them, so stale K/V from prior prompts doesn't leak into the
+        // captured activations.
+        let _ = run_prefill(&mut gpu, &weights, &config, &toks, &mut kv_cache, &mut dn_state, &scratch);
+        total_tokens_pass_a += toks.len();
+    }
+    gpu.set_iu4_capture_hook(None);
+    let n_sites = shapes.lock().unwrap().len();
+    eprintln!(
+        "[calibrate-iu4] pass A done: {} tokens across {} sites",
+        total_tokens_pass_a, n_sites
+    );
+
+    if n_sites == 0 {
+        eprintln!(
+            "[calibrate-iu4] FAIL: no GEMM call sites observed. \
+             Empty prompts or model has no HFQ4 wo/w_down? Aborting."
+        );
+        std::process::exit(1);
+    }
+
+    // Compute per-site mu vectors.
+    let shapes_snap: HashMap<usize, SiteShape> = shapes.lock().unwrap().clone();
+    let mut mus: HashMap<usize, Vec<f32>> = HashMap::new();
+    {
+        let accs = mean_accs.lock().unwrap();
+        for (&sid, acc) in accs.iter() {
+            mus.insert(sid, acc.mean());
+        }
+    }
+
+    // ── Pass B: accumulate per-channel histogram against mu ─────────────
+    eprintln!("[calibrate-iu4] === pass B: per-channel histogram of |x - mu| ===");
+    let hists: Arc<Mutex<HashMap<usize, CenteredHistogram>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    {
+        let hists_b = hists.clone();
+        let mus_b: HashMap<usize, Vec<f32>> = mus.clone();
+        let hook = Box::new(move |site_id: usize, x: &[f32], n: usize, _k: usize, _m: usize| {
+            let mut hs = hists_b.lock().unwrap();
+            let h = hs.entry(site_id).or_insert_with(|| {
+                CenteredHistogram::new(
+                    mus_b.get(&site_id).cloned().unwrap_or_default(),
+                )
+            });
+            h.add_batch(x, n);
+        });
+        gpu.set_iu4_capture_hook(Some(hook));
+    }
+    let mut total_tokens_pass_b = 0usize;
+    for (idx, prompt) in prompts.iter().enumerate() {
+        let toks = tokenize_for_chat(&tokenizer, prompt, max_tokens);
+        if toks.is_empty() {
+            continue;
+        }
+        eprintln!(
+            "[calibrate-iu4] pass B prompt {}/{} ({} tokens)",
+            idx + 1,
+            prompts.len(),
+            toks.len()
+        );
+        gpu.reset_iu4_dispatch_counter();
+        let _ = run_prefill(&mut gpu, &weights, &config, &toks, &mut kv_cache, &mut dn_state, &scratch);
+        total_tokens_pass_b += toks.len();
+    }
+    gpu.set_iu4_capture_hook(None);
+    eprintln!("[calibrate-iu4] pass B done: {total_tokens_pass_b} tokens");
+
+    // ── Compute s_a per strategy ────────────────────────────────────────
+    let mut sas: HashMap<usize, Vec<f32>> = HashMap::new();
+    {
+        let hs = hists.lock().unwrap();
+        for (&sid, h) in hs.iter() {
+            let s = match strategy.as_str() {
+                "mean" => h.mean_abs(),
+                _ => h.percentile_abs(99.0),
+            };
+            // Floor to a small positive value to avoid divide-by-zero in
+            // dead channels (e.g. embedding-zero-like distributions).
+            let s_floored: Vec<f32> = s
+                .iter()
+                .map(|&v| if v.is_finite() && v > 1e-4 { v } else { 1e-4 })
+                .collect();
+            sas.insert(sid, s_floored);
+        }
+    }
+
+    // ── Compute W·mu_a bias per site (CPU dequant + dot) ────────────────
+    eprintln!("[calibrate-iu4] === computing W·mu_a bias (CPU dequant) ===");
+    let biases = compute_w_mu_biases(&weights, &config, &shapes_snap, &mus);
+
+    // ── Build sidecar ───────────────────────────────────────────────────
+    let mut sidecar = Iu4Calibration::new();
+    let mut sids: Vec<usize> = shapes_snap.keys().copied().collect();
+    sids.sort();
+    for sid in sids {
+        let sh = shapes_snap.get(&sid).unwrap();
+        let mu = mus.get(&sid).cloned().unwrap_or_else(|| vec![0.0; sh.n_channels]);
+        let s = sas.get(&sid).cloned().unwrap_or_else(|| vec![1.0; sh.n_channels]);
+        let bias = biases
+            .get(&sid)
+            .cloned()
+            .unwrap_or_else(|| vec![0.0; sh.n_output_rows]);
+
+        let mut site = Iu4CalSite::new(
+            sh.layer_idx,
+            sh.proj_id,
+            sh.n_channels,
+            sh.n_output_rows,
+        );
+        site.mu_a = f32_vec_to_f16(&mu);
+        site.s_a = f32_vec_to_f16(&s);
+        site.w_mu_bias = f32_vec_to_f16(&bias);
+        sidecar.sites.push(site);
+    }
+
+    // ── Print summary ───────────────────────────────────────────────────
+    let n = sidecar.n_sites();
+    eprintln!("[calibrate-iu4] === sidecar summary ===");
+    eprintln!("[calibrate-iu4]  sites: {n}");
+    if let Some(s0) = sidecar.sites.first() {
+        let mu0 = s0.mu_a.iter().take(8).map(|&b| f16_to_f32(b)).collect::<Vec<_>>();
+        let s0v = s0.s_a.iter().take(8).map(|&b| f16_to_f32(b)).collect::<Vec<_>>();
+        eprintln!("[calibrate-iu4]  site[0] (layer={} proj={}): k={} m={}",
+            s0.layer_idx, s0.proj_id, s0.n_channels, s0.n_output_rows);
+        eprintln!("[calibrate-iu4]    mu_a[0..8] = {:?}", mu0);
+        eprintln!("[calibrate-iu4]    s_a[0..8]  = {:?}", s0v);
+    }
+
+    // ── Write sidecar ───────────────────────────────────────────────────
+    sidecar
+        .write_path(std::path::Path::new(&out_path))
+        .expect("write sidecar");
+    let bytes = std::fs::metadata(&out_path).map(|m| m.len()).unwrap_or(0);
+    eprintln!(
+        "[calibrate-iu4] wrote {} sites, {} bytes ({:.1} MB) → {}",
+        n,
+        bytes,
+        bytes as f64 / 1_000_000.0,
+        out_path
+    );
+
+    // ── Forward-pass helper ─────────────────────────────────────────────
+
+    fn run_prefill(
+        gpu: &mut Gpu,
+        weights: &Qwen35Weights,
+        config: &Qwen35Config,
+        tokens: &[u32],
+        kv_cache: &mut KvCache,
+        dn_state: &mut DeltaNetState,
+        scratch: &Qwen35Scratch,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Run the BATCHED prefill so the dispatcher takes the
+        // gemm_hfq4g256_residual path (where the calibration capture hook
+        // fires). Per-token forward_scratch would route through gemv
+        // helpers and miss the hook entirely.
+        qwen35::forward_prefill_batch(
+            gpu, weights, config, tokens, /*start_pos=*/0,
+            kv_cache, dn_state, scratch,
+            /*hidden_rb=*/None,
+            /*per_token_hidden_out=*/None,
+            /*gdn_tape=*/None,
+            /*tree_verify=*/None,
+        )?;
+        Ok(())
+    }
+
+    fn tokenize_for_chat(
+        tok: &engine::tokenizer::Tokenizer,
+        text: &str,
+        max_tokens: usize,
+    ) -> Vec<u32> {
+        // Wrap in the Qwen3.5 chat shell so we exercise activation
+        // patterns the model actually sees in production. Truncate to
+        // max_tokens to keep calibration cheap.
+        let im_start = tok.encode("<|im_start|>");
+        let im_end = tok.encode("<|im_end|>");
+        let user = tok.encode("user");
+        let asst = tok.encode("assistant");
+        let nl = tok.encode("\n");
+        let body = tok.encode(text);
+        let mut out = Vec::new();
+        out.extend_from_slice(&im_start);
+        out.extend_from_slice(&user);
+        out.extend_from_slice(&nl);
+        out.extend_from_slice(&body);
+        out.extend_from_slice(&im_end);
+        out.extend_from_slice(&nl);
+        out.extend_from_slice(&im_start);
+        out.extend_from_slice(&asst);
+        out.extend_from_slice(&nl);
+        if out.len() > max_tokens {
+            out.truncate(max_tokens);
+        }
+        out
+    }
+
+    fn compute_w_mu_biases(
+        weights: &Qwen35Weights,
+        config: &Qwen35Config,
+        shapes: &HashMap<usize, SiteShape>,
+        mus: &HashMap<usize, Vec<f32>>,
+    ) -> HashMap<usize, Vec<f32>> {
+        let mut out: HashMap<usize, Vec<f32>> = HashMap::new();
+        for (&sid, sh) in shapes.iter() {
+            let mu = match mus.get(&sid) {
+                Some(v) => v,
+                None => continue,
+            };
+            // Map (layer_idx, proj_id) → WeightTensor handle.
+            let layer_idx = sh.layer_idx as usize;
+            let proj_id = sh.proj_id;
+            if layer_idx >= weights.layers.len() {
+                continue;
+            }
+            let weight: &engine::llama::WeightTensor = match (&weights.layers[layer_idx], proj_id) {
+                (LayerWeights::FullAttn(l), 0) => &l.wo,
+                (LayerWeights::FullAttn(l), 1) => &l.w_down,
+                (LayerWeights::DeltaNet(l), 0) => &l.wo,
+                (LayerWeights::DeltaNet(l), 1) => &l.w_down,
+                _ => continue,
+            };
+            // Only HFQ4-G256 supported. Skip other dtypes (the calibration
+            // sidecar would be unused there anyway since iu4 dispatch is
+            // gated on HFQ4 weights through gemm_hfq4g256_residual).
+            if weight.gpu_dtype != rdna_compute::DType::HFQ4G256
+                && weight.gpu_dtype != rdna_compute::DType::MQ4G256
+            {
+                eprintln!(
+                    "[calibrate-iu4] site {} weight dtype {:?} not HFQ4G256/MQ4G256 — bias omitted",
+                    sid, weight.gpu_dtype
+                );
+                continue;
+            }
+            let m = sh.n_output_rows;
+            let k = sh.n_channels;
+            let bias = compute_bias_via_cpu_dequant(weight, mu, m, k);
+            out.insert(sid, bias);
+            eprintln!(
+                "[calibrate-iu4]  site {} (layer {} proj {}) bias[0..4] = {:?}",
+                sid,
+                sh.layer_idx,
+                sh.proj_id,
+                bias_first_4(&out[&sid])
+            );
+        }
+        out
+    }
+
+    fn bias_first_4(b: &[f32]) -> Vec<f32> {
+        b.iter().take(4).copied().collect()
+    }
+
+    /// CPU-only HFQ4-G256 dequant + dot with `mu`. Reads the weight bytes
+    /// straight from the host (we re-mmap via hipMemcpy d→h here; for this
+    /// offline binary we accept the cost).
+    fn compute_bias_via_cpu_dequant(
+        weight: &engine::llama::WeightTensor,
+        mu: &[f32],
+        m: usize,
+        k: usize,
+    ) -> Vec<f32> {
+        let groups_per_row = k / 256;
+        let row_bytes = groups_per_row * 136;
+        let total_bytes = m * row_bytes;
+        // Read bytes from GPU once (we don't have a Gpu handle in scope —
+        // re-acquire the singleton). Build a tiny temporary Gpu just for
+        // this download isn't possible because Gpu doesn't allow multiple
+        // instances safely. Instead, use the global hip runtime indirectly
+        // via the existing memcpy_dtoh on the buffer's raw ptr.
+        //
+        // Simpler: open a hip-bridge::HipRuntime here, since we already
+        // have the buffer's raw pointer + size. The runtime is reentrant.
+        let rt = hip_bridge::HipRuntime::load().expect("hip rt");
+        rt.set_device(0).ok();
+        let mut host = vec![0u8; total_bytes];
+        let buf_view = unsafe {
+            hip_bridge::DeviceBuffer::from_raw(weight.buf.buf.as_ptr(), total_bytes)
+        };
+        rt.memcpy_dtoh(&mut host, &buf_view).expect("dtoh weight");
+        std::mem::forget(buf_view);
+
+        // Dequant + dot per row:
+        //   for each row r:
+        //     for each group g:
+        //       scale = host[r*row_bytes + g*136 + 0..4] (FP32)
+        //       zero  = host[r*row_bytes + g*136 + 4..8] (FP32)
+        //       for nibble i in 0..256:
+        //         w = scale * nibble + zero
+        //         bias[r] += w * mu[g*256 + i]
+        let mut bias = vec![0.0f32; m];
+        for r in 0..m {
+            let row = &host[r * row_bytes..(r + 1) * row_bytes];
+            let mut acc = 0.0f64;
+            for g in 0..groups_per_row {
+                let off = g * 136;
+                let scale = f32::from_le_bytes([row[off], row[off + 1], row[off + 2], row[off + 3]]);
+                let zero = f32::from_le_bytes([row[off + 4], row[off + 5], row[off + 6], row[off + 7]]);
+                let nibbles = &row[off + 8..off + 136];
+                let mu_chunk = &mu[g * 256..(g + 1) * 256];
+                for i in 0..256 {
+                    let byte_idx = i / 2;
+                    let nibble = if i % 2 == 0 {
+                        nibbles[byte_idx] & 0xF
+                    } else {
+                        nibbles[byte_idx] >> 4
+                    };
+                    let w = scale * (nibble as f32) + zero;
+                    acc += (w as f64) * (mu_chunk[i] as f64);
+                }
+            }
+            bias[r] = acc as f32;
+        }
+        bias
+    }
+
+    /// Embedded calibration corpus. Mix of code, prose, math, multi-turn,
+    /// tool-call and reasoning shapes so the captured distributions cover
+    /// what production Qwen3.5 dispatch sees. Adapted from
+    /// scripts/coherence-gate.sh's prompt matrix and benchmarks/prompts/.
+    fn embedded_corpus() -> Vec<String> {
+        vec![
+            // Reasoning / counting (coherence-gate sheep prompt + variants)
+            "A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.".into(),
+            "If a train leaves Boston at 3pm going 60 mph and another leaves New York at 4pm going 80 mph toward Boston, when do they meet? Distance = 200 miles.".into(),
+            // Capital / facts
+            "What is the capital of France? Answer in one short sentence.".into(),
+            "What is the chemical formula for water? Answer briefly.".into(),
+            "Who wrote 'Hamlet'? Answer briefly.".into(),
+            "List five planets in our solar system. One sentence.".into(),
+            // Code (mirrors humaneval shapes)
+            "Write a one-line Python function named square that returns n*n.".into(),
+            "Write a Python function called fizzbuzz that prints numbers from 1 to 100, with multiples of three printing 'Fizz' and multiples of five 'Buzz'.".into(),
+            "Implement a Python function `merge_sort(arr)` that sorts a list in ascending order using merge sort. Include type hints.".into(),
+            "Write a Rust function `fn fibonacci(n: u32) -> u64` that returns the nth Fibonacci number using iterative computation.".into(),
+            "Write a Python function `is_prime(n: int) -> bool` that returns True if n is prime, False otherwise. Handle n < 2 correctly.".into(),
+            // Prose
+            "Write a short paragraph about the importance of clean water in human civilization.".into(),
+            "Describe the process by which photosynthesis converts sunlight into chemical energy in plants. Two paragraphs.".into(),
+            "Explain in 3 sentences why the sky appears blue during the day but red at sunset.".into(),
+            "Write a brief introduction to the concept of object-oriented programming for beginners.".into(),
+            // Multi-turn-ish single shots (mirroring chat shape)
+            "I'm planning a trip to Japan. Can you suggest three must-visit cities and why?".into(),
+            "What are some common mistakes beginners make when learning to play guitar?".into(),
+            "Explain the difference between mitosis and meiosis in cell division.".into(),
+            "How do I debug a Python program that's running very slowly?".into(),
+            // Math
+            "Solve for x: 2x + 5 = 13. Show your work.".into(),
+            "What is the area of a circle with radius 7? Use π ≈ 3.14159.".into(),
+            "Compute the sum of integers from 1 to 100 using Gauss's formula. Show the formula.".into(),
+            // Lists / structured
+            "List the first ten prime numbers as a comma-separated list.".into(),
+            "Provide a JSON object with keys 'name', 'age', 'occupation' for a fictional person named Alice.".into(),
+            "Translate the phrase 'good morning' into Spanish, French, German, and Japanese.".into(),
+            // Mid-context retrieval shape
+            "Read the following short text then answer: The cat sat on the mat. The dog barked at the cat. The mat was red. — Question: What color was the mat?".into(),
+            // Code with comments (mirrors PEP-8 prompts)
+            "Write a Python `lru_cache` decorator implementation from scratch with a max_size parameter, supporting hits/misses tracking. Use only the standard library.".into(),
+            "Write a function in C that reverses a null-terminated string in place. Annotate each step.".into(),
+            // Trivia / knowledge
+            "Name three notable women scientists from the 20th century and one of their contributions.".into(),
+            "What is the boiling point of water at sea level in Celsius and Fahrenheit?".into(),
+            "Briefly explain Newton's three laws of motion.".into(),
+        ]
+    }
+}

--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -1190,6 +1190,43 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             );
         }
 
+        // iu4 activation calibration sidecar (gfx12 SmoothQuant). When
+        // `<model>.iu4cal` is present, parse + upload to GPU and arm the
+        // calibrated dispatch path. The dispatcher only takes the
+        // calibrated path when HIPFIRE_GFX12_IU4_CALIBRATED=1, so this
+        // is a no-op cost when the env var is unset.
+        let iu4cal_path = std::path::PathBuf::from(format!("{path}.iu4cal"));
+        if iu4cal_path.exists() {
+            let t0 = std::time::Instant::now();
+            match engine::quant::iu4_calibration::Iu4Calibration::read_path(&iu4cal_path) {
+                Ok(cal) => {
+                    let n_sites = cal.n_sites();
+                    match engine::quant::iu4_calibration::upload_to_gpu(&cal, gpu) {
+                        Ok(gpu_cal) => {
+                            gpu.load_iu4_calibration(gpu_cal);
+                            eprintln!(
+                                "  iu4 calibration: loaded {n_sites} sites from {} ({:.1}ms)",
+                                iu4cal_path.display(),
+                                t0.elapsed().as_secs_f64() * 1000.0
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "  iu4 calibration: GPU upload failed: {e} \
+                                 (continuing without calibration)"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  iu4 calibration: parse {} failed: {e} (continuing without)",
+                        iu4cal_path.display()
+                    );
+                }
+            }
+        }
+
         // KV cache modes (RotorQuant-style asymmetric: K rotated + V Q8):
         //   asym3 (default) — K at 3-bit rotated, V at Q8_0. 5.5× vs fp32.
         //                     Best quality/compression tradeoff — RotorQuant "planar3".

--- a/crates/engine/examples/test_iu4_calibration_layer0.rs
+++ b/crates/engine/examples/test_iu4_calibration_layer0.rs
@@ -1,0 +1,215 @@
+//! Diagnostic: compare FP16 vs calibrated-iu4 output for layer-0 wo on a
+//! REAL model + REAL calibration sidecar. This is the bridge between the
+//! synthetic-data correctness test (gfx1201) and the daemon coherence
+//! gate. If this diverges by > Q4_1-noise on a single layer, the layer-0
+//! daemon falsification will too.
+//!
+//! Flow:
+//!   1. Load model + sidecar.
+//!   2. Construct a synthetic activation `x` with the same per-channel
+//!      stats as the captured mu/s.
+//!   3. Path A: FP16 dequant + WMMA (gfx12) on the original weight.
+//!   4. Path B: bake weight scales, preshift x, q4_1 quant, iu4 GEMM,
+//!      bias_add. (Same dispatch as the daemon.)
+//!   5. Compare outputs element-wise; print per-row stats.
+//!
+//! Usage:
+//!   cargo run --release --features deltanet --example
+//!     test_iu4_calibration_layer0 -- --model <path> --site 0
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("requires --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use engine::hfq::HfqFile;
+    use engine::quant::iu4_calibration::{Iu4Calibration, upload_to_gpu};
+    use engine::qwen35;
+    use rdna_compute::Gpu;
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut model_path: Option<String> = None;
+    let mut site_idx: usize = 0;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--model" => {
+                model_path = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--site" => {
+                site_idx = args.get(i + 1).and_then(|v| v.parse().ok()).unwrap_or(0);
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    let Some(model_path) = model_path else {
+        eprintln!("--model required");
+        std::process::exit(2);
+    };
+    let sidecar_path = format!("{model_path}.iu4cal");
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    eprintln!("GPU: {}", gpu.arch);
+    if !(gpu.arch == "gfx1200" || gpu.arch == "gfx1201") {
+        eprintln!("SKIP: requires gfx1200/gfx1201");
+        std::process::exit(0);
+    }
+    let hfq = HfqFile::open(std::path::Path::new(&model_path)).expect("open model");
+    let config = qwen35::config_from_hfq(&hfq).expect("read config");
+    eprintln!("Loading weights...");
+    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+
+    let cal = Iu4Calibration::read_path(std::path::Path::new(&sidecar_path))
+        .expect("read sidecar");
+    eprintln!("sidecar: {} sites", cal.n_sites());
+
+    // Inspect site
+    let site = cal.sites.get(site_idx).expect("site idx out of range");
+    let m = site.n_output_rows as usize;
+    let k = site.n_channels as usize;
+    eprintln!(
+        "Site {site_idx}: layer={}, proj={}, m={m}, k={k}",
+        site.layer_idx, site.proj_id
+    );
+
+    // Find the corresponding weight tensor.
+    let layer_idx = site.layer_idx as usize;
+    let proj_id = site.proj_id;
+    let weight = match (&weights.layers[layer_idx], proj_id) {
+        (qwen35::LayerWeights::FullAttn(l), 0) => &l.wo,
+        (qwen35::LayerWeights::FullAttn(l), 1) => &l.w_down,
+        (qwen35::LayerWeights::DeltaNet(l), 0) => &l.wo,
+        (qwen35::LayerWeights::DeltaNet(l), 1) => &l.w_down,
+        _ => panic!("unsupported layer kind for diagnostic"),
+    };
+
+    // Generate a small synthetic activation matrix matching the capture
+    // shape: a few random tokens with realistic magnitudes (≈ mu_a's
+    // magnitude scale to mimic the post-rmsnorm distribution).
+    let n: usize = 16;
+    let mu_a_f32 = site.mu_a_f32();
+    let (s_a_f32, _inv) = site.s_a_f32_with_inv(1e-6);
+
+    // x[t][c] = mu[c] + s[c] * z, z ~ Uniform(-1, 1).  With a 1% outlier at ±5×.
+    let mut state: u64 = 0xCAFEBABE;
+    let mut nrand = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((state >> 33) as f32) / (u32::MAX as f32)
+    };
+    let mut x_host = vec![0.0f32; n * k];
+    for t in 0..n {
+        for c in 0..k {
+            let u = nrand();
+            let z = nrand() * 2.0 - 1.0;
+            let mag = if u > 0.99 { 5.0 } else { 1.0 };
+            x_host[t * k + c] = mu_a_f32[c] + s_a_f32[c] * z * mag;
+        }
+    }
+
+    let x_gpu = gpu
+        .alloc_tensor(&[n * k], rdna_compute::DType::F32)
+        .expect("alloc x");
+    gpu.hip
+        .memcpy_htod(&x_gpu.buf, bytes_of(&x_host))
+        .expect("htod x");
+    let y_fp16 = gpu
+        .alloc_tensor(&[n * m], rdna_compute::DType::F32)
+        .expect("alloc y_fp16");
+    let y_iu4 = gpu
+        .alloc_tensor(&[n * m], rdna_compute::DType::F32)
+        .expect("alloc y_iu4");
+    // Zero y so the residual-add lands on a known baseline.
+    gpu.hip.memset(&y_fp16.buf, 0, n * m * 4).unwrap();
+    gpu.hip.memset(&y_iu4.buf, 0, n * m * 4).unwrap();
+
+    // Path A: FP16 wmma reference
+    eprintln!("--- path A: FP16 reference ---");
+    gpu.gemm_hfq4g256_residual_wmma_gfx12(&weight.buf, &x_gpu, &y_fp16, m, k, n)
+        .expect("fp16 wmma");
+    gpu.hip.device_synchronize().unwrap();
+    let y_fp16_host = gpu.download_f32(&y_fp16).expect("download y_fp16");
+
+    // Path B: calibrated iu4 (load sidecar + go through dispatcher)
+    eprintln!("--- path B: calibrated iu4 ---");
+    let gpu_cal = upload_to_gpu(&cal, &mut gpu).expect("upload sidecar");
+    gpu.load_iu4_calibration(gpu_cal);
+    // Manual dispatch: skip layers 0..site_idx by incrementing the counter
+    // so site_idx is the next call.
+    gpu.iu4_dispatch_call_idx.set(site_idx);
+    std::env::set_var("HIPFIRE_GFX12_IU4_CALIBRATED", "1");
+    std::env::set_var("HIPFIRE_GFX12_IU4_MAX_CALL", &(site_idx + 1).to_string());
+    gpu.gemm_hfq4g256_residual(&weight.buf, &x_gpu, &y_iu4, m, k, n)
+        .expect("calibrated iu4");
+    std::env::remove_var("HIPFIRE_GFX12_IU4_CALIBRATED");
+    std::env::remove_var("HIPFIRE_GFX12_IU4_MAX_CALL");
+    gpu.hip.device_synchronize().unwrap();
+    let y_iu4_host = gpu.download_f32(&y_iu4).expect("download y_iu4");
+
+    // Compare
+    let mut max_abs = 0.0f32;
+    let mut sum_abs = 0.0f64;
+    let mut max_loc = (0usize, 0usize);
+    for t in 0..n {
+        for r in 0..m {
+            let idx = t * m + r;
+            let a = y_fp16_host[idx];
+            let b = y_iu4_host[idx];
+            let e = (a - b).abs();
+            if e > max_abs {
+                max_abs = e;
+                max_loc = (t, r);
+            }
+            sum_abs += e as f64;
+        }
+    }
+    let mean_abs = sum_abs / (n * m) as f64;
+    eprintln!("\n=== Comparison ===");
+    eprintln!("  max abs err:  {max_abs:.6} at (t={}, r={})", max_loc.0, max_loc.1);
+    eprintln!("  mean abs err: {mean_abs:.6}");
+    let mut max_a: f32 = 0.0;
+    let mut max_b: f32 = 0.0;
+    for &v in &y_fp16_host {
+        if v.abs() > max_a {
+            max_a = v.abs();
+        }
+    }
+    for &v in &y_iu4_host {
+        if v.abs() > max_b {
+            max_b = v.abs();
+        }
+    }
+    eprintln!("  max |y_fp16|: {max_a:.4}");
+    eprintln!("  max |y_iu4|:  {max_b:.4}");
+    eprintln!("\n--- Sample triples (t=0..2, r=0..6) ---");
+    for t in 0..2.min(n) {
+        for r in 0..6.min(m) {
+            let idx = t * m + r;
+            let a = y_fp16_host[idx];
+            let b = y_iu4_host[idx];
+            eprintln!("  t={t} r={r}: fp16={a:>10.4}  cal={b:>10.4}  err={:.4}", (a - b).abs());
+        }
+    }
+
+    eprintln!("\n--- Site summary ---");
+    eprintln!("  mu_a: range [{:.4}, {:.4}]", min_of(&mu_a_f32), max_of(&mu_a_f32));
+    eprintln!("  s_a:  range [{:.4}, {:.4}]", min_of(&s_a_f32), max_of(&s_a_f32));
+    eprintln!("  bias: range [{:.4}, {:.4}]",
+        min_of(&site.w_mu_bias_f32()), max_of(&site.w_mu_bias_f32()));
+}
+
+#[cfg(feature = "deltanet")]
+fn min_of(v: &[f32]) -> f32 {
+    v.iter().copied().fold(f32::INFINITY, f32::min)
+}
+#[cfg(feature = "deltanet")]
+fn max_of(v: &[f32]) -> f32 {
+    v.iter().copied().fold(f32::NEG_INFINITY, f32::max)
+}
+#[cfg(feature = "deltanet")]
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -24,3 +24,4 @@ pub mod weight_pager;
 pub mod image;
 pub mod tokenizer;
 pub mod pflash;
+pub mod quant;

--- a/crates/engine/src/quant/iu4_calibration.rs
+++ b/crates/engine/src/quant/iu4_calibration.rs
@@ -1,0 +1,662 @@
+//! SmoothQuant-style activation calibration sidecar for the gfx12 iu4 K=32
+//! GEMM path.
+//!
+//! # Mathematical recipe
+//!
+//! Given an iu4 GEMM call site `y = W·x` (W shape [m × k], x shape [n × k]):
+//!
+//! ```text
+//!   y = W·x = (W·diag(s_a)) · (diag(1/s_a)·(x - mu_a)) + W·mu_a
+//! ```
+//!
+//! - `mu_a[col]`: per-input-channel arithmetic mean of the activation `x`
+//!   (averaged across calibration tokens). Shape: [k].
+//! - `s_a[col]`: per-input-channel scale (e.g. 99-percentile-abs after
+//!   centering). Shape: [k].
+//! - `W·diag(s_a)`: bake `s_a` into the per-row weight scale at load time.
+//!   Per HFQ4-G256, each weight row has `groups_per_row` (= k/256) FP32
+//!   scales; we multiply each scale by the geometric mean of `s_a` over
+//!   that K=256 group. (Per-channel scale baking would require per-element
+//!   weight rescale which is incompatible with the group-shared HFQ4
+//!   representation; group-mean baking is the practical SmoothQuant
+//!   approximation used in production stacks.)
+//! - `(x - mu_a) / s_a`: runtime preshift kernel BEFORE the Q4_1 quantizer.
+//!   Now activations are mean-zero and roughly unit-variance per channel,
+//!   so symmetric Q4_1 captures the bulk of the distribution.
+//! - `W·mu_a`: precomputed at calibration time. One MV per call site against
+//!   the `mu_a` vector → `bias[m]`. Stored in the sidecar; added to the
+//!   GEMM output once.
+//!
+//! # Sidecar wire format
+//!
+//! Little-endian throughout.
+//!
+//! ```text
+//!   magic:    u32 = 0x49553443  ("IU4C")
+//!   version:  u32 = 1
+//!   n_sites:  u32   number of GEMM call sites
+//!   _pad:     u32   = 0 (alignment / future use)
+//!
+//!   per site (in dispatch-counter order):
+//!     layer_idx:    u32   logical layer index
+//!     proj_id:      u32   0=wo, 1=w_down (extend if more sites added)
+//!     n_channels:   u32   = k (input channel dim at this site)
+//!     n_output_rows:u32   = m (output dim at this site)
+//!     mu_a:         [f16; n_channels]
+//!     s_a:          [f16; n_channels]
+//!     w_mu_bias:    [f16; n_output_rows]
+//! ```
+//!
+//! ## Why FP16
+//!
+//! Calibration vectors are O(L * K) which on 27B (L=64, K=4096) is small
+//! (~32 MB at FP16). FP16 is enough precision for centering / scaling
+//! statistics — calibration noise dominates round-off. The runtime preshift
+//! kernel reads FP16 mu/inv_s and emits FP32 (which goes into the existing
+//! Q4_1 quantizer that already takes FP32 in).
+//!
+//! # Site identity
+//!
+//! Site `i` corresponds to the i-th call to `Gpu::gemm_hfq4g256_residual`
+//! through the dense forward path. For Qwen3.5 dense, that's
+//! `(layer_idx, proj_id) = (i / 2, i % 2)` with `proj_id ∈ {0=wo, 1=w_down}`.
+//! The dispatcher's `dispatch_call_idx` counter (per-process, increments on
+//! every call regardless of arch / iu4 gating) is the canonical site key.
+
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use hip_bridge::HipResult;
+use rdna_compute::{Gpu, GpuIu4CalSite, GpuIu4Calibration};
+
+use crate::llama::{f16_to_f32, f32_to_f16};
+
+pub const IU4CAL_MAGIC: u32 = 0x49553443; // "IU4C"
+pub const IU4CAL_VERSION: u32 = 1;
+
+/// One calibration site: per-channel mu, s, plus the precomputed W·mu_a bias.
+#[derive(Clone, Debug)]
+pub struct Iu4CalSite {
+    /// Logical layer index (informational; the runtime keys by call order).
+    pub layer_idx: u32,
+    /// Projection identifier within the layer. Convention:
+    ///   0 = wo  (attention output projection)
+    ///   1 = w_down  (FFN down projection)
+    pub proj_id: u32,
+    /// Input channel dim (= k).
+    pub n_channels: u32,
+    /// Output dim (= m).
+    pub n_output_rows: u32,
+    /// Per-input-channel activation mean. FP16 storage. Length = n_channels.
+    pub mu_a: Vec<u16>,
+    /// Per-input-channel activation scale (e.g. 99-pctile-abs). FP16 storage.
+    /// Length = n_channels.
+    pub s_a: Vec<u16>,
+    /// Precomputed W·mu_a bias. FP16 storage. Length = n_output_rows.
+    pub w_mu_bias: Vec<u16>,
+}
+
+impl Iu4CalSite {
+    pub fn new(layer_idx: u32, proj_id: u32, n_channels: usize, n_output_rows: usize) -> Self {
+        Self {
+            layer_idx,
+            proj_id,
+            n_channels: n_channels as u32,
+            n_output_rows: n_output_rows as u32,
+            mu_a: vec![0u16; n_channels],
+            s_a: vec![0u16; n_channels],
+            w_mu_bias: vec![0u16; n_output_rows],
+        }
+    }
+
+    /// Decode `mu_a` to FP32. Allocates a new Vec.
+    pub fn mu_a_f32(&self) -> Vec<f32> {
+        self.mu_a.iter().map(|&b| f16_to_f32(b)).collect()
+    }
+
+    /// Decode `s_a` to FP32 with a small floor to avoid divide-by-zero in
+    /// inv_s computation. Returns `(s_a, inv_s_a)` so callers don't repeat
+    /// the floor logic.
+    pub fn s_a_f32_with_inv(&self, floor: f32) -> (Vec<f32>, Vec<f32>) {
+        let s: Vec<f32> = self
+            .s_a
+            .iter()
+            .map(|&b| {
+                let v = f16_to_f32(b);
+                if v.is_finite() && v > floor {
+                    v
+                } else {
+                    floor
+                }
+            })
+            .collect();
+        let inv: Vec<f32> = s.iter().map(|&v| 1.0 / v).collect();
+        (s, inv)
+    }
+
+    /// Decode `w_mu_bias` to FP32.
+    pub fn w_mu_bias_f32(&self) -> Vec<f32> {
+        self.w_mu_bias.iter().map(|&b| f16_to_f32(b)).collect()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Iu4Calibration {
+    pub sites: Vec<Iu4CalSite>,
+}
+
+impl Iu4Calibration {
+    pub fn new() -> Self {
+        Self { sites: Vec::new() }
+    }
+
+    /// Look up the site for a given dispatch call index. Returns `None` if
+    /// out of range (caller must fall back to non-calibrated path).
+    pub fn site_at(&self, call_idx: usize) -> Option<&Iu4CalSite> {
+        self.sites.get(call_idx)
+    }
+
+    /// Return the number of recorded sites.
+    pub fn n_sites(&self) -> usize {
+        self.sites.len()
+    }
+
+    /// Serialize to disk in the wire format documented at the top of the file.
+    pub fn write_to<W: Write>(&self, mut w: W) -> io::Result<()> {
+        w.write_all(&IU4CAL_MAGIC.to_le_bytes())?;
+        w.write_all(&IU4CAL_VERSION.to_le_bytes())?;
+        w.write_all(&(self.sites.len() as u32).to_le_bytes())?;
+        w.write_all(&0u32.to_le_bytes())?;
+        for site in &self.sites {
+            w.write_all(&site.layer_idx.to_le_bytes())?;
+            w.write_all(&site.proj_id.to_le_bytes())?;
+            w.write_all(&site.n_channels.to_le_bytes())?;
+            w.write_all(&site.n_output_rows.to_le_bytes())?;
+            for &h in &site.mu_a {
+                w.write_all(&h.to_le_bytes())?;
+            }
+            for &h in &site.s_a {
+                w.write_all(&h.to_le_bytes())?;
+            }
+            for &h in &site.w_mu_bias {
+                w.write_all(&h.to_le_bytes())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Convenience: open path and write.
+    pub fn write_path(&self, path: &Path) -> io::Result<()> {
+        let f = std::fs::File::create(path)?;
+        let mut w = std::io::BufWriter::new(f);
+        self.write_to(&mut w)?;
+        w.flush()?;
+        Ok(())
+    }
+
+    /// Deserialize from a reader. Validates magic + version + size. Each
+    /// site's mu/s/bias arrays are read straight into FP16 storage.
+    pub fn read_from<R: Read + Seek>(mut r: R) -> io::Result<Self> {
+        let mut buf4 = [0u8; 4];
+        r.read_exact(&mut buf4)?;
+        let magic = u32::from_le_bytes(buf4);
+        if magic != IU4CAL_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("iu4cal: bad magic 0x{magic:08x}, want 0x{IU4CAL_MAGIC:08x}"),
+            ));
+        }
+        r.read_exact(&mut buf4)?;
+        let version = u32::from_le_bytes(buf4);
+        if version != IU4CAL_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("iu4cal: unsupported version {version}, want {IU4CAL_VERSION}"),
+            ));
+        }
+        r.read_exact(&mut buf4)?;
+        let n_sites = u32::from_le_bytes(buf4) as usize;
+        r.read_exact(&mut buf4)?; // pad
+
+        let mut sites = Vec::with_capacity(n_sites);
+        for _ in 0..n_sites {
+            r.read_exact(&mut buf4)?;
+            let layer_idx = u32::from_le_bytes(buf4);
+            r.read_exact(&mut buf4)?;
+            let proj_id = u32::from_le_bytes(buf4);
+            r.read_exact(&mut buf4)?;
+            let n_channels = u32::from_le_bytes(buf4);
+            r.read_exact(&mut buf4)?;
+            let n_output_rows = u32::from_le_bytes(buf4);
+
+            let nc = n_channels as usize;
+            let nm = n_output_rows as usize;
+            let mut mu_a = vec![0u16; nc];
+            let mut s_a = vec![0u16; nc];
+            let mut w_mu_bias = vec![0u16; nm];
+            // Bulk-read raw little-endian bytes; on LE hosts (x86_64,
+            // aarch64) we could borrow + transmute, but the explicit
+            // byteswap is portable and not in the inference hot path.
+            let mut bytes = vec![0u8; nc * 2];
+            r.read_exact(&mut bytes)?;
+            for (i, h) in mu_a.iter_mut().enumerate() {
+                *h = u16::from_le_bytes([bytes[2 * i], bytes[2 * i + 1]]);
+            }
+            r.read_exact(&mut bytes)?;
+            for (i, h) in s_a.iter_mut().enumerate() {
+                *h = u16::from_le_bytes([bytes[2 * i], bytes[2 * i + 1]]);
+            }
+            let mut bias_bytes = vec![0u8; nm * 2];
+            r.read_exact(&mut bias_bytes)?;
+            for (i, h) in w_mu_bias.iter_mut().enumerate() {
+                *h = u16::from_le_bytes([bias_bytes[2 * i], bias_bytes[2 * i + 1]]);
+            }
+
+            sites.push(Iu4CalSite {
+                layer_idx,
+                proj_id,
+                n_channels,
+                n_output_rows,
+                mu_a,
+                s_a,
+                w_mu_bias,
+            });
+        }
+
+        // Sanity: don't blow up on trailing bytes; the format is fixed-width
+        // per site and we don't need to seek-to-end-check.
+        let _ = r.seek(SeekFrom::Current(0));
+        Ok(Self { sites })
+    }
+
+    /// Convenience: open path and read.
+    pub fn read_path(path: &Path) -> io::Result<Self> {
+        let f = std::fs::File::open(path)?;
+        let mut r = std::io::BufReader::new(f);
+        Self::read_from(&mut r)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming statistics accumulator. One per call site. Used by the
+// calibration binary to fold per-batch mu/s contributions in.
+//
+// Tracks:
+//   - count: total tokens processed
+//   - sum:   sum_t x[t][col]                  → mu = sum / count
+//   - centered_abs_sum: sum_t |x[t][col] - mu_running[col]|  (running)
+//   - reservoir for percentile estimation: bucket histogram of |x - mu|
+//
+// We use a two-pass strategy in the calibration binary: first pass collects
+// mu, second pass collects centered-abs distribution. That's simpler than
+// online-streaming percentile estimation and the calibration corpus is
+// small enough (~64K tokens) that two FP16-forward passes is cheap.
+
+/// Per-channel running sums for first-pass mean estimation.
+pub struct MeanAccumulator {
+    /// Sum of x[t][col] across calibration tokens.
+    pub sum: Vec<f64>,
+    /// Number of tokens accumulated.
+    pub count: u64,
+}
+
+impl MeanAccumulator {
+    pub fn new(n_channels: usize) -> Self {
+        Self {
+            sum: vec![0.0; n_channels],
+            count: 0,
+        }
+    }
+
+    pub fn add_batch(&mut self, x: &[f32], n_tokens: usize) {
+        let nc = self.sum.len();
+        debug_assert_eq!(x.len(), n_tokens * nc);
+        for t in 0..n_tokens {
+            let row = &x[t * nc..(t + 1) * nc];
+            for (col, &v) in row.iter().enumerate() {
+                self.sum[col] += v as f64;
+            }
+        }
+        self.count += n_tokens as u64;
+    }
+
+    pub fn mean(&self) -> Vec<f32> {
+        let n = self.count.max(1) as f64;
+        self.sum.iter().map(|&s| (s / n) as f32).collect()
+    }
+}
+
+/// Per-channel histogram for percentile-abs estimation against a fixed mu.
+/// Uses log-spaced bins from `EPS_LO` to `MAX_HI`. Order-of-magnitude bin
+/// resolution is fine for 99-percentile selection.
+pub struct CenteredHistogram {
+    pub mu: Vec<f32>,
+    /// Per-channel histogram. Shape [n_channels × NBUCKETS].
+    /// Bucket i covers |z| in [BIN_EDGES[i], BIN_EDGES[i+1]).
+    pub hist: Vec<u32>,
+    /// Per-channel running max-abs (for fallback / floor).
+    pub max_abs: Vec<f32>,
+    /// Per-channel running sum-abs (for mean-abs s_a strategy).
+    pub sum_abs: Vec<f64>,
+    pub count: u64,
+}
+
+pub const NBUCKETS: usize = 64;
+
+/// Log-spaced bin edges from 1e-4 to 1e4 (8 decades, 8 buckets per decade).
+/// Bucket index for value v: `((v.log10() + 4.0) * 8.0).floor()` clamped to
+/// [0, NBUCKETS). Out-of-range high goes to the last bucket; ≤0 is undefined
+/// (we accumulate |z| > 0 only).
+pub fn bin_edges() -> [f32; NBUCKETS + 1] {
+    let mut edges = [0.0f32; NBUCKETS + 1];
+    for i in 0..=NBUCKETS {
+        let log10 = -4.0 + (i as f32) / 8.0;
+        edges[i] = 10f32.powf(log10);
+    }
+    edges
+}
+
+pub fn bucket_for(abs_v: f32) -> usize {
+    if !(abs_v > 0.0) {
+        return 0;
+    }
+    let log10 = abs_v.log10();
+    let raw = ((log10 + 4.0) * 8.0).floor() as i32;
+    raw.clamp(0, NBUCKETS as i32 - 1) as usize
+}
+
+impl CenteredHistogram {
+    pub fn new(mu: Vec<f32>) -> Self {
+        let nc = mu.len();
+        Self {
+            mu,
+            hist: vec![0u32; nc * NBUCKETS],
+            max_abs: vec![0.0f32; nc],
+            sum_abs: vec![0.0f64; nc],
+            count: 0,
+        }
+    }
+
+    pub fn n_channels(&self) -> usize {
+        self.mu.len()
+    }
+
+    pub fn add_batch(&mut self, x: &[f32], n_tokens: usize) {
+        let nc = self.mu.len();
+        debug_assert_eq!(x.len(), n_tokens * nc);
+        for t in 0..n_tokens {
+            let row = &x[t * nc..(t + 1) * nc];
+            for (col, &v) in row.iter().enumerate() {
+                let z = (v - self.mu[col]).abs();
+                self.sum_abs[col] += z as f64;
+                if z > self.max_abs[col] {
+                    self.max_abs[col] = z;
+                }
+                let b = bucket_for(z);
+                self.hist[col * NBUCKETS + b] = self.hist[col * NBUCKETS + b].saturating_add(1);
+            }
+        }
+        self.count += n_tokens as u64;
+    }
+
+    /// Estimate the per-channel `pctile`-th percentile of |x - mu|. Returns
+    /// the upper-edge of the bin where the cumulative fraction crosses the
+    /// percentile (a slight over-estimate, which is the conservative side for
+    /// Q4 fitting — we'd rather widen the bucket than clip too aggressively).
+    pub fn percentile_abs(&self, pctile: f32) -> Vec<f32> {
+        let edges = bin_edges();
+        let nc = self.n_channels();
+        let mut out = Vec::with_capacity(nc);
+        for col in 0..nc {
+            let total: u64 = self.hist[col * NBUCKETS..(col + 1) * NBUCKETS]
+                .iter()
+                .map(|&v| v as u64)
+                .sum();
+            if total == 0 {
+                out.push(0.0);
+                continue;
+            }
+            let target = (total as f32 * pctile / 100.0) as u64;
+            let mut cum: u64 = 0;
+            let mut sel: usize = NBUCKETS - 1;
+            for b in 0..NBUCKETS {
+                cum += self.hist[col * NBUCKETS + b] as u64;
+                if cum >= target {
+                    sel = b;
+                    break;
+                }
+            }
+            // Use upper edge of bin for percentile estimate, capped by
+            // observed max_abs (small bin counts can over-shoot).
+            let est = edges[sel + 1].min(self.max_abs[col].max(edges[sel]));
+            out.push(est);
+        }
+        out
+    }
+
+    pub fn mean_abs(&self) -> Vec<f32> {
+        let n = self.count.max(1) as f64;
+        self.sum_abs.iter().map(|&s| (s / n) as f32).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers — convert FP32 calibration vectors into FP16 storage in
+// place.
+
+pub fn f32_vec_to_f16(src: &[f32]) -> Vec<u16> {
+    src.iter().map(|&v| f32_to_f16(v)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// GPU upload — convert sidecar to GPU-resident form.
+
+/// Compute per-K=256-group activation scales by averaging per-channel s_a
+/// values within each group. Used for the SmoothQuant weight-side bake
+/// (the iu4 GEMM's HFQ4-G256 layout has a single FP32 scale per group, so
+/// the s_a migration must operate at group resolution).
+///
+/// Returns `s_group` with length `n_channels / 256` (must be exact). Uses
+/// the geometric mean by default — matches how s values are commonly
+/// composed in SmoothQuant. Falls back to arithmetic mean if any per-channel
+/// s_a is non-positive (avoids log(0) blowing up).
+pub fn s_group_from_per_channel(s_a: &[f32]) -> Vec<f32> {
+    const GROUP: usize = 256;
+    assert!(s_a.len() % GROUP == 0, "s_a length must be divisible by 256");
+    let n_groups = s_a.len() / GROUP;
+    let mut out = Vec::with_capacity(n_groups);
+    for g in 0..n_groups {
+        let slice = &s_a[g * GROUP..(g + 1) * GROUP];
+        let any_nonpos = slice.iter().any(|&v| !(v > 0.0) || !v.is_finite());
+        if any_nonpos {
+            // Arithmetic mean as fallback; clamp to a small positive floor
+            // so the inv_s preshift doesn't blow up.
+            let sum: f64 = slice.iter().map(|&v| v as f64).sum();
+            let mean = (sum / GROUP as f64) as f32;
+            out.push(mean.max(1e-6));
+        } else {
+            // Geometric mean: exp(mean(log(s))).
+            let log_sum: f64 = slice.iter().map(|&v| (v as f64).ln()).sum();
+            let g_mean = ((log_sum / GROUP as f64).exp()) as f32;
+            out.push(g_mean.max(1e-6));
+        }
+    }
+    out
+}
+
+/// Replace per-channel s_a with the group-broadcast version: for each
+/// channel c, `s_a_grouped[c] = s_group[group(c)]`. Used so the activation
+/// preshift's per-channel `inv_s_a` exactly inverts the weight-side bake's
+/// per-group `s_group` — the math closes at group granularity.
+pub fn broadcast_s_group_to_channels(s_group: &[f32]) -> Vec<f32> {
+    const GROUP: usize = 256;
+    let mut out = Vec::with_capacity(s_group.len() * GROUP);
+    for &v in s_group {
+        for _ in 0..GROUP {
+            out.push(v);
+        }
+    }
+    out
+}
+
+const INV_S_FLOOR: f32 = 1e-6;
+
+/// Upload an in-memory `Iu4Calibration` sidecar to GPU memory. Allocates
+/// per-site FP16 mu/inv_s/s_group buffers and an FP32 W·mu_a bias buffer.
+///
+/// At upload time we apply the group-shared s_a transform: per-channel
+/// `s_a` is reduced to per-K=256-group `s_group` (geometric mean), then
+/// broadcast back to per-channel for the preshift kernel. This guarantees
+/// the math closes exactly at group resolution against the weight-side
+/// bake.
+///
+/// The W·mu_a bias is uploaded as-is (FP16 source on disk → FP16-decoded
+/// FP32 → uploaded as FP32 bytes for the bias_add_f32 kernel).
+pub fn upload_to_gpu(cal: &Iu4Calibration, gpu: &mut Gpu) -> HipResult<GpuIu4Calibration> {
+    let mut sites_gpu = Vec::with_capacity(cal.sites.len());
+    for site in &cal.sites {
+        let nc = site.n_channels as usize;
+        let nm = site.n_output_rows as usize;
+        if nc % 256 != 0 {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "iu4 calibration site n_channels={} not divisible by 256 \
+                 — HFQ4-G256 group bake requires K alignment.", nc
+            )));
+        }
+        let groups_per_row = nc / 256;
+
+        // Decode per-channel s_a and reduce to per-group, then broadcast
+        // back so preshift uses group-constant per-channel scales.
+        let s_a_raw_f32: Vec<f32> = site.s_a.iter().map(|&b| f16_to_f32(b)).collect();
+        let s_group_f32 = s_group_from_per_channel(&s_a_raw_f32);
+        debug_assert_eq!(s_group_f32.len(), groups_per_row);
+        let s_a_grouped_f32 = broadcast_s_group_to_channels(&s_group_f32);
+        debug_assert_eq!(s_a_grouped_f32.len(), nc);
+
+        // Compute per-channel inv_s with a small floor (avoids divide-by-
+        // zero in degenerate channels with no calibration signal).
+        let inv_s_grouped_f32: Vec<f32> = s_a_grouped_f32
+            .iter()
+            .map(|&v| if v > INV_S_FLOOR { 1.0 / v } else { 1.0 / INV_S_FLOOR })
+            .collect();
+
+        // Encode for upload.
+        let mu_a_fp16: Vec<u16> = site.mu_a.clone();
+        let inv_s_a_fp16: Vec<u16> = inv_s_grouped_f32.iter().map(|&v| f32_to_f16(v)).collect();
+        let s_group_fp16: Vec<u16> = s_group_f32.iter().map(|&v| f32_to_f16(v)).collect();
+        let w_mu_bias_f32: Vec<f32> = site.w_mu_bias.iter().map(|&b| f16_to_f32(b)).collect();
+
+        // Upload to GPU.
+        let mu_a_bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(mu_a_fp16.as_ptr() as *const u8, mu_a_fp16.len() * 2)
+        };
+        let inv_s_bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(inv_s_a_fp16.as_ptr() as *const u8, inv_s_a_fp16.len() * 2)
+        };
+        let s_group_bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(s_group_fp16.as_ptr() as *const u8, s_group_fp16.len() * 2)
+        };
+        let bias_bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(w_mu_bias_f32.as_ptr() as *const u8, w_mu_bias_f32.len() * 4)
+        };
+
+        let mu_a_buf = gpu.hip.malloc(mu_a_bytes.len())?;
+        gpu.hip.memcpy_htod(&mu_a_buf, mu_a_bytes)?;
+        let inv_s_buf = gpu.hip.malloc(inv_s_bytes.len())?;
+        gpu.hip.memcpy_htod(&inv_s_buf, inv_s_bytes)?;
+        let s_group_buf = gpu.hip.malloc(s_group_bytes.len())?;
+        gpu.hip.memcpy_htod(&s_group_buf, s_group_bytes)?;
+        let bias_buf = gpu.hip.malloc(bias_bytes.len())?;
+        gpu.hip.memcpy_htod(&bias_buf, bias_bytes)?;
+
+        sites_gpu.push(GpuIu4CalSite {
+            layer_idx: site.layer_idx,
+            proj_id: site.proj_id,
+            n_channels: site.n_channels,
+            n_output_rows: site.n_output_rows,
+            groups_per_row: groups_per_row as u32,
+            mu_a: mu_a_buf,
+            inv_s_a: inv_s_buf,
+            s_group: s_group_buf,
+            w_mu_bias_f32: bias_buf,
+        });
+    }
+    Ok(GpuIu4Calibration { sites: sites_gpu })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_empty() {
+        let cal = Iu4Calibration::new();
+        let mut buf = Vec::new();
+        cal.write_to(&mut buf).unwrap();
+        let mut cur = std::io::Cursor::new(buf);
+        let back = Iu4Calibration::read_from(&mut cur).unwrap();
+        assert_eq!(back.n_sites(), 0);
+    }
+
+    #[test]
+    fn roundtrip_single_site() {
+        let mut cal = Iu4Calibration::new();
+        let mut s = Iu4CalSite::new(0, 1, 16, 8);
+        for i in 0..16 {
+            s.mu_a[i] = f32_to_f16((i as f32) * 0.1);
+            s.s_a[i] = f32_to_f16(0.5 + (i as f32) * 0.01);
+        }
+        for i in 0..8 {
+            s.w_mu_bias[i] = f32_to_f16((i as f32) * 0.25);
+        }
+        cal.sites.push(s);
+
+        let mut buf = Vec::new();
+        cal.write_to(&mut buf).unwrap();
+
+        let mut cur = std::io::Cursor::new(buf);
+        let back = Iu4Calibration::read_from(&mut cur).unwrap();
+        assert_eq!(back.n_sites(), 1);
+        let s2 = &back.sites[0];
+        assert_eq!(s2.layer_idx, 0);
+        assert_eq!(s2.proj_id, 1);
+        assert_eq!(s2.n_channels, 16);
+        assert_eq!(s2.n_output_rows, 8);
+        assert_eq!(s2.mu_a.len(), 16);
+        assert_eq!(s2.s_a.len(), 16);
+        assert_eq!(s2.w_mu_bias.len(), 8);
+        // bit-exact roundtrip on FP16 fields
+        assert_eq!(s2.mu_a[5], f32_to_f16(0.5));
+    }
+
+    #[test]
+    fn bucket_monotone() {
+        assert_eq!(bucket_for(0.0), 0);
+        let bsmall = bucket_for(1e-3);
+        let bmid = bucket_for(1.0);
+        let bbig = bucket_for(100.0);
+        assert!(bsmall < bmid);
+        assert!(bmid < bbig);
+    }
+
+    #[test]
+    fn percentile_basic() {
+        // Single channel, 10000 samples uniform in [-1, 1] → 99% of |x|
+        // should be ≤ ~0.99.
+        let mu = vec![0.0f32];
+        let mut h = CenteredHistogram::new(mu);
+        let mut state = 0xC0FFEEu64;
+        let n = 10000usize;
+        let mut x = Vec::with_capacity(n);
+        for _ in 0..n {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            let t = ((state >> 33) as f32) / (u32::MAX as f32);
+            x.push(t * 2.0 - 1.0);
+        }
+        h.add_batch(&x, n);
+        let p99 = h.percentile_abs(99.0)[0];
+        // log-spaced bucket: edge near 1.0 should land us within [0.56, 1.78]
+        // (8 buckets per decade, log10(1.0)=0 → edges 1.0 and 1.33).
+        assert!(p99 >= 0.5 && p99 <= 2.0, "p99 = {p99}");
+    }
+}

--- a/crates/engine/src/quant/mod.rs
+++ b/crates/engine/src/quant/mod.rs
@@ -1,0 +1,9 @@
+//! Quantization sidecars and runtime calibration data.
+//!
+//! Currently provides:
+//!   - `iu4_calibration` — runtime SmoothQuant-style activation calibration
+//!     for the gfx12 iu4 K=32 GEMM path. Sidecar produced offline by
+//!     `examples/calibrate_iu4_activations.rs`, loaded at model-load time
+//!     when `<model>.iu4cal` exists alongside the model file.
+
+pub mod iu4_calibration;

--- a/crates/rdna-compute/examples/build_check_fp8_gfx12.rs
+++ b/crates/rdna-compute/examples/build_check_fp8_gfx12.rs
@@ -1,0 +1,67 @@
+//! gfx12 (RDNA4) FP8 (E4M3) HFQ4 residual GEMM kernel build-check.
+//!
+//! Compile-only validation that hipcc accepts the new
+//! `gemm_hfq4g256_residual_fp8.gfx12.hip` source on gfx1201 silicon. Calls
+//! `Gpu::ensure_kernel_public` for `gemm_hfq4g256_residual_fp8_gfx12` —
+//! the function-load step exercises hipcc/lld end-to-end (FP8 wmma builtin
+//! lowering + cvt_pk_fp8_f32 codegen) without dispatching the kernel.
+//! Useful as a CI gate before wiring the kernel into Rust dispatch (a
+//! separate task — first cut leaves the dispatch fn opt-in only via direct
+//! call, NOT routed from production prefill).
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example build_check_fp8_gfx12
+//!
+//! On non-gfx12 archs the kernel stubs out via the `#if HIPFIRE_GFX12` guard,
+//! so the example still verifies the source compiles cleanly through the
+//! Rust-side hipcc pipeline (just doesn't exercise the FP8 wmma codegen).
+
+use rdna_compute::Gpu;
+
+// Embed the kernel source directly. The const in `rdna_compute::kernels` is
+// not pub-reexported — examples consume the .hip file straight via
+// include_str! (matches the pattern in `build_check_mmq_gfx12.rs` and the
+// gfx12 layout probes' rust callers).
+const GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC: &str =
+    include_str!("../../../kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip");
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    let is_gfx12 = arch == "gfx1200" || arch == "gfx1201";
+    if !is_gfx12 {
+        eprintln!(
+            "INFO: arch {arch} is not gfx12 — the kernel will stub out via \
+             the #if HIPFIRE_GFX12 guard, but we still compile the source to \
+             catch parse/preprocessor errors."
+        );
+    }
+
+    eprintln!("\n--- compiling gemm_hfq4g256_residual_fp8_gfx12 ---");
+    gpu.ensure_kernel_public(
+        "gemm_hfq4g256_residual_fp8_gfx12",
+        GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC,
+        "gemm_hfq4g256_residual_fp8_gfx12",
+    )
+    .expect("gemm_hfq4g256_residual_fp8_gfx12 compile/load failed");
+    eprintln!("  OK");
+
+    if is_gfx12 {
+        eprintln!(
+            "\nPASS: kernel compiled and loaded cleanly on {arch}. \
+             hipcc accepts the gfx12 FP8 source (FP8 wmma builtin + \
+             cvt_pk_fp8_f32 codegen exercised). Next step: wire dispatch \
+             entry point through production routing and run a numeric \
+             correctness test against the FP16 dequant->WMMA reference \
+             (separate task)."
+        );
+    } else {
+        eprintln!(
+            "\nPASS (stub mode): kernel compiled cleanly on {arch} via the \
+             non-gfx12 stub branch. Re-run on gfx1200/gfx1201 to exercise \
+             the FP8 wmma codegen path."
+        );
+    }
+}

--- a/crates/rdna-compute/examples/build_check_iu4_gfx12.rs
+++ b/crates/rdna-compute/examples/build_check_iu4_gfx12.rs
@@ -1,0 +1,81 @@
+//! gfx12 (RDNA4) iu4 K=32 HFQ4 residual GEMM + Q4_1 quantizer build-check.
+//!
+//! Compile-only validation that hipcc accepts the new
+//! `gemm_hfq4g256_residual_iu4.gfx12.hip` and `quantize_q4_1.gfx12.hip`
+//! sources on gfx1201 silicon. Calls `Gpu::ensure_kernel_public` for both
+//! `quantize_q4_1_mmq_ds4_gfx12` and `gemm_hfq4g256_residual_iu4_gfx12` —
+//! the function-load step exercises hipcc/lld end-to-end (iu4 K=32 wmma
+//! builtin lowering + INT4 byte-pack codegen) without dispatching either
+//! kernel.
+//!
+//! Useful as a CI gate before wiring the kernel into Rust dispatch (a
+//! separate task — first cut leaves `gemm_hfq4g256_residual_iu4_gfx12`
+//! opt-in only via direct call, NOT routed from production prefill).
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example build_check_iu4_gfx12
+//!
+//! On non-gfx12 archs both kernels stub out via the `#if HIPFIRE_GFX12`
+//! guard, so the example still verifies the source compiles cleanly through
+//! the Rust-side hipcc pipeline (just doesn't exercise the iu4 wmma codegen).
+
+use rdna_compute::Gpu;
+
+// Embed the kernel sources directly. The const in `rdna_compute::kernels` is
+// not pub-reexported — examples consume the .hip file straight via
+// include_str! (matches the pattern in `build_check_fp8_gfx12.rs` and the
+// gfx12 layout probes' rust callers).
+const QUANTIZE_Q4_1_GFX12_SRC: &str =
+    include_str!("../../../kernels/src/quantize_q4_1.gfx12.hip");
+const GEMM_HFQ4G256_RESIDUAL_IU4_GFX12_SRC: &str =
+    include_str!("../../../kernels/src/gemm_hfq4g256_residual_iu4.gfx12.hip");
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    let is_gfx12 = arch == "gfx1200" || arch == "gfx1201";
+    if !is_gfx12 {
+        eprintln!(
+            "INFO: arch {arch} is not gfx12 — both kernels will stub out via \
+             the #if HIPFIRE_GFX12 guard, but we still compile the source to \
+             catch parse/preprocessor errors."
+        );
+    }
+
+    eprintln!("\n--- compiling quantize_q4_1_mmq_ds4_gfx12 ---");
+    gpu.ensure_kernel_public(
+        "quantize_q4_1_mmq_ds4_gfx12",
+        QUANTIZE_Q4_1_GFX12_SRC,
+        "quantize_q4_1_mmq_ds4_gfx12",
+    )
+    .expect("quantize_q4_1_mmq_ds4_gfx12 compile/load failed");
+    eprintln!("  OK");
+
+    eprintln!("\n--- compiling gemm_hfq4g256_residual_iu4_gfx12 ---");
+    gpu.ensure_kernel_public(
+        "gemm_hfq4g256_residual_iu4_gfx12",
+        GEMM_HFQ4G256_RESIDUAL_IU4_GFX12_SRC,
+        "gemm_hfq4g256_residual_iu4_gfx12",
+    )
+    .expect("gemm_hfq4g256_residual_iu4_gfx12 compile/load failed");
+    eprintln!("  OK");
+
+    if is_gfx12 {
+        eprintln!(
+            "\nPASS: both kernels compiled and loaded cleanly on {arch}. \
+             hipcc accepts the gfx12 iu4 K=32 source (iu4 wmma builtin + \
+             INT4 byte-pack codegen exercised). Next step: run a numeric \
+             correctness test against the FP16 dequant->WMMA reference \
+             (separate task — wire ensure_q4_1_x + \
+             gemm_hfq4g256_residual_iu4_gfx12 into a smoke harness)."
+        );
+    } else {
+        eprintln!(
+            "\nPASS (stub mode): both kernels compiled cleanly on {arch} via \
+             the non-gfx12 stub branch. Re-run on gfx1200/gfx1201 to exercise \
+             the iu4 K=32 wmma codegen path."
+        );
+    }
+}

--- a/crates/rdna-compute/examples/build_check_mmq_gfx12.rs
+++ b/crates/rdna-compute/examples/build_check_mmq_gfx12.rs
@@ -1,0 +1,74 @@
+//! gfx12 (RDNA4) MMQ kernel build-check.
+//!
+//! Compile-only validation that hipcc accepts the new
+//! `gemm_hfq4g256_residual_mmq.gfx12.hip` source on gfx1201 silicon. Calls
+//! `Gpu::ensure_kernel_public` for both `quantize_q8_1_mmq_ds4_gfx12` and
+//! `gemm_hfq4g256_residual_mmq_gfx12` — the function-load step exercises
+//! hipcc/lld end-to-end without dispatching either kernel. Useful as a CI
+//! gate before wiring the kernels into Rust dispatch (a separate task).
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example build_check_mmq_gfx12
+//!
+//! On non-gfx12 archs the kernels stub out via the `#if HIPFIRE_GFX12` guard,
+//! so the example still verifies the source compiles cleanly through the
+//! Rust-side hipcc pipeline (just doesn't exercise the WMMA codegen path).
+//! On those archs we still attempt to load both functions to surface any
+//! preprocessor / parse errors early.
+
+use rdna_compute::Gpu;
+
+// Embed the kernel source directly. The const in `rdna_compute::kernels` is
+// not pub-reexported — examples consume the .hip file straight via
+// include_str! (matches the pattern used by the gfx12 layout probes' rust
+// callers, which only need the source string for ensure_kernel).
+const GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC: &str =
+    include_str!("../../../kernels/src/gemm_hfq4g256_residual_mmq.gfx12.hip");
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    let is_gfx12 = arch == "gfx1200" || arch == "gfx1201";
+    if !is_gfx12 {
+        eprintln!(
+            "INFO: arch {arch} is not gfx12 — the kernels will stub out via \
+             the #if HIPFIRE_GFX12 guard, but we still compile the source to \
+             catch parse/preprocessor errors."
+        );
+    }
+
+    eprintln!("\n--- compiling quantize_q8_1_mmq_ds4_gfx12 ---");
+    gpu.ensure_kernel_public(
+        "gemm_hfq4g256_residual_mmq_gfx12",
+        GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC,
+        "quantize_q8_1_mmq_ds4_gfx12",
+    )
+    .expect("quantize_q8_1_mmq_ds4_gfx12 compile/load failed");
+    eprintln!("  OK");
+
+    eprintln!("\n--- compiling gemm_hfq4g256_residual_mmq_gfx12 ---");
+    gpu.ensure_kernel_public(
+        "gemm_hfq4g256_residual_mmq_gfx12",
+        GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC,
+        "gemm_hfq4g256_residual_mmq_gfx12",
+    )
+    .expect("gemm_hfq4g256_residual_mmq_gfx12 compile/load failed");
+    eprintln!("  OK");
+
+    if is_gfx12 {
+        eprintln!(
+            "\nPASS: both kernels compiled and loaded cleanly on {arch}. \
+             hipcc accepts the gfx12 MMQ source. Next step: wire dispatch \
+             entry points and run a numeric correctness test against the \
+             RDNA3 reference (separate task)."
+        );
+    } else {
+        eprintln!(
+            "\nPASS (stub mode): kernels compiled cleanly on {arch} via the \
+             non-gfx12 stub branch. Re-run on gfx1200/gfx1201 to exercise \
+             the WMMA codegen path."
+        );
+    }
+}

--- a/crates/rdna-compute/examples/probe_wmma_fp8_layout.rs
+++ b/crates/rdna-compute/examples/probe_wmma_fp8_layout.rs
@@ -1,0 +1,133 @@
+//! gfx12 (RDNA4) FP8 (E4M3) WMMA layout-discovery probe — issue #136 part B.
+//!
+//! Probes `__builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12` on gfx1201
+//! to confirm the wave32 layout before writing an FP8 GEMM port. The iu4 K=32
+//! and iu8 K=16 probes both discovered an 8-row-block acc layout — first guess
+//! is FP8 wmma uses the same.
+//!
+//! Per CK header amd_wmma.hpp: signature is
+//!   wmma_f32_16x16x16_fp8_fp8_w32_gfx12(int32x2 a, int32x2 b, float8 acc) -> float8
+//! No clamp/sign args. Acc is 8 FP32 per lane.
+//!
+//! Patterns (one wave per launch, dumped to consecutive 256-FP32 regions):
+//!   0 — A=B=1.0                 → every entry = 16.0 (sanity)
+//!   1 — A[m][k]=(m+1).0, B=1.0  → acc[l, j] = 16 * (8*(l>>4) + j + 1)
+//!   2 — A=1.0, B[k][n]=(n+1).0  → acc[l, j] = 16 * ((l & 0xF) + 1)
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example probe_wmma_fp8_layout
+
+use rdna_compute::{DType, Gpu};
+
+fn pattern_label(p: usize) -> &'static str {
+    match p {
+        0 => "A=1.0, B=1.0",
+        1 => "A=row-id+1.0, B=1.0",
+        2 => "A=1.0, B=col-id+1.0",
+        _ => "?",
+    }
+}
+
+fn expected_pattern(p: usize, lane: usize, slot: usize) -> f32 {
+    // First guess: 8-row-block acc layout (same as iu4/iu8).
+    let row = (8 * (lane >> 4) + slot) as f32;
+    let col = (lane & 0xF) as f32;
+    match p {
+        0 => 16.0,
+        1 => 16.0 * (row + 1.0),
+        2 => 16.0 * (col + 1.0),
+        _ => 0.0,
+    }
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!(
+            "SKIP: this probe requires gfx1200/gfx1201 (RDNA4). \
+             Current arch: {arch}. The FP8 wmma builtin only exists on RDNA4."
+        );
+        std::process::exit(0);
+    }
+
+    eprintln!("\n=== gfx12 FP8 (E4M3) WMMA layout-discovery probe ===");
+    eprintln!(
+        "First-guess wave32 layout (8-row-block, matching iu4/iu8):\n  \
+         A input: int32x2/lane = 8 FP8 bytes = K-half of one row\n  \
+         B input: int32x2/lane (same shape)\n  \
+         acc:     float8/lane. lane l, slot j → C[8*(l>>4) + j][l & 0xF]"
+    );
+
+    let out = gpu.alloc_tensor(&[3 * 32 * 8], DType::F32).expect("alloc out");
+
+    gpu.probe_wmma_fp8_layout(&out)
+        .expect("probe dispatch failed");
+
+    let host: Vec<f32> = gpu.download_f32(&out).expect("download out");
+    assert_eq!(host.len(), 3 * 256);
+
+    // FP8 → FP32 mul has perfect representation for integer values 1..16
+    // (E4M3 represents these exactly). The accumulated dot product sums 16
+    // exact integers, which fits exactly in FP32. So the comparison is
+    // bit-exact in principle — use a tiny tolerance to absorb any
+    // accumulator-order rounding.
+    const TOL: f32 = 1e-4;
+
+    let mut all_pass = true;
+
+    for p in 0..3 {
+        let region = &host[p * 256..(p + 1) * 256];
+        let mut mismatches: Vec<(usize, usize, f32, f32)> = Vec::new();
+        for lane in 0..32 {
+            for slot in 0..8 {
+                let v = region[lane * 8 + slot];
+                let want = expected_pattern(p, lane, slot);
+                if (v - want).abs() > TOL {
+                    mismatches.push((lane, slot, v, want));
+                }
+            }
+        }
+        let pat_pass = mismatches.is_empty();
+        all_pass &= pat_pass;
+
+        eprintln!("\n--- pattern {p} ({}) — {} ---",
+                  pattern_label(p),
+                  if pat_pass { "PASS" } else { "MISMATCH (first-guess layout is wrong)" });
+        if pat_pass {
+            eprintln!("  every (lane, slot) matched expected_pattern(p, lane, slot).");
+        } else {
+            eprintln!("  {} mismatches (showing first 32):", mismatches.len());
+            for (lane, slot, got, want) in mismatches.iter().take(32) {
+                eprintln!("    lane {lane:>2}, slot {slot}: got {got:>10.4}, want {want:>10.4}");
+            }
+            eprintln!("\n  full per-lane dump for pattern {p}:");
+            for lane in 0..32 {
+                let s = &region[lane * 8..(lane + 1) * 8];
+                eprintln!("    lane {lane:>2}: {s:?}");
+            }
+        }
+    }
+
+    if all_pass {
+        eprintln!(
+            "\nPASS: all three patterns matched. gfx12 FP8 (E4M3) wmma wave32 \
+             layout is the same 8-row-block as iu4/iu8:\n  \
+             A input: int32x2/lane (8 FP8 = K-half of one row)\n  \
+             B input: int32x2/lane (same shape)\n  \
+             acc:     float8/lane. lane l, slot j → C[8*(l>>4) + j][l & 0xF]\n\
+             Safe to write the FP8 GEMM port using this layout — same acc-store \
+             path as iu8 MMQ, just with FP32 acc instead of INT32."
+        );
+        std::process::exit(0);
+    } else {
+        eprintln!(
+            "\nFAIL: at least one pattern mismatched. Inspect the per-lane dump \
+             above to extract the actual layout map before writing the FP8 GEMM \
+             port."
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/examples/probe_wmma_iu4_k32.rs
+++ b/crates/rdna-compute/examples/probe_wmma_iu4_k32.rs
@@ -1,0 +1,89 @@
+//! gfx12 (RDNA4) iu4 K=32 WMMA probe — POC for issue #136 part B.
+//!
+//! Validates that `__builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12` works
+//! correctly on gfx1201 silicon (R9700, 9070 XT). Probe-1 uses A=B=all-ones
+//! (every INT4 = 1); expected output at every (m, n) in the 16x16 result is
+//! `sum_{k=0..31} 1*1 = 32`. This is layout-independent — every lane should
+//! read 32 in every accumulator slot — so it's a clean yes/no on whether
+//! the intrinsic dispatches and accumulates correctly without first having
+//! to discover the per-lane element layout.
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example probe_wmma_iu4_k32
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {}", arch);
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!(
+            "SKIP: this probe requires gfx1200/gfx1201 (RDNA4). \
+             Current arch: {arch}. The iu4 K=32 builtin only exists on RDNA4."
+        );
+        std::process::exit(0);
+    }
+
+    eprintln!("\n=== gfx12 iu4 K=32 WMMA probe-1: all-ones ===");
+    eprintln!(
+        "Input A: 16x32 INT4, every value = 1 (packed as 0x11111111 per int)\n\
+         Input B: 16x32 INT4, every value = 1\n\
+         Expected C[m][n] = sum_{{k=0..31}} 1*1 = 32 for every (m, n)\n\
+         Expected per-lane accumulator: every one of the 8 ints = 32"
+    );
+
+    // Output: 32 lanes x 8 ints = 256 i32. Allocate as F32 (same 4 bytes/element);
+    // the kernel writes int32 and we reinterpret on the host side.
+    let out = gpu.alloc_tensor(&[32 * 8], DType::F32).expect("alloc out");
+
+    gpu.probe_wmma_iu4_k32_allones(&out)
+        .expect("probe dispatch failed");
+
+    // Sync, read back as i32 by reinterpreting the f32 download (the
+    // download path doesn't have a dedicated i32 helper). We allocated
+    // the tensor as I32 so the byte layout is correct; we just need to
+    // get the bytes back.
+    let raw_f32 = gpu.download_f32(&out).expect("download out");
+    // Same-byte reinterpret f32 -> i32 element-wise.
+    let out_host: Vec<i32> = raw_f32
+        .iter()
+        .map(|f| f.to_bits() as i32)
+        .collect();
+
+    let n_outputs = 32 * 8;
+    let mut all_pass = true;
+    let mut nonzero = 0usize;
+    let mut histogram = std::collections::BTreeMap::<i32, usize>::new();
+    for &v in &out_host {
+        *histogram.entry(v).or_insert(0) += 1;
+        if v != 0 {
+            nonzero += 1;
+        }
+        if v != 32 {
+            all_pass = false;
+        }
+    }
+
+    eprintln!("\n--- result histogram (value : count out of {n_outputs}) ---");
+    for (v, c) in &histogram {
+        eprintln!("  {v:>10} : {c}");
+    }
+    eprintln!("non-zero entries: {nonzero}/{n_outputs}");
+
+    if all_pass {
+        eprintln!("\nPASS: every accumulator entry = 32. wmma_i32_16x16x32_iu4_w32_gfx12 works on {arch}.");
+        std::process::exit(0);
+    } else {
+        eprintln!(
+            "\nFAIL: not every entry equals 32. The intrinsic ran (output is {nonzero}/{n_outputs} non-zero) \
+             but produced unexpected values. Per-lane dump below."
+        );
+        for lane in 0..32 {
+            let slice = &out_host[lane * 8..(lane + 1) * 8];
+            eprintln!("  lane {lane:>2}: {slice:?}");
+        }
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/examples/probe_wmma_iu4_k32_layout.rs
+++ b/crates/rdna-compute/examples/probe_wmma_iu4_k32_layout.rs
@@ -1,0 +1,133 @@
+//! gfx12 (RDNA4) iu4 K=32 WMMA layout-discovery probe — issue #136 part B.
+//!
+//! Runs three patterns through `__builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12`
+//! to confirm the wave32 WMMA layout before writing the production GEMM port.
+//!
+//! Confirmed layout (gfx12 iu4 K=32 wmma, wave32) — discovered 2026-05-03 on R9700:
+//!   A input: lane l → row m = l & 0xF, k-half = l >> 4. v2i[0]/v2i[1] each
+//!            pack 8 INT4 of that half-row.
+//!   B input: lane l → col n = l & 0xF, k-half = l >> 4.
+//!   acc:     lane l, slot j ∈ [0,7] → C[8*(l>>4) + j][l & 0xF].
+//!
+//! This is an **8-row-block** layout — DIFFERENT from the RDNA3
+//! wmma_f32_16x16x16_f16 stride-2 interleave (slot j → row 2j + (l>>4)).
+//! Lanes 0..15 own rows 0..7, lanes 16..31 own rows 8..15. The production
+//! GEMM port writes acc-to-C using this 8-row-block formula.
+//!
+//! Patterns (run in one wave, dumped to consecutive 256-i32 regions):
+//!   0 — A=ones, B=ones    → every entry = 32 (sanity)
+//!   1 — A=row-id, B=ones  → acc[l, j] = 32 * (8*(l>>4) + j), independent of (l & 0xF)
+//!   2 — A=ones, B=col-id  → acc[l, j] = 32 * (l & 0xF), same across all 8 slots
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example probe_wmma_iu4_k32_layout
+
+use rdna_compute::{DType, Gpu};
+
+fn pattern_label(p: usize) -> &'static str {
+    match p {
+        0 => "A=ones, B=ones",
+        1 => "A=row-id, B=ones",
+        2 => "A=ones, B=col-id",
+        _ => "?",
+    }
+}
+
+fn expected_pattern(p: usize, lane: usize, slot: usize) -> i32 {
+    // 8-row-block acc layout: lane l, slot j → C[8*(l>>4) + j][l & 0xF].
+    let row = (8 * (lane >> 4) + slot) as i32;
+    let col = (lane & 0xF) as i32;
+    match p {
+        0 => 32,
+        1 => 32 * row,
+        2 => 32 * col,
+        _ => 0,
+    }
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!(
+            "SKIP: this probe requires gfx1200/gfx1201 (RDNA4). \
+             Current arch: {arch}. The iu4 K=32 builtin only exists on RDNA4."
+        );
+        std::process::exit(0);
+    }
+
+    eprintln!("\n=== gfx12 iu4 K=32 WMMA layout-discovery probe ===");
+    eprintln!(
+        "Confirmed wave32 layout (locked in 2026-05-03 on R9700):\n  \
+         A input: lane l → row m = l & 0xF, k-half = l >> 4\n  \
+         B input: lane l → col n = l & 0xF, k-half = l >> 4\n  \
+         acc:     lane l, slot j → C[8*(l>>4) + j][l & 0xF]   (8-row-block, NOT RDNA3 stride-2)"
+    );
+
+    // 3 patterns × 32 lanes × 8 slots = 768 i32. Allocate as F32, byte-reinterpret.
+    let out = gpu.alloc_tensor(&[3 * 32 * 8], DType::F32).expect("alloc out");
+
+    gpu.probe_wmma_iu4_k32_layout(&out)
+        .expect("probe dispatch failed");
+
+    let raw_f32 = gpu.download_f32(&out).expect("download out");
+    let host: Vec<i32> = raw_f32.iter().map(|f| f.to_bits() as i32).collect();
+    assert_eq!(host.len(), 3 * 256);
+
+    let mut all_pass = true;
+
+    for p in 0..3 {
+        let region = &host[p * 256..(p + 1) * 256];
+        let mut mismatches: Vec<(usize, usize, i32, i32)> = Vec::new();
+        for lane in 0..32 {
+            for slot in 0..8 {
+                let v = region[lane * 8 + slot];
+                let want = expected_pattern(p, lane, slot);
+                if v != want {
+                    mismatches.push((lane, slot, v, want));
+                }
+            }
+        }
+        let pat_pass = mismatches.is_empty();
+        all_pass &= pat_pass;
+
+        eprintln!("\n--- pattern {p} ({}) — {} ---",
+                  pattern_label(p),
+                  if pat_pass { "PASS" } else { "MISMATCH (assumed layout is wrong)" });
+        if pat_pass {
+            // Print first row of expected for context.
+            eprintln!("  every (lane, slot) matched expected_pattern(p, lane, slot).");
+        } else {
+            eprintln!("  {} mismatches (showing first 32):", mismatches.len());
+            for (lane, slot, got, want) in mismatches.iter().take(32) {
+                eprintln!("    lane {lane:>2}, slot {slot}: got {got:>5}, want {want:>5}");
+            }
+            // Full per-lane dump for offline analysis.
+            eprintln!("\n  full per-lane dump for pattern {p}:");
+            for lane in 0..32 {
+                let s = &region[lane * 8..(lane + 1) * 8];
+                eprintln!("    lane {lane:>2}: {s:?}");
+            }
+        }
+    }
+
+    if all_pass {
+        eprintln!(
+            "\nPASS: all three patterns matched. gfx12 iu4 K=32 WMMA wave32 layout is:\n  \
+             A input: lane l → row m = l & 0xF, k-half = l >> 4\n  \
+             B input: lane l → col n = l & 0xF, k-half = l >> 4\n  \
+             acc:     lane l, slot j → C[8*(l>>4) + j][l & 0xF]\n\
+             Safe to write the production GEMM port against this layout."
+        );
+        std::process::exit(0);
+    } else {
+        eprintln!(
+            "\nFAIL: at least one pattern did not match the assumed layout. \
+             Inspect per-lane dump above to extract the actual layout map \
+             before writing the production GEMM port."
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/examples/probe_wmma_iu8_k16_layout.rs
+++ b/crates/rdna-compute/examples/probe_wmma_iu8_k16_layout.rs
@@ -1,0 +1,128 @@
+//! gfx12 (RDNA4) iu8 K=16 WMMA layout-discovery probe — issue #136 part B.
+//!
+//! Probes `__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32` on gfx1201 to confirm
+//! the wave32 layout before porting the existing RDNA3 MMQ kernel
+//! (`gemm_hfq4g256_residual_mmq.hip`) to gfx12. The iu4 K=32 probe discovered
+//! an 8-row-block acc layout — this probe checks whether iu8 K=16 follows
+//! the same layout or differs.
+//!
+//! First-guess layout (same as iu4 K=32):
+//!   A input: lane l → row m = l & 0xF, k-half = l >> 4 (8 INT8/half = int32x2 per lane)
+//!   B input: lane l → col n = l & 0xF, k-half = l >> 4
+//!   acc:     lane l, slot j ∈ [0,7] → C[8*(l>>4) + j][l & 0xF]
+//!
+//! Patterns (one wave per launch, dumped to consecutive 256-i32 regions):
+//!   0 — A=1, B=1               → every entry = 16 (sanity)
+//!   1 — A[m][k]=m+1, B=1       → acc[l, j] = 16 * (8*(l>>4) + j + 1)
+//!   2 — A=1, B[k][n]=n+1       → acc[l, j] = 16 * ((l & 0xF) + 1), all 8 slots same
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example probe_wmma_iu8_k16_layout
+
+use rdna_compute::{DType, Gpu};
+
+fn pattern_label(p: usize) -> &'static str {
+    match p {
+        0 => "A=1, B=1",
+        1 => "A=row-id+1, B=1",
+        2 => "A=1, B=col-id+1",
+        _ => "?",
+    }
+}
+
+fn expected_pattern(p: usize, lane: usize, slot: usize) -> i32 {
+    // First guess: 8-row-block acc layout (same as iu4 K=32).
+    let row = (8 * (lane >> 4) + slot) as i32;
+    let col = (lane & 0xF) as i32;
+    match p {
+        0 => 16,
+        1 => 16 * (row + 1),
+        2 => 16 * (col + 1),
+        _ => 0,
+    }
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!(
+            "SKIP: this probe requires gfx1200/gfx1201 (RDNA4). \
+             Current arch: {arch}. The iu8 K=16 builtin works on RDNA3 too \
+             but with a different lane layout — see the RDNA3 MMQ kernel."
+        );
+        std::process::exit(0);
+    }
+
+    eprintln!("\n=== gfx12 iu8 K=16 WMMA layout-discovery probe ===");
+    eprintln!(
+        "First-guess wave32 layout (8-row-block, matching iu4 K=32):\n  \
+         A input: lane l → row m = l & 0xF, k-half = l >> 4\n  \
+         B input: lane l → col n = l & 0xF, k-half = l >> 4\n  \
+         acc:     lane l, slot j → C[8*(l>>4) + j][l & 0xF]"
+    );
+
+    let out = gpu.alloc_tensor(&[3 * 32 * 8], DType::F32).expect("alloc out");
+
+    gpu.probe_wmma_iu8_k16_layout(&out)
+        .expect("probe dispatch failed");
+
+    let raw_f32 = gpu.download_f32(&out).expect("download out");
+    let host: Vec<i32> = raw_f32.iter().map(|f| f.to_bits() as i32).collect();
+    assert_eq!(host.len(), 3 * 256);
+
+    let mut all_pass = true;
+
+    for p in 0..3 {
+        let region = &host[p * 256..(p + 1) * 256];
+        let mut mismatches: Vec<(usize, usize, i32, i32)> = Vec::new();
+        for lane in 0..32 {
+            for slot in 0..8 {
+                let v = region[lane * 8 + slot];
+                let want = expected_pattern(p, lane, slot);
+                if v != want {
+                    mismatches.push((lane, slot, v, want));
+                }
+            }
+        }
+        let pat_pass = mismatches.is_empty();
+        all_pass &= pat_pass;
+
+        eprintln!("\n--- pattern {p} ({}) — {} ---",
+                  pattern_label(p),
+                  if pat_pass { "PASS" } else { "MISMATCH (first-guess layout is wrong)" });
+        if pat_pass {
+            eprintln!("  every (lane, slot) matched expected_pattern(p, lane, slot).");
+        } else {
+            eprintln!("  {} mismatches (showing first 32):", mismatches.len());
+            for (lane, slot, got, want) in mismatches.iter().take(32) {
+                eprintln!("    lane {lane:>2}, slot {slot}: got {got:>5}, want {want:>5}");
+            }
+            eprintln!("\n  full per-lane dump for pattern {p}:");
+            for lane in 0..32 {
+                let s = &region[lane * 8..(lane + 1) * 8];
+                eprintln!("    lane {lane:>2}: {s:?}");
+            }
+        }
+    }
+
+    if all_pass {
+        eprintln!(
+            "\nPASS: all three patterns matched the first-guess layout. \
+             gfx12 iu8 K=16 WMMA wave32 layout is the same 8-row-block as iu4 K=32:\n  \
+             A input: lane l → row m = l & 0xF, k-half = l >> 4\n  \
+             B input: lane l → col n = l & 0xF, k-half = l >> 4\n  \
+             acc:     lane l, slot j → C[8*(l>>4) + j][l & 0xF]\n\
+             The MMQ port can use the same acc-store path as the iu4 GEMM port."
+        );
+        std::process::exit(0);
+    } else {
+        eprintln!(
+            "\nFAIL: at least one pattern mismatched. Inspect the per-lane dump \
+             above to extract the actual layout map before porting the MMQ kernel."
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/examples/test_fp8_gfx12_correctness.rs
+++ b/crates/rdna-compute/examples/test_fp8_gfx12_correctness.rs
@@ -1,0 +1,234 @@
+//! gfx12 (RDNA4) HFQ4-G256 FP8 GEMM correctness test (issue #136 part B).
+//!
+//! Compares the new gfx12 FP8 (E4M3) residual GEMM kernel
+//! (`gemm_hfq4g256_residual_fp8_gfx12`, commit c77e1d1) against the existing
+//! gfx12 FP16 dequant→WMMA reference path. Same shape as the iu8 MMQ
+//! correctness test (test_mmq_gfx12_correctness.rs) but with looser
+//! tolerances since FP8 has ~3-bit mantissa precision (vs Q8_1's ~7 bits).
+//!
+//! Expected error sources:
+//!   - FP8 weight cast: HFQ4 dequant → FP32 → FP8 introduces E4M3 rounding
+//!     (~3% relative per weight element).
+//!   - FP8 activation cast: FP32 → FP8 with per-(tile_y col) dynamic scale.
+//!     Adds another rounding pass.
+//!   - Saturation: if any activation × scale exceeds E4M3_MAX (=448), it
+//!     saturates. Synthetic test inputs are bounded to avoid this.
+//!
+//! PASS thresholds (FP8-realistic, calibrated against R9700 measurements):
+//!   max abs err        < 0.20   (catches algorithmic bugs: layout, saturation, bounds)
+//!   mean abs err       < 0.02   (average drift bound)
+//!   max rel err†       < 0.75   (E4M3 worst-case on small-magnitude outputs)
+//!   mean rel err†      < 0.10   (per-element distribution drift)
+//!   pct rel-err > 10%† < 25%    (thin-tail bound — FP8 has more than MMQ)
+//!
+//! Rel-err metrics are looser than the MMQ test by an order of magnitude
+//! because FP8 has materially worse per-element precision than Q8_1.
+//! Empirically at K=512, mean_rel_err≈1.6%; at K=2048 it grows to ~6%
+//! (super-√K — likely amax-statistic noise widening with K in the per-kb
+//! scale calc). Production K runs 2K-27K, so thresholds are sized for that.
+//!
+//! † Rel-err only on elements where |fp16_output| > REL_FLOOR (0.1).
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example test_fp8_gfx12_correctness
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let m: usize = std::env::var("M").ok().and_then(|s| s.parse().ok()).unwrap_or(256);
+    let k: usize = std::env::var("K").ok().and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n: usize = std::env::var("N").ok().and_then(|s| s.parse().ok()).unwrap_or(128);
+
+    assert!(k % 256 == 0, "K must be a multiple of 256 for HFQ4-G256");
+    assert!(m % 16 == 0);
+    assert!(n % 16 == 0);
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!(
+            "SKIP: this test requires gfx1200/gfx1201 (RDNA4). \
+             Current arch: {arch}. The gfx12 FP8 GEMM kernel only exists on RDNA4."
+        );
+        std::process::exit(0);
+    }
+
+    eprintln!("=== gfx12 FP8 vs FP16-WMMA correctness test ===");
+    eprintln!("M={m}, K={k}, N={n}");
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+
+    // Random HFQ4-G256 weights (deterministic).
+    let weight_bytes: Vec<u8> = synth_hfq4g256_weights(m, groups_per_row, 0xC0DE_FACEu64);
+    let a_raw = gpu.upload_raw(&weight_bytes, &[m * row_bytes]).expect("upload weights");
+
+    // Random FP32 activations (deterministic) bounded to ±1 (well under E4M3_MAX=448).
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(1103515245).wrapping_add(12345)) as f32;
+            (v * 1e-9) % 2.0 - 1.0
+        })
+        .collect();
+    let y_init_host: Vec<f32> = (0..n * m)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(2147483647).wrapping_add(7)) as f32;
+            (v * 1e-7) % 1.0
+        })
+        .collect();
+
+    let x_gpu = gpu.alloc_tensor(&[n * k], DType::F32).expect("alloc x");
+    let y_fp16 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_fp16");
+    let y_fp8 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_fp8");
+
+    gpu.hip.memcpy_htod(&x_gpu.buf, bytes_of(&x_host)).unwrap();
+
+    // Path A: FP16 dequant → WMMA gfx12 reference.
+    gpu.hip.memcpy_htod(&y_fp16.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.gemm_hfq4g256_residual_wmma_gfx12(&a_raw, &x_gpu, &y_fp16, m, k, n)
+        .expect("fp16 wmma gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_fp16_host: Vec<f32> = gpu.download_f32(&y_fp16).expect("download y_fp16");
+
+    // Path B: FP8 GEMM gfx12 (in-kernel HFQ4 dequant → FP8 → wmma).
+    gpu.hip.memcpy_htod(&y_fp8.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.gemm_hfq4g256_residual_fp8_gfx12(&a_raw, &x_gpu, &y_fp8, m, k, n)
+        .expect("fp8 gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_fp8_host: Vec<f32> = gpu.download_f32(&y_fp8).expect("download y_fp8");
+
+    assert_eq!(y_fp16_host.len(), n * m);
+    assert_eq!(y_fp8_host.len(), n * m);
+
+    // Compare per channel; rel-err floor at |out| > 0.1 (looser than the MMQ
+    // test's 0.05 floor since FP8 noise is larger).
+    const REL_FLOOR: f32 = 0.1;
+    let mut max_abs_err: f32 = 0.0;
+    let mut max_rel_err: f32 = 0.0;
+    let mut sum_abs_err: f64 = 0.0;
+    let mut sum_rel_err: f64 = 0.0;
+    let mut max_loc: (usize, usize) = (0, 0);
+    let mut samples_above_10pct: usize = 0;
+    let mut rel_eligible: usize = 0;
+
+    for col in 0..n {
+        for row in 0..m {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_fp8_host[idx];
+            let err = (a - b).abs();
+            if err > max_abs_err {
+                max_abs_err = err;
+                max_loc = (col, row);
+            }
+            sum_abs_err += err as f64;
+            if a.abs() > REL_FLOOR {
+                let rel = err / a.abs();
+                if rel > max_rel_err { max_rel_err = rel; }
+                sum_rel_err += rel as f64;
+                rel_eligible += 1;
+                if rel > 0.10 { samples_above_10pct += 1; }
+            }
+        }
+    }
+
+    let total = (n * m) as f64;
+    let mean_abs_err = sum_abs_err / total;
+    let mean_rel_err = if rel_eligible > 0 { sum_rel_err / (rel_eligible as f64) } else { 0.0 };
+    let pct_above = 100.0 * samples_above_10pct as f32 / rel_eligible.max(1) as f32;
+
+    eprintln!("\n--- per-channel error (n*m = {} elements) ---", n * m);
+    eprintln!("  max abs err:                       {:.6}  at (col={}, row={})",
+              max_abs_err, max_loc.0, max_loc.1);
+    eprintln!("  mean abs err:                      {:.6}", mean_abs_err);
+    eprintln!("  rel-err eligible (|out| > {:.2}):    {} / {} ({:.1}%)",
+              REL_FLOOR, rel_eligible, n * m,
+              100.0 * rel_eligible as f32 / (n * m) as f32);
+    eprintln!("  max rel err†:                      {:.4}", max_rel_err);
+    eprintln!("  mean rel err†:                     {:.4}", mean_rel_err);
+    eprintln!("  samples > 10% rel†:                {} / {} ({:.3}%)",
+              samples_above_10pct, rel_eligible.max(1), pct_above);
+    eprintln!("  † counted only on non-near-zero outputs (|out| > {REL_FLOOR})");
+
+    // Sample triples for human eyeball.
+    eprintln!("\n--- sample triples (col=0..2, row=0..4) ---");
+    for col in 0..2.min(n) {
+        for row in 0..4.min(m) {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_fp8_host[idx];
+            eprintln!("  col={col} row={row}: fp16={a:>10.4}  fp8={b:>10.4}  err={:.4}", (a - b).abs());
+        }
+    }
+
+    // PASS thresholds. Substantially looser than the MMQ test because:
+    //   - E4M3 has ~3-bit mantissa (vs Q8_1's effective ~7 bits)
+    //   - Per-tile dynamic scale on activations adds another rounding pass
+    //   - Empirically: at K=512, mean_rel_err is ~1.6%; at K=2048 it grows to
+    //     ~6% (super-√K scaling — likely amax-statistic noise widening with K
+    //     in the per-kb scale calculation). Production K runs 2K-27K.
+    // The max-abs metric is the meaningful "did the kernel work" signal; rel
+    // metrics catch distribution drift but need to tolerate FP8 reality.
+    let max_abs_thresh = 0.20;     // catches algorithmic bugs (saturation, layout, bounds)
+    let mean_abs_thresh = 0.02;    // average output drift bound
+    let max_rel_thresh = 0.75;     // E4M3 worst-case on small-magnitude outputs
+    let mean_rel_thresh = 0.10;    // per-element distribution drift (10% accepted for FP8)
+    let pct_thresh = 25.0;         // up to 25% of elements may exceed 10% rel-err on FP8
+
+    let max_abs_ok = max_abs_err < max_abs_thresh;
+    let mean_abs_ok = (mean_abs_err as f32) < mean_abs_thresh;
+    let max_rel_ok = max_rel_err < max_rel_thresh;
+    let mean_rel_ok = (mean_rel_err as f32) < mean_rel_thresh;
+    let pct_ok = pct_above < pct_thresh;
+
+    eprintln!("\n--- PASS criteria (FP8 E4M3 expected ~3-bit mantissa precision) ---");
+    eprintln!("  max abs err   < {max_abs_thresh}:   {}", if max_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean abs err  < {mean_abs_thresh}:   {}", if mean_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  max rel err†  < {max_rel_thresh}:   {}", if max_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean rel err† < {mean_rel_thresh}:   {}", if mean_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  pct >10% rel† < {pct_thresh}%: {}", if pct_ok { "OK" } else { "FAIL" });
+
+    if max_abs_ok && mean_abs_ok && max_rel_ok && mean_rel_ok && pct_ok {
+        eprintln!("\nPASS: gfx12 FP8 GEMM is numerically equivalent to FP16 WMMA reference \
+                   within E4M3 precision tolerance.");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL: gfx12 FP8 GEMM diverges from FP16 WMMA reference beyond E4M3 \
+                   tolerance. Investigate before flipping any default routing.");
+        std::process::exit(1);
+    }
+}
+
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            let scale_bits = 0x3a000000u32 | (next() & 0x007F_FFFF);
+            let zp_bits = ((next() & 0x80) << 24) | 0x39000000u32 | (next() & 0x007F_FFFF);
+            let scale = f32::from_bits(scale_bits);
+            let zp = f32::from_bits(zp_bits);
+            let scale_ok = if scale.is_finite() && scale.abs() < 1e-2 && scale > 0.0 { scale } else { 1e-3 };
+            let zp_ok = if zp.is_finite() && zp.abs() < 1.0 { zp } else { -0.5 };
+            out[gp..gp + 4].copy_from_slice(&scale_ok.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp_ok.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/test_fp8_shadow_smoke.rs
+++ b/crates/rdna-compute/examples/test_fp8_shadow_smoke.rs
@@ -1,0 +1,118 @@
+//! Smoke test for the gfx12 FP8 weight preload path.
+//!
+//! Allocates a small synthetic HFQ4-G256 weight tensor, runs the FP8 dequant
+//! kernel via `ensure_fp8_shadow`, downloads the resulting FP8 bytes, decodes
+//! a few back to FP32 (via the reverse OCP E4M3 mapping) and compares against
+//! the FP16 reference dequant. Expected divergence: bounded by E4M3 precision
+//! (~1.5% relative for typical HFQ4 dequantized weights).
+//!
+//! The point of this test is NOT exhaustive correctness — it's "the new
+//! ensure_fp8_shadow helper actually launches the kernel, populates the cache,
+//! and the FP8 bytes round-trip to plausible FP32 values."
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example test_fp8_shadow_smoke
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let m: usize = 256;
+    let k: usize = 512;
+    assert!(k % 256 == 0);
+    let groups_per_row = k / 256;
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!("SKIP: ensure_fp8_shadow is gfx12-only.");
+        std::process::exit(0);
+    }
+
+    // Synth HFQ4-G256 weights: 4 B FP32 scale + 4 B FP32 zero + 128 B nibbles
+    // per group. Use a stable scale (0.1) and zero (0.0) so the dequant outputs
+    // are easy to reason about: w = 0.1 * q for q in 0..15, range [0, 1.5].
+    let row_bytes = groups_per_row * 136;
+    let mut weight_bytes = vec![0u8; m * row_bytes];
+    let mut state = 0xDEAD_BEEFu64;
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            weight_bytes[gp..gp + 4].copy_from_slice(&0.1f32.to_le_bytes());
+            weight_bytes[gp + 4..gp + 8].copy_from_slice(&0.0f32.to_le_bytes());
+            for i in 0..128 {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                weight_bytes[gp + 8 + i] = (state >> 32) as u8;  // random nibble pairs
+            }
+        }
+    }
+
+    let a_raw = gpu.upload_raw(&weight_bytes, &[m * row_bytes]).expect("upload weights");
+    // Wrap as a GpuTensor with an HFQ4-flavor dtype so ensure_fp8_shadow can key on it.
+    // upload_raw returns a Raw-dtype tensor; that's fine — ensure_fp8_shadow only
+    // uses the buf pointer + the (m, k) dims passed in.
+
+    eprintln!("\n=== ensure_fp8_shadow smoke ===");
+    eprintln!("HFQ4 weight: M={m}, K={k}, {} bytes", m * row_bytes);
+
+    let fp8_ptr = gpu
+        .ensure_fp8_shadow(&a_raw, m, k)
+        .expect("ensure_fp8_shadow")
+        .expect("must return Some on gfx12");
+    eprintln!("FP8 shadow ptr: {:p}", fp8_ptr);
+
+    // Second call should hit the cache and return the same pointer.
+    let fp8_ptr2 = gpu
+        .ensure_fp8_shadow(&a_raw, m, k)
+        .expect("ensure_fp8_shadow #2")
+        .expect("must return Some");
+    assert_eq!(fp8_ptr as usize, fp8_ptr2 as usize, "cache should return the same ptr");
+    eprintln!("cache hit on 2nd call: ptr identical OK");
+
+    // Read FP8 bytes back via raw download (allocate a fresh GpuTensor wrapping
+    // the cached buffer). Easier: just allocate our own + dequant directly.
+    let fp8_buf = gpu.alloc_tensor(&[m * k], DType::Raw).expect("alloc fp8");
+    gpu.dequantize_hfq4g256_to_fp8_gfx12(&a_raw.buf, &fp8_buf.buf, m, k)
+        .expect("direct dequant");
+
+    // download_raw doesn't exist; use the lower-level memcpy_dtoh on the buffer.
+    let mut fp8_bytes: Vec<u8> = vec![0u8; m * k];
+    gpu.hip.memcpy_dtoh(&mut fp8_bytes, &fp8_buf.buf).expect("dtoh fp8 bytes");
+
+    // Decode a sample of FP8 bytes back to FP32. OCP E4M3 (1 sign + 4 exp + 3 mantissa,
+    // bias 7). 0x00 = +0; 0x80 = -0; 0x7F = NaN; everything else = (-1)^s * 2^(e-7) * 1.mmm.
+    fn fp8_e4m3_to_f32(b: u8) -> f32 {
+        let sign = if b & 0x80 != 0 { -1.0f32 } else { 1.0f32 };
+        let exp = (b >> 3) & 0x0F;
+        let mantissa = (b & 0x07) as f32;
+        if exp == 0 {
+            // Subnormal: value = sign * 2^(1 - bias) * (mantissa / 8)
+            return sign * (mantissa / 8.0) * 2f32.powi(-6);
+        }
+        if exp == 0x0F && (b & 0x07) == 0x07 { return f32::NAN; }
+        sign * (1.0 + mantissa / 8.0) * 2f32.powi(exp as i32 - 7)
+    }
+
+    eprintln!("\n--- sample first 16 FP8 bytes (row 0, K=0..15) ---");
+    let mut max_err: f32 = 0.0;
+    for i in 0..16 {
+        let q_byte_offset = (i / 2) as usize;
+        let q_byte = weight_bytes[8 + q_byte_offset];
+        let q = if i & 1 == 0 { (q_byte & 0x0F) as f32 } else { (q_byte >> 4) as f32 };
+        let want_fp32 = 0.1f32 * q;
+        let got_fp32 = fp8_e4m3_to_f32(fp8_bytes[i]);
+        let err = (got_fp32 - want_fp32).abs();
+        max_err = max_err.max(err);
+        eprintln!("  K={i:>2}: q={q:>2}  want={want_fp32:.4}  fp8_byte=0x{:02x}  got={got_fp32:.4}  err={err:.4}",
+                  fp8_bytes[i], );
+    }
+
+    eprintln!("\nmax abs err over 16 samples: {max_err:.4}");
+    if max_err < 0.1 {
+        eprintln!("PASS: ensure_fp8_shadow + dequantize_hfq4g256_to_fp8_gfx12 round-trip OK");
+        std::process::exit(0);
+    } else {
+        eprintln!("FAIL: FP8 dequant decoded values diverge from FP16 reference beyond E4M3 expected tolerance.");
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/examples/test_iu4_calibration_correctness.rs
+++ b/crates/rdna-compute/examples/test_iu4_calibration_correctness.rs
@@ -69,13 +69,21 @@ fn main() {
         state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
         ((state >> 33) as f32) / (u32::MAX as f32)
     };
+    // Two regimes:
+    //   - REGIME=normal (default): synthetic data with ±1 typical, ±5 outliers.
+    //     Tests the math at the favorable activation scale.
+    //   - REGIME=tiny: synthetic data scaled to ±0.03 range (mimicking real
+    //     post-rmsnorm activations entering wo). Tests the bake math when
+    //     inv_s ≈ 33 (huge per-channel scale).
+    let regime = std::env::var("REGIME").unwrap_or_else(|_| "normal".to_string());
+    let act_scale: f32 = if regime == "tiny" { 0.03 } else { 1.0 };
     let x_host: Vec<f32> = (0..n * k)
         .map(|_| {
             let u = nrand();
             let v = nrand() * 2.0 - 1.0;
             // 1% outliers at ±5×, the rest within ±1.
             let mag = if u > 0.99 { 5.0 } else { 1.0 };
-            v * mag
+            v * mag * act_scale
         })
         .collect();
     let y_init_host: Vec<f32> = (0..n * m)

--- a/crates/rdna-compute/examples/test_iu4_calibration_correctness.rs
+++ b/crates/rdna-compute/examples/test_iu4_calibration_correctness.rs
@@ -1,0 +1,417 @@
+//! gfx12 (RDNA4) HFQ4-G256 iu4 K=32 GEMM with SmoothQuant-style activation
+//! calibration — correctness test.
+//!
+//! This is the calibrated companion to `test_iu4_gfx12_correctness.rs`. It
+//! exercises the calibrated dispatch path:
+//!
+//!   1. activation_preshift_gfx12     (x_centered = (x - mu) * inv_s)
+//!   2. quantize_q4_1_mmq_ds4_gfx12   (Q4_1 of x_centered, unchanged)
+//!   3. iu4_bake_weight_scales_gfx12  (W * s_group baked into a clone)
+//!   4. gemm_hfq4g256_residual_iu4    (unchanged kernel; consumes baked W)
+//!   5. bias_add_f32                   (broadcast W·mu_a bias on output)
+//!
+//! Compares against the existing FP16 dequant→WMMA reference. Calibrated
+//! iu4 should be SUBSTANTIALLY tighter than raw iu4 (since the math
+//! closes at group resolution + the activation-distribution shape is now
+//! mean-zero / unit-variance per group rather than raw FP16).
+//!
+//! Calibration in this test is SYNTHETIC — we compute mu from the same
+//! random activation matrix the test uses, then derive s_a from the same
+//! data. That's the best-case "perfect" calibration; production calibration
+//! has corpus-vs-runtime distribution drift on top.
+//!
+//! PASS thresholds (substantially tighter than raw-iu4's 0.30/0.15):
+//!   max abs err        < 0.20
+//!   mean abs err       < 0.02
+//!   max rel err†       < 0.5
+//!   mean rel err†      < 0.10
+//!   pct rel-err > 10%† < 30%
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example test_iu4_calibration_correctness
+
+use rdna_compute::{
+    iu4_calibration::{GpuIu4CalSite, GpuIu4Calibration},
+    DType, Gpu,
+};
+
+fn main() {
+    let m: usize = std::env::var("M").ok().and_then(|s| s.parse().ok()).unwrap_or(256);
+    let k: usize = std::env::var("K").ok().and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n: usize = std::env::var("N").ok().and_then(|s| s.parse().ok()).unwrap_or(128);
+
+    assert!(k % 256 == 0);
+    assert!(m % 16 == 0);
+    assert!(n % 16 == 0);
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!("SKIP: requires gfx1200/gfx1201 (RDNA4). Current: {arch}");
+        std::process::exit(0);
+    }
+
+    eprintln!("=== gfx12 calibrated iu4 K=32 vs FP16-WMMA correctness test ===");
+    eprintln!("M={m}, K={k}, N={n}");
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+
+    let weight_bytes: Vec<u8> = synth_hfq4g256_weights(m, groups_per_row, 0xC0DE_FACEu64);
+    let a_raw = gpu.upload_raw(&weight_bytes, &[m * row_bytes]).expect("upload weights");
+
+    // Synthesize activation. Heavy-tail flavoring: 99% Gaussian-ish in
+    // [-1, 1], 1% in [-5, 5] — this is what Q4_1 raw fails on and what
+    // SmoothQuant should fix.
+    let mut state: u64 = 0xDEAD_BEEF;
+    let mut nrand = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((state >> 33) as f32) / (u32::MAX as f32)
+    };
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|_| {
+            let u = nrand();
+            let v = nrand() * 2.0 - 1.0;
+            // 1% outliers at ±5×, the rest within ±1.
+            let mag = if u > 0.99 { 5.0 } else { 1.0 };
+            v * mag
+        })
+        .collect();
+    let y_init_host: Vec<f32> = (0..n * m)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(2147483647).wrapping_add(7)) as f32;
+            (v * 1e-7) % 1.0
+        })
+        .collect();
+
+    let x_gpu = gpu.alloc_tensor(&[n * k], DType::F32).expect("alloc x");
+    let y_fp16 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_fp16");
+    let y_iu4 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_iu4");
+
+    gpu.hip.memcpy_htod(&x_gpu.buf, bytes_of(&x_host)).unwrap();
+
+    // Path A: FP16 dequant → WMMA gfx12 reference (with the residual init).
+    gpu.hip.memcpy_htod(&y_fp16.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.gemm_hfq4g256_residual_wmma_gfx12(&a_raw, &x_gpu, &y_fp16, m, k, n)
+        .expect("fp16 wmma gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_fp16_host: Vec<f32> = gpu.download_f32(&y_fp16).expect("download y_fp16");
+
+    // Build a synthetic calibration FROM THE TEST DATA. Compute per-channel
+    // mu and s_a (99-pctile-abs after centering). Compute W·mu_a bias by
+    // CPU-dequanting the synthetic weight and dotting against mu_a.
+    eprintln!("--- building synthetic calibration from test data ---");
+    let mu_a: Vec<f32> = compute_mu(&x_host, n, k);
+    let s_a_per_channel: Vec<f32> = compute_p99_abs(&x_host, &mu_a, n, k);
+    // Expand to group-shared form via geomean within each K=256 group.
+    let s_group: Vec<f32> = s_group_geomean(&s_a_per_channel);
+    let s_a_grouped: Vec<f32> = broadcast_s_group(&s_group);
+    let inv_s_a_grouped: Vec<f32> = s_a_grouped
+        .iter()
+        .map(|&v| if v > 1e-6 { 1.0 / v } else { 1.0 })
+        .collect();
+    let bias: Vec<f32> = compute_bias(&weight_bytes, &mu_a, m, k);
+
+    // Upload calibration to GPU.
+    let mu_fp16: Vec<u16> = mu_a.iter().map(|&v| f32_to_f16(v)).collect();
+    let inv_s_fp16: Vec<u16> = inv_s_a_grouped.iter().map(|&v| f32_to_f16(v)).collect();
+    let s_group_fp16: Vec<u16> = s_group.iter().map(|&v| f32_to_f16(v)).collect();
+    let mu_buf = gpu.hip.malloc(mu_fp16.len() * 2).unwrap();
+    gpu.hip.memcpy_htod(&mu_buf, bytes_of_u16(&mu_fp16)).unwrap();
+    let inv_s_buf = gpu.hip.malloc(inv_s_fp16.len() * 2).unwrap();
+    gpu.hip.memcpy_htod(&inv_s_buf, bytes_of_u16(&inv_s_fp16)).unwrap();
+    let s_group_buf = gpu.hip.malloc(s_group_fp16.len() * 2).unwrap();
+    gpu.hip.memcpy_htod(&s_group_buf, bytes_of_u16(&s_group_fp16)).unwrap();
+    let bias_buf = gpu.hip.malloc(bias.len() * 4).unwrap();
+    gpu.hip.memcpy_htod(&bias_buf, bytes_of(&bias)).unwrap();
+
+    let cal = GpuIu4Calibration {
+        sites: vec![GpuIu4CalSite {
+            layer_idx: 0,
+            proj_id: 0,
+            n_channels: k as u32,
+            n_output_rows: m as u32,
+            groups_per_row: groups_per_row as u32,
+            mu_a: mu_buf,
+            inv_s_a: inv_s_buf,
+            s_group: s_group_buf,
+            w_mu_bias_f32: bias_buf,
+        }],
+    };
+    gpu.load_iu4_calibration(cal);
+
+    // Path B: calibrated iu4. Set the env var so dispatch takes the path,
+    // pre-init y, then call gemm_hfq4g256_residual which in turn dispatches
+    // through the calibrated branch.
+    std::env::set_var("HIPFIRE_GFX12_IU4_CALIBRATED", "1");
+    gpu.hip.memcpy_htod(&y_iu4.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.reset_iu4_dispatch_counter();
+    gpu.gemm_hfq4g256_residual(&a_raw, &x_gpu, &y_iu4, m, k, n)
+        .expect("calibrated iu4 dispatch");
+    gpu.hip.device_synchronize().unwrap();
+    std::env::remove_var("HIPFIRE_GFX12_IU4_CALIBRATED");
+
+    let y_iu4_host: Vec<f32> = gpu.download_f32(&y_iu4).expect("download y_iu4");
+
+    assert_eq!(y_fp16_host.len(), n * m);
+    assert_eq!(y_iu4_host.len(), n * m);
+
+    // Compare.
+    const REL_FLOOR: f32 = 0.1;
+    let mut max_abs_err: f32 = 0.0;
+    let mut max_rel_err: f32 = 0.0;
+    let mut sum_abs_err: f64 = 0.0;
+    let mut sum_rel_err: f64 = 0.0;
+    let mut max_loc: (usize, usize) = (0, 0);
+    let mut samples_above_10pct: usize = 0;
+    let mut rel_eligible: usize = 0;
+
+    for col in 0..n {
+        for row in 0..m {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_iu4_host[idx];
+            let err = (a - b).abs();
+            if err > max_abs_err {
+                max_abs_err = err;
+                max_loc = (col, row);
+            }
+            sum_abs_err += err as f64;
+            if a.abs() > REL_FLOOR {
+                let rel = err / a.abs();
+                if rel > max_rel_err {
+                    max_rel_err = rel;
+                }
+                sum_rel_err += rel as f64;
+                rel_eligible += 1;
+                if rel > 0.10 {
+                    samples_above_10pct += 1;
+                }
+            }
+        }
+    }
+
+    let total = (n * m) as f64;
+    let mean_abs_err = sum_abs_err / total;
+    let mean_rel_err = if rel_eligible > 0 {
+        sum_rel_err / rel_eligible as f64
+    } else {
+        0.0
+    };
+    let pct_above = 100.0 * samples_above_10pct as f32 / rel_eligible.max(1) as f32;
+
+    eprintln!("\n--- per-channel error (n*m = {} elements) ---", n * m);
+    eprintln!("  max abs err:           {:.6}  at (col={}, row={})", max_abs_err, max_loc.0, max_loc.1);
+    eprintln!("  mean abs err:          {:.6}", mean_abs_err);
+    eprintln!("  rel-err eligible:      {} / {} ({:.1}%)", rel_eligible, n * m,
+        100.0 * rel_eligible as f32 / (n * m) as f32);
+    eprintln!("  max rel err†:          {:.4}", max_rel_err);
+    eprintln!("  mean rel err†:         {:.4}", mean_rel_err);
+    eprintln!("  samples > 10% rel†:    {} / {} ({:.1}%)",
+        samples_above_10pct, rel_eligible.max(1), pct_above);
+
+    eprintln!("\n--- sample triples ---");
+    for col in 0..2.min(n) {
+        for row in 0..4.min(m) {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_iu4_host[idx];
+            eprintln!(
+                "  col={col} row={row}: fp16={a:>10.4}  cal_iu4={b:>10.4}  err={:.4}",
+                (a - b).abs()
+            );
+        }
+    }
+
+    // Tighter thresholds than raw iu4 — calibration should shrink errors
+    // ~3-5× depending on activation tail mass.
+    let max_abs_thresh = 0.20;
+    let mean_abs_thresh = 0.02;
+    let max_rel_thresh = 0.5;
+    let mean_rel_thresh = 0.10;
+    let pct_thresh = 30.0;
+
+    let max_abs_ok = max_abs_err < max_abs_thresh;
+    let mean_abs_ok = (mean_abs_err as f32) < mean_abs_thresh;
+    let max_rel_ok = max_rel_err < max_rel_thresh;
+    let mean_rel_ok = (mean_rel_err as f32) < mean_rel_thresh;
+    let pct_ok = pct_above < pct_thresh;
+
+    eprintln!("\n--- PASS criteria (calibrated iu4 — tighter than raw) ---");
+    eprintln!("  max abs err   < {max_abs_thresh}:  {}", if max_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean abs err  < {mean_abs_thresh}: {}", if mean_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  max rel err†  < {max_rel_thresh}:  {}", if max_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean rel err† < {mean_rel_thresh}: {}", if mean_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  pct >10% rel† < {pct_thresh}%:    {}", if pct_ok { "OK" } else { "FAIL" });
+
+    if max_abs_ok && mean_abs_ok && max_rel_ok && mean_rel_ok && pct_ok {
+        eprintln!("\nPASS: gfx12 calibrated iu4 GEMM tighter than raw iu4 — SmoothQuant working.");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL: calibrated iu4 not converging within expected tolerance.");
+        std::process::exit(1);
+    }
+}
+
+fn compute_mu(x: &[f32], n: usize, k: usize) -> Vec<f32> {
+    let mut sum = vec![0.0f64; k];
+    for t in 0..n {
+        for c in 0..k {
+            sum[c] += x[t * k + c] as f64;
+        }
+    }
+    sum.into_iter().map(|s| (s / n as f64) as f32).collect()
+}
+
+fn compute_p99_abs(x: &[f32], mu: &[f32], n: usize, k: usize) -> Vec<f32> {
+    // Not a true percentile — sample max-abs after centering, multiply by
+    // 0.85 as a proxy for "above-99-pctile clipping". Fast and good enough
+    // for synthetic test data where the distribution is symmetric.
+    let mut max_abs = vec![0.0f32; k];
+    for t in 0..n {
+        for c in 0..k {
+            let v = (x[t * k + c] - mu[c]).abs();
+            if v > max_abs[c] {
+                max_abs[c] = v;
+            }
+        }
+    }
+    max_abs.into_iter().map(|v| (v * 0.85).max(1e-4)).collect()
+}
+
+fn s_group_geomean(s_a: &[f32]) -> Vec<f32> {
+    const GROUP: usize = 256;
+    assert!(s_a.len() % GROUP == 0);
+    let n_groups = s_a.len() / GROUP;
+    let mut out = Vec::with_capacity(n_groups);
+    for g in 0..n_groups {
+        let slice = &s_a[g * GROUP..(g + 1) * GROUP];
+        let log_sum: f64 = slice.iter().map(|&v| (v as f64).ln()).sum();
+        let g_mean = ((log_sum / GROUP as f64).exp()) as f32;
+        out.push(g_mean.max(1e-6));
+    }
+    out
+}
+
+fn broadcast_s_group(s_group: &[f32]) -> Vec<f32> {
+    const GROUP: usize = 256;
+    let mut out = Vec::with_capacity(s_group.len() * GROUP);
+    for &v in s_group {
+        for _ in 0..GROUP {
+            out.push(v);
+        }
+    }
+    out
+}
+
+fn compute_bias(weight_bytes: &[u8], mu: &[f32], m: usize, k: usize) -> Vec<f32> {
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+    let mut bias = vec![0.0f32; m];
+    for r in 0..m {
+        let row_off = r * row_bytes;
+        let mut acc = 0.0f64;
+        for g in 0..groups_per_row {
+            let off = row_off + g * 136;
+            let scale = f32::from_le_bytes([
+                weight_bytes[off + 0],
+                weight_bytes[off + 1],
+                weight_bytes[off + 2],
+                weight_bytes[off + 3],
+            ]);
+            let zero = f32::from_le_bytes([
+                weight_bytes[off + 4],
+                weight_bytes[off + 5],
+                weight_bytes[off + 6],
+                weight_bytes[off + 7],
+            ]);
+            for i in 0..256 {
+                let nibbles = &weight_bytes[off + 8..off + 136];
+                let byte_idx = i / 2;
+                let nibble = if i % 2 == 0 {
+                    nibbles[byte_idx] & 0xF
+                } else {
+                    nibbles[byte_idx] >> 4
+                };
+                let w = scale * (nibble as f32) + zero;
+                acc += (w as f64) * (mu[g * 256 + i] as f64);
+            }
+        }
+        bias[r] = acc as f32;
+    }
+    bias
+}
+
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            let scale_bits = 0x3a000000u32 | (next() & 0x007F_FFFF);
+            let zp_bits = ((next() & 0x80) << 24) | 0x39000000u32 | (next() & 0x007F_FFFF);
+            let scale = f32::from_bits(scale_bits);
+            let zp = f32::from_bits(zp_bits);
+            let scale_ok = if scale.is_finite() && scale.abs() < 1e-2 && scale > 0.0 {
+                scale
+            } else {
+                1e-3
+            };
+            let zp_ok = if zp.is_finite() && zp.abs() < 1.0 {
+                zp
+            } else {
+                -0.5
+            };
+            out[gp..gp + 4].copy_from_slice(&scale_ok.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp_ok.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+// Local FP16 conversion (no engine-side dependency to keep this test
+// self-contained inside rdna-compute).
+fn f32_to_f16(val: f32) -> u16 {
+    let bits = val.to_bits();
+    let sign = (bits >> 31) & 1;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let frac = bits & 0x7FFFFF;
+    if exp == 0xFF {
+        let f16_frac = if frac == 0 { 0 } else { (frac >> 13) | 1 };
+        return ((sign << 15) | (0x1F << 10) | f16_frac) as u16;
+    }
+    let new_exp = exp - 127 + 15;
+    if new_exp >= 31 {
+        return ((sign << 15) | (0x1F << 10)) as u16;
+    }
+    if new_exp <= 0 {
+        if new_exp < -10 {
+            return (sign << 15) as u16;
+        }
+        let frac_with_implicit = frac | (1 << 23);
+        let shift = 14 - new_exp as u32;
+        let f16_frac = (frac_with_implicit >> shift) as u16;
+        return ((sign << 15) as u16) | f16_frac;
+    }
+    let f16_frac = (frac >> 13) as u16;
+    ((sign << 15) as u16) | ((new_exp as u16) << 10) | f16_frac
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}
+
+fn bytes_of_u16(v: &[u16]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 2) }
+}

--- a/crates/rdna-compute/examples/test_iu4_gfx12_correctness.rs
+++ b/crates/rdna-compute/examples/test_iu4_gfx12_correctness.rs
@@ -1,0 +1,210 @@
+//! gfx12 (RDNA4) HFQ4-G256 iu4 K=32 GEMM correctness test (issue #136 part B).
+//!
+//! Compares the new gfx12 iu4 K=32 residual GEMM kernel
+//! (`gemm_hfq4g256_residual_iu4_gfx12`, commit faace73) + the Q4_1 activation
+//! quantizer against the existing gfx12 FP16 dequant→WMMA reference path.
+//!
+//! Expected error sources:
+//!   - Q4_1 activation quant: signed INT4 in [-7,7] = ~14% precision per
+//!     element pre-accumulation. Bigger noise floor than Q8_1 (~0.8%) by ~8×.
+//!   - Per-K=32 sub-block d/sum metadata round-trip.
+//!   - HFQ4 weight is consumed AS-IS as iu4 — no FP8/FP16 cast loss on the
+//!     weight side.
+//!
+//! PASS thresholds (looser than MMQ + tighter than FP8; calibrated for Q4_1):
+//!   max abs err        < 0.30   (E4M3 was 0.20 — Q4_1 has bigger range hits)
+//!   mean abs err       < 0.03
+//!   max rel err†       < 1.0    (Q4_1 worst-case on near-floor outputs)
+//!   mean rel err†      < 0.15   (15% per-element noise — Q4_1 reality)
+//!   pct rel-err > 10%† < 50%    (Q4_1 has substantial elements above 10% rel)
+//!
+//! † Rel-err only on elements where |fp16_output| > REL_FLOOR (0.1).
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example test_iu4_gfx12_correctness
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let m: usize = std::env::var("M").ok().and_then(|s| s.parse().ok()).unwrap_or(256);
+    let k: usize = std::env::var("K").ok().and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n: usize = std::env::var("N").ok().and_then(|s| s.parse().ok()).unwrap_or(128);
+
+    assert!(k % 256 == 0);
+    assert!(m % 16 == 0);
+    assert!(n % 16 == 0);
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!("SKIP: requires gfx1200/gfx1201 (RDNA4). Current: {arch}");
+        std::process::exit(0);
+    }
+
+    eprintln!("=== gfx12 iu4 K=32 vs FP16-WMMA correctness test ===");
+    eprintln!("M={m}, K={k}, N={n}");
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+
+    let weight_bytes: Vec<u8> = synth_hfq4g256_weights(m, groups_per_row, 0xC0DE_FACEu64);
+    let a_raw = gpu.upload_raw(&weight_bytes, &[m * row_bytes]).expect("upload weights");
+
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(1103515245).wrapping_add(12345)) as f32;
+            (v * 1e-9) % 2.0 - 1.0
+        })
+        .collect();
+    let y_init_host: Vec<f32> = (0..n * m)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(2147483647).wrapping_add(7)) as f32;
+            (v * 1e-7) % 1.0
+        })
+        .collect();
+
+    let x_gpu = gpu.alloc_tensor(&[n * k], DType::F32).expect("alloc x");
+    let y_fp16 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_fp16");
+    let y_iu4 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_iu4");
+
+    gpu.hip.memcpy_htod(&x_gpu.buf, bytes_of(&x_host)).unwrap();
+
+    // Path A: FP16 dequant → WMMA gfx12 reference.
+    gpu.hip.memcpy_htod(&y_fp16.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.gemm_hfq4g256_residual_wmma_gfx12(&a_raw, &x_gpu, &y_fp16, m, k, n)
+        .expect("fp16 wmma gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_fp16_host: Vec<f32> = gpu.download_f32(&y_fp16).expect("download y_fp16");
+
+    // Path B: iu4 K=32 gfx12 (Q4_1 prequant + iu4 wmma).
+    gpu.hip.memcpy_htod(&y_iu4.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    let xq_ptr = gpu.ensure_q4_1_x(&x_gpu, n, k).expect("ensure_q4_1_x");
+    gpu.gemm_hfq4g256_residual_iu4_gfx12(&a_raw, xq_ptr, &y_iu4, m, k, n, true)
+        .expect("iu4 gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_iu4_host: Vec<f32> = gpu.download_f32(&y_iu4).expect("download y_iu4");
+
+    assert_eq!(y_fp16_host.len(), n * m);
+    assert_eq!(y_iu4_host.len(), n * m);
+
+    const REL_FLOOR: f32 = 0.1;
+    let mut max_abs_err: f32 = 0.0;
+    let mut max_rel_err: f32 = 0.0;
+    let mut sum_abs_err: f64 = 0.0;
+    let mut sum_rel_err: f64 = 0.0;
+    let mut max_loc: (usize, usize) = (0, 0);
+    let mut samples_above_10pct: usize = 0;
+    let mut rel_eligible: usize = 0;
+
+    for col in 0..n {
+        for row in 0..m {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_iu4_host[idx];
+            let err = (a - b).abs();
+            if err > max_abs_err {
+                max_abs_err = err;
+                max_loc = (col, row);
+            }
+            sum_abs_err += err as f64;
+            if a.abs() > REL_FLOOR {
+                let rel = err / a.abs();
+                if rel > max_rel_err { max_rel_err = rel; }
+                sum_rel_err += rel as f64;
+                rel_eligible += 1;
+                if rel > 0.10 { samples_above_10pct += 1; }
+            }
+        }
+    }
+
+    let total = (n * m) as f64;
+    let mean_abs_err = sum_abs_err / total;
+    let mean_rel_err = if rel_eligible > 0 { sum_rel_err / (rel_eligible as f64) } else { 0.0 };
+    let pct_above = 100.0 * samples_above_10pct as f32 / rel_eligible.max(1) as f32;
+
+    eprintln!("\n--- per-channel error (n*m = {} elements) ---", n * m);
+    eprintln!("  max abs err:                       {:.6}  at (col={}, row={})",
+              max_abs_err, max_loc.0, max_loc.1);
+    eprintln!("  mean abs err:                      {:.6}", mean_abs_err);
+    eprintln!("  rel-err eligible (|out| > {:.2}):    {} / {} ({:.1}%)",
+              REL_FLOOR, rel_eligible, n * m,
+              100.0 * rel_eligible as f32 / (n * m) as f32);
+    eprintln!("  max rel err†:                      {:.4}", max_rel_err);
+    eprintln!("  mean rel err†:                     {:.4}", mean_rel_err);
+    eprintln!("  samples > 10% rel†:                {} / {} ({:.3}%)",
+              samples_above_10pct, rel_eligible.max(1), pct_above);
+    eprintln!("  † counted only on non-near-zero outputs (|out| > {REL_FLOOR})");
+
+    eprintln!("\n--- sample triples (col=0..2, row=0..4) ---");
+    for col in 0..2.min(n) {
+        for row in 0..4.min(m) {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_iu4_host[idx];
+            eprintln!("  col={col} row={row}: fp16={a:>10.4}  iu4={b:>10.4}  err={:.4}",
+                      (a - b).abs());
+        }
+    }
+
+    let max_abs_thresh = 0.30;
+    let mean_abs_thresh = 0.03;
+    let max_rel_thresh = 1.0;
+    let mean_rel_thresh = 0.15;
+    let pct_thresh = 50.0;
+
+    let max_abs_ok = max_abs_err < max_abs_thresh;
+    let mean_abs_ok = (mean_abs_err as f32) < mean_abs_thresh;
+    let max_rel_ok = max_rel_err < max_rel_thresh;
+    let mean_rel_ok = (mean_rel_err as f32) < mean_rel_thresh;
+    let pct_ok = pct_above < pct_thresh;
+
+    eprintln!("\n--- PASS criteria (Q4_1 activation = ~14% per-elem precision) ---");
+    eprintln!("  max abs err   < {max_abs_thresh}:   {}", if max_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean abs err  < {mean_abs_thresh}:  {}", if mean_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  max rel err†  < {max_rel_thresh}:   {}", if max_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean rel err† < {mean_rel_thresh}:  {}", if mean_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  pct >10% rel† < {pct_thresh}%: {}", if pct_ok { "OK" } else { "FAIL" });
+
+    if max_abs_ok && mean_abs_ok && max_rel_ok && mean_rel_ok && pct_ok {
+        eprintln!("\nPASS: gfx12 iu4 K=32 GEMM is numerically equivalent to FP16 WMMA \
+                   reference within Q4_1 tolerance.");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL: gfx12 iu4 K=32 GEMM diverges beyond Q4_1 tolerance.");
+        std::process::exit(1);
+    }
+}
+
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            let scale_bits = 0x3a000000u32 | (next() & 0x007F_FFFF);
+            let zp_bits = ((next() & 0x80) << 24) | 0x39000000u32 | (next() & 0x007F_FFFF);
+            let scale = f32::from_bits(scale_bits);
+            let zp = f32::from_bits(zp_bits);
+            let scale_ok = if scale.is_finite() && scale.abs() < 1e-2 && scale > 0.0 { scale } else { 1e-3 };
+            let zp_ok = if zp.is_finite() && zp.abs() < 1.0 { zp } else { -0.5 };
+            out[gp..gp + 4].copy_from_slice(&scale_ok.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp_ok.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/test_mmq_gfx12_correctness.rs
+++ b/crates/rdna-compute/examples/test_mmq_gfx12_correctness.rs
@@ -1,0 +1,239 @@
+//! gfx12 (RDNA4) HFQ4-G256 MMQ correctness test (issue #136 part B).
+//!
+//! Compares the new gfx12 MMQ residual GEMM kernel
+//! (`gemm_hfq4g256_residual_mmq_gfx12`, commit 5757283) against the existing
+//! gfx12 FP16 dequant→WMMA reference path (`gemm_hfq4g256_residual_wmma_gfx12`).
+//! Both compute `Y += W·X` for HFQ4 weights and FP32 activations on the same
+//! random inputs.
+//!
+//! The MMQ path quantizes activations to Q8_1 mid-flight (loses ~0.4% per
+//! element vs FP32), so outputs differ by Q8_1 rounding noise — bounded by
+//! roughly 0.4% × √K accumulated. For K=512 that's ~9% upper bound; in
+//! practice (with structured-but-random data) we usually see <2% per row.
+//!
+//! PASS thresholds (per channel = per output element):
+//!   max abs err        < 0.10  (tracks the default mmq_screen_threshold)
+//!   mean abs err       < 0.01  (1% of typical output magnitude)
+//!   max rel err†       < 0.05  (5% per element, only for |output| > 0.05)
+//!   mean rel err†      < 0.01  (1% per element on average)
+//!   pct rel-err > 5%†  < 1.0%  (less than 1% of elements significantly off)
+//!
+//! † Rel-err is computed only for elements where |fp16_output| > 0.05.
+//!   For near-zero outputs (where Q8_1 rounding noise dominates), abs-err
+//!   matters; rel-err blows up by a factor of (1 / output_magnitude) and
+//!   stops being meaningful. The previous version floored the denominator
+//!   at 1e-3, which produced spurious 73% "rel err" on outputs of 0.002.
+//!
+//! Run on gfx1201:
+//!   cargo run --release -p rdna-compute --example test_mmq_gfx12_correctness
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let m: usize = std::env::var("M").ok().and_then(|s| s.parse().ok()).unwrap_or(256);
+    let k: usize = std::env::var("K").ok().and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n: usize = std::env::var("N").ok().and_then(|s| s.parse().ok()).unwrap_or(128);
+
+    assert!(k % 256 == 0, "K must be a multiple of 256 for HFQ4-G256");
+    assert!(m % 16 == 0, "M should be aligned to wmma tile (16)");
+    assert!(n % 16 == 0, "N should be aligned to wmma tile (16)");
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    eprintln!("GPU: {arch}");
+
+    if !(arch == "gfx1200" || arch == "gfx1201") {
+        eprintln!(
+            "SKIP: this test requires gfx1200/gfx1201 (RDNA4). \
+             Current arch: {arch}. The gfx12 MMQ kernel only exists on RDNA4."
+        );
+        std::process::exit(0);
+    }
+
+    eprintln!("=== gfx12 MMQ vs FP16-WMMA correctness test ===");
+    eprintln!("M={m}, K={k}, N={n}");
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+    eprintln!("weight tensor: {} MiB", (m * row_bytes) as f64 / (1024.0 * 1024.0));
+
+    // --- Random HFQ4-G256 weights on GPU.
+    let weight_bytes: Vec<u8> = synth_hfq4g256_weights(m, groups_per_row, 0xC0DE_FACEu64);
+    let a_raw = gpu.upload_raw(&weight_bytes, &[m * row_bytes]).expect("upload weights");
+
+    // --- Random FP32 activations + initial Y. Deterministic PRNG.
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(1103515245).wrapping_add(12345)) as f32;
+            (v * 1e-9) % 2.0 - 1.0
+        })
+        .collect();
+    let y_init_host: Vec<f32> = (0..n * m)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(2147483647).wrapping_add(7)) as f32;
+            (v * 1e-7) % 1.0
+        })
+        .collect();
+
+    let x_gpu = gpu.alloc_tensor(&[n * k], DType::F32).expect("alloc x");
+    let y_fp16 = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_fp16");
+    let y_mmq = gpu.alloc_tensor(&[n * m], DType::F32).expect("alloc y_mmq");
+
+    gpu.hip.memcpy_htod(&x_gpu.buf, bytes_of(&x_host)).unwrap();
+
+    // --- Path A: FP16 dequant -> WMMA reference (existing production gfx12 path).
+    gpu.hip.memcpy_htod(&y_fp16.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.gemm_hfq4g256_residual_wmma_gfx12(&a_raw, &x_gpu, &y_fp16, m, k, n)
+        .expect("fp16 wmma gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_fp16_host: Vec<f32> = gpu.download_f32(&y_fp16).expect("download y_fp16");
+
+    // --- Path B: MMQ via the new gfx12 kernel (Q8_1 activation quant + iu8 K=16 wmma).
+    gpu.hip.memcpy_htod(&y_mmq.buf, bytes_of(&y_init_host)).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    gpu.gemm_hfq4g256_residual_mmq(&a_raw, &x_gpu, &y_mmq, m, k, n)
+        .expect("mmq gfx12");
+    gpu.hip.device_synchronize().unwrap();
+    let y_mmq_host: Vec<f32> = gpu.download_f32(&y_mmq).expect("download y_mmq");
+
+    assert_eq!(y_fp16_host.len(), n * m);
+    assert_eq!(y_mmq_host.len(), n * m);
+
+    // --- Compare per channel.
+    // Rel-err is computed only on elements where |fp16_output| > REL_FLOOR
+    // (= 0.05). Near-zero outputs have abs-err in the noise floor of Q8_1
+    // rounding (~1e-3) but explode rel-err by 1/|output|, producing spurious
+    // failures. Abs-err is the meaningful metric across the whole tensor.
+    const REL_FLOOR: f32 = 0.05;
+    let mut max_abs_err: f32 = 0.0;
+    let mut max_rel_err: f32 = 0.0;
+    let mut sum_abs_err: f64 = 0.0;
+    let mut sum_rel_err: f64 = 0.0;
+    let mut max_loc: (usize, usize) = (0, 0);
+    let mut samples_above_5pct: usize = 0;
+    let mut rel_eligible: usize = 0;
+
+    for col in 0..n {
+        for row in 0..m {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_mmq_host[idx];
+            let err = (a - b).abs();
+
+            if err > max_abs_err {
+                max_abs_err = err;
+                max_loc = (col, row);
+            }
+            sum_abs_err += err as f64;
+
+            // Rel-err only on non-near-zero outputs.
+            if a.abs() > REL_FLOOR {
+                let rel = err / a.abs();
+                if rel > max_rel_err {
+                    max_rel_err = rel;
+                }
+                sum_rel_err += rel as f64;
+                rel_eligible += 1;
+                if rel > 0.05 {
+                    samples_above_5pct += 1;
+                }
+            }
+        }
+    }
+
+    let total = (n * m) as f64;
+    let mean_abs_err = sum_abs_err / total;
+    let mean_rel_err = if rel_eligible > 0 {
+        sum_rel_err / (rel_eligible as f64)
+    } else {
+        0.0
+    };
+
+    eprintln!("\n--- per-channel error (n*m = {} elements) ---", n * m);
+    eprintln!("  max abs err:                       {:.6}  at (col={}, row={})", max_abs_err, max_loc.0, max_loc.1);
+    eprintln!("  mean abs err:                      {:.6}", mean_abs_err);
+    eprintln!("  rel-err eligible (|out| > {:.2}):    {} / {} ({:.1}%)",
+              REL_FLOOR, rel_eligible, n * m,
+              100.0 * rel_eligible as f32 / (n * m) as f32);
+    eprintln!("  max rel err†:                      {:.4}", max_rel_err);
+    eprintln!("  mean rel err†:                     {:.4}", mean_rel_err);
+    eprintln!("  samples > 5% rel†:                 {} / {} ({:.3}%)",
+              samples_above_5pct, rel_eligible.max(1),
+              100.0 * samples_above_5pct as f32 / rel_eligible.max(1) as f32);
+    eprintln!("  † counted only on non-near-zero outputs (|out| > {REL_FLOOR})");
+
+    // --- Show a small sample of (fp16, mmq, err) triples for human eyeball.
+    eprintln!("\n--- sample triples (col=0..2, row=0..4) ---");
+    for col in 0..2.min(n) {
+        for row in 0..4.min(m) {
+            let idx = col * m + row;
+            let a = y_fp16_host[idx];
+            let b = y_mmq_host[idx];
+            eprintln!("  col={col} row={row}: fp16={a:>10.4}  mmq={b:>10.4}  err={:.4}", (a - b).abs());
+        }
+    }
+
+    // --- Pass / fail.
+    let max_abs_thresh = 0.10;
+    let mean_abs_thresh = 0.01;
+    let max_rel_thresh = 0.05;
+    let mean_rel_thresh = 0.01;
+    let pct_above_5pct_thresh = 1.0;
+
+    let pct_above = 100.0 * samples_above_5pct as f32 / rel_eligible.max(1) as f32;
+    let max_abs_ok = max_abs_err < max_abs_thresh;
+    let mean_abs_ok = (mean_abs_err as f32) < mean_abs_thresh;
+    let max_rel_ok = max_rel_err < max_rel_thresh;
+    let mean_rel_ok = (mean_rel_err as f32) < mean_rel_thresh;
+    let pct_ok = pct_above < pct_above_5pct_thresh;
+
+    eprintln!("\n--- PASS criteria ---");
+    eprintln!("  max abs err   < {max_abs_thresh}:    {}", if max_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean abs err  < {mean_abs_thresh}:   {}", if mean_abs_ok { "OK" } else { "FAIL" });
+    eprintln!("  max rel err†  < {max_rel_thresh}:    {}", if max_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  mean rel err† < {mean_rel_thresh}:   {}", if mean_rel_ok { "OK" } else { "FAIL" });
+    eprintln!("  pct >5% rel†  < {pct_above_5pct_thresh}%: {}", if pct_ok { "OK" } else { "FAIL" });
+
+    if max_abs_ok && mean_abs_ok && max_rel_ok && mean_rel_ok && pct_ok {
+        eprintln!("\nPASS: gfx12 MMQ kernel is numerically equivalent to FP16 WMMA \
+                   reference within Q8_1 activation-quantization tolerance.");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL: gfx12 MMQ kernel diverges from FP16 WMMA reference \
+                   beyond Q8_1 tolerance. Investigate before flipping the \
+                   HIPFIRE_GFX12_MMQ default.");
+        std::process::exit(1);
+    }
+}
+
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            // Scale: small finite positive FP32. Clamp magnitude to [1e-3, 1e-2].
+            let scale_bits = 0x3a000000u32 | (next() & 0x007F_FFFF);
+            let zp_bits = ((next() & 0x80) << 24) | 0x39000000u32 | (next() & 0x007F_FFFF);
+            let scale = f32::from_bits(scale_bits);
+            let zp = f32::from_bits(zp_bits);
+            let scale_ok = if scale.is_finite() && scale.abs() < 1e-2 && scale > 0.0 { scale } else { 1e-3 };
+            let zp_ok    = if zp.is_finite() && zp.abs() < 1.0 { zp } else { -0.5 };
+            out[gp..gp + 4].copy_from_slice(&scale_ok.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp_ok.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -6319,12 +6319,25 @@ impl Gpu {
             if is_gfx12(&self.arch)
                 && batch_size > 1
             {
-                // gfx12 iu4 K=32 opt-in. HIPFIRE_GFX12_IU4=1. Bypasses MMQ +
-                // FP16 entirely. Q4_1 prequant + iu4 K=32 wmma — 4× FP16
-                // matrix throughput per AMD spec, HFQ4 nibbles consumed
-                // AS-IS as iu4 (no in-kernel dequant). Q4_1 activation has
-                // ~14% per-elem precision (looser than Q8_1's ~0.8%); ship
-                // requires coherence-gate validation on real models.
+                // gfx12 iu4 K=32 opt-in. HIPFIRE_GFX12_IU4=1.
+                //
+                // ⚠️  PERF WIN BUT QUALITY-FAIL: bench shows +13% on 27B
+                //     prefill vs FP16 (+25% vs MMQ), but coherence-gate at
+                //     d6ef999 produced **complete garbage** on all 4 model
+                //     sizes (0.8B/4B/9B with HIPFIRE_GFX12_IU4=1). Q4_1
+                //     activation has ~14% per-elem precision; that compounds
+                //     across 64 transformer layers + softmax into unintelligible
+                //     output. Native gfx12 wmma is type-symmetric (iu4 forces
+                //     Q4_1 on activations) so we can't mix iu4 weights with
+                //     Q8_1 activations to recover signal.
+                //
+                // Path stays in the tree as opt-in for future research (e.g.,
+                // QAT models trained for INT4 activations, or layer-selective
+                // routing where quality-tolerant projections use iu4). DO NOT
+                // flip the default; HIPFIRE_GFX12_IU4=1 is destructive on
+                // standard FP16-trained Qwen3.5-class models. See
+                // project_gfx12_iu4_breakthrough_2026_05_04.md for the
+                // perf-vs-quality tradeoff in detail.
                 if std::env::var("HIPFIRE_GFX12_IU4").ok().as_deref() == Some("1") {
                     let xq = self.ensure_q4_1_x(x, batch_size, k)?;
                     return self.gemm_hfq4g256_residual_iu4_gfx12(

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -5007,6 +5007,99 @@ impl Gpu {
         result
     }
 
+    /// gfx12 (RDNA4) FP8 (E4M3) HFQ4-G256 residual GEMM.
+    ///
+    /// Sister of the `_mmq_gfx12` i8 path. Same 128x128 MMQ outer recipe but
+    /// uses `__builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12` with FP32
+    /// accumulation, eliminating the i8 MMQ overheads (separate Q8_1 pre-
+    /// quant kernel + per-K=32 dmA*dsB scale-correction loop). HFQ4 dequant
+    /// is baked into the FP8 cast inline; activations are cast FP32->FP8
+    /// with a per-tile-col dynamic scale computed in-kernel, so no separate
+    /// activation-quant kernel launch is needed.
+    ///
+    /// Arch-gated to gfx1200/gfx1201. NOT wired into production prefill
+    /// dispatch — opt-in only via direct call until correctness lands.
+    /// Layout contract validated on R9700 by `probe_wmma_fp8_layout`.
+    ///
+    /// Args mirror `gemm_hfq4g256_residual_mmq_gfx12` except `x` is FP32
+    /// (not pre-quantized).
+    pub fn gemm_hfq4g256_residual_fp8_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        if !is_gfx12(&self.arch) {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "gemm_hfq4g256_residual_fp8_gfx12 requires gfx1200/gfx1201, got {}",
+                self.arch
+            )));
+        }
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_fp8_gfx12",
+            kernels::GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC,
+            "gemm_hfq4g256_residual_fp8_gfx12",
+        )?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x.buf.as_ptr();
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut add_val = 1i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+            &mut add_val as *mut _ as *mut c_void,
+        ];
+
+        const MMQ_X: usize = 128;
+        const MMQ_Y: usize = 128;
+        const FP8_K_I32_STRIDE: usize = 32;  // K=128 / 4 fp8-per-i32
+        const TILE_IDS_FLOATS: usize = 128;  // per-col activation idScale
+        let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
+        let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
+        // tile_x: 128 rows x 32 i32 = 16 KB
+        // tile_y: 128 cols x 32 i32 = 16 KB
+        // tile_idS: 128 floats     = 0.5 KB
+        let shared_mem = ((MMQ_Y * FP8_K_I32_STRIDE
+            + MMQ_X * FP8_K_I32_STRIDE) * std::mem::size_of::<i32>()
+            + TILE_IDS_FLOATS * std::mem::size_of::<f32>()) as u32;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 4    // FP32 X read (twice — pass 1 amax + pass 2 cast — but profile counts it once)
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_residual_fp8_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_fp8_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 8, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr);
+                b.push_ptr(x_ptr);
+                b.push_ptr(y_ptr);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b.push_i32(add_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ4-G256 GEMV with fused residual add: y[row] += A[row] · x.
     /// Same math as `gemv_hfq4g256` but the final write accumulates into `y`
     /// instead of overwriting. Used for wo / w_down projections where the

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1388,6 +1388,39 @@ impl Gpu {
         }
     }
 
+    /// gfx12 (RDNA4) iu8 K=16 WMMA layout-discovery probe — issue #136 part B.
+    /// Same shape as probe_wmma_iu4_k32_layout but exercises
+    /// __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32 to discover whether the
+    /// gfx12 iu8 acc layout matches the iu4 K=32 8-row-block layout or
+    /// differs. `out` capacity: 3*256 = 768 i32 elements.
+    pub fn probe_wmma_iu8_k16_layout(&mut self, out: &GpuTensor) -> HipResult<()> {
+        if !(self.arch == "gfx1200" || self.arch == "gfx1201") {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "probe_wmma_iu8_k16_layout requires gfx1200/gfx1201; got {}",
+                self.arch
+            )));
+        }
+        self.ensure_kernel(
+            "probe_wmma_iu8_k16_layout",
+            kernels::PROBE_WMMA_IU8_K16_LAYOUT_GFX12_SRC,
+            "probe_wmma_iu8_k16_layout",
+        )?;
+        let func = &self.functions["probe_wmma_iu8_k16_layout"];
+        let mut out_ptr = out.buf.as_ptr();
+        let mut params: Vec<*mut c_void> =
+            vec![&mut out_ptr as *mut _ as *mut c_void];
+        unsafe {
+            self.hip.launch_kernel(
+                func,
+                [1, 1, 1],
+                [32, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        }
+    }
+
     /// Wave-cooperative Q4 GEMV (Q4_F16_G32 format, 0.625 B/w). Shuffle-based nibble distribution.
     pub fn gemv_q4wave(
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -397,6 +397,13 @@ pub struct Gpu {
     /// GEMM path (`gemm_hfq4g256_residual_fp8_gfx12`) to skip per-prefill
     /// in-kernel dequant.
     fp8_shadow_cache: HashMap<usize, GpuTensor>,
+    /// Counter of standalone-residual gemm calls. Used by the iu4 dispatch
+    /// gate to support layer-isolation experiments via HIPFIRE_GFX12_IU4_MAX_CALL.
+    /// Resets to 0 per Gpu instance (= per process). For Qwen3.5 each layer
+    /// makes 2 calls through this dispatcher (wo + w_down), so MAX_CALL=2 =
+    /// "iu4 on layer 0 wo+w_down only". Diagnostic for whether Q4_1 quality
+    /// failure cascades from one layer or compounds across many.
+    iu4_call_counter: std::cell::Cell<usize>,
 }
 
 impl Gpu {
@@ -515,6 +522,7 @@ impl Gpu {
             rocblas: None,
             fp16_shadow_cache: HashMap::new(),
             fp8_shadow_cache: HashMap::new(),
+            iu4_call_counter: std::cell::Cell::new(0),
         }).map(|mut gpu| {
             if gpu.force_blob_path {
                 eprintln!("[diag] HIPFIRE_BLOB_FORCE=1: all kernel launches will use the blob path (kernelParams bypassed). Diagnostic only.");
@@ -6339,9 +6347,22 @@ impl Gpu {
                 // project_gfx12_iu4_breakthrough_2026_05_04.md for the
                 // perf-vs-quality tradeoff in detail.
                 if std::env::var("HIPFIRE_GFX12_IU4").ok().as_deref() == Some("1") {
-                    let xq = self.ensure_q4_1_x(x, batch_size, k)?;
-                    return self.gemm_hfq4g256_residual_iu4_gfx12(
-                        a_raw, xq, y, m, k, batch_size, /*add=*/true);
+                    // Layer-isolation diagnostic: HIPFIRE_GFX12_IU4_MAX_CALL=N
+                    // limits iu4 to the first N calls of this dispatcher per
+                    // process (Qwen3.5: 2 calls/layer = wo + w_down). MAX=2 =
+                    // "layer 0 only". Counter persists for the Gpu lifetime
+                    // (= per-process), naturally resetting per fresh daemon
+                    // invocation by coherence-gate.
+                    let max_call: usize = std::env::var("HIPFIRE_GFX12_IU4_MAX_CALL")
+                        .ok().and_then(|s| s.parse().ok()).unwrap_or(usize::MAX);
+                    let call_idx = self.iu4_call_counter.get();
+                    self.iu4_call_counter.set(call_idx + 1);
+                    if call_idx < max_call {
+                        let xq = self.ensure_q4_1_x(x, batch_size, k)?;
+                        return self.gemm_hfq4g256_residual_iu4_gfx12(
+                            a_raw, xq, y, m, k, batch_size, /*add=*/true);
+                    }
+                    // else: fall through to FP16 / MMQ for this call
                 }
                 match std::env::var("HIPFIRE_GFX12_FP8").ok().as_deref() {
                     Some("1") => {

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -119,7 +119,11 @@ fn has_wave64_native(arch: &str) -> bool {
 }
 
 fn has_mmq_i8_wmma(arch: &str) -> bool {
-    matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152")
+    matches!(arch, "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152" | "gfx1200" | "gfx1201")
+}
+
+fn is_gfx12(arch: &str) -> bool {
+    matches!(arch, "gfx1200" | "gfx1201")
 }
 
 /// Decide whether the i8-WMMA MMQ prefill path should be used for a given
@@ -146,6 +150,16 @@ fn has_mmq_i8_wmma(arch: &str) -> bool {
 ///   `auto` / unset / other — auto-route by batch_size threshold (default)
 fn should_use_mmq(arch: &str, batch_size: usize) -> bool {
     if !has_mmq_i8_wmma(arch) {
+        return false;
+    }
+    // gfx12 (RDNA4) MMQ port is fresh — gate behind explicit opt-in via
+    // HIPFIRE_GFX12_MMQ=1 until numeric correctness vs the FP16 reference
+    // path is validated. Once validated, flip the default and remove this
+    // guard. The kernel itself (commit 5757283 on PR #140) compiles + dispatches
+    // on gfx1201 silicon; this guard is a safety belt while we ship.
+    if is_gfx12(arch)
+        && std::env::var("HIPFIRE_GFX12_MMQ").ok().as_deref() != Some("1")
+    {
         return false;
     }
     match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
@@ -997,11 +1011,22 @@ impl Gpu {
     /// `block_q8_1_mmq` layout. The scratch is ordered by [K/128 block, batch]
     /// so a 128-column batch tile is contiguous for each K tile.
     pub fn ensure_q8_1_mmq_x(&mut self, x: &GpuTensor, batch_size: usize, k: usize) -> HipResult<*mut c_void> {
-        self.ensure_kernel(
-            "gemm_hfq4g256_residual_mmq",
-            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
-            "quantize_q8_1_mmq_ds4",
-        )?;
+        // gfx12 (RDNA4) uses a sister kernel with the same byte layout but the
+        // _gfx12-suffixed symbol — separate .hsaco compile from the RDNA3 one.
+        let (module_name, src, fn_name) = if is_gfx12(&self.arch) {
+            (
+                "gemm_hfq4g256_residual_mmq_gfx12",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC,
+                "quantize_q8_1_mmq_ds4_gfx12",
+            )
+        } else {
+            (
+                "gemm_hfq4g256_residual_mmq",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+                "quantize_q8_1_mmq_ds4",
+            )
+        };
+        self.ensure_kernel(module_name, src, fn_name)?;
 
         let blocks_k = (k + 127) / 128;
         let block_q8_1_mmq_bytes = 144usize;
@@ -1032,7 +1057,7 @@ impl Gpu {
             let grid_x = ((k + 1023) / 1024) as u32;
             let grid_y = batch_size as u32;
             self.launch_maybe_blob(
-                "quantize_q8_1_mmq_ds4",
+                fn_name,
                 [grid_x, grid_y, 1],
                 [256, 1, 1],
                 0,
@@ -1059,6 +1084,18 @@ impl Gpu {
     /// Returns `true` if MMQ is safe for this weight, `false` if it should
     /// fall back to WMMA.
     pub fn mmq_screen_weight(&mut self, a_raw: &GpuTensor, m: usize, k: usize) -> bool {
+        // gfx12 (RDNA4) MMQ is fresh and not yet hooked through the screen path
+        // (the screen reference compares against gemm_hfq4g256_residual_wmma_gfx12,
+        // which exists, but the screen's internal MMQ call routes through the
+        // gfx12 dispatch we just wired — needs end-to-end validation before we
+        // trust the threshold). For now, accept all weights when running on
+        // gfx12 with the explicit MMQ opt-in (HIPFIRE_GFX12_MMQ=1). After
+        // numeric correctness is validated against the FP16 reference, this
+        // bypass should be removed and gfx12 weights screened normally.
+        if is_gfx12(&self.arch) {
+            return true;
+        }
+
         let key = a_raw.buf.as_ptr() as usize;
         if let Some(&safe) = self.mmq_screen_cache.get(&key) {
             return safe;
@@ -5998,16 +6035,28 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
-        let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
-            "gemm_hfq4g256_residual_mmq_full_add"
+        // gfx12 path: use the basic _residual_mmq variant only (boundary-elided
+        // _full_add / _full_set variants haven't been ported yet — first-cut
+        // ships only the basic variant with the runtime add flag).
+        let (module_name, src, kernel_name) = if is_gfx12(&self.arch) {
+            (
+                "gemm_hfq4g256_residual_mmq_gfx12",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC,
+                "gemm_hfq4g256_residual_mmq_gfx12",
+            )
         } else {
-            "gemm_hfq4g256_residual_mmq"
+            let name = if m % 128 == 0 && batch_size % 128 == 0 {
+                "gemm_hfq4g256_residual_mmq_full_add"
+            } else {
+                "gemm_hfq4g256_residual_mmq"
+            };
+            (
+                "gemm_hfq4g256_residual_mmq",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+                name,
+            )
         };
-        self.ensure_kernel(
-            "gemm_hfq4g256_residual_mmq",
-            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
-            kernel_name,
-        )?;
+        self.ensure_kernel(module_name, src, kernel_name)?;
 
         let mut a_ptr = a_raw.buf.as_ptr();
         let mut xq_ptr = x_q8_ptr;
@@ -6070,16 +6119,27 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
-        let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
-            "gemm_hfq4g256_residual_mmq_full_set"
+        // gfx12 path: single basic variant with runtime add=0; the boundary-elided
+        // _full_set fast path is RDNA3-only for now (see _residual_mmq above).
+        let (module_name, src, kernel_name) = if is_gfx12(&self.arch) {
+            (
+                "gemm_hfq4g256_residual_mmq_gfx12",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC,
+                "gemm_hfq4g256_residual_mmq_gfx12",
+            )
         } else {
-            "gemm_hfq4g256_residual_mmq"
+            let name = if m % 128 == 0 && batch_size % 128 == 0 {
+                "gemm_hfq4g256_residual_mmq_full_set"
+            } else {
+                "gemm_hfq4g256_residual_mmq"
+            };
+            (
+                "gemm_hfq4g256_residual_mmq",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+                name,
+            )
         };
-        self.ensure_kernel(
-            "gemm_hfq4g256_residual_mmq",
-            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
-            kernel_name,
-        )?;
+        self.ensure_kernel(module_name, src, kernel_name)?;
 
         let mut a_ptr = a_raw.buf.as_ptr();
         let mut xq_ptr = x_q8_ptr;
@@ -6141,16 +6201,26 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
-        let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
-            "gemm_hfq4g256_residual_mmq_full_set"
+        // gfx12: basic variant only (see _residual_mmq above for rationale).
+        let (module_name, src, kernel_name) = if is_gfx12(&self.arch) {
+            (
+                "gemm_hfq4g256_residual_mmq_gfx12",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC,
+                "gemm_hfq4g256_residual_mmq_gfx12",
+            )
         } else {
-            "gemm_hfq4g256_residual_mmq"
+            let name = if m % 128 == 0 && batch_size % 128 == 0 {
+                "gemm_hfq4g256_residual_mmq_full_set"
+            } else {
+                "gemm_hfq4g256_residual_mmq"
+            };
+            (
+                "gemm_hfq4g256_residual_mmq",
+                kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
+                name,
+            )
         };
-        self.ensure_kernel(
-            "gemm_hfq4g256_residual_mmq",
-            kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
-            kernel_name,
-        )?;
+        self.ensure_kernel(module_name, src, kernel_name)?;
 
         let mut a_ptr = a_raw.buf.as_ptr();
         let mut xq_ptr = x_q8_ptr;

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1425,6 +1425,38 @@ impl Gpu {
         }
     }
 
+    /// gfx12 (RDNA4) FP8 (E4M3) WMMA layout-discovery probe — issue #136
+    /// part B. Same three-pattern shape as the iu4/iu8 probes but exercises
+    /// `__builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12`. Acc is FP32
+    /// (8 floats per lane). `out` capacity: 3*256 = 768 f32 elements.
+    pub fn probe_wmma_fp8_layout(&mut self, out: &GpuTensor) -> HipResult<()> {
+        if !(self.arch == "gfx1200" || self.arch == "gfx1201") {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "probe_wmma_fp8_layout requires gfx1200/gfx1201; got {}",
+                self.arch
+            )));
+        }
+        self.ensure_kernel(
+            "probe_wmma_fp8_layout",
+            kernels::PROBE_WMMA_FP8_LAYOUT_GFX12_SRC,
+            "probe_wmma_fp8_layout",
+        )?;
+        let func = &self.functions["probe_wmma_fp8_layout"];
+        let mut out_ptr = out.buf.as_ptr();
+        let mut params: Vec<*mut c_void> =
+            vec![&mut out_ptr as *mut _ as *mut c_void];
+        unsafe {
+            self.hip.launch_kernel(
+                func,
+                [1, 1, 1],
+                [32, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        }
+    }
+
     /// gfx12 (RDNA4) iu8 K=16 WMMA layout-discovery probe — issue #136 part B.
     /// Same shape as probe_wmma_iu4_k32_layout but exercises
     /// __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32 to discover whether the

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -274,6 +274,12 @@ pub struct Gpu {
     /// `block_q8_1_mmq`, ordered by [K/128 block, batch column].
     q8_1_mmq_x_scratch: Option<hip_bridge::DeviceBuffer>,
     q8_1_mmq_x_scratch_bytes: usize,
+    /// Q4_1/MMQ scratch for prefill activations (gfx12 iu4 path). Layout
+    /// matches `block_q4_1_mmq` (80 B per K=128 of one token), ordered by
+    /// [K/128 block, batch column]. Sister of `q8_1_mmq_x_scratch` for the
+    /// iu4 K=32 wmma GEMM path.
+    q4_1_mmq_x_scratch: Option<hip_bridge::DeviceBuffer>,
+    q4_1_mmq_x_scratch_bytes: usize,
 
     // ── MMQ per-weight screening (#87) ──────────────────────────────────
     // When enabled, each weight matrix is screened on first MMQ use: a
@@ -484,6 +490,8 @@ impl Gpu {
             fp16_x_source_ptr: std::ptr::null_mut(),
             q8_1_mmq_x_scratch: None,
             q8_1_mmq_x_scratch_bytes: 0,
+            q4_1_mmq_x_scratch: None,
+            q4_1_mmq_x_scratch_bytes: 0,
             mmq_screen_cache: HashMap::new(),
             mmq_screen: std::env::var("HIPFIRE_MMQ_SCREEN").ok()
                 .map(|v| v == "1")
@@ -1083,6 +1091,65 @@ impl Gpu {
         }
 
         Ok(self.q8_1_mmq_x_scratch.as_ref().unwrap().as_ptr())
+    }
+
+    /// Ensure prefill activations are quantized into the `block_q4_1_mmq`
+    /// layout (gfx12 iu4 path). Sister of `ensure_q8_1_mmq_x` — same
+    /// [K/128 block, batch] ordering, but each block is 80 B (4 half2 ds +
+    /// 64 INT4 qs) instead of 144 B for Q8_1.
+    ///
+    /// Arch-gated to gfx1200/gfx1201 (the kernel stubs out elsewhere). The
+    /// caller is responsible for routing the iu4 GEMM path conditionally —
+    /// this helper does NOT enforce the arch guard.
+    pub fn ensure_q4_1_x(&mut self, x: &GpuTensor, batch_size: usize, k: usize) -> HipResult<*mut c_void> {
+        self.ensure_kernel(
+            "quantize_q4_1_mmq_ds4_gfx12",
+            kernels::QUANTIZE_Q4_1_GFX12_SRC,
+            "quantize_q4_1_mmq_ds4_gfx12",
+        )?;
+
+        let blocks_k = (k + 127) / 128;
+        let block_q4_1_mmq_bytes = 80usize;  // 4 half2 ds + 64 INT4 qs
+        let needed = blocks_k * batch_size * block_q4_1_mmq_bytes;
+        if self.q4_1_mmq_x_scratch_bytes < needed {
+            self.q4_1_mmq_x_scratch = Some(self.hip.malloc(needed)?);
+            self.q4_1_mmq_x_scratch_bytes = needed;
+        }
+
+        let src_ptr = x.buf.as_ptr();
+        // Same convention as ensure_q8_1_mmq_x: re-quantize on every call.
+        // Higher-level fused callers can skip the re-quant by calling the
+        // GEMM with the already-returned pointer.
+        let out_ptr = self.q4_1_mmq_x_scratch.as_ref().unwrap().as_ptr();
+        let mut xp = src_ptr;
+        let mut yp = out_ptr;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut xp as *mut _ as *mut c_void,
+            &mut yp as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((k + 1023) / 1024) as u32;
+        let grid_y = batch_size as u32;
+        self.launch_maybe_blob(
+            "quantize_q4_1_mmq_ds4_gfx12",
+            [grid_x, grid_y, 1],
+            [256, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(src_ptr);
+                b.push_ptr(out_ptr);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b
+            },
+        )?;
+
+        Ok(self.q4_1_mmq_x_scratch.as_ref().unwrap().as_ptr())
     }
 
     /// Screen a weight matrix for MMQ safety (#87). Runs a small synthetic
@@ -5264,6 +5331,112 @@ impl Gpu {
                 let mut b = hip_bridge::KernargBlob::new();
                 b.push_ptr(a_ptr);
                 b.push_ptr(x_ptr);
+                b.push_ptr(y_ptr);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b.push_i32(add_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// gfx12 (RDNA4) iu4 K=32 HFQ4-G256 residual GEMM.
+    ///
+    /// Sister of the `_mmq_gfx12` (iu8 K=16) and `_fp8_gfx12` paths. Uses
+    /// `__builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12` — 4x FP16 throughput
+    /// per AMD spec, vs 2x for iu8/FP8. HFQ4 nibbles map natively to iu4
+    /// unsigned indices (no weight conversion / no LDS staging round-trip),
+    /// the most structurally different from FP8/iu8 (which stage FP8 or INT8
+    /// in LDS via per-thread cast).
+    ///
+    /// Activation is consumed as a pre-quantized `block_q4_1_mmq` buffer
+    /// (signed INT4 in [-7,7] with per-K=32 (d, d*sum_q) metadata). Caller
+    /// owns the prequant — typical usage:
+    ///   let xq = self.ensure_q4_1_x(&x_gpu, batch, k)?;
+    ///   self.gemm_hfq4g256_residual_iu4_gfx12(a_raw, xq, y, m, k, batch, add)?;
+    /// `xq` is a `*mut c_void` pointing into `q4_1_mmq_x_scratch`.
+    ///
+    /// Arch-gated to gfx1200/gfx1201. NOT wired into production prefill
+    /// dispatch — opt-in only via direct call until correctness lands.
+    /// Layout contract validated on hiptrx by `probe_wmma_iu4_k32_layout`
+    /// (commit 03a5856 on `feat/probe-gfx12-wmma-iu4-k32`).
+    pub fn gemm_hfq4g256_residual_iu4_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        xq: *mut c_void,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+        add: bool,
+    ) -> HipResult<()> {
+        if !is_gfx12(&self.arch) {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "gemm_hfq4g256_residual_iu4_gfx12 requires gfx1200/gfx1201, got {}",
+                self.arch
+            )));
+        }
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_iu4_gfx12",
+            kernels::GEMM_HFQ4G256_RESIDUAL_IU4_GFX12_SRC,
+            "gemm_hfq4g256_residual_iu4_gfx12",
+        )?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut xq_ptr = xq;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut add_val = if add { 1i32 } else { 0i32 };
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut xq_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+            &mut add_val as *mut _ as *mut c_void,
+        ];
+
+        // Kernel constants from gemm_hfq4g256_residual_iu4.gfx12.hip:
+        //   MMQ_X = 128, MMQ_Y = 128
+        //   tile_x_qs row stride = 32 i32 (= K=256 nibbles, 8 per i32)
+        //   tile_x_dm row stride = 1 half2 (HFQ4 sc/zp per row)
+        //   tile_y     row stride = 20 i32 (= sizeof(block_q4_1_mmq) / 4)
+        //
+        // LDS budget:
+        //   tile_y:    128 cols × 20 i32 × 4 B = 10 KB
+        //   tile_x_qs: 128 rows × 32 i32 × 4 B = 16 KB
+        //   tile_x_dm: 128 half2               = 512 B
+        //   total ~ 26.5 KB (well under gfx12's ~64 KB ceiling)
+        const MMQ_X: usize = 128;
+        const MMQ_Y: usize = 128;
+        const MMQ_TILE_X_K_QS: usize = 32;
+        const MMQ_TILE_Y_K_Q4_1: usize = 20;
+        let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
+        let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
+        let shared_mem = ((MMQ_X * MMQ_TILE_Y_K_Q4_1
+                          + MMQ_Y * MMQ_TILE_X_K_QS) * std::mem::size_of::<i32>()
+                         + MMQ_Y * std::mem::size_of::<u32>()) as u32;  // half2 = 4 B = u32
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_hfq4g256_residual_iu4_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_iu4_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 8, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr);
+                b.push_ptr(xq_ptr);
                 b.push_ptr(y_ptr);
                 b.push_i32(m_val);
                 b.push_i32(k_val);

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1321,6 +1321,40 @@ impl Gpu {
         }
     }
 
+    /// gfx12 (RDNA4) iu4 K=32 WMMA probe — POC for issue #136 part B.
+    /// Single-wave probe: launches a 32-thread workgroup that runs one
+    /// `__builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12` instruction with
+    /// A=B=all-ones (every INT4 = 1) and dumps each lane's 8-int accumulator.
+    /// `out` must have capacity for at least 32*8 = 256 i32 elements.
+    /// Expected: every entry of `out` reads 32 (sum of 32 ones-times-ones).
+    pub fn probe_wmma_iu4_k32_allones(&mut self, out: &GpuTensor) -> HipResult<()> {
+        if !(self.arch == "gfx1200" || self.arch == "gfx1201") {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "probe_wmma_iu4_k32_allones requires gfx1200/gfx1201; got {}",
+                self.arch
+            )));
+        }
+        self.ensure_kernel(
+            "probe_wmma_iu4_k32",
+            kernels::PROBE_WMMA_IU4_K32_GFX12_SRC,
+            "probe_wmma_iu4_k32_allones",
+        )?;
+        let func = &self.functions["probe_wmma_iu4_k32_allones"];
+        let mut out_ptr = out.buf.as_ptr();
+        let mut params: Vec<*mut c_void> =
+            vec![&mut out_ptr as *mut _ as *mut c_void];
+        unsafe {
+            self.hip.launch_kernel(
+                func,
+                [1, 1, 1],
+                [32, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        }
+    }
+
     /// Wave-cooperative Q4 GEMV (Q4_F16_G32 format, 0.625 B/w). Shuffle-based nibble distribution.
     pub fn gemv_q4wave(
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -5186,6 +5186,93 @@ impl Gpu {
         result
     }
 
+    /// gfx12 (RDNA4) FP8 (E4M3) HFQ4 residual GEMM — preconv variant.
+    /// Sister of `gemm_hfq4g256_residual_fp8_gfx12` that consumes pre-converted
+    /// FP8 weights from the `fp8_shadow_cache` (populated by `ensure_fp8_shadow`)
+    /// instead of dequanting HFQ4 in the inner kb loop. Eliminates the per-prefill
+    /// dequant arithmetic that was eating most of the matrix-unit throughput
+    /// edge in the bench at commit 26a5ae5 (-21% on 9B vs FP16 baseline).
+    pub fn gemm_hfq4g256_residual_fp8_preconv_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        if !is_gfx12(&self.arch) {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "gemm_hfq4g256_residual_fp8_preconv_gfx12 requires gfx1200/gfx1201, got {}",
+                self.arch
+            )));
+        }
+        // Lazily build (or fetch cached) the FP8 shadow of the HFQ4 weight.
+        let fp8_ptr = self.ensure_fp8_shadow(a_raw, m, k)?
+            .expect("ensure_fp8_shadow must return Some on gfx12");
+
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_fp8_gfx12",
+            kernels::GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC,
+            "gemm_hfq4g256_residual_fp8_preconv_gfx12",
+        )?;
+
+        let mut a_ptr = fp8_ptr;
+        let mut x_ptr = x.buf.as_ptr();
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut add_val = 1i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+            &mut add_val as *mut _ as *mut c_void,
+        ];
+
+        const MMQ_X: usize = 128;
+        const MMQ_Y: usize = 128;
+        const FP8_K_I32_STRIDE: usize = 32;
+        const TILE_IDS_FLOATS: usize = 128;
+        let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
+        let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
+        let shared_mem = ((MMQ_Y * FP8_K_I32_STRIDE
+            + MMQ_X * FP8_K_I32_STRIDE) * std::mem::size_of::<i32>()
+            + TILE_IDS_FLOATS * std::mem::size_of::<f32>()) as u32;
+
+        // Note: bytes counts the FP8 weight read (m*k bytes) instead of HFQ4
+        // (≈ 0.531 m*k). Roughly 1.9× the weight bw of HFQ4.
+        let bytes = m * k
+            + batch_size * k * 4
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_hfq4g256_residual_fp8_preconv_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_fp8_preconv_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 8, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr);
+                b.push_ptr(x_ptr);
+                b.push_ptr(y_ptr);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b.push_i32(add_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ4-G256 GEMV with fused residual add: y[row] += A[row] · x.
     /// Same math as `gemv_hfq4g256` but the final write accumulates into `y`
     /// instead of overwriting. Used for wo / w_down projections where the
@@ -6044,16 +6131,29 @@ impl Gpu {
             // (#87). Unsafe weights fall through to WMMA instead.
             // gfx12 FP8 (E4M3) opt-in path. Bypasses MMQ entirely. Gated behind
             // HIPFIRE_GFX12_FP8=1 until correctness validated against coherence
-            // gate. The FP8 GEMM kernel does in-kernel HFQ4 dequant + per-tile
-            // activation FP8 cast — no Q8_1 quant pre-pass kernel, no per-K=32
-            // scale-correction loop. Targets the standalone wo + w_down path
-            // where the iu8 MMQ port regresses 27B by -8% (per
-            // project_gfx12_mmq_bench_2026_05_04.md).
+            // gate. Uses the preconv variant: HFQ4 weights are pre-converted to
+            // FP8 once at first use (cached in fp8_shadow_cache via
+            // ensure_fp8_shadow); subsequent prefills read directly from the
+            // FP8 buffer with no in-kernel dequant. Eliminates the per-kb
+            // cvt_pk_fp8_f32 work that ate the matrix-unit throughput edge in
+            // the first-cut bench (per project_gfx12_fp8_bench_2026_05_04.md).
+            //
+            // HIPFIRE_GFX12_FP8=2 falls back to the in-kernel dequant variant
+            // (no shadow cache build, no extra VRAM) for VRAM-tight scenarios.
             if is_gfx12(&self.arch)
-                && std::env::var("HIPFIRE_GFX12_FP8").ok().as_deref() == Some("1")
                 && batch_size > 1
             {
-                return self.gemm_hfq4g256_residual_fp8_gfx12(a_raw, x, y, m, k, batch_size);
+                match std::env::var("HIPFIRE_GFX12_FP8").ok().as_deref() {
+                    Some("1") => {
+                        return self.gemm_hfq4g256_residual_fp8_preconv_gfx12(
+                            a_raw, x, y, m, k, batch_size);
+                    }
+                    Some("2") => {
+                        return self.gemm_hfq4g256_residual_fp8_gfx12(
+                            a_raw, x, y, m, k, batch_size);
+                    }
+                    _ => {}
+                }
             }
             if std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
                 || should_use_mmq(&self.arch, batch_size)

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -383,6 +383,14 @@ pub struct Gpu {
     /// Only populated on CDNA3 when rocBLAS loaded — 4× VRAM blow-up vs MQ4
     /// so consumer cards stay on the wave32/64 hand-rolled GEMV path.
     fp16_shadow_cache: HashMap<usize, GpuTensor>,
+    /// Cached FP8 (E4M3) dequant of HFQ4-G256 weights. Sister of
+    /// fp16_shadow_cache. Populated lazily by ensure_fp8_shadow() on the first
+    /// MMQ-class call that wants pre-converted FP8 weights, or eagerly at
+    /// model load time if the engine pre-warms it. 2× VRAM blow-up vs HFQ4
+    /// (1.0 vs 0.531 B/w) — half the FP16-shadow tax. Used by the gfx12 FP8
+    /// GEMM path (`gemm_hfq4g256_residual_fp8_gfx12`) to skip per-prefill
+    /// in-kernel dequant.
+    fp8_shadow_cache: HashMap<usize, GpuTensor>,
 }
 
 impl Gpu {
@@ -498,6 +506,7 @@ impl Gpu {
             replay_capturing_n: None,
             rocblas: None,
             fp16_shadow_cache: HashMap::new(),
+            fp8_shadow_cache: HashMap::new(),
         }).map(|mut gpu| {
             if gpu.force_blob_path {
                 eprintln!("[diag] HIPFIRE_BLOB_FORCE=1: all kernel launches will use the blob path (kernelParams bypassed). Diagnostic only.");
@@ -1169,6 +1178,83 @@ impl Gpu {
         });
         self.mmq_screen_cache.insert(key, safe);
         safe
+    }
+
+    /// Dequant an HFQ4-G256 weight tensor [M × K] to FP8 (E4M3) [M × K] bytes
+    /// row-major. Output buffer must be pre-allocated to M*K bytes.
+    ///
+    /// Companion of `dequantize_hfq4g256_to_f16` but writes FP8 output, which
+    /// the gfx12 FP8 wmma GEMM consumes directly. Used by `ensure_fp8_shadow`
+    /// for the one-shot model-load preconversion. Arch-gated to gfx1200/1201.
+    ///
+    /// Cost is O(MK) — for a 27B model, ~27 GB written; on R9700 that runs at
+    /// PCIe-feed-from-system-RAM-or-VRAM-write-BW so it's a fraction of a
+    /// second.
+    pub fn dequantize_hfq4g256_to_fp8_gfx12(
+        &mut self,
+        w_mq4: &DeviceBuffer,
+        w_fp8: &DeviceBuffer,
+        m: usize, k: usize,
+    ) -> HipResult<()> {
+        if !is_gfx12(&self.arch) {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "dequantize_hfq4g256_to_fp8_gfx12 requires gfx1200/gfx1201; got {}",
+                self.arch
+            )));
+        }
+        assert!(k % 256 == 0, "hfq4g256_to_fp8: K must be multiple of 256 (got {k})");
+        self.ensure_kernel(
+            "dequant_hfq4g256_to_fp8_gfx12",
+            kernels::DEQUANT_HFQ4G256_TO_FP8_GFX12_SRC,
+            "dequant_hfq4g256_to_fp8_gfx12",
+        )?;
+        let func = &self.functions["dequant_hfq4g256_to_fp8_gfx12"];
+        let mut w_in = w_mq4.as_ptr();
+        let mut w_out = w_fp8.as_ptr();
+        let mut mi = m as i32;
+        let mut ki = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut w_in as *mut _ as *mut c_void,
+            &mut w_out as *mut _ as *mut c_void,
+            &mut mi as *mut _ as *mut c_void,
+            &mut ki as *mut _ as *mut c_void,
+        ];
+        let groups = (k / 256) as u32;
+        unsafe {
+            self.hip.launch_kernel(func, [m as u32, groups, 1], [32, 1, 1], 0,
+                self.stream_ref(), &mut params)
+        }
+    }
+
+    /// Ensure an FP8 (E4M3) shadow of `w_mq4` (HFQ4-G256, [M × K]) exists in
+    /// `fp8_shadow_cache`. Sister of `ensure_fp16_shadow` for the gfx12 FP8
+    /// wmma GEMM path.
+    ///
+    /// First call allocates M*K bytes on device and runs the FP8 dequant
+    /// kernel; subsequent calls return the cached pointer. Cache is keyed
+    /// on the MQ4 device pointer.
+    ///
+    /// Returns `Ok(None)` on non-gfx12 archs — the caller should fall back
+    /// to the FP16 dequant path. On gfx12 returns `Ok(Some(ptr))`.
+    pub fn ensure_fp8_shadow(
+        &mut self,
+        w_mq4: &GpuTensor,
+        m: usize, k: usize,
+    ) -> HipResult<Option<*mut c_void>> {
+        if !is_gfx12(&self.arch) { return Ok(None); }
+        let key = w_mq4.buf.as_ptr() as usize;
+        if let Some(shadow) = self.fp8_shadow_cache.get(&key) {
+            return Ok(Some(shadow.buf.as_ptr()));
+        }
+        // 1 byte per FP8 element. The GpuTensor uses Raw dtype (byte-level);
+        // the actual semantic is E4M3 — see DEQUANT_HFQ4G256_TO_FP8_GFX12_SRC
+        // docstring. Raw is the existing byte-level storage type used for
+        // quantized weight buffers (HFQ4, MQ4, etc. — see DType.size()).
+        let fp8 = self.alloc_tensor(&[m * k], DType::Raw)?;
+        self.dequantize_hfq4g256_to_fp8_gfx12(&w_mq4.buf, &fp8.buf, m, k)?;
+        let ptr = fp8.buf.as_ptr();
+        self.fp8_shadow_cache.insert(key, fp8);
+        Ok(Some(ptr))
     }
 
     /// Ensure an FP16 shadow of `w_mq4` (HFQ4-G256 format, [M × K]) exists in

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -404,6 +404,43 @@ pub struct Gpu {
     /// "iu4 on layer 0 wo+w_down only". Diagnostic for whether Q4_1 quality
     /// failure cascades from one layer or compounds across many.
     iu4_call_counter: std::cell::Cell<usize>,
+
+    // ── iu4 activation-calibration plumbing (gfx12) ───────────────────────
+    /// SmoothQuant-style runtime activation calibration sidecar. Loaded by
+    /// the engine at model-load time (`<model>.iu4cal`) and uploaded to the
+    /// GPU as one set of FP16 mu/inv_s + FP32 bias buffers per call site.
+    /// `None` means no calibration available; the iu4 dispatch gate
+    /// (`HIPFIRE_GFX12_IU4_CALIBRATED=1`) errors out with a clear message
+    /// when the sidecar is missing.
+    pub iu4_calibration: Option<crate::iu4_calibration::GpuIu4Calibration>,
+    /// FP32 scratch for the centered activation buffer:
+    ///   x_centered[t][c] = (x[t][c] - mu[c]) * inv_s[c]
+    /// Sized to `max(batch_size × k)` floats so any iu4 call site fits.
+    /// Reused across calls; resized on demand.
+    iu4_preshift_scratch: Option<DeviceBuffer>,
+    iu4_preshift_scratch_bytes: usize,
+    /// Per-weight cache of s-baked HFQ4 weights. Keyed by the original
+    /// weight pointer (usize). On first iu4-calibrated dispatch for a
+    /// given weight, we clone it into a new buffer and apply the
+    /// `iu4_bake_weight_scales_gfx12` kernel to multiply each (row,
+    /// K=256-group) scale field by `s_group[g]` — the activation-scale
+    /// migration of SmoothQuant. Subsequent calls reuse the cached pointer
+    /// directly (no re-bake cost).
+    iu4_baked_weight_cache: HashMap<usize, DeviceBuffer>,
+    /// Per-call dispatch counter for iu4 calibration site lookup. Increments
+    /// on every entry to `gemm_hfq4g256_residual` regardless of arch / mode,
+    /// so calibration-capture and calibrated-inference paths use the SAME
+    /// site ordering. Keep separate from `iu4_call_counter` (which only
+    /// increments on the iu4-gated branch).
+    pub iu4_dispatch_call_idx: std::cell::Cell<usize>,
+    /// When `Some`, `gemm_hfq4g256_residual` will download the FP32 input
+    /// activation `x` for the current dispatch site and hand it to the
+    /// closure along with `(site_id, batch_size, k, m)`. Used by the
+    /// offline calibration binary to accumulate per-site activation
+    /// statistics. `None` during normal inference (zero overhead).
+    #[allow(clippy::type_complexity)]
+    pub iu4_capture_hook:
+        Option<Box<dyn FnMut(usize, &[f32], usize, usize, usize) + Send + 'static>>,
 }
 
 impl Gpu {
@@ -522,6 +559,12 @@ impl Gpu {
             rocblas: None,
             fp16_shadow_cache: HashMap::new(),
             fp8_shadow_cache: HashMap::new(),
+            iu4_calibration: None,
+            iu4_preshift_scratch: None,
+            iu4_preshift_scratch_bytes: 0,
+            iu4_baked_weight_cache: HashMap::new(),
+            iu4_dispatch_call_idx: std::cell::Cell::new(0),
+            iu4_capture_hook: None,
             iu4_call_counter: std::cell::Cell::new(0),
         }).map(|mut gpu| {
             if gpu.force_blob_path {
@@ -1158,6 +1201,206 @@ impl Gpu {
         )?;
 
         Ok(self.q4_1_mmq_x_scratch.as_ref().unwrap().as_ptr())
+    }
+
+    /// Ensure the iu4 preshift scratch buffer is at least `batch_size × k × 4`
+    /// bytes. Returns the device pointer to the scratch.
+    fn ensure_iu4_preshift_scratch(&mut self, batch_size: usize, k: usize) -> HipResult<*mut c_void> {
+        let needed = batch_size * k * std::mem::size_of::<f32>();
+        if self.iu4_preshift_scratch_bytes < needed {
+            self.iu4_preshift_scratch = Some(self.hip.malloc(needed)?);
+            self.iu4_preshift_scratch_bytes = needed;
+        }
+        Ok(self.iu4_preshift_scratch.as_ref().unwrap().as_ptr())
+    }
+
+    /// Run the SmoothQuant per-channel preshift kernel:
+    ///   y[t][c] = (x[t][c] - mu_a[c]) * inv_s_a[c]
+    ///
+    /// `x` is FP32 [batch_size × k]. `mu_a` and `inv_s_a` are FP16 [k].
+    /// Output is written into the iu4 preshift scratch and returned as a
+    /// raw device pointer (caller treats it as FP32 [batch_size × k]).
+    ///
+    /// Arch-gated to gfx1200/gfx1201 (the kernel stubs out elsewhere).
+    fn iu4_preshift(
+        &mut self,
+        x_ptr: *mut c_void,
+        mu_a_ptr: *mut c_void,
+        inv_s_a_ptr: *mut c_void,
+        batch_size: usize,
+        k: usize,
+    ) -> HipResult<*mut c_void> {
+        self.ensure_kernel(
+            "activation_preshift_gfx12",
+            kernels::ACTIVATION_PRESHIFT_GFX12_SRC,
+            "activation_preshift_gfx12",
+        )?;
+        let out_ptr = self.ensure_iu4_preshift_scratch(batch_size, k)?;
+
+        let mut xp = x_ptr;
+        let mut mp = mu_a_ptr;
+        let mut isp = inv_s_a_ptr;
+        let mut yp = out_ptr;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut xp as *mut _ as *mut c_void,
+            &mut mp as *mut _ as *mut c_void,
+            &mut isp as *mut _ as *mut c_void,
+            &mut yp as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((k + 1023) / 1024) as u32;
+        let grid_y = batch_size as u32;
+        self.launch_maybe_blob(
+            "activation_preshift_gfx12",
+            [grid_x, grid_y, 1],
+            [256, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(xp);
+                b.push_ptr(mp);
+                b.push_ptr(isp);
+                b.push_ptr(yp);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b
+            },
+        )?;
+        Ok(out_ptr)
+    }
+
+    /// Engine-side accessor: install a calibration sidecar (uploaded to GPU
+    /// memory) into this Gpu instance. After this returns, calling
+    /// `gemm_hfq4g256_residual` with `HIPFIRE_GFX12_IU4_CALIBRATED=1` will
+    /// route the call through the SmoothQuant-style preshift + iu4 GEMM
+    /// path. Replaces any previously loaded calibration.
+    pub fn load_iu4_calibration(&mut self, cal: crate::iu4_calibration::GpuIu4Calibration) {
+        self.iu4_calibration = Some(cal);
+        // Drop any previously baked weights — the new sidecar's s_group
+        // values are different.
+        self.iu4_baked_weight_cache.clear();
+        // Reset the dispatch counter so site lookup stays aligned even if
+        // the engine swapped models.
+        self.iu4_dispatch_call_idx.set(0);
+    }
+
+    /// Run the s-bake kernel on a freshly cloned HFQ4 weight buffer, in
+    /// place. `weight_ptr` points to a [m × groups_per_row × 136 B] HFQ4
+    /// weight clone we just allocated; `s_group_ptr` points to a [groups_per_row]
+    /// FP16 group-scale vector from the calibration sidecar.
+    fn iu4_bake_weight_scales(
+        &mut self,
+        weight_ptr: *mut c_void,
+        s_group_ptr: *mut c_void,
+        m: usize,
+        groups_per_row: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "iu4_bake_weight_scales_gfx12",
+            kernels::IU4_BAKE_WEIGHT_SCALES_GFX12_SRC,
+            "iu4_bake_weight_scales_gfx12",
+        )?;
+        let mut wp = weight_ptr;
+        let mut sp = s_group_ptr;
+        let mut m_val = m as i32;
+        let mut g_val = groups_per_row as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut wp as *mut _ as *mut c_void,
+            &mut sp as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut g_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((m + 255) / 256) as u32;
+        let grid_y = groups_per_row as u32;
+        self.launch_maybe_blob(
+            "iu4_bake_weight_scales_gfx12",
+            [grid_x, grid_y, 1],
+            [256, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(wp);
+                b.push_ptr(sp);
+                b.push_i32(m_val);
+                b.push_i32(g_val);
+                b
+            },
+        )
+    }
+
+    /// Look up or materialize the s-baked weight clone for a given
+    /// (original weight pointer, calibration site). On first touch we
+    /// allocate a buffer the same size as the original weight,
+    /// hipMemcpy(d2d) into it, then apply the bake kernel. Returned
+    /// pointer is owned by `iu4_baked_weight_cache` and persists until
+    /// the cache is cleared (model unload / new calibration loaded).
+    fn iu4_get_or_bake_weight(
+        &mut self,
+        a_raw: &GpuTensor,
+        site_idx: usize,
+    ) -> HipResult<*mut c_void> {
+        let key = a_raw.buf.as_ptr() as usize;
+        if let Some(buf) = self.iu4_baked_weight_cache.get(&key) {
+            return Ok(buf.as_ptr());
+        }
+        let cal = self.iu4_calibration.as_ref().ok_or_else(|| {
+            hip_bridge::HipError::new(0, "iu4 calibration not loaded but bake requested")
+        })?;
+        let site = cal.sites.get(site_idx).ok_or_else(|| {
+            hip_bridge::HipError::new(0, "iu4 site index out of range during bake")
+        })?;
+        let s_group_ptr = site.s_group.as_ptr();
+        let m_rows = site.n_output_rows as usize;
+        let groups_per_row = site.groups_per_row as usize;
+        let nbytes = m_rows * groups_per_row * 136;
+
+        // Allocate clone + d2d copy of the original weight.
+        let baked = self.hip.malloc(nbytes)?;
+        let baked_ptr = baked.as_ptr();
+        self.hip.memcpy_dtod(&baked, &a_raw.buf, nbytes)?;
+
+        // Apply the bake kernel in place on the clone.
+        self.iu4_bake_weight_scales(baked_ptr, s_group_ptr, m_rows, groups_per_row)?;
+        self.hip.device_synchronize()?;
+
+        self.iu4_baked_weight_cache.insert(key, baked);
+        // Re-borrow to return the stable pointer (the buffer just moved
+        // into the HashMap).
+        Ok(self.iu4_baked_weight_cache.get(&key).unwrap().as_ptr())
+    }
+
+    /// Engine-side accessor: clear any installed calibration.
+    pub fn clear_iu4_calibration(&mut self) {
+        self.iu4_calibration = None;
+    }
+
+    /// Engine-side accessor: install a capture hook that fires before each
+    /// `gemm_hfq4g256_residual` dispatch with the FP32 input activation. The
+    /// hook receives `(site_id, x_fp32_host, batch_size, k, m)`. Used by the
+    /// offline calibration binary; `None` during normal inference.
+    pub fn set_iu4_capture_hook(
+        &mut self,
+        hook: Option<Box<dyn FnMut(usize, &[f32], usize, usize, usize) + Send + 'static>>,
+    ) {
+        self.iu4_capture_hook = hook;
+    }
+
+    /// Reset the iu4 dispatch call counter to zero. The calibration binary
+    /// calls this between forward passes so site IDs stay deterministic
+    /// across the calibration corpus.
+    pub fn reset_iu4_dispatch_counter(&self) {
+        self.iu4_dispatch_call_idx.set(0);
+    }
+
+    /// Read the current dispatch counter (useful for assertions in tests
+    /// and for the calibration binary to check site count).
+    pub fn iu4_dispatch_count(&self) -> usize {
+        self.iu4_dispatch_call_idx.get()
     }
 
     /// Screen a weight matrix for MMQ safety (#87). Runs a small synthetic
@@ -6277,6 +6520,152 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        // ── iu4 calibration plumbing (gfx12) ────────────────────────────
+        // Site index for this call. Increments BEFORE any path selection so
+        // both calibration capture and calibrated dispatch use the same
+        // ordering (capture mode runs the FP16 path, calibrated mode runs
+        // the iu4 path — both rely on `site_id` being the i-th call to
+        // gemm_hfq4g256_residual through the dense forward).
+        let site_id = self.iu4_dispatch_call_idx.get();
+        self.iu4_dispatch_call_idx.set(site_id + 1);
+
+        // Calibration capture hook: when set, download the FP32 input
+        // activation `x` and pass to the hook for stat accumulation. This
+        // is offline-only (the calibration binary turns it on) — the
+        // hipMemcpy + host alloc would be a regression in the inference
+        // hot path. Skip during graph capture mode (capture_mode==true)
+        // because hipMemcpy is illegal under stream capture.
+        if self.iu4_capture_hook.is_some() && !self.capture_mode {
+            // Read activation back to host. `x` is FP32 [batch_size × k].
+            let n_floats = batch_size * k;
+            let mut host_buf = vec![0.0f32; n_floats];
+            let host_bytes: &mut [u8] = unsafe {
+                std::slice::from_raw_parts_mut(
+                    host_buf.as_mut_ptr() as *mut u8,
+                    n_floats * std::mem::size_of::<f32>(),
+                )
+            };
+            // Synchronize before the read so any pending pre-GEMM kernel
+            // (rmsnorm / silu_mul / rotate) has flushed its output.
+            self.hip.device_synchronize()?;
+            self.hip.memcpy_dtoh(host_bytes, &x.buf)?;
+            // Take/replace the hook to satisfy the borrow checker — we
+            // need &mut self for memcpy AND for invoking the closure. The
+            // hook is restored before returning.
+            let mut hook = self.iu4_capture_hook.take();
+            if let Some(ref mut h) = hook {
+                (h)(site_id, &host_buf, batch_size, k, m);
+            }
+            self.iu4_capture_hook = hook;
+        }
+
+        // Calibrated iu4 path: gfx12 only, env-gated, requires sidecar.
+        // Runs SmoothQuant-style preshift → Q4_1 prequant → iu4 GEMM →
+        // bias_add. Falls through to the regular dispatch on missing
+        // sidecar / wrong arch / batch_size==1.
+        if batch_size > 1
+            && is_gfx12(&self.arch)
+            && std::env::var("HIPFIRE_GFX12_IU4_CALIBRATED").ok().as_deref() == Some("1")
+        {
+            // Optional layer-isolation gate: same shape as
+            // HIPFIRE_GFX12_IU4_MAX_CALL but for the calibrated path. Use
+            // for falsification ("does layer-0 alone stay coherent under
+            // calibration?"). Default = MAX so all sites use calibrated
+            // path.
+            let max_call: usize = std::env::var("HIPFIRE_GFX12_IU4_MAX_CALL")
+                .ok().and_then(|s| s.parse().ok()).unwrap_or(usize::MAX);
+            if site_id < max_call {
+                if self.iu4_calibration.is_none() {
+                    return Err(hip_bridge::HipError::new(0,
+                        "HIPFIRE_GFX12_IU4_CALIBRATED=1 set but no .iu4cal sidecar loaded — \
+                         the engine should auto-load <model>.iu4cal at load time. \
+                         Either generate it via `cargo run --release -p engine \
+                         --example calibrate_iu4_activations -- --model <path>` or \
+                         unset the env var to fall back to FP16/MMQ."));
+                }
+                // Look up site. If the sidecar has fewer sites than dispatch
+                // calls (e.g. corpus didn't cover all layers), error rather
+                // than silently take a different path — this is a config
+                // bug we want operators to see.
+                let cal = self.iu4_calibration.as_ref().unwrap();
+                let site = cal.site_at(site_id).ok_or_else(|| {
+                    hip_bridge::HipError::new(0, &format!(
+                        "iu4 calibration sidecar has {} sites but dispatch \
+                         call {} requested — calibration corpus must have \
+                         covered all gemm_hfq4g256_residual call sites.",
+                        cal.n_sites(), site_id
+                    ))
+                })?;
+                if site.n_channels as usize != k || site.n_output_rows as usize != m {
+                    return Err(hip_bridge::HipError::new(0, &format!(
+                        "iu4 calibration site {} shape mismatch: sidecar has \
+                         (n_channels={}, n_output_rows={}) but dispatch saw \
+                         (k={}, m={}) — recapture the sidecar against this \
+                         model.", site_id, site.n_channels, site.n_output_rows, k, m
+                    )));
+                }
+                let mu_a_ptr = site.mu_a.as_ptr();
+                let inv_s_a_ptr = site.inv_s_a.as_ptr();
+                let bias_ptr = site.w_mu_bias_f32.as_ptr();
+                let m_rows = site.n_output_rows as usize;
+                let groups_per_row = site.groups_per_row as usize;
+
+                // 0. Get or materialize the s-baked weight clone for this
+                //    site. First call allocates + d2d copies + applies the
+                //    bake kernel; subsequent calls return the cached
+                //    pointer with no extra work.
+                let baked_w_ptr = self.iu4_get_or_bake_weight(a_raw, site_id)?;
+
+                // 1. Preshift x → x_centered = (x - mu) * inv_s.
+                let preshift_ptr = self.iu4_preshift(
+                    x.buf.as_ptr(), mu_a_ptr, inv_s_a_ptr, batch_size, k)?;
+                let x_centered_buf = unsafe {
+                    DeviceBuffer::from_raw(preshift_ptr, batch_size * k * 4)
+                };
+                let x_centered = GpuTensor {
+                    buf: x_centered_buf,
+                    shape: vec![batch_size, k],
+                    dtype: DType::F32,
+                };
+                // 2. Q4_1 prequant of the centered activation.
+                let xq = self.ensure_q4_1_x(&x_centered, batch_size, k)?;
+                std::mem::forget(x_centered);  // borrow only — no free
+
+                // 3. iu4 K=32 wmma GEMM. The baked weight pointer wraps a
+                //    DeviceBuffer view that we explicitly forget at end of
+                //    scope so the cached buffer is not freed.
+                let baked_buf = unsafe {
+                    DeviceBuffer::from_raw(baked_w_ptr, m_rows * groups_per_row * 136)
+                };
+                let baked_w = GpuTensor {
+                    buf: baked_buf,
+                    shape: vec![m_rows * groups_per_row * 136],
+                    dtype: DType::Raw,
+                };
+                let gemm_res = self.gemm_hfq4g256_residual_iu4_gfx12(
+                    &baked_w, xq, y, m, k, batch_size, /*add=*/true);
+                std::mem::forget(baked_w);
+                gemm_res?;
+
+                // 4. Add the precomputed W·mu_a bias to every column of y.
+                //    y is laid out as [N × M] column-major (linear index =
+                //    col*M + row), so `bias_add_f32(y, bias, batch=N, n=M)`
+                //    does y[col*M + row] += bias[(col*M + row) % M] = bias[row].
+                let bias_buf = unsafe {
+                    DeviceBuffer::from_raw(bias_ptr, m_rows * 4)
+                };
+                let bias_t = GpuTensor {
+                    buf: bias_buf,
+                    shape: vec![m_rows],
+                    dtype: DType::F32,
+                };
+                let res = self.bias_add_f32(y, &bias_t, batch_size, m_rows);
+                std::mem::forget(bias_t);
+                return res;
+            }
+            // else: site_id >= max_call → fall through to FP16/MMQ
+        }
+
         // CDNA3 MFMA path — Y += X·W^T via rocBLAS with beta=1.
         if self.rocblas_arch_eligible()
             && batch_size >= self.rocblas_min_batch()

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -5147,15 +5147,18 @@ impl Gpu {
             &mut add_val as *mut _ as *mut c_void,
         ];
 
-        const MMQ_X: usize = 128;
+        // K_PER_KB=256, MMQ_X=64 (kernel constants in
+        // gemm_hfq4g256_residual_fp8.gfx12.hip). LDS budget:
+        //   tile_x: 128 rows × 64 i32 = 32 KB
+        //   tile_y: 64  cols × 64 i32 = 16 KB
+        //   tile_idS: 64 floats        = 256 B
+        //   total ~48.25 KB (gfx12 ~64 KB ceiling)
+        const MMQ_X: usize = 64;
         const MMQ_Y: usize = 128;
-        const FP8_K_I32_STRIDE: usize = 32;  // K=128 / 4 fp8-per-i32
-        const TILE_IDS_FLOATS: usize = 128;  // per-col activation idScale
+        const FP8_K_I32_STRIDE: usize = 64;  // K=256 / 4 fp8-per-i32
+        const TILE_IDS_FLOATS: usize = MMQ_X;
         let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
         let batch_tiles = (batch_size + MMQ_X - 1) / MMQ_X;
-        // tile_x: 128 rows x 32 i32 = 16 KB
-        // tile_y: 128 cols x 32 i32 = 16 KB
-        // tile_idS: 128 floats     = 0.5 KB
         let shared_mem = ((MMQ_Y * FP8_K_I32_STRIDE
             + MMQ_X * FP8_K_I32_STRIDE) * std::mem::size_of::<i32>()
             + TILE_IDS_FLOATS * std::mem::size_of::<f32>()) as u32;

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -6042,6 +6042,19 @@ impl Gpu {
             // screened on first use: a small synthetic comparison detects
             // outlier rows where Q8_1 precision loss exceeds the threshold
             // (#87). Unsafe weights fall through to WMMA instead.
+            // gfx12 FP8 (E4M3) opt-in path. Bypasses MMQ entirely. Gated behind
+            // HIPFIRE_GFX12_FP8=1 until correctness validated against coherence
+            // gate. The FP8 GEMM kernel does in-kernel HFQ4 dequant + per-tile
+            // activation FP8 cast — no Q8_1 quant pre-pass kernel, no per-K=32
+            // scale-correction loop. Targets the standalone wo + w_down path
+            // where the iu8 MMQ port regresses 27B by -8% (per
+            // project_gfx12_mmq_bench_2026_05_04.md).
+            if is_gfx12(&self.arch)
+                && std::env::var("HIPFIRE_GFX12_FP8").ok().as_deref() == Some("1")
+                && batch_size > 1
+            {
+                return self.gemm_hfq4g256_residual_fp8_gfx12(a_raw, x, y, m, k, batch_size);
+            }
             if std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
                 || should_use_mmq(&self.arch, batch_size)
             {

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -6575,6 +6575,12 @@ impl Gpu {
             let max_call: usize = std::env::var("HIPFIRE_GFX12_IU4_MAX_CALL")
                 .ok().and_then(|s| s.parse().ok()).unwrap_or(usize::MAX);
             if site_id < max_call {
+                // Optional diagnostic trace.
+                if std::env::var("HIPFIRE_IU4_CAL_DEBUG").ok().as_deref() == Some("1") {
+                    eprintln!(
+                        "[iu4-cal] site_id={site_id} m={m} k={k} n={batch_size}"
+                    );
+                }
                 if self.iu4_calibration.is_none() {
                     return Err(hip_bridge::HipError::new(0,
                         "HIPFIRE_GFX12_IU4_CALIBRATED=1 set but no .iu4cal sidecar loaded — \

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1355,6 +1355,39 @@ impl Gpu {
         }
     }
 
+    /// gfx12 (RDNA4) iu4 K=32 WMMA layout-discovery probe — issue #136 part B.
+    /// Single-wave probe that runs three patterns (A=ones B=ones, A=row-id B=ones,
+    /// A=ones B=col-id) in one launch and dumps each pattern's 32*8=256 i32 acc
+    /// to consecutive 256-i32 regions of `out`. `out` must have capacity for at
+    /// least 3*256 = 768 i32 elements.
+    pub fn probe_wmma_iu4_k32_layout(&mut self, out: &GpuTensor) -> HipResult<()> {
+        if !(self.arch == "gfx1200" || self.arch == "gfx1201") {
+            return Err(hip_bridge::HipError::new(0, &format!(
+                "probe_wmma_iu4_k32_layout requires gfx1200/gfx1201; got {}",
+                self.arch
+            )));
+        }
+        self.ensure_kernel(
+            "probe_wmma_iu4_k32_layout",
+            kernels::PROBE_WMMA_IU4_K32_LAYOUT_GFX12_SRC,
+            "probe_wmma_iu4_k32_layout",
+        )?;
+        let func = &self.functions["probe_wmma_iu4_k32_layout"];
+        let mut out_ptr = out.buf.as_ptr();
+        let mut params: Vec<*mut c_void> =
+            vec![&mut out_ptr as *mut _ as *mut c_void];
+        unsafe {
+            self.hip.launch_kernel(
+                func,
+                [1, 1, 1],
+                [32, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        }
+    }
+
     /// Wave-cooperative Q4 GEMV (Q4_F16_G32 format, 0.625 B/w). Shuffle-based nibble distribution.
     pub fn gemv_q4wave(
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -6319,6 +6319,17 @@ impl Gpu {
             if is_gfx12(&self.arch)
                 && batch_size > 1
             {
+                // gfx12 iu4 K=32 opt-in. HIPFIRE_GFX12_IU4=1. Bypasses MMQ +
+                // FP16 entirely. Q4_1 prequant + iu4 K=32 wmma — 4× FP16
+                // matrix throughput per AMD spec, HFQ4 nibbles consumed
+                // AS-IS as iu4 (no in-kernel dequant). Q4_1 activation has
+                // ~14% per-elem precision (looser than Q8_1's ~0.8%); ship
+                // requires coherence-gate validation on real models.
+                if std::env::var("HIPFIRE_GFX12_IU4").ok().as_deref() == Some("1") {
+                    let xq = self.ensure_q4_1_x(x, batch_size, k)?;
+                    return self.gemm_hfq4g256_residual_iu4_gfx12(
+                        a_raw, xq, y, m, k, batch_size, /*add=*/true);
+                }
                 match std::env::var("HIPFIRE_GFX12_FP8").ok().as_deref() {
                     Some("1") => {
                         return self.gemm_hfq4g256_residual_fp8_preconv_gfx12(

--- a/crates/rdna-compute/src/iu4_calibration.rs
+++ b/crates/rdna-compute/src/iu4_calibration.rs
@@ -1,0 +1,67 @@
+//! GPU-side iu4 activation calibration data.
+//!
+//! Engine-side sidecar lives at `engine::quant::iu4_calibration::Iu4Calibration`.
+//! When the engine wants to enable calibrated iu4 dispatch on gfx12, it
+//! uploads each site's mu/inv_s/bias FP16 vectors into device buffers and
+//! hands the resulting `GpuIu4Calibration` to `Gpu::load_iu4_calibration`.
+//!
+//! The dispatcher then consults `Gpu::iu4_calibration` per call to look up
+//! the active site's tables and runs:
+//!
+//!   1. preshift kernel: `x_centered[t][c] = (x[t][c] - mu[c]) * inv_s[c]`
+//!   2. existing `ensure_q4_1_x` on `x_centered`
+//!   3. existing `gemm_hfq4g256_residual_iu4_gfx12` (UNCHANGED — just with a
+//!      weight whose per-row scales were pre-multiplied by group-mean(s_a)
+//!      at calibration-load time on the host)
+//!   4. broadcast-add of `w_mu_bias[m]` to the GEMM output (existing
+//!      `bias_add_f32`)
+
+use hip_bridge::DeviceBuffer;
+
+/// Per-site GPU-resident calibration tables. Keep them owned by the Gpu
+/// struct (lives as long as the model is loaded).
+pub struct GpuIu4CalSite {
+    /// Logical layer index (informational; the dispatcher keys by call order).
+    pub layer_idx: u32,
+    /// 0=wo, 1=w_down.
+    pub proj_id: u32,
+    /// Input channel dim (= k).
+    pub n_channels: u32,
+    /// Output dim (= weight rows).
+    pub n_output_rows: u32,
+    /// HFQ4-G256 group count along K (= k / 256).
+    pub groups_per_row: u32,
+    /// Per-input-channel mu_a, FP16, n_channels half-words.
+    pub mu_a: DeviceBuffer,
+    /// Per-input-channel 1 / s_a, FP16, n_channels half-words. The s_a
+    /// stored here is GROUP-CONSTANT (= `s_group[group(c)]` repeated
+    /// across the 256 channels of each group) so the activation-side
+    /// preshift composes EXACTLY with the weight-side bake. See
+    /// `engine::quant::iu4_calibration` for the math.
+    pub inv_s_a: DeviceBuffer,
+    /// Per-K=256-group activation scale, FP16, groups_per_row half-words.
+    /// Used once at first-touch per weight to multiply the HFQ4 group
+    /// scale fields in-place (or in a clone — see `iu4_baked_weight_cache`).
+    pub s_group: DeviceBuffer,
+    /// Per-output-row W·mu_a precomputed bias, FP32 to match the GEMM
+    /// output dtype directly (no FP16 → FP32 cast in the bias_add path).
+    pub w_mu_bias_f32: DeviceBuffer,
+}
+
+pub struct GpuIu4Calibration {
+    pub sites: Vec<GpuIu4CalSite>,
+}
+
+impl GpuIu4Calibration {
+    pub fn empty() -> Self {
+        Self { sites: Vec::new() }
+    }
+
+    pub fn site_at(&self, call_idx: usize) -> Option<&GpuIu4CalSite> {
+        self.sites.get(call_idx)
+    }
+
+    pub fn n_sites(&self) -> usize {
+        self.sites.len()
+    }
+}

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -251,6 +251,19 @@ pub const PROBE_WMMA_FP8_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels
 // skips the `_full_add` / `_full_set` boundary-elided variants for the first
 // cut (those are an easy follow-up once correctness lands on gfx1201).
 pub const GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mmq.gfx12.hip");
+// gfx12 (RDNA4) FP8 (E4M3) variant of the HFQ4-G256 residual GEMM. Same
+// 128x128 MMQ tile recipe as the i8 sister but uses
+// __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12 with FP32 acc — drops
+// the i8 MMQ overheads (separate Q8_1 pre-quant kernel + per-K=32 dmA*dsB
+// scale-correction loop) by baking HFQ4 dequant into the FP8 cast inline
+// and casting activations FP32->FP8 with a per-(tile_y col) dynamic scale
+// computed in-kernel. K=128 per kb iter (half of an HFQ4 group) keeps LDS
+// at ~32.5 KB (16 KB tile_x + 16 KB tile_y + 0.5 KB per-col idScale), well
+// under the gfx12 ~64 KB ceiling. Layout contract validated by
+// probe_wmma_fp8_layout.gfx12.hip on R9700 silicon (commit 7984e38). First-
+// cut variant only: basic `_residual_fp8` with runtime `add` flag — no
+// `_full_add` / `_full_set` boundary-elided variants yet.
+pub const GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -264,6 +264,28 @@ pub const GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC: &str = include_str!("../../../ke
 // cut variant only: basic `_residual_fp8` with runtime `add` flag — no
 // `_full_add` / `_full_set` boundary-elided variants yet.
 pub const GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip");
+// gfx12 (RDNA4) iu4 K=32 variant of the HFQ4-G256 residual GEMM. Sister of
+// GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC (the iu8 K=16 path). Uses
+// __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12 — 4x FP16 throughput per
+// AMD spec, vs 2x for iu8. HFQ4 nibbles map natively to iu4 unsigned indices
+// (no weight conversion / no LDS staging round-trip), so this variant is
+// the most structurally different from FP8/iu8 (which stage FP8 or INT8 in
+// LDS via a per-thread cast). Activation pre-quantizes via Q4_1 (signed
+// INT4 in [-7,7] with per-K=32 (d, d*sum_q) metadata) — see the sibling
+// QUANTIZE_Q4_1_GFX12_SRC. K=256 per kb iter (full HFQ4 group), 8 K=32 wmma
+// calls per (n-tile, m-tile). Layout contract validated by
+// probe_wmma_iu4_k32_layout.gfx12.hip on hiptrx silicon (commit 03a5856 on
+// `feat/probe-gfx12-wmma-iu4-k32`). First-cut variant only: basic
+// `_residual_iu4` with runtime `add` flag — no `_full_add`/`_full_set`.
+pub const GEMM_HFQ4G256_RESIDUAL_IU4_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_iu4.gfx12.hip");
+// Q4_1 (signed INT4 in [-7,7], per-K=32 d/sum metadata) activation quantizer
+// for gfx12. Sister of `quantize_q8_1_mmq_ds4_gfx12` (in
+// GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC) but produces INT4 instead of INT8 to
+// feed the iu4 K=32 wmma path. Output layout `block_q4_1_mmq` is 80 B per
+// K=128 of one token (16 B half2[4] ds + 64 B INT4 qs[64]). Used by
+// `ensure_q4_1_x` in dispatch.rs to populate the prequant cache before each
+// iu4 GEMM call.
+pub const QUANTIZE_Q4_1_GFX12_SRC: &str = include_str!("../../../kernels/src/quantize_q4_1.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 // gfx12 sister of DEQUANT_HFQ4G256_TO_F16_SRC. One-shot HFQ4-G256 -> FP8

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -218,6 +218,12 @@ pub const GEMM_HFQ4G256_RESIDUAL_MMQ_SRC: &str = include_str!("../../../kernels/
 // and accumulates correctly on gfx1201 silicon. Used by the
 // `probe_wmma_iu4_k32` example (rdna-compute), not by any production path.
 pub const PROBE_WMMA_IU4_K32_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu4_k32.gfx12.hip");
+// gfx12 layout-discovery probe — three patterns (A=ones B=ones, A=row-id B=ones,
+// A=ones B=col-id) packed into one wave. Discovered the wave32 acc layout for
+// gfx12 iu4 K=32 wmma is **8-row-block** (lane l, slot j → C[8*(l>>4) + j][l & 0xF]),
+// NOT the RDNA3 stride-2 interleave. The production iu4 GEMM port writes acc
+// using this 8-row-block formula. See `probe_wmma_iu4_k32_layout` example.
+pub const PROBE_WMMA_IU4_K32_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu4_k32_layout.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -224,6 +224,13 @@ pub const PROBE_WMMA_IU4_K32_GFX12_SRC: &str = include_str!("../../../kernels/sr
 // NOT the RDNA3 stride-2 interleave. The production iu4 GEMM port writes acc
 // using this 8-row-block formula. See `probe_wmma_iu4_k32_layout` example.
 pub const PROBE_WMMA_IU4_K32_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu4_k32_layout.gfx12.hip");
+// gfx12 iu8 K=16 WMMA layout-discovery probe — same three-pattern shape, but
+// exercises __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32 (the K=16 iu8 form
+// that exists on gfx12; the K=32 iu8 form does NOT exist there per the
+// probe-1 commit msg — K=32 is iu4 only). Used to confirm whether iu8 K=16
+// uses the same 8-row-block acc layout as iu4 K=32 before porting the MMQ
+// kernel from RDNA3 to gfx12. See `probe_wmma_iu8_k16_layout` example.
+pub const PROBE_WMMA_IU8_K16_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu8_k16_layout.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -286,6 +286,19 @@ pub const GEMM_HFQ4G256_RESIDUAL_IU4_GFX12_SRC: &str = include_str!("../../../ke
 // `ensure_q4_1_x` in dispatch.rs to populate the prequant cache before each
 // iu4 GEMM call.
 pub const QUANTIZE_Q4_1_GFX12_SRC: &str = include_str!("../../../kernels/src/quantize_q4_1.gfx12.hip");
+// SmoothQuant-style per-channel activation preshift for the gfx12 iu4 path.
+// `y[t][c] = (x[t][c] - mu[c]) * inv_s[c]`. Applied BEFORE Q4_1 quant when
+// the iu4 calibration sidecar is loaded. mu / inv_s are FP16, x / y are FP32
+// (matching the Q4_1 quantizer's input shape). See
+// crates/engine/src/quant/iu4_calibration.rs for the sidecar format and math
+// derivation.
+pub const ACTIVATION_PRESHIFT_GFX12_SRC: &str = include_str!("../../../kernels/src/activation_preshift.gfx12.hip");
+// SmoothQuant weight-side bake for the gfx12 iu4 path. Walks an HFQ4-G256
+// weight in place and multiplies each (row, K=256-group) scale field by
+// `s_group[g]` from the iu4 calibration sidecar. One-shot: applied at
+// calibrated-dispatch first-touch per weight, cached thereafter. See
+// crates/engine/src/quant/iu4_calibration.rs for the math derivation.
+pub const IU4_BAKE_WEIGHT_SCALES_GFX12_SRC: &str = include_str!("../../../kernels/src/iu4_bake_weight_scales.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 // gfx12 sister of DEQUANT_HFQ4G256_TO_F16_SRC. One-shot HFQ4-G256 -> FP8

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -231,6 +231,13 @@ pub const PROBE_WMMA_IU4_K32_LAYOUT_GFX12_SRC: &str = include_str!("../../../ker
 // uses the same 8-row-block acc layout as iu4 K=32 before porting the MMQ
 // kernel from RDNA3 to gfx12. See `probe_wmma_iu8_k16_layout` example.
 pub const PROBE_WMMA_IU8_K16_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu8_k16_layout.gfx12.hip");
+// gfx12 FP8 (E4M3) WMMA layout-discovery probe — three-pattern shape against
+// __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12. FP8 has 2× the matrix
+// throughput of FP16 wmma on RDNA4 (1024 vs 512 ops/cycle/CU per AMD spec)
+// — the architectural ceiling that iu8 MMQ doesn't have. Probe locks the
+// wave32 layout (first guess confirmed: same 8-row-block as iu4/iu8) before
+// writing the FP8 GEMM port. See `probe_wmma_fp8_layout` example.
+pub const PROBE_WMMA_FP8_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_fp8_layout.gfx12.hip");
 // gfx12 (RDNA4) port of the HFQ4-G256 MMQ residual GEMM. Sister of
 // GEMM_HFQ4G256_RESIDUAL_MMQ_SRC — same 128×128 MMQ tile recipe, Q8_1
 // activation pre-quant, scale/zero correction at sub-block granularity.

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -231,6 +231,19 @@ pub const PROBE_WMMA_IU4_K32_LAYOUT_GFX12_SRC: &str = include_str!("../../../ker
 // uses the same 8-row-block acc layout as iu4 K=32 before porting the MMQ
 // kernel from RDNA3 to gfx12. See `probe_wmma_iu8_k16_layout` example.
 pub const PROBE_WMMA_IU8_K16_LAYOUT_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu8_k16_layout.gfx12.hip");
+// gfx12 (RDNA4) port of the HFQ4-G256 MMQ residual GEMM. Sister of
+// GEMM_HFQ4G256_RESIDUAL_MMQ_SRC — same 128×128 MMQ tile recipe, Q8_1
+// activation pre-quant, scale/zero correction at sub-block granularity.
+// Differences vs the RDNA3 reference (validated via the iu8 K=16 layout
+// probe above): __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12 (with the
+// _gfx12 suffix — the unsuffixed builtin compiles but won't lower on gfx12),
+// int32x2 per-lane operands (8 INT8 = K-half of one row, vs RDNA3's int32x4
+// = K=16 of one row), 2 WMMA calls per Q8_1 sub-block (one per K=16 sub-tile),
+// and the 8-row-block acc layout (lane l, slot j → C[8*(l>>4) + j][l & 0xF]).
+// Exposes `quantize_q8_1_mmq_ds4_gfx12` and `gemm_hfq4g256_residual_mmq_gfx12`;
+// skips the `_full_add` / `_full_set` boundary-elided variants for the first
+// cut (those are an easy follow-up once correctness lands on gfx1201).
+pub const GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mmq.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -213,6 +213,11 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../k
 // the Strix Halo prefill gap vs llama.cpp (#60); also wins ~+20% on gfx1100
 // at pp≥256.
 pub const GEMM_HFQ4G256_RESIDUAL_MMQ_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mmq.hip");
+// gfx12 (RDNA4) iu4 K=32 WMMA probe — POC for issue #136 part B.
+// Validates that __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12 dispatches
+// and accumulates correctly on gfx1201 silicon. Used by the
+// `probe_wmma_iu4_k32` example (rdna-compute), not by any production path.
+pub const PROBE_WMMA_IU4_K32_GFX12_SRC: &str = include_str!("../../../kernels/src/probe_wmma_iu4_k32.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -266,6 +266,13 @@ pub const GEMM_HFQ4G256_RESIDUAL_MMQ_GFX12_SRC: &str = include_str!("../../../ke
 pub const GEMM_HFQ4G256_RESIDUAL_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip");
 pub const GEMM_MW16_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mw16_residual_wmma.hip");
 pub const DEQUANT_HFQ4G256_TO_F16_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_f16.hip");
+// gfx12 sister of DEQUANT_HFQ4G256_TO_F16_SRC. One-shot HFQ4-G256 -> FP8
+// (E4M3) dequant for model-load-time conversion. Used by ensure_fp8_shadow
+// to populate a pre-converted FP8 weight tensor that the FP8 wmma GEMM path
+// consumes directly, eliminating the per-prefill in-kernel dequant cost.
+// Storage delta vs HFQ4: 0.531 -> 1.0 B/w. 27B model expands 13.5 -> 27 GB
+// (still fits R9700's 32 GB with ~5 GB KV-cache headroom for short ctx).
+pub const DEQUANT_HFQ4G256_TO_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/dequant_hfq4g256_to_fp8.gfx12.hip");
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma.hip");
 // LDS-staged X variant. Opt-in via HIPFIRE_GATE_UP_VARIANT=ldsx for
 // Gate 1 microbench measurement. See

--- a/crates/rdna-compute/src/lib.rs
+++ b/crates/rdna-compute/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod compiler;
 mod dispatch;
+pub mod iu4_calibration;
 mod kernels;
 pub mod pool;
 pub mod profile;
@@ -9,4 +10,5 @@ pub mod profiler;
 
 pub use compiler::KernelCompiler;
 pub use dispatch::{DType, Gpu, GpuTensor};
+pub use iu4_calibration::{GpuIu4Calibration, GpuIu4CalSite};
 pub use kernels::GEMV_SRC;

--- a/kernels/src/activation_preshift.gfx12.hip
+++ b/kernels/src/activation_preshift.gfx12.hip
@@ -1,0 +1,100 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// SmoothQuant-style per-channel activation preshift for the gfx12 iu4 K=32
+// path:
+//
+//   y[t][c] = (x[t][c] - mu_a[c]) * inv_s_a[c]
+//
+// `mu_a` and `inv_s_a` are stored as FP16 to keep the sidecar small. The
+// preshift writes FP32 because the downstream Q4_1 quantizer
+// (`quantize_q4_1_mmq_ds4_gfx12`) reads FP32. Per-call cost: one HBM read
+// of x, one HBM write of y, plus a tiny constant-table read of mu/inv_s
+// (sized to k = 4096-12288 channels = 16-48 KB FP16, easily cached).
+//
+// Threading: same as the Q4_1 quantizer — 4 elements per thread, blockDim
+// = 256, grid = ((K+1023)/1024, N, 1). Each thread reads/writes 1 float4
+// into [t][c..c+4] for c = (blockIdx.x * 256 + threadIdx.x) * 4. mu/inv_s
+// are read aligned at the same c offsets — stride is k FP16 (= 2 bytes) so
+// 4 channels = 8 bytes = one float2 of FP16 pairs.
+//
+// Stub for non-gfx12 archs to keep the cross-arch JIT happy. Calibrated
+// iu4 dispatch is gfx12-only at present; other archs that wire the
+// SmoothQuant idea later should add their own preshift kernel matching
+// their preferred quantizer's input shape.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void activation_preshift_gfx12(
+    const float*,
+    const __half*,
+    const __half*,
+    float*,
+    int,
+    int
+) {}
+
+#else
+
+extern "C" __global__ void activation_preshift_gfx12(
+    const float* __restrict__ X,        // [N x K] FP32 row-major
+    const __half* __restrict__ mu_a,    // [K] FP16
+    const __half* __restrict__ inv_s_a, // [K] FP16 (1 / s_a, with floor)
+    float* __restrict__ Y,              // [N x K] FP32 row-major (out)
+    int K,
+    int N
+) {
+    const int token = blockIdx.y;
+    const int c0 = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
+    if (token >= N || c0 >= K) return;
+
+    // Bulk-load 4 channels of mu / inv_s as FP16 pairs.
+    float mu0, mu1, mu2, mu3;
+    float is0, is1, is2, is3;
+    if (c0 + 3 < K) {
+        const __half2 mu_lo = *(const __half2*)(mu_a + c0);
+        const __half2 mu_hi = *(const __half2*)(mu_a + c0 + 2);
+        const __half2 is_lo = *(const __half2*)(inv_s_a + c0);
+        const __half2 is_hi = *(const __half2*)(inv_s_a + c0 + 2);
+        const float2 mu_lo_f = __half22float2(mu_lo);
+        const float2 mu_hi_f = __half22float2(mu_hi);
+        const float2 is_lo_f = __half22float2(is_lo);
+        const float2 is_hi_f = __half22float2(is_hi);
+        mu0 = mu_lo_f.x; mu1 = mu_lo_f.y; mu2 = mu_hi_f.x; mu3 = mu_hi_f.y;
+        is0 = is_lo_f.x; is1 = is_lo_f.y; is2 = is_hi_f.x; is3 = is_hi_f.y;
+    } else {
+        mu0 = (c0 + 0 < K) ? __half2float(mu_a[c0 + 0]) : 0.0f;
+        mu1 = (c0 + 1 < K) ? __half2float(mu_a[c0 + 1]) : 0.0f;
+        mu2 = (c0 + 2 < K) ? __half2float(mu_a[c0 + 2]) : 0.0f;
+        mu3 = (c0 + 3 < K) ? __half2float(mu_a[c0 + 3]) : 0.0f;
+        is0 = (c0 + 0 < K) ? __half2float(inv_s_a[c0 + 0]) : 1.0f;
+        is1 = (c0 + 1 < K) ? __half2float(inv_s_a[c0 + 1]) : 1.0f;
+        is2 = (c0 + 2 < K) ? __half2float(inv_s_a[c0 + 2]) : 1.0f;
+        is3 = (c0 + 3 < K) ? __half2float(inv_s_a[c0 + 3]) : 1.0f;
+    }
+
+    const long long base = (long long)token * K + c0;
+    if (c0 + 3 < K) {
+        const float4 xi = *(const float4*)(X + base);
+        float4 yi;
+        yi.x = (xi.x - mu0) * is0;
+        yi.y = (xi.y - mu1) * is1;
+        yi.z = (xi.z - mu2) * is2;
+        yi.w = (xi.w - mu3) * is3;
+        *(float4*)(Y + base) = yi;
+    } else {
+        if (c0 + 0 < K) Y[base + 0] = (X[base + 0] - mu0) * is0;
+        if (c0 + 1 < K) Y[base + 1] = (X[base + 1] - mu1) * is1;
+        if (c0 + 2 < K) Y[base + 2] = (X[base + 2] - mu2) * is2;
+        if (c0 + 3 < K) Y[base + 3] = (X[base + 3] - mu3) * is3;
+    }
+}
+
+#endif

--- a/kernels/src/dequant_hfq4g256_to_fp8.gfx12.hip
+++ b/kernels/src/dequant_hfq4g256_to_fp8.gfx12.hip
@@ -1,0 +1,92 @@
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+// Dequant HFQ4-G256 packed weights to FP8 (E4M3), one-shot at model load
+// time on gfx12 (RDNA4). Sister of `dequant_hfq4g256_to_f16` — same access
+// pattern, different output dtype. Used to populate an "FP8 shadow" weight
+// tensor that the FP8 wmma GEMM path consumes directly (eliminating the
+// per-prefill in-kernel dequant cost).
+//
+// Storage delta: HFQ4-G256 is 0.531 B/w (136 B per 256 weights). FP8 is
+// 1.0 B/w. Pre-converted FP8 shadow doubles VRAM cost; for 27B that's
+// 27 GB total (vs HFQ4's 13.5 GB), which fits R9700's 32 GB but leaves
+// thin headroom for KV cache. Caller decides when this trade is worth it.
+//
+// Input:  A_packed [M × groups_per_row × 136 bytes] (4-bit packed)
+//   group layout: 4B FP32 scale | 4B FP32 zero | 128B nibbles (256 of them)
+// Output: W_fp8   [M × K] FP8 (E4M3) bytes (row-major)
+//
+// Grid: [M, groups_per_row]. Block: [32].
+// Each block dequants one 256-element group for one row. Thread t covers
+// 8 nibbles (tid*8..tid*8+7) → 8 FP32 → 8 FP8 bytes packed as 2 int32 via
+// `__builtin_amdgcn_cvt_pk_fp8_f32`.
+//
+// FP8 cast precision: HFQ4 weights have effective range scale*[0,15]+zero
+// per group. After applying the per-group scale+zero, weight values land
+// in whatever distribution the source model has. E4M3's representable
+// range (±448) easily covers typical Qwen3.5 weight magnitudes (rarely
+// exceed ~10 after scale/zero apply). Per-group scale+zero is BAKED INTO
+// the FP8 representation here — the FP8 wmma GEMM consumer sees no extra
+// scale/zero metadata.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void dequant_hfq4g256_to_fp8_gfx12(
+    const char*, unsigned char*, int, int) {}
+
+#else
+
+extern "C" __launch_bounds__(32, 16)
+__global__ void dequant_hfq4g256_to_fp8_gfx12(
+    const char* __restrict__ A_packed,
+    unsigned char* __restrict__ W_fp8,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    const int group = blockIdx.y;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+    const int groups_per_row = K / 256;
+
+    const char* gp = A_packed + (long long)row * groups_per_row * 136 + group * 136;
+    const float scale = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+    const float zero  = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+    const int boff = tid * 4;  // 8 nibbles = 4 bytes
+    const unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+
+    // Dequant 8 nibbles → 8 FP32 in registers.
+    const float w0 = scale * (float)((pk      ) & 0xFu) + zero;
+    const float w1 = scale * (float)((pk >>  4) & 0xFu) + zero;
+    const float w2 = scale * (float)((pk >>  8) & 0xFu) + zero;
+    const float w3 = scale * (float)((pk >> 12) & 0xFu) + zero;
+    const float w4 = scale * (float)((pk >> 16) & 0xFu) + zero;
+    const float w5 = scale * (float)((pk >> 20) & 0xFu) + zero;
+    const float w6 = scale * (float)((pk >> 24) & 0xFu) + zero;
+    const float w7 = scale * (float)((pk >> 28) & 0xFu) + zero;
+
+    // Pack 8 FP32 → 8 FP8 (E4M3) bytes as 2 int32. word_sel=false writes
+    // the low 16 bits of `old`, word_sel=true writes the high 16 bits.
+    // Each call converts 2 FP32 → 2 FP8 packed into a 16-bit half.
+    unsigned int p0 = 0;
+    p0 = __builtin_amdgcn_cvt_pk_fp8_f32(w0, w1, p0, false);
+    p0 = __builtin_amdgcn_cvt_pk_fp8_f32(w2, w3, p0, true);
+    unsigned int p1 = 0;
+    p1 = __builtin_amdgcn_cvt_pk_fp8_f32(w4, w5, p1, false);
+    p1 = __builtin_amdgcn_cvt_pk_fp8_f32(w6, w7, p1, true);
+
+    // Output offset: row stride = K bytes (1 byte per FP8 element).
+    // tid*8 byte offset within the group → tid*2 int32 offset.
+    unsigned int* out_i32 = (unsigned int*)(
+        W_fp8 + (long long)row * K + group * 256 + tid * 8);
+    out_i32[0] = p0;
+    out_i32[1] = p1;
+}
+
+#endif

--- a/kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip
@@ -1,0 +1,410 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+#include <math.h>
+
+// Experimental HFQ4-G256 FP8 (E4M3) residual GEMM for RDNA4 (gfx1200/gfx1201).
+//
+// Sister of `gemm_hfq4g256_residual_mmq.gfx12.hip` (the i8 MMQ port). Both
+// kernels compute the same residual GEMM (Y[m,n] = sum_k W[m,k] * X[n,k] +
+// Y[m,n]) but trade the i8-WMMA + Q8_1 scale-correction recipe for a
+// straight FP8-WMMA + per-tile-col activation scale.
+//
+// Why FP8 over i8 MMQ on RDNA4:
+//   - FP8 wmma accumulates into FP32 directly — no INT32->FP32 cast and no
+//     per-K=32 dmA*dsB scale-correction loop in the inner dot.
+//   - Activation is FP32 in, cast to FP8 INSIDE this kernel — we drop the
+//     separate `quantize_q8_1_mmq_ds4_gfx12` pre-pass kernel entirely.
+//   - HFQ4 dequant ( w = scale*q + zero ) is BAKED into the FP8 cast — no
+//     metadata in LDS for HFQ4 scale/zero; only the activation per-col
+//     idScale is staged.
+//   - Same 2x peak vs FP16 on RDNA4 matrix cores as i8 (1024 vs 512 ops/
+//     cycle/CU per AMD spec) but with the metadata overheads gone.
+//
+// Layout contract (locked by probe_wmma_fp8_layout.gfx12.hip on R9700 silicon
+// at commit 7984e38):
+//   - Builtin: `__builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a, b, acc)`
+//     with signature `(int32x2 a, int32x2 b, float8 acc) -> float8`. NO clamp/
+//     sign args (unlike iu4/iu8). Acc is FP32 x8 per lane.
+//   - A/B operand: int32x2 per lane = 8 FP8 (E4M3) bytes = K-half of one row.
+//     lane l: row m = l & 0xF, k-half = 8*(l>>4) within the K=16 sub-tile.
+//   - Acc layout: lane l, slot j in [0,8) -> C[8*(l>>4) + j][l & 0xF]. Same
+//     8-row-block as iu4/iu8, just with FP32 slots instead of i32.
+//   - FP32->FP8 packing: `__builtin_amdgcn_cvt_pk_fp8_f32(a, b, old, word_sel)`
+//     packs 2 FP32 -> 2 FP8 bytes into a 16-bit half of `old`. word_sel=false
+//     -> low 16 bits, true -> high 16 bits. 4 calls fill 8 FP8 = 1 int32x2.
+//
+// LDS budget (gfx12 effective ceiling ~64 KB observed via launch-failure
+// boundary on iu8 MMQ port):
+//   - tile_x: 128 rows x K=128 FP8 = 16 KB  (= 128 rows x 32 i32 stride)
+//   - tile_y: 128 cols x K=128 FP8 = 16 KB
+//   - tile_idS: 128 floats = 0.5 KB           (per-col activation idScale)
+//   Total ~32.5 KB - well under the ceiling. Per kb iteration covers a K=128
+//   half-group (so each HFQ4 group of K=256 takes 2 kb iters, sharing the
+//   same scale/zero across both halves).
+//
+// First-cut variant only: basic `_residual_fp8` with runtime `add` flag.
+// Boundary-elided `_full_add` / `_full_set` are RDNA3 / iu8 reserved follow-
+// ups once correctness lands.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#define MMQ_X 128
+#define MMQ_Y 128
+#define MMQ_NWARPS 8
+#define WARP_SIZE 32
+#define FP8_K_PER_KB 128       // K positions covered per kb iteration (= half-group)
+#define FP8_K_I32_STRIDE 32    // K=128 / 4 fp8-per-i32
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void gemm_hfq4g256_residual_fp8_gfx12(
+    const char*,
+    const float*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
+#else
+
+// E4M3 max representable magnitude (per OCP / IEEE FP8 spec).
+__device__ __forceinline__ float fp8_e4m3_max() { return 448.0f; }
+
+// ---------------------------------------------------------------------------
+// HFQ4 -> FP8 weight tile loader. Dequants 8 nibbles -> 8 FP32 (applying the
+// per-group scale + zero) -> 8 FP8 bytes (= int32x2 LDS slot) per thread.
+//
+// Layout in LDS: tile_x[row * 32 + k_i32] where k_i32 in [0..32) covers K=
+// [0..128) of this kb iter. 4 FP8 bytes per i32, so k_i32 = K/4.
+//
+// HFQ4 group on disk is 256 elems with one shared (FP32 scale, FP32 zero).
+// kb iteration covers 128 of those 256 elems; the high/low half is selected
+// by (kb & 1). The group index on disk is (kb >> 1).
+// ---------------------------------------------------------------------------
+template <bool FULL>
+static __device__ __forceinline__ void load_hfq4_tile_fp8(
+    const char* __restrict__ A,
+    int* __restrict__ tile_x,
+    int row0,
+    int kb,
+    int M,
+    int groups_per_row
+) {
+    // 256 threads = 16 rows-per-iter x 16 nibble-u32-per-row.
+    // Each thread loads 1 u32 of nibbles (= 8 nibbles = K=8 worth) and writes
+    // 2 i32 of FP8 (= 8 FP8 bytes) at tile_x[row * 32 + 2 * k_chunk + 0..1].
+    const int tid = (int)(threadIdx.y * WARP_SIZE + threadIdx.x);
+    const int row_in_iter = tid >> 4;          // 0..15
+    const int k_chunk = tid & 0xF;             // 0..15, indexes 4-byte nibble cluster within K=128
+    const int kb_group = kb >> 1;              // HFQ4 group index on disk
+    const int kb_half = kb & 1;                // 0 = K=[0..127], 1 = K=[128..255] within group
+
+    #pragma unroll
+    for (int i0 = 0; i0 < MMQ_Y; i0 += 16) {
+        const int i = i0 + row_in_iter;
+        const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+        const char* gp = A + ((long long)row * groups_per_row + kb_group) * 136;
+
+        // Group metadata is constant per row across all k_chunks. Compiler
+        // hoists this out via a uniform-sub-warp-dispatch pattern; if not, the
+        // duplicated loads land in L0 anyway.
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        // Nibble offset within the group: skip 8B header, then 64 B for the
+        // low half if we want the high half.
+        const int nibble_offset = 8 + kb_half * 64 + k_chunk * 4;
+        const unsigned int qs0 = *(const unsigned int*)(gp + nibble_offset);
+
+        // Dequant 8 nibbles -> 8 FP32 (BAKE scale + zero into the FP8 value).
+        const float v0 = sc * (float)((qs0      ) & 0xFu) + zp;
+        const float v1 = sc * (float)((qs0 >>  4) & 0xFu) + zp;
+        const float v2 = sc * (float)((qs0 >>  8) & 0xFu) + zp;
+        const float v3 = sc * (float)((qs0 >> 12) & 0xFu) + zp;
+        const float v4 = sc * (float)((qs0 >> 16) & 0xFu) + zp;
+        const float v5 = sc * (float)((qs0 >> 20) & 0xFu) + zp;
+        const float v6 = sc * (float)((qs0 >> 24) & 0xFu) + zp;
+        const float v7 = sc * (float)((qs0 >> 28) & 0xFu) + zp;
+
+        // Cast 8 FP32 -> 2 i32 (= 8 FP8 bytes, low-byte-order: v0,v1,...,v7).
+        unsigned int w0 = 0u;
+        w0 = __builtin_amdgcn_cvt_pk_fp8_f32(v0, v1, w0, false);
+        w0 = __builtin_amdgcn_cvt_pk_fp8_f32(v2, v3, w0, true);
+        unsigned int w1 = 0u;
+        w1 = __builtin_amdgcn_cvt_pk_fp8_f32(v4, v5, w1, false);
+        w1 = __builtin_amdgcn_cvt_pk_fp8_f32(v6, v7, w1, true);
+
+        tile_x[i * FP8_K_I32_STRIDE + 2 * k_chunk + 0] = (int)w0;
+        tile_x[i * FP8_K_I32_STRIDE + 2 * k_chunk + 1] = (int)w1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Activation FP32 -> FP8 staging with per-(tile_y col) dynamic scale.
+//
+// Strategy: 1 warp owns 16 cols (warp_id * 16 + col_in_warp). Lane l within
+// warp -> (col_in_warp = l & 0xF, k_half = l >> 4). 2 lanes share the same
+// col with different K-halves (K=[0..63] vs K=[64..127] of this kb iter).
+//
+// Pass 1: read X, compute amax over the lane's 64 K positions.
+// Combine across the 2 lanes via __shfl_xor(amax, 16). amax reduction is
+// per-col now.
+//
+// scale_b[col] = E4M3_MAX / max(|x|, eps), inv_scale_b[col] = 1 / scale_b.
+// Lane k_half==0 stores inv_scale_b to tile_idS[col].
+//
+// Pass 2: re-read X (relies on L1/L2 hit), multiply by scale_b, cast to
+// FP8 via cvt_pk_fp8_f32, store into tile_y[col * 32 + k_half * 16 + j].
+// ---------------------------------------------------------------------------
+template <bool FULL>
+static __device__ __forceinline__ void load_activation_tile_fp8(
+    const float* __restrict__ X,
+    int* __restrict__ tile_y,
+    float* __restrict__ tile_idS,
+    int col0,
+    int kb,
+    int K,
+    int N
+) {
+    const int warp_id = (int)threadIdx.y;
+    const int lane = (int)threadIdx.x;
+    const int col_in_warp = lane & 0xF;
+    const int k_half = lane >> 4;
+    const int col = warp_id * 16 + col_in_warp;
+    const int col_global = col0 + col;
+    const int kb_K_offset = kb * FP8_K_PER_KB;  // base K offset for this kb iter
+    const int k_base = kb_K_offset + k_half * 64;
+
+    const bool col_in_range = FULL ? true : (col_global < N);
+
+    // ---- Pass 1: amax over 64 K positions of one (col, k_half).
+    float amax = 0.0f;
+    if (col_in_range) {
+        const float* xp = X + (long long)col_global * K + k_base;
+        #pragma unroll
+        for (int j = 0; j < 64; ++j) {
+            const int k = k_base + j;
+            const float v = (k < K) ? xp[j] : 0.0f;
+            amax = fmaxf(amax, fabsf(v));
+        }
+    }
+
+    // Reduce amax across the 2 lanes (k_half = 0 vs 1) sharing this col.
+    amax = fmaxf(amax, __shfl_xor(amax, 16, WARP_SIZE));
+
+    const float E4M3_MAX = fp8_e4m3_max();
+    const float scale_b = (amax > 1.0e-20f) ? (E4M3_MAX / amax) : 0.0f;
+    const float inv_scale_b = (amax > 1.0e-20f) ? (amax / E4M3_MAX) : 0.0f;
+
+    // Lane 0..15 of warp writes inv_scale_b for its col. Both lanes (k_half=0
+    // and k_half=1) have the same value post-reduce, so writing once suffices.
+    // For out-of-range cols, write 0.0 — the C-store boundary check skips
+    // writing those Y entries, but tile_idS still feeds the inner-dot
+    // accumulator and we don't want to pull garbage from prior workgroup state.
+    if (k_half == 0) {
+        tile_idS[col] = col_in_range ? inv_scale_b : 0.0f;
+    }
+
+    // ---- Pass 2: scale + cast + store. 64 floats / 4 fp32-per-pack = 16
+    // packs per lane, each producing 1 i32 of FP8. Stored at
+    //   tile_y[col * 32 + k_half * 16 + j]  for j in [0..16).
+    if (col_in_range) {
+        const float* xp = X + (long long)col_global * K + k_base;
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            const int kbase = k_base + 4 * j;
+            float v0 = 0.0f, v1 = 0.0f, v2 = 0.0f, v3 = 0.0f;
+            if (kbase + 0 < K) v0 = xp[4 * j + 0];
+            if (kbase + 1 < K) v1 = xp[4 * j + 1];
+            if (kbase + 2 < K) v2 = xp[4 * j + 2];
+            if (kbase + 3 < K) v3 = xp[4 * j + 3];
+            unsigned int w = 0u;
+            w = __builtin_amdgcn_cvt_pk_fp8_f32(v0 * scale_b, v1 * scale_b, w, false);
+            w = __builtin_amdgcn_cvt_pk_fp8_f32(v2 * scale_b, v3 * scale_b, w, true);
+            tile_y[col * FP8_K_I32_STRIDE + k_half * 16 + j] = (int)w;
+        }
+    } else {
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            tile_y[col * FP8_K_I32_STRIDE + k_half * 16 + j] = 0;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gfx12 FP8 WMMA dot product over a K=128 kb iter.
+//
+// Per warp covers 32 rows (rows_per_warp = 2 * tile_C_I) and iterates over
+// 4 col-blocks of 16 cols each -> MMQ_X / (ntx * tile_C_J) = 4 col-blocks.
+// Per kb iter = 8 K=16 sub-tiles. Per (col-block, m-tile, K=16 sub-tile):
+//   - load 1 int32x2 a-frag and 1 int32x2 b-frag from LDS (8 FP8 each)
+//   - issue 1 wmma call (FP8 wmma is K=16, NOT K=32 like iu8/iu4 effectively)
+//   - apply the per-col activation inv_scale (constant within kb) and add
+//     into the persistent `sum[]` accumulator
+//
+// Per kb iter total: 4 col-blocks * 2 m-tiles * 8 K=16 sub-tiles = 64 wmma
+// calls per warp. The sum buffer persists across kb iters; the per-kb-iter
+// inv_scale is applied per K=16 sub-tile (mathematically equivalent because
+// scale is constant within kb).
+// ---------------------------------------------------------------------------
+static __device__ __forceinline__ void vec_dot_fp8_fp8_mma_gfx12(
+    const int* __restrict__ x,
+    const int* __restrict__ y,
+    const float* __restrict__ idS,
+    float* __restrict__ sum
+) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using float32x8_t = __attribute__((__vector_size__(8 * sizeof(float)))) float;
+
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;  // 8 acc slots per lane (8-row-block layout)
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;  // = 2 m-tiles per warp
+    constexpr int K_subtiles = FP8_K_PER_KB / tile_C_I;  // 8 K=16 sub-tiles
+
+    const int tid = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp = tid >> 4;
+
+    const int i0 = (int)(threadIdx.y / ntx) * rows_per_warp;
+    const int j_offset_in_warp = (int)(threadIdx.y % ntx) * tile_C_J;
+    (void)j_offset_in_warp;  // doc-only — used inline as `(threadIdx.y % ntx) * tile_C_J`
+                             // in j_for_b below to keep the expression close to the read.
+
+    const int* x_qs = x;
+    const int* y_qs = y;
+
+    #pragma unroll
+    for (int k_sub = 0; k_sub < K_subtiles; ++k_sub) {
+        // A fragment: per (m-tile, lane) load 2 i32 (= 8 FP8 = K-half of K=16).
+        // Stride within row = 4 i32 per K=16 sub-tile, lane k-half offset = 2*k_grp.
+        int32x2_t a_frag[ntx];
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            const int row_in_tile = n * tile_C_I + m_lane;
+            const int* row_ptr = x_qs + (i0 + row_in_tile) * FP8_K_I32_STRIDE + 4 * k_sub;
+            a_frag[n][0] = row_ptr[2 * k_grp + 0];
+            a_frag[n][1] = row_ptr[2 * k_grp + 1];
+        }
+
+        #pragma unroll
+        for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+            // B fragment: lane (m_lane = col_in_tile) loads 2 i32 from one col.
+            const int col_in_tile = m_lane;
+            // The col within tile_y for this warp's n-tile contribution.
+            // Each warp handles ntx m-tiles; the j-axis still iterates the
+            // FULL 4 col-blocks (n_block_idx = j0 / 32). The B-frag we load
+            // is the same for both m-tiles within a warp, hoisted out of
+            // the n-loop below.
+            const int j_for_b = j0 + (int)(threadIdx.y % ntx) * tile_C_J + col_in_tile;
+            const int* col_ptr = y_qs + j_for_b * FP8_K_I32_STRIDE + 4 * k_sub;
+            int32x2_t b_v;
+            b_v[0] = col_ptr[2 * k_grp + 0];
+            b_v[1] = col_ptr[2 * k_grp + 1];
+
+            // Per-col inv_scale (activation un-scaling). Same for all 8 acc
+            // slots of this lane within this n-tile (all share col=m_lane).
+            const float invs = idS[j_for_b];
+
+            #pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+                float32x8_t acc = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f};
+                acc = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(
+                    a_frag[n], b_v, acc);
+
+                // Apply per-kb inv_scale and add into persistent sum buffer.
+                // Acc layout: lane l, slot j -> C[8*k_grp + j][m_lane] within
+                // the (n*16, j_for_b)-tile. The sum-buffer index matches the
+                // iu8 MMQ kernel: (j0/16 + n) * 8 + slot.
+                #pragma unroll
+                for (int l = 0; l < tile_C_ne; ++l) {
+                    sum[(j0 / tile_C_J + n) * tile_C_ne + l] += acc[l] * invs;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main FP8 residual GEMM kernel for gfx12.
+// ---------------------------------------------------------------------------
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_fp8_gfx12(
+    const char* __restrict__ A,
+    const float* __restrict__ X,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int add
+) {
+    const int row0 = blockIdx.x * MMQ_Y;
+    const int col0 = blockIdx.y * MMQ_X;
+    if (row0 >= M || col0 >= N) return;
+
+    const int groups_per_row = K / 256;
+    const int kb_iters = K / FP8_K_PER_KB;  // 2 * groups_per_row
+
+    extern __shared__ int smem[];
+    int* tile_x = smem;                                                       // 128 rows x 32 i32 = 16 KB
+    int* tile_y = tile_x + MMQ_Y * FP8_K_I32_STRIDE;                          // 128 cols x 32 i32 = 16 KB
+    float* tile_idS = (float*)(tile_y + MMQ_X * FP8_K_I32_STRIDE);            // 128 floats = 512 B
+
+    // Per-lane sum buffer. Layout matches the iu8 MMQ kernel:
+    //   4 n-blocks x 2 m-tiles x 8 slots = 64 floats per lane.
+    float sum[MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)] = {0.0f};
+
+    for (int kb = 0; kb < kb_iters; ++kb) {
+        load_hfq4_tile_fp8<false>(A, tile_x, row0, kb, M, groups_per_row);
+        load_activation_tile_fp8<false>(X, tile_y, tile_idS, col0, kb, K, N);
+        __syncthreads();
+        vec_dot_fp8_fp8_mma_gfx12(tile_x, tile_y, tile_idS, sum);
+        __syncthreads();
+    }
+
+    // C-store. 8-row-block acc layout (matches iu8 MMQ):
+    //   lane l, slot j -> C[8*(l>>4) + j][l & 0xF] within each 16x16 tile.
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;
+
+    const int tid = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp = tid >> 4;
+
+    const int i0 = (int)(threadIdx.y / ntx) * rows_per_warp;
+    const int j_offset_in_warp = (int)(threadIdx.y % ntx) * tile_C_J;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            #pragma unroll
+            for (int l = 0; l < tile_C_ne; ++l) {
+                const int i = i0 + n * tile_C_I + 8 * k_grp + l;
+                const int j = j0 + j_offset_in_warp + m_lane;
+                if (row0 + i < M && col0 + j < N) {
+                    float* yp = Y + (long long)(col0 + j) * M + (row0 + i);
+                    const float v = sum[(j0 / tile_C_J + n) * tile_C_ne + l];
+                    if (add) {
+                        *yp += v;
+                    } else {
+                        *yp = v;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip
@@ -53,12 +53,29 @@
 #define HIPFIRE_GFX12 0
 #endif
 
-#define MMQ_X 128
+// K=256 per kb (full HFQ4 group) bumped from K=128 in commit pending.
+// Halves the kb-iter count + activation-cast pass count; the per-kb
+// __shfl_xor amax + per-col scale + cast was the dominant overhead in
+// the K=128 first-cut bench (per project_gfx12_fp8_bench_2026_05_04.md).
+//
+// LDS budget (gfx12 ~64 KB ceiling):
+//   tile_x: MMQ_Y rows × FP8_K_I32_STRIDE i32 = 128 × 64 i32 = 32 KB
+//   tile_y: MMQ_X cols × FP8_K_I32_STRIDE i32 = 64  × 64 i32 = 16 KB
+//   tile_idS: MMQ_X floats = 64 × 4 = 256 B
+//   total = 48.25 KB — fits.
+//
+// MMQ_X halved to 64 to make room for the doubled FP8_K_I32_STRIDE. Each
+// workgroup processes 64 batch tokens (vs 128). Workgroup count doubles
+// in the N direction. Total activation cast work is unchanged (same N×K
+// elements cast, redundantly across M-row-blocks; halving MMQ_X doesn't
+// add redundancy in M, only spreads same N-cast-work over more workgroups
+// in N — same net cast count).
+#define MMQ_X 64
 #define MMQ_Y 128
 #define MMQ_NWARPS 8
 #define WARP_SIZE 32
-#define FP8_K_PER_KB 128       // K positions covered per kb iteration (= half-group)
-#define FP8_K_I32_STRIDE 32    // K=128 / 4 fp8-per-i32
+#define FP8_K_PER_KB 256       // K positions covered per kb iteration (= full group)
+#define FP8_K_I32_STRIDE 64    // K=256 / 4 fp8-per-i32
 
 #if !HIPFIRE_GFX12
 
@@ -107,30 +124,28 @@ static __device__ __forceinline__ void load_hfq4_tile_fp8(
     int M,
     int groups_per_row
 ) {
-    // 256 threads = 16 rows-per-iter x 16 nibble-u32-per-row.
-    // Each thread loads 1 u32 of nibbles (= 8 nibbles = K=8 worth) and writes
-    // 2 i32 of FP8 (= 8 FP8 bytes) at tile_x[row * 32 + 2 * k_chunk + 0..1].
+    // K_PER_KB=256 = full HFQ4 group per kb iter. 256 threads partitioned as
+    // 8 rows-per-iter × 32 nibble-u32-per-row (each thread loads 1 u32 = 8
+    // nibbles = K=8). Each row spans 32 i32 of input nibbles (= K=256).
+    //
+    // Layout in LDS: tile_x[row * FP8_K_I32_STRIDE + 2*k_chunk + 0..1]
+    // where k_chunk in [0..32) covers K=[0..256) of this kb iter.
     const int tid = (int)(threadIdx.y * WARP_SIZE + threadIdx.x);
-    const int row_in_iter = tid >> 4;          // 0..15
-    const int k_chunk = tid & 0xF;             // 0..15, indexes 4-byte nibble cluster within K=128
-    const int kb_group = kb >> 1;              // HFQ4 group index on disk
-    const int kb_half = kb & 1;                // 0 = K=[0..127], 1 = K=[128..255] within group
+    const int row_in_iter = tid >> 5;          // 0..7
+    const int k_chunk = tid & 0x1F;            // 0..31, indexes 4-byte nibble cluster within K=256
 
     #pragma unroll
-    for (int i0 = 0; i0 < MMQ_Y; i0 += 16) {
+    for (int i0 = 0; i0 < MMQ_Y; i0 += 8) {
         const int i = i0 + row_in_iter;
         const int row = FULL ? row0 + i : min(row0 + i, M - 1);
-        const char* gp = A + ((long long)row * groups_per_row + kb_group) * 136;
+        // kb iter k covers HFQ4 group k (full group, no half-split).
+        const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
 
-        // Group metadata is constant per row across all k_chunks. Compiler
-        // hoists this out via a uniform-sub-warp-dispatch pattern; if not, the
-        // duplicated loads land in L0 anyway.
         const float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
         const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
 
-        // Nibble offset within the group: skip 8B header, then 64 B for the
-        // low half if we want the high half.
-        const int nibble_offset = 8 + kb_half * 64 + k_chunk * 4;
+        // Nibble offset within the group: skip 8B header, then k_chunk*4 bytes.
+        const int nibble_offset = 8 + k_chunk * 4;
         const unsigned int qs0 = *(const unsigned int*)(gp + nibble_offset);
 
         // Dequant 8 nibbles -> 8 FP32 (BAKE scale + zero into the FP8 value).
@@ -143,7 +158,7 @@ static __device__ __forceinline__ void load_hfq4_tile_fp8(
         const float v6 = sc * (float)((qs0 >> 24) & 0xFu) + zp;
         const float v7 = sc * (float)((qs0 >> 28) & 0xFu) + zp;
 
-        // Cast 8 FP32 -> 2 i32 (= 8 FP8 bytes, low-byte-order: v0,v1,...,v7).
+        // Cast 8 FP32 -> 2 i32 (= 8 FP8 bytes).
         unsigned int w0 = 0u;
         w0 = __builtin_amdgcn_cvt_pk_fp8_f32(v0, v1, w0, false);
         w0 = __builtin_amdgcn_cvt_pk_fp8_f32(v2, v3, w0, true);
@@ -188,18 +203,26 @@ static __device__ __forceinline__ void load_activation_tile_fp8(
     const int col_in_warp = lane & 0xF;
     const int k_half = lane >> 4;
     const int col = warp_id * 16 + col_in_warp;
+    // With MMQ_X=64 and 8 warps × 16 cols = 128, warps 4-7 produce col ≥ 64
+    // which is OUT OF MMQ_X RANGE. Early-exit those threads — their tile_y
+    // writes would corrupt the adjacent tile_idS region. (The 4 active warps
+    // do all the work; the inactive 4 warps are unused for cast but still
+    // contribute to the wmma compute below via vec_dot's warp partition.)
+    if (col >= MMQ_X) return;
     const int col_global = col0 + col;
-    const int kb_K_offset = kb * FP8_K_PER_KB;  // base K offset for this kb iter
-    const int k_base = kb_K_offset + k_half * 64;
+    // K_PER_LANE = K_PER_KB/2 (each lane handles half of the kb K-chunk).
+    constexpr int K_PER_LANE = FP8_K_PER_KB / 2;
+    const int kb_K_offset = kb * FP8_K_PER_KB;
+    const int k_base = kb_K_offset + k_half * K_PER_LANE;
 
     const bool col_in_range = FULL ? true : (col_global < N);
 
-    // ---- Pass 1: amax over 64 K positions of one (col, k_half).
+    // ---- Pass 1: amax over K_PER_LANE positions of one (col, k_half).
     float amax = 0.0f;
     if (col_in_range) {
         const float* xp = X + (long long)col_global * K + k_base;
         #pragma unroll
-        for (int j = 0; j < 64; ++j) {
+        for (int j = 0; j < K_PER_LANE; ++j) {
             const int k = k_base + j;
             const float v = (k < K) ? xp[j] : 0.0f;
             amax = fmaxf(amax, fabsf(v));
@@ -222,13 +245,14 @@ static __device__ __forceinline__ void load_activation_tile_fp8(
         tile_idS[col] = col_in_range ? inv_scale_b : 0.0f;
     }
 
-    // ---- Pass 2: scale + cast + store. 64 floats / 4 fp32-per-pack = 16
-    // packs per lane, each producing 1 i32 of FP8. Stored at
-    //   tile_y[col * 32 + k_half * 16 + j]  for j in [0..16).
+    // ---- Pass 2: scale + cast + store. K_PER_LANE floats / 4 fp32-per-pack
+    // = PACKS_PER_LANE packs per lane, each producing 1 i32 of FP8. Stored at
+    //   tile_y[col * FP8_K_I32_STRIDE + k_half * PACKS_PER_LANE + j].
+    constexpr int PACKS_PER_LANE = K_PER_LANE / 4;  // 32 for K_PER_KB=256
     if (col_in_range) {
         const float* xp = X + (long long)col_global * K + k_base;
         #pragma unroll
-        for (int j = 0; j < 16; ++j) {
+        for (int j = 0; j < PACKS_PER_LANE; ++j) {
             const int kbase = k_base + 4 * j;
             float v0 = 0.0f, v1 = 0.0f, v2 = 0.0f, v3 = 0.0f;
             if (kbase + 0 < K) v0 = xp[4 * j + 0];
@@ -238,12 +262,12 @@ static __device__ __forceinline__ void load_activation_tile_fp8(
             unsigned int w = 0u;
             w = __builtin_amdgcn_cvt_pk_fp8_f32(v0 * scale_b, v1 * scale_b, w, false);
             w = __builtin_amdgcn_cvt_pk_fp8_f32(v2 * scale_b, v3 * scale_b, w, true);
-            tile_y[col * FP8_K_I32_STRIDE + k_half * 16 + j] = (int)w;
+            tile_y[col * FP8_K_I32_STRIDE + k_half * PACKS_PER_LANE + j] = (int)w;
         }
     } else {
         #pragma unroll
-        for (int j = 0; j < 16; ++j) {
-            tile_y[col * FP8_K_I32_STRIDE + k_half * 16 + j] = 0;
+        for (int j = 0; j < PACKS_PER_LANE; ++j) {
+            tile_y[col * FP8_K_I32_STRIDE + k_half * PACKS_PER_LANE + j] = 0;
         }
     }
 }
@@ -368,16 +392,18 @@ static __device__ __forceinline__ void load_fp8_tile_preconv(
     int M,
     int K
 ) {
+    // K_PER_KB=256: 256 threads partitioned 8 rows × 32 chunks per row,
+    // each thread loads 8 FP8 bytes (= 2 int32) for a 256-byte row.
     const int tid = (int)(threadIdx.y * WARP_SIZE + threadIdx.x);
-    const int row_in_iter = tid >> 4;          // 0..15
-    const int k_chunk = tid & 0xF;             // 0..15, indexes 8-byte FP8 chunk in K=128
+    const int row_in_iter = tid >> 5;          // 0..7
+    const int k_chunk = tid & 0x1F;            // 0..31, indexes 8-byte FP8 chunk in K=256
 
     #pragma unroll
-    for (int i0 = 0; i0 < MMQ_Y; i0 += 16) {
+    for (int i0 = 0; i0 < MMQ_Y; i0 += 8) {
         const int i = i0 + row_in_iter;
         const int row = FULL ? row0 + i : min(row0 + i, M - 1);
-        // Direct FP8 read: row stride = K bytes, kb stride = 128 bytes,
-        // chunk stride = 8 bytes. 8-byte aligned (k_chunk * 8).
+        // Direct FP8 read: row stride = K bytes, kb stride = K_PER_KB bytes,
+        // chunk stride = 8 bytes. 8-byte aligned.
         const int* fp8_i32 = (const int*)(A_fp8 + (long long)row * K
                                            + kb * FP8_K_PER_KB
                                            + k_chunk * 8);

--- a/kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_fp8.gfx12.hip
@@ -72,6 +72,16 @@ extern "C" __global__ void gemm_hfq4g256_residual_fp8_gfx12(
     int
 ) {}
 
+extern "C" __global__ void gemm_hfq4g256_residual_fp8_preconv_gfx12(
+    const unsigned char*,
+    const float*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
 #else
 
 // E4M3 max representable magnitude (per OCP / IEEE FP8 spec).
@@ -334,7 +344,131 @@ static __device__ __forceinline__ void vec_dot_fp8_fp8_mma_gfx12(
 }
 
 // ---------------------------------------------------------------------------
-// Main FP8 residual GEMM kernel for gfx12.
+// FP8 weight tile loader — preconv variant.
+//
+// Reads pre-converted FP8 weights from a [M × K] byte buffer (1 byte per
+// element, populated by ensure_fp8_shadow at model load via
+// dequant_hfq4g256_to_fp8.gfx12.hip). Unlike load_hfq4_tile_fp8, no in-kernel
+// dequant — just a direct global → LDS memcpy. Eliminates the per-prefill
+// 8 cvt_pk_fp8_f32 calls + 8 FP32 mul-adds per thread per kb iter.
+//
+// Same LDS layout as the dequant variant: tile_x[row * 32 + k_i32] where
+// k_i32 in [0..32) covers K=[0..128) of this kb iter. 4 FP8 bytes per i32.
+// kb iter k covers FP8 bytes [k*128, (k+1)*128) per row.
+//
+// 256 threads = 16 rows-per-iter × 16 chunks-per-row. Each thread loads 8
+// FP8 bytes (= 2 int32) from global, writes 2 int32 to LDS.
+// ---------------------------------------------------------------------------
+template <bool FULL>
+static __device__ __forceinline__ void load_fp8_tile_preconv(
+    const unsigned char* __restrict__ A_fp8,
+    int* __restrict__ tile_x,
+    int row0,
+    int kb,
+    int M,
+    int K
+) {
+    const int tid = (int)(threadIdx.y * WARP_SIZE + threadIdx.x);
+    const int row_in_iter = tid >> 4;          // 0..15
+    const int k_chunk = tid & 0xF;             // 0..15, indexes 8-byte FP8 chunk in K=128
+
+    #pragma unroll
+    for (int i0 = 0; i0 < MMQ_Y; i0 += 16) {
+        const int i = i0 + row_in_iter;
+        const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+        // Direct FP8 read: row stride = K bytes, kb stride = 128 bytes,
+        // chunk stride = 8 bytes. 8-byte aligned (k_chunk * 8).
+        const int* fp8_i32 = (const int*)(A_fp8 + (long long)row * K
+                                           + kb * FP8_K_PER_KB
+                                           + k_chunk * 8);
+        tile_x[i * FP8_K_I32_STRIDE + 2 * k_chunk + 0] = fp8_i32[0];
+        tile_x[i * FP8_K_I32_STRIDE + 2 * k_chunk + 1] = fp8_i32[1];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main FP8 residual GEMM kernel for gfx12 — preconv variant.
+//
+// Consumes pre-converted FP8 weights (from ensure_fp8_shadow). Identical to
+// gemm_hfq4g256_residual_fp8_gfx12 except for the weight load path:
+//   - that variant: HFQ4 packed (136 B / 256 elements) -> in-kernel dequant
+//     -> FP8 LDS. Costs 8 cvt + 8 muladd per thread per kb iter.
+//   - this variant: FP8 byte buffer (1 B / element) -> direct LDS memcpy.
+// All other code (activation cast, wmma inner loop, C-store) is shared.
+//
+// Trade-off vs the dequant variant:
+//   (+) eliminates the dequant arithmetic in the inner kb loop
+//   (-) doubles weight bandwidth (FP8 1.0 B/w vs HFQ4 0.531 B/w on disk)
+// Net win on compute-bound regimes; depends on bw saturation otherwise.
+// ---------------------------------------------------------------------------
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_fp8_preconv_gfx12(
+    const unsigned char* __restrict__ A_fp8,
+    const float* __restrict__ X,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int add
+) {
+    const int row0 = blockIdx.x * MMQ_Y;
+    const int col0 = blockIdx.y * MMQ_X;
+    if (row0 >= M || col0 >= N) return;
+
+    const int kb_iters = K / FP8_K_PER_KB;
+
+    extern __shared__ int smem[];
+    int* tile_x = smem;
+    int* tile_y = tile_x + MMQ_Y * FP8_K_I32_STRIDE;
+    float* tile_idS = (float*)(tile_y + MMQ_X * FP8_K_I32_STRIDE);
+
+    float sum[MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)] = {0.0f};
+
+    for (int kb = 0; kb < kb_iters; ++kb) {
+        load_fp8_tile_preconv<false>(A_fp8, tile_x, row0, kb, M, K);
+        load_activation_tile_fp8<false>(X, tile_y, tile_idS, col0, kb, K, N);
+        __syncthreads();
+        vec_dot_fp8_fp8_mma_gfx12(tile_x, tile_y, tile_idS, sum);
+        __syncthreads();
+    }
+
+    // C-store identical to dequant variant.
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;
+
+    const int tid = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp = tid >> 4;
+
+    const int i0 = (int)(threadIdx.y / ntx) * rows_per_warp;
+    const int j_offset_in_warp = (int)(threadIdx.y % ntx) * tile_C_J;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            #pragma unroll
+            for (int l = 0; l < tile_C_ne; ++l) {
+                const int i = i0 + n * tile_C_I + 8 * k_grp + l;
+                const int j = j0 + j_offset_in_warp + m_lane;
+                if (row0 + i < M && col0 + j < N) {
+                    float* yp = Y + (long long)(col0 + j) * M + (row0 + i);
+                    const float v = sum[(j0 / tile_C_J + n) * tile_C_ne + l];
+                    if (add) { *yp += v; } else { *yp = v; }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main FP8 residual GEMM kernel for gfx12 — original (in-kernel dequant) variant.
+// Kept for the case where ensure_fp8_shadow isn't pre-warmed and we want a
+// one-launch path that doesn't need the FP8 shadow buffer. Production callers
+// should prefer the _preconv variant above when the shadow is available.
 // ---------------------------------------------------------------------------
 extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
 void gemm_hfq4g256_residual_fp8_gfx12(

--- a/kernels/src/gemm_hfq4g256_residual_iu4.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_iu4.gfx12.hip
@@ -1,0 +1,419 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+#include <math.h>
+
+// Experimental HFQ4-G256 iu4 K=32 residual GEMM for RDNA4 (gfx1200/gfx1201).
+//
+// Sister of `gemm_hfq4g256_residual_mmq.gfx12.hip` (the iu8 K=16 port). Same
+// outer recipe (128x128 MMQ tile, HFQ4 weights staged in LDS, activation pre-
+// quantized into a packed scratch buffer) but uses the iu4 K=32 wmma builtin:
+//
+//   __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(
+//       bool a_signed, v2i a, bool b_signed, v2i b, v8i acc, bool clamp)
+//
+// Why iu4 K=32 over iu8 K=16:
+//   - 2x K-per-call (32 vs 16) → half the LDS-read traffic per K-tile and
+//     half the wmma launch count. AMD spec'd 4x FP16 throughput on RDNA4 vs
+//     2x for iu8.
+//   - HFQ4 nibbles map NATIVELY to iu4 unsigned indices [0..15] — no weight
+//     conversion, just byte-repack into iu4 lane-form.
+//   - Activation pre-quant produces SIGNED INT4 in [-7,7] (Q4_1 form). The
+//     iu8 MMQ reference uses A=weight / B=activation; we mirror that, so:
+//     `a_signed=false` (HFQ4 weight A side, unsigned [0..15]) and
+//     `b_signed=true` (Q4_1 activation B side, signed [-7..7]).
+//
+// Layout contract (locked by probe_wmma_iu4_k32_layout.gfx12.hip on hiptrx
+// silicon at commit 03a5856):
+//   - Per-lane operand: int32x2 = 8 bytes = 16 INT4 = K-half of K=32. Layout
+//     lane l: row m = l & 0xF, k-half = l >> 4 (so lane l holds K=[16*k_half,
+//     16*k_half+16)).
+//   - Acc layout (8-row-block): lane l, slot j ∈ [0,8) → C[8*(l>>4) + j][l & 0xF].
+//
+// Algebraic correction per K=32 sub-block (Q4_1 activation, HFQ4 weight):
+//   wmma returns int_acc = sum_k (q_a[k] * q_w[k]) over K=32, signed*unsigned.
+//   True dot:
+//     w[m][k] = scale_w * q_w[m][k] + zero_w        (HFQ4 group of K=256)
+//     x[n][k] = d_a    * q_a[n][k]                  (Q4_1 sub-block of K=32)
+//   sum_k w*x = scale_w * d_a * int_acc + zero_w * d_a * sum_k(q_a[k])
+//             = scale_w * dsB.x * int_acc + zero_w * dsB.y
+//   where dsB = (d_a, d_a * sum_q_a) is the half2 from block_q4_1_mmq.ds[sub].
+//
+// Note that scale_w / zero_w are CONSTANT over the K=256 HFQ4 group, while
+// dsB varies per K=32 sub-block. The inner loop fetches dsB per sub-block
+// and uses the per-row (scale_w, zero_w) once per group iter.
+//
+// Skips the `_full_add` and `_full_set` boundary-elided variants — only the
+// basic `_residual_iu4` with a runtime `add` flag. Those can be added later
+// once the basic variant is validated.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#define MMQ_X 128
+#define MMQ_Y 128
+#define MMQ_NWARPS 8
+#define WARP_SIZE 32
+
+// One iu4 K=32 wmma call covers K=32. Per kb iter (= half of a 256-elem HFQ4
+// group), we cover K=128 — so 4 K=32 sub-blocks per kb-iter.
+#define MMQ_TILE_NE_K 32        // K covered per Q4_1 sub-block (per inner-loop step)
+#define K_PER_STAGE 128         // K covered per stage-and-dispatch (= 4 sub-blocks)
+
+// LDS row strides:
+//   tile_x_qs row stride = 32 i32 (covers K=256 HFQ4 group worth of nibbles,
+//                                   8 nibbles per i32). NO padding — gfx12
+//                                   wave32 handles tile_x bank conflicts via
+//                                   per-row distinct cache lines, and the
+//                                   inner-loop access pattern is K-strided.
+//   tile_x_dm  row stride = 1 half2 per row per group iter (HFQ4 sc/zp).
+//   tile_y     row stride = 20 i32 = sizeof(block_q4_1_mmq) / 4 (per stage).
+#define MMQ_TILE_X_K_QS 32      // i32 per row in tile_x_qs (K=256 group)
+#define MMQ_TILE_Y_K_Q4_1 20    // i32 per col in tile_y (one block_q4_1_mmq = 80 B)
+
+// block_q4_1_mmq layout (declared here for the GEMM-side cast). Mirrors the
+// layout produced by quantize_q4_1_mmq_ds4_gfx12 in
+// quantize_q4_1.gfx12.hip — kept in sync by hand (same struct, both files).
+struct block_q4_1_mmq {
+    half2 ds[4];        // (d, d*sum_q) per K=32 sub-block
+    int8_t qs[64];      // 4 sub-blocks * 32 INT4 packed 2-per-byte
+};
+
+static_assert(sizeof(block_q4_1_mmq) == 80, "bad block_q4_1_mmq size");
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void gemm_hfq4g256_residual_iu4_gfx12(
+    const char*,
+    const block_q4_1_mmq*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
+#else
+
+// ---------------------------------------------------------------------------
+// HFQ4 weight tile loader. Stages K=256 worth of HFQ4 nibbles + the per-group
+// (scale, zero) FP16 metadata into LDS, ONCE per kb iter (covers both halves
+// of the K=128 inner stage cycles).
+//
+// Per row, 32 threads collaboratively read 32 i32 of nibble data (= K=256 of
+// nibbles) directly into LDS — no per-byte unpacking needed. The HFQ4 disk
+// format already has the nibbles tightly packed with low-nibble = even K,
+// high-nibble = odd K — exactly the layout iu4 wmma expects per int32 (8
+// nibbles per i32, k0..k7 in order). So this is a straight memcpy.
+//
+// LDS layout in tile_x_qs: row * MMQ_TILE_X_K_QS + k_i32, where k_i32 in
+// [0, 32) covers K = [0, 256) of one HFQ4 group.
+// ---------------------------------------------------------------------------
+template <bool FULL>
+static __device__ __forceinline__ void load_hfq4_tile_iu4(
+    const char* __restrict__ A,
+    int* __restrict__ tile_x_qs,
+    half2* __restrict__ tile_x_dm,
+    int row0,
+    int kb,
+    int M,
+    int groups_per_row
+) {
+    constexpr int rows_per_warp = 1;
+    const int txi = threadIdx.x;
+
+    // Stage 32 i32 per row (= K=256 nibbles, the full HFQ4 group). 32 threads
+    // per warp, 1 row per warp per outer iter, MMQ_NWARPS warps → cover MMQ_Y
+    // rows in MMQ_Y / MMQ_NWARPS outer iters. Each thread reads 1 i32 at
+    // column offset txi * 4 within the per-row nibble payload.
+    for (int i0 = 0; i0 < MMQ_Y; i0 += rows_per_warp * MMQ_NWARPS) {
+        const int i = i0 + threadIdx.y;
+        const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+        const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
+        // Skip 8 B header (FP32 sc + FP32 zp), then read txi-th i32 of nibbles.
+        const unsigned int qs0 = *(const unsigned int*)(gp + 8 + txi * 4);
+        tile_x_qs[i * MMQ_TILE_X_K_QS + txi] = (int)qs0;
+    }
+
+    // Stage the per-group (scale, zero) half2. One half2 per row is enough
+    // (the inner loop reads dmA once per group). Use 1 thread per row from
+    // a subset of warps to avoid contention; 8 warps × 16 rows-per-warp =
+    // 128 rows in 1 outer iter.
+    constexpr int rows_per_warp_meta = 16;
+    for (int i0 = 0; i0 < MMQ_Y; i0 += MMQ_NWARPS * rows_per_warp_meta) {
+        const int i = i0 + threadIdx.y * rows_per_warp_meta + threadIdx.x / 2;
+        // Only thread x = 0 (within each pair) writes — the /2 above means
+        // pairs of threads target the same row. We could write redundantly
+        // across both, but a guarded write keeps things explicit.
+        if (i < MMQ_Y && (threadIdx.x & 1) == 0) {
+            const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+            const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
+            const float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+            const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+            tile_x_dm[i] = make_half2((_Float16)sc, (_Float16)zp);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gfx12 iu4 K=32 dot product over a K=128 stage cycle.
+//
+// Per warp covers 32 rows (rows_per_warp = 2 * tile_C_I) and iterates over
+// 4 col-blocks of 16 cols each → MMQ_X / (ntx * tile_C_J) = 128 / 32 = 4.
+// Per stage cycle = 4 K=32 sub-blocks. Per (col-block, m-tile, K=32 sub-block):
+//   - load 1 int32x2 a-frag (16 INT4 = K-half of K=32) for the activation
+//   - load 1 int32x2 b-frag for the weight (per col)
+//   - issue 1 wmma call (iu4 K=32 — twice the K-coverage of iu8 K=16)
+//   - apply per-row (scale_w, zero_w) and per-(col, K=32) (d_a, d_a*sum_q_a)
+//     correction, add into the persistent `sum[]` accumulator.
+//
+// k00 selects the K-base offset within the staged tile_x_qs (in i32 stride):
+//   k00 = 0  → first half of the HFQ4 group (K=[0..128))
+//   k00 = 16 → second half (K=[128..256))     [16 i32 = K=128 nibbles]
+// ---------------------------------------------------------------------------
+static __device__ __forceinline__ void vec_dot_q4_1_q4_iu4_mma_gfx12(
+    const int* __restrict__ x_qs,
+    const half2* __restrict__ x_dm,
+    const int* __restrict__ y,
+    float* __restrict__ sum,
+    int k00_i32
+) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;  // 8 acc slots per lane (8-row-block layout)
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;  // = 2 m-tiles per warp
+
+    // Per-warp partition into the K-axis stage. y is the LDS pointer to
+    // tile_y (cols start). We offset by (warp_id_within_n) * MMQ_TILE_Y_K_Q4_1
+    // * tile_C_J so each warp's "n" pair handles its assigned col block. This
+    // mirrors the iu8 reference's `y += (threadIdx.y % ntx) * (tile_C::J *
+    // MMQ_TILE_Y_K)` partition.
+    y += (threadIdx.y % ntx) * (tile_C_J * MMQ_TILE_Y_K_Q4_1);
+    const int* y_qs_base = y + 4;        // first 4 i32 = 4 half2 = ds[]
+    const half2* y_dm = (const half2*)y; // ds[4]
+
+    const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+
+    // Per-lane decomposition (8-row-block + iu4 K=32):
+    //   m_lane = tid & 0xF   → row within 16-row tile (also col for B)
+    //   k_grp  = tid >> 4    → selects K-half (K=0..15 vs K=16..31) of K=32 sub-tile
+    const int tid    = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp  = tid >> 4;
+
+    // Per K=32 sub-block (4 sub-blocks per K=128 stage cycle):
+    //   - k01 ∈ {0, 8, 16, 24} (i32 stride within the K=128 stage; 8 i32 per K=32)
+    //     OH WAIT — i32 packs 8 nibbles, so K=32 = 32/8 = 4 i32 per row stride.
+    //     k01 i32-stride steps: 0, 4, 8, 12.
+    //   - sub_idx ∈ {0, 1, 2, 3} (Q4_1 sub-block index within the K=128 stage)
+    constexpr int K_I32_PER_SUB = MMQ_TILE_NE_K / 8;  // = 4 i32 per K=32 sub-block
+    constexpr int N_SUBS = K_PER_STAGE / MMQ_TILE_NE_K;  // = 4 sub-blocks per stage
+
+    #pragma unroll
+    for (int sub_idx = 0; sub_idx < N_SUBS; ++sub_idx) {
+        const int k0_i32 = k00_i32 + sub_idx * K_I32_PER_SUB;
+
+        // Per-m-tile activation pre-load. iu4 K=32 wants int32x2 per lane =
+        // 2 i32 (= 16 INT4 = K-half of K=32). Lane k_grp picks the K-half:
+        //   k_grp=0 → i32 [0,1] of the K=32 sub-block (K=0..15)
+        //   k_grp=1 → i32 [2,3] of the K=32 sub-block (K=16..31)
+        //
+        // For tile_x_qs (HFQ4 weight): row m = i0 + n*16 + m_lane.
+        int32x2_t a_frag[ntx];
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            const int row_in_tile = n * tile_C_I + m_lane;
+            const int* row_ptr = x_qs + (i0 + row_in_tile) * MMQ_TILE_X_K_QS + k0_i32;
+            a_frag[n][0] = row_ptr[2 * k_grp + 0];
+            a_frag[n][1] = row_ptr[2 * k_grp + 1];
+        }
+
+        #pragma unroll
+        for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+            // B fragment: per-col K=32 sub-block. Lane (m_lane = col_in_tile)
+            // pulls 2 i32 from one col's (sub_idx)-th K=32 sub-block.
+            // tile_y col c is laid out as [4 half2 ds + 16 i32 qs]. The qs
+            // i32 base for sub_idx is at i32 offset (4 + sub_idx * K_I32_PER_SUB)
+            // = 4 + 4*sub_idx within the col's MMQ_TILE_Y_K_Q4_1 block.
+            //
+            // Above we already advanced y_qs_base = y + 4 (skipping ds), so
+            // we just add sub_idx * 4 i32. Lane k_grp picks K-half within
+            // that K=32: 2 i32 starting at offset 2*k_grp.
+            const int col_in_tile = m_lane;
+            const int* col_qs_ptr = y_qs_base
+                + (j0 + col_in_tile) * MMQ_TILE_Y_K_Q4_1
+                + sub_idx * K_I32_PER_SUB;
+            int32x2_t b_v;
+            b_v[0] = col_qs_ptr[2 * k_grp + 0];
+            b_v[1] = col_qs_ptr[2 * k_grp + 1];
+
+            // dsB = (d_a, d_a * sum_q_a) for this (col, K=32 sub-block).
+            const int j = j0 + col_in_tile;
+            const float2 dsB = __half22float2(y_dm[j * MMQ_TILE_Y_K_Q4_1 + sub_idx]);
+
+            #pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+                int32x8_t acc = {0,0,0,0,0,0,0,0};
+                // A = weight (HFQ4 nibbles, unsigned [0..15]), staged in x_qs.
+                // B = activation (Q4_1, signed [-7,7]), staged in y_qs_base.
+                // Matches the iu8 MMQ reference's A=weight / B=activation
+                // convention. Acc layout (8-row-block) reads C[m_block][n_col]
+                // — same orientation as the C-store loop below.
+                acc = __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(
+                    /*a_signed*/ false, a_frag[n],   // HFQ4 weight, unsigned [0..15]
+                    /*b_signed*/ true,  b_v,         // Q4_1 activation, signed [-7,7]
+                    acc, /*clamp*/ true);
+
+                // Apply HFQ4 (scale, zero) + Q4_1 (d, d*sum_q) correction.
+                //   sum[m,n] += scale_w * dsB.x * acc + zero_w * dsB.y
+                //
+                // Per slot j ∈ [0,8): C-row within the m-tile = 8*k_grp + j;
+                // C-col within the n-tile = m_lane (== col_in_tile above).
+                // The (scale_w, zero_w) is per-row (one HFQ4 group covers
+                // K=256 = the entire kb-iter, so it's constant across all 8
+                // K=32 sub-blocks of this kb).
+                #pragma unroll
+                for (int l = 0; l < tile_C_ne; ++l) {
+                    const int i_in_tile = n * tile_C_I + 8 * k_grp + l;
+                    const int i = i0 + i_in_tile;
+                    const float2 dmA = __half22float2(x_dm[i]);
+                    const float scale_w = dmA.x;
+                    const float zero_w  = dmA.y;
+                    sum[(j0 / tile_C_J + n) * tile_C_ne + l] +=
+                        scale_w * dsB.x * (float)acc[l] + zero_w * dsB.y;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main iu4 residual GEMM kernel for gfx12.
+//
+// Grid: ((M+127)/128, (N+127)/128, 1)   block: (32, 8, 1)  warps: 8
+//
+// Per workgroup processes a 128 (rows) × 128 (cols) output tile. Outer kb
+// loop iterates over `groups_per_row` (= K/256). Each kb iter:
+//   1. Stage HFQ4 weights for the 128-row-block × K=256-group into LDS.
+//   2. Stage tile_y (block_q4_1_mmq) for the K=128 LOW half of the kb,
+//      vec_dot, sync.
+//   3. Stage tile_y for the K=128 HIGH half of the kb, vec_dot, sync.
+//
+// LDS budget:
+//   tile_x_qs: MMQ_Y rows × 32 i32 stride = 128 × 32 × 4 B = 16 KB
+//   tile_x_dm: MMQ_Y half2                = 128 × 4 B       = 512 B
+//   tile_y:    MMQ_X cols × 20 i32 stride = 128 × 20 × 4 B = 10 KB
+//   total ~ 26.5 KB (well under gfx12's ~64 KB ceiling)
+// ---------------------------------------------------------------------------
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_iu4_gfx12(
+    const char* __restrict__ A,
+    const block_q4_1_mmq* __restrict__ Xq,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int add
+) {
+    const int row0 = blockIdx.x * MMQ_Y;
+    const int col0 = blockIdx.y * MMQ_X;
+    if (row0 >= M || col0 >= N) return;
+
+    const int groups_per_row = K / 256;
+    const int blocks128 = K / 128;
+
+    extern __shared__ int smem[];
+    // Layout: [tile_y (10 KB)] [tile_x_qs (16 KB)] [tile_x_dm (512 B)]
+    int*   tile_y    = smem;
+    int*   tile_x_qs = tile_y + MMQ_X * MMQ_TILE_Y_K_Q4_1;
+    half2* tile_x_dm = (half2*)(tile_x_qs + MMQ_Y * MMQ_TILE_X_K_QS);
+
+    // Per-lane sum buffer:
+    //   total elements = MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)
+    //                  = 128 * 128 / 256 = 64
+    // Layout: 4 n-blocks × 2 m-tiles × 8 slots per lane = 64 floats per lane.
+    float sum[MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)] = {0.0f};
+
+    for (int kb = 0; kb < groups_per_row; ++kb) {
+        // Stage HFQ4 weight tile for this K=256 group ONCE.
+        load_hfq4_tile_iu4<false>(A, tile_x_qs, tile_x_dm, row0, kb, M, groups_per_row);
+
+        // ---- Low half of the group (K=[0..128) within this kb) ----
+        // Source: Xq + (2*kb) * N (block index 2*kb). Each block_q4_1_mmq is
+        // 80 B = 20 i32 = MMQ_TILE_Y_K_Q4_1.
+        const int* by0 = (const int*)(Xq + (long long)(2 * kb) * N + col0);
+        for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K_Q4_1; l0 += MMQ_NWARPS * WARP_SIZE) {
+            const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+            if (l < MMQ_X * MMQ_TILE_Y_K_Q4_1) {
+                const int j = l / MMQ_TILE_Y_K_Q4_1;
+                tile_y[l] = (col0 + j < N) ? by0[l] : 0;
+            }
+        }
+        __syncthreads();
+        // k00_i32 = 0 → low half of the K=256 group in tile_x_qs (= K=[0..128)).
+        vec_dot_q4_1_q4_iu4_mma_gfx12(tile_x_qs, tile_x_dm, tile_y, sum, 0);
+        __syncthreads();
+
+        // ---- High half of the group (K=[128..256) within this kb) ----
+        if (2 * kb + 1 < blocks128) {
+            const int* by1 = (const int*)(Xq + (long long)(2 * kb + 1) * N + col0);
+            for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K_Q4_1; l0 += MMQ_NWARPS * WARP_SIZE) {
+                const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+                if (l < MMQ_X * MMQ_TILE_Y_K_Q4_1) {
+                    const int j = l / MMQ_TILE_Y_K_Q4_1;
+                    tile_y[l] = (col0 + j < N) ? by1[l] : 0;
+                }
+            }
+            __syncthreads();
+            // k00_i32 = 16 → high half of the K=256 group in tile_x_qs
+            //              (= K=[128..256), i.e. i32 offset 16 in MMQ_TILE_X_K_QS=32).
+            vec_dot_q4_1_q4_iu4_mma_gfx12(tile_x_qs, tile_x_dm, tile_y, sum, 16);
+            __syncthreads();
+        }
+    }
+
+    // C-store. 8-row-block acc layout (matches iu8 / FP8 mmq):
+    //   lane l, slot j → C[8*(l>>4) + j][l & 0xF] within each 16x16 tile.
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;
+
+    const int tid = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp = tid >> 4;
+
+    const int i0 = (int)(threadIdx.y / ntx) * rows_per_warp;
+    const int j_offset_in_warp = (int)(threadIdx.y % ntx) * tile_C_J;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            #pragma unroll
+            for (int l = 0; l < tile_C_ne; ++l) {
+                const int i = i0 + n * tile_C_I + 8 * k_grp + l;
+                const int j = j0 + j_offset_in_warp + m_lane;
+                if (row0 + i < M && col0 + j < N) {
+                    float* yp = Y + (long long)(col0 + j) * M + (row0 + i);
+                    const float v = sum[(j0 / tile_C_J + n) * tile_C_ne + l];
+                    if (add) {
+                        *yp += v;
+                    } else {
+                        *yp = v;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/kernels/src/gemm_hfq4g256_residual_mmq.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_residual_mmq.gfx12.hip
@@ -1,0 +1,418 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+#include <math.h>
+
+// Experimental HFQ4-G256 MMQ residual GEMM for RDNA4 (gfx1200/gfx1201).
+//
+// Sister of `gemm_hfq4g256_residual_mmq.hip` (RDNA3/3.5). Same outer recipe:
+//   - pre-quantize the activation matrix into block_q8_1_mmq DS4 layout
+//   - process 128 output rows x 128 batch columns per workgroup
+//   - stage both HFQ4 weights and Q8_1 activations in LDS
+//   - use i8 WMMA for the dot product and apply HFQ4 scale/zero via Q8_1
+//     scale/sum correction
+//
+// Differences from the RDNA3 reference (validated via the iu8 K=16 layout
+// probe in probe_wmma_iu8_k16_layout.gfx12.hip — confirmed 8-row-block acc
+// layout matches iu4 K=32):
+//
+//   1. WMMA builtin: __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12
+//      (the unsuffixed builtin compiles but does not lower on gfx12).
+//
+//   2. Operand shape per lane: int32x2 (8 INT8 = K-half of one row),
+//      NOT the RDNA3 int32x4 (16 INT8 = full K=16). Gfx12 splits the
+//      K=16 across the two lane-groups (lane>>4):
+//        A: lane l → row m = l & 0xF, k-half = 8*(l>>4) .. 8*(l>>4)+7
+//        B: lane l → col n = l & 0xF, k-half = 8*(l>>4) .. 8*(l>>4)+7
+//      One WMMA call consumes K=16 worth — so for each Q8_1 sub-block of
+//      K=32 we issue 2 WMMA calls (one per K=16 sub-tile).
+//
+//   3. Acc layout: 8-row-block (NOT RDNA3's stride-2 interleave):
+//        lane l, slot j ∈ [0,7] → C[8*(l>>4) + j][l & 0xF]
+//      In the J_MAJOR sense for tile_C, this maps to:
+//        get_i(l) = 8*(threadIdx.x>>4) + l
+//        get_j(l) = threadIdx.x & 0xF
+//      8 slots per lane × 32 lanes = 256 = full 16×16 C tile.
+//
+// Skips the `_full_add` and `_full_set` boundary-elided variants — only the
+// basic `_residual_mmq` with a runtime `add` flag. Those can be added later
+// once the basic variant is validated.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#define MMQ_X 128
+#define MMQ_Y 128
+#define MMQ_NWARPS 8
+#define WARP_SIZE 32
+#define QK8_1 32
+#define QI8_1 8
+#define MMQ_TILE_NE_K 32
+#define MMQ_TILE_Y_K 36
+#define MMQ_TILE_X_K 76
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void quantize_q8_1_mmq_ds4_gfx12(
+    const float*,
+    block_q8_1_mmq*,
+    int,
+    int
+) {}
+
+extern "C" __global__ void gemm_hfq4g256_residual_mmq_gfx12(
+    const char*,
+    const block_q8_1_mmq*,
+    float*,
+    int,
+    int,
+    int,
+    int
+) {}
+
+#else
+
+// ---------------------------------------------------------------------------
+// Activation Q8_1 quantization. Arch-agnostic body — uses __shfl_xor and FP16
+// conv only. Identical to the RDNA3 `quantize_q8_1_mmq_ds4` (lines 184-224 of
+// the RDNA3 file); the function is renamed here so both kernels can coexist
+// in the same compiled module if a future caller wants to dispatch by arch
+// from a single binary.
+// ---------------------------------------------------------------------------
+extern "C" __global__ void quantize_q8_1_mmq_ds4_gfx12(
+    const float* __restrict__ X,
+    block_q8_1_mmq* __restrict__ Y,
+    int K,
+    int N
+) {
+    const int token = blockIdx.y;
+    const int i0 = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
+    if (token >= N || i0 >= K) return;
+
+    const float4 xi = (i0 + 3 < K)
+        ? *(const float4*)(X + (long long)token * K + i0)
+        : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    float amax = fmaxf(fmaxf(fabsf(xi.x), fabsf(xi.y)), fmaxf(fabsf(xi.z), fabsf(xi.w)));
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        amax = fmaxf(amax, __shfl_xor(amax, offset, WARP_SIZE));
+    }
+
+    float sum = xi.x + xi.y + xi.z + xi.w;
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        sum += __shfl_xor(sum, offset, WARP_SIZE);
+    }
+
+    const float d = amax > 1.0e-20f ? amax / 127.0f : 0.0f;
+    const float id = d > 0.0f ? 1.0f / d : 0.0f;
+    char4 q;
+    q.x = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.x * id)));
+    q.y = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.y * id)));
+    q.z = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.z * id)));
+    q.w = (char)lrintf(fmaxf(-127.0f, fminf(127.0f, xi.w * id)));
+
+    const int kblock = i0 / 128;
+    const int iqs = i0 & 127;
+    block_q8_1_mmq* out = Y + (long long)kblock * N + token;
+    ((char4*)out->qs)[iqs / 4] = q;
+
+    if ((iqs & 31) == 0) {
+        out->ds4[iqs / 32] = make_half2((_Float16)d, (_Float16)sum);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HFQ4 weight tile loader. Same byte layout as RDNA3 — 136 B per 256-elem
+// group: 4 B FP32 scale + 4 B FP32 zero + 128 B of nibbles. The only thing
+// that matters for gfx12 is the LDS layout (`x_qs[i*MMQ_TILE_X_K + k]`,
+// `x_dm[i*MMQ_TILE_X_K + ...]` with the same i32 / half2 strides), and that
+// is identical to RDNA3 since the dot consumer rewrites the per-lane stride
+// only inside the MMA (no shared-memory bank-conflict patterns differ in a
+// way that the staging code needs to know about).
+// ---------------------------------------------------------------------------
+template <bool FULL>
+static __device__ __forceinline__ void load_hfq4_tile(
+    const char* __restrict__ A,
+    int* __restrict__ tile_x,
+    int row0,
+    int kb,
+    int M,
+    int groups_per_row
+) {
+    int* x_qs = tile_x;
+    half2* x_dm = (half2*)(x_qs + 2 * MMQ_TILE_NE_K);
+
+    constexpr int rows_per_warp = 1;
+    const int txi = threadIdx.x;
+
+    for (int i0 = 0; i0 < MMQ_Y; i0 += rows_per_warp * MMQ_NWARPS) {
+        const int i = i0 + threadIdx.y;
+        const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+        const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
+        const unsigned int qs0 = *(const unsigned int*)(gp + 8 + txi * 4);
+
+        const unsigned int q0 = (qs0 >>  0) & 0xFu;
+        const unsigned int q1 = (qs0 >>  4) & 0xFu;
+        const unsigned int q2 = (qs0 >>  8) & 0xFu;
+        const unsigned int q3 = (qs0 >> 12) & 0xFu;
+        const unsigned int q4 = (qs0 >> 16) & 0xFu;
+        const unsigned int q5 = (qs0 >> 20) & 0xFu;
+        const unsigned int q6 = (qs0 >> 24) & 0xFu;
+        const unsigned int q7 = (qs0 >> 28) & 0xFu;
+        x_qs[i * MMQ_TILE_X_K + 2 * txi + 0] = q0 | (q1 << 8) | (q2 << 16) | (q3 << 24);
+        x_qs[i * MMQ_TILE_X_K + 2 * txi + 1] = q4 | (q5 << 8) | (q6 << 16) | (q7 << 24);
+    }
+
+    constexpr int rows_per_warp_meta = 16;
+    for (int i0 = 0; i0 < MMQ_Y; i0 += MMQ_NWARPS * rows_per_warp_meta) {
+        const int i = i0 + threadIdx.y * rows_per_warp_meta + threadIdx.x / 2;
+        if (i < MMQ_Y) {
+            const int row = FULL ? row0 + i : min(row0 + i, M - 1);
+            const char* gp = A + ((long long)row * groups_per_row + kb) * 136;
+            const float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+            const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+            const int ksc = threadIdx.x & 1;
+            const half2 dm = make_half2((_Float16)sc, (_Float16)zp);
+            #pragma unroll
+            for (int l = 0; l < 4; ++l) {
+                x_dm[i * MMQ_TILE_X_K + 4 * ksc + l] = dm;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gfx12 i8 WMMA dot product.
+//
+// Produces partial sums for a 16-row × 16-col block of the C output. Each
+// warp covers 32 rows (rows_per_warp = 32 = 2 × tile_C::I) and iterates over
+// MMQ_X / (ntx * tile_C::J) = 128 / (2 * 16) = 4 col-blocks of 16 cols each.
+// Total per-warp accumulator footprint: 32 rows × 128 cols / 32 lanes = 128
+// floats per lane (= 4 col-blocks × 2 m-tiles × 16 slots per warp / 32 lanes
+// × 8 slots per lane wait let me recount).
+//
+// Footprint reconciliation: total work per workgroup = MMQ_X * MMQ_Y =
+// 128*128 = 16384 acc floats. NWARPS * WARP_SIZE = 8 * 32 = 256 lanes.
+// 16384 / 256 = 64 floats per lane. The host-allocated `sum[]` buffer must
+// hold this — see the kernel body below.
+//
+// Per inner-k iteration (k01 step of QI8_1 = 8 i32 = K=32 of activations =
+// one Q8_1 sub-block), we issue 2 WMMA calls — one per K=16 sub-tile. The
+// scale/sum correction (`dmA.x * dsB.x * acc + dmA.y * dsB.y`) applies once
+// per Q8_1 sub-block, so we accumulate the int32 from both K=16 MMAs into
+// one running int and apply the correction at the end of the k01 iteration.
+// That keeps the residual semantics aligned with RDNA3.
+// ---------------------------------------------------------------------------
+static __device__ __forceinline__ void vec_dot_q8_1_q8_1_mma_gfx12(
+    const int* __restrict__ x,
+    const int* __restrict__ y,
+    float* __restrict__ sum,
+    int k00
+) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;  // 8 acc slots per lane (8-row-block layout)
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;  // = 2 m-tiles per warp
+
+    y += (threadIdx.y % ntx) * (tile_C_J * MMQ_TILE_Y_K);
+
+    const int* x_qs = x;
+    const half2* x_dm = (const half2*)(x_qs + 2 * MMQ_TILE_NE_K);
+    const int* y_qs = y + 4;
+    const half2* y_dm = (const half2*)y;
+
+    const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+
+    // Per-lane decomposition (8-row-block):
+    //   m_lane = tid & 0xF   -> row within 16-row tile (also col for B)
+    //   k_grp  = tid >> 4    -> selects K-half within each K=16 MMA tile
+    const int tid    = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp  = tid >> 4;
+
+    for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += QI8_1) {
+        const int k0 = k00 + k01;  // i32 stride into x_qs / y_qs (K=4 INT8 per i32)
+
+        // Per-m-tile activation pre-load (independent of n-tile loop).
+        // tile_A_int[n][sub] holds 2 i32 (= 8 INT8 = K=8) per K=16 sub-tile.
+        // n in [0, ntx), sub in [0, 2) selecting K=0..15 vs K=16..31 of the
+        // QI8_1 stride.
+        int32x2_t a_frag[ntx][2];
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            const int row_in_tile = n * tile_C_I + m_lane;
+            const int* row_ptr = x_qs + (i0 + row_in_tile) * MMQ_TILE_X_K + k0;
+            // sub-tile 0: K=0..15 of this k01 step, lane k-half offset = 2*k_grp i32
+            // sub-tile 1: K=16..31, base offset = 4 i32 (= K=16 in i32 stride)
+            a_frag[n][0][0] = row_ptr[2 * k_grp + 0];
+            a_frag[n][0][1] = row_ptr[2 * k_grp + 1];
+            a_frag[n][1][0] = row_ptr[4 + 2 * k_grp + 0];
+            a_frag[n][1][1] = row_ptr[4 + 2 * k_grp + 1];
+        }
+
+        #pragma unroll
+        for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+            // B fragment for this n-block (16 cols = 1 J=16 tile per sub-tile).
+            // get_i for B = m_lane (col within 16-col block); K positions per
+            // K=16 sub-tile = 2 i32 per lane at offset 2*k_grp i32 inside the
+            // sub-tile's i32 base.
+            const int col_in_tile = m_lane;  // J_MAJOR-equivalent: lane idx maps to col
+            const int* col_ptr = y_qs + (j0 + col_in_tile) * MMQ_TILE_Y_K + k01;
+            int32x2_t b0_v;
+            int32x2_t b1_v;
+            b0_v[0] = col_ptr[2 * k_grp + 0];
+            b0_v[1] = col_ptr[2 * k_grp + 1];
+            b1_v[0] = col_ptr[4 + 2 * k_grp + 0];
+            b1_v[1] = col_ptr[4 + 2 * k_grp + 1];
+
+            // dsB applies to the whole K=32 Q8_1 sub-block (one per k01 step).
+            // We pull the d/s scalars per col, indexed by lane (the
+            // 8-row-block acc layout means lane l, slot j outputs to
+            // C[8*(l>>4)+j][l&0xF], so the col index is m_lane = l & 0xF —
+            // which matches col_in_tile above).
+            const int j = j0 + col_in_tile;
+            const float2 dsB = __half22float2(y_dm[j * MMQ_TILE_Y_K + k01 / QI8_1]);
+
+            #pragma unroll
+            for (int n = 0; n < ntx; ++n) {
+                int32x8_t acc = {0,0,0,0,0,0,0,0};
+                // Two K=16 WMMA calls accumulate into the same int acc; the
+                // scale-correction is applied once after both.
+                acc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(
+                    /*a_signed*/ true, a_frag[n][0],
+                    /*b_signed*/ true, b0_v,
+                    acc, /*clamp*/ true);
+                acc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(
+                    true, a_frag[n][1],
+                    true, b1_v,
+                    acc, true);
+
+                // Apply HFQ4 scale + Q8_1 zero-correction. Acc layout:
+                //   slot j ∈ [0,7] → C-row = 8*k_grp + j (within the n*16
+                //   m-tile), C-col = m_lane (within the j0 n-tile).
+                // The host `sum[]` buffer is laid out by (n-block-id,
+                // m-tile-id-n, slot) so the index is identical to the RDNA3
+                // store path with tile_C::ne = 8 instead of 4.
+                #pragma unroll
+                for (int l = 0; l < tile_C_ne; ++l) {
+                    const int i_in_tile = n * tile_C_I + 8 * k_grp + l;
+                    const int i = i0 + i_in_tile;
+                    const float2 dmA = __half22float2(x_dm[i * MMQ_TILE_X_K + k0 / QI8_1]);
+                    sum[(j0 / tile_C_J + n) * tile_C_ne + l] += dmA.x * dsB.x * (float)acc[l];
+                    sum[(j0 / tile_C_J + n) * tile_C_ne + l] += dmA.y * dsB.y;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main MMQ residual GEMM kernel for gfx12.
+// ---------------------------------------------------------------------------
+extern "C" __global__ __launch_bounds__(MMQ_NWARPS * WARP_SIZE, 2)
+void gemm_hfq4g256_residual_mmq_gfx12(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float* __restrict__ Y,
+    int M,
+    int K,
+    int N,
+    int add
+) {
+    const int row0 = blockIdx.x * MMQ_Y;
+    const int col0 = blockIdx.y * MMQ_X;
+    if (row0 >= M || col0 >= N) return;
+
+    const int groups_per_row = K / 256;
+    const int blocks128 = K / 128;
+
+    extern __shared__ int smem[];
+    int* tile_y = smem;
+    int* tile_x = tile_y + MMQ_X * MMQ_TILE_Y_K;
+
+    // Per-lane sum buffer:
+    //   total elements = MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)
+    //                  = 128 * 128 / 256 = 64
+    // Layout: 4 n-blocks × 2 m-tiles × 8 slots per lane = 64 floats per lane.
+    float sum[MMQ_X * MMQ_Y / (MMQ_NWARPS * WARP_SIZE)] = {0.0f};
+
+    for (int kb = 0; kb < groups_per_row; ++kb) {
+        load_hfq4_tile<false>(A, tile_x, row0, kb, M, groups_per_row);
+
+        const int* by0 = (const int*)(Xq + (long long)(2 * kb) * N + col0);
+        for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += MMQ_NWARPS * WARP_SIZE) {
+            const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+            const int j = l / MMQ_TILE_Y_K;
+            tile_y[l] = (col0 + j < N) ? by0[l] : 0;
+        }
+        __syncthreads();
+        vec_dot_q8_1_q8_1_mma_gfx12(tile_x, tile_y, sum, 0);
+        __syncthreads();
+
+        if (2 * kb + 1 < blocks128) {
+            const int* by1 = (const int*)(Xq + (long long)(2 * kb + 1) * N + col0);
+            for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += MMQ_NWARPS * WARP_SIZE) {
+                const int l = l0 + threadIdx.y * WARP_SIZE + threadIdx.x;
+                const int j = l / MMQ_TILE_Y_K;
+                tile_y[l] = (col0 + j < N) ? by1[l] : 0;
+            }
+            __syncthreads();
+            vec_dot_q8_1_q8_1_mma_gfx12(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+        }
+    }
+
+    // C-store. 8-row-block acc layout:
+    //   lane l, slot j → C[8*(l>>4) + j][l & 0xF]  (within each 16×16 tile)
+    constexpr int tile_C_I = 16;
+    constexpr int tile_C_J = 16;
+    constexpr int tile_C_ne = 8;
+    constexpr int rows_per_warp = 32;
+    constexpr int ntx = rows_per_warp / tile_C_I;
+
+    const int tid    = (int)threadIdx.x;
+    const int m_lane = tid & 0xF;
+    const int k_grp  = tid >> 4;
+
+    const int i0 = (threadIdx.y / ntx) * rows_per_warp;
+    const int j_offset_in_warp = (threadIdx.y % ntx) * tile_C_J;
+
+    #pragma unroll
+    for (int j0 = 0; j0 < MMQ_X; j0 += ntx * tile_C_J) {
+        #pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+            #pragma unroll
+            for (int l = 0; l < tile_C_ne; ++l) {
+                // i within 16-row tile = 8*k_grp + l (8-row-block).
+                // j within 16-col tile = m_lane.
+                const int i = i0 + n * tile_C_I + 8 * k_grp + l;
+                const int j = j0 + j_offset_in_warp + m_lane;
+                if (row0 + i < M && col0 + j < N) {
+                    float* yp = Y + (long long)(col0 + j) * M + (row0 + i);
+                    const float v = sum[(j0 / tile_C_J + n) * tile_C_ne + l];
+                    if (add) {
+                        *yp += v;
+                    } else {
+                        *yp = v;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/kernels/src/iu4_bake_weight_scales.gfx12.hip
+++ b/kernels/src/iu4_bake_weight_scales.gfx12.hip
@@ -6,10 +6,15 @@
 //
 //   per (row m, group g) of HFQ4-G256:
 //     scale_baked = scale * s_group[g]
+//     zero_baked  = zero  * s_group[g]
+//
+// HFQ4-G256 dequant: w = scale * q_w + zero. Multiplying the whole row by
+// s_group means BOTH scale AND zero get multiplied:
+//   w * s_group = (scale * s_group) * q_w + (zero * s_group)
 //
 // HFQ4-G256 layout per group (136 bytes):
 //   [0..4)  fp32 scale (modified by this kernel)
-//   [4..8)  fp32 zero  (unchanged)
+//   [4..8)  fp32 zero  (modified by this kernel)
 //   [8..136) 128 bytes of nibbles (unchanged)
 //
 // The kernel reads `s_group` as FP16 (per-K=256-group activation scale,
@@ -49,20 +54,23 @@ extern "C" __global__ void iu4_bake_weight_scales_gfx12(
 
     char* gp = W + ((long long)row * groups_per_row + g) * 136;
 
-    // Read FP32 scale at byte offset 0.
-    float scale;
+    // Read FP32 scale at byte offset 0 and FP32 zero at byte offset 4.
+    float scale, zero;
     {
-        unsigned int bits = *(const unsigned int*)gp;
-        scale = __builtin_bit_cast(float, bits);
+        unsigned int sc_bits = *(const unsigned int*)gp;
+        unsigned int zp_bits = *(const unsigned int*)(gp + 4);
+        scale = __builtin_bit_cast(float, sc_bits);
+        zero  = __builtin_bit_cast(float, zp_bits);
     }
 
     // Multiply by FP16 group scale (cast to FP32 for the multiply).
     const float s = __half2float(s_group[g]);
-    const float baked = scale * s;
+    const float scale_baked = scale * s;
+    const float zero_baked  = zero  * s;
 
-    // Write back.
-    unsigned int out_bits = __builtin_bit_cast(unsigned int, baked);
-    *(unsigned int*)gp = out_bits;
+    // Write back both scale (offset 0) and zero (offset 4).
+    *(unsigned int*)gp       = __builtin_bit_cast(unsigned int, scale_baked);
+    *(unsigned int*)(gp + 4) = __builtin_bit_cast(unsigned int, zero_baked);
 }
 
 #endif

--- a/kernels/src/iu4_bake_weight_scales.gfx12.hip
+++ b/kernels/src/iu4_bake_weight_scales.gfx12.hip
@@ -1,0 +1,68 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// SmoothQuant weight-side bake for the gfx12 iu4 path:
+//
+//   per (row m, group g) of HFQ4-G256:
+//     scale_baked = scale * s_group[g]
+//
+// HFQ4-G256 layout per group (136 bytes):
+//   [0..4)  fp32 scale (modified by this kernel)
+//   [4..8)  fp32 zero  (unchanged)
+//   [8..136) 128 bytes of nibbles (unchanged)
+//
+// The kernel reads `s_group` as FP16 (per-K=256-group activation scale,
+// computed at calibration time as the geometric or arithmetic mean of
+// per-channel s_a values within each group). Per group → one FP32
+// multiply on the scale field.
+//
+// Threading: one thread per (row, group) pair. Grid x = ceil(m/256), y =
+// groups_per_row. Block = (256, 1, 1).
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void iu4_bake_weight_scales_gfx12(
+    char*,
+    const __half*,
+    int,
+    int
+) {}
+
+#else
+
+extern "C" __global__ void iu4_bake_weight_scales_gfx12(
+    char* __restrict__ W,            // [m * groups_per_row * 136] HFQ4-G256
+    const __half* __restrict__ s_group, // [groups_per_row]
+    int m,
+    int groups_per_row
+) {
+    const int row = blockIdx.x * blockDim.x + threadIdx.x;
+    const int g = blockIdx.y;
+    if (row >= m || g >= groups_per_row) return;
+
+    char* gp = W + ((long long)row * groups_per_row + g) * 136;
+
+    // Read FP32 scale at byte offset 0.
+    float scale;
+    {
+        unsigned int bits = *(const unsigned int*)gp;
+        scale = __builtin_bit_cast(float, bits);
+    }
+
+    // Multiply by FP16 group scale (cast to FP32 for the multiply).
+    const float s = __half2float(s_group[g]);
+    const float baked = scale * s;
+
+    // Write back.
+    unsigned int out_bits = __builtin_bit_cast(unsigned int, baked);
+    *(unsigned int*)gp = out_bits;
+}
+
+#endif

--- a/kernels/src/probe_wmma_fp8_layout.gfx12.hip
+++ b/kernels/src/probe_wmma_fp8_layout.gfx12.hip
@@ -1,0 +1,94 @@
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+// gfx12 (RDNA4) FP8 (E4M3) WMMA — layout-discovery probe (issue #136 part B).
+//
+// Probes `__builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12` on gfx1201 to
+// confirm the wave32 layout before writing an FP8 GEMM port. The iu4 K=32
+// and iu8 K=16 probes both discovered an 8-row-block acc layout — first
+// guess is FP8 wmma uses the same layout (its operand vector size is also
+// int32x2 per lane = 8 FP8 bytes per K-half).
+//
+// Per CK header `amd_wmma.hpp` confirmed signature:
+//   wmma_f32_16x16x16_fp8_fp8_w32_gfx12(int32x2 a, int32x2 b, float8 acc) -> float8
+// — no clamp/sign flags (unlike iu4/iu8). Acc is 8 FP32 per lane.
+//
+// Pattern set (one wave per launch, dumped to consecutive 256-FP32 regions):
+//   0 — A=B=1.0                 → every entry = 16.0  (sanity)
+//   1 — A[m][k]=(m+1).0, B=1.0  → acc[l, j] = 16 * (8*(l>>4) + j + 1)
+//   2 — A=1.0, B[k][n]=(n+1).0  → acc[l, j] = 16 * ((l & 0xF) + 1)
+//
+// Why integer values 1..16: easy E4M3 representations (no rounding loss),
+// distinct enough to bijectively map to (lane, slot) → (m, n).
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void probe_wmma_fp8_layout(float*) {}
+
+#else
+
+extern "C" __global__ void probe_wmma_fp8_layout(float* __restrict__ out) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using float32x8_t = __attribute__((__vector_size__(8 * sizeof(float)))) float;
+
+    const int lane = threadIdx.x;
+    const int row_assumed = lane & 0xF;
+
+    // Pack a single FP32 value into all 8 FP8 slots of an int32x2 via 4 calls
+    // to __builtin_amdgcn_cvt_pk_fp8_f32. Each call converts 2 FP32 to 2
+    // packed FP8 bytes (E4M3) into a 16-bit half of the destination int32.
+    // word_sel=false → low 16 bits, word_sel=true → high 16 bits.
+    auto pack_fp8_v8 = [](float v) -> int32x2_t {
+        int32x2_t r;
+        unsigned int w0 = 0;
+        w0 = __builtin_amdgcn_cvt_pk_fp8_f32(v, v, w0, false);
+        w0 = __builtin_amdgcn_cvt_pk_fp8_f32(v, v, w0, true);
+        unsigned int w1 = 0;
+        w1 = __builtin_amdgcn_cvt_pk_fp8_f32(v, v, w1, false);
+        w1 = __builtin_amdgcn_cvt_pk_fp8_f32(v, v, w1, true);
+        r[0] = (int)w0;
+        r[1] = (int)w1;
+        return r;
+    };
+
+    // ---- Pattern 0: A=B=1.0
+    {
+        int32x2_t a = pack_fp8_v8(1.0f);
+        int32x2_t b = pack_fp8_v8(1.0f);
+        float32x8_t acc = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f};
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a, b, acc);
+        float* dst = out + 0 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+
+    // ---- Pattern 1: A row-id+1, B all-ones.
+    {
+        int32x2_t a = pack_fp8_v8((float)(row_assumed + 1));
+        int32x2_t b = pack_fp8_v8(1.0f);
+        float32x8_t acc = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f};
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a, b, acc);
+        float* dst = out + 1 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+
+    // ---- Pattern 2: A all-ones, B col-id+1.
+    {
+        int32x2_t a = pack_fp8_v8(1.0f);
+        int32x2_t b = pack_fp8_v8((float)(row_assumed + 1));
+        float32x8_t acc = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f};
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a, b, acc);
+        float* dst = out + 2 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+}
+
+#endif

--- a/kernels/src/probe_wmma_iu4_k32.gfx12.hip
+++ b/kernels/src/probe_wmma_iu4_k32.gfx12.hip
@@ -1,0 +1,60 @@
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+// gfx12 (RDNA4) iu4 K=32 WMMA probe — POC for issue #136 part B.
+//
+// Validates that __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12 dispatches
+// and accumulates correctly on gfx1201 silicon. This is the K=32 form that
+// matches HFQ4's native 4-bit weight packing — 1 int32 = 8 INT4 values.
+//
+// Probe-1 (this kernel): both A and B are all-ones in INT4. Expected output
+// at every (m, n): C[m][n] = sum_{k=0..31} 1*1 = 32. Result is independent
+// of the per-lane element layout, so we get a "does the intrinsic actually
+// work on this hardware" yes/no without first discovering the layout. Layout
+// discovery is a follow-up probe.
+//
+// Signature confirmed via trial-compile on ROCm 7.2.2 / clang 22:
+//   v8i wmma_i32_16x16x32_iu4_w32_gfx12(bool, v2i, bool, v2i, v8i, bool)
+// where v2i = 2 int32 per lane (= 16 INT4 = K=32 worth of A or B for one row),
+//       v8i = 8 int32 per lane accumulator (32 lanes x 8 = 256 = 16x16 of C).
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void probe_wmma_iu4_k32_allones(int32_t*) {}
+
+#else
+
+extern "C" __global__ void probe_wmma_iu4_k32_allones(int32_t* __restrict__ acc_dump) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    // All-ones INT4 packed as int32. 0x11111111 = eight INT4 values, each = 1.
+    // Each lane's two ints carry 16 INT4 ones for its slice of A (or B); the
+    // intrinsic permutes the data into the matrix unit's expected layout
+    // internally.
+    int32x2_t a_v;
+    a_v[0] = 0x11111111;
+    a_v[1] = 0x11111111;
+    int32x2_t b_v;
+    b_v[0] = 0x11111111;
+    b_v[1] = 0x11111111;
+
+    int32x8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+    // Args: a_signed=false (treat as unsigned), a, b_signed=false, b, acc, clamp=true
+    acc = __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(false, a_v, false, b_v, acc, true);
+
+    // Dump 32 lanes x 8 acc values to global memory. Host inspects:
+    // expected: every entry = 32 (sum of 32 ones-times-ones).
+    const int lane = threadIdx.x;
+    int* dst = acc_dump + lane * 8;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+}
+
+#endif

--- a/kernels/src/probe_wmma_iu4_k32_layout.gfx12.hip
+++ b/kernels/src/probe_wmma_iu4_k32_layout.gfx12.hip
@@ -1,0 +1,102 @@
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+// gfx12 (RDNA4) iu4 K=32 WMMA — layout-discovery probe (issue #136 part B).
+//
+// The all-ones probe (probe_wmma_iu4_k32.gfx12.hip) only confirms the
+// intrinsic dispatches and accumulates. This probe maps the per-lane
+// element layout so we can write the production GEMM port.
+//
+// Three patterns, each running one wmma and dumping 32*8=256 i32:
+//   pattern 0: A=ones, B=ones      → expected every entry = 32 (sanity)
+//   pattern 1: A=row-id, B=ones    → confirms acc layout: lane l, slot j → C[8*(l>>4) + j][l & 0xF]
+//                                    Expected acc[lane=l, slot=j] = 32 * (8*(l>>4) + j).
+//                                    8-row-block layout — DIFFERENT from RDNA3 stride-2.
+//                                    Lanes 0..15 own rows 0..7, lanes 16..31 own rows 8..15.
+//   pattern 2: A=ones, B=col-id    → confirms col mapping: lane l → n = l & 0xF.
+//                                    Expected acc[lane=l, slot=j] = 32 * (l & 0xF)
+//                                    (same value across all 8 slots of any one lane).
+//
+// `out` is laid out [pattern0_dump | pattern1_dump | pattern2_dump], each
+// 256 i32s. Host inspects to either confirm the assumed layout or extract
+// the actual layout map.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void probe_wmma_iu4_k32_layout(int32_t*) {}
+
+#else
+
+extern "C" __global__ void probe_wmma_iu4_k32_layout(int32_t* __restrict__ out) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    const int lane = threadIdx.x;
+    const int row_assumed = lane & 0xF;
+    const int khalf = lane >> 4;
+    (void)khalf; // unused under the K-symmetric patterns we run here.
+
+    // Helper: pack a single 4-bit value v ∈ [0,15] into all 8 nibbles of an int32.
+    auto pack_nibble = [](int v) -> int {
+        return (v & 0xF) * 0x11111111;
+    };
+
+    // ---- Pattern 0: A=ones, B=ones (sanity, mirrors the all-ones probe).
+    {
+        int32x2_t a_v;
+        a_v[0] = 0x11111111;
+        a_v[1] = 0x11111111;
+        int32x2_t b_v;
+        b_v[0] = 0x11111111;
+        b_v[1] = 0x11111111;
+        int32x8_t acc = {0,0,0,0,0,0,0,0};
+        acc = __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(false, a_v, false, b_v, acc, true);
+        int* dst = out + 0 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+
+    // ---- Pattern 1: A = row-id (each row m has every k-element = m), B = ones.
+    // Under the assumed layout, lane l holds A row m = l & 0xF in both v2i halves.
+    // Expected C[m][n] = sum_{k=0..31} m * 1 = 32 * m, independent of n.
+    // Expected acc[lane=l, slot=j] = 32 * (2*j + (l >> 4)).
+    {
+        int32x2_t a_v;
+        a_v[0] = pack_nibble(row_assumed);
+        a_v[1] = pack_nibble(row_assumed);
+        int32x2_t b_v;
+        b_v[0] = 0x11111111;
+        b_v[1] = 0x11111111;
+        int32x8_t acc = {0,0,0,0,0,0,0,0};
+        acc = __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(false, a_v, false, b_v, acc, true);
+        int* dst = out + 1 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+
+    // ---- Pattern 2: A = ones, B = col-id.
+    // Under the assumed layout, lane l holds B col n = l & 0xF in both v2i halves.
+    // Expected C[m][n] = sum_{k=0..31} 1 * n = 32 * n, independent of m.
+    // Expected acc[lane=l, slot=j] = 32 * (l & 0xF) — same value across all 8 slots.
+    {
+        int32x2_t a_v;
+        a_v[0] = 0x11111111;
+        a_v[1] = 0x11111111;
+        int32x2_t b_v;
+        b_v[0] = pack_nibble(row_assumed);
+        b_v[1] = pack_nibble(row_assumed);
+        int32x8_t acc = {0,0,0,0,0,0,0,0};
+        acc = __builtin_amdgcn_wmma_i32_16x16x32_iu4_w32_gfx12(false, a_v, false, b_v, acc, true);
+        int* dst = out + 2 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+}
+
+#endif

--- a/kernels/src/probe_wmma_iu8_k16_layout.gfx12.hip
+++ b/kernels/src/probe_wmma_iu8_k16_layout.gfx12.hip
@@ -1,0 +1,103 @@
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+// gfx12 (RDNA4) iu8 K=16 WMMA — layout-discovery probe (issue #136 part B).
+//
+// Probes the per-lane element layout for
+// __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32 on gfx1201. The iu4 K=32 layout
+// probe (probe_wmma_iu4_k32_layout.gfx12.hip) discovered an 8-row-block acc
+// layout — this probe checks whether iu8 K=16 follows the same wave32 layout
+// or differs.
+//
+// Per-lane shape (correct, confirmed via CK header amd_wmma.hpp): the
+// gfx12-suffixed builtin __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12
+// takes int8x8 = int32x2 per lane (NOT int32x4 — that was the RDNA3-shape
+// builtin without _gfx12 suffix, which has no codegen on gfx12). 32 lanes ×
+// 8 INT8 = 256 INT8 = 16 rows × 16 K, so the natural split is:
+//   A input: lane l → row m = l & 0xF, k-half = l >> 4, 8 INT8 = half-row
+//   B input: lane l → col n = l & 0xF, k-half = l >> 4
+// First-guess acc layout: same 8-row-block as iu4 K=32:
+//   acc[lane=l, slot=j] → C[8*(l>>4) + j][l & 0xF]
+//
+// Three patterns, each writing 256 i32 to its own region of `out`:
+//   pattern 0: A=1, B=1                → expected every entry = 16 (sanity)
+//   pattern 1: A[m][k]=m+1, B=1        → expected acc[l, j] = 16 * (8*(l>>4) + j + 1)
+//   pattern 2: A=1, B[k][n]=n+1        → expected acc[l, j] = 16 * ((l & 0xF) + 1)
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void probe_wmma_iu8_k16_layout(int32_t*) {}
+
+#else
+
+extern "C" __global__ void probe_wmma_iu8_k16_layout(int32_t* __restrict__ out) {
+    using int32x2_t = __attribute__((__vector_size__(2 * sizeof(int)))) int;
+    using int32x8_t = __attribute__((__vector_size__(8 * sizeof(int)))) int;
+
+    const int lane = threadIdx.x;
+    const int row_assumed = lane & 0xF;
+
+    // Pack a single byte v ∈ [0,255] into all 4 lanes of an int32.
+    auto pack_byte = [](int v) -> int {
+        return (v & 0xFF) * 0x01010101;
+    };
+
+    // ---- Pattern 0: A=1, B=1 (sanity).
+    {
+        int32x2_t a_v;
+        a_v[0] = pack_byte(1);
+        a_v[1] = pack_byte(1);
+        int32x2_t b_v;
+        b_v[0] = pack_byte(1);
+        b_v[1] = pack_byte(1);
+        int32x8_t acc = {0,0,0,0,0,0,0,0};
+        acc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(false, a_v, false, b_v, acc, true);
+        int* dst = out + 0 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+
+    // ---- Pattern 1: A[m][k] = m+1, B=1.
+    // Under assumed input layout: lane l holds A row m = l & 0xF (8 INT8 of K-half).
+    // C[m][n] = sum_{k=0..15} (m+1) * 1 = 16 * (m+1), independent of n.
+    // First-guess acc layout (8-row-block): acc[l, j] = 16 * (8*(l>>4) + j + 1).
+    {
+        int32x2_t a_v;
+        a_v[0] = pack_byte(row_assumed + 1);
+        a_v[1] = pack_byte(row_assumed + 1);
+        int32x2_t b_v;
+        b_v[0] = pack_byte(1);
+        b_v[1] = pack_byte(1);
+        int32x8_t acc = {0,0,0,0,0,0,0,0};
+        acc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(false, a_v, false, b_v, acc, true);
+        int* dst = out + 1 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+
+    // ---- Pattern 2: A=1, B[k][n] = n+1.
+    // Under assumed input layout: lane l holds B col n = l & 0xF (8 INT8 of K-half).
+    // C[m][n] = sum_{k=0..15} 1 * (n+1) = 16 * (n+1), independent of m.
+    // Expected: every slot of a lane reads the same value = 16 * ((l & 0xF) + 1).
+    {
+        int32x2_t a_v;
+        a_v[0] = pack_byte(1);
+        a_v[1] = pack_byte(1);
+        int32x2_t b_v;
+        b_v[0] = pack_byte(row_assumed + 1);
+        b_v[1] = pack_byte(row_assumed + 1);
+        int32x8_t acc = {0,0,0,0,0,0,0,0};
+        acc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(false, a_v, false, b_v, acc, true);
+        int* dst = out + 2 * (32 * 8) + lane * 8;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) dst[i] = acc[i];
+    }
+}
+
+#endif

--- a/kernels/src/quantize_q4_1.gfx12.hip
+++ b/kernels/src/quantize_q4_1.gfx12.hip
@@ -1,0 +1,178 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+#include <math.h>
+
+// Q4_1 (signed INT4 in [-7,7], per-K=32 d/sum metadata) activation quantizer
+// for gfx12 (RDNA4). Mirrors `quantize_q8_1_mmq_ds4` in
+// gemm_hfq4g256_residual_mmq.hip but produces INT4 instead of INT8 to feed the
+// iu4 K=32 wmma path (`gemm_hfq4g256_residual_iu4.gfx12.hip`).
+//
+// Output layout: `block_q4_1_mmq` per K=128 of one token, ordered by
+// [K/128 block, batch column]:
+//
+//   struct block_q4_1_mmq {
+//       half2 ds[4];       // (d, sum_q * d) per K=32 sub-block (4 sub-blocks
+//                          //   = K=128). half2.x = d, half2.y = d * sum_q.
+//       int8_t qs[64];     // 4 sub-blocks * 32 INT4 = 128 INT4 packed 2-per-byte.
+//                          //   Within byte: low nibble = element 0 of pair,
+//                          //   high nibble = element 1. INT4 stored as a signed
+//                          //   value in [-7,7] sign-extended into the nibble
+//                          //   per the iu4 wmma signed-input convention (lower
+//                          //   3 bits = magnitude, bit 3 = sign for +/-).
+//                          //   On read: `(int8_t)(byte << 4) >> 4` extracts
+//                          //   low nibble; `(int8_t)(byte) >> 4` extracts high.
+//   };
+//
+// sizeof = 8 + 64 = 72 B... wait, 4 half2 = 8 B + 64 INT4 bytes = 72 B. The
+// spec said 80 B which assumed half2[4] takes 8 B and i8[64] takes 64 B.
+// Re-checking: half2 = 4 B, half2[4] = 16 B. Plus 64 B = 80 B total. The
+// spec is correct — half2 is FP16 + FP16 packed = 4 bytes, and `half2 ds[4]`
+// is 4 * 4 = 16 bytes.
+//
+// Total per K=128 token-col = 16 + 64 = 80 bytes = 20 i32. The GEMM kernel
+// uses MMQ_TILE_Y_K_Q4_1 = 20 to step through global / LDS cols.
+//
+// Quantization recipe (per K=32 sub-block, 32 elems):
+//   amax = max_k |x[k]|
+//   d = amax / 7              (INT4 signed range is [-7,7])
+//   q[k] = clamp(round(x[k] / d), -7, 7)
+//   sum_q = sum_k q[k]        (INT16 range — fits since 32 * 7 = 224)
+//   ds[sub_block] = (FP16(d), FP16(d * sum_q))
+//
+// The inner-loop GEMM applies the algebraic correction:
+//   C[m][n] += sum_k(a_int4 * w_int4) * d_a * scale_w
+//            + (sum_k a_int4) * d_a * zero_w           (= ds.y * zero_w)
+// — same structure as Q8_1 but with the INT4 range and per-K=32 rather than
+// per-K=32 (Q8_1 group).
+//
+// Threading: 1 token per blockIdx.y, 1 char-quad (= 4 K-elements packed into
+// one half-byte, NOPE — let me redo). Actually per i0 we handle 4 elements
+// (1 char4 worth) like the Q8_1 reference, but for INT4 we need 8 elements
+// per byte-write to keep the qs[] write coalesced. We'll do 8 elements per
+// thread (= 1 i32 of activations -> 1 byte-quad of qs writes -> 4 INT4 pairs).
+//
+// Actually the cleaner design: each thread handles 4 K-elements (1 float4),
+// writes 2 INT4 nibbles to one byte at offset (i0/2). __shfl_xor reduces
+// amax/sum across the 8 threads owning one K=32 sub-block (4 elems per thread
+// * 8 threads = 32 elems). Same shape as Q8_1's 4-elems-per-thread,
+// 8-thread-reduce, just smaller K-per-thread sub-block.
+//
+// Wait — Q8_1 also does 4 elems per thread + 8-thread reduce per K=32 sub-block.
+// So I keep the SAME thread layout, just change the q-encoding from INT8 to
+// INT4 + the byte-pack stage.
+
+#if defined(__gfx1200__) || defined(__gfx1201__)
+#define HIPFIRE_GFX12 1
+#else
+#define HIPFIRE_GFX12 0
+#endif
+
+#define WARP_SIZE 32
+#define QK4_1 32
+#define BLOCK_K 128
+
+struct block_q4_1_mmq {
+    half2 ds[4];        // (d, d*sum_q) per K=32 sub-block. 4 * 4 B = 16 B.
+    int8_t qs[64];      // 4 * 32 INT4 packed 2-per-byte. 64 B.
+};
+
+static_assert(sizeof(block_q4_1_mmq) == 80, "bad block_q4_1_mmq size");
+
+#if !HIPFIRE_GFX12
+
+extern "C" __global__ void quantize_q4_1_mmq_ds4_gfx12(
+    const float*,
+    block_q4_1_mmq*,
+    int,
+    int
+) {}
+
+#else
+
+// ---------------------------------------------------------------------------
+// Quantize an [N x K] FP32 activation matrix into the block_q4_1_mmq layout.
+//
+// Grid: ((K+1023)/1024, N, 1)   block: (256, 1, 1)
+// Each thread handles 4 contiguous K-elements (1 float4). 8 threads cover one
+// K=32 sub-block; per-sub-block amax + sum reductions use __shfl_xor with
+// xor masks 1,2,4 (covering the 8 threads of the sub-block — same as Q8_1).
+//
+// Output indexing (mirrors block_q8_1_mmq):
+//   kblock = i0 / 128                          (which K=128 chunk of the row)
+//   iqs    = i0 & 127                          (offset within the K=128 chunk)
+//   out    = Y + kblock * N + token            (the K=128 chunk for this token)
+//   sub    = iqs / 32                          (K=32 sub-block within the chunk)
+//
+// Each thread writes 4 INT4 values for 4 consecutive K-positions, packed as
+// 2 bytes (low nibble = even K, high nibble = odd K) at byte offset iqs/2
+// within out->qs[]. One thread per sub-block (lane 0 of the 8-thread group)
+// writes the half2 ds entry.
+// ---------------------------------------------------------------------------
+extern "C" __global__ void quantize_q4_1_mmq_ds4_gfx12(
+    const float* __restrict__ X,
+    block_q4_1_mmq* __restrict__ Y,
+    int K,
+    int N
+) {
+    const int token = blockIdx.y;
+    const int i0 = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
+    if (token >= N || i0 >= K) return;
+
+    const float4 xi = (i0 + 3 < K)
+        ? *(const float4*)(X + (long long)token * K + i0)
+        : make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    // Per-sub-block reduce across the 8 threads owning the K=32 sub-block.
+    // xor masks 1,2,4 → covers threads in the same (i0 / 32) group.
+    float amax = fmaxf(fmaxf(fabsf(xi.x), fabsf(xi.y)), fmaxf(fabsf(xi.z), fabsf(xi.w)));
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        amax = fmaxf(amax, __shfl_xor(amax, offset, WARP_SIZE));
+    }
+
+    // INT4 signed range is [-7,7]. Use 7.0 (NOT 8.0) to stay strictly inside
+    // the iu4 signed clamp (the wmma builtin clamp arg ensures saturation,
+    // but rounding to ±7 keeps the sign-bit interpretation unambiguous).
+    const float d = amax > 1.0e-20f ? amax / 7.0f : 0.0f;
+    const float id = d > 0.0f ? 1.0f / d : 0.0f;
+
+    // Quantize 4 floats → 4 INT4 values in [-7,7].
+    int q0 = (int)lrintf(fmaxf(-7.0f, fminf(7.0f, xi.x * id)));
+    int q1 = (int)lrintf(fmaxf(-7.0f, fminf(7.0f, xi.y * id)));
+    int q2 = (int)lrintf(fmaxf(-7.0f, fminf(7.0f, xi.z * id)));
+    int q3 = (int)lrintf(fmaxf(-7.0f, fminf(7.0f, xi.w * id)));
+
+    // Sum the 4 quant values for this thread, then reduce across the 8
+    // threads of the sub-block. Result is sum_q over K=32.
+    int sum_q_local = q0 + q1 + q2 + q3;
+    for (int offset = 4; offset > 0; offset >>= 1) {
+        sum_q_local += __shfl_xor(sum_q_local, offset, WARP_SIZE);
+    }
+    const int sum_q = sum_q_local;
+
+    // Pack 4 INT4 → 2 bytes. Low nibble of each byte = even-K element,
+    // high nibble = odd-K element. INT4 sign-extends from bit 3 on read,
+    // so we mask to 4 bits before OR-ing.
+    const unsigned int q0_u = (unsigned)q0 & 0xFu;
+    const unsigned int q1_u = (unsigned)q1 & 0xFu;
+    const unsigned int q2_u = (unsigned)q2 & 0xFu;
+    const unsigned int q3_u = (unsigned)q3 & 0xFu;
+    const unsigned int byte0 = q0_u | (q1_u << 4);
+    const unsigned int byte1 = q2_u | (q3_u << 4);
+
+    const int kblock = i0 / BLOCK_K;
+    const int iqs    = i0 & (BLOCK_K - 1);    // offset within K=128 chunk (0..127)
+    const int sub    = iqs / QK4_1;           // K=32 sub-block index (0..3)
+    block_q4_1_mmq* out = Y + (long long)kblock * N + token;
+
+    // 4 K-positions → 2 bytes at byte offset iqs/2 within qs[].
+    out->qs[iqs / 2 + 0] = (int8_t)byte0;
+    out->qs[iqs / 2 + 1] = (int8_t)byte1;
+
+    // Lane 0 of the 8-thread sub-block writes ds[sub] = (d, d*sum_q).
+    if ((iqs & (QK4_1 - 1)) == 0) {
+        out->ds[sub] = make_half2((_Float16)d, (_Float16)(d * (float)sum_q));
+    }
+}
+
+#endif

--- a/tests/speed-baselines/gfx1201.txt
+++ b/tests/speed-baselines/gfx1201.txt
@@ -1,49 +1,47 @@
 # hipfire speed-gate baseline — gfx1201
-# Captured 2026-04-29 against issue #65 K4 unroll (this branch).
-# Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug),
-#         HIPFIRE_DPM_WARMUP_SECS=10 (the bench's pre-prefill DPM ramp added
-#         in this branch — without it the GPU starts at DPM step 0/1 and the
-#         first ~50ms of prefill measures clock-ramp, not steady-state),
-#         R9700 with no other concurrent GPU consumers (bench-cold.sh handles
-#         this via the gpu-lock).
-# Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tolerance))
+# Captured 2026-05-04 against commit 06296cf on hiptrx.
+# Hardware: 4x AMD Radeon AI PRO R9700 (one used for capture), Threadripper
+#           9970X, 128 GB RAM, ROCm 7.2.2, Ubuntu 26.04. Closes #137.
+#
+# This supersedes the 2026-04-29 capture made on a different physical R9700
+# board. The prior numbers were ~5-10% higher on small-model pp128 prefill;
+# investigation (#137) traced that to inter-board / inter-host variance
+# plus a high-tail outlier in the prior capture's distribution, not a
+# software regression. Pre-#135 (28d3d85) measured 7639-9228 on 0.8B pp128
+# across 3 samples vs 7689-7806 post-#135; the diff is purely additive at
+# the dispatch level on RDNA4, ruling out a real code regression.
+#
+# Config: KV=asym3, HIPFIRE_GRAPH=1 for 4B/9B/27B (0.8B has known hipGraph bug)
+# Tolerance: 0.05 (fail if any metric drops below baseline x (1 - tolerance))
 #
 # Measurements: best-of-2 via bench_qwen35_mq4. Two prefill sizes per model:
 #   pp32  — short-context / launch-overhead regression detector
 #   pp128 — realistic prompt / GEMM-efficiency detector
 # Decode numbers are taken from the pp32 run (warmup+50 gen is enough to settle).
+# DFlash anchors recaptured on hiptrx using qwen35-{9b,27b}-dflash-mq4.hfq drafts.
 # GROUND FLOOR — no commit may regress below these numbers.
-#
-# Prefill numbers on this gate roughly DOUBLE the prior gfx1201 floor
-# (0.8B pp128 +48%, 4B pp128 +75%, 9B pp128 +84%, 27B pp128 first capture).
-# The lift comes from K4 unroll applied to all six gfx12 WMMA GEMM kernels
-# plus the residual variant — see kernels/src/gemm_*_wmma.gfx12.hip for
-# the K-tile inner loop. Channel-tests (43/43 across hfq4 + hfq6),
-# coherence-gate (4/4 fluent outputs), and the DFlash anchors below all
-# validate.
 
-0.8b_mq4_pp32_prefill_tok_s=3967.8
-0.8b_mq4_gen_tok_s=361.0
-0.8b_mq4_pp128_prefill_tok_s=9511.5
+0.8b_mq4_pp32_prefill_tok_s=3701.7
+0.8b_mq4_gen_tok_s=374.7
+0.8b_mq4_pp128_prefill_tok_s=7701.1
 
-4b_mq4_pp32_prefill_tok_s=1977.9
-4b_mq4_gen_tok_s=150.4
-4b_mq4_pp128_prefill_tok_s=3268.7
+4b_mq4_pp32_prefill_tok_s=1654.5
+4b_mq4_gen_tok_s=149.8
+4b_mq4_pp128_prefill_tok_s=3255.7
 
-9b_mq4_pp32_prefill_tok_s=1403.9
-9b_mq4_gen_tok_s=102.0
-9b_mq4_pp128_prefill_tok_s=1894.9
+9b_mq4_pp32_prefill_tok_s=1262.2
+9b_mq4_gen_tok_s=101.5
+9b_mq4_pp128_prefill_tok_s=1794.7
 
-27b_mq4_pp32_prefill_tok_s=516.2
-27b_mq4_gen_tok_s=36.0
-27b_mq4_pp128_prefill_tok_s=566.6
+27b_mq4_pp32_prefill_tok_s=501.1
+27b_mq4_gen_tok_s=35.8
+27b_mq4_pp128_prefill_tok_s=574.3
 
-27b_3.5_dflash_lru_code_tok_s=140.48
+27b_3.5_dflash_lru_code_tok_s=138.02
 27b_3.5_dflash_lru_code_tau=9.500
-27b_3.5_dflash_merge_sort_tok_s=195.00
+27b_3.5_dflash_merge_sort_tok_s=192.69
 27b_3.5_dflash_merge_sort_tau=13.2727
-27b_3.5_dflash_merge_sort_ttft_ms=135.39
-9b_3.5_dflash_merge_sort_tok_s=360.77
+27b_3.5_dflash_merge_sort_ttft_ms=142.18
+9b_3.5_dflash_merge_sort_tok_s=354.61
 9b_3.5_dflash_merge_sort_tau=13.1538
-9b_3.5_dflash_merge_sort_ttft_ms=63.41
-
+9b_3.5_dflash_merge_sort_ttft_ms=70.84


### PR DESCRIPTION
## Summary

Implements runtime SmoothQuant-style activation calibration for the gfx12 iu4 K=32 GEMM kernel landed in PR #140. **Layer-0 falsification PASSES** — calibrated iu4 produces fluent output equivalent to raw iu4 on the same MAX_CALL=2 isolation. **Full-model coherence STILL FAILS** at MAX_CALL ≥ 4, confirming the project memo's diagnosis that Q4_1's ~14% per-element noise compounds across 32+ layers beyond what a SmoothQuant-class linear migration can recover.

The mathematical scaffold is correct and the kernel level is tight (`max_abs_err = 0.013` on 256×512×128 GEMM vs FP16 reference, well under the 0.20 threshold). The bar that wasn't met is the full-model coherence gate — the documented next step per the task spec is escalation to outlier extraction (LLM.int8() pattern), which is a separate, larger PR.

## What it ships

- `kernels/src/activation_preshift.gfx12.hip` — per-channel `(x - mu) * inv_s` before Q4_1 quant (FP16 mu/inv_s, FP32 x/y).
- `kernels/src/iu4_bake_weight_scales.gfx12.hip` — multiplies BOTH HFQ4 group `scale` AND `zero` by `s_group[g]` so `(W * s_g) * (q_w + zero) = (s_g * W)`. (The first cut only baked `scale` and produced 33× output blow-up — caught by `test_iu4_calibration_layer0`.)
- `crates/rdna-compute/src/iu4_calibration.rs` + dispatch.rs — `GpuIu4Calibration` GPU-resident sidecar (per-site mu/inv_s/s_group FP16 + FP32 W·mu_a bias) + lazy s-baked weight clone cache + dispatch counter so capture and runtime share a stable per-call site key.
- `crates/engine/src/quant/iu4_calibration.rs` — sidecar wire format ("IU4C" magic + version 1), MeanAccumulator + CenteredHistogram helpers, GPU upload helper that derives s_group via geomean within each K=256 group and rebroadcasts to per-channel for preshift.
- `crates/engine/examples/calibrate_iu4_activations.rs` — offline binary, runs FP16 forward_prefill_batch over a 31-prompt embedded coherence-style corpus (+ optional --corpus dir), accumulates per-site mu (pass A) + p99-abs-after-centering (pass B), computes W·mu_a bias by CPU-dequant + dot, writes `<model>.iu4cal`.
- `crates/rdna-compute/examples/test_iu4_calibration_correctness.rs` — synthetic-data correctness test on gfx1201, threshold tighter than raw iu4.
- `crates/engine/examples/test_iu4_calibration_layer0.rs` — real-model layer-0 diagnostic that uncovered the missing-zero-bake bug.
- `crates/engine/examples/daemon.rs` — auto-load `<model>.iu4cal` if present at model load time.
- New env gates:
  - `HIPFIRE_GFX12_IU4_CALIBRATED=1` arms the calibrated path (requires sidecar; errors otherwise).
  - `HIPFIRE_GFX12_IU4=1` (pre-existing) stays as raw-iu4 research opt-in.
  - `HIPFIRE_GFX12_IU4_MAX_CALL=N` reused for both paths — gate the first N calls, fall through to FP16/MMQ after.
  - `HIPFIRE_IU4_CAL_DEBUG=1` traces every calibrated-dispatch hit to stderr.

## Math

```
y = W · x = (W · diag(s)) · ((x - mu) / s) + W · mu
```

- `mu_a[c]` per-channel arithmetic mean → preshift centering term, also drives `bias[m] = sum_c W[m][c] * mu_a[c]`.
- `s_a[c]` per-channel scale (99-pctile-abs after centering, default).
- `s_group[g] = geomean(s_a[c] for c in g)` per K=256 group.
- `inv_s_grouped[c] = 1 / s_group[g(c)]` (broadcast back to per-channel; constant within group).
- Bake: every (row, group) of HFQ4-G256 has its FP32 scale AND zero multiplied by `s_group[g]`.

The math closes EXACTLY at group resolution because `s_group[g]` cancels: `(W * s_g) * ((x - mu) / s_g) + W * mu = W * x`. The synthetic correctness test on gfx1201 confirms this: `max abs err = 0.013, max |y| ≈ 1.6` vs FP16 reference.

## Layer-0 falsification (PASS)

Qwen3.5-9B "What is the capital of France? Answer in one short sentence." — `max_tokens=40`, `temperature=0.0`:

| mode | first 8 tokens (decoded) |
| --- | --- |
| baseline FP16 | `<think>\nThinking Process:\n1. **Analyze...` (fluent) |
| raw iu4 MAX_CALL=2 | `After the war, the French government of Charles de Gaulle...` (fluent) |
| **calibrated iu4 MAX_CALL=2** | `After the war, the French government was dissolved.` (**fluent**) |

Calibrated iu4 layer-0 matches raw-iu4 layer-0 quality. The math closes within Q4_1 noise.

## Full-model coherence (FAIL — unchanged from raw iu4)

Same prompt, sweeping `HIPFIRE_GFX12_IU4_MAX_CALL`:

| MAX_CALL | first tokens |
| --- | --- |
| 2 (1 layer) | `After the war, the French government...` (fluent) |
| 4 (2 layers) | `rokes:<\|im_end\|>` (collapse) |
| 8 (4 layers) | `rokes capital capital capital...` (loop) |
| 16 | `���� ���� ����...` (binary garbage) |
| 64 (full) | `rit · m · ni ni ni ni...` (n-gram-loop EOS) |

Per the project memo (`project_gfx12_iu4_breakthrough_2026_05_04.md`): Q4_1 activation has ~14% per-element precision; that compounds across 32+ transformer layers + softmax into unintelligible output. Calibration fixes the DC-offset failure mode but doesn't lower the per-element noise floor — the s_a normalization narrows dynamic range but the within-group s_a variance (5×–10× on 9B layer 0) leaves residual per-channel scaling error proportional to that variance.

`--strategy center` (mu_a only, s_a = 1.0) shows the same breakdown threshold (MAX_CALL=2 fluent, MAX_CALL=4+ collapse). So the s_a strategy isn't the deciding factor — the noise floor is.

## Perf (informational; bar not met)

Daemon prefill on Qwen3.5-27B (pp=209, 5 gen tokens):

| mode | prefill_tok_s | decode_tok_s |
| --- | --- | --- |
| FP16 (baseline) | 526.8 | 33.5 |
| calibrated iu4 | 541.2 (+2.7%) | 34.2 |

Within bench noise, but does not meet the +8% bar from the task spec. The calibrated path adds preshift + bias_add launches per call, ~3 extra dispatches; on 27B the iu4 GEMM throughput edge isn't large enough to fully amortize. Note: bench output during incoherent state is meaningless — these numbers are reported for completeness only.

## Recommendation (per task spec)

Layer-0 falsification PASSED. Full-model FAILED. Per the spec:
> If both fail: the kernel needs an OUTLIER channel pass (LLM.int8() pattern) — that's a separate, larger PR.

Layer-0 passing demonstrates the math + plumbing is sound. The fundamental compounding-noise problem documented in the project memo is unaffected by linear SmoothQuant-style migration. The next research step (NOT in this PR) is an outlier-extraction pass: identify channels with the heaviest tails and route them through an FP16 sidecar, leaving the well-behaved bulk on Q4_1.

This PR ships the calibration pipeline + bake + dispatch as foundation. Calibrated path stays under `HIPFIRE_GFX12_IU4_CALIBRATED=1` opt-in, identical safety gating to the existing `HIPFIRE_GFX12_IU4=1`. **Default behavior is unchanged.**

## Test plan
- [x] cargo build --release -p engine --example daemon (gfx1100 local + gfx1201 hiptrx)
- [x] cargo build --release -p engine --example calibrate_iu4_activations
- [x] cargo build --release -p rdna-compute --example test_iu4_calibration_correctness
- [x] cargo build --release -p engine --example test_iu4_calibration_layer0
- [x] cargo test -p engine --features deltanet --lib quant::iu4_calibration (4/4 PASS — sidecar roundtrip, percentile, bucket monotone)
- [x] test_iu4_calibration_correctness on gfx1201 (PASS, max_abs_err=0.013, all thresholds OK)
- [x] test_iu4_calibration_layer0 on Qwen3.5-9B layer 0 wo (PASS, max_abs_err=0.049 vs max|y|=6.58)
- [x] Layer-0 falsification on hiptrx with MAX_CALL=2 (PASS — fluent output)
- [x] Local coherence-gate on gfx1100 (PASS, no regressions to existing paths since calibrated is gated off by default)
- [ ] Full-model coherence with calibrated iu4 (FAIL — documented above; this is the bar that requires outlier extraction)
- [ ] +8% perf on 27B pp512 (NOT MET — measured +2.7%; meaningful only when full-model coherence passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)