### PR TITLE
fix(install.ps1): honor CARGO_TARGET_DIR — Windows parity for #159

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -269,13 +269,28 @@ $RepoDir = $SrcDir
 Write-Host ""
 Write-Host "Installing hipfire binaries..." -ForegroundColor Cyan
 
+# Resolve cargo's actual target directory. Honors CARGO_TARGET_DIR and any
+# workspace target overrides — without this, users with a shared target
+# directory (common when juggling several Rust projects) would see install
+# fail because the binaries we expect at $RepoDir\target\... actually live
+# elsewhere. Falls back to the conventional location when cargo is not yet
+# installed, since pre-built binaries can only sit at the default path in
+# that case.
+$TargetDir = "$RepoDir\target"
+if (Get-Command cargo -ErrorAction SilentlyContinue) {
+    try {
+        $Meta = cargo metadata --format-version 1 --manifest-path "$RepoDir\Cargo.toml" 2>$null | ConvertFrom-Json
+        if ($Meta.target_directory) { $TargetDir = $Meta.target_directory }
+    } catch {}
+}
+
 # Source preference order — the prior install's $BinDir\daemon.exe is NOT
 # a source. Including it would re-use stale binaries forever. The repo-side
 # paths (only meaningful when running install.ps1 from a checkout) are
 # treated as developer-authoritative and used if present; everyone else
 # always pulls the latest release asset.
 $PreBuilt = @(
-    "$RepoDir\target\release\examples\daemon.exe",
+    "$TargetDir\release\examples\daemon.exe",
     "$RepoDir\bin\daemon.exe"
 ) | Where-Object { Test-Path $_ } | Select-Object -First 1
 
@@ -365,7 +380,15 @@ if ($PreBuilt -and $PreBuilt -ne "$BinDir\daemon.exe") {
         Pop-Location
     }
 
-    $BuiltExe = "$RepoDir\target\release\examples\daemon.exe"
+    # Re-resolve TargetDir now that cargo is guaranteed available — covers the
+    # case where rustup was just installed above and the initial probe fell
+    # back to the default path.
+    try {
+        $Meta = cargo metadata --format-version 1 --manifest-path "$RepoDir\Cargo.toml" 2>$null | ConvertFrom-Json
+        if ($Meta.target_directory) { $TargetDir = $Meta.target_directory }
+    } catch {}
+
+    $BuiltExe = "$TargetDir\release\examples\daemon.exe"
     if (-not (Test-Path $BuiltExe)) {
         Write-Host ""
         Write-Host "  BUILD FAILED." -ForegroundColor Red
@@ -384,7 +407,7 @@ if ($PreBuilt -and $PreBuilt -ne "$BinDir\daemon.exe") {
 
 # Copy optional helper binaries if present
 foreach ($exe in @("infer.exe", "infer_hfq.exe")) {
-    $src = "$RepoDir\target\release\examples\$exe"
+    $src = "$TargetDir\release\examples\$exe"
     if (Test-Path $src) { Copy-Item $src "$BinDir\$exe" -Force }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #159 (merged at f5ee068, generalized `scripts/install.sh` to detect cargo's actual target directory via `cargo metadata`). `install.ps1` had the same three hardcoded `\$RepoDir\target\release\...` references and the same failure mode on Windows when the user has `CARGO_TARGET_DIR` set or a workspace `target` override.

This PR mirrors Janno's bash approach with PowerShell idioms.

## Changes

- Probe `\$TargetDir` up front via `cargo metadata --format-version 1 --manifest-path \$RepoDir\Cargo.toml | ConvertFrom-Json`, taking `target_directory`.
- Default to `\$RepoDir\target` when cargo is not yet installed (the pre-built fallback can only sit at the conventional location in that case — kept lazy on purpose so we don't force a rustup install for users who already have a `daemon.exe` from a release asset).
- Re-probe inside the build-from-source branch after rustup just installed cargo, so the post-build verification and copy honor any `CARGO_TARGET_DIR` set in the user's profile.

All three usage sites switched from `\$RepoDir\target\release\examples\...` to `\$TargetDir\release\examples\...`:
- `\$PreBuilt` source-preference list
- `\$BuiltExe` post-build verification
- optional helper-binary (`infer.exe`, `infer_hfq.exe`) copy

## Test plan

- [x] `grep -n 'RepoDir\\\\target' scripts/install.ps1` → no matches
- [x] All three call sites use `\$TargetDir`
- [x] `cargo metadata --format-version 1` JSON shape verified (top-level `target_directory` string key); `ConvertFrom-Json` will hydrate `\$Meta.target_directory` directly
- [ ] (recommended on a Windows box) `powershell -File scripts/install.ps1` succeeds with `\$env:CARGO_TARGET_DIR` set to a non-default path

🤖 Generated with [Claude Code](https://claude.com/claude-code)