### PR TITLE
feat(loader+quantizer): UMA-safe loader, MQ6 expert quant, disk spill

### DIFF
--- a/crates/hipfire-arch-llama/src/arch.rs
+++ b/crates/hipfire-arch-llama/src/arch.rs
@@ -58,7 +58,7 @@ impl Architecture for Llama {
     }
 
     fn load_weights(
-        hfq: &HfqFile,
+        hfq: &mut HfqFile,
         cfg: &Self::Config,
         gpu: &mut Gpu,
     ) -> Result<Self::Weights, String> {

--- a/crates/hipfire-arch-qwen35-vl/src/arch.rs
+++ b/crates/hipfire-arch-qwen35-vl/src/arch.rs
@@ -67,7 +67,7 @@ impl Architecture for Qwen35Vl {
     }
 
     fn load_weights(
-        hfq: &HfqFile,
+        hfq: &mut HfqFile,
         cfg: &Self::Config,
         gpu: &mut Gpu,
     ) -> Result<Self::Weights, String> {

--- a/crates/hipfire-arch-qwen35/src/arch.rs
+++ b/crates/hipfire-arch-qwen35/src/arch.rs
@@ -63,7 +63,7 @@ impl Architecture for Qwen35 {
     }
 
     fn load_weights(
-        hfq: &HfqFile,
+        hfq: &mut HfqFile,
         cfg: &Self::Config,
         gpu: &mut Gpu,
     ) -> Result<Self::Weights, String> {

--- a/crates/hipfire-arch-qwen35/src/pflash.rs
+++ b/crates/hipfire-arch-qwen35/src/pflash.rs
@@ -482,7 +482,7 @@ pub fn load_drafter(
     target_tokenizer: &Tokenizer,
     max_kv_seq: usize,
 ) -> HipResult<()> {
-    let hfq = HfqFile::open(path).map_err(|e| hip_bridge::HipError::new(0, &format!(
+    let mut hfq = HfqFile::open(path).map_err(|e| hip_bridge::HipError::new(0, &format!(
         "pflash: open drafter HFQ at {}: {e}", path.display(),
     )))?;
     let drafter_tokenizer = Tokenizer::from_hfq_metadata(&hfq.metadata_json).ok_or_else(||
@@ -506,7 +506,7 @@ pub fn load_drafter(
         if is_hybrid {
             let q35_cfg = qwen35::config_from_hfq(&hfq).ok_or_else(||
                 hip_bridge::HipError::new(0, "pflash: hybrid tensors detected but qwen35 config parse failed"))?;
-            let weights = qwen35::load_weights(&hfq, &q35_cfg, gpu)?;
+            let weights = qwen35::load_weights(&mut hfq, &q35_cfg, gpu)?;
             let scratch = qwen35::Qwen35Scratch::new_with_kv_max(gpu, &q35_cfg, 128, max_kv_seq)?;
             let dn_state = qwen35::DeltaNetState::new(gpu, &q35_cfg)?;
             let kv = KvCache::new_gpu_q8(gpu, q35_cfg.n_layers, q35_cfg.n_kv_heads, q35_cfg.head_dim, max_kv_seq)?;

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -661,8 +661,8 @@ impl DeltaNetState {
 /// Load norm weight for Qwen3.5: stored as offset from 1.0 (output = x * (1 + weight))
 fn load_norm_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: &[usize]) -> HipResult<GpuTensor> {
     let full_name = format!("model.language_model.{name}");
-    let (info, data) = hfq.tensor_data(&full_name)
-        .or_else(|| hfq.tensor_data(name))
+    let (info, data) = hfq.tensor_data_vec(&full_name)
+        .or_else(|| hfq.tensor_data_vec(name))
         .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
 
     let mut f32_data: Vec<f32> = match info.quant_type {
@@ -680,8 +680,8 @@ fn load_norm_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: &[usize]) -
 /// mean ~1.6 on Qwen3.5-MoE A3B). Applying +1.0 would over-amplify by ~60%.
 fn load_norm_weight_raw(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: &[usize]) -> HipResult<GpuTensor> {
     let full_name = format!("model.language_model.{name}");
-    let (info, data) = hfq.tensor_data(&full_name)
-        .or_else(|| hfq.tensor_data(name))
+    let (info, data) = hfq.tensor_data_vec(&full_name)
+        .or_else(|| hfq.tensor_data_vec(name))
         .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
     let f32_data: Vec<f32> = match info.quant_type {
         1 => data.chunks_exact(2).map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]]))).collect(),
@@ -778,14 +778,14 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
 /// Load a tensor as F32 on GPU, handling any quant type by dequanting on CPU.
 fn load_any_as_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, n: usize) -> HipResult<GpuTensor> {
     let full_name = format!("model.language_model.{name}");
-    let (info, data) = hfq.tensor_data(&full_name)
-        .or_else(|| hfq.tensor_data(name))
+    let (info, data) = hfq.tensor_data_vec(&full_name)
+        .or_else(|| hfq.tensor_data_vec(name))
         .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
 
     let f32_data: Vec<f32> = match info.quant_type {
         1 => data.chunks_exact(2).map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]]))).collect(),
         2 => data.chunks_exact(4).map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect(),
-        3 => hipfire_runtime::llama::dequantize_q8_0(data, n),
+        3 => hipfire_runtime::llama::dequantize_q8_0(&data, n),
         14 => {
             // MQ8-G256: [f16 scale][int8 × 256] = 258 bytes per 256 weights
             let group_size: usize = 256;
@@ -1071,26 +1071,35 @@ fn load_raw_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, n: usize) -> HipResult
     load_any_as_f32(hfq, gpu, name, n)
 }
 
-pub fn load_weights(hfq: &HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> HipResult<Qwen35Weights> {
+pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> HipResult<Qwen35Weights> {
+    // Drop the mmap on unix to avoid double-buffering on UMA systems.
+    // All tensor data reads go through pread + fadvise_dontneed, which
+    // doesn't require the mmap. On discrete-GPU systems this is harmless
+    // (pread is slightly slower than mmap but avoids page cache buildup).
+    #[cfg(unix)]
+    hfq.drop_mmap();
+
     eprintln!("  loading token_embd...");
-    let embd_info = hfq.tensor_data("model.language_model.embed_tokens.weight")
+    let (embd_meta, embd_data) = hfq.tensor_data_vec("model.language_model.embed_tokens.weight")
         .expect("embed_tokens not found");
-    let (token_embd, embd_fmt) = if embd_info.0.quant_type == 6 {
-        eprintln!("    (HFQ4-G256 raw, {} MB)", embd_info.1.len() / 1_000_000);
-        (gpu.upload_raw(embd_info.1, &[embd_info.1.len()])?, EmbeddingFormat::HFQ4G256)
-    } else if embd_info.0.quant_type == 7 {
-        eprintln!("    (HFQ4-G128 raw, {} MB)", embd_info.1.len() / 1_000_000);
-        (gpu.upload_raw(embd_info.1, &[embd_info.1.len()])?, EmbeddingFormat::HFQ4G128)
-    } else if embd_info.0.quant_type == 3 {
+    let embd_qt = embd_meta.quant_type;
+    let (token_embd, embd_fmt) = if embd_qt == 6 {
+        eprintln!("    (HFQ4-G256 raw, {} MB)", embd_data.len() / 1_000_000);
+        (gpu.upload_raw(&embd_data, &[embd_data.len()])?, EmbeddingFormat::HFQ4G256)
+    } else if embd_qt == 7 {
+        eprintln!("    (HFQ4-G128 raw, {} MB)", embd_data.len() / 1_000_000);
+        (gpu.upload_raw(&embd_data, &[embd_data.len()])?, EmbeddingFormat::HFQ4G128)
+    } else if embd_qt == 3 {
         // Q8_0: [f16 scale][32 × int8] per block — upload raw, use Q8 embedding lookup
-        eprintln!("    (Q8_0 raw, {} MB)", embd_info.1.len() / 1_000_000);
-        (gpu.upload_raw(embd_info.1, &[embd_info.1.len()])?, EmbeddingFormat::Q8_0)
+        eprintln!("    (Q8_0 raw, {} MB)", embd_data.len() / 1_000_000);
+        (gpu.upload_raw(&embd_data, &[embd_data.len()])?, EmbeddingFormat::Q8_0)
     } else {
-        let f32_data: Vec<f32> = embd_info.1.chunks_exact(2)
+        let f32_data: Vec<f32> = embd_data.chunks_exact(2)
             .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
             .collect();
         (gpu.upload_f32(&f32_data, &[config.vocab_size, config.dim])?, EmbeddingFormat::F32)
     };
+    drop(embd_data); // free source buffer before loading more tensors
 
     eprintln!("  loading output_norm...");
     // Final output norm: on Qwen3.5/3.6-MoE (A3B, arch_id=6) this tensor is
@@ -1108,34 +1117,31 @@ pub fn load_weights(hfq: &HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> HipR
     };
 
     // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens
-    let lm_head_info = hfq.tensor_data("lm_head.weight")
-        .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
+    let lm_head_info = hfq.tensor_data_vec("lm_head.weight")
+        .or_else(|| hfq.tensor_data_vec("model.language_model.lm_head.weight"));
     let output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
-        load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
+        load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, config.vocab_size, config.dim)?
     } else {
-        eprintln!("  loading output (tied embeddings, qt={})...", embd_info.0.quant_type);
-        let embd_data = hfq.tensor_data("model.language_model.embed_tokens.weight").unwrap().1;
-        if embd_info.0.quant_type == 6 || embd_info.0.quant_type == 7 || embd_info.0.quant_type == 8 {
-            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
-            let dtype = match embd_info.0.quant_type {
+        eprintln!("  loading output (tied embeddings, qt={})...", embd_qt);
+        let (_, tied_data) = hfq.tensor_data_vec("model.language_model.embed_tokens.weight").unwrap();
+        if embd_qt == 6 || embd_qt == 7 || embd_qt == 8 {
+            let buf = gpu.upload_raw(&tied_data, &[tied_data.len()])?;
+            let dtype = match embd_qt {
                 6 => DType::HFQ4G256, 7 => DType::HFQ4G128, 8 => DType::HFQ6G256, _ => unreachable!()
             };
             WeightTensor { buf, gpu_dtype: dtype, m: config.vocab_size, k: config.dim, row_stride: 0 }
-        } else if embd_info.0.quant_type == 13 {
-            // MQ4-G256 tied embedding — produced by hipfire-quantize
-            // `--format mq4-all`. DFlash uses this to make the target's
-            // lm_head (tied to embed_tokens) hit the batched MQ4 GEMM path.
-            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+        } else if embd_qt == 13 {
+            let buf = gpu.upload_raw(&tied_data, &[tied_data.len()])?;
             WeightTensor { buf, gpu_dtype: DType::MQ4G256, m: config.vocab_size, k: config.dim, row_stride: 0 }
-        } else if embd_info.0.quant_type == 14 {
-            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+        } else if embd_qt == 14 {
+            let buf = gpu.upload_raw(&tied_data, &[tied_data.len()])?;
             WeightTensor { buf, gpu_dtype: DType::MQ8G256, m: config.vocab_size, k: config.dim, row_stride: 0 }
-        } else if embd_info.0.quant_type == 3 {
-            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+        } else if embd_qt == 3 {
+            let buf = gpu.upload_raw(&tied_data, &[tied_data.len()])?;
             WeightTensor { buf, gpu_dtype: DType::Q8_0, m: config.vocab_size, k: config.dim, row_stride: 0 }
         } else {
-            let f32_data: Vec<f32> = embd_data.chunks_exact(2)
+            let f32_data: Vec<f32> = tied_data.chunks_exact(2)
                 .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
                 .collect();
             let bytes: &[u8] = unsafe {

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -197,13 +197,13 @@ impl ModelSlot {
         slot_config: ModelSlotConfig,
     ) -> HipResult<Self> {
         let name = name.into();
-        let hfq = HfqFile::open(path).map_err(|e| {
+        let mut hfq = HfqFile::open(path).map_err(|e| {
             hip_bridge::HipError::new(0, &format!("open {} ({}): {}", path.display(), name, e))
         })?;
         let config = qwen35::config_from_hfq(&hfq).ok_or_else(|| {
             hip_bridge::HipError::new(0, &format!("invalid Qwen3.5 config in {} ({})", path.display(), name))
         })?;
-        let weights = qwen35::load_weights(&hfq, &config, gpu)?;
+        let weights = qwen35::load_weights(&mut hfq, &config, gpu)?;
 
         let n_kv_layers = config
             .layer_types

--- a/crates/hipfire-arch-qwen35/tests/pp_parity.rs
+++ b/crates/hipfire-arch-qwen35/tests/pp_parity.rs
@@ -60,10 +60,10 @@ fn build_prompt_tokens(tok: &Tokenizer) -> Vec<u32> {
 }
 
 fn run_pp1(path: &str, prompt: &[u32]) -> Vec<u32> {
-    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let mut hfq = HfqFile::open(Path::new(path)).expect("open hfq");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let mut gpu = Gpu::init().expect("Gpu::init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load_weights");
     let mut kv = KvCache::new_gpu_asym3_capped(
         &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
     ).expect("kv");

--- a/crates/hipfire-arch-toy/src/arch.rs
+++ b/crates/hipfire-arch-toy/src/arch.rs
@@ -55,7 +55,7 @@ impl Architecture for Toy {
     /// The weight pager (lazy-load + LRU eviction) is wired through
     /// `WeightTensor` and is not arch-specific.
     fn load_weights(
-        hfq: &HfqFile,
+        hfq: &mut HfqFile,
         cfg: &Self::Config,
         _gpu: &mut Gpu,
     ) -> Result<Self::Weights, String> {

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1094,7 +1094,14 @@ impl TensorSpill {
     }
 
     fn cleanup(self) {
-        drop(self.file);
+        // Explicit cleanup — Drop impl handles the actual removal.
+        drop(self);
+    }
+}
+
+impl Drop for TensorSpill {
+    fn drop(&mut self) {
+        // Ensure the temp file is removed even on panic.
         let _ = std::fs::remove_file(&self.path);
     }
 }

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -73,6 +73,26 @@ impl SafetensorsFile {
         Some((meta, &self.mmap[start..end]))
     }
 
+    /// Advise the kernel to drop page cache for a tensor's data region.
+    /// On UMA systems this is critical: 234 GB of mmap'd safetensors
+    /// pages compete with hipMalloc for the same physical RAM.
+    #[cfg(unix)]
+    fn drop_tensor_pages(&self, name: &str) {
+        if let Some(meta) = self.tensors.get(name) {
+            let start = self.header_size + meta.data_offsets[0];
+            let len = meta.data_offsets[1] - meta.data_offsets[0];
+            use std::os::unix::io::AsRawFd;
+            // POSIX_FADV_DONTNEED = 4
+            unsafe {
+                extern "C" { fn posix_fadvise(fd: i32, offset: i64, len: i64, advice: i32) -> i32; }
+                posix_fadvise(self._file.as_raw_fd(), start as i64, len as i64, 4);
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn drop_tensor_pages(&self, _name: &str) {}
+
     fn tensor_names(&self) -> Vec<&str> {
         self.tensors.keys().map(|s| s.as_str()).collect()
     }
@@ -1035,6 +1055,63 @@ struct HfqTensor {
     shape: Vec<u32>,
     group_size: u32,
     data: Vec<u8>,
+    /// When data is spilled to disk, this holds the byte count.
+    /// `data` is empty and the bytes live in the spill file.
+    spilled_len: u64,
+}
+
+/// Streaming tensor spill file. When the quantizer accumulates more than
+/// `SPILL_THRESHOLD` bytes of tensor data in memory, it flushes completed
+/// tensors to this file. At write_hfq time, spilled data is copied from
+/// the spill file instead of from memory, keeping peak RSS bounded.
+struct TensorSpill {
+    file: std::io::BufWriter<File>,
+    path: PathBuf,
+    offset: u64,
+}
+
+impl TensorSpill {
+    fn new(dir: &Path) -> std::io::Result<Self> {
+        let path = dir.join(".hipfire_quant_spill.tmp");
+        let file = std::io::BufWriter::with_capacity(
+            4 * 1024 * 1024,
+            File::create(&path)?,
+        );
+        Ok(Self { file, path, offset: 0 })
+    }
+
+    /// Write tensor data to the spill file. Returns the byte count written.
+    fn spill(&mut self, data: &[u8]) -> std::io::Result<u64> {
+        use std::io::Write;
+        self.file.write_all(data)?;
+        self.offset += data.len() as u64;
+        Ok(data.len() as u64)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        use std::io::Write;
+        self.file.flush()
+    }
+
+    fn cleanup(self) {
+        drop(self.file);
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Spill tensors whose data is in memory to the spill file, freeing RAM.
+/// Called after each layer's expert batch to keep peak RSS bounded.
+fn maybe_spill(tensors: &mut [HfqTensor], spill: &mut TensorSpill, threshold: usize) {
+    let in_mem: usize = tensors.iter().filter(|t| t.spilled_len == 0).map(|t| t.data.len()).sum();
+    if in_mem < threshold { return; }
+    for t in tensors.iter_mut() {
+        if t.spilled_len == 0 && !t.data.is_empty() {
+            let len = spill.spill(&t.data).unwrap_or(0);
+            t.spilled_len = len;
+            t.data = Vec::new(); // free the memory
+        }
+    }
+    let _ = spill.flush();
 }
 
 fn write_hfq(
@@ -1042,6 +1119,7 @@ fn write_hfq(
     arch: u32,
     metadata_json: &str,
     tensors: &[HfqTensor],
+    spill: Option<&mut TensorSpill>,
 ) -> std::io::Result<()> {
     let mut f = File::create(path)?;
 
@@ -1072,7 +1150,8 @@ fn write_hfq(
         // group size
         index_bytes.extend_from_slice(&t.group_size.to_le_bytes());
         // data size (offset computed at read time from cumulative sizes)
-        index_bytes.extend_from_slice(&(t.data.len() as u64).to_le_bytes());
+        let data_len = if t.spilled_len > 0 { t.spilled_len } else { t.data.len() as u64 };
+        index_bytes.extend_from_slice(&data_len.to_le_bytes());
     }
 
     // Data starts after index, aligned to 4096
@@ -1097,9 +1176,32 @@ fn write_hfq(
     let pad_size = (data_offset - data_start_unaligned) as usize;
     f.write_all(&vec![0u8; pad_size])?;
 
-    // Write tensor data
-    for t in tensors {
-        f.write_all(&t.data)?;
+    // Write tensor data — from spill file or from memory
+    if let Some(spill) = spill {
+        let _ = spill.flush();
+        let mut spill_reader = std::io::BufReader::new(
+            File::open(&spill.path)?
+        );
+        let mut buf = vec![0u8; 4 * 1024 * 1024]; // 4 MB copy buffer
+        for t in tensors {
+            if t.spilled_len > 0 {
+                // Copy from spill file
+                let mut remaining = t.spilled_len as usize;
+                while remaining > 0 {
+                    let chunk = remaining.min(buf.len());
+                    use std::io::Read;
+                    spill_reader.read_exact(&mut buf[..chunk])?;
+                    f.write_all(&buf[..chunk])?;
+                    remaining -= chunk;
+                }
+            } else {
+                f.write_all(&t.data)?;
+            }
+        }
+    } else {
+        for t in tensors {
+            f.write_all(&t.data)?;
+        }
     }
 
     Ok(())
@@ -1628,6 +1730,7 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat) -> std::io
             shape,
             group_size,
             data,
+            spilled_len: 0,
         });
     }
 
@@ -1645,7 +1748,7 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat) -> std::io
         100.0 * total_bytes_out as f64 / total_bytes_in as f64,
     );
 
-    write_hfq(output, arch_id, &metadata_json, &hfq_tensors)?;
+    write_hfq(output, arch_id, &metadata_json, &hfq_tensors, None)?;
     eprintln!("\nWrote: {}", output.display());
     Ok(())
 }
@@ -1698,6 +1801,9 @@ fn main() {
     let use_hfq2g128 = format == "hfq2g128" || format == "hfq2" || format == "hf2";
     let use_hfq_mixed = format == "hfq-mixed";  // Q8 attn + HFQ4 FFN
     let use_mq6g256 = format == "mq6" || format == "mq6g256";
+    // Mixed: MQ4 for attention/shared-expert + MQ6 for routed experts only.
+    // Saves ~15 GB vs full MQ6 on 122B-A10B (75 GB vs 90 GB), fits in 125 GB UMA.
+    let use_mq4_mq6exp = format == "mq4-mq6exp" || format == "mq4-mq6experts";
     let use_mq3g256 = format == "mq3" || format == "mq3g256";
     let use_mq2g256 = format == "mq2" || format == "mq2g256";
     let use_hfq6 = format == "hfq6" || format == "hfq6g256" || format == "hf6";
@@ -1844,6 +1950,10 @@ fn main() {
     let mut hfq_tensors = Vec::new();
     let mut total_params = 0u64;
     let mut quantized_params = 0u64;
+    // Spill file for large models — keeps peak RSS bounded by flushing
+    // completed tensor data to disk when accumulated memory exceeds 32 GB.
+    let spill_dir = output_path.parent().unwrap_or(Path::new("."));
+    let mut spill = TensorSpill::new(spill_dir).ok();
     let mut total_quant_error = 0.0f64;
     let mut max_quant_error = 0.0f32;
     let mut _n_quant_groups = 0u64;
@@ -1901,12 +2011,15 @@ fn main() {
             // Strip the trailing base; what remains is the parent path with `experts.` already on the end
             let parent = &name[..name.len() - base_name.len()];
 
-            // Inner MQ4G256 quantization helpers — we know we want MQ4 for experts
-            // (router/shared_expert use the standard format-flag path below).
+            // Inner quantization for experts — respects --format flag.
+            // MQ6 reduces quantization error that compounds across 48 MoE
+            // layers × 9 expert contributions per layer at the cost of ~50%
+            // more VRAM per expert. MQ4 is the default for VRAM efficiency.
             let signs1 = gen_fwht_signs(42, 256);
             let signs2 = gen_fwht_signs(1042, 256);
             let inner_k = inner_shape[1] as usize;
-            let supports_mq4 = inner_k % 256 == 0;
+            let supports_g256 = inner_k % 256 == 0;
+            let expert_mq6 = (use_mq6g256 || use_mq4_mq6exp) && supports_g256;
 
             // Parallelize across the 256 expert slices via rayon. Each slice
             // dequant→FWHT→quant→pack is a CPU-bound, self-contained job.
@@ -1920,7 +2033,10 @@ fn main() {
                 let slice_off = x * inner_bytes;
                 let slice = &raw_data[slice_off..slice_off + inner_bytes];
                 let f32_slice = to_f32(slice, &dtype);
-                let (quantized, qt, gs) = if supports_mq4 {
+                let (quantized, qt, gs) = if expert_mq6 {
+                    let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
+                    (q, QuantType::MQ6G256, 256u32)
+                } else if supports_g256 {
                     let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
                     (q, QuantType::MQ4G256, 256u32)
                 } else {
@@ -1933,15 +2049,21 @@ fn main() {
                     shape: inner_shape_clone.clone(),
                     group_size: gs,
                     data: quantized,
+                    spilled_len: 0,
                 }
             }).collect();
             quantized_params += inner_n as u64 * n_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
-            let label = if supports_mq4 { "MQ4G256" } else { "HFQ4G128" };
+            let label = if expert_mq6 { "MQ6G256" } else if supports_g256 { "MQ4G256" } else { "HFQ4G128" };
             let bytes_per = new_tensors.first().map(|t| t.data.len()).unwrap_or(0);
             eprintln!("  {label:>8}: {parent_owned}{{0..{n_experts}}}.{base_owned}.weight {:?} (×{n_experts} experts || {:.1} KB/expert, parallel)",
                 inner_shape, bytes_per as f64 / 1024.0);
             hfq_tensors.append(&mut new_tensors);
+            // Drop source pages and spill quantized data after each expert batch.
+            st_files[*file_idx].drop_tensor_pages(name);
+            if let Some(ref mut s) = spill {
+                maybe_spill(&mut hfq_tensors, s, 2 * 1024 * 1024 * 1024); // 2 GB threshold
+            }
             continue;
         }
 
@@ -1992,6 +2114,7 @@ fn main() {
                     shape,
                     group_size: 32,
                     data: quantized,
+                    spilled_len: 0,
                 });
             } else {
             // Choose quant format per tensor
@@ -2067,10 +2190,10 @@ fn main() {
                     let q = quantize_q8f16(&f32_data);
                     (q, QuantType::Q8F16, 32u32, "Q8_F16")
                 }
-            } else if use_mq4g256 && is_embed {
+            } else if (use_mq4g256 || use_mq4_mq6exp) && is_embed {
                 let q = quantize_q8f16(&f32_data);
                 (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_mq4g256 {
+            } else if use_mq4g256 || use_mq4_mq6exp {
                 let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
@@ -2249,6 +2372,7 @@ fn main() {
                 shape,
                 group_size: gs,
                 data: quantized,
+                spilled_len: 0,
             });
             } // end else (non-Q8HFQ path)
         } else if is_vision && vision_quant == "hfq4" && n_elements >= 32 {
@@ -2273,6 +2397,7 @@ fn main() {
                 shape,
                 group_size: gs,
                 data: quantized,
+                spilled_len: 0,
             });
         } else if is_vision && vision_quant == "bf16" && meta.dtype == "BF16" {
             // Store vision weights as original BF16 (zero precision loss)
@@ -2286,6 +2411,7 @@ fn main() {
                 shape,
                 group_size: 0,
                 data: raw_data.to_vec(),
+                spilled_len: 0,
             });
         } else if is_vision && vision_quant == "bf16" {
             // Non-BF16 source (F16/F32) — store as F16
@@ -2299,7 +2425,7 @@ fn main() {
                 name, meta.shape, data.len() as f64 / 1024.0);
             hfq_tensors.push(HfqTensor {
                 name: name.to_string(), quant_type: QuantType::F16,
-                shape, group_size: 0, data,
+                shape, group_size: 0, data, spilled_len: 0,
             });
         } else {
             // Keep as F16 (convert BF16 -> F16 if needed)
@@ -2331,12 +2457,16 @@ fn main() {
                 shape,
                 group_size: 0,
                 data: f16_data,
+                spilled_len: 0,
             });
         }
+        // Release source file page cache after each tensor to prevent
+        // mmap'd pages from starving GPU allocations on UMA systems.
+        st_files[*file_idx].drop_tensor_pages(name);
     }
 
     // Summary
-    let total_bytes: usize = hfq_tensors.iter().map(|t| t.data.len()).sum();
+    let total_bytes: usize = hfq_tensors.iter().map(|t| if t.spilled_len > 0 { t.spilled_len as usize } else { t.data.len() }).sum();
     let mean_quant_error = if quantized_params > 0 {
         total_quant_error / quantized_params as f64
     } else { 0.0 };
@@ -2353,7 +2483,12 @@ fn main() {
 
     // Write .hfq file
     eprintln!("\nWriting: {}", output_path.display());
-    write_hfq(output_path, arch_id, &metadata_json, &hfq_tensors).unwrap();
+    // Final spill before writing
+    if let Some(ref mut s) = spill {
+        maybe_spill(&mut hfq_tensors, s, 0); // spill everything remaining
+    }
+    write_hfq(output_path, arch_id, &metadata_json, &hfq_tensors, spill.as_mut()).unwrap();
+    if let Some(s) = spill { s.cleanup(); }
 
     let file_size = std::fs::metadata(output_path).unwrap().len();
     eprintln!("Done: {:.1} MB written", file_size as f64 / 1e6);

--- a/crates/hipfire-runtime/examples/a3b_load_check.rs
+++ b/crates/hipfire-runtime/examples/a3b_load_check.rs
@@ -49,7 +49,7 @@ fn main() {
 
     eprintln!("\nInitializing GPU + loading weights ...");
     let mut gpu = rdna_compute::Gpu::init().expect("Gpu::init failed");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights failed");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load_weights failed");
 
     eprintln!("\n=== LOAD SUCCEEDED ===");
     eprintln!("Loaded {} layers:", weights.layers.len());

--- a/crates/hipfire-runtime/examples/a3b_load_check.rs
+++ b/crates/hipfire-runtime/examples/a3b_load_check.rs
@@ -23,7 +23,7 @@ fn main() {
     let model_path = &args[1];
     eprintln!("Opening: {model_path}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
 
     eprintln!("Config:");

--- a/crates/hipfire-runtime/examples/a3b_multiturn_oneshot.rs
+++ b/crates/hipfire-runtime/examples/a3b_multiturn_oneshot.rs
@@ -21,7 +21,7 @@ fn main() {
     let hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load");
 
     let mut kv = KvCache::new_gpu_q8(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 2048).unwrap();
     let mut dn = DeltaNetState::new(&mut gpu, &config).unwrap();

--- a/crates/hipfire-runtime/examples/a3b_multiturn_oneshot.rs
+++ b/crates/hipfire-runtime/examples/a3b_multiturn_oneshot.rs
@@ -18,7 +18,7 @@ fn main() {
     let n_gen: usize = std::env::var("HIPFIRE_GEN")
         .ok().and_then(|v| v.parse().ok()).unwrap_or(80);
 
-    let hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
     let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load");

--- a/crates/hipfire-runtime/examples/a3b_smoke_forward.rs
+++ b/crates/hipfire-runtime/examples/a3b_smoke_forward.rs
@@ -39,7 +39,7 @@ fn main() {
 
     eprintln!("Loading weights ...");
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
     eprintln!("Loaded {} layers.", weights.layers.len());
 
     let kv_seq = std::env::var("HIPFIRE_SMOKE_KV_SEQ")

--- a/crates/hipfire-runtime/examples/a3b_smoke_forward.rs
+++ b/crates/hipfire-runtime/examples/a3b_smoke_forward.rs
@@ -29,7 +29,7 @@ fn main() {
         .ok().and_then(|v| v.parse().ok()).unwrap_or(1);
 
     eprintln!("Opening: {model_path}");
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     assert!(config.num_experts > 0, "this smoke test expects a MoE model");
 

--- a/crates/hipfire-runtime/examples/bench_qwen35_forward.rs
+++ b/crates/hipfire-runtime/examples/bench_qwen35_forward.rs
@@ -28,7 +28,7 @@ fn main() {
 
     let mut gpu = rdna_compute::Gpu::init().expect("GPU init failed");
     eprintln!("Loading {}...", model_path);
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
     eprintln!("Loaded: {} layers, dim={}", config.n_layers, config.dim);

--- a/crates/hipfire-runtime/examples/bench_qwen35_forward.rs
+++ b/crates/hipfire-runtime/examples/bench_qwen35_forward.rs
@@ -30,7 +30,7 @@ fn main() {
     eprintln!("Loading {}...", model_path);
     let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
     eprintln!("Loaded: {} layers, dim={}", config.n_layers, config.dim);
 
     let max_seq = 2048;

--- a/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
+++ b/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
@@ -57,7 +57,7 @@ fn main() {
     eprintln!("GPU: {}", gpu.arch);
 
     let t_load = Instant::now();
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
     eprintln!("Weights loaded in {:.2}s", t_load.elapsed().as_secs_f64());
 
     let kv_seq = (prefill_len + warmup_len + gen_len + 16).max(512);

--- a/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
+++ b/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
@@ -44,7 +44,7 @@ fn main() {
     eprintln!("Model: {model_path}");
     eprintln!("Phases: prefill={prefill_len} prefill_runs={prefill_runs} warmup={warmup_len} gen={gen_len}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     eprintln!(
         "Config: dim={} layers={} heads={} kv_heads={} vocab={}",

--- a/crates/hipfire-runtime/examples/channel_test_mmq.rs
+++ b/crates/hipfire-runtime/examples/channel_test_mmq.rs
@@ -168,7 +168,7 @@ fn main() {
         "Config: dim={} layers={} heads={} kv_heads={} vocab={}",
         config.dim, config.n_layers, config.n_heads, config.n_kv_heads, config.vocab_size
     );
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load_weights");
     eprintln!("Weights loaded. Running stage: {stage}");
 
     // ── Dispatch stage ───────────────────────────────────────────────────

--- a/crates/hipfire-runtime/examples/channel_test_mmq.rs
+++ b/crates/hipfire-runtime/examples/channel_test_mmq.rs
@@ -162,7 +162,7 @@ fn main() {
 
     // ── Model loading ────────────────────────────────────────────────────
     eprintln!("Loading model: {model_path}");
-    let hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config_from_hfq");
     eprintln!(
         "Config: dim={} layers={} heads={} kv_heads={} vocab={}",

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1089,7 +1089,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .unwrap_or_else(|| std::env::var("HIPFIRE_KV_MODE").unwrap_or_default());
-    let hfq = HfqFile::open(Path::new(path)).map_err(|e| format!("{e}"))?;
+    let mut hfq = HfqFile::open(Path::new(path)).map_err(|e| format!("{e}"))?;
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .ok_or("tokenizer not found")?;
 
@@ -1237,7 +1237,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         let vision_config = <Qwen35Vl as Architecture>::config_from_hfq(&hfq).ok();
         let (vision_config, vision_weights) = if let Some(vc) = vision_config {
             if has_vision_tensors {
-                let vw = <Qwen35Vl as Architecture>::load_weights(&hfq, &vc, gpu)
+                let vw = <Qwen35Vl as Architecture>::load_weights(&mut hfq, &vc, gpu)
                     .map_err(|e| format!("{e}"))?;
                 eprintln!("  VL model: vision encoder (hidden={}, layers={})", vc.hidden_size, vc.num_layers);
                 (Some(vc), Some(vw))
@@ -1248,7 +1248,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             (None, None)
         };
 
-        let weights = <Qwen35 as Architecture>::load_weights(&hfq, &config, gpu)?;
+        let weights = <Qwen35 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
 
         // MMQ per-weight screening (#87): pre-screen all weight matrices at
         // load time so the first prefill doesn't pay the screening overhead.
@@ -1395,7 +1395,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         use hipfire_runtime::arch::Architecture;
         let config = <Llama as Architecture>::config_from_hfq(&hfq)
             .map_err(|e| e.to_string())?;
-        let weights = <Llama as Architecture>::load_weights(&hfq, &config, gpu)?;
+        let weights = <Llama as Architecture>::load_weights(&mut hfq, &config, gpu)?;
         eprintln!("  KV cache: Q8");
         let kv = llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?;
         let scratch = <Llama as Architecture>::new_state(gpu, &config)?;

--- a/crates/hipfire-runtime/examples/dump_logits_qwen35.rs
+++ b/crates/hipfire-runtime/examples/dump_logits_qwen35.rs
@@ -52,7 +52,7 @@ fn main() {
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
     eprintln!("dump_logits_qwen35: arch={} prefill_len={}", gpu.arch, prefill_len);
 
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
 
     let kv_seq = (prefill_len + 16).max(512);
     let kv_mode = std::env::var("HIPFIRE_KV_MODE").unwrap_or_else(|_| "q8".to_string());

--- a/crates/hipfire-runtime/examples/dump_logits_qwen35.rs
+++ b/crates/hipfire-runtime/examples/dump_logits_qwen35.rs
@@ -47,7 +47,7 @@ fn main() {
         }
     }
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
     eprintln!("dump_logits_qwen35: arch={} prefill_len={}", gpu.arch, prefill_len);

--- a/crates/hipfire-runtime/examples/greedy_dump.rs
+++ b/crates/hipfire-runtime/examples/greedy_dump.rs
@@ -60,7 +60,7 @@ fn main() {
     eprintln!("prompt: {} tokens", prompt_tokens.len());
 
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
 
     let kv_seq = 2048usize;
     let kv_mode = std::env::var("HIPFIRE_KV_MODE").unwrap_or_else(|_| "q8".to_string());

--- a/crates/hipfire-runtime/examples/greedy_dump.rs
+++ b/crates/hipfire-runtime/examples/greedy_dump.rs
@@ -27,7 +27,7 @@ fn main() {
     let mode = std::env::var("PROMPT_MODE").unwrap_or_else(|_| "thinking".to_string());
     eprintln!("greedy_dump: {model_path} mode={mode}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tok");
 

--- a/crates/hipfire-runtime/examples/greedy_dump_top5.rs
+++ b/crates/hipfire-runtime/examples/greedy_dump_top5.rs
@@ -38,7 +38,7 @@ fn main() {
     let mode = std::env::var("PROMPT_MODE").unwrap_or_else(|_| "thinking".to_string());
     eprintln!("greedy_dump_top5: {model_path} mode={mode}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tok");
 

--- a/crates/hipfire-runtime/examples/greedy_dump_top5.rs
+++ b/crates/hipfire-runtime/examples/greedy_dump_top5.rs
@@ -71,7 +71,7 @@ fn main() {
     eprintln!("prompt: {} tokens", prompt_tokens.len());
 
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
 
     let kv_seq = 2048usize;
     let mut kv_cache = KvCache::new_gpu_q8(

--- a/crates/hipfire-runtime/examples/infer.rs
+++ b/crates/hipfire-runtime/examples/infer.rs
@@ -120,7 +120,7 @@ fn main() {
 
     // Load text weights
     eprintln!("Loading text weights...");
-    let weights = qwen35::load_weights(&hfq, &text_config, &mut gpu).expect("failed to load text weights");
+    let weights = qwen35::load_weights(&mut hfq, &text_config, &mut gpu).expect("failed to load text weights");
 
     let kv_seq = 4096usize;
     eprintln!("KV cache: {kv_mode}");

--- a/crates/hipfire-runtime/examples/infer.rs
+++ b/crates/hipfire-runtime/examples/infer.rs
@@ -69,7 +69,7 @@ fn main() {
     eprintln!("Prompt: {prompt_text}");
 
     // Load model config + tokenizer
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
     let text_config = qwen35::config_from_hfq(&hfq).expect("failed to read Qwen3.5 config");
     eprintln!("Text: dim={}, layers={}, vocab={}", text_config.dim, text_config.n_layers, text_config.vocab_size);
 

--- a/crates/hipfire-runtime/examples/infer_hfq.rs
+++ b/crates/hipfire-runtime/examples/infer_hfq.rs
@@ -48,7 +48,7 @@ fn main() {
     else { eprintln!("Sampling: temp={temp}, top_p={top_p}"); }
 
     // Parse HFQ. PR 11: bring-up triple via `Architecture` trait dispatch.
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
     let config = <Llama as Architecture>::config_from_hfq(&hfq)
         .expect("failed to read model config");
     eprintln!("Config: dim={}, layers={}, heads={}, kv_heads={}, vocab={}",
@@ -102,7 +102,7 @@ fn main() {
     // Load weights via the trait.
     eprintln!("Loading weights...");
     let t0 = Instant::now();
-    let weights = <Llama as Architecture>::load_weights(&hfq, &config, &mut gpu)
+    let weights = <Llama as Architecture>::load_weights(&mut hfq, &config, &mut gpu)
         .expect("failed to load weights");
     eprintln!("  Loaded in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/crates/hipfire-runtime/examples/infer_qwen3.rs
+++ b/crates/hipfire-runtime/examples/infer_qwen3.rs
@@ -80,7 +80,7 @@ fn main() {
     // Parse HFQ. PR 11: route bring-up triple through `Architecture` trait
     // dispatch — same hybrid pattern as PR 8's qwen35 daemon path. Forward
     // calls below stay direct `llama::*` static dispatch for the hot loop.
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
     let config = <Llama as Architecture>::config_from_hfq(&hfq)
         .expect("failed to read model config");
     eprintln!("Config: dim={}, layers={}, heads={}, kv_heads={}, vocab={}",
@@ -150,7 +150,7 @@ fn main() {
     // Load weights via the trait — same dispatch path as the daemon.
     eprintln!("Loading weights...");
     let t0 = Instant::now();
-    let weights = <Llama as Architecture>::load_weights(&hfq, &config, &mut gpu)
+    let weights = <Llama as Architecture>::load_weights(&mut hfq, &config, &mut gpu)
         .expect("failed to load weights");
     eprintln!("  Loaded in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/crates/hipfire-runtime/examples/infer_qwen35.rs
+++ b/crates/hipfire-runtime/examples/infer_qwen35.rs
@@ -71,7 +71,7 @@ fn main() {
         eprintln!("Guards: ON (prompt_frame + sampler + eos_filter + loop_guard)");
     }
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
     let config = qwen35::config_from_hfq(&hfq).expect("failed to read Qwen3.5 config");
     eprintln!("Config: dim={}, layers={}, heads={}, vocab={}", config.dim, config.n_layers, config.n_heads, config.vocab_size);
 

--- a/crates/hipfire-runtime/examples/infer_qwen35.rs
+++ b/crates/hipfire-runtime/examples/infer_qwen35.rs
@@ -130,7 +130,7 @@ fn main() {
 
     let mut gpu = rdna_compute::Gpu::init().expect("GPU init failed");
     eprintln!("Loading weights...");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("failed to load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("failed to load weights");
 
     let kv_seq = 2048usize;
     let kv_mode = std::env::var("HIPFIRE_KV_MODE").unwrap_or_else(|_| "q8".to_string());

--- a/crates/hipfire-runtime/examples/infer_vl.rs
+++ b/crates/hipfire-runtime/examples/infer_vl.rs
@@ -44,7 +44,7 @@ fn main() {
     use hipfire_runtime::arch::Architecture;
     use hipfire_arch_qwen35::Qwen35;
     use hipfire_arch_qwen35_vl::Qwen35Vl;
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
     let text_config = <Qwen35 as Architecture>::config_from_hfq(&hfq)
         .expect("failed to read text config");
     let vision_config = <Qwen35Vl as Architecture>::config_from_hfq(&hfq)
@@ -81,7 +81,7 @@ fn main() {
 
     // Load vision weights (GPU-side for fast inference)
     eprintln!("Loading vision weights...");
-    let vision_weights = <Qwen35Vl as Architecture>::load_weights(&hfq, &vision_config, &mut gpu)
+    let vision_weights = <Qwen35Vl as Architecture>::load_weights(&mut hfq, &vision_config, &mut gpu)
         .expect("failed to load vision weights");
 
     // Run vision encoder (GPU linear layers + CPU attention).
@@ -94,7 +94,7 @@ fn main() {
     assert_eq!(visual_tokens.len(), n_visual_tokens * text_config.dim);
 
     eprintln!("Loading text weights...");
-    let weights = <Qwen35 as Architecture>::load_weights(&hfq, &text_config, &mut gpu)
+    let weights = <Qwen35 as Architecture>::load_weights(&mut hfq, &text_config, &mut gpu)
         .expect("failed to load text weights");
 
     let kv_seq = 2048usize;

--- a/crates/hipfire-runtime/examples/logit_dump.rs
+++ b/crates/hipfire-runtime/examples/logit_dump.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let prompt_text = "The quick brown fox jumps over the lazy dog. Explain step by step how a combustion engine works, covering the four stroke cycle, fuel injection, and exhaust.";
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to open model");
     let config = qwen35::config_from_hfq(&hfq).expect("failed to read config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .expect("need tokenizer");

--- a/crates/hipfire-runtime/examples/logit_dump.rs
+++ b/crates/hipfire-runtime/examples/logit_dump.rs
@@ -30,7 +30,7 @@ fn main() {
     let arch = gpu.arch.clone();
     eprintln!("GPU: {arch}");
 
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("failed to load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("failed to load weights");
     let max_seq = 2048usize;
     let mut kv_cache = KvCache::new_gpu_q8(
         &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq

--- a/crates/hipfire-runtime/examples/pflash_niah_bench.rs
+++ b/crates/hipfire-runtime/examples/pflash_niah_bench.rs
@@ -362,7 +362,7 @@ fn main() {
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .expect("tokenizer");
     let mut gpu = rdna_compute::Gpu::init().expect("GPU init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
     eprintln!("loaded in {:.1}s | dim={} layers={} heads={} kv_heads={}",
         t_load_start.elapsed().as_secs_f64(),
         config.dim, config.n_layers, config.n_heads, config.n_kv_heads);

--- a/crates/hipfire-runtime/examples/pflash_niah_bench.rs
+++ b/crates/hipfire-runtime/examples/pflash_niah_bench.rs
@@ -357,7 +357,7 @@ fn main() {
     eprintln!("model md5:   {model_md5}");
 
     let t_load_start = Instant::now();
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open HFQ");
     let config = qwen35::config_from_hfq(&hfq).expect("qwen35 config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .expect("tokenizer");

--- a/crates/hipfire-runtime/examples/pp_parity.rs
+++ b/crates/hipfire-runtime/examples/pp_parity.rs
@@ -33,10 +33,10 @@ fn argmax(logits: &[f32]) -> u32 {
 }
 
 fn run_single_gpu(path: &str) -> Vec<u32> {
-    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let mut hfq = HfqFile::open(Path::new(path)).expect("open hfq");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let mut gpu = Gpu::init().expect("Gpu::init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load_weights");
     let mut kv = KvCache::new_gpu_asym3_capped(
         &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
     )

--- a/crates/hipfire-runtime/examples/pp_parity_chatml.rs
+++ b/crates/hipfire-runtime/examples/pp_parity_chatml.rs
@@ -64,10 +64,10 @@ fn build_prompt_tokens(tok: &Tokenizer) -> Vec<u32> {
 }
 
 fn run_single_gpu(path: &str, prompt_tokens: &[u32]) -> (Vec<u32>, Vec<Vec<f32>>) {
-    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let mut hfq = HfqFile::open(Path::new(path)).expect("open hfq");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let mut gpu = Gpu::init().expect("Gpu::init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load_weights");
     let mut kv = KvCache::new_gpu_asym3_capped(
         &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
     )

--- a/crates/hipfire-runtime/examples/probe_argmax_agreement.rs
+++ b/crates/hipfire-runtime/examples/probe_argmax_agreement.rs
@@ -46,21 +46,21 @@ fn main() {
 
     // Load both models.
     let t0 = Instant::now();
-    let small_hfq = HfqFile::open(Path::new(small_path)).expect("small hfq");
+    let mut small_hfq = HfqFile::open(Path::new(small_path)).expect("small hfq");
     let small_cfg = qwen35::config_from_hfq(&small_hfq).expect("small cfg");
     eprintln!("small: dim={} layers={} heads={} vocab={}",
         small_cfg.dim, small_cfg.n_layers, small_cfg.n_heads, small_cfg.vocab_size);
-    let small_weights = qwen35::load_weights(&small_hfq, &small_cfg, &mut gpu).expect("small load");
+    let small_weights = qwen35::load_weights(&mut small_hfq, &small_cfg, &mut gpu).expect("small load");
     eprintln!("small loaded in {:.1}s", t0.elapsed().as_secs_f32());
 
     let t1 = Instant::now();
-    let large_hfq = HfqFile::open(Path::new(large_path)).expect("large hfq");
+    let mut large_hfq = HfqFile::open(Path::new(large_path)).expect("large hfq");
     let large_cfg = qwen35::config_from_hfq(&large_hfq).expect("large cfg");
     eprintln!("large: dim={} layers={} heads={} vocab={}",
         large_cfg.dim, large_cfg.n_layers, large_cfg.n_heads, large_cfg.vocab_size);
     assert_eq!(small_cfg.vocab_size, large_cfg.vocab_size,
         "vocab sizes must match for argmax comparison");
-    let large_weights = qwen35::load_weights(&large_hfq, &large_cfg, &mut gpu).expect("large load");
+    let large_weights = qwen35::load_weights(&mut large_hfq, &large_cfg, &mut gpu).expect("large load");
     eprintln!("large loaded in {:.1}s", t1.elapsed().as_secs_f32());
 
     let tokenizer = Tokenizer::from_hfq_metadata(&large_hfq.metadata_json)

--- a/crates/hipfire-runtime/examples/profile_attention_phases.rs
+++ b/crates/hipfire-runtime/examples/profile_attention_phases.rs
@@ -62,7 +62,7 @@ fn main() {
     eprintln!("GPU: {}", gpu.arch);
 
     let t_load = Instant::now();
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
     eprintln!("Weights loaded in {:.2}s", t_load.elapsed().as_secs_f64());
 
     // Find first FA layer so we know which layer's KV to probe.

--- a/crates/hipfire-runtime/examples/profile_attention_phases.rs
+++ b/crates/hipfire-runtime/examples/profile_attention_phases.rs
@@ -51,7 +51,7 @@ fn main() {
     eprintln!("Model: {model_path}");
     eprintln!("Prefill: {prefill_len}  Repeats: {repeats}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     eprintln!(
         "Config: dim={} layers={} n_heads={} n_kv_heads={} head_dim={}",

--- a/crates/hipfire-runtime/examples/profile_bandwidth_fwd.rs
+++ b/crates/hipfire-runtime/examples/profile_bandwidth_fwd.rs
@@ -35,7 +35,7 @@ fn main() {
     eprintln!("Loading {}...", model_path);
     let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
     eprintln!("Loaded: {} layers, dim={}", config.n_layers, config.dim);
 
     let max_seq = 2048usize;

--- a/crates/hipfire-runtime/examples/profile_bandwidth_fwd.rs
+++ b/crates/hipfire-runtime/examples/profile_bandwidth_fwd.rs
@@ -33,7 +33,7 @@ fn main() {
 
     let mut gpu = rdna_compute::Gpu::init().expect("GPU init failed");
     eprintln!("Loading {}...", model_path);
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
     eprintln!("Loaded: {} layers, dim={}", config.n_layers, config.dim);

--- a/crates/hipfire-runtime/examples/profile_deltanet.rs
+++ b/crates/hipfire-runtime/examples/profile_deltanet.rs
@@ -22,7 +22,7 @@ fn main() {
         config.dim, config.n_heads, config.linear_num_key_heads, config.linear_key_head_dim);
 
     let mut gpu = rdna_compute::Gpu::init().expect("GPU init failed");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights failed");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights failed");
     let mut dn_state = qwen35::DeltaNetState::new(&mut gpu, &config).unwrap();
     let mut kv_cache = llama::KvCache::new_gpu(
         &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 128,

--- a/crates/hipfire-runtime/examples/profile_deltanet.rs
+++ b/crates/hipfire-runtime/examples/profile_deltanet.rs
@@ -16,7 +16,7 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let model_path = args.get(1).expect("Usage: profile_deltanet <model.hfq>");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to open HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to open HFQ");
     let config = qwen35::config_from_hfq(&hfq).expect("failed to parse config");
     eprintln!("dim={}, heads={}, linear_heads={}, head_dim={}",
         config.dim, config.n_heads, config.linear_num_key_heads, config.linear_key_head_dim);

--- a/crates/hipfire-runtime/examples/profile_host_vs_gpu.rs
+++ b/crates/hipfire-runtime/examples/profile_host_vs_gpu.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let mut gpu = rdna_compute::Gpu::init().expect("Gpu::init");
     eprintln!("Loading {}...", model_path);
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
     eprintln!("Loaded: {} layers, dim={}", config.n_layers, config.dim);

--- a/crates/hipfire-runtime/examples/profile_host_vs_gpu.rs
+++ b/crates/hipfire-runtime/examples/profile_host_vs_gpu.rs
@@ -43,7 +43,7 @@ fn main() {
     eprintln!("Loading {}...", model_path);
     let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
     eprintln!("Loaded: {} layers, dim={}", config.n_layers, config.dim);
 
     let max_seq = 2048;

--- a/crates/hipfire-runtime/examples/profile_qwen35_mq4.rs
+++ b/crates/hipfire-runtime/examples/profile_qwen35_mq4.rs
@@ -65,7 +65,7 @@ fn main() {
     eprintln!("GPU: {}", gpu.arch);
 
     let t_load = Instant::now();
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
     eprintln!("Weights loaded in {:.2}s", t_load.elapsed().as_secs_f64());
 
     let kv_seq = (prefill_len + warmup_len + profile_steps + 16).max(512);

--- a/crates/hipfire-runtime/examples/profile_qwen35_mq4.rs
+++ b/crates/hipfire-runtime/examples/profile_qwen35_mq4.rs
@@ -56,7 +56,7 @@ fn main() {
     eprintln!("Model: {model_path}");
     eprintln!("Prefill: {prefill_len}  Warmup: {warmup_len}  Profile: {profile_steps}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     eprintln!("Config: dim={} layers={} heads={} kv_heads={}",
         config.dim, config.n_layers, config.n_heads, config.n_kv_heads);

--- a/crates/hipfire-runtime/examples/test_inference.rs
+++ b/crates/hipfire-runtime/examples/test_inference.rs
@@ -31,7 +31,7 @@ fn main() {
     let mut gpu = rdna_compute::Gpu::init().expect("GPU init failed");
     eprintln!("GPU: {}", gpu.arch);
 
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("failed to load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("failed to load weights");
 
     let mut passed = 0;
     let mut failed = 0;

--- a/crates/hipfire-runtime/examples/test_inference.rs
+++ b/crates/hipfire-runtime/examples/test_inference.rs
@@ -20,7 +20,7 @@ fn main() {
     eprintln!("=== hipfire inference integration tests ===");
     eprintln!("Model: {model_path}");
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("failed to parse HFQ");
     let config = qwen35::config_from_hfq(&hfq).expect("failed to read config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .expect("tokenizer not found");

--- a/crates/hipfire-runtime/examples/test_inferenceQA.rs
+++ b/crates/hipfire-runtime/examples/test_inferenceQA.rs
@@ -280,7 +280,7 @@ fn run_case(case_name: &str, model_path: Option<&Path>) -> ExitCode {
 
 #[cfg(feature = "deltanet")]
 fn build_context(model_path: &Path) -> Result<Context, CaseOutcome> {
-    let hfq = HfqFile::open(model_path)
+    let mut hfq = HfqFile::open(model_path)
         .map_err(|e| CaseOutcome::Fail(format!("failed to open HFQ: {e}")))?;
     let model_label = classify_qwen35_candidate(&hfq)?;
     let config = qwen35::config_from_hfq(&hfq)

--- a/crates/hipfire-runtime/examples/test_inferenceQA.rs
+++ b/crates/hipfire-runtime/examples/test_inferenceQA.rs
@@ -289,7 +289,7 @@ fn build_context(model_path: &Path) -> Result<Context, CaseOutcome> {
     let mut gpu = rdna_compute::Gpu::init()
         .map_err(|e| CaseOutcome::Skip(format!("GPU init unavailable: {e}")))?;
     let weights = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        qwen35::load_weights(&hfq, &config, &mut gpu)
+        qwen35::load_weights(&mut hfq, &config, &mut gpu)
     }))
     .map_err(|panic| CaseOutcome::Fail(format!("weight load panicked: {}", panic_message(panic))))?
     .map_err(|e| CaseOutcome::Fail(format!("failed to load weights: {e}")))?;

--- a/crates/hipfire-runtime/examples/test_long_ctx.rs
+++ b/crates/hipfire-runtime/examples/test_long_ctx.rs
@@ -97,7 +97,7 @@ it?".to_string(),
     eprintln!("turns: {}", turns.len());
 
     // ── Load model ──────────────────────────────────────────────────────
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("read config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tok");
 

--- a/crates/hipfire-runtime/examples/test_long_ctx.rs
+++ b/crates/hipfire-runtime/examples/test_long_ctx.rs
@@ -102,7 +102,7 @@ it?".to_string(),
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tok");
 
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
 
     // Size the KV cache for the sum of all turn prompts + generations, with slack.
     let max_seq = 8192usize;

--- a/crates/hipfire-runtime/examples/test_qwen35_load.rs
+++ b/crates/hipfire-runtime/examples/test_qwen35_load.rs
@@ -78,7 +78,7 @@ fn main() {
         let q35_config = qwen35::config_from_hfq(&hfq).expect("failed to parse Qwen3.5 config");
         eprintln!("\nLoading Qwen3.5 weights...");
         let mut gpu = rdna_compute::Gpu::init().expect("GPU init failed");
-        let weights = qwen35::load_weights(&hfq, &q35_config, &mut gpu).expect("failed to load weights");
+        let weights = qwen35::load_weights(&mut hfq, &q35_config, &mut gpu).expect("failed to load weights");
         eprintln!("Loaded {} layers", weights.layers.len());
         for (i, layer) in weights.layers.iter().enumerate() {
             match layer {

--- a/crates/hipfire-runtime/examples/test_qwen35_load.rs
+++ b/crates/hipfire-runtime/examples/test_qwen35_load.rs
@@ -8,7 +8,7 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let path = args.get(1).expect("Usage: test_qwen35_load <model.hfq>");
 
-    let hfq = HfqFile::open(Path::new(path)).expect("failed to open HFQ");
+    let mut hfq = HfqFile::open(Path::new(path)).expect("failed to open HFQ");
     eprintln!("HFQ arch_id: {}", hfq.arch_id);
 
     // Parse metadata

--- a/crates/hipfire-runtime/examples/test_qwen35_loadQA.rs
+++ b/crates/hipfire-runtime/examples/test_qwen35_loadQA.rs
@@ -47,7 +47,7 @@ enum Outcome {
 }
 
 fn run(path: &str) -> Result<String, Outcome> {
-    let hfq = HfqFile::open(Path::new(path))
+    let mut hfq = HfqFile::open(Path::new(path))
         .map_err(|e| Outcome::Fail(format!("failed to open HFQ: {e}")))?;
     let meta: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
         .map_err(|e| Outcome::Fail(format!("bad metadata JSON: {e}")))?;
@@ -103,7 +103,7 @@ fn run(path: &str) -> Result<String, Outcome> {
         let mut gpu = rdna_compute::Gpu::init()
             .map_err(|e| Outcome::Skip(format!("GPU init unavailable: {e}")))?;
         let weights = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hipfire_arch_qwen35::qwen35::load_weights(&hfq, &q35_config, &mut gpu)
+            hipfire_arch_qwen35::qwen35::load_weights(&mut hfq, &q35_config, &mut gpu)
         }))
         .map_err(|panic| Outcome::Fail(format!("weight load panicked: {}", panic_message(panic))))?
         .map_err(|e| Outcome::Fail(format!("weight load failed: {e}")))?;

--- a/crates/hipfire-runtime/examples/triattn_accuracy_sweep.rs
+++ b/crates/hipfire-runtime/examples/triattn_accuracy_sweep.rs
@@ -106,7 +106,7 @@ fn main() {
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
 
     let mut gpu = Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
 
     let scratch = Qwen35Scratch::new(&mut gpu, &config, 128).expect("scratch");
     let alloc_kv = |gpu: &mut Gpu, seq: usize| match kv_mode.as_str() {

--- a/crates/hipfire-runtime/examples/triattn_accuracy_sweep.rs
+++ b/crates/hipfire-runtime/examples/triattn_accuracy_sweep.rs
@@ -96,7 +96,7 @@ fn main() {
 
     let budget_fractions: &[f32] = &[1.00, 0.50, 0.25];
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
     let centers = TriAttnCenters::load(Path::new(sidecar_path)).expect("load sidecar");

--- a/crates/hipfire-runtime/examples/triattn_decode_demo.rs
+++ b/crates/hipfire-runtime/examples/triattn_decode_demo.rs
@@ -37,7 +37,7 @@ fn main() {
     let prompt = "James Madison wrote Federalist No. 10 arguing that a large republic would curb the effects of factions better than a small one. Drawing on his reading of Montesquieu, Hume, and his own experiences in the Virginia legislature, Madison argued that factions were inevitable in a free society and that the only way to control them was to extend the sphere of the republic. By enlarging the territory and population, the influence of any single faction would be diluted because the larger the society, the more varied the interests and passions of its members. This diversity, Madison reasoned, made it harder for a single faction to gain a majority large enough to tyrannize the minority. The paper was written in November 1787 and published under the pseudonym Publius. It stands today as one of the most important works of political philosophy in American history. The core insight";
 
     // ── Model + centers ────────────────────────────────────────────────
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
     let centers = TriAttnCenters::load(Path::new(sidecar_path)).expect("load sidecar");

--- a/crates/hipfire-runtime/examples/triattn_decode_demo.rs
+++ b/crates/hipfire-runtime/examples/triattn_decode_demo.rs
@@ -55,7 +55,7 @@ fn main() {
     eprintln!("budget={budget} prefill={prefill_len} gen={gen_len}");
 
     let mut gpu = Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
 
     let kv_seq = 512usize;
     let scratch = Qwen35Scratch::new(&mut gpu, &config, 128).expect("scratch");

--- a/crates/hipfire-runtime/examples/triattn_infer.rs
+++ b/crates/hipfire-runtime/examples/triattn_infer.rs
@@ -108,7 +108,7 @@ fn main() {
     let kv_seq = budget + beta + 8;
 
     let mut gpu = Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
 
     let mut kv = match kv_mode.as_str() {
         "asym2" => KvCache::new_gpu_asym2(&mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq).unwrap(),

--- a/crates/hipfire-runtime/examples/triattn_infer.rs
+++ b/crates/hipfire-runtime/examples/triattn_infer.rs
@@ -95,7 +95,7 @@ fn main() {
     };
     let prompt = hipfire_runtime::tokenizer::maybe_normalize_prompt(&prompt).into_owned();
 
-    let hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
     let centers = TriAttnCenters::load(Path::new(&sidecar_path)).expect("load sidecar");

--- a/crates/hipfire-runtime/examples/triattn_longctx_demo.rs
+++ b/crates/hipfire-runtime/examples/triattn_longctx_demo.rs
@@ -38,7 +38,7 @@ fn main() {
     // Stitch a long prompt. ~175 tokens; comfortably exceeds budget=64.
     let prompt = "James Madison wrote Federalist No. 10 arguing that a large republic would curb the effects of factions better than a small one. Drawing on his reading of Montesquieu, Hume, and his own experiences in the Virginia legislature, Madison argued that factions were inevitable in a free society and that the only way to control them was to extend the sphere of the republic. By enlarging the territory and population, the influence of any single faction would be diluted. The paper was written in November 1787 and published under the pseudonym Publius. Its core insight, often cited today, is";
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
     let centers = TriAttnCenters::load(Path::new(sidecar_path)).expect("load sidecar");

--- a/crates/hipfire-runtime/examples/triattn_longctx_demo.rs
+++ b/crates/hipfire-runtime/examples/triattn_longctx_demo.rs
@@ -48,7 +48,7 @@ fn main() {
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
 
     let mut gpu = Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
 
     let prompt_tokens = tok.encode(prompt);
     let prompt_len = prompt_tokens.len();

--- a/crates/hipfire-runtime/examples/triattn_periodic_demo.rs
+++ b/crates/hipfire-runtime/examples/triattn_periodic_demo.rs
@@ -43,7 +43,7 @@ fn main() {
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
 
     let mut gpu = Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
 
     let prompt_tokens = tok.encode(prompt);
     let prompt_len = prompt_tokens.len();

--- a/crates/hipfire-runtime/examples/triattn_periodic_demo.rs
+++ b/crates/hipfire-runtime/examples/triattn_periodic_demo.rs
@@ -33,7 +33,7 @@ fn main() {
 
     let prompt = "James Madison wrote Federalist No. 10 to argue that a large republic would check the dangers of majority factions. The paper is famous for its insight that";
 
-    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
     let centers = TriAttnCenters::load(Path::new(sidecar_path)).expect("load sidecar");

--- a/crates/hipfire-runtime/examples/triattn_validate.rs
+++ b/crates/hipfire-runtime/examples/triattn_validate.rs
@@ -156,7 +156,7 @@ fn main() {
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
 
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
-    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("weights");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
 
     let kv_seq = 512usize;
     let mut kv = KvCache::new_gpu_q8(

--- a/crates/hipfire-runtime/examples/triattn_validate.rs
+++ b/crates/hipfire-runtime/examples/triattn_validate.rs
@@ -151,7 +151,7 @@ fn main() {
     }
 
     // ── Load model ─────────────────────────────────────────────────────
-    let hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
     let config = qwen35::config_from_hfq(&hfq).expect("config");
     let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
 

--- a/crates/hipfire-runtime/src/arch.rs
+++ b/crates/hipfire-runtime/src/arch.rs
@@ -128,7 +128,7 @@ pub trait Architecture: Send + 'static {
     /// (lazy load + LRU eviction for >VRAM models) is wired through
     /// `WeightTensor` and is not arch-specific.
     fn load_weights(
-        hfq: &HfqFile,
+        hfq: &mut HfqFile,
         cfg: &Self::Config,
         gpu: &mut Gpu,
     ) -> Result<Self::Weights, String>;

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -211,6 +211,10 @@ impl HfqFile {
     pub fn tensor_data(&self, name: &str) -> Option<(&HfqTensorInfo, &[u8])> {
         let idx = *self.tensor_map.get(name)?;
         let info = &self.tensors[idx];
+        debug_assert!(
+            self.mmap.is_some(),
+            "tensor_data() called after drop_mmap() — use tensor_data_vec() or tensor_data_pread() instead (tensor: {name})"
+        );
         let mmap = self.mmap.as_ref()?;
         Some((info, &mmap[info.data_offset..info.data_offset + info.data_size]))
     }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -42,9 +42,13 @@ pub struct HfqFile {
     /// going through this struct (cleanly separates HfqFile's mmap-based
     /// tensor lookup from the pager's pread/io_uring transport).
     path: std::path::PathBuf,
-    /// mmap kept for backward compat (small models, non-APU systems).
-    /// On unified-memory APUs, tensor data is read via pread instead.
-    mmap: Mmap,
+    /// mmap for tensor data access on discrete-GPU systems where GPU VRAM
+    /// is separate from system RAM (no double-buffering cost).
+    /// `None` on unified-memory APUs (Strix Halo etc.) where mmap pages
+    /// and hipMalloc share physical RAM — keeping the mmap alive doubles
+    /// memory consumption. Dropped after header/index parsing via
+    /// `drop_mmap()`. When `None`, all tensor reads go through `pread`.
+    mmap: Option<Mmap>,
     pub arch_id: u32,
     pub metadata_json: String,
     tensors: Vec<HfqTensorInfo>,
@@ -169,9 +173,24 @@ impl HfqFile {
         Ok(Self {
             _file: file,
             path: path.to_path_buf(),
-            mmap, arch_id, metadata_json, tensors, tensor_map,
+            mmap: Some(mmap), arch_id, metadata_json, tensors, tensor_map,
             pread_buf: std::cell::RefCell::new(Vec::new()),
         })
+    }
+
+    /// Drop the mmap to free the virtual address mapping. After this call,
+    /// `tensor_data()` returns `None` and all reads go through `tensor_data_pread()`.
+    ///
+    /// On unified-memory APUs (Strix Halo, Steam Deck, etc.), GPU and CPU
+    /// share physical RAM. Keeping the mmap alive while hipMalloc copies
+    /// tensor data into GPU buffers doubles memory consumption (mmap pages
+    /// + GPU copy both resident). Dropping the mmap after header/index
+    /// parsing lets the kernel reclaim those pages.
+    ///
+    /// On discrete-GPU systems this is unnecessary (GPU VRAM is separate),
+    /// so callers should only invoke this when UMA is detected.
+    pub fn drop_mmap(&mut self) {
+        self.mmap = None;
     }
 
     /// Path the HFQ file was opened from. The weight pager uses this to
@@ -192,7 +211,8 @@ impl HfqFile {
     pub fn tensor_data(&self, name: &str) -> Option<(&HfqTensorInfo, &[u8])> {
         let idx = *self.tensor_map.get(name)?;
         let info = &self.tensors[idx];
-        Some((info, &self.mmap[info.data_offset..info.data_offset + info.data_size]))
+        let mmap = self.mmap.as_ref()?;
+        Some((info, &mmap[info.data_offset..info.data_offset + info.data_size]))
     }
 
     /// Read tensor data via pread into a reusable buffer, then FADV_DONTNEED
@@ -234,6 +254,44 @@ impl HfqFile {
     #[cfg(not(unix))]
     pub fn tensor_data_pread(&self, name: &str) -> Option<(&HfqTensorInfo, &[u8])> {
         self.tensor_data(name)
+    }
+
+    /// Read tensor data using the best available path:
+    /// - Unix with pread support: pread + fadvise_dontneed (avoids page cache buildup)
+    /// - Fallback: mmap slice (returns None if mmap was dropped)
+    ///
+    /// Returns owned Vec<u8> to avoid lifetime issues with the pread RefCell.
+    pub fn tensor_data_vec(&self, name: &str) -> Option<(&HfqTensorInfo, Vec<u8>)> {
+        let idx = *self.tensor_map.get(name)?;
+        let info = &self.tensors[idx];
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            let fd = self._file.as_raw_fd();
+            let mut buf = vec![0u8; info.data_size];
+            let mut total_read = 0usize;
+            while total_read < info.data_size {
+                let n = unsafe {
+                    libc::pread(
+                        fd,
+                        buf[total_read..].as_mut_ptr() as *mut libc::c_void,
+                        info.data_size - total_read,
+                        (info.data_offset + total_read) as libc::off_t,
+                    )
+                };
+                if n <= 0 { break; }
+                total_read += n as usize;
+            }
+            fadvise_dontneed(fd, info.data_offset, info.data_size);
+            return Some((info, buf));
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mmap = self.mmap.as_ref()?;
+            Some((info, mmap[info.data_offset..info.data_offset + info.data_size].to_vec()))
+        }
     }
 
     /// Release page cache for a byte range. Only works if the range is NOT mmap'd.


### PR DESCRIPTION
## Summary
- **HFQ loader**: optional mmap drop for UMA systems — prevents double-buffering (mmap + hipMalloc both consuming system RAM)
- **Quantizer**: `--format mq6` now applies to routed expert weights (was hardcoded MQ4); new `--format mq4-mq6exp` for mixed precision; disk spill for large-model quantization
- **Signature change**: `load_weights` takes `&mut HfqFile` to support mmap drop

## Details

### Loader
On unified-memory APUs (Strix Halo etc.), mmap'd model pages and hipMalloc'd GPU copies share physical RAM. A 90 GB model needs ~180 GB without this fix. `drop_mmap()` releases the mapping after header parsing; all tensor reads go through `pread` + `fadvise_dontneed`.

### Quantizer
- Expert weights were hardcoded to MQ4 regardless of `--format`. Now `--format mq6` applies MQ6 to experts too.
- `--format mq4-mq6exp`: MQ4 for attention/shared-expert + MQ6 for routed experts only (~75 GB vs 90 GB full MQ6)
- `TensorSpill`: writes quantized tensor data to a temp file when accumulated memory exceeds threshold, preventing OOM on large MoE models
- `drop_tensor_pages()`: releases source safetensors page cache after each tensor

## Test plan
- [x] Builds clean (warnings only)
- [x] MQ6 full quantization of 122B-A10B produces correct 90 GB output
- [x] Disk spill keeps RSS bounded during quantization (verified: RSS ≤ 36 GB for 90 GB output)
- [ ] Mixed quant (`mq4-mq6exp`) blocked by 234 GB source mmap OOM — needs streaming safetensors reader (future work)
- [ ] MQ6 model loading blocked by 90 GB > 125 GB UMA headroom — needs system with >128 GB RAM to validate quality

Refs #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)