### PR TITLE
bugfix (cli): fix missing cli chat files installation for unix 

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -428,6 +428,8 @@ if (-not (Test-Path "$RepoDir\cli\registry.json") -or -not (Test-Path "$RepoDir\
 Copy-Item "$RepoDir\cli\registry.json" "$CliDir\registry.json" -Force
 Copy-Item "$RepoDir\cli\package.json"  "$CliDir\package.json"  -Force
 Copy-Item "$RepoDir\cli\index.ts"      "$CliDir\index.ts"      -Force
+Copy-Item "$RepoDir\cli\chat.ts"       "$CliDir\chat.ts"       -Force
+Copy-Item "$RepoDir\cli\chat_pure.ts"  "$CliDir\chat_pure.ts"  -Force
 
 # Create hipfire.cmd wrapper
 $CmdWrapper = "@echo off`r`nbun run `"%USERPROFILE%\.hipfire\cli\index.ts`" %*`r`n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -407,6 +407,8 @@ fi
 cp "$REPO_DIR/cli/registry.json" "$HIPFIRE_DIR/cli/registry.json"
 cp "$REPO_DIR/cli/package.json"  "$HIPFIRE_DIR/cli/package.json"
 cp "$REPO_DIR/cli/index.ts"      "$HIPFIRE_DIR/cli/index.ts"
+cp "$REPO_DIR/cli/chat.ts"       "$HIPFIRE_DIR/cli/chat.ts"
+cp "$REPO_DIR/cli/chat_pure.ts"  "$HIPFIRE_DIR/cli/chat_pure.ts"
 
 # Create hipfire wrapper. The shim resolves `bun` even when it isn't on
 # $PATH — rustup and bun both install to under-home bindirs that shell


### PR DESCRIPTION
## Summary

Simple - quite naive - fix for `hipfire chat` for the case of using the install.sh or install.ps1 script.
Fixes https://github.com/Kaden-Schutt/hipfire/issues/163

The naive part is that this will probably break again in the future if the file list is not kept up to date. But this optionally be done in a follow-up PR. The current PR is just fix, a structural fix would also be a bit of a refactor.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [x] docs / CI / scripts

## Test plan

- [x] `cargo build --release --workspace --features deltanet` clean
- [x] `cargo test --lib --workspace --features deltanet` passes
- [x] If kernel/dispatch changed: `./scripts/coherence-gate.sh` clean
- [x] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines

## Architecture-trait change?
NO
