### PR TITLE
fix(kernels/moe): clamp top-k winner to valid expert range — closes #152

### DIFF
--- a/kernels/src/moe_softmax_topk_k8.hip
+++ b/kernels/src/moe_softmax_topk_k8.hip
@@ -137,8 +137,22 @@ __global__ void moe_softmax_topk_renorm_k8(
     __syncthreads();
 
     // ── 5. Write output ──
+    // Clamp the winner to a valid expert range before write-out. Under MQ4
+    // expert quant on 122B-A10B, a NaN in the softmax can cause the argmax
+    // reduction to select the sentinel `-1` (or any garbage); without this
+    // guard the dispatch picks an out-of-bounds expert and the matmul
+    // either GPU-faults (aperture violation) or reads stale weights.
+    // Clamp: if invalid, route to expert 0 with weight 0 — output stays
+    // mathematically correct (zero contribution) and dispatch stays in-bounds.
+    // Closes #152.
     if (tid < K_TOP) {
-        topk_idx[tid] = picked_idx[tid];
-        topk_w[tid]   = picked_w[tid];
+        int   safe_idx = picked_idx[tid];
+        float safe_w   = picked_w[tid];
+        if (safe_idx < 0 || safe_idx >= n_exp) {
+            safe_idx = 0;
+            safe_w   = 0.0f;
+        }
+        topk_idx[tid] = safe_idx;
+        topk_w[tid]   = safe_w;
     }
 }

--- a/kernels/src/moe_softmax_topk_k8_batched.hip
+++ b/kernels/src/moe_softmax_topk_k8_batched.hip
@@ -127,8 +127,16 @@ __global__ void moe_softmax_topk_renorm_k8_batched(
     __syncthreads();
 
     // ── 5. Write output ──
+    // Clamp the winner to a valid expert range before write-out. See the
+    // single-token kernel for the full rationale (closes #152).
     if (tid < K_TOP) {
-        row_idx[tid] = picked_idx[tid];
-        row_w[tid]   = picked_w[tid];
+        int   safe_idx = picked_idx[tid];
+        float safe_w   = picked_w[tid];
+        if (safe_idx < 0 || safe_idx >= n_exp) {
+            safe_idx = 0;
+            safe_w   = 0.0f;
+        }
+        row_idx[tid] = safe_idx;
+        row_w[tid]   = safe_w;
     }
 }

--- a/scripts/pflash-gate.sh
+++ b/scripts/pflash-gate.sh
@@ -100,7 +100,7 @@ else
 fi
 if [ "$rebuild" -eq 1 ]; then
     echo "pflash-gate: rebuilding pflash_niah_bench (binary missing or stale)..."
-    if ! cargo build --release --features deltanet --example pflash_niah_bench -p engine >&2; then
+    if ! cargo build --release --features deltanet --example pflash_niah_bench -p hipfire-runtime >&2; then
         echo "pflash-gate: build failed" >&2
         exit 2
     fi


### PR DESCRIPTION
## Summary

Defensive guard at the write-out of `moe_softmax_topk_renorm_k8` (and its batched sibling). Under MQ4 expert quant on 122B-A10B, a NaN in the softmax can leave the argmax-reduce slot holding the sentinel `-1` (or any garbage); without this clamp the dispatch picks an OOB expert and the matmul either GPU-faults (aperture violation) or silently reads stale weights — both of which manifest as the bug filed in #152.

**Clamp policy:** if `picked_idx[k]` is `< 0` or `>= n_exp`, route to expert 0 with weight 0. The contribution stays mathematically correct (zero) and the dispatch pointer stays in-bounds, so the forward pass degrades gracefully on the rare degenerate softmax input rather than crashing the daemon.

**Cost:** per-thread one two-sided range check on the `K_TOP=8` write threads — speed-gate neutral.

## Verification

- Coherence battery (6/6 small models, no hard errors) on gfx1100.
- 122B-A10B mq4 + asym3 KV on hipx (gfx1151) end-to-end: previously aperture-violated on first MoE dispatch; now decodes coherently and self-EOSes (verified earlier this session, locked baseline behavior preserved).
- `hipcc --offload-arch=gfx1100 --genco` builds both kernels clean.

## Out of scope (follow-up PRs)

- `scripts/install.sh` / `scripts/install.ps1` and ~12 other scripts still reference `-p engine` (post-0.1.20-modular-split miss). The curl-pipe install path on master is currently broken for fresh checkouts. Separate small chore PR.
- `niah_8k_pflash30` flagged +73.7 % drift in `scripts/pflash-gate.sh` against `gfx1100-2026-05-02.json`. The clamp only runs on the MoE softmax write-out, not on the dense 27B pflash NIAH path the gate exercises — orthogonal regression to investigate (likely DPM/cache state or genuine post-modular drift on the smallest test).

## Test plan

- [ ] CI green
- [x] coherence-gate.sh passes (6/6 hard error free)
- [x] hipx 122B-A10B no longer aperture-faults on first MoE dispatch
- [ ] (post-merge) attribute the niah_8k_pflash30 drift in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)