### PR TITLE
fix(qwen35-moe): split moe_softmax_topk_renorm into softmax + topk_renorm

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1465,10 +1465,17 @@ fn moe_ffn_decode_impl(
 
     // ── 2a. Top-K selection — GPU fast path or CPU fallback ──
     let (topk_indices_cpu, topk_weights_cpu): (Option<Vec<usize>>, Option<Vec<f32>>) = if use_gpu_topk {
-        // GPU path: softmax + top-K + renorm in one launch, results land
-        // in s.topk_indices [k] (i32) and s.topk_weights [k] (f32) on
-        // device. Indexed MoE kernels consume them directly — no D2H.
-        gpu.moe_softmax_topk_renorm_k8(
+        // GPU path: split softmax + top-K + renorm into two kernels so
+        // the routing path uses identical softmax math to gpu.softmax_f32
+        // (and thus to a CPU reference). The fused
+        // moe_softmax_topk_renorm_k8 variant produced topk_weights that
+        // differed from gpu.softmax_f32 + manual `*w /= sum` by exactly
+        // 1 ULP per element, which compounds across 30+ MoE layers and
+        // 8 experts/layer into a structural attractor on Qwen3.5-A3B
+        // and 122B-A10B at MQ4. The new moe_topk_renorm_k8 takes
+        // pre-softmaxed probs and uses direct division for renorm.
+        gpu.softmax_f32(router_logits)?;
+        gpu.moe_topk_renorm_k8(
             router_logits, s.topk_indices, s.topk_weights,
             n_exp, config.norm_topk_prob,
         )?;
@@ -3259,7 +3266,19 @@ fn prefill_moe_ffn_body_batched(
     )?;
 
     // ── 3. GPU softmax + top-K + renorm, batched over N tokens ──
-    gpu.moe_softmax_topk_renorm_k8_batched(
+    //
+    // Same Path B split as the decode call site: split the fused
+    // softmax+topk+renorm into gpu.softmax_f32 + moe_topk_renorm_k8_batched
+    // so prefill activations match the CPU-reference softmax math
+    // exactly. router_logits is allocated 1D as [n × n_exp]; alias it
+    // into a 2D view so gpu.softmax_f32 takes rows = n.
+    let router_logits_2d = GpuTensor {
+        buf: unsafe { router_logits.buf.alias() },
+        shape: vec![n, n_exp],
+        dtype: DType::F32,
+    };
+    gpu.softmax_f32(&router_logits_2d)?;
+    gpu.moe_topk_renorm_k8_batched(
         router_logits, topk_indices, topk_weights,
         n_exp, config.norm_topk_prob, n,
     )?;

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -5328,6 +5328,52 @@ impl Gpu {
         result
     }
 
+    /// MoE top-K + renorm given pre-softmaxed probs. Companion to the
+    /// regular `softmax_f32`. The dispatch site runs `softmax_f32` first,
+    /// then this kernel — same softmax math everywhere, no 1-ULP
+    /// divergence between the routing path and a CPU reference.
+    pub fn moe_topk_renorm_k8(
+        &mut self,
+        probs: &GpuTensor,        // [n_exp] f32, pre-softmaxed
+        topk_idx: &GpuTensor,     // i32 [k_top]
+        topk_w:   &GpuTensor,     // f32 [k_top]
+        n_exp: usize,
+        norm_topk: bool,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "moe_topk_renorm_k8",
+            kernels::MOE_TOPK_RENORM_K8_SRC,
+            "moe_topk_renorm_k8",
+        )?;
+        let lp = probs.buf.as_ptr();
+        let ip = topk_idx.buf.as_ptr();
+        let wp = topk_w.buf.as_ptr();
+        let n  = n_exp as i32;
+        let nr = if norm_topk { 1i32 } else { 0i32 };
+        let mut params: Vec<*mut c_void> = vec![
+            &lp as *const _ as *mut c_void,
+            &ip as *const _ as *mut c_void,
+            &wp as *const _ as *mut c_void,
+            &n  as *const _ as *mut c_void,
+            &nr as *const _ as *mut c_void,
+        ];
+        let bytes = n_exp * 4 + 8 * 8;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "elementwise", "moe_topk_renorm_k8", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "moe_topk_renorm_k8", [1, 1, 1], [256, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(lp); b.push_ptr(ip); b.push_ptr(wp);
+                b.push_i32(n); b.push_i32(nr);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// Index-aware MoE gate_up GEMV. Reads expert_ids from a device-side
     /// topk_indices buffer and weight bases from expert_ptrs[expert_id].
     /// hipGraph-capture-safe replacement for the kernarg-pointer variant.
@@ -5491,6 +5537,55 @@ impl Gpu {
         );
         let result = self.launch_maybe_blob(
             "moe_softmax_topk_renorm_k8_batched",
+            [batch_size as u32, 1, 1], [256, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(lp); b.push_ptr(ip); b.push_ptr(wp);
+                b.push_i32(n); b.push_i32(nr);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// Batched companion of `moe_topk_renorm_k8` for the prefill path.
+    /// Takes pre-softmaxed probs of shape `[batch_size × n_exp]` and writes
+    /// `[batch_size × K_TOP]` indices and weights. Caller must run a batched
+    /// softmax (`gpu.softmax_f32` on a [batch_size × n_exp] tensor) before
+    /// calling this kernel.
+    pub fn moe_topk_renorm_k8_batched(
+        &mut self,
+        probs: &GpuTensor,
+        topk_idx: &GpuTensor,
+        topk_w:   &GpuTensor,
+        n_exp: usize,
+        norm_topk: bool,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "moe_topk_renorm_k8_batched",
+            kernels::MOE_TOPK_RENORM_K8_BATCHED_SRC,
+            "moe_topk_renorm_k8_batched",
+        )?;
+        let lp = probs.buf.as_ptr();
+        let ip = topk_idx.buf.as_ptr();
+        let wp = topk_w.buf.as_ptr();
+        let n  = n_exp as i32;
+        let nr = if norm_topk { 1i32 } else { 0i32 };
+        let mut params: Vec<*mut c_void> = vec![
+            &lp as *const _ as *mut c_void,
+            &ip as *const _ as *mut c_void,
+            &wp as *const _ as *mut c_void,
+            &n  as *const _ as *mut c_void,
+            &nr as *const _ as *mut c_void,
+        ];
+        let bytes = (n_exp * 4 + 8 * 8) * batch_size;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "elementwise", "moe_topk_renorm_k8_batched", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "moe_topk_renorm_k8_batched",
             [batch_size as u32, 1, 1], [256, 1, 1], 0, &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
@@ -8739,32 +8834,38 @@ impl Gpu {
     /// In-place softmax over last dimension
     pub fn softmax_f32(&mut self, x: &GpuTensor) -> HipResult<()> {
         self.ensure_kernel("softmax", kernels::SOFTMAX_SRC, "softmax_f32")?;
-        let func = &self.functions["softmax_f32"];
 
         let rows = if x.shape.len() > 1 { x.shape[0] } else { 1 };
         let n = x.shape.last().copied().unwrap() as i32;
 
-        let mut x_ptr = x.buf.as_ptr();
-        let mut n_val = n;
+        let x_ptr = x.buf.as_ptr();
+        let n_val = n;
 
         let mut params: Vec<*mut c_void> = vec![
-            &mut x_ptr as *mut _ as *mut c_void,
-            &mut n_val as *mut _ as *mut c_void,
+            &x_ptr as *const _ as *mut c_void,
+            &n_val as *const _ as *mut c_void,
         ];
 
         let block = 256u32.min(n as u32);
         let shared_mem = block * 4;
 
-        unsafe {
-            self.hip.launch_kernel(
-                func,
-                [rows as u32, 1, 1],
-                [block, 1, 1],
-                shared_mem,
-                self.stream_ref(),
-                &mut params,
-            )
-        }
+        // Graph-safe launch via launch_maybe_blob. Path B inserts this
+        // call into the MoE forward path which gets captured under the
+        // verify/HIPFIRE_GRAPH path; raw self.hip.launch_kernel would
+        // capture stack-borne kernarg pointers that go dangling on replay.
+        self.launch_maybe_blob(
+            "softmax_f32",
+            [rows as u32, 1, 1],
+            [block, 1, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(x_ptr);
+                b.push_i32(n_val);
+                b
+            },
+        )
     }
 
     /// GPU-side RoPE (rotary positional embedding) applied in-place to Q and K.

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -121,6 +121,21 @@ pub const GEMV_HFQ4G256_MOE_DOWN_SRC: &str = include_str!("../../../kernels/src/
 /// to need — required for hipGraph capture of MoE decode.
 pub const MOE_SOFTMAX_TOPK_K8_SRC: &str = include_str!("../../../kernels/src/moe_softmax_topk_k8.hip");
 
+/// MoE top-K + renorm only, given pre-softmaxed probs. Companion to
+/// the regular softmax_f32 kernel; the dispatch site runs softmax_f32
+/// first, then this kernel for top-K + renorm. Avoids the 1-ULP
+/// precision divergence that the fused softmax+topk variant exhibits
+/// on MQ4 MoE: in-kernel softmax order + mul-by-reciprocal renorm
+/// produced weights that differed from gpu.softmax_f32 + manual
+/// division by 1 LSB per element, which compounds to a structural
+/// attractor on Qwen3.5-A3B / 122B-A10B.
+pub const MOE_TOPK_RENORM_K8_SRC: &str = include_str!("../../../kernels/src/moe_topk_renorm_k8.hip");
+
+/// Batched companion of MOE_TOPK_RENORM_K8_SRC for the prefill path.
+/// Same per-block algorithm; one workgroup per token row.
+pub const MOE_TOPK_RENORM_K8_BATCHED_SRC: &str =
+    include_str!("../../../kernels/src/moe_topk_renorm_k8_batched.hip");
+
 /// Index-aware MoE gate_up GEMV — reads expert IDs from a device-side
 /// topk_indices buffer and the per-expert weight base from an
 /// expert-pointers table. hipGraph-capture-safe replacement for the

--- a/kernels/src/moe_topk_renorm_k8.hip
+++ b/kernels/src/moe_topk_renorm_k8.hip
@@ -1,0 +1,105 @@
+#include <hip/hip_runtime.h>
+
+// MoE router top-8 + (optional) renormalize, given PRE-SOFTMAXED probs.
+// Companion to gpu.softmax_f32(router_logits); the dispatch site runs that
+// regular softmax kernel first, then this kernel for top-K + renorm. This
+// matches the CPU fallback path's softmax math exactly and avoids the
+// 1-ULP precision divergence seen when softmax + topk + renorm were all
+// fused into one kernel.
+//
+// Reads [n_exp] PROBS in [0, 1] summing to 1, writes [8] i32 indices and
+// [8] f32 weights to device buffers. One workgroup, 256 threads. Supports
+// n_exp up to 1024. For n_exp=256 (A3B/A10B) the loops degenerate to one
+// slot per thread.
+
+#define BLOCK_SIZE 256
+#define MAX_NEXP   1024
+#define K_TOP      8
+
+extern "C" __launch_bounds__(BLOCK_SIZE, 2)
+__global__ void moe_topk_renorm_k8(
+    const float* __restrict__ probs_in,    // [n_exp] pre-softmaxed
+    int*         __restrict__ topk_idx,    // [8]
+    float*       __restrict__ topk_w,      // [8]
+    int n_exp,
+    int norm_topk
+) {
+    __shared__ float smem_v[MAX_NEXP];
+    __shared__ int   smem_i[MAX_NEXP];
+    __shared__ float reduce_v[BLOCK_SIZE];
+    __shared__ int   reduce_i[BLOCK_SIZE];
+    __shared__ int   picked_idx[K_TOP];
+    __shared__ float picked_w[K_TOP];
+
+    const int tid = threadIdx.x;
+
+    for (int i = tid; i < MAX_NEXP; i += BLOCK_SIZE) {
+        smem_v[i] = (i < n_exp) ? probs_in[i] : -INFINITY;
+        smem_i[i] = i;
+    }
+    __syncthreads();
+
+    for (int k = 0; k < K_TOP; k++) {
+        float best_v = -INFINITY;
+        int   best_i = -1;
+        for (int i = tid; i < n_exp; i += BLOCK_SIZE) {
+            float v = smem_v[i];
+            if (v > best_v) { best_v = v; best_i = smem_i[i]; }
+        }
+        reduce_v[tid] = best_v;
+        reduce_i[tid] = best_i;
+        __syncthreads();
+
+        for (int s = BLOCK_SIZE >> 1; s > 0; s >>= 1) {
+            if (tid < s) {
+                float va = reduce_v[tid];
+                float vb = reduce_v[tid + s];
+                if (vb > va) {
+                    reduce_v[tid] = vb;
+                    reduce_i[tid] = reduce_i[tid + s];
+                }
+            }
+            __syncthreads();
+        }
+        const int   winner = reduce_i[0];
+        const float winner_w = reduce_v[0];
+        if (tid == 0) {
+            picked_idx[k] = winner;
+            picked_w[k]   = winner_w;
+        }
+        if (winner >= 0 && winner < n_exp) {
+            if ((winner & (BLOCK_SIZE - 1)) == tid) {
+                smem_v[winner] = -INFINITY;
+            }
+        }
+        __syncthreads();
+    }
+
+    // Renormalize using direct division (matches CPU fallback path
+    // *w /= sum exactly; mul-by-reciprocal would add 1 ULP error per
+    // element which the hyper-quantized MoE layer stack amplifies into
+    // a structural attractor).
+    if (tid == 0) {
+        float s = 0.0f;
+        for (int k = 0; k < K_TOP; k++) s += picked_w[k];
+        if (norm_topk && s > 0.0f) {
+            for (int k = 0; k < K_TOP; k++) picked_w[k] /= s;
+        }
+    }
+    __syncthreads();
+
+    // Write output. Clamp invalid winner (NaN/OOB from corrupted probs)
+    // to expert 0 with weight 0 — same defense as moe_softmax_topk_k8
+    // (closes #152). With pre-softmaxed probs this should never fire,
+    // but keep the safety net.
+    if (tid < K_TOP) {
+        int   safe_idx = picked_idx[tid];
+        float safe_w   = picked_w[tid];
+        if (safe_idx < 0 || safe_idx >= n_exp) {
+            safe_idx = 0;
+            safe_w   = 0.0f;
+        }
+        topk_idx[tid] = safe_idx;
+        topk_w[tid]   = safe_w;
+    }
+}

--- a/kernels/src/moe_topk_renorm_k8_batched.hip
+++ b/kernels/src/moe_topk_renorm_k8_batched.hip
@@ -1,0 +1,99 @@
+#include <hip/hip_runtime.h>
+
+// Batched MoE top-K + renorm given pre-softmaxed probs. Companion to
+// moe_topk_renorm_k8 for the prefill path.
+//
+// One workgroup per token. blockIdx.x selects the token row in
+// [N × n_exp] probs. Same algorithm as the single-token kernel, just
+// strided by bid * n_exp / bid * K_TOP.
+
+#define BLOCK_SIZE 256
+#define MAX_NEXP   1024
+#define K_TOP      8
+
+extern "C" __launch_bounds__(BLOCK_SIZE, 2)
+__global__ void moe_topk_renorm_k8_batched(
+    const float* __restrict__ probs_in,    // [N × n_exp] pre-softmaxed
+    int*         __restrict__ topk_idx,    // [N × 8]
+    float*       __restrict__ topk_w,      // [N × 8]
+    int n_exp,
+    int norm_topk
+) {
+    __shared__ float smem_v[MAX_NEXP];
+    __shared__ int   smem_i[MAX_NEXP];
+    __shared__ float reduce_v[BLOCK_SIZE];
+    __shared__ int   reduce_i[BLOCK_SIZE];
+    __shared__ int   picked_idx[K_TOP];
+    __shared__ float picked_w[K_TOP];
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const float* __restrict__ row_probs = probs_in + (long long)bid * n_exp;
+    int*   __restrict__ row_idx = topk_idx + bid * K_TOP;
+    float* __restrict__ row_w   = topk_w   + bid * K_TOP;
+
+    for (int i = tid; i < MAX_NEXP; i += BLOCK_SIZE) {
+        smem_v[i] = (i < n_exp) ? row_probs[i] : -INFINITY;
+        smem_i[i] = i;
+    }
+    __syncthreads();
+
+    for (int k = 0; k < K_TOP; k++) {
+        float best_v = -INFINITY;
+        int   best_i = -1;
+        for (int i = tid; i < n_exp; i += BLOCK_SIZE) {
+            float v = smem_v[i];
+            if (v > best_v) { best_v = v; best_i = smem_i[i]; }
+        }
+        reduce_v[tid] = best_v;
+        reduce_i[tid] = best_i;
+        __syncthreads();
+
+        for (int s = BLOCK_SIZE >> 1; s > 0; s >>= 1) {
+            if (tid < s) {
+                float va = reduce_v[tid];
+                float vb = reduce_v[tid + s];
+                if (vb > va) {
+                    reduce_v[tid] = vb;
+                    reduce_i[tid] = reduce_i[tid + s];
+                }
+            }
+            __syncthreads();
+        }
+        const int   winner = reduce_i[0];
+        const float winner_w = reduce_v[0];
+        if (tid == 0) {
+            picked_idx[k] = winner;
+            picked_w[k]   = winner_w;
+        }
+        if (winner >= 0 && winner < n_exp) {
+            if ((winner & (BLOCK_SIZE - 1)) == tid) {
+                smem_v[winner] = -INFINITY;
+            }
+        }
+        __syncthreads();
+    }
+
+    // Renorm via direct division (matches CPU reference; mul-by-reciprocal
+    // adds 1 ULP/element which the MoE layer stack amplifies).
+    if (tid == 0) {
+        float s = 0.0f;
+        for (int k = 0; k < K_TOP; k++) s += picked_w[k];
+        if (norm_topk && s > 0.0f) {
+            for (int k = 0; k < K_TOP; k++) picked_w[k] /= s;
+        }
+    }
+    __syncthreads();
+
+    // Defense-in-depth NaN/OOB clamp (issue #152 sibling).
+    if (tid < K_TOP) {
+        int   safe_idx = picked_idx[tid];
+        float safe_w   = picked_w[tid];
+        if (safe_idx < 0 || safe_idx >= n_exp) {
+            safe_idx = 0;
+            safe_w   = 0.0f;
+        }
+        row_idx[tid] = safe_idx;
+        row_w[tid]   = safe_w;
+    }
+}


### PR DESCRIPTION
## Summary

Split the fused `moe_softmax_topk_renorm_k8` kernel into a regular `softmax_f32` followed by a new `moe_topk_renorm_k8` (and batched companion for prefill) so the MoE routing path uses identical softmax math to a CPU reference. The fused variant produced topk_weights that diverged from `gpu.softmax_f32` + manual `*w /= sum` by exactly 1 ULP per element; on Qwen3.5-A3B and 122B-A10B at MQ4 quant the MoE forward path is hyper-sensitive to topk-weight precision and that 1-LSB difference compounds across 30+ MoE layers × 8 experts/layer into a structural attractor (meta-recursive loop on A3B; `?` artifacts + Roman block-attractor on A10B).

The 1-ULP came from two combined sources:
- in-kernel softmax tree-reduction order differs from `gpu.softmax_f32`.
- kernel renorm used `picked_w[k] *= 1.0f/s` (mul-by-reciprocal) vs CPU's `*w /= sum` (direct division).

Both fixed in the new kernels: drop the in-kernel softmax, use direct division for renorm. Also makes `softmax_f32` graph-safe (`launch_maybe_blob` + explicit `KernargBlob`) so the captured-MoE forward path doesn't capture stack-borne kernarg pointers.

## Validation

| test | sha | tokens | decode tok/s |
| --- | --- | --- | --- |
| A3B mq4 greedy 1500 tok | `b0864c650603dfc4` | 1500 | 79.9 (vs 80.9 baseline; ~1% slower) |
| A3B mq4 + HIPFIRE_GRAPH=1 | `b0864c650603dfc4` | 1500 | 79.9 (bit-identical to non-graph) |
| A10B mq4 greedy | `d4d0112e7a4045be` | 684 (partial) | 34.2 |
| A10B mq4 RP=1.05 + temp=0.3 | `a9ea76dcaee180a6` | 1500 (coherent) | 34.1 |

Pre-fix A3B: meta-recursive collapse, sha `f1444886e01968ef`.
Pre-fix A10B: 487 tokens then `?` artifacts + Roman block-attractor.

A10B greedy still has mild content looping in Section IV (the structural bug is fixed but the model's MQ4 distribution is narrow enough that greedy is risky). RP=1.05 + temp=0.3 + top_p=0.95 is the recommended A10B config.

## Test plan

- [x] coherence-gate (auto-run by pre-commit hook): passed
- [x] speed-gate gfx1100 (auto-run by pre-commit hook): passed (4B mq4 pp32 +56.9% prefill, 4B mq4 decode -0.8%, both within tolerance)
- [x] A3B 1500-token greedy on Strix Halo gfx1151: clean essay
- [x] A10B 1500-token RP=1.05 on Strix Halo gfx1151: coherent prose
- [x] HIPFIRE_GRAPH=1 capture path: bit-identical to eager
- [ ] Cross-arch validation (gfx1100 7900 XTX): not yet run; algorithmic change is arch-agnostic but worth confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)