### PR TITLE
fix(daemon): use FP32 DeltaNet state for MoE models

### DIFF
--- a/crates/engine/examples/daemon.rs
+++ b/crates/engine/examples/daemon.rs
@@ -1221,7 +1221,17 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                 llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
             }
         };
-        let dn = DeltaNetState::new(gpu, &config).map_err(|e| format!("{e}"))?;
+        // MoE models (num_experts > 0) have ~10x smaller hidden-state
+        // magnitudes than dense models, making Q8 DeltaNet state quantization
+        // error proportionally larger. Use FP32 state to avoid cumulative
+        // drift that degenerates output after ~200 tokens.
+        let dn_quant = if config.num_experts > 0 {
+            eprintln!("  DeltaNet state: FP32 (MoE model — Q8 drift mitigation)");
+            engine::qwen35::StateQuant::FP32
+        } else {
+            engine::qwen35::StateQuant::Q8
+        };
+        let dn = DeltaNetState::new_with_quant(gpu, &config, dn_quant).map_err(|e| format!("{e}"))?;
         // Flash partials size with physical_cap (bounds the max_tiles the
         // flash kernel must address). When physical_cap == max_seq this is
         // identical to sizing-by-max_seq; under eviction it's much smaller.


### PR DESCRIPTION
## Summary
- MoE models (num_experts > 0) use FP32 DeltaNet state instead of Q8
- Extends coherent output from ~200 to ~350 tokens on qwen3.5-122b-a10b
- Cost: ~0.2 GB extra VRAM (negligible on any system running a 122B model)

## Root cause
MoE models have ~10x smaller hidden-state magnitudes than dense models, making Q8 state quantization error proportionally larger. The error compounds across 36 DeltaNet layers × hundreds of tokens.

## Test plan
- [x] Verified FP32 state eliminates punctuation-loop degeneration at ~200 tokens
- [x] Verified output stays coherent to ~350 tokens (remaining drift from MQ4 expert weights)
- [x] Dense models (9B, 27B) unaffected — they continue using Q8 state

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)