### PR TITLE
fix(scripts): post-modular -p engine → -p hipfire-runtime sweep

### DIFF
--- a/scripts/bench-cold.sh
+++ b/scripts/bench-cold.sh
@@ -82,7 +82,7 @@ if [ -z "$MODEL" ] || [ ! -f "$MODEL" ]; then
 fi
 if [ ! -x "$EXE" ]; then
     echo "ERR: bench binary missing — build with:" >&2
-    echo "  cargo build --release --features deltanet -p engine --example bench_qwen35_mq4" >&2
+    echo "  cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4" >&2
     exit 2
 fi
 

--- a/scripts/bisect_9b_decode.sh
+++ b/scripts/bisect_9b_decode.sh
@@ -19,7 +19,7 @@ echo "=== bisect at $commit ==="
 # Incremental build. Also remove the old binary so a silent build-skip
 # can't hand us a stale target/release/examples/bench_qwen35_mq4.
 rm -f target/release/examples/bench_qwen35_mq4
-build_log=$(cargo build --release --features deltanet -p engine --example bench_qwen35_mq4 2>&1)
+build_log=$(cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4 2>&1)
 build_rc=$?
 echo "$build_log" | tail -3
 if [ $build_rc -ne 0 ] || [ ! -x target/release/examples/bench_qwen35_mq4 ]; then

--- a/scripts/coherence-gate-dflash.sh
+++ b/scripts/coherence-gate-dflash.sh
@@ -61,9 +61,9 @@ rebuild=0
 if [ ! -x "$EXE" ]; then
     rebuild=1
 else
-    for src in crates/engine/src/qwen35.rs crates/engine/src/llama.rs \
-               crates/engine/src/dflash.rs crates/engine/src/speculative.rs \
-               crates/engine/src/ddtree.rs crates/engine/examples/dflash_spec_demo.rs \
+    for src in crates/hipfire-arch-qwen35/src/qwen35.rs crates/hipfire-runtime/src/llama.rs \
+               crates/hipfire-runtime/src/dflash.rs crates/hipfire-arch-qwen35/src/speculative.rs \
+               crates/hipfire-runtime/src/ddtree.rs crates/hipfire-runtime/examples/dflash_spec_demo.rs \
                crates/rdna-compute/src/dispatch.rs; do
         if [ -f "$src" ] && [ "$src" -nt "$EXE" ]; then
             rebuild=1

--- a/scripts/coherence-gate.sh
+++ b/scripts/coherence-gate.sh
@@ -46,8 +46,8 @@ rebuild=0
 if [ ! -x "$EXE" ]; then
     rebuild=1
 else
-    for src in crates/engine/src/qwen35.rs crates/engine/src/llama.rs \
-               crates/engine/src/hfq.rs crates/engine/examples/daemon.rs \
+    for src in crates/hipfire-arch-qwen35/src/qwen35.rs crates/hipfire-runtime/src/llama.rs \
+               crates/hipfire-runtime/src/hfq.rs crates/hipfire-runtime/examples/daemon.rs \
                crates/rdna-compute/src/dispatch.rs; do
         if [ -f "$src" ] && [ "$src" -nt "$EXE" ]; then
             rebuild=1

--- a/scripts/gfx906_fallback_canary.sh
+++ b/scripts/gfx906_fallback_canary.sh
@@ -31,7 +31,7 @@ if [ ! -f "$MODEL" ]; then
 fi
 
 # Build once — both runs share the binary.
-cargo build --release --features deltanet -p engine --example bench_qwen35_mq4 \
+cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4 \
     >/tmp/gfx906_canary_build.log 2>&1 || {
     echo "BUILD FAILED — see /tmp/gfx906_canary_build.log" >&2
     exit 1

--- a/scripts/gfx906_logit_divergence.sh
+++ b/scripts/gfx906_logit_divergence.sh
@@ -34,7 +34,7 @@ if [ ! -f "$MODEL" ]; then
 fi
 
 # Build once.
-cargo build --release --features deltanet -p engine --example dump_logits_qwen35 \
+cargo build --release --features deltanet -p hipfire-runtime --example dump_logits_qwen35 \
     >/tmp/divergence_build.log 2>&1 || {
     echo "BUILD FAILED — see /tmp/divergence_build.log" >&2
     exit 1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -360,7 +360,7 @@ if ($PreBuilt -and $PreBuilt -ne "$BinDir\daemon.exe") {
     Write-Host "  cargo build --release (this may take several minutes)..."
     Push-Location $RepoDir
     try {
-        cargo build --release --features deltanet --example daemon --example infer --example infer_hfq -p engine
+        cargo build --release --features deltanet --example daemon --example infer --example infer_hfq -p hipfire-runtime
     } finally {
         Pop-Location
     }
@@ -375,7 +375,7 @@ if ($PreBuilt -and $PreBuilt -ne "$BinDir\daemon.exe") {
         Write-Host ""
         Write-Host "  After fixing, re-run this installer or build manually:"
         Write-Host "    cd $RepoDir"
-        Write-Host "    cargo build --release --features deltanet --example daemon -p engine"
+        Write-Host "    cargo build --release --features deltanet --example daemon -p hipfire-runtime"
         exit 1
     }
     Copy-Item $BuiltExe "$BinDir\daemon.exe" -Force

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -370,7 +370,7 @@ else
     fi
     (cd "$REPO_DIR" && \
         echo "  cargo build --release (this may take several minutes)..." && \
-        cargo build --release --features deltanet --example daemon --example infer --example infer_hfq -p engine 2>&1 | tail -5)
+        cargo build --release --features deltanet --example daemon --example infer --example infer_hfq -p hipfire-runtime 2>&1 | tail -5)
     if [ ! -f "$REPO_DIR/target/release/examples/daemon" ]; then
         echo ""
         echo "  BUILD FAILED."
@@ -379,7 +379,7 @@ else
         echo "    - Missing system libs (check error above)"
         echo ""
         echo "  After fixing, re-run this installer or build manually:"
-        echo "    cd $REPO_DIR && cargo build --release --features deltanet --example daemon -p engine"
+        echo "    cd $REPO_DIR && cargo build --release --features deltanet --example daemon -p hipfire-runtime"
         exit 1
     fi
     echo "  Build complete ✓"

--- a/scripts/logit_dump.sh
+++ b/scripts/logit_dump.sh
@@ -22,10 +22,10 @@ echo "Model: $MODEL"
 echo "Output: $OUTDIR/"
 
 # Build the diagnostic example if needed
-cargo build --release -p engine --features deltanet --example logit_dump 2>&1 | tail -1
+cargo build --release -p hipfire-runtime --features deltanet --example logit_dump 2>&1 | tail -1
 
 # Run it
-cargo run --release -p engine --features deltanet --example logit_dump -- \
+cargo run --release -p hipfire-runtime --features deltanet --example logit_dump -- \
     "$MODEL" "$OUTDIR" 2>"$OUTDIR/stderr.log"
 
 echo "Done. Files in $OUTDIR/"

--- a/scripts/mq3-mq2-sweep.sh
+++ b/scripts/mq3-mq2-sweep.sh
@@ -34,7 +34,7 @@ PROMPTS_DIR="${HIPFIRE_SWEEP_PROMPTS_DIR:-./benchmarks/prompts/sweep}"
 LOCK_SCRIPT="./scripts/gpu-lock.sh"
 
 if [ ! -x "$EXE" ]; then
-    echo "$EXE missing — run: cargo build --release --features deltanet --example daemon -p engine" >&2
+    echo "$EXE missing — run: cargo build --release --features deltanet --example daemon -p hipfire-runtime" >&2
     exit 2
 fi
 

--- a/scripts/path-c-smoke.sh
+++ b/scripts/path-c-smoke.sh
@@ -70,9 +70,9 @@ rebuild=0
 if [ ! -x "$EXE" ]; then
     rebuild=1
 else
-    for src in crates/engine/src/qwen35.rs crates/engine/src/llama.rs \
-               crates/engine/src/dflash.rs crates/engine/src/speculative.rs \
-               crates/engine/src/ddtree.rs crates/engine/examples/dflash_spec_demo.rs \
+    for src in crates/hipfire-arch-qwen35/src/qwen35.rs crates/hipfire-runtime/src/llama.rs \
+               crates/hipfire-runtime/src/dflash.rs crates/hipfire-arch-qwen35/src/speculative.rs \
+               crates/hipfire-runtime/src/ddtree.rs crates/hipfire-runtime/examples/dflash_spec_demo.rs \
                crates/rdna-compute/src/dispatch.rs; do
         if [ -f "$src" ] && [ "$src" -nt "$EXE" ]; then
             rebuild=1

--- a/scripts/pflash-gate.sh
+++ b/scripts/pflash-gate.sh
@@ -75,12 +75,12 @@ if [ ! -x "$EXE" ]; then
     rebuild=1
 else
     for src in \
-        crates/engine/src/pflash.rs \
-        crates/engine/src/qwen35.rs \
-        crates/engine/src/llama.rs \
-        crates/engine/src/hfq.rs \
-        crates/engine/src/tokenizer.rs \
-        crates/engine/examples/pflash_niah_bench.rs \
+        crates/hipfire-arch-qwen35/src/pflash.rs \
+        crates/hipfire-arch-qwen35/src/qwen35.rs \
+        crates/hipfire-runtime/src/llama.rs \
+        crates/hipfire-runtime/src/hfq.rs \
+        crates/hipfire-runtime/src/tokenizer.rs \
+        crates/hipfire-runtime/examples/pflash_niah_bench.rs \
         crates/rdna-compute/src/lib.rs \
         crates/rdna-compute/src/kernels.rs \
         crates/rdna-compute/src/dispatch.rs \
@@ -100,7 +100,7 @@ else
 fi
 if [ "$rebuild" -eq 1 ]; then
     echo "pflash-gate: rebuilding pflash_niah_bench (binary missing or stale)..."
-    if ! cargo build --release --features deltanet --example pflash_niah_bench -p engine >&2; then
+    if ! cargo build --release --features deltanet --example pflash_niah_bench -p hipfire-runtime >&2; then
         echo "pflash-gate: build failed" >&2
         exit 2
     fi

--- a/scripts/pflash-niah-bench.sh
+++ b/scripts/pflash-niah-bench.sh
@@ -83,7 +83,7 @@ if [ -z "$FIXTURE" ] || [ ! -f "$FIXTURE" ]; then
 fi
 if [ ! -x "$EXE" ]; then
     echo "ERR: bench binary missing -- build with:" >&2
-    echo "  cargo build --release --features deltanet -p engine --example pflash_niah_bench" >&2
+    echo "  cargo build --release --features deltanet -p hipfire-runtime --example pflash_niah_bench" >&2
     exit 2
 fi
 

--- a/scripts/probe_commits.sh
+++ b/scripts/probe_commits.sh
@@ -21,7 +21,7 @@ for h in "${COMMITS[@]}"; do
         continue
     fi
     rm -f target/release/examples/bench_qwen35_mq4
-    if ! cargo build --release --features deltanet -p engine --example bench_qwen35_mq4 >/tmp/probe_build.log 2>&1; then
+    if ! cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4 >/tmp/probe_build.log 2>&1; then
         echo "BUILD_FAIL  $msg"
         continue
     fi

--- a/scripts/speed-gate.sh
+++ b/scripts/speed-gate.sh
@@ -122,7 +122,7 @@ fi
 ensure_build() {
     if [ ! -x "$EXE" ]; then
         echo "Building bench_qwen35_mq4 (release)..."
-        cargo build --release -p engine --example bench_qwen35_mq4 --features deltanet 2>&1 \
+        cargo build --release -p hipfire-runtime --example bench_qwen35_mq4 --features deltanet 2>&1 \
             | grep -E '^(error|   Compiling)' | tail -5
         if [ ! -x "$EXE" ]; then
             color red "BUILD FAILED"; echo

--- a/scripts/test-kernels.sh
+++ b/scripts/test-kernels.sh
@@ -16,7 +16,7 @@ echo "=== hipfire kernel test harness (${ARCH}) ==="
 
 # Build the test binary
 BUILD_LOG=$(mktemp)
-if cargo build --release --features deltanet --example test_kernels -p engine >"$BUILD_LOG" 2>&1; then
+if cargo build --release --features deltanet --example test_kernels -p hipfire-runtime >"$BUILD_LOG" 2>&1; then
     tail -2 "$BUILD_LOG"
 else
     tail -40 "$BUILD_LOG"

--- a/scripts/test-kernelsQA.sh
+++ b/scripts/test-kernelsQA.sh
@@ -35,7 +35,7 @@ if [[ -n "$ARCH_EXPECTED" ]]; then
 fi
 
 set +e
-timeout "$BUILD_TIMEOUT" cargo build --release --features "$FEATURES" --example "$EXAMPLE" -p engine
+timeout "$BUILD_TIMEOUT" cargo build --release --features "$FEATURES" --example "$EXAMPLE" -p hipfire-runtime
 BUILD_RC=$?
 set -e
 if [[ $BUILD_RC -ne 0 ]]; then


### PR DESCRIPTION
## Summary

The 0.1.20 modular split renamed the `engine` crate to `hipfire-runtime` and split sources into per-arch crates, but ~17 scripts still referenced the old paths. Any cargo invocation with `-p engine` fails with `cannot specify features for packages outside of workspace`, breaking the README curl-pipe install on fresh checkouts plus most gates / benches / bisects.

This PR follows up #156 (which fixed `pflash-gate.sh` only) and closes the broader sweep.

## Scope (17 scripts)

**`-p engine` → `-p hipfire-runtime`** (15): `bench-cold.sh`, `bisect_9b_decode.sh`, `gfx906_fallback_canary.sh`, `gfx906_logit_divergence.sh`, `install.sh`, `install.ps1`, `logit_dump.sh`, `mq3-mq2-sweep.sh`, `pflash-niah-bench.sh`, `probe_commits.sh`, `speed-gate.sh`, `test-kernels.sh`, `test-kernelsQA.sh` — plus the source-path-list scripts below.

**Source-path lists in stale-rebuild blocks** updated for `coherence-gate.sh`, `coherence-gate-dflash.sh`, `path-c-smoke.sh`, `pflash-gate.sh`:
- `crates/engine/src/qwen35.rs` → `crates/hipfire-arch-qwen35/src/qwen35.rs`
- `crates/engine/src/speculative.rs` → `crates/hipfire-arch-qwen35/src/speculative.rs`
- `crates/engine/src/pflash.rs` → `crates/hipfire-arch-qwen35/src/pflash.rs`
- `crates/engine/src/{llama,hfq,dflash,ddtree,tokenizer}.rs` → `crates/hipfire-runtime/src/...`
- `crates/engine/examples/{daemon,dflash_spec_demo,pflash_niah_bench}.rs` → `crates/hipfire-runtime/examples/...`

`scripts/rebase-onto-modular.sh` intentionally retains `crates/engine/` references — it's the migration helper that maps old paths to new for off-master branches.

Closes #70.

## Test plan

- [x] `grep -rn "\-p engine\|crates/engine/" scripts/ .githooks/ | grep -v rebase-onto-modular.sh` returns nothing
- [x] `cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4 --example dump_logits_qwen35 --example logit_dump --example test_kernels --example daemon --example infer --example infer_hfq --example dflash_spec_demo` succeeds
- [x] `./scripts/coherence-gate.sh` passes (no hard errors; 6/6 fixtures across 0.8b/4b/9b/27b)
- [x] `./scripts/pflash-gate.sh` passes 12/12 against `gfx1100-2026-05-02.json` baseline (drift -0.3% to -3.9%)
- [ ] (recommended on a fresh box) `curl -fsSL https://raw.githubusercontent.com/.../scripts/install.sh | bash` succeeds without the `-p engine` build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)