### PR TITLE
docs(path-d): preserve DDTree pipelining empirical findings (closes #131)

### DIFF
--- a/findings/path-d-bandwidth-contention.md
+++ b/findings/path-d-bandwidth-contention.md
@@ -1,0 +1,211 @@
+# Path D D0 risk-check — Bandwidth contention micro-bench
+
+**Issue:** [#38](https://github.com/Kaden-Schutt/hipfire/issues/38) (Path D —
+DDTree pipeline)
+**Branch:** `feat/38-ddtree-pipeline` at `abf9408` (D0c) on top of master
+`80330c3`.
+**Hardware:** AMD RX 7900 XT (gfx1100, 21.5 GB VRAM, HIP 7.2).
+**Date:** 2026-05-02.
+
+## What this measures
+
+Plan §3 / `plans/path_d.md` requires a pre-D1 risk-check: synthetic
+bandwidth-contention micro-bench mimicking the real cycle's overlap (verify
+on one stream, draft on a second stream concurrently). If observed wall-time
+savings are **< 8 %**, Path D is paused and rescoped, because the plan's
+60-ms cycle target (20 % savings on a 75-ms baseline) is unreachable on this
+hardware regardless of correct stream wiring.
+
+The bench is `crates/rdna-compute/examples/bench_stream_overlap.rs` (already
+in the tree, predates this plan). It exercises real
+`gemm_hfq4g256_residual` kernels on synthetic MQ4-layout weights — same
+quantization as production target/draft weights — so contention is realistic
+to actual DFlash bandwidth pressure, not an idealized memcpy proxy.
+
+Two probes:
+
+1. **Symmetric** — N kernel launches split half on stream A, half on
+   stream B vs the same N launched on a single stream. Tests whether the
+   GPU's two ACE (asynchronous compute engine) queues can saturate
+   simultaneously when both streams want roughly equal work.
+2. **Asymmetric** — large verify-shaped workload on stream A concurrent
+   with a smaller draft-shaped workload on stream B, vs the sum of each
+   alone. This is the Path D scenario: verify N runs while draft N+1
+   overlaps on `draft_stream`.
+
+`overlap_ratio = (T_a_alone + T_b_alone) / T_both_concurrent`. Wall-time
+savings = `1 - 1/ratio`.
+
+## Results (3 runs)
+
+### Run 1 — default (symmetric stress + 5v+5d asymmetric)
+
+```
+=== gemm_hfq4g256_residual M=5120 K=5120 N=16 ===
+
+  N   T_serial(µs)  T_parallel(µs)  overlap_ratio
+   8         849.4           871.8     0.974x  (-2.6 %  — warmup noise)
+  16        1559.0          1488.8     1.047x  ( +4.5 %)
+  32        2876.4          2728.1     1.054x  ( +5.1 %)
+  64        5890.2          5041.0     1.168x  (+14.4 %)
+
+Asymmetric probe (5 verify layers + 5 draft layers, same shape):
+  t_verify_alone:    620.8 µs
+  t_draft_alone:     653.2 µs
+  t_both:           1012.2 µs
+  ratio = 1.259x → 20.6 % wall savings
+```
+
+### Run 2 — realistic verify-dominated (64v + 5d, draft=2048×2048)
+
+```
+Symmetric:
+  N=64  → 1.272x  (+21.4 %)
+
+Asymmetric (the Path-D-relevant case):
+  verify: 64 layers, M=5120 K=5120 N=16
+  draft:   5 layers, M=2048 K=2048 N=16
+  t_verify_alone: 5881.2 µs
+  t_draft_alone:   292.2 µs    (4.7 % of verify)
+  t_both:         5842.2 µs    (≈ verify alone — draft fully hides)
+  ratio = 1.057x → 5.4 % wall savings    ← BELOW 8 % THRESHOLD
+```
+
+This is the case where the plan's caveat bites: when draft is much smaller
+than verify, draft hides perfectly inside the verify time but the absolute
+wall savings are bounded by `T_draft / (T_v + T_d) ≈ 5 %`. The bench's
+"asymm" gate annotates this as `ratio < 1.3 → A-full doomed on gfx1100,
+pivot to kernel grinds`.
+
+### Run 3 — realistic 4:1 work ratio (64v + 20d, draft=4096×4096)
+
+```
+Symmetric:
+  N=64  → 1.236x  (+19.1 %)
+
+Asymmetric (closer to real T_v / T_d ratio):
+  verify: 64 layers, M=5120 K=5120 N=16
+  draft:  20 layers, M=4096 K=4096 N=16
+  t_verify_alone: 6050.9 µs
+  t_draft_alone:  1400.9 µs    (23 % of verify)
+  t_both:         6571.1 µs
+  ratio = 1.134x → 11.8 % wall savings   ← ABOVE 8 %, BELOW PLAN'S 20 %
+```
+
+When the synthetic draft work is sized to roughly mirror the **time** ratio
+that real 27B + 5-layer DFlash exhibits (verify ≈ 75–80 % of cycle, draft
+≈ 20–25 %), the bench shows `1.134×` = **11.8 % wall savings**.
+
+## Interpretation
+
+### What the data says about Path D
+
+| Scenario | Verify time | Draft time | T_d / T_v | Overlap ratio | Wall savings |
+|----------|-------------|------------|-----------|---------------|--------------|
+| Verify-dominated (run 2) | 5.9 ms | 0.3 ms |  5 % | 1.057× |  5.4 % |
+| Realistic 4:1 (run 3)    | 6.1 ms | 1.4 ms | 23 % | 1.134× | 11.8 % |
+| Symmetric stress (any)   | n/a    | n/a    |~100 %| 1.17–1.27× | 14–21 % |
+
+The plan's **8 % pause threshold is satisfied** when the simulated verify-to-
+draft work ratio matches what the real DFlash cycle exhibits (run 3, 4:1).
+The threshold **fails** when the draft is artificially tiny relative to
+verify (run 2). The headroom on the realistic case is modest: 11.8 % vs an
+8 % floor, with run-to-run noise on the bench at ~2 %.
+
+### What the plan's 20 % target requires
+
+Plan-stated quantitative target: `cycle 75 ms → 60 ms (-20 %) if τ stays
+≥ 90 %`. On the run-3 model:
+
+  - To hit 20 % wall savings via overlap alone, we need
+    `T_d / (T_v + T_d) ≥ 0.20`, i.e. `T_d / T_v ≥ 0.25`.
+  - Run 3 measures `T_d / T_v = 0.23` and yields 11.8 %. Half the plan's
+    target.
+  - The arithmetic ceiling is `min(T_v, T_d) / (T_v + T_d)`. Even with
+    100 % overlap (no contention), a workload with T_d = 0.25 × T_v can save
+    at most 20 %. Bandwidth contention on shared GDDR6 erodes this further.
+
+### What the plan's 4 % worst-case warning meant
+
+The plan's `§1` caveat:
+
+> Worst-case analytical model says effective savings could be as low as
+> ~4 %, not 20 %.
+
+Run 2 (5.4 %) confirms this analytical worst case is the right ballpark when
+the draft is tiny. It's not a crash-and-burn outcome — pipelining still
+works, just with diminishing absolute returns.
+
+## Recommendation
+
+**Proceed with D1+, but rebaseline the perf target.**
+
+The 8 % threshold is satisfied at the verify:draft work ratio that real
+DFlash exhibits. The hardware is capable of overlapping concurrent streams
+on gfx1100 — the bench shows `1.13–1.27×` ratios across configurations,
+consistent with partial-but-real ACE concurrency.
+
+What to update before D1 lands:
+
+1. **Plan §1 quantitative target:** revise `75 ms → 60 ms (-20 %)` to a
+   more defensible `75 ms → 67 ms (-10 %)` until the actual D1+D2+D3
+   end-to-end bench refutes or confirms it. The 20 % figure was derived
+   from a perfect-overlap analytical model; the synthetic measurement
+   here ceilings around 12 % at realistic verify:draft work ratios.
+
+2. **Plan §1 acceptance bars:** the per-class speed gates (210 / 195 /
+   180 tok/s) should be revisited against this finding. Current 199 tok/s
+   median × 1.10 = ~219 tok/s upper-bound code expectation. The bars at
+   210 / 195 / 180 are reachable but tight.
+
+3. **Plan §3 D5 ship-gate:** keep the existing «if observed cycle savings
+   drop below 8 % we pause and rescope» — this micro-bench validates the
+   gate is the right kind of check, not the right *post-implementation*
+   threshold. Reuse the asymmetric probe (run 3 config) as a smoke test
+   inside `coherence-gate-dflash.sh` once D1+ lands.
+
+What this measurement does **not** decide:
+
+- Whether the realistic 4:1 work-ratio assumption holds for every prompt
+  class. Code-class generations often have higher τ → larger B → bigger
+  draft per cycle → better ratio. Prose-class with smaller B may be
+  closer to run 2 (verify-dominated, low savings). The per-class speed
+  gates in §1 of the plan handle this — they remain the right shape.
+- Whether kernel concurrency on the same stream-pair is stable enough at
+  the 75-ms timescale. Bench iterations are µs-scale; real cycles are
+  ms-scale and may interact with DPM throttling and L2 sharing
+  differently. D1's DPM warmup on `draft_stream` (per plan) addresses
+  the first; the second is observable only end-to-end.
+- Any τ regression cost. Pipelining trades τ for cycle wall time
+  (one-cycle-stale draft context). The 4:1 wall-savings bound assumes τ
+  stays at 90 % of pre-pipeline baseline; if the staleness costs more,
+  net savings shrink further. The §D4 adaptive bypass + per-class
+  baseline-keying is the safety net.
+
+## Repro
+
+```sh
+# Symmetric + default asymmetric (5v + 5d, same shape):
+cargo build --release -p rdna-compute --example bench_stream_overlap
+./target/release/examples/bench_stream_overlap
+
+# Realistic verify-dominated (the case that fails the threshold):
+BENCH_VERIFY_LAYERS=64 BENCH_DRAFT_LAYERS=5 \
+BENCH_DRAFT_M=2048 BENCH_DRAFT_K=2048 BENCH_DRAFT_N=16 \
+  ./target/release/examples/bench_stream_overlap
+
+# Realistic 4:1 work ratio (the case that supports proceeding):
+BENCH_VERIFY_LAYERS=64 BENCH_DRAFT_LAYERS=20 \
+BENCH_DRAFT_M=4096 BENCH_DRAFT_K=4096 BENCH_DRAFT_N=16 \
+  ./target/release/examples/bench_stream_overlap
+```
+
+GPU lock acquired via `gpu-lock.sh` for the duration of the bench (so the
+numbers don't get clobbered by another agent's cargo run). 7900 XTX was
+otherwise idle; no DPM warmup was applied (numbers are post the bench's
+own 20-iteration warmup loop).
+
+## Decision
+
+D0a / D0b / D0c are committed (`fda7899`, `4306ff5`, `abf9408`). D1
+proceeds.

--- a/findings/path-d-model-b-validation.md
+++ b/findings/path-d-model-b-validation.md
@@ -1,0 +1,242 @@
+# Path D D3b validation — model B optimistic-seed cost on real workloads
+
+**Issue:** [#38](https://github.com/Kaden-Schutt/hipfire/issues/38)
+**Branch:** `feat/38-ddtree-pipeline` at `55c0e8b` (D3b.1) on top of master
+`80330c3`.
+**Hardware:** AMD RX 7900 XT (gfx1100, 21.5 GB VRAM, HIP 7.2).
+**Date:** 2026-05-03.
+**Status:** Model B as written is non-viable on code prompts.
+
+## What this measures
+
+Pipeline model B (chosen earlier in this branch — see
+`memory/project_path_d_pipeline_model.md`) launches draft N+1 concurrent
+with verify N using a guessed seed: `seed = drafted_N[B-1]`,
+`position = position + B`. The guess is correct **only when
+accept_len_N == B-1** (full accept). On any cycle where the verifier
+rejects mid-block, the pipelined draft launches at the wrong absolute
+position — its tokens are predictions for the wrong slots and verify
+N+1 will reject them.
+
+Before sinking the ~400 LOC of pipelined-branch implementation, this
+experiment measures the empirical full-accept fraction on the workloads
+plan §1 targets (code, prose). If full-accept is rare, model B's
+pipelined draft is wasted GPU work and bandwidth contention with verify
+is a net regression.
+
+## Method
+
+Two prompts run end-to-end through `dflash_spec_demo` with
+`DFLASH_LIVE_TAU=1` for per-cycle accept_len logging:
+
+  - **Code** (LRU cache, PEP-8 strict):
+    `benchmarks/prompts/lru_cache_pep8_strict.txt`, `--max 120`.
+  - **Prose / structured code** (merge sort, thinking off):
+    `benchmarks/prompts/merge_sort_thinking_off.txt`, `--max 256`.
+
+Both use the canonical 27B-3.5 LRU bench config: `--no-chatml --kv-mode
+asym3`. Block size `B=16` (draft-trained default). `prompt_normalize`
+default-on (per CLAUDE.md as of 2026-04-26). 7900 XT, idle GPU lock.
+
+Per-cycle `accept_len` is reported by the demo's `live-tau` mode plus
+the `seed-oracle` summary. `full_accept_count` is the fraction of cycles
+with `accept_len == B-1`.
+
+## Results
+
+### Code (LRU PEP-8) — 12 cycles, mean accept_len 9.5
+
+```
+histogram (accept_len → cycles):
+  0: 0    1: 0    2: 1    3: 1    4: 1    5: 0    6: 0
+  7: 1    8: 1    9: 0   10: 1   11: 1   12: 1   13: 1
+ 14: 1   15: 2   16: 0
+
+mean_accept_len: 9.500    full_accept: 2/12 = 17 %
+decode_tau: 9.50          decode_accept_rate: 0.633
+```
+
+### Prose (merge sort) — 11 cycles, mean accept_len 13.27
+
+```
+histogram:
+  0: 0    1: 0    2: 1    3: 0    4: 0    5: 0    6: 0
+  7: 0    8: 0    9: 1   10: 0   11: 0   12: 0   13: 0
+ 14: 0   15: 9   16: 0
+
+mean_accept_len: 13.273   full_accept: 9/11 = 82 %
+decode_tau: 13.27         decode_accept_rate: 0.885
+```
+
+## Interpretation
+
+### Code workloads — model B is a regression
+
+On the code prompt (the hardest target in plan §1's per-class gates,
+210 tok/s on 27B-3.5 LRU), only **17 %** of cycles satisfy model B's
+optimistic-seed assumption. The remaining 83 % of cycles produce
+pipelined drafts at the wrong absolute position — verify N+1 rejects
+them and the GPU work is wasted.
+
+Wall-time math:
+
+  - **Best-case savings** when pipelining helps: ~11.8 % per cycle
+    (D0-bandwidth contention bench, `findings/path-d-bandwidth-
+    contention.md`).
+  - **Regression cost** when pipelining is wasted: bandwidth contention
+    on shared GDDR6 slows verify by ~5 % (D0-bandwidth bench, run 2).
+    Plus the wasted draft compute.
+
+  Net code wall change ≈
+    `0.17 × 11.8 % - 0.83 × 5 % ≈ +2.0 % - 4.2 % = -2.2 %`
+
+  Model B is a **2 % wall-time regression on code**, not a win. The
+  plan's 210 tok/s target on this class is unreachable via model B —
+  it'd land below 200 tok/s.
+
+### Prose workloads — model B helps significantly
+
+On the merge-sort prompt, **82 %** of cycles satisfy the optimistic-seed
+assumption.
+
+  Net prose wall change ≈
+    `0.82 × 11.8 % - 0.18 × 5 % ≈ +9.7 % - 0.9 % = +8.8 %`
+
+  Plan's 180 tok/s prose target is comfortably reachable — would land
+  near 196 tok/s (current 180 baseline × 1.088).
+
+### The split is structural, not noise
+
+The split between code and prose isn't a small perturbation — it's a
+fundamental property of how the draft+verify alignment interacts with
+greedy decoding:
+
+  - On highly-deterministic generations (boilerplate code, well-trained
+    structured patterns like merge_sort), the draft predicts what the
+    verifier wants, accept_len ≈ B-1, model B is sound.
+  - On code with branching choices (real algorithm, conditional logic,
+    LRU semantics) the verifier's greedy argmax frequently diverges
+    from the draft mid-block. accept_len lands in the 7–12 range
+    (mean 9.5 here). model B is broken.
+
+This is exactly the workload class plan §1 most wants to accelerate
+(code generation, agentic turns), so the failure mode lands on the
+target use case.
+
+## Implications for D3b
+
+Model B as specified in `plans/path_d.md` §D3b — pre-launched draft
+with optimistic seed, no recovery — produces a regression on code
+prompts that's larger than the wins on prose. The per-class speed
+gates in plan §1 (code 210, instruct 195, prose 180) cannot all pass
+with this approach; at minimum the code gate fails.
+
+Three viable pivots:
+
+### A. Commit-overlap-only (former model A)
+
+Cycle N still runs draft N → verify N → commit N sequentially. The
+overlap is *only* `commit_N` (small async memcpys, ~1 ms) with the
+START of cycle N+1's `draft_forward` (compute-bound). Real bonus_N
+used as seed — no τ regression.
+
+  - Pros: zero correctness/τ risk.
+  - Cons: arithmetic ceiling on wall savings is ~2 %; effectively no
+    measurable improvement at the 50-ms cycle scale.
+  - Verdict: passes coherence gates and ±2 % default check, but
+    **fails the per-class speed gates** (no improvement).
+
+### B. Predictive bypass on model B
+
+Engage model B's pipelined draft *only* when the prior cycle had
+`accept_len_{N-1} == B-1` (or some recent EWMA threshold). On cycles
+where the optimistic-seed assumption is unlikely to hold, fall back
+to sequential.
+
+  Empirical engagement rates with single-cycle predictor:
+    - Code: ~0.17 × P(full | full) ≈ 0.08 (assume 50 % autocorrelation).
+    - Prose: ~0.82 × P(full | full) ≈ 0.7 (high-correlation regime).
+
+  - Pros: prose gets ~6 % wall savings (down from 8.8 %); code stays
+    near zero (no win, but no regression — the 92 % of cycles that
+    bypass run sequentially).
+  - Cons: implementation cost ~ same as full model B (the predictive
+    gate is a few LOC; the pipelined branch itself is the bulk).
+  - Verdict: passes code gate (no change) and prose gate (improvement);
+    fails the 210 tok/s aspirational code target but probably reaches
+    a defensible ≥199 tok/s baseline.
+
+### C. Optimistic launch + sync re-launch on miss
+
+Launch draft N+1 optimistically. If `accept_len_N < B-1`, on cycle N+1
+discard the pipelined draft and run draft N+1 sequentially.
+
+  - Pros: τ stays at sequential level.
+  - Cons: the wasted optimistic launch consumed bandwidth concurrent
+    with verify N (~5 % verify slowdown via bandwidth bench), AND
+    cycle N+1 pays full sequential cost. Net: positive on full-accept
+    cycles, **negative** on miss cycles.
+  - Verdict: probably worse than pure A on code; comparable to B on
+    prose.
+
+### Out of scope but worth noting
+
+  - **Multi-position draft** (predict B+1 token sets, one per possible
+    accept_len): would always have a usable draft. Requires a different
+    draft training objective. Not feasible without retraining the draft
+    model.
+
+  - **Asynchronous draft re-issue**: launch draft optimistically;
+    overlap a SECOND draft launch with verify N+1's forward using the
+    real seed. Only the second draft's tokens are used. Effectively
+    doubles draft compute with no acceptance benefit; worse than A.
+
+## Recommendation
+
+**Either pivot to model A or stop work on Path D pipelining.**
+
+Model A is cheap (~150 LOC vs ~400 for full model B) and
+correctness-safe. It will likely fail the per-class speed gates as
+written, but those gates were derived from the optimistic 11.8 %
+wall-savings projection — which this experiment shows is unreachable
+at the workload mix (code-dominated) plan §1 cares about.
+
+If we pursue model A:
+
+  1. Implement the minimal cross-stream wiring: pre_commit_evt +
+     `commit_staging_to_ring_on_stream` on verify_stream concurrent
+     with cycle N+1's draft_forward starting on draft_stream.
+  2. **Rebaseline plan §1 quantitative target** to ~75 ms → 73 ms
+     (-3 %) — defensible as a "no regression, small overlap" claim
+     rather than the 20 % aspiration.
+  3. **Revise the per-class gates** to ±2 % of the existing baseline
+     (no improvement expected; the gate becomes a regression check
+     rather than a perf-target check).
+
+If we stop: the D0a/D0b/D0c primitive refactors still land cleanly as
+infrastructure (they're useful for any future stream-aware work). D1
+(stream allocation) and D2 (DflashScratchPair) become dead code —
+follow-up issue to remove. D3a (verify_dflash_block_inner skip flag)
+becomes dead code likewise. D3b.1 signature refactor becomes dead
+code — revert.
+
+## Repro
+
+```sh
+# Code (LRU PEP-8):
+PROMPT=$(cat benchmarks/prompts/lru_cache_pep8_strict.txt)
+DFLASH_LIVE_TAU=1 ./target/release/examples/dflash_spec_demo \
+    --target ~/.hipfire/models/qwen3.5-27b.mq4 \
+    --draft  ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
+    --prompt "$PROMPT" --max 120 --no-chatml --kv-mode asym3
+
+# Prose (merge sort thinking-off):
+PROMPT=$(cat benchmarks/prompts/merge_sort_thinking_off.txt)
+DFLASH_LIVE_TAU=1 ./target/release/examples/dflash_spec_demo \
+    --target ~/.hipfire/models/qwen3.5-27b.mq4 \
+    --draft  ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
+    --prompt "$PROMPT" --max 256 --no-chatml --kv-mode asym3
+```
+
+The `seed-oracle` line at end-of-run reports `full_accept` count and
+`mean_accept_len`. Histograms in the bench summary block.

--- a/findings/path-d-vs-path-c.md
+++ b/findings/path-d-vs-path-c.md
@@ -1,0 +1,193 @@
+# Path D vs Path C — chain mode vs tree mode on 27B-3.5
+
+**Issue:** [#38](https://github.com/Kaden-Schutt/hipfire/issues/38) (Path D)
+in light of [#41](https://github.com/Kaden-Schutt/hipfire/issues/41) +
+PR #72 (Path C tree-mode orchestrator on gfx1100).
+**Branch:** `feat/38-ddtree-pipeline` at `b38ce06` on top of master `80330c3`.
+**Hardware:** AMD RX 7900 XT (gfx1100, 21.5 GB VRAM, HIP 7.2).
+**Date:** 2026-05-03.
+
+## Why this exists
+
+The model-B validation in `findings/path-d-model-b-validation.md`
+measured chain-mode `spec_step_dflash` only. The PR's recommendation
+hedged: *"if Path C tree mode lifts the full-accept fraction enough,
+the chain-mode regression on code might not apply to the production-
+default path."* This experiment closes that loop with empirical
+chain-vs-tree data on the same Qwen3.5-27B + DFlash MQ4 draft pair.
+
+## Method
+
+Same prompts as the chain-mode validation:
+
+  - Code: `benchmarks/prompts/lru_cache_pep8_strict.txt`, `--max 120`.
+  - Prose: `benchmarks/prompts/merge_sort_thinking_off.txt`, `--max 256`.
+
+All runs: `--no-chatml --kv-mode asym3` (canonical 27B-3.5 LRU bench
+config, plan §1). DPM warmup 3 s for representative tok/s.
+
+Three modes:
+
+  - **Chain** — default `spec_step_dflash` (B=16 chain block).
+  - **Path C phase 1** — `--ddtree-budget 12 --ddtree-topk 2
+    --ddtree-path-c phase1`. Tree mode, main-path-first linear verify.
+  - **Path C phase 2** — same flags with `phase2`. Adds lazy
+    branch FA-only re-verify on the unique structurally-acceptable
+    candidate.
+
+## Results
+
+### Code prompt (LRU PEP-8)
+
+| Mode | tok/s | τ | Full-path-accept | Mode-specific full-block size |
+|---|---:|---:|---|---:|
+| Chain                  | **153.75** | 8.85 | 2/13 = 15 % | 15 |
+| Path C phase 1         | 138.64     | 8.69 | 5/13 = 38 % | 12 |
+| Path C phase 2         | 131.48     | 8.69 | 3/13 = 23 % | 12 |
+
+### Prose prompt (merge sort)
+
+| Mode | tok/s | τ | Full-path-accept | Mode-specific full-block size |
+|---|---:|---:|---|---:|
+| Chain                  | **228.99** | 13.27 | 8/11 = 73 % | 15 |
+| Path C phase 1         | 177.55     | 11.08 | 11/13 = 85 % | 12 |
+| Path C phase 2         | 177.29     | 11.08 | 11/13 = 85 % | 12 |
+
+(Full-path-accept counts cycles where the longest accepted path equals
+the mode-specific maximum: B-1 = 15 for chain, budget = 12 for Path C.)
+
+### Sanity check: env=both (chain pipelining + tree mode)
+
+`HIPFIRE_DFLASH_PIPELINE=1 ... --ddtree-path-c phase1` on the code
+prompt: 138.70 tok/s, τ=8.69. **Within run-to-run noise of Path C
+phase 1 alone** (138.64 / 8.69). Confirms the demo dispatches to
+`spec_step_ddtree_path_c` when `--ddtree-path-c` is set; our chain-
+mode pipelining never engages. The pair's `b` half is allocated
+(~64 MB extra VRAM, observed bump 16.56 → 17.69 GB) but unused.
+
+## Interpretation
+
+### Path C is slower than chain on 27B-3.5 in our config
+
+  - **Code:** Path C phase 1 is **−10 %** vs chain (138.64 vs 153.75
+    tok/s). Phase 2 is even slower at −15 %.
+  - **Prose:** Path C phase 1 is **−22 %** vs chain (177.55 vs 228.99
+    tok/s).
+
+This is consistent with #41's TL;DR observation:
+
+> "DDTree b12-k2 on 27B-3.5 code = 109 tok/s vs plain DFlash 185 tok/s
+> (-41 %)."
+
+Path C unblocks the *correctness* problem (no attractor failure mode
+that broke Paths A and B per #41). It does **not** deliver perf wins
+on Qwen3.5-27B at the canonical LRU config — the tree-mode per-cycle
+overhead exceeds the τ benefit. This holds even though full-path-
+accept fraction is higher under Path C (38 % code, 85 % prose vs
+chain's 15 % / 73 %).
+
+The +30–40 % τ wins for tree mode cited in #41's body ("memory:
+asym3 KV b12-k2 wins +28 % prose / +29 % instruct") were
+**pre-Phase-1** numbers — measured before the Phase 1 prompt
+normalization (default-on as of 2026-04-26 per `CLAUDE.md`) raised
+chain-mode τ on PEP-8 / structured prompts by ~24 %. Chain mode in
+the post-Phase-1 regime is a stronger baseline than the historical
+DDTree comparisons assumed.
+
+### Implications for the Path D PR's recommendation
+
+The PR's hedge — "if Path C becomes production default, model B's
+chain-mode regression might not apply" — is **empirically refuted**.
+Path C is slower than chain mode on Qwen3.5-27B at canonical config,
+so users won't migrate to it as a default for these models. Chain
+mode remains the production-default path, and the chain-mode model-B
+finding (regression on code, win on prose) is the relevant data.
+
+This **strengthens option C** (stop pursuing pipelining):
+
+  - Chain mode is the production-default path on Qwen3.5-27B.
+  - Pipelining model B regresses on chain-mode code by ~2.2 %
+    (`findings/path-d-model-b-validation.md`).
+  - Path C tree mode doesn't change this conclusion — it's a slower
+    alternative on the model pair plan §1 targets.
+
+Path C remains useful for Qwen3.6 + matching draft pair (per #41
+comment's smoke results, where chain-mode τ is much lower at ~1.5–8
+and Path C's tree-mode wins materialize). But that's a different
+model regime than plan §1's 27B-3.5 LRU bench targets.
+
+### Implications for tree-mode pipelining (P3 follow-up)
+
+The full-path-accept rates under Path C are higher than chain mode
+(38 % vs 15 % on code, 85 % vs 73 % on prose). If we *did* pipeline
+Path C with model B, the optimistic-seed assumption would hold more
+often.
+
+But the per-cycle wall time is also longer in Path C (tree-verify
+overhead). The pipelining wall-savings calculation:
+
+  - Path C code: `0.38 × ~12 % overlap - 0.62 × ~5 % contention
+    ≈ +4.6 % - 3.1 % = +1.5 %`. Marginal positive.
+  - Path C prose: `0.85 × ~12 % - 0.15 × ~5 %  ≈ +10.2 % - 0.75 % =
+    +9.4 %`. Solid positive.
+
+But the absolute tok/s ceiling under Path C is already lower than
+chain mode (138 / 178 vs 153 / 229). Even with a +9 % wall savings
+on Path C prose, you'd land at ~194 tok/s — still under chain mode's
+229. **Tree-mode pipelining would not catch chain mode** on
+Qwen3.5-27B prose.
+
+So tree-mode pipelining on this model regime is structurally
+dominated by chain mode. Worth pursuing only if there's a model
+regime where Path C beats chain (e.g. Qwen3.6 + matching draft per
+#41 comment data) — and even then, the engineering cost is non-
+trivial since `spec_step_ddtree_path_c` would need a D3b-equivalent
+refactor.
+
+## Recommendation update
+
+**Lock in option C** (stop pursuing pipelining). The "Path C might
+flip the picture" hedge in the PR is empirically refuted on the
+model regime that matters. Path C is correct but slower; users won't
+adopt it as default; chain-mode pipelining model B's chain-mode
+regression is the real data; that data argues against shipping Path
+D as the plan §1 perf lever.
+
+Specific PR actions:
+
+  1. **Recommendation flips from "C with a hedge" to "C, locked in."**
+  2. **Strike the test plan bullet** asking to re-run model-B
+     validation under Path C — done, results above.
+  3. **Plan rebaseline** under option C stays as `75 ms → 75 ms (0 %)`,
+     no perf claim. Plan §1's 210 / 195 / 180 tok/s gates were
+     aspirational under the assumption pipelining would deliver
+     11–20 %. They're unreachable on this hardware/model pair via
+     either pipelining (this experiment + chain validation) or Path
+     C alone (this experiment).
+  4. **Plan §6 (Out of scope)** should add: "Tree-mode pipelining
+     on `spec_step_ddtree_path_c`. Empirically dominated by chain
+     mode on 27B-3.5 (this finding); only worth pursuing on model
+     regimes where Path C beats chain."
+
+## Repro
+
+```sh
+# Chain mode (baseline):
+HIPFIRE_DPM_WARMUP_SECS=3 ./target/release/examples/dflash_spec_demo \
+    --target ~/.hipfire/models/qwen3.5-27b.mq4 \
+    --draft  ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
+    --prompt "$(cat benchmarks/prompts/lru_cache_pep8_strict.txt)" \
+    --max 120 --no-chatml --kv-mode asym3
+
+# Path C phase 1 (add):
+    --ddtree-budget 12 --ddtree-topk 2 --ddtree-path-c phase1
+
+# Path C phase 2 (substitute):
+    --ddtree-budget 12 --ddtree-topk 2 --ddtree-path-c phase2
+
+# env=both sanity:
+HIPFIRE_DFLASH_PIPELINE=1 [chain mode flags] [Path C flags]
+```
+
+Histograms read from the bench summary block at end-of-run.
+Tok/s + τ from the `emitted:` and `cycles:` lines.


### PR DESCRIPTION
## Summary

Cherry-picks the three findings docs from #131 (closed as not-planned per @unverbraucht's recommendation) onto master so the empirical work is preserved in tree.

The code scaffolding (D0–D3b.1) stays accessible via the [#131 branch ref](https://github.com/Kaden-Schutt/hipfire/tree/feat/38-ddtree-pipeline) for any future revival on different hardware/model regimes.

## What landed

- \`findings/path-d-bandwidth-contention.md\` — 7900 XT D0 pre-D1 micro-bench. 11.8% wall-savings ceiling, conditional on \`accept_len == B-1\`.
- \`findings/path-d-model-b-validation.md\` — D3b chain-mode empirical. 17% full-accept rate on code → ~2.2% wall regression.
- \`findings/path-d-vs-path-c.md\` — Chain vs Path C tree-mode on Qwen3.5-27B. Path C is slower (-10% code, -22% prose). Tree-mode pipelining can't recover the chain-mode ceiling.

Bottom line for future readers: no pipelining variant we've tested beats chain mode on the workload class plan §1 targets. Pursuit gated on a model regime where Path C already beats chain (e.g. Qwen3.6 + matching draft per #41 comment data).

## Test plan

Doc-only — no tests beyond \`git diff --check\` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)