### PR TITLE
feat: multi-GPU pipeline-parallel (pp≥2) for Qwen3.5 — closes #58

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -50,11 +50,13 @@ CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
 # - The 4 PR1-4 modules (loop_guard, sampler, prompt_frame, eos_filter)
 #   are all hot-path; touching any of them affects every model load.
 # - `gemma4\.rs` covered for when the gemma branch forward-ports.
-HOTSPOT='\.hip$|gemv|forward|quant|rotate|dispatch|fwht|rmsnorm|fused|mq4|hfq|magnum|gemm|wmma|llama\.rs|qwen35\.rs|qwen35_vl\.rs|gemma4\.rs|sampler\.rs|loop_guard\.rs|prompt_frame\.rs|eos_filter\.rs|arch\.rs'
+# multi_gpu\.rs is listed here so that touching the PP dispatch path
+# triggers the coherence battery (same contract as single-GPU forward).
+HOTSPOT='\.hip$|gemv|forward|quant|rotate|dispatch|fwht|rmsnorm|fused|mq4|hfq|magnum|gemm|wmma|llama\.rs|qwen35\.rs|qwen35_vl\.rs|gemma4\.rs|sampler\.rs|loop_guard\.rs|prompt_frame\.rs|eos_filter\.rs|arch\.rs|multi_gpu\.rs'
 
-# Multi-GPU PP hotspots — different bucket than the single-GPU forward
-# bucket above. pp-gate.sh runs only when one of these is touched AND
-# 2+ GPUs are visible; otherwise it skips (CI / single-GPU dev box).
+# Multi-GPU PP hotspots — superset of the HOTSPOT entry above. pp-gate.sh
+# runs only when one of these is touched AND 2+ GPUs are visible; otherwise
+# it skips (CI / single-GPU dev box).
 PP_HOTSPOT='multi_gpu\.rs|peer_access|pp_|pipeline|stages|forward_prefill_batch_multi|forward_scratch_multi|Gpus|init_uniform|init_layers|boundary_copy'
 
 PP_TOUCHED=0
@@ -62,7 +64,7 @@ if echo "$CHANGED" | grep -qE "$PP_HOTSPOT"; then
     PP_TOUCHED=1
 fi
 
-if ! echo "$CHANGED" | grep -qE "$HOTSPOT" && [ "$PP_TOUCHED" -eq 0 ]; then
+if ! echo "$CHANGED" | grep -qE "$HOTSPOT"; then
     exit 0
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -72,6 +72,26 @@ else
     PFLASH_GATE_NOTE="(skipped — no pflash path in diff; force with HIPFIRE_FORCE_PFLASH_GATE=1)"
 fi
 
+# ── bind_thread invariant on dispatch.rs ────────────────────────────────
+# Multi-GPU plan (issue #58) requires every pub fn in `impl Gpu` to either
+# call `self.bind_thread()` first, or carry a `// bind_thread: skip` marker.
+# Silent mis-bind = malloc-on-wrong-device → cross-device pointer corruption.
+if echo "$CHANGED" | grep -qE 'crates/rdna-compute/src/dispatch\.rs'; then
+    if ! ./scripts/verify-bind-thread.sh; then
+        echo
+        echo "========================================================================"
+        echo "COMMIT BLOCKED: dispatch.rs has pub fn missing bind_thread()."
+        echo "========================================================================"
+        echo
+        echo 'Add `self.bind_thread()?;` (or `self.bind_thread_or_warn();` for'
+        echo 'non-HipResult fn) as the first statement, OR add a'
+        echo '`// bind_thread: skip — <reason>` comment for pure-state queries.'
+        echo
+        exit 1
+    fi
+    echo
+fi
+
 # ── Coherence battery ────────────────────────────────────────────────────
 echo "=== Coherence Battery (short) ==="
 echo "Engine code changed. Running coherence battery (~2-4 min)..."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -52,7 +52,17 @@ CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
 # - `gemma4\.rs` covered for when the gemma branch forward-ports.
 HOTSPOT='\.hip$|gemv|forward|quant|rotate|dispatch|fwht|rmsnorm|fused|mq4|hfq|magnum|gemm|wmma|llama\.rs|qwen35\.rs|qwen35_vl\.rs|gemma4\.rs|sampler\.rs|loop_guard\.rs|prompt_frame\.rs|eos_filter\.rs|arch\.rs'
 
-if ! echo "$CHANGED" | grep -qE "$HOTSPOT"; then
+# Multi-GPU PP hotspots — different bucket than the single-GPU forward
+# bucket above. pp-gate.sh runs only when one of these is touched AND
+# 2+ GPUs are visible; otherwise it skips (CI / single-GPU dev box).
+PP_HOTSPOT='multi_gpu\.rs|peer_access|pp_|pipeline|stages|forward_prefill_batch_multi|forward_scratch_multi|Gpus|init_uniform|init_layers|boundary_copy'
+
+PP_TOUCHED=0
+if echo "$CHANGED" | grep -qE "$PP_HOTSPOT"; then
+    PP_TOUCHED=1
+fi
+
+if ! echo "$CHANGED" | grep -qE "$HOTSPOT" && [ "$PP_TOUCHED" -eq 0 ]; then
     exit 0
 fi
 
@@ -171,6 +181,31 @@ if [ "${HIPFIRE_FORCE_SPEC_GATE:-0}" = "1" ] \
 fi
 
 echo
+
+# ── Multi-GPU PP gate ────────────────────────────────────────────────────
+# Skips silently when fewer than 2 GPU are visible — single-GPU CI and
+# dev boxes don't block on multi-GPU regressions. When 2+ GPU AND a
+# multi_gpu/pp_/peer_access hotspot is touched, run the parity battery.
+if [ "$PP_TOUCHED" -eq 1 ]; then
+    echo "=== Multi-GPU PP Gate ==="
+    echo "Multi-GPU code changed. Running pp-gate (skips if <2 GPU)..."
+    echo
+    if ! ./scripts/pp-gate.sh; then
+        echo
+        echo "========================================================================"
+        echo "COMMIT BLOCKED: pp-gate.sh hit a HARD failure."
+        echo "========================================================================"
+        echo
+        echo "Multi-GPU pp=2 ≢ pp=1 byte-identical, refusal contract broken,"
+        echo "or daemon panic. Investigation:"
+        echo "  ./scripts/pp-gate.sh                       # full battery"
+        echo "  ./scripts/pp-gate.sh --skip-end-to-end     # parity-only"
+        echo
+        echo "Refer to docs/multi-gpu.md for the validation contract."
+        exit 1
+    fi
+    echo
+fi
 
 # ── Speed gate ────────────────────────────────────────────────────────────
 echo "=== MQ4 Speed Gate (fast) ==="

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ and pointers at where the fat is. Cached snapshot at
 | [BENCHMARKS.md](docs/BENCHMARKS.md) | Measured perf per arch, vs ollama |
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Engine layout, dispatch, two model paths |
 | [QUANTIZATION.md](docs/QUANTIZATION.md) | MQ4 / HF4 design, asym KV cache, FWHT math |
+| [multi-gpu.md](docs/multi-gpu.md) | Pipeline-parallel (pp≥2) — memory budget, deployment, refusals |
 | [methodology/perf-benchmarking.md](docs/methodology/perf-benchmarking.md) | Bench protocol — read before claiming a perf win |
 
 ## License

--- a/crates/hip-bridge/examples/peer_smoke.rs
+++ b/crates/hip-bridge/examples/peer_smoke.rs
@@ -1,0 +1,133 @@
+//! Peer-access smoke: bidirectional enable_peer_access, hipMemcpyPeer
+//! byte-equality round-trip, pointer_get_attributes device verification.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p hip-bridge --example peer_smoke
+
+use hip_bridge::{HipRuntime, MemoryType};
+
+const SIZE: usize = 1 << 20; // 1 MiB
+
+fn main() {
+    println!("Loading HIP runtime via dlopen...");
+    let hip = HipRuntime::load().expect("failed to load HIP runtime");
+
+    let count = hip.device_count().expect("failed to get device count");
+    println!("Visible devices: {count}");
+    assert!(count >= 2, "peer_smoke requires ≥2 devices (got {count}). Set HIP_VISIBLE_DEVICES=0,1");
+
+    for id in 0..count {
+        hip.set_device(id).expect("set_device");
+        let arch = hip.get_arch(id).unwrap_or_else(|_| "unknown".to_string());
+        let cur = hip.current_device().expect("current_device");
+        let (free, total) = hip.get_vram_info().unwrap_or((0, 0));
+        println!(
+            "  dev {id}: arch={arch} current_device={cur} vram={:.1}/{:.1} GiB",
+            free as f64 / 1e9,
+            total as f64 / 1e9,
+        );
+        assert_eq!(cur, id, "current_device disagrees with set_device");
+    }
+
+    // ── Probe peer access ────────────────────────────────────────
+    println!("\nProbing peer access (0↔1):");
+    let can_0_to_1 = hip.can_access_peer(0, 1).expect("can_access_peer 0→1");
+    let can_1_to_0 = hip.can_access_peer(1, 0).expect("can_access_peer 1→0");
+    println!("  can 0→1: {can_0_to_1}");
+    println!("  can 1→0: {can_1_to_0}");
+    if !can_0_to_1 || !can_1_to_0 {
+        eprintln!("WARN: peer access not bidirectional — Stage 3 host-stage fallback path applies.");
+    }
+
+    // ── Bidirectional enable (idempotent) ────────────────────────
+    if can_0_to_1 {
+        hip.set_device(0).expect("bind dev 0");
+        hip.enable_peer_access(1).expect("enable 0→1");
+        // Second call exercises the 704→Ok translation:
+        hip.enable_peer_access(1).expect("enable 0→1 (idempotent)");
+        println!("Peer 0→1 enabled (idempotent).");
+    }
+    if can_1_to_0 {
+        hip.set_device(1).expect("bind dev 1");
+        hip.enable_peer_access(0).expect("enable 1→0");
+        hip.enable_peer_access(0).expect("enable 1→0 (idempotent)");
+        println!("Peer 1→0 enabled (idempotent).");
+    }
+
+    // ── Allocate buffers on dev 0 and dev 1 ──────────────────────
+    hip.set_device(0).expect("bind dev 0");
+    let buf0 = hip.malloc(SIZE).expect("malloc dev 0");
+    hip.set_device(1).expect("bind dev 1");
+    let buf1 = hip.malloc(SIZE).expect("malloc dev 1");
+
+    // Write pattern from host into dev_0 buffer.
+    let pattern: Vec<u8> = (0..SIZE).map(|i| ((i * 31 + 7) % 256) as u8).collect();
+    hip.set_device(0).expect("bind dev 0");
+    hip.memcpy_htod(&buf0, &pattern).expect("H2D dev 0");
+
+    // ── pointer_get_attributes verifies dev 0 buffer maps to dev 0 ──
+    let attr0 = hip.pointer_get_attributes(&buf0).expect("attr buf0");
+    println!(
+        "\nbuf0 attributes: device={} mem_type={:?} is_managed={} alloc_flags=0x{:x}",
+        attr0.device,
+        MemoryType::from_raw(attr0.mem_type),
+        attr0.is_managed,
+        attr0.allocation_flags,
+    );
+    assert_eq!(attr0.device, 0, "buf0 should live on device 0");
+    assert_eq!(
+        MemoryType::from_raw(attr0.mem_type),
+        Some(MemoryType::Device),
+        "buf0 should be Device-type memory"
+    );
+
+    let attr1 = hip.pointer_get_attributes(&buf1).expect("attr buf1");
+    assert_eq!(attr1.device, 1, "buf1 should live on device 1");
+
+    // ── memcpy_peer: dev_0 → dev_1 ───────────────────────────────
+    let t0 = std::time::Instant::now();
+    hip.memcpy_peer(&buf1, 1, &buf0, 0, SIZE).expect("memcpy_peer");
+    hip.device_synchronize().expect("device_synchronize");
+    let elapsed_us = t0.elapsed().as_micros();
+    let mb_per_s = (SIZE as f64 / 1e6) / (elapsed_us as f64 / 1e6);
+    println!(
+        "memcpy_peer 0→1: {} bytes in {} µs (~{:.1} MB/s)",
+        SIZE, elapsed_us, mb_per_s
+    );
+
+    // ── Download from dev_1 and verify byte-equality ─────────────
+    let mut readback = vec![0u8; SIZE];
+    hip.set_device(1).expect("bind dev 1");
+    hip.memcpy_dtoh(&mut readback, &buf1).expect("D2H dev 1");
+
+    if readback != pattern {
+        // Find first diff for a useful failure message
+        let first_diff = pattern
+            .iter()
+            .zip(readback.iter())
+            .position(|(a, b)| a != b);
+        panic!(
+            "data mismatch after peer copy: first diff at byte {first_diff:?} \
+             (expected={:?}, got={:?})",
+            first_diff.map(|i| pattern[i]),
+            first_diff.map(|i| readback[i]),
+        );
+    }
+    println!("memcpy_peer round-trip VERIFIED — all {SIZE} bytes match.");
+
+    // ── Async variant exercise ───────────────────────────────────
+    hip.set_device(0).expect("bind dev 0");
+    let stream0 = hip.stream_create().expect("stream create");
+    hip.memcpy_peer_async(&buf1, 1, &buf0, 0, SIZE, &stream0)
+        .expect("memcpy_peer_async");
+    hip.stream_synchronize(&stream0).expect("stream_synchronize");
+    println!("memcpy_peer_async on dev_0 stream: ok");
+    hip.stream_destroy(stream0).expect("stream_destroy");
+
+    // ── Cleanup ──────────────────────────────────────────────────
+    hip.set_device(0).expect("bind dev 0");
+    hip.free(buf0).expect("free buf0");
+    hip.set_device(1).expect("bind dev 1");
+    hip.free(buf1).expect("free buf1");
+
+    println!("\npeer_smoke: PASS");
+}

--- a/crates/hip-bridge/src/error.rs
+++ b/crates/hip-bridge/src/error.rs
@@ -9,6 +9,10 @@ pub type HipErrorCode = u32;
 /// HIP operation result.
 pub type HipResult<T> = Result<T, HipError>;
 
+pub const HIP_ERROR_PEER_ACCESS_UNSUPPORTED: HipErrorCode = 217;
+pub const HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED: HipErrorCode = 704;
+pub const HIP_ERROR_PEER_ACCESS_NOT_ENABLED: HipErrorCode = 705;
+
 #[derive(Debug)]
 pub struct HipError {
     pub code: HipErrorCode,

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -99,6 +99,31 @@ type HipGraphExec = *mut c_void;
 
 const HIP_SUCCESS: u32 = 0;
 
+/// `hipPointerAttribute_t` per ROCm 6.4.3 layout. ROCm 5.x not supported.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HipPointerAttribute {
+    pub mem_type: u32,
+    pub device: c_int,
+    pub device_pointer: *mut c_void,
+    pub host_pointer: *mut c_void,
+    pub is_managed: c_int,
+    pub allocation_flags: c_uint,
+}
+
+impl Default for HipPointerAttribute {
+    fn default() -> Self {
+        Self {
+            mem_type: 0,
+            device: -1,
+            device_pointer: ptr::null_mut(),
+            host_pointer: ptr::null_mut(),
+            is_managed: 0,
+            allocation_flags: 0,
+        }
+    }
+}
+
 /// Loaded HIP runtime — holds the dlopen'd library and resolved function pointers.
 pub struct HipRuntime {
     _lib: Library,
@@ -109,6 +134,17 @@ pub struct HipRuntime {
     // Device management
     fn_get_device_count: unsafe extern "C" fn(*mut c_int) -> u32,
     fn_set_device: unsafe extern "C" fn(c_int) -> u32,
+    fn_get_device: unsafe extern "C" fn(*mut c_int) -> u32,
+
+    // Multi-device / peer access
+    fn_device_can_access_peer: unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32,
+    fn_device_enable_peer_access: unsafe extern "C" fn(c_int, c_uint) -> u32,
+    fn_memcpy_peer:
+        unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize) -> u32,
+    fn_memcpy_peer_async:
+        unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize, HipStream) -> u32,
+    fn_pointer_get_attributes:
+        unsafe extern "C" fn(*mut HipPointerAttribute, *const c_void) -> u32,
 
     // Memory
     fn_malloc: unsafe extern "C" fn(*mut *mut c_void, usize) -> u32,
@@ -252,6 +288,17 @@ impl HipRuntime {
                 fn_runtime_get_version: load_fn!(lib, "hipRuntimeGetVersion", unsafe extern "C" fn(*mut c_int) -> u32),
                 fn_get_device_count: load_fn!(lib, "hipGetDeviceCount", unsafe extern "C" fn(*mut c_int) -> u32),
                 fn_set_device: load_fn!(lib, "hipSetDevice", unsafe extern "C" fn(c_int) -> u32),
+                fn_get_device: load_fn!(lib, "hipGetDevice", unsafe extern "C" fn(*mut c_int) -> u32),
+                fn_device_can_access_peer: load_fn!(lib, "hipDeviceCanAccessPeer",
+                    unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32),
+                fn_device_enable_peer_access: load_fn!(lib, "hipDeviceEnablePeerAccess",
+                    unsafe extern "C" fn(c_int, c_uint) -> u32),
+                fn_memcpy_peer: load_fn!(lib, "hipMemcpyPeer",
+                    unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize) -> u32),
+                fn_memcpy_peer_async: load_fn!(lib, "hipMemcpyPeerAsync",
+                    unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize, HipStream) -> u32),
+                fn_pointer_get_attributes: load_fn!(lib, "hipPointerGetAttributes",
+                    unsafe extern "C" fn(*mut HipPointerAttribute, *const c_void) -> u32),
                 fn_malloc: load_fn!(lib, "hipMalloc", unsafe extern "C" fn(*mut *mut c_void, usize) -> u32),
                 fn_free: load_fn!(lib, "hipFree", unsafe extern "C" fn(*mut c_void) -> u32),
                 fn_memcpy: load_fn!(lib, "hipMemcpy", unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_uint) -> u32),
@@ -327,6 +374,91 @@ impl HipRuntime {
     pub fn set_device(&self, id: i32) -> HipResult<()> {
         let code = unsafe { (self.fn_set_device)(id) };
         self.check(code, "hipSetDevice")
+    }
+
+    pub fn current_device(&self) -> HipResult<i32> {
+        let mut id: c_int = 0;
+        let code = unsafe { (self.fn_get_device)(&mut id) };
+        self.check(code, "hipGetDevice")?;
+        Ok(id)
+    }
+
+    // ── Multi-device / peer access ──────────────────────────────
+
+    pub fn can_access_peer(&self, device: i32, peer_device: i32) -> HipResult<bool> {
+        let mut can: c_int = 0;
+        let code = unsafe { (self.fn_device_can_access_peer)(&mut can, device, peer_device) };
+        self.check(code, "hipDeviceCanAccessPeer")?;
+        Ok(can != 0)
+    }
+
+    /// Idempotent: hipErrorPeerAccessAlreadyEnabled (704) → Ok. Caller must
+    /// have bound the source device first (`set_device`).
+    pub fn enable_peer_access(&self, peer_device: i32) -> HipResult<()> {
+        let code = unsafe { (self.fn_device_enable_peer_access)(peer_device, 0) };
+        if code == HIP_SUCCESS || code == crate::HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED {
+            Ok(())
+        } else {
+            Err(HipError::from_code(
+                code,
+                "hipDeviceEnablePeerAccess",
+                Some(&self.fn_get_error_string),
+            ))
+        }
+    }
+
+    pub fn memcpy_peer(
+        &self,
+        dst: &DeviceBuffer,
+        dst_device: i32,
+        src: &DeviceBuffer,
+        src_device: i32,
+        size: usize,
+    ) -> HipResult<()> {
+        assert!(size <= dst.size(), "size ({size}) exceeds dst ({})", dst.size());
+        assert!(size <= src.size(), "size ({size}) exceeds src ({})", src.size());
+        let code = unsafe {
+            (self.fn_memcpy_peer)(
+                dst.as_ptr(),
+                dst_device,
+                src.as_ptr() as *const c_void,
+                src_device,
+                size,
+            )
+        };
+        self.check(code, "hipMemcpyPeer")
+    }
+
+    /// Stream must belong to one of the two devices involved.
+    pub fn memcpy_peer_async(
+        &self,
+        dst: &DeviceBuffer,
+        dst_device: i32,
+        src: &DeviceBuffer,
+        src_device: i32,
+        size: usize,
+        stream: &Stream,
+    ) -> HipResult<()> {
+        assert!(size <= dst.size(), "size ({size}) exceeds dst ({})", dst.size());
+        assert!(size <= src.size(), "size ({size}) exceeds src ({})", src.size());
+        let code = unsafe {
+            (self.fn_memcpy_peer_async)(
+                dst.as_ptr(),
+                dst_device,
+                src.as_ptr() as *const c_void,
+                src_device,
+                size,
+                stream.0,
+            )
+        };
+        self.check(code, "hipMemcpyPeerAsync")
+    }
+
+    pub fn pointer_get_attributes(&self, buf: &DeviceBuffer) -> HipResult<HipPointerAttribute> {
+        let mut attr = HipPointerAttribute::default();
+        let code = unsafe { (self.fn_pointer_get_attributes)(&mut attr, buf.as_ptr()) };
+        self.check(code, "hipPointerGetAttributes")?;
+        Ok(attr)
     }
 
     // ── Memory management ───────────────────────────────────────

--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -6,8 +6,11 @@ mod error;
 mod kernarg;
 mod rocblas;
 
-pub use error::{HipError, HipResult};
-pub use ffi::{Event, Function, Graph, GraphExec, HipRuntime, Module, Stream};
+pub use error::{
+    HipError, HipResult, HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED,
+    HIP_ERROR_PEER_ACCESS_NOT_ENABLED, HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
+};
+pub use ffi::{Event, Function, Graph, GraphExec, HipPointerAttribute, HipRuntime, Module, Stream};
 pub use ffi::launch_counters;
 pub use kernarg::KernargBlob;
 pub use rocblas::{Rocblas, RocblasDatatype, RocblasError, RocblasOperation, RocblasResult};
@@ -21,6 +24,32 @@ pub enum MemcpyKind {
     DeviceToHost = 2,
     DeviceToDevice = 3,
     Default = 4,
+}
+
+/// Mirrors `hipMemoryType`. FFI stores raw `u32`; use `from_raw` to convert.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryType {
+    Unregistered = 0,
+    Host = 1,
+    Device = 2,
+    Managed = 3,
+    Array = 10,
+    Unified = 11,
+}
+
+impl MemoryType {
+    pub fn from_raw(v: u32) -> Option<Self> {
+        match v {
+            0 => Some(Self::Unregistered),
+            1 => Some(Self::Host),
+            2 => Some(Self::Device),
+            3 => Some(Self::Managed),
+            10 => Some(Self::Array),
+            11 => Some(Self::Unified),
+            _ => None,
+        }
+    }
 }
 
 /// Opaque GPU buffer handle. Tracks pointer + size for safety.

--- a/crates/hipfire-arch-qwen35/Cargo.toml
+++ b/crates/hipfire-arch-qwen35/Cargo.toml
@@ -17,3 +17,13 @@ hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[[example]]
+name = "test_qwen35_load_multi"
+path = "examples/test_qwen35_load_multi.rs"
+required-features = ["deltanet"]
+
+[[example]]
+name = "test_qwen35_state_multi"
+path = "examples/test_qwen35_state_multi.rs"
+required-features = ["deltanet"]

--- a/crates/hipfire-arch-qwen35/examples/test_qwen35_load_multi.rs
+++ b/crates/hipfire-arch-qwen35/examples/test_qwen35_load_multi.rs
@@ -1,0 +1,91 @@
+//! Stage 4 smoke: load qwen3.5 weights distributed across 2 GPUs via
+//! `qwen35::load_weights_multi`. Verifies Variant 2 placement
+//! (token_embd → dev 0, output_norm + lm_head → dev_last, per-layer
+//! weights → gpus.device_for_layer(i)) using `pointer_get_attributes`.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run --release --features deltanet \
+//!         -p hipfire-arch-qwen35 \
+//!         --example test_qwen35_load_multi -- \
+//!         ~/.hipfire/models/qwen3.5-0.8b.mq4
+
+use hipfire_arch_qwen35::qwen35;
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::multi_gpu::Gpus;
+use std::path::Path;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("Usage: ... <model.mq4>");
+    let hfq = HfqFile::open(Path::new(&path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config_from_hfq");
+    eprintln!(
+        "config: {} layers, vocab={}, dim={}, hidden={}",
+        config.n_layers, config.vocab_size, config.dim, config.hidden_dim,
+    );
+
+    let mut gpus = Gpus::init_uniform(2, config.n_layers).expect("init_uniform");
+    let n = gpus.devices.len();
+    let out_dev = gpus.output_device;
+    println!(
+        "Gpus: {n} devices, output_device={out_dev}, layer_to_device={:?}",
+        gpus.layer_to_device,
+    );
+
+    println!("\n── load_weights_multi ────────────────────────────────────");
+    let weights = qwen35::load_weights_multi(&hfq, &config, &mut gpus).expect("load_weights_multi");
+
+    println!("\n── verify per-tensor device placement ───────────────────");
+    let attr0 = gpus.devices[0]
+        .hip
+        .pointer_get_attributes(&weights.token_embd.buf)
+        .expect("attr token_embd");
+    println!("  token_embd: attr.device={} (expect 0)", attr0.device);
+    assert_eq!(attr0.device, 0, "token_embd must live on dev 0");
+
+    let attr_norm = gpus.devices[out_dev]
+        .hip
+        .pointer_get_attributes(&weights.output_norm.buf)
+        .expect("attr output_norm");
+    println!("  output_norm: attr.device={} (expect {out_dev})", attr_norm.device);
+    assert_eq!(attr_norm.device, out_dev as i32, "output_norm must live on dev_last");
+
+    let attr_out = gpus.devices[out_dev]
+        .hip
+        .pointer_get_attributes(&weights.output.buf.buf)
+        .expect("attr output");
+    println!("  output (lm_head): attr.device={} (expect {out_dev})", attr_out.device);
+    assert_eq!(attr_out.device, out_dev as i32, "output must live on dev_last");
+
+    let probe_layers = [0usize, config.n_layers / 2, config.n_layers - 1];
+    for &i in &probe_layers {
+        let dev_idx = gpus.device_for_layer(i);
+        let attn_norm_buf = match &weights.layers[i] {
+            qwen35::LayerWeights::DeltaNet(l) => &l.attn_norm,
+            qwen35::LayerWeights::FullAttn(l) => &l.attn_norm,
+            qwen35::LayerWeights::DeltaNetMoe(l) => &l.attn_norm,
+            qwen35::LayerWeights::FullAttnMoe(l) => &l.attn_norm,
+        };
+        let attr = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&attn_norm_buf.buf)
+            .expect("attr layer attn_norm");
+        println!(
+            "  layer {i}: dev_idx={dev_idx}, attn_norm.attr.device={} (expect {dev_idx})",
+            attr.device
+        );
+        assert_eq!(
+            attr.device, dev_idx as i32,
+            "layer {i} attn_norm must live on dev {dev_idx}"
+        );
+    }
+
+    println!("\n── enable_peer_all (post-load per ROCm gotcha) ──────────");
+    let peer_ok = gpus.enable_peer_all().expect("enable_peer_all");
+    assert!(peer_ok, "peer access bidirectional on 2× 7900 XTX");
+    println!("  peer_access_enabled = true");
+
+    println!("\n── free_gpu_multi ───────────────────────────────────────");
+    weights.free_gpu_multi(&mut gpus);
+    println!("  all weights freed on owning devices");
+
+    println!("\ntest_qwen35_load_multi: PASS");
+}

--- a/crates/hipfire-arch-qwen35/examples/test_qwen35_state_multi.rs
+++ b/crates/hipfire-arch-qwen35/examples/test_qwen35_state_multi.rs
@@ -1,0 +1,227 @@
+//! Stage 4 smoke: build the full multi-GPU state stack on a real model:
+//! `Qwen35ScratchSet` (per-device), `KvCache::new_gpu_asym3_capped_multi`
+//! (per-layer K/V on band-owning device + per-device givens replicas),
+//! `DeltaNetState::new_with_quant_multi` (per-LA-layer state on owning
+//! device). Verifies each per-layer / per-device buffer's
+//! `pointer_get_attributes` matches the layer-band assignment, then runs
+//! a HipRuntime bind-gap regression battery.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run --release --features deltanet \
+//!         -p hipfire-arch-qwen35 \
+//!         --example test_qwen35_state_multi -- \
+//!         ~/.hipfire/models/qwen3.5-0.8b.mq4
+
+use hipfire_arch_qwen35::qwen35::{self, DeltaNetState, LayerType, Qwen35ScratchSet, StateQuant};
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::KvCache;
+use hipfire_runtime::multi_gpu::Gpus;
+use std::path::Path;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("Usage: ... <model.mq4>");
+    let hfq = HfqFile::open(Path::new(&path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config_from_hfq");
+    eprintln!(
+        "config: {} layers (head_dim={}, n_kv_heads={}, vocab={})",
+        config.n_layers, config.head_dim, config.n_kv_heads, config.vocab_size,
+    );
+
+    let mut gpus = Gpus::init_uniform(2, config.n_layers).expect("init_uniform");
+    let n_dev = gpus.devices.len();
+    let out_dev = gpus.output_device;
+    println!(
+        "Gpus: {n_dev} devices, output_device={out_dev}, layer_to_device={:?}",
+        gpus.layer_to_device,
+    );
+
+    println!("\n── Qwen35ScratchSet::new_with_kv_max_multi ───────────────");
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 64, 4096)
+        .expect("ScratchSet");
+    assert_eq!(scratch_set.per_device.len(), n_dev);
+    for (dev_idx, scratch) in scratch_set.per_device.iter().enumerate() {
+        let attr = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&scratch.x.buf)
+            .expect("attr scratch.x");
+        println!("  per_device[{dev_idx}].x: attr.device={} (expect {dev_idx})", attr.device);
+        assert_eq!(attr.device, dev_idx as i32);
+    }
+
+    println!("\n── KvCache::new_gpu_asym3_capped_multi ───────────────────");
+    let kv = KvCache::new_gpu_asym3_capped_multi(
+        &mut gpus,
+        config.n_layers,
+        config.n_kv_heads,
+        config.head_dim,
+        4096,
+        4096,
+    )
+    .expect("KvCache asym3 multi");
+    assert_eq!(kv.k_gpu.len(), config.n_layers);
+    let probe_layers = [0usize, config.n_layers / 2, config.n_layers - 1];
+    for &i in &probe_layers {
+        let dev_idx = gpus.device_for_layer(i);
+        let attr_k = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&kv.k_gpu[i].buf)
+            .expect("attr kv k");
+        let attr_v = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&kv.v_gpu[i].buf)
+            .expect("attr kv v");
+        println!(
+            "  layer {i}: dev_idx={dev_idx}, k.device={}, v.device={}",
+            attr_k.device, attr_v.device
+        );
+        assert_eq!(attr_k.device, dev_idx as i32, "kv.k_gpu[{i}] off-device");
+        assert_eq!(attr_v.device, dev_idx as i32, "kv.v_gpu[{i}] off-device");
+    }
+
+    println!("\n── givens_*_per_dev replicas ─────────────────────────────");
+    assert_eq!(gpus.givens_cos_per_dev.len(), n_dev);
+    assert_eq!(gpus.givens_sin_per_dev.len(), n_dev);
+    for dev_idx in 0..n_dev {
+        let attr_cos = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&gpus.givens_cos_per_dev[dev_idx].buf)
+            .expect("attr givens cos");
+        let attr_sin = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&gpus.givens_sin_per_dev[dev_idx].buf)
+            .expect("attr givens sin");
+        println!(
+            "  givens_cos_per_dev[{dev_idx}].device={}, sin.device={}",
+            attr_cos.device, attr_sin.device,
+        );
+        assert_eq!(attr_cos.device, dev_idx as i32);
+        assert_eq!(attr_sin.device, dev_idx as i32);
+    }
+
+    println!("\n── DeltaNetState::new_with_quant_multi ───────────────────");
+    let (dn, la_to_device) =
+        DeltaNetState::new_with_quant_multi(&mut gpus, &config, StateQuant::Q8).expect("DN multi");
+    let n_la = config
+        .layer_types
+        .iter()
+        .filter(|t| **t == LayerType::LinearAttention)
+        .count();
+    assert_eq!(dn.s_matrices.len(), n_la);
+    assert_eq!(la_to_device.len(), n_la);
+    println!("  n_la={n_la}, la_to_device={:?}", la_to_device);
+    let probe_la = [0usize, n_la / 2, n_la - 1];
+    for &i in &probe_la {
+        let dev_idx = la_to_device[i] as usize;
+        let attr = gpus.devices[dev_idx]
+            .hip
+            .pointer_get_attributes(&dn.s_matrices[i].buf)
+            .expect("attr dn s_matrix");
+        println!("  la {i}: dev_idx={dev_idx}, s_matrix.device={}", attr.device);
+        assert_eq!(attr.device, dev_idx as i32);
+    }
+
+    println!("\n── enable_peer_all (post-allocation per ROCm gotcha) ─────");
+    let peer_ok = gpus.enable_peer_all().expect("enable_peer_all");
+    assert!(peer_ok);
+    println!("  peer_access_enabled = true");
+
+    println!("\n── free everything on owning devices ─────────────────────");
+    dn.free_gpu_multi(&mut gpus, &la_to_device);
+    kv.free_gpu_multi(&mut gpus);
+    scratch_set.free_gpu_multi(&mut gpus);
+    println!("  all state freed");
+
+    println!("\n══ HipRuntime bind-gap regression checks ══════════════════");
+    // Stage 2 finding (carried into Stage 4): gpu.hip.* (HipRuntime methods)
+    // bypass the bind_thread audit. In multi-GPU contexts a raw hipMalloc/
+    // memset/memcpy_htod lands on whatever device the host thread last
+    // bound, not necessarily gpu.device_id. The fix in
+    // DeltaNetState::new_with_quant_multi was an explicit g.bind_thread()
+    // before the raw HIP ops. These checks deliberately misbind the
+    // "wrong" device before each multi ctor call so any future regression
+    // (a contributor removing the explicit bind) trips the device assert.
+
+    println!("\n  [1/3] DeltaNetState::new_with_quant_multi Q8 — first LA on dev 0");
+    gpus.devices[1].bind_thread().expect("misbind dev 1");
+    let (dn2, la_to_device2) =
+        DeltaNetState::new_with_quant_multi(&mut gpus, &config, StateQuant::Q8)
+            .expect("DN regression");
+    let attr = gpus.devices[0]
+        .hip
+        .pointer_get_attributes(&dn2.s_matrices[0].buf)
+        .expect("attr dn2 s_matrix[0]");
+    assert_eq!(
+        attr.device, 0,
+        "REGRESSION: DeltaNetState s_matrix[0] expected on dev 0 \
+         but landed on dev {} after pre-misbinding dev 1. \
+         Likely a removed bind_thread in new_with_quant_multi.",
+        attr.device,
+    );
+    println!("    s_matrices[0].device={} OK", attr.device);
+    dn2.free_gpu_multi(&mut gpus, &la_to_device2);
+
+    println!("  [2/3] KvCache::new_gpu_asym3_capped_multi — layer 0 on dev 0");
+    gpus.devices[1].bind_thread().expect("misbind dev 1");
+    let kv2 = KvCache::new_gpu_asym3_capped_multi(
+        &mut gpus,
+        config.n_layers,
+        config.n_kv_heads,
+        config.head_dim,
+        4096,
+        4096,
+    )
+    .expect("KvCache regression");
+    let attr_k = gpus.devices[0]
+        .hip
+        .pointer_get_attributes(&kv2.k_gpu[0].buf)
+        .expect("attr kv2 k_gpu[0]");
+    assert_eq!(
+        attr_k.device, 0,
+        "REGRESSION: KvCache k_gpu[0] expected on dev 0 but landed on dev {} \
+         after pre-misbinding dev 1. Likely a removed bind in new_gpu_asym3_capped_multi.",
+        attr_k.device,
+    );
+    println!("    k_gpu[0].device={} OK", attr_k.device);
+    let attr_givens = gpus.devices[0]
+        .hip
+        .pointer_get_attributes(&gpus.givens_cos_per_dev[0].buf)
+        .expect("attr givens dev 0");
+    assert_eq!(
+        attr_givens.device, 0,
+        "REGRESSION: givens_cos_per_dev[0] expected on dev 0 after misbind+ctor",
+    );
+    println!("    givens_cos_per_dev[0].device={} OK", attr_givens.device);
+    kv2.free_gpu_multi(&mut gpus);
+
+    println!("  [3/3] Qwen35ScratchSet::new_with_kv_max_multi — per_device[0] on dev 0");
+    gpus.devices[1].bind_thread().expect("misbind dev 1");
+    let scratch_set2 = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 64, 4096)
+        .expect("ScratchSet regression");
+    let attr = gpus.devices[0]
+        .hip
+        .pointer_get_attributes(&scratch_set2.per_device[0].x.buf)
+        .expect("attr scratch_set2 per_device[0].x");
+    assert_eq!(
+        attr.device, 0,
+        "REGRESSION: ScratchSet per_device[0].x expected on dev 0 but landed on dev {} \
+         after pre-misbinding dev 1.",
+        attr.device,
+    );
+    println!("    per_device[0].x.device={} OK", attr.device);
+    let attr_pos = gpus.devices[0]
+        .hip
+        .pointer_get_attributes(&scratch_set2.per_device[0].pos_buf)
+        .expect("attr scratch_set2 pos_buf");
+    assert_eq!(
+        attr_pos.device, 0,
+        "REGRESSION: ScratchSet per_device[0].pos_buf (raw gpu.hip.malloc) expected on dev 0 \
+         but landed on dev {} after pre-misbinding dev 1.",
+        attr_pos.device,
+    );
+    println!(
+        "    per_device[0].pos_buf.device={} OK (raw gpu.hip.malloc honored bind)",
+        attr_pos.device
+    );
+    scratch_set2.free_gpu_multi(&mut gpus);
+
+    println!("\ntest_qwen35_state_multi: PASS");
+}

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -5,6 +5,7 @@ use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{self, f16_to_f32, EmbeddingFormat, WeightTensor, weight_gemv,
                               weight_gemv_prerotated, fused_rmsnorm_rotate_for_mq,
                               weight_gemv_residual, weight_gemv_swiglu_residual};
+use hipfire_runtime::multi_gpu::Gpus;
 use crate::speculative::HiddenStateRingBuffer;
 use hip_bridge::HipResult;
 use rdna_compute::{DType, Gpu, GpuTensor};
@@ -419,6 +420,81 @@ impl Qwen35Weights {
             pager_cell.into_inner().free_all(gpu);
         }
     }
+
+    /// Multi-GPU companion to `free_gpu`. Each layer freed on its
+    /// band-owning device per `gpus.device_for_layer(i)`; `token_embd`
+    /// freed on dev 0; `output_norm + output` on `gpus.output_device`.
+    /// Mirror of `load_weights_multi` placement. The `pager` field is
+    /// always `None` on the multi path (paged-experts is not wired into
+    /// pp>1 yet); a non-None pager would need its own per-band drain
+    /// strategy and is rejected at load.
+    pub fn free_gpu_multi(self, gpus: &mut Gpus) {
+        debug_assert!(self.pager.is_none(), "free_gpu_multi: pager must be None on pp>1 path");
+        let _ = gpus.devices[0].free_tensor(self.token_embd);
+        let out_dev = gpus.output_device;
+        let _ = gpus.devices[out_dev].free_tensor(self.output_norm);
+        let _ = gpus.devices[out_dev].free_tensor(self.output.buf);
+        for (i, layer) in self.layers.into_iter().enumerate() {
+            let dev_idx = gpus.device_for_layer(i);
+            let gpu = &mut gpus.devices[dev_idx];
+            match layer {
+                LayerWeights::DeltaNet(l) => {
+                    let _ = gpu.free_tensor(l.attn_norm);
+                    let _ = gpu.free_tensor(l.wqkv.buf);
+                    let _ = gpu.free_tensor(l.wz.buf);
+                    let _ = gpu.free_tensor(l.w_alpha.buf);
+                    let _ = gpu.free_tensor(l.w_beta.buf);
+                    let _ = gpu.free_tensor(l.a_log);
+                    let _ = gpu.free_tensor(l.dt_bias);
+                    let _ = gpu.free_tensor(l.conv_weight);
+                    let _ = gpu.free_tensor(l.norm_weight);
+                    let _ = gpu.free_tensor(l.wo.buf);
+                    let _ = gpu.free_tensor(l.ffn_norm);
+                    let _ = gpu.free_tensor(l.w_gate.buf);
+                    let _ = gpu.free_tensor(l.w_up.buf);
+                    let _ = gpu.free_tensor(l.w_down.buf);
+                }
+                LayerWeights::FullAttn(l) => {
+                    let _ = gpu.free_tensor(l.attn_norm);
+                    let _ = gpu.free_tensor(l.wq.buf);
+                    let _ = gpu.free_tensor(l.wk.buf);
+                    let _ = gpu.free_tensor(l.wv.buf);
+                    let _ = gpu.free_tensor(l.wo.buf);
+                    let _ = gpu.free_tensor(l.q_norm);
+                    let _ = gpu.free_tensor(l.k_norm);
+                    let _ = gpu.free_tensor(l.ffn_norm);
+                    let _ = gpu.free_tensor(l.w_gate.buf);
+                    let _ = gpu.free_tensor(l.w_up.buf);
+                    let _ = gpu.free_tensor(l.w_down.buf);
+                }
+                LayerWeights::DeltaNetMoe(l) => {
+                    let _ = gpu.free_tensor(l.attn_norm);
+                    let _ = gpu.free_tensor(l.wqkv.buf);
+                    let _ = gpu.free_tensor(l.wz.buf);
+                    let _ = gpu.free_tensor(l.w_alpha.buf);
+                    let _ = gpu.free_tensor(l.w_beta.buf);
+                    let _ = gpu.free_tensor(l.a_log);
+                    let _ = gpu.free_tensor(l.dt_bias);
+                    let _ = gpu.free_tensor(l.conv_weight);
+                    let _ = gpu.free_tensor(l.norm_weight);
+                    let _ = gpu.free_tensor(l.wo.buf);
+                    let _ = gpu.free_tensor(l.ffn_norm);
+                    free_moe_ffn(gpu, l.ffn);
+                }
+                LayerWeights::FullAttnMoe(l) => {
+                    let _ = gpu.free_tensor(l.attn_norm);
+                    let _ = gpu.free_tensor(l.wq.buf);
+                    let _ = gpu.free_tensor(l.wk.buf);
+                    let _ = gpu.free_tensor(l.wv.buf);
+                    let _ = gpu.free_tensor(l.wo.buf);
+                    let _ = gpu.free_tensor(l.q_norm);
+                    let _ = gpu.free_tensor(l.k_norm);
+                    let _ = gpu.free_tensor(l.ffn_norm);
+                    free_moe_ffn(gpu, l.ffn);
+                }
+            }
+        }
+    }
 }
 
 fn free_moe_ffn(gpu: &mut Gpu, ffn: MoeFfnWeights) {
@@ -506,6 +582,77 @@ impl DeltaNetState {
         for t in self.s_matrices { let _ = gpu.free_tensor(t); }
         for t in self.s_scales { let _ = gpu.free_tensor(t); }
         for t in self.conv_states { let _ = gpu.free_tensor(t); }
+    }
+
+    /// Multi-GPU companion to `new_with_quant`. Each LA-layer's state is
+    /// allocated on the device that owns the layer in the multi-GPU band
+    /// split: `gpus.devices[gpus.device_for_layer(orig_layer_idx)]` for the
+    /// `orig_layer_idx` of the LA-layer. Returns the state alongside the
+    /// `la_to_device` mapping the daemon needs to route reset memsets to
+    /// the correct device.
+    pub fn new_with_quant_multi(
+        gpus: &mut Gpus,
+        config: &Qwen35Config,
+        quant: StateQuant,
+    ) -> HipResult<(Self, Vec<u8>)> {
+        let s_dim = config.linear_key_head_dim;
+        let n_heads = config.linear_num_value_heads;
+        let s_size = n_heads * s_dim * s_dim;
+        let conv_channels = config.linear_num_key_heads * config.linear_key_head_dim * 2
+                          + config.linear_num_value_heads * config.linear_value_head_dim;
+        let conv_state_size = conv_channels * (config.conv_kernel_dim - 1);
+
+        let mut s_matrices = Vec::new();
+        let mut s_scales = Vec::new();
+        let mut conv_states = Vec::new();
+        let mut la_to_device: Vec<u8> = Vec::new();
+
+        for (orig_layer_idx, lt) in config.layer_types.iter().enumerate() {
+            if *lt != LayerType::LinearAttention {
+                continue;
+            }
+            let dev_idx = gpus.device_for_layer(orig_layer_idx);
+            la_to_device.push(dev_idx as u8);
+            let g = &mut gpus.devices[dev_idx];
+            // g.hip.malloc/memset bypass the Stage 2 bind_thread audit
+            // (HipRuntime methods don't carry a device id). Bind explicitly
+            // before any raw HIP ops so allocations land on the right device.
+            g.bind_thread()?;
+            match quant {
+                StateQuant::FP32 => {
+                    s_matrices.push(g.zeros(&[s_size], DType::F32)?);
+                    s_scales.push(g.zeros(&[n_heads], DType::F32)?);
+                }
+                StateQuant::Q8 => {
+                    let buf = g.hip.malloc(s_size)?;
+                    g.hip.memset(&buf, 0, s_size)?;
+                    s_matrices.push(GpuTensor { buf, shape: vec![s_size], dtype: DType::F32 });
+                    s_scales.push(g.zeros(&[n_heads * s_dim], DType::F32)?);
+                }
+                StateQuant::Q4 => {
+                    let buf = g.hip.malloc(s_size / 2)?;
+                    g.hip.memset(&buf, 0, s_size / 2)?;
+                    s_matrices.push(GpuTensor { buf, shape: vec![s_size / 2], dtype: DType::F32 });
+                    s_scales.push(g.zeros(&[n_heads * s_dim], DType::F32)?);
+                }
+            }
+            conv_states.push(g.zeros(&[conv_state_size], DType::F32)?);
+        }
+        Ok((Self { s_matrices, s_scales, conv_states, quant }, la_to_device))
+    }
+
+    /// Free per-LA-layer tensors on the devices listed in `la_to_device`
+    /// (the second tuple element returned by `new_with_quant_multi`).
+    pub fn free_gpu_multi(self, gpus: &mut Gpus, la_to_device: &[u8]) {
+        for (i, t) in self.s_matrices.into_iter().enumerate() {
+            let _ = gpus.devices[la_to_device[i] as usize].free_tensor(t);
+        }
+        for (i, t) in self.s_scales.into_iter().enumerate() {
+            let _ = gpus.devices[la_to_device[i] as usize].free_tensor(t);
+        }
+        for (i, t) in self.conv_states.into_iter().enumerate() {
+            let _ = gpus.devices[la_to_device[i] as usize].free_tensor(t);
+        }
     }
 }
 
@@ -1107,6 +1254,227 @@ pub fn load_weights(hfq: &HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> HipR
         // The non-paged `load_weights` always returns `None` so today's
         // callers see no behavior change.
         pager: None,
+    })
+}
+
+/// Multi-GPU weight loader. Variant 2 placement: `token_embd` on `gpus.devices[0]`,
+/// `output_norm + output` on `gpus.devices[gpus.output_device]`, each layer on
+/// `gpus.devices[gpus.device_for_layer(i)]`. The single-GPU `load_weights` path is
+/// not consumed by this — keeping it byte-exact for the pp=1 daemon.
+///
+/// `pager` is always `None` on this path: paged-experts (MAD-93) is not wired
+/// for pp>1 yet — would need per-band drain semantics in `WeightPager::free_all`.
+pub fn load_weights_multi(
+    hfq: &HfqFile,
+    config: &Qwen35Config,
+    gpus: &mut Gpus,
+) -> HipResult<Qwen35Weights> {
+    let (token_embd, embd_fmt) = load_token_embd_into(hfq, config, &mut gpus.devices[0])?;
+    let out_dev = gpus.output_device;
+    let (output_norm, output) =
+        load_output_into(hfq, config, &mut gpus.devices[out_dev])?;
+    let is_moe = config.num_experts > 0;
+    let mut layers = Vec::with_capacity(config.n_layers);
+    for i in 0..config.n_layers {
+        let dev_idx = gpus.device_for_layer(i);
+        eprintln!(
+            "  loading layer {i}/{} on dev {dev_idx} ({:?}{})...",
+            config.n_layers,
+            config.layer_types[i],
+            if is_moe { " + MoE" } else { "" },
+        );
+        let p = format!("layers.{i}");
+        let layer_page_start = hfq.layer_data_range(&p);
+        layers.push(load_layer_into(hfq, config, i, &p, &mut gpus.devices[dev_idx])?);
+        if let Some((start, end)) = layer_page_start {
+            hfq.drop_pages_range(start, end - start);
+        }
+    }
+    Ok(Qwen35Weights {
+        token_embd, embd_format: embd_fmt, output_norm, output, layers,
+        pager: None,
+    })
+}
+
+fn load_token_embd_into(
+    hfq: &HfqFile,
+    config: &Qwen35Config,
+    gpu: &mut Gpu,
+) -> HipResult<(GpuTensor, EmbeddingFormat)> {
+    eprintln!("  loading token_embd...");
+    let embd_info = hfq
+        .tensor_data("model.language_model.embed_tokens.weight")
+        .expect("embed_tokens not found");
+    Ok(if embd_info.0.quant_type == 6 {
+        eprintln!("    (HFQ4-G256 raw, {} MB)", embd_info.1.len() / 1_000_000);
+        (gpu.upload_raw(embd_info.1, &[embd_info.1.len()])?, EmbeddingFormat::HFQ4G256)
+    } else if embd_info.0.quant_type == 7 {
+        eprintln!("    (HFQ4-G128 raw, {} MB)", embd_info.1.len() / 1_000_000);
+        (gpu.upload_raw(embd_info.1, &[embd_info.1.len()])?, EmbeddingFormat::HFQ4G128)
+    } else if embd_info.0.quant_type == 3 {
+        eprintln!("    (Q8_0 raw, {} MB)", embd_info.1.len() / 1_000_000);
+        (gpu.upload_raw(embd_info.1, &[embd_info.1.len()])?, EmbeddingFormat::Q8_0)
+    } else {
+        let f32_data: Vec<f32> = embd_info
+            .1
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect();
+        (
+            gpu.upload_f32(&f32_data, &[config.vocab_size, config.dim])?,
+            EmbeddingFormat::F32,
+        )
+    })
+}
+
+fn load_output_into(
+    hfq: &HfqFile,
+    config: &Qwen35Config,
+    gpu: &mut Gpu,
+) -> HipResult<(GpuTensor, WeightTensor)> {
+    eprintln!("  loading output_norm...");
+    let output_norm = if config.num_experts > 0 {
+        load_norm_weight_raw(hfq, gpu, "norm.weight", &[config.dim])?
+    } else {
+        load_norm_weight(hfq, gpu, "norm.weight", &[config.dim])?
+    };
+
+    let lm_head_info = hfq
+        .tensor_data("lm_head.weight")
+        .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
+    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+        eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
+        load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
+    } else {
+        let embd_info = hfq
+            .tensor_data("model.language_model.embed_tokens.weight")
+            .expect("embed_tokens not found");
+        eprintln!("  loading output (tied embeddings, qt={})...", embd_info.0.quant_type);
+        let embd_data = embd_info.1;
+        if embd_info.0.quant_type == 6 || embd_info.0.quant_type == 7 || embd_info.0.quant_type == 8 {
+            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+            let dtype = match embd_info.0.quant_type {
+                6 => DType::HFQ4G256,
+                7 => DType::HFQ4G128,
+                8 => DType::HFQ6G256,
+                _ => unreachable!(),
+            };
+            WeightTensor { buf, gpu_dtype: dtype, m: config.vocab_size, k: config.dim, row_stride: 0 }
+        } else if embd_info.0.quant_type == 13 {
+            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+            WeightTensor { buf, gpu_dtype: DType::MQ4G256, m: config.vocab_size, k: config.dim, row_stride: 0 }
+        } else if embd_info.0.quant_type == 14 {
+            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+            WeightTensor { buf, gpu_dtype: DType::MQ8G256, m: config.vocab_size, k: config.dim, row_stride: 0 }
+        } else if embd_info.0.quant_type == 3 {
+            let buf = gpu.upload_raw(embd_data, &[embd_data.len()])?;
+            WeightTensor { buf, gpu_dtype: DType::Q8_0, m: config.vocab_size, k: config.dim, row_stride: 0 }
+        } else {
+            let f32_data: Vec<f32> = embd_data
+                .chunks_exact(2)
+                .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+                .collect();
+            let bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(f32_data.as_ptr() as *const u8, f32_data.len() * 4)
+            };
+            let buf = gpu.upload_raw(bytes, &[config.vocab_size, config.dim])?;
+            WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0 }
+        }
+    };
+    Ok((output_norm, output))
+}
+
+/// Build one layer's `LayerWeights` on `gpu`. Extracted for `load_weights_multi`
+/// so the multi-GPU loader can route each layer to its band-owning device
+/// without duplicating the tensor-name table. Master's `load_weights` keeps
+/// its inline body — does not consume this helper.
+fn load_layer_into(
+    hfq: &HfqFile,
+    config: &Qwen35Config,
+    layer_idx: usize,
+    p: &str,
+    gpu: &mut Gpu,
+) -> HipResult<LayerWeights> {
+    let is_moe = config.num_experts > 0;
+    Ok(match (config.layer_types[layer_idx], is_moe) {
+        (LayerType::LinearAttention, false) => {
+            let qkv_dim = config.linear_num_key_heads * config.linear_key_head_dim * 2
+                        + config.linear_num_value_heads * config.linear_value_head_dim;
+            let d_inner = config.linear_num_value_heads * config.linear_value_head_dim;
+            LayerWeights::DeltaNet(DeltaNetLayerWeights {
+                attn_norm: load_norm_weight(hfq, gpu, &format!("{p}.input_layernorm.weight"), &[config.dim])?,
+                wqkv: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_qkv.weight"), qkv_dim, config.dim)?,
+                wz: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_z.weight"), d_inner, config.dim)?,
+                w_alpha: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_a.weight"),
+                    config.linear_num_value_heads, config.dim)?,
+                w_beta: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_b.weight"),
+                    config.linear_num_value_heads, config.dim)?,
+                a_log: load_raw_f32(hfq, gpu, &format!("{p}.linear_attn.A_log"), config.linear_num_value_heads)?,
+                dt_bias: load_raw_f32(hfq, gpu, &format!("{p}.linear_attn.dt_bias"), config.linear_num_value_heads)?,
+                conv_weight: load_any_as_f32(hfq, gpu, &format!("{p}.linear_attn.conv1d.weight"),
+                    qkv_dim * config.conv_kernel_dim)?,
+                norm_weight: load_any_as_f32(hfq, gpu, &format!("{p}.linear_attn.norm.weight"), config.linear_value_head_dim)?,
+                wo: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.out_proj.weight"), config.dim, d_inner)?,
+                ffn_norm: load_norm_weight(hfq, gpu, &format!("{p}.post_attention_layernorm.weight"), &[config.dim])?,
+                w_gate: load_weight_tensor(hfq, gpu, &format!("{p}.mlp.gate_proj.weight"), config.hidden_dim, config.dim)?,
+                w_up: load_weight_tensor(hfq, gpu, &format!("{p}.mlp.up_proj.weight"), config.hidden_dim, config.dim)?,
+                w_down: load_weight_tensor(hfq, gpu, &format!("{p}.mlp.down_proj.weight"), config.dim, config.hidden_dim)?,
+            })
+        }
+        (LayerType::FullAttention, false) => {
+            let q_out_dim = config.n_heads * config.head_dim * 2;
+            let kv_dim = config.n_kv_heads * config.head_dim;
+            LayerWeights::FullAttn(FullAttnLayerWeights {
+                attn_norm: load_norm_weight(hfq, gpu, &format!("{p}.input_layernorm.weight"), &[config.dim])?,
+                wq: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.q_proj.weight"), q_out_dim, config.dim)?,
+                wk: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.k_proj.weight"), kv_dim, config.dim)?,
+                wv: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.v_proj.weight"), kv_dim, config.dim)?,
+                wo: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.o_proj.weight"), config.dim, config.n_heads * config.head_dim)?,
+                q_norm: load_norm_weight(hfq, gpu, &format!("{p}.self_attn.q_norm.weight"), &[config.head_dim])?,
+                k_norm: load_norm_weight(hfq, gpu, &format!("{p}.self_attn.k_norm.weight"), &[config.head_dim])?,
+                ffn_norm: load_norm_weight(hfq, gpu, &format!("{p}.post_attention_layernorm.weight"), &[config.dim])?,
+                w_gate: load_weight_tensor(hfq, gpu, &format!("{p}.mlp.gate_proj.weight"), config.hidden_dim, config.dim)?,
+                w_up: load_weight_tensor(hfq, gpu, &format!("{p}.mlp.up_proj.weight"), config.hidden_dim, config.dim)?,
+                w_down: load_weight_tensor(hfq, gpu, &format!("{p}.mlp.down_proj.weight"), config.dim, config.hidden_dim)?,
+            })
+        }
+        (LayerType::LinearAttention, true) => {
+            let qkv_dim = config.linear_num_key_heads * config.linear_key_head_dim * 2
+                        + config.linear_num_value_heads * config.linear_value_head_dim;
+            let d_inner = config.linear_num_value_heads * config.linear_value_head_dim;
+            LayerWeights::DeltaNetMoe(DeltaNetMoeLayerWeights {
+                attn_norm: load_norm_weight(hfq, gpu, &format!("{p}.input_layernorm.weight"), &[config.dim])?,
+                wqkv: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_qkv.weight"), qkv_dim, config.dim)?,
+                wz: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_z.weight"), d_inner, config.dim)?,
+                w_alpha: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_a.weight"),
+                    config.linear_num_value_heads, config.dim)?,
+                w_beta: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.in_proj_b.weight"),
+                    config.linear_num_value_heads, config.dim)?,
+                a_log: load_raw_f32(hfq, gpu, &format!("{p}.linear_attn.A_log"), config.linear_num_value_heads)?,
+                dt_bias: load_raw_f32(hfq, gpu, &format!("{p}.linear_attn.dt_bias"), config.linear_num_value_heads)?,
+                conv_weight: load_any_as_f32(hfq, gpu, &format!("{p}.linear_attn.conv1d.weight"),
+                    qkv_dim * config.conv_kernel_dim)?,
+                norm_weight: load_any_as_f32(hfq, gpu, &format!("{p}.linear_attn.norm.weight"), config.linear_value_head_dim)?,
+                wo: load_weight_tensor(hfq, gpu, &format!("{p}.linear_attn.out_proj.weight"), config.dim, d_inner)?,
+                ffn_norm: load_norm_weight(hfq, gpu, &format!("{p}.post_attention_layernorm.weight"), &[config.dim])?,
+                ffn: load_moe_ffn(hfq, gpu, p, config, layer_idx as u16)?,
+            })
+        }
+        (LayerType::FullAttention, true) => {
+            let q_out_dim = config.n_heads * config.head_dim * 2;
+            let kv_dim = config.n_kv_heads * config.head_dim;
+            LayerWeights::FullAttnMoe(FullAttnMoeLayerWeights {
+                attn_norm: load_norm_weight(hfq, gpu, &format!("{p}.input_layernorm.weight"), &[config.dim])?,
+                wq: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.q_proj.weight"), q_out_dim, config.dim)?,
+                wk: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.k_proj.weight"), kv_dim, config.dim)?,
+                wv: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.v_proj.weight"), kv_dim, config.dim)?,
+                wo: load_weight_tensor(hfq, gpu, &format!("{p}.self_attn.o_proj.weight"), config.dim, config.n_heads * config.head_dim)?,
+                q_norm: load_norm_weight(hfq, gpu, &format!("{p}.self_attn.q_norm.weight"), &[config.head_dim])?,
+                k_norm: load_norm_weight(hfq, gpu, &format!("{p}.self_attn.k_norm.weight"), &[config.head_dim])?,
+                ffn_norm: load_norm_weight(hfq, gpu, &format!("{p}.post_attention_layernorm.weight"), &[config.dim])?,
+                ffn: load_moe_ffn(hfq, gpu, p, config, layer_idx as u16)?,
+            })
+        }
     })
 }
 
@@ -2338,6 +2706,11 @@ impl Qwen35Scratch {
     pub fn free_gpu(self, gpu: &mut Gpu) {
         let _ = gpu.free_tensor(self.x);
         let _ = gpu.free_tensor(self.tmp);
+        // pos_buf is held as a raw DeviceBuffer and dropped via gpu.hip.free
+        // directly (free_tensor would have bound the thread internally).
+        // Bind explicitly so HIP affinity doesn't depend on the order of
+        // preceding free_tensor calls.
+        let _ = gpu.bind_thread();
         let _ = gpu.hip.free(self.pos_buf);
         for t in [self.dn_qkv, self.dn_z, self.dn_alpha, self.dn_beta, self.dn_conv_out,
                    self.dn_q, self.dn_k, self.dn_v, self.dn_q_raw, self.dn_k_raw,
@@ -2358,6 +2731,38 @@ impl Qwen35Scratch {
         }
         if let Some(pbs) = self.prefill_batch {
             pbs.free_gpu(gpu);
+        }
+    }
+}
+
+/// Per-device scratch bundle for the multi-GPU forward path. Each device gets
+/// its own `Qwen35Scratch` because the residual stream `s.x` (and `s.logits`)
+/// must live on the device executing the current band's layers — cross-band
+/// boundaries copy `s.x` between devices via `Gpus::boundary_copy`. `s.logits`
+/// is also allocated per-device for simplicity (~600 KB each at vocab=152K)
+/// even though only the output device's `s.logits` is consumed post-loop.
+pub struct Qwen35ScratchSet {
+    pub per_device: Vec<Qwen35Scratch>,
+}
+
+impl Qwen35ScratchSet {
+    pub fn new_with_kv_max_multi(
+        gpus: &mut Gpus,
+        config: &Qwen35Config,
+        repeat_window: usize,
+        kv_max_seq: usize,
+    ) -> HipResult<Self> {
+        let mut per_device = Vec::with_capacity(gpus.devices.len());
+        for dev_idx in 0..gpus.devices.len() {
+            let g = &mut gpus.devices[dev_idx];
+            per_device.push(Qwen35Scratch::new_with_kv_max(g, config, repeat_window, kv_max_seq)?);
+        }
+        Ok(Self { per_device })
+    }
+
+    pub fn free_gpu_multi(self, gpus: &mut Gpus) {
+        for (dev_idx, scratch) in self.per_device.into_iter().enumerate() {
+            scratch.free_gpu(&mut gpus.devices[dev_idx]);
         }
     }
 }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -3284,6 +3284,7 @@ pub fn forward_prefill_batch_single_chunk_captured(
         per_token_hidden_out.map(|t| (t, 0)),
         gdn_tape, 0, tree_verify,
         true, // pre_uploaded: caller must have run upload_prefill_batch_inputs
+        None, // band: full-stack single-GPU path
     )
 }
 
@@ -3514,6 +3515,7 @@ pub fn forward_prefill_batch_with_pbs(
                 kv_cache, dn_state, scratch, pbs, hidden_rb.as_deref(),
                 pth_slot, tape_for_chunk, chunk_start, tv_for_chunk,
                 false, // pre_uploaded: default path uploads inside
+                None,  // band: full-stack single-GPU path
             )?;
             if let Some(rb) = hidden_rb.as_mut() {
                 // Scatter fixed-offset staging writes (done inside the chunk)
@@ -3734,6 +3736,33 @@ fn prefill_moe_ffn_body_batched(
     Ok(())
 }
 
+/// Band view for `forward_prefill_chunk`. `None` (the default) means the
+/// chunk processes the whole stack: embedding → all layers → final norm
+/// + lm_head. `Some(b)` restricts the chunk to layers `b.layer_start..
+/// b.layer_end`, skips the embedding when `!b.is_first_band` (input is
+/// already in `pbs.x_batch` from a prior peer-copy), and skips the final
+/// norm + lm_head when `!b.is_last_band` (output activation stays in
+/// `pbs.x_batch` for the next band's peer-copy).
+///
+/// Counter offsets seed the running per-LA / per-KV / per-FA counters so
+/// the band's first DeltaNet/FullAttn layer indexes the correct
+/// `dn_state.s_matrices[i]` / `kv_cache.k_caches[i]` slot.
+pub(crate) struct PrefillBandCtx<'a> {
+    pub layer_start: usize,
+    pub layer_end: usize,
+    pub delta_layer_offset: usize,
+    pub kv_layer_offset: usize,
+    pub fa_layer_offset: usize,
+    pub is_first_band: bool,
+    pub is_last_band: bool,
+    /// Per-device asym{2,3,4} givens replicas. When `Some`, the chunk's
+    /// FA-layer batched KV writers use these instead of `kv_cache.givens_*`
+    /// (which is `None` in multi-GPU mode by design — each device needs its
+    /// own copy of the rotation tables).
+    pub givens_cos: Option<&'a GpuTensor>,
+    pub givens_sin: Option<&'a GpuTensor>,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn forward_prefill_chunk(
     gpu: &mut Gpu,
@@ -3751,6 +3780,7 @@ fn forward_prefill_chunk(
     tape_offset: usize,
     tree_verify: Option<TreeVerifyCtx<'_>>,
     pre_uploaded: bool,
+    band: Option<&PrefillBandCtx<'_>>,
 ) -> HipResult<()> {
     let n = tokens.len();
     debug_assert!(n > 0);
@@ -3764,6 +3794,24 @@ fn forward_prefill_chunk(
     let hd = config.linear_key_head_dim;
     let dim_row_bytes = dim * 4;
 
+    let do_embed = band.map(|b| b.is_first_band).unwrap_or(true);
+    let do_lm_head = band.map(|b| b.is_last_band).unwrap_or(true);
+    let layer_start = band.map(|b| b.layer_start).unwrap_or(0);
+    let layer_end = band.map(|b| b.layer_end).unwrap_or(config.n_layers);
+    // Per-call-site `givens_cos_view` / `givens_sin_view` macros below
+    // resolve to either the band-supplied per-device replica (multi-GPU
+    // mode where `kv_cache.givens_*` is `None` by design) or the
+    // kv_cache's own table (single-GPU). Held as macros, not top-level
+    // bindings, so the immutable borrow on `kv_cache.givens_*` doesn't
+    // outlive the kernel-call statement and conflict with later
+    // mutable borrows of `kv_cache` (e.g. inside `run_fa_layer_body`).
+    macro_rules! givens_cos_view { () => {
+        band.and_then(|b| b.givens_cos).or(kv_cache.givens_cos.as_ref())
+    } }
+    macro_rules! givens_sin_view { () => {
+        band.and_then(|b| b.givens_sin).or(kv_cache.givens_sin.as_ref())
+    } }
+
     // ── 1. Embed tokens into pbs.x_batch ─────────────────────────────────
     //
     // Fast path for HFQ4G256 (all MQ4-quantized Qwen3.5 models + friends):
@@ -3775,7 +3823,11 @@ fn forward_prefill_chunk(
     //
     // Other formats fall back to the per-token loop (kept for correctness
     // breadth; the MQ4-quantized hot path doesn't hit them).
-    if matches!(weights.embd_format, EmbeddingFormat::HFQ4G256 | EmbeddingFormat::Q8_0) {
+    //
+    // Multi-GPU band-mode: skip embedding when this is not the first band.
+    // The activation already lives in `pbs.x_batch` from a peer-copy of
+    // the previous band's `pbs.x_batch`.
+    if do_embed && matches!(weights.embd_format, EmbeddingFormat::HFQ4G256 | EmbeddingFormat::Q8_0) {
         if !pre_uploaded {
             let tokens_host: Vec<i32> = tokens.iter().map(|&t| t as i32).collect();
             let tokens_bytes: &[u8] = unsafe {
@@ -3792,7 +3844,7 @@ fn forward_prefill_chunk(
             }
             _ => unreachable!(),
         }
-    } else {
+    } else if do_embed {
         for (i, &tok) in tokens.iter().enumerate() {
             match weights.embd_format {
                 EmbeddingFormat::HFQ4G256 => unreachable!(),
@@ -3872,14 +3924,18 @@ fn forward_prefill_chunk(
     };
 
     // ── 2. Per-layer loop ────────────────────────────────────────────────
-    let mut delta_layer_idx = 0usize;
-    let mut kv_layer_idx = 0usize;
+    // Multi-GPU band-mode: counters seed from the band's running offsets so
+    // the band's first DeltaNet/FullAttn layer reads the correct
+    // `dn_state.s_matrices[i]` / `kv_cache.k_caches[i]` slot. Single-GPU
+    // (band==None) seeds zeros — original behavior.
+    let mut delta_layer_idx = band.map(|b| b.delta_layer_offset).unwrap_or(0);
+    let mut kv_layer_idx = band.map(|b| b.kv_layer_offset).unwrap_or(0);
     // Path B: per-FA-layer counter, drives the index into
     // tree_verify.pre_rope_k_capture[]. Increments alongside each
     // FullAttention layer iteration regardless of MoE/non-MoE variant.
-    let mut fa_layer_idx = 0usize;
+    let mut fa_layer_idx = band.map(|b| b.fa_layer_offset).unwrap_or(0);
 
-    for layer_idx in 0..config.n_layers {
+    for layer_idx in layer_start..layer_end {
         match (&weights.layers[layer_idx], config.layer_types[layer_idx]) {
             (LayerWeights::DeltaNet(layer), LayerType::LinearAttention) => {
                 // Per-layer dtype branch: MQ4 needs FWHT-rotation on the
@@ -4318,24 +4374,24 @@ fn forward_prefill_chunk(
 
                 // 6. Batched KV cache writes (per-row positions).
                 if kv_cache.quant_asym4 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.kv_cache_write_asym4_batched(
                         &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_k_batch, &pbs.fa_v_batch, &pbs.positions,
                         ct, st, config.n_kv_heads, config.head_dim, n,
                     )?;
                 } else if kv_cache.quant_asym3 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.kv_cache_write_asym3_batched(
                         &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_k_batch, &pbs.fa_v_batch, &pbs.positions,
                         ct, st, config.n_kv_heads, config.head_dim, n,
                     )?;
                 } else if kv_cache.quant_asym2 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.kv_cache_write_asym2_batched(
                         &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_k_batch, &pbs.fa_v_batch, &pbs.positions,
@@ -4368,8 +4424,8 @@ fn forward_prefill_chunk(
                     None => (0, 0),
                 };
                 if kv_cache.quant_asym4 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.attention_flash_asym4_batched_masked(
                         &pbs.fa_q_batch, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_attn_out_batch, &pbs.positions, ct, st,
@@ -4378,8 +4434,8 @@ fn forward_prefill_chunk(
                         tree_bias, block_start, block_cols,
                     )?;
                 } else if kv_cache.quant_asym3 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.attention_flash_asym3_batched_masked(
                         &pbs.fa_q_batch, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_attn_out_batch, &pbs.positions, ct, st,
@@ -4392,8 +4448,8 @@ fn forward_prefill_chunk(
                         tree_verify.is_none(),
                         "tree-verify mode not supported on asym2 KV (use asym3)",
                     );
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.attention_flash_asym2_batched(
                         &pbs.fa_q_batch, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_attn_out_batch, &pbs.positions, ct, st,
@@ -4833,24 +4889,24 @@ fn forward_prefill_chunk(
                     config.rope_theta, n,
                 )?;
                 if kv_cache.quant_asym4 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.kv_cache_write_asym4_batched(
                         &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_k_batch, &pbs.fa_v_batch, &pbs.positions,
                         ct, st, config.n_kv_heads, config.head_dim, n,
                     )?;
                 } else if kv_cache.quant_asym3 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.kv_cache_write_asym3_batched(
                         &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_k_batch, &pbs.fa_v_batch, &pbs.positions,
                         ct, st, config.n_kv_heads, config.head_dim, n,
                     )?;
                 } else if kv_cache.quant_asym2 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.kv_cache_write_asym2_batched(
                         &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_k_batch, &pbs.fa_v_batch, &pbs.positions,
@@ -4873,8 +4929,8 @@ fn forward_prefill_chunk(
                     None => (0, 0),
                 };
                 if kv_cache.quant_asym4 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.attention_flash_asym4_batched_masked(
                         &pbs.fa_q_batch, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_attn_out_batch, &pbs.positions, ct, st,
@@ -4883,8 +4939,8 @@ fn forward_prefill_chunk(
                         tree_bias, block_start, block_cols,
                     )?;
                 } else if kv_cache.quant_asym3 {
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.attention_flash_asym3_batched_masked(
                         &pbs.fa_q_batch, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_attn_out_batch, &pbs.positions, ct, st,
@@ -4897,8 +4953,8 @@ fn forward_prefill_chunk(
                         tree_verify.is_none(),
                         "tree-verify mode not supported on asym2 KV (use asym3)",
                     );
-                    let ct = kv_cache.givens_cos.as_ref().unwrap();
-                    let st = kv_cache.givens_sin.as_ref().unwrap();
+                    let ct = givens_cos_view!().unwrap();
+                    let st = givens_sin_view!().unwrap();
                     gpu.attention_flash_asym2_batched(
                         &pbs.fa_q_batch, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
                         &pbs.fa_attn_out_batch, &pbs.positions, ct, st,
@@ -4972,26 +5028,32 @@ fn forward_prefill_chunk(
     }
 
     // ── 3. Final output norm + logits ───────────────────────────────────
-    // If the caller requested per-token hidden output (DFlash verify path),
-    // run rmsnorm over all N rows into their buffer. Otherwise use the
-    // legacy last-token-only path.
-    if let Some((dst, offset_rows)) = per_token_hidden_out {
-        let dst_view = dst.sub_offset(offset_rows * dim, n * dim);
-        gpu.rmsnorm_batched(
-            &pbs.x_batch, &weights.output_norm, &dst_view,
-            n, dim, config.norm_eps,
-        )?;
-        // Still populate s.logits with the last-token logits for callers
-        // that rely on it (the legacy prefill path's post-condition).
-        let last = n - 1;
-        let last_view = dst.sub_offset((offset_rows + last) * dim, dim);
-        weight_gemv(gpu, &weights.output, &last_view, &s.logits)?;
-    } else {
-        // Legacy path: only last-token logits.
-        let last = n - 1;
-        gpu.hip.memcpy_dtod_at(&s.x.buf, 0, &pbs.x_batch.buf, last * dim_row_bytes, dim_row_bytes)?;
-        gpu.rmsnorm_f32(&s.x, &weights.output_norm, &s.tmp, config.norm_eps)?;
-        weight_gemv(gpu, &weights.output, &s.tmp, &s.logits)?;
+    // Multi-GPU band-mode: skip when this is not the last band — the
+    // running activation in `pbs.x_batch` is what the next band's
+    // peer-copy reads. `weights.output_norm` and `weights.output` only
+    // live on the last band's device anyway.
+    if do_lm_head {
+        // If the caller requested per-token hidden output (DFlash verify path),
+        // run rmsnorm over all N rows into their buffer. Otherwise use the
+        // legacy last-token-only path.
+        if let Some((dst, offset_rows)) = per_token_hidden_out {
+            let dst_view = dst.sub_offset(offset_rows * dim, n * dim);
+            gpu.rmsnorm_batched(
+                &pbs.x_batch, &weights.output_norm, &dst_view,
+                n, dim, config.norm_eps,
+            )?;
+            // Still populate s.logits with the last-token logits for callers
+            // that rely on it (the legacy prefill path's post-condition).
+            let last = n - 1;
+            let last_view = dst.sub_offset((offset_rows + last) * dim, dim);
+            weight_gemv(gpu, &weights.output, &last_view, &s.logits)?;
+        } else {
+            // Legacy path: only last-token logits.
+            let last = n - 1;
+            gpu.hip.memcpy_dtod_at(&s.x.buf, 0, &pbs.x_batch.buf, last * dim_row_bytes, dim_row_bytes)?;
+            gpu.rmsnorm_f32(&s.x, &weights.output_norm, &s.tmp, config.norm_eps)?;
+            weight_gemv(gpu, &weights.output, &s.tmp, &s.logits)?;
+        }
     }
 
     Ok(())
@@ -6438,6 +6500,221 @@ pub fn forward_scratch_multi(
         gpu.hip.memcpy_htod(&s.pos_buf, &pos_bytes)?;
     }
     forward_scratch_layers_multi(gpus, weights, config, pos, kv_cache, dn_state, scratch_set)
+}
+
+/// Multi-GPU batched prefill (Stage 6 of #58 — multi-gpu pipeline-parallel).
+/// Closes the daemon-time pp=1 vs pp=2 divergence — single-GPU
+/// `forward_prefill_batch` runs through the WMMA-batched fast path, while
+/// pp=2 was previously stuck on per-token `forward_scratch_multi` (a
+/// different kernel sequence with a different reduction order). This
+/// routes both paths through the same `forward_prefill_chunk` body, just
+/// band-restricted via `PrefillBandCtx`.
+///
+/// Flow per chunk of up to `max_batch` tokens:
+///   1. Allocate per-band `PrefillBatchScratch` on each device's pbs.
+///   2. Run `forward_prefill_chunk` on dev 0 with band 0 layers,
+///      `is_first_band=true` (does the embedding) and
+///      `is_last_band=(n_bands==1)`.
+///   3. peer-copy band 0's `pbs.x_batch` into band 1's `pbs.x_batch`.
+///   4. Run `forward_prefill_chunk` on dev 1 with band 1 layers,
+///      `is_first_band=false` (skips embedding, reads already-populated
+///      `x_batch`) and `is_last_band=true` (does final norm + lm_head).
+///   5. Repeat for any further bands.
+///
+/// `tree_verify`, DFlash hidden-rb, GdnTape, and per_token_hidden_out
+/// are pp=1 only in v1. They've been refused at the daemon load-time
+/// gate, so this function does not accept them as parameters.
+#[allow(clippy::too_many_arguments)]
+pub fn forward_prefill_batch_multi(
+    gpus: &mut Gpus,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    tokens: &[u32],
+    start_pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch_set: &Qwen35ScratchSet,
+) -> HipResult<()> {
+    let n_total = tokens.len();
+    if n_total == 0 {
+        return Ok(());
+    }
+
+    let n_bands = gpus.devices.len();
+    if n_bands == 0 {
+        return Err(hip_bridge::HipError::new(0, "forward_prefill_batch_multi: no devices"));
+    }
+
+    // F3 (review-pattern from forward_scratch_multi): asym{2,3,4} KV requires
+    // per-device givens replicas. Refuse up-front — the band-mode macros in
+    // forward_prefill_chunk fall back to kv_cache.givens_* if the band's
+    // givens override is None, which silently hands a wrong-device tensor
+    // to attention kernels.
+    if (kv_cache.quant_asym2 || kv_cache.quant_asym3 || kv_cache.quant_asym4)
+        && (gpus.givens_cos_per_dev.len() != n_bands
+            || gpus.givens_sin_per_dev.len() != n_bands)
+    {
+        return Err(hip_bridge::HipError::new(
+            0,
+            "forward_prefill_batch_multi: asym KV mode requires gpus.givens_*_per_dev \
+             populated for every device. Construct KvCache via the *_multi ctor \
+             (e.g. KvCache::new_gpu_asym3_capped_multi) — single-GPU ctors leave \
+             gpus.givens_*_per_dev empty.",
+        ));
+    }
+
+    let max_batch: usize = std::env::var("HIPFIRE_PREFILL_MAX_BATCH")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&v| v >= 2)
+        .unwrap_or(PREFILL_MAX_BATCH);
+
+    let force_fallback = std::env::var("HIPFIRE_PREFILL_BATCHED").ok().as_deref() == Some("0");
+
+    // Eligibility: same checks as `forward_prefill_batch_with_pbs`. If any
+    // layer fails the batched gate, fall back to per-token forward —
+    // correctness preserved at the cost of per-token kernel sequence.
+    let arch0 = gpus.devices[0].arch.as_str();
+    let moe_topk_ok = config.num_experts_per_tok == 8 && config.num_experts <= 1024;
+    let eligible = !force_fallback
+        && n_total >= 2
+        && dn_state.quant == StateQuant::Q8
+        && weights.layers.iter().any(|lw| matches!(
+            lw,
+            LayerWeights::DeltaNet(_) | LayerWeights::DeltaNetMoe(_),
+        ))
+        && weights.layers.iter().all(|lw| match lw {
+            LayerWeights::DeltaNet(l) =>
+                is_batchable_la(l.wqkv.gpu_dtype, arch0)
+                    && is_batchable_la(l.wz.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_beta.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_alpha.gpu_dtype, arch0)
+                    && is_batchable_la(l.wo.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_gate.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_up.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_down.gpu_dtype, arch0),
+            LayerWeights::FullAttn(l) =>
+                is_batchable_la(l.wq.gpu_dtype, arch0)
+                    && is_batchable_la(l.wk.gpu_dtype, arch0)
+                    && is_batchable_la(l.wv.gpu_dtype, arch0)
+                    && is_batchable_la(l.wo.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_gate.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_up.gpu_dtype, arch0)
+                    && is_batchable_la(l.w_down.gpu_dtype, arch0),
+            LayerWeights::DeltaNetMoe(_) | LayerWeights::FullAttnMoe(_) => moe_topk_ok,
+        });
+
+    if !eligible {
+        // Per-token fallback. Correctness over speed when the batched
+        // path's preconditions are not met.
+        for (i, &tok) in tokens.iter().enumerate() {
+            forward_scratch_multi(gpus, weights, config, tok, start_pos + i, kv_cache, dn_state, scratch_set)?;
+        }
+        return Ok(());
+    }
+
+    // Per-band cumulative offsets into LA / FA layer indices. The band's
+    // first layer of a given type (DeltaNet or FullAttn) reads
+    // `dn_state.s_matrices[delta_off]` / `kv_cache.k_caches[fa_off]`.
+    let mut delta_off_per_band = vec![0usize; n_bands];
+    let mut fa_off_per_band = vec![0usize; n_bands];
+    {
+        let mut delta_run = 0usize;
+        let mut fa_run = 0usize;
+        for b in 0..n_bands {
+            delta_off_per_band[b] = delta_run;
+            fa_off_per_band[b] = fa_run;
+            let band_start = gpus.band_starts[b];
+            let band_end = if b + 1 < n_bands { gpus.band_starts[b + 1] } else { config.n_layers };
+            for li in band_start..band_end {
+                match config.layer_types[li] {
+                    LayerType::LinearAttention => delta_run += 1,
+                    LayerType::FullAttention => fa_run += 1,
+                }
+            }
+        }
+    }
+
+    // Allocate one PrefillBatchScratch per band. Each lives on the band's
+    // device. Freed at the end of the call (matches forward_prefill_batch's
+    // own_pbs pattern). Future opt: cache on Qwen35ScratchSet.
+    let mut pbs_per_band: Vec<PrefillBatchScratch> = Vec::with_capacity(n_bands);
+    for b in 0..n_bands {
+        let g = &mut gpus.devices[b];
+        g.bind_thread()?;
+        pbs_per_band.push(PrefillBatchScratch::new(g, config, max_batch)?);
+    }
+
+    let dim = config.dim;
+    let dim_row_bytes = dim * 4;
+
+    let result = (|| -> HipResult<()> {
+        let mut chunk_start = 0usize;
+        while chunk_start < n_total {
+            let chunk_end = (chunk_start + max_batch).min(n_total);
+            let chunk = &tokens[chunk_start..chunk_end];
+            let chunk_n = chunk.len();
+
+            for b in 0..n_bands {
+                let band_layer_start = gpus.band_starts[b];
+                let band_layer_end = if b + 1 < n_bands { gpus.band_starts[b + 1] } else { config.n_layers };
+                let givens_cos = gpus.givens_cos_per_dev.get(b);
+                let givens_sin = gpus.givens_sin_per_dev.get(b);
+                let band_ctx = PrefillBandCtx {
+                    layer_start: band_layer_start,
+                    layer_end: band_layer_end,
+                    delta_layer_offset: delta_off_per_band[b],
+                    kv_layer_offset: fa_off_per_band[b],
+                    fa_layer_offset: fa_off_per_band[b],
+                    is_first_band: b == 0,
+                    is_last_band: b + 1 == n_bands,
+                    givens_cos,
+                    givens_sin,
+                };
+                {
+                    let pbs_b: &PrefillBatchScratch = &pbs_per_band[b];
+                    let s_b = &scratch_set.per_device[b];
+                    let g_b = &mut gpus.devices[b];
+                    forward_prefill_chunk(
+                        g_b, weights, config, chunk, start_pos + chunk_start,
+                        kv_cache, dn_state, s_b, pbs_b,
+                        None, // hidden_rb: pp=1 only
+                        None, // per_token_hidden_out: pp=1 only
+                        None, // gdn_tape: pp=1 only
+                        0,
+                        None, // tree_verify: pp=1 only
+                        false, // pre_uploaded
+                        Some(&band_ctx),
+                    )?;
+                }
+
+                if b + 1 < n_bands {
+                    // Hand off the chunk's residual stream to the next band.
+                    // pbs.x_batch holds [N × dim] f32 — copy `chunk_n` rows
+                    // from band b to band b+1. wait_boundary makes the dst
+                    // device wait on the copy's completion event before the
+                    // next forward_prefill_chunk dispatch reads x_batch.
+                    let copy_bytes = chunk_n * dim_row_bytes;
+                    let (left, right) = pbs_per_band.split_at(b + 1);
+                    let pbs_src = &left[b];
+                    let pbs_dst = &right[0];
+                    let evt = gpus.boundary_copy(b, b + 1, &pbs_src.x_batch.buf, &pbs_dst.x_batch.buf, copy_bytes)?;
+                    gpus.wait_boundary(evt)?;
+                }
+            }
+
+            chunk_start = chunk_end;
+        }
+        Ok(())
+    })();
+
+    for (b, pbs) in pbs_per_band.into_iter().enumerate() {
+        let g = &mut gpus.devices[b];
+        let _ = g.bind_thread();
+        pbs.free_gpu(g);
+    }
+
+    result
 }
 
 /// Forward pass returning logits ON GPU (no download). Caller must free the tensor.

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -5872,6 +5872,574 @@ fn forward_scratch_layers(
     Ok(())
 }
 
+/// Multi-GPU layer-loop dispatcher (Stage 5 of multi-GPU pp migration #58).
+/// Mirrors `forward_scratch_layers` but routes per-layer work to
+/// `gpus.devices[gpus.device_for_layer(i)]` and copies the residual
+/// stream `s.x` across band boundaries via `Gpus::boundary_copy`.
+/// Final `output_norm + lm_head` runs on `gpus.output_device`
+/// (Variant 2 — no copy back to dev_0). Spec-decode `hidden_rb` is
+/// not threaded — refused at load time when pp > 1.
+fn forward_scratch_layers_multi(
+    gpus: &mut Gpus,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch_set: &Qwen35ScratchSet,
+) -> HipResult<()> {
+    let dim = config.dim;
+    let k_dim = config.linear_num_key_heads * config.linear_key_head_dim;
+    let v_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+    let qkv_dim = k_dim * 2 + v_dim;
+    let _ = qkv_dim;
+    let n_v_heads = config.linear_num_value_heads;
+    let hd = config.linear_key_head_dim;
+
+    let mut delta_layer_idx = 0usize;
+    let mut prev_dev: Option<usize> = None;
+
+    for layer_idx in 0..config.n_layers {
+        let dev_idx = gpus.device_for_layer(layer_idx);
+
+        if let Some(pd) = prev_dev {
+            if dev_idx != pd {
+                let src_buf = &scratch_set.per_device[pd].x.buf;
+                let dst_buf = &scratch_set.per_device[dev_idx].x.buf;
+                let evt = gpus.boundary_copy(pd, dev_idx, src_buf, dst_buf, dim * 4)?;
+                gpus.wait_boundary(evt)?;
+            }
+        }
+
+        {
+            let s = &scratch_set.per_device[dev_idx];
+            let givens_cos_dev = gpus.givens_cos_per_dev.get(dev_idx);
+            let givens_sin_dev = gpus.givens_sin_per_dev.get(dev_idx);
+            let gpu = &mut gpus.devices[dev_idx];
+
+            // Resolve givens lazily — asym{2,3,4} branches use these,
+            // others don't. Multi-GPU prefers the per-device replica
+            // populated by the KV ctor; fall back to kv_cache.givens_*
+            // for single-GPU shape compatibility (shouldn't fire in
+            // pp > 1 since asym ctors always populate per-device).
+            macro_rules! ct {
+                () => {
+                    givens_cos_dev.unwrap_or_else(|| kv_cache.givens_cos.as_ref().unwrap())
+                };
+            }
+            macro_rules! st {
+                () => {
+                    givens_sin_dev.unwrap_or_else(|| kv_cache.givens_sin.as_ref().unwrap())
+                };
+            }
+
+            match (&weights.layers[layer_idx], config.layer_types[layer_idx]) {
+                (LayerWeights::DeltaNet(layer), LayerType::LinearAttention) => {
+                    let x_rot = fused_rmsnorm_rotate_for_mq(
+                        gpu, &layer.wqkv, &s.x, &layer.attn_norm, &s.tmp, &s.x_rot, config.norm_eps,
+                    )?;
+                    let dt = layer.wqkv.gpu_dtype;
+                    let fused_la4_ok = (dt == DType::MQ4G256 || dt == DType::HFQ4G256)
+                        && layer.wz.gpu_dtype == dt
+                        && layer.w_beta.gpu_dtype == dt
+                        && layer.w_alpha.gpu_dtype == dt;
+                    if fused_la4_ok {
+                        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                        gpu.fused_qkvza_hfq4g256(
+                            &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
+                            eff_x,
+                            &s.dn_qkv, &s.dn_z, &s.dn_beta, &s.dn_alpha,
+                            layer.wqkv.m, layer.wz.m, layer.w_beta.m, layer.w_alpha.m,
+                            layer.wqkv.k,
+                        )?;
+                    } else {
+                        weight_gemv_prerotated(gpu, &layer.wqkv, &s.tmp, x_rot, &s.dn_qkv)?;
+                        weight_gemv_prerotated(gpu, &layer.wz, &s.tmp, x_rot, &s.dn_z)?;
+                        weight_gemv_prerotated(gpu, &layer.w_beta, &s.tmp, x_rot, &s.dn_beta)?;
+                        weight_gemv_prerotated(gpu, &layer.w_alpha, &s.tmp, x_rot, &s.dn_alpha)?;
+                    }
+                    gpu.fused_sigmoid_alpha_gate_f32(
+                        &s.dn_beta, &s.dn_alpha, &layer.dt_bias, &layer.a_log, n_v_heads,
+                    )?;
+                    gpu.conv1d_silu_split_f32(
+                        &s.dn_q_raw, &s.dn_k_raw, &s.dn_v,
+                        &s.dn_qkv, &layer.conv_weight,
+                        &dn_state.conv_states[delta_layer_idx],
+                        k_dim, v_dim,
+                    )?;
+                    gpu.fused_qk_l2_norm_scale_f32(
+                        &s.dn_q_raw, &s.dn_k_raw,
+                        config.linear_num_key_heads, hd,
+                        1.0 / (hd as f32).sqrt(),
+                        config.norm_eps,
+                    )?;
+                    if config.linear_num_key_heads < n_v_heads {
+                        let ratio = n_v_heads / config.linear_num_key_heads;
+                        gpu.repeat_interleave_qk_f32(
+                            &s.dn_q_raw, &s.dn_k_raw, &s.dn_q, &s.dn_k,
+                            config.linear_num_key_heads, ratio, hd,
+                        )?;
+                    } else {
+                        gpu.memcpy_dtod_auto(&s.dn_q.buf, &s.dn_q_raw.buf, k_dim * 4)?;
+                        gpu.memcpy_dtod_auto(&s.dn_k.buf, &s.dn_k_raw.buf, k_dim * 4)?;
+                    }
+                    match dn_state.quant {
+                        StateQuant::FP32 => gpu.gated_delta_net_f32(
+                            &s.dn_q, &s.dn_k, &s.dn_v, &s.dn_alpha, &s.dn_beta,
+                            &dn_state.s_matrices[delta_layer_idx], &s.dn_attn_out,
+                            1, n_v_heads, config.linear_value_head_dim,
+                        )?,
+                        StateQuant::Q8 => gpu.gated_delta_net_q8(
+                            &s.dn_q, &s.dn_k, &s.dn_v, &s.dn_alpha, &s.dn_beta,
+                            &dn_state.s_matrices[delta_layer_idx],
+                            &dn_state.s_scales[delta_layer_idx], &s.dn_attn_out,
+                            1, n_v_heads, config.linear_value_head_dim,
+                        )?,
+                        StateQuant::Q4 => gpu.gated_delta_net_q4(
+                            &s.dn_q, &s.dn_k, &s.dn_v, &s.dn_alpha, &s.dn_beta,
+                            &dn_state.s_matrices[delta_layer_idx],
+                            &dn_state.s_scales[delta_layer_idx], &s.dn_attn_out,
+                            1, n_v_heads, config.linear_value_head_dim,
+                        )?,
+                    }
+                    gpu.gated_norm_f32(&s.dn_attn_out, &s.dn_z, &layer.norm_weight, &s.dn_normed,
+                        n_v_heads, config.linear_value_head_dim, config.norm_eps)?;
+                    weight_gemv_residual(gpu, &layer.wo, &s.dn_normed, &s.x)?;
+
+                    let x_rot = fused_rmsnorm_rotate_for_mq(
+                        gpu, &layer.w_gate, &s.x, &layer.ffn_norm, &s.tmp, &s.x_rot, config.norm_eps,
+                    )?;
+                    let dt_g = layer.w_gate.gpu_dtype;
+                    let fused_gu_ok = (dt_g == DType::MQ4G256 || dt_g == DType::HFQ4G256)
+                        && layer.w_up.gpu_dtype == dt_g;
+                    if fused_gu_ok {
+                        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                        gpu.fused_gate_up_hfq4g256(
+                            &layer.w_gate.buf, &layer.w_up.buf,
+                            eff_x,
+                            &s.gate_ffn, &s.up,
+                            layer.w_gate.m, layer.w_up.m,
+                            layer.w_gate.k,
+                        )?;
+                    } else {
+                        weight_gemv_prerotated(gpu, &layer.w_gate, &s.tmp, x_rot, &s.gate_ffn)?;
+                        weight_gemv_prerotated(gpu, &layer.w_up, &s.tmp, x_rot, &s.up)?;
+                    }
+                    weight_gemv_swiglu_residual(
+                        gpu, &layer.w_down, &s.gate_ffn, &s.up, &s.ffn_hidden, &s.x,
+                    )?;
+                    delta_layer_idx += 1;
+                }
+
+                (LayerWeights::FullAttn(layer), LayerType::FullAttention) => {
+                    let x_rot = fused_rmsnorm_rotate_for_mq(
+                        gpu, &layer.wq, &s.x, &layer.attn_norm, &s.tmp, &s.x_rot, config.norm_eps,
+                    )?;
+                    let dt = layer.wq.gpu_dtype;
+                    let fused_fa3_ok = (dt == DType::MQ4G256 || dt == DType::HFQ4G256)
+                        && layer.wk.gpu_dtype == dt
+                        && layer.wv.gpu_dtype == dt;
+                    if fused_fa3_ok {
+                        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                        gpu.fused_qkv_hfq4g256(
+                            &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                            eff_x,
+                            &s.fa_q_full, &s.fa_k, &s.fa_v,
+                            layer.wq.m, layer.wk.m, layer.wv.m,
+                            layer.wq.k,
+                        )?;
+                    } else {
+                        weight_gemv_prerotated(gpu, &layer.wq, &s.tmp, x_rot, &s.fa_q_full)?;
+                        weight_gemv_prerotated(gpu, &layer.wk, &s.tmp, x_rot, &s.fa_k)?;
+                        weight_gemv_prerotated(gpu, &layer.wv, &s.tmp, x_rot, &s.fa_v)?;
+                    }
+                    gpu.deinterleave_f32(&s.fa_q_full, &s.fa_q, &s.fa_gate, config.n_heads, config.head_dim)?;
+                    gpu.rmsnorm_batched(&s.fa_q, &layer.q_norm, &s.fa_q, config.n_heads, config.head_dim, config.norm_eps)?;
+                    let kv_dim = config.n_kv_heads * config.head_dim;
+                    gpu.rmsnorm_batched(&s.fa_k, &layer.k_norm, &s.fa_k, config.n_kv_heads, config.head_dim, config.norm_eps)?;
+
+                    if kv_cache.compact_offset > 0 {
+                        let abs = (pos + kv_cache.compact_offset) as i32;
+                        gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+                    }
+                    let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
+                    gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
+                        config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
+                    if kv_cache.compact_offset > 0 {
+                        let phys = pos as i32;
+                        gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+                    }
+
+                    if kv_cache.quant_asym4 {
+                        let ct = ct!(); let st = st!();
+                        gpu.kv_cache_write_asym4_fused(
+                            &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_k, &s.fa_v, &s.pos_buf, ct, st, config.n_kv_heads, config.head_dim)?;
+                        gpu.attention_flash_asym4(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, ct, st, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            &s.flash_partials,
+                        )?;
+                    } else if kv_cache.quant_asym3 {
+                        let ct = ct!(); let st = st!();
+                        gpu.kv_cache_write_asym3_fused(
+                            &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_k, &s.fa_v, &s.pos_buf, ct, st, config.n_kv_heads, config.head_dim)?;
+                        gpu.attention_flash_asym3(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, ct, st, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            &s.flash_partials,
+                        )?;
+                    } else if kv_cache.quant_asym2 {
+                        let ct = ct!(); let st = st!();
+                        gpu.kv_cache_write_asym2_fused(
+                            &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_k, &s.fa_v, &s.pos_buf, ct, st, config.n_kv_heads, config.head_dim)?;
+                        gpu.attention_flash_asym2(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, ct, st, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            &s.flash_partials,
+                        )?;
+                    } else if kv_cache.quant_q8 {
+                        gpu.kv_cache_write_q8_0(&kv_cache.k_gpu[layer_idx], &s.fa_k, &s.pos_buf, config.n_kv_heads, config.head_dim)?;
+                        gpu.kv_cache_write_q8_0(&kv_cache.v_gpu[layer_idx], &s.fa_v, &s.pos_buf, config.n_kv_heads, config.head_dim)?;
+                        let use_flash = gpu.capture_mode
+                            || s.flash_mode == 2
+                            || (s.flash_mode == 1 && pos + 1 >= 2048)
+                            || pos + 1 > 15000;
+                        if use_flash {
+                            gpu.attention_flash_q8_0(
+                                &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                                &s.fa_attn_out, &s.pos_buf, pos + 1,
+                                config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                                &s.flash_partials,
+                            )?;
+                        } else {
+                            gpu.attention_q8_0_kv(
+                                &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                                &s.fa_attn_out, &s.pos_buf, pos + 1,
+                                config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            )?;
+                        }
+                    } else {
+                        gpu.kv_cache_write(&kv_cache.k_gpu[layer_idx], &s.fa_k, &s.pos_buf, kv_dim)?;
+                        gpu.kv_cache_write(&kv_cache.v_gpu[layer_idx], &s.fa_v, &s.pos_buf, kv_dim)?;
+                        gpu.attention_f32(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                        )?;
+                    }
+
+                    gpu.sigmoid_mul_f32(&s.fa_attn_out, &s.fa_gate)?;
+                    weight_gemv_residual(gpu, &layer.wo, &s.fa_attn_out, &s.x)?;
+
+                    let x_rot = fused_rmsnorm_rotate_for_mq(
+                        gpu, &layer.w_gate, &s.x, &layer.ffn_norm, &s.tmp, &s.x_rot, config.norm_eps,
+                    )?;
+                    let dt_g = layer.w_gate.gpu_dtype;
+                    let fused_gu_ok = (dt_g == DType::MQ4G256 || dt_g == DType::HFQ4G256)
+                        && layer.w_up.gpu_dtype == dt_g;
+                    if fused_gu_ok {
+                        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                        gpu.fused_gate_up_hfq4g256(
+                            &layer.w_gate.buf, &layer.w_up.buf,
+                            eff_x,
+                            &s.gate_ffn, &s.up,
+                            layer.w_gate.m, layer.w_up.m,
+                            layer.w_gate.k,
+                        )?;
+                    } else {
+                        weight_gemv_prerotated(gpu, &layer.w_gate, &s.tmp, x_rot, &s.gate_ffn)?;
+                        weight_gemv_prerotated(gpu, &layer.w_up, &s.tmp, x_rot, &s.up)?;
+                    }
+                    weight_gemv_swiglu_residual(
+                        gpu, &layer.w_down, &s.gate_ffn, &s.up, &s.ffn_hidden, &s.x,
+                    )?;
+                }
+
+                (LayerWeights::DeltaNetMoe(layer), LayerType::LinearAttention) => {
+                    let x_rot = fused_rmsnorm_rotate_for_mq(
+                        gpu, &layer.wqkv, &s.x, &layer.attn_norm, &s.tmp, &s.x_rot, config.norm_eps,
+                    )?;
+                    let dt = layer.wqkv.gpu_dtype;
+                    let fused_la4_ok = (dt == DType::MQ4G256 || dt == DType::HFQ4G256)
+                        && layer.wz.gpu_dtype == dt
+                        && layer.w_beta.gpu_dtype == dt
+                        && layer.w_alpha.gpu_dtype == dt;
+                    if fused_la4_ok {
+                        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                        gpu.fused_qkvza_hfq4g256(
+                            &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
+                            eff_x,
+                            &s.dn_qkv, &s.dn_z, &s.dn_beta, &s.dn_alpha,
+                            layer.wqkv.m, layer.wz.m, layer.w_beta.m, layer.w_alpha.m,
+                            layer.wqkv.k,
+                        )?;
+                    } else {
+                        weight_gemv_prerotated(gpu, &layer.wqkv, &s.tmp, x_rot, &s.dn_qkv)?;
+                        weight_gemv_prerotated(gpu, &layer.wz, &s.tmp, x_rot, &s.dn_z)?;
+                        weight_gemv_prerotated(gpu, &layer.w_beta, &s.tmp, x_rot, &s.dn_beta)?;
+                        weight_gemv_prerotated(gpu, &layer.w_alpha, &s.tmp, x_rot, &s.dn_alpha)?;
+                    }
+                    gpu.fused_sigmoid_alpha_gate_f32(
+                        &s.dn_beta, &s.dn_alpha, &layer.dt_bias, &layer.a_log, n_v_heads,
+                    )?;
+                    gpu.conv1d_silu_split_f32(
+                        &s.dn_q_raw, &s.dn_k_raw, &s.dn_v,
+                        &s.dn_qkv, &layer.conv_weight,
+                        &dn_state.conv_states[delta_layer_idx],
+                        k_dim, v_dim,
+                    )?;
+                    gpu.fused_qk_l2_norm_scale_f32(
+                        &s.dn_q_raw, &s.dn_k_raw,
+                        config.linear_num_key_heads, hd,
+                        1.0 / (hd as f32).sqrt(),
+                        config.norm_eps,
+                    )?;
+                    if config.linear_num_key_heads < n_v_heads {
+                        let ratio = n_v_heads / config.linear_num_key_heads;
+                        gpu.repeat_interleave_qk_f32(
+                            &s.dn_q_raw, &s.dn_k_raw, &s.dn_q, &s.dn_k,
+                            config.linear_num_key_heads, ratio, hd,
+                        )?;
+                    } else {
+                        gpu.memcpy_dtod_auto(&s.dn_q.buf, &s.dn_q_raw.buf, k_dim * 4)?;
+                        gpu.memcpy_dtod_auto(&s.dn_k.buf, &s.dn_k_raw.buf, k_dim * 4)?;
+                    }
+                    match dn_state.quant {
+                        StateQuant::FP32 => gpu.gated_delta_net_f32(
+                            &s.dn_q, &s.dn_k, &s.dn_v, &s.dn_alpha, &s.dn_beta,
+                            &dn_state.s_matrices[delta_layer_idx], &s.dn_attn_out,
+                            1, n_v_heads, config.linear_value_head_dim,
+                        )?,
+                        StateQuant::Q8 => gpu.gated_delta_net_q8(
+                            &s.dn_q, &s.dn_k, &s.dn_v, &s.dn_alpha, &s.dn_beta,
+                            &dn_state.s_matrices[delta_layer_idx],
+                            &dn_state.s_scales[delta_layer_idx], &s.dn_attn_out,
+                            1, n_v_heads, config.linear_value_head_dim,
+                        )?,
+                        StateQuant::Q4 => gpu.gated_delta_net_q4(
+                            &s.dn_q, &s.dn_k, &s.dn_v, &s.dn_alpha, &s.dn_beta,
+                            &dn_state.s_matrices[delta_layer_idx],
+                            &dn_state.s_scales[delta_layer_idx], &s.dn_attn_out,
+                            1, n_v_heads, config.linear_value_head_dim,
+                        )?,
+                    }
+                    gpu.gated_norm_f32(&s.dn_attn_out, &s.dn_z, &layer.norm_weight, &s.dn_normed,
+                        n_v_heads, config.linear_value_head_dim, config.norm_eps)?;
+                    weight_gemv_residual(gpu, &layer.wo, &s.dn_normed, &s.x)?;
+
+                    if ffn_all_mq4_for_moe(&layer.ffn) {
+                        gpu.fused_rmsnorm_rotate_mq(
+                            &s.x, &layer.ffn_norm,
+                            s.moe_x_rot.as_ref().expect("MoE scratch"),
+                            config.dim, config.norm_eps,
+                        )?;
+                        moe_ffn_decode_with_scratch_prerotated(gpu, &layer.ffn, &s.x, &s.x, config, s)?;
+                    } else {
+                        gpu.rmsnorm_f32(&s.x, &layer.ffn_norm, &s.tmp, config.norm_eps)?;
+                        moe_ffn_decode_with_scratch(gpu, &layer.ffn, &s.tmp, &s.x, config, s)?;
+                    }
+                    delta_layer_idx += 1;
+                }
+
+                (LayerWeights::FullAttnMoe(layer), LayerType::FullAttention) => {
+                    let x_rot = fused_rmsnorm_rotate_for_mq(
+                        gpu, &layer.wq, &s.x, &layer.attn_norm, &s.tmp, &s.x_rot, config.norm_eps,
+                    )?;
+                    let dt = layer.wq.gpu_dtype;
+                    let fused_fa3_ok = (dt == DType::MQ4G256 || dt == DType::HFQ4G256)
+                        && layer.wk.gpu_dtype == dt
+                        && layer.wv.gpu_dtype == dt;
+                    if fused_fa3_ok {
+                        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                        gpu.fused_qkv_hfq4g256(
+                            &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                            eff_x,
+                            &s.fa_q_full, &s.fa_k, &s.fa_v,
+                            layer.wq.m, layer.wk.m, layer.wv.m,
+                            layer.wq.k,
+                        )?;
+                    } else {
+                        weight_gemv_prerotated(gpu, &layer.wq, &s.tmp, x_rot, &s.fa_q_full)?;
+                        weight_gemv_prerotated(gpu, &layer.wk, &s.tmp, x_rot, &s.fa_k)?;
+                        weight_gemv_prerotated(gpu, &layer.wv, &s.tmp, x_rot, &s.fa_v)?;
+                    }
+                    gpu.deinterleave_f32(&s.fa_q_full, &s.fa_q, &s.fa_gate, config.n_heads, config.head_dim)?;
+                    gpu.rmsnorm_batched(&s.fa_q, &layer.q_norm, &s.fa_q, config.n_heads, config.head_dim, config.norm_eps)?;
+                    let kv_dim = config.n_kv_heads * config.head_dim;
+                    gpu.rmsnorm_batched(&s.fa_k, &layer.k_norm, &s.fa_k, config.n_kv_heads, config.head_dim, config.norm_eps)?;
+
+                    if kv_cache.compact_offset > 0 {
+                        let abs = (pos + kv_cache.compact_offset) as i32;
+                        gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+                    }
+                    let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
+                    gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
+                        config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
+                    if kv_cache.compact_offset > 0 {
+                        let phys = pos as i32;
+                        gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+                    }
+
+                    if kv_cache.quant_asym4 {
+                        let ct = ct!(); let st = st!();
+                        gpu.kv_cache_write_asym4_fused(
+                            &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_k, &s.fa_v, &s.pos_buf, ct, st, config.n_kv_heads, config.head_dim)?;
+                        gpu.attention_flash_asym4(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, ct, st, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            &s.flash_partials,
+                        )?;
+                    } else if kv_cache.quant_asym3 {
+                        let ct = ct!(); let st = st!();
+                        gpu.kv_cache_write_asym3_fused(
+                            &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_k, &s.fa_v, &s.pos_buf, ct, st, config.n_kv_heads, config.head_dim)?;
+                        gpu.attention_flash_asym3(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, ct, st, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            &s.flash_partials,
+                        )?;
+                    } else if kv_cache.quant_asym2 {
+                        let ct = ct!(); let st = st!();
+                        gpu.kv_cache_write_asym2_fused(
+                            &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_k, &s.fa_v, &s.pos_buf, ct, st, config.n_kv_heads, config.head_dim)?;
+                        gpu.attention_flash_asym2(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, ct, st, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            &s.flash_partials,
+                        )?;
+                    } else if kv_cache.quant_q8 {
+                        gpu.kv_cache_write_q8_0(&kv_cache.k_gpu[layer_idx], &s.fa_k, &s.pos_buf, config.n_kv_heads, config.head_dim)?;
+                        gpu.kv_cache_write_q8_0(&kv_cache.v_gpu[layer_idx], &s.fa_v, &s.pos_buf, config.n_kv_heads, config.head_dim)?;
+                        let use_flash = gpu.capture_mode
+                            || s.flash_mode == 2
+                            || (s.flash_mode == 1 && pos + 1 >= 2048)
+                            || pos + 1 > 15000;
+                        if use_flash {
+                            gpu.attention_flash_q8_0(
+                                &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                                &s.fa_attn_out, &s.pos_buf, pos + 1,
+                                config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                                &s.flash_partials,
+                            )?;
+                        } else {
+                            gpu.attention_q8_0_kv(
+                                &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                                &s.fa_attn_out, &s.pos_buf, pos + 1,
+                                config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                            )?;
+                        }
+                    } else {
+                        gpu.kv_cache_write(&kv_cache.k_gpu[layer_idx], &s.fa_k, &s.pos_buf, kv_dim)?;
+                        gpu.kv_cache_write(&kv_cache.v_gpu[layer_idx], &s.fa_v, &s.pos_buf, kv_dim)?;
+                        gpu.attention_f32(
+                            &s.fa_q, &kv_cache.k_gpu[layer_idx], &kv_cache.v_gpu[layer_idx],
+                            &s.fa_attn_out, &s.pos_buf, pos + 1,
+                            config.n_heads, config.n_kv_heads, config.head_dim, kv_cache.physical_cap,
+                        )?;
+                    }
+
+                    gpu.sigmoid_mul_f32(&s.fa_attn_out, &s.fa_gate)?;
+                    weight_gemv_residual(gpu, &layer.wo, &s.fa_attn_out, &s.x)?;
+
+                    if ffn_all_mq4_for_moe(&layer.ffn) {
+                        gpu.fused_rmsnorm_rotate_mq(
+                            &s.x, &layer.ffn_norm,
+                            s.moe_x_rot.as_ref().expect("MoE scratch"),
+                            config.dim, config.norm_eps,
+                        )?;
+                        moe_ffn_decode_with_scratch_prerotated(gpu, &layer.ffn, &s.x, &s.x, config, s)?;
+                    } else {
+                        gpu.rmsnorm_f32(&s.x, &layer.ffn_norm, &s.tmp, config.norm_eps)?;
+                        moe_ffn_decode_with_scratch(gpu, &layer.ffn, &s.tmp, &s.x, config, s)?;
+                    }
+                }
+
+                _ => panic!("layer type mismatch at layer {layer_idx}"),
+            }
+        }
+
+        prev_dev = Some(dev_idx);
+    }
+
+    let dev_last = gpus.output_device;
+    let s_last = &scratch_set.per_device[dev_last];
+    let gpu_last = &mut gpus.devices[dev_last];
+    gpu_last.rmsnorm_f32(&s_last.x, &weights.output_norm, &s_last.tmp, config.norm_eps)?;
+    weight_gemv(gpu_last, &weights.output, &s_last.tmp, &s_last.logits)?;
+
+    Ok(())
+}
+
+/// Multi-GPU decode forward (Stage 5 of multi-GPU pp migration #58).
+/// Embedding lookup on dev 0 (token_embd lives there per Stage 4 placement),
+/// then the layer loop via `forward_scratch_layers_multi`. `s.logits` ends
+/// up on `gpus.output_device`. hipGraph capture is bypassed for pp > 1.
+pub fn forward_scratch_multi(
+    gpus: &mut Gpus,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    token: u32,
+    pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch_set: &Qwen35ScratchSet,
+) -> HipResult<()> {
+    // F3 (review): asym{2,3,4} KV requires per-device givens replicas. The
+    // ct!()/st!() macros in forward_scratch_layers_multi fall back to
+    // kv_cache.givens_* if the per-device replica is None — which silently
+    // hands a wrong-device tensor to attention kernels. Refuse up-front.
+    if (kv_cache.quant_asym2 || kv_cache.quant_asym3 || kv_cache.quant_asym4)
+        && (gpus.givens_cos_per_dev.len() != gpus.devices.len()
+            || gpus.givens_sin_per_dev.len() != gpus.devices.len())
+    {
+        return Err(hip_bridge::HipError::new(
+            0,
+            "forward_scratch_multi: asym KV mode requires gpus.givens_*_per_dev \
+             populated for every device. Construct KvCache via the *_multi ctor \
+             (e.g. KvCache::new_gpu_asym3_capped_multi) — single-GPU ctors leave \
+             gpus.givens_*_per_dev empty.",
+        ));
+    }
+
+    let dim = config.dim;
+    let pos_bytes = (pos as i32).to_ne_bytes();
+    {
+        let gpu0 = &mut gpus.devices[0];
+        let s0 = &scratch_set.per_device[0];
+        match weights.embd_format {
+            EmbeddingFormat::HFQ4G256 => gpu0.embedding_lookup_hfq4g256(&weights.token_embd, &s0.x, token, dim)?,
+            EmbeddingFormat::HFQ4G128 => gpu0.embedding_lookup_hfq4g128(&weights.token_embd, &s0.x, token, dim)?,
+            EmbeddingFormat::Q8_0 => gpu0.embedding_lookup_q8(&weights.token_embd, &s0.x, token, dim)?,
+            EmbeddingFormat::F32 => gpu0.embedding_lookup(&weights.token_embd, &s0.x, token, dim)?,
+            _ => panic!("unsupported embedding format"),
+        }
+    }
+    // pos_buf written to every device's scratch — every band reads it inside
+    // RoPE / KV write for FullAttention layers. F1 (review): bind_thread
+    // before each raw gpu.hip.memcpy_htod — HipRuntime methods bypass the
+    // Stage 2b bind audit, so without explicit bind the writes land on
+    // whatever device was last bound (dev 0 from the embedding lookup above).
+    for dev_idx in 0..gpus.devices.len() {
+        let gpu = &mut gpus.devices[dev_idx];
+        gpu.bind_thread()?;
+        let s = &scratch_set.per_device[dev_idx];
+        gpu.hip.memcpy_htod(&s.pos_buf, &pos_bytes)?;
+    }
+    forward_scratch_layers_multi(gpus, weights, config, pos, kv_cache, dn_state, scratch_set)
+}
+
 /// Forward pass returning logits ON GPU (no download). Caller must free the tensor.
 /// Use with gpu.sample_top_p() after applying CPU-side n-gram blocking via download/modify/upload.
 pub fn forward_gpu(

--- a/crates/hipfire-arch-qwen35/tests/pp_parity.rs
+++ b/crates/hipfire-arch-qwen35/tests/pp_parity.rs
@@ -1,0 +1,210 @@
+//! Stage 9 multi-GPU parity test (env-gated).
+//!
+//! Runs only when `HIPFIRE_HAVE_2_GPU=1` is set — single-GPU dev boxes
+//! and CI without dual GPUs silently skip. Mirrors the
+//! `pp_parity_chatml` example as a `cargo test`-driven gate so
+//! `cargo test --workspace` exercises pp parity when the hardware
+//! supports it.
+//!
+//! Asserts: per-token `forward_scratch_multi` ≡ `forward_scratch` bit-
+//! exact across 50 decode tokens after a 15-token ChatML prefill on
+//! qwen3.5-0.8b.mq4 + asym3 KV. This is the floor — if this regresses,
+//! pp=2 is broken.
+//!
+//! Model location: `$HOME/.hipfire/models/qwen3.5-0.8b.mq4` (override
+//! via `HIPFIRE_PP_PARITY_MODEL`).
+
+use hipfire_arch_qwen35::qwen35::{
+    self, DeltaNetState, Qwen35Scratch, Qwen35ScratchSet, StateQuant,
+};
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::KvCache;
+use hipfire_runtime::multi_gpu::Gpus;
+use hipfire_runtime::tokenizer::Tokenizer;
+use rdna_compute::Gpu;
+use std::path::Path;
+
+const N_DECODE: usize = 50;
+const PROMPT: &str = "Write a one-sentence greeting.";
+
+fn argmax(logits: &[f32]) -> u32 {
+    let mut best_idx = 0u32;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i as u32;
+        }
+    }
+    best_idx
+}
+
+fn build_prompt_tokens(tok: &Tokenizer) -> Vec<u32> {
+    let im_start = tok.encode("<|im_start|>");
+    let im_end = tok.encode("<|im_end|>");
+    let nl = tok.encode("\n");
+    let user = tok.encode("user");
+    let asst = tok.encode("assistant");
+    let q = tok.encode(PROMPT);
+    let mut t = Vec::new();
+    t.extend_from_slice(&im_start);
+    t.extend_from_slice(&user);
+    t.extend_from_slice(&nl);
+    t.extend_from_slice(&q);
+    t.extend_from_slice(&im_end);
+    t.extend_from_slice(&nl);
+    t.extend_from_slice(&im_start);
+    t.extend_from_slice(&asst);
+    t.extend_from_slice(&nl);
+    t
+}
+
+fn run_pp1(path: &str, prompt: &[u32]) -> Vec<u32> {
+    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpu = Gpu::init().expect("Gpu::init");
+    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let mut kv = KvCache::new_gpu_asym3_capped(
+        &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
+    ).expect("kv");
+    let mut dn = DeltaNetState::new_with_quant(&mut gpu, &config, StateQuant::Q8).expect("dn");
+    let scratch = Qwen35Scratch::new_with_kv_max(&mut gpu, &config, 64, 4096).expect("scratch");
+
+    for (i, &tok) in prompt.iter().enumerate() {
+        qwen35::forward_scratch(&mut gpu, &weights, &config, tok, i, &mut kv, &mut dn, &scratch)
+            .expect("forward_scratch prefill");
+    }
+    let mut tokens = Vec::with_capacity(N_DECODE);
+    let mut tok = {
+        let logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        argmax(&logits)
+    };
+    tokens.push(tok);
+    for step in 1..N_DECODE {
+        let pos = prompt.len() + step - 1;
+        qwen35::forward_scratch(&mut gpu, &weights, &config, tok, pos, &mut kv, &mut dn, &scratch)
+            .expect("forward_scratch decode");
+        let logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        tok = argmax(&logits);
+        tokens.push(tok);
+    }
+    scratch.free_gpu(&mut gpu);
+    dn.free_gpu(&mut gpu);
+    kv.free_gpu(&mut gpu);
+    weights.free_gpu(&mut gpu);
+    gpu.drain_pool();
+    tokens
+}
+
+fn run_pp2(path: &str, prompt: &[u32]) -> Vec<u32> {
+    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpus = Gpus::init_uniform(2, config.n_layers).expect("init_uniform");
+    let weights =
+        qwen35::load_weights_multi(&hfq, &config, &mut gpus).expect("load_weights_multi");
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 64, 4096)
+        .expect("scratch_set");
+    let mut kv = KvCache::new_gpu_asym3_capped_multi(
+        &mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
+    ).expect("kv multi");
+    let (mut dn, _la_to_device) =
+        DeltaNetState::new_with_quant_multi(&mut gpus, &config, StateQuant::Q8)
+            .expect("dn multi");
+    let _ = gpus.enable_peer_all().expect("enable_peer_all");
+
+    let dev_last = gpus.output_device;
+    for (i, &tok) in prompt.iter().enumerate() {
+        qwen35::forward_scratch_multi(
+            &mut gpus, &weights, &config, tok, i, &mut kv, &mut dn, &scratch_set,
+        ).expect("forward_scratch_multi prefill");
+    }
+    let mut tokens = Vec::with_capacity(N_DECODE);
+    let mut tok = {
+        let s_last = &scratch_set.per_device[dev_last];
+        let logits = gpus.devices[dev_last]
+            .download_f32(&s_last.logits)
+            .expect("download logits");
+        argmax(&logits)
+    };
+    tokens.push(tok);
+    for step in 1..N_DECODE {
+        let pos = prompt.len() + step - 1;
+        qwen35::forward_scratch_multi(
+            &mut gpus, &weights, &config, tok, pos, &mut kv, &mut dn, &scratch_set,
+        ).expect("forward_scratch_multi decode");
+        let s_last = &scratch_set.per_device[dev_last];
+        let logits = gpus.devices[dev_last]
+            .download_f32(&s_last.logits)
+            .expect("download logits");
+        tok = argmax(&logits);
+        tokens.push(tok);
+    }
+    tokens
+}
+
+// `#[ignore]`d by default. The cargo-test environment doesn't pre-compile
+// the full hot-path kernel set the daemon ships with — JIT via hipcc fails
+// on NixOS (and any host without ROCm SDK on PATH). Run explicitly:
+//
+//   HIP_VISIBLE_DEVICES=0,1 HIPFIRE_HAVE_2_GPU=1 \
+//       cargo test -p hipfire-arch-qwen35 --release --features deltanet \
+//                  --test pp_parity -- --ignored
+//
+// The canonical hands-free regression is `scripts/pp-gate.sh`, which
+// drives the daemon binary (carries pre-compiled kernels) end-to-end
+// and is wired into the pre-commit hook.
+#[test]
+#[ignore]
+fn pp_parity_chatml_50_decode() {
+    if std::env::var("HIPFIRE_HAVE_2_GPU").ok().as_deref() != Some("1") {
+        eprintln!("skipping: HIPFIRE_HAVE_2_GPU not set");
+        return;
+    }
+    let model = std::env::var("HIPFIRE_PP_PARITY_MODEL")
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").expect("HOME");
+            format!("{home}/.hipfire/models/qwen3.5-0.8b.mq4")
+        });
+    if !Path::new(&model).is_file() {
+        eprintln!("skipping: model {model} not found");
+        return;
+    }
+
+    let hfq = HfqFile::open(Path::new(&model)).expect("open hfq");
+    let tokenizer =
+        Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
+    let prompt = build_prompt_tokens(&tokenizer);
+    drop(hfq);
+
+    let toks_pp1 = run_pp1(&model, &prompt);
+    let toks_pp2 = run_pp2(&model, &prompt);
+
+    assert_eq!(
+        toks_pp1.len(),
+        N_DECODE,
+        "pp=1 generated {} tokens, expected {N_DECODE}",
+        toks_pp1.len(),
+    );
+    assert_eq!(
+        toks_pp2.len(),
+        N_DECODE,
+        "pp=2 generated {} tokens, expected {N_DECODE}",
+        toks_pp2.len(),
+    );
+
+    let common = toks_pp1
+        .iter()
+        .zip(toks_pp2.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    if common < N_DECODE {
+        let i = common;
+        panic!(
+            "pp parity broke at decode step {i}: pp=1={}, pp=2={}\n\
+             pp=1 head: {:?}\npp=2 head: {:?}",
+            toks_pp1[i], toks_pp2[i],
+            &toks_pp1[..i.min(toks_pp1.len())],
+            &toks_pp2[..i.min(toks_pp2.len())],
+        );
+    }
+}

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -83,6 +83,10 @@ name = "daemon"
 required-features = ["arch-qwen35", "arch-qwen35-vl", "arch-llama"]
 
 [[example]]
+name = "gpus_smoke"
+required-features = []
+
+[[example]]
 name = "infer_qwen35"
 required-features = ["arch-qwen35"]
 

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -233,3 +233,15 @@ required-features = ["arch-qwen35"]
 [[example]]
 name = "triattn_validate"
 required-features = ["arch-qwen35"]
+
+[[example]]
+name = "pp_parity"
+required-features = ["arch-qwen35", "deltanet"]
+
+[[example]]
+name = "pp_parity_chatml"
+required-features = ["arch-qwen35", "deltanet"]
+
+[[example]]
+name = "pp2_vram_probe"
+required-features = ["arch-qwen35", "deltanet"]

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -22,9 +22,10 @@ use hipfire_runtime::dflash::{DflashConfig, DflashScratch, DflashWeights};
 use hipfire_runtime::eos_filter::{EosFilter, EosFilterConfig, FilterAction};
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama;
+use hipfire_runtime::multi_gpu::Gpus;
 use hipfire_arch_llama::Llama;
 use hipfire_arch_qwen35::qwen35;
-use hipfire_arch_qwen35::qwen35::{DeltaNetState, LayerType};
+use hipfire_arch_qwen35::qwen35::{DeltaNetState, LayerType, Qwen35ScratchSet};
 use hipfire_arch_qwen35_vl::qwen35_vl;
 use hipfire_runtime::sampler::{self, SamplerConfig};
 use hipfire_arch_qwen35::speculative::{
@@ -253,6 +254,22 @@ struct DdtreeState {
 
 struct LoadedModel {
     arch_id: u32,
+    /// Pipeline-parallel degree. 1 = single-GPU (all existing fields below in
+    /// use, q35_scratch populated). >1 = multi-GPU (pp_gpus + pp_scratch_set
+    /// populated; q35_scratch stays None; kv_cache + dn_state still hold the
+    /// per-layer-routed tensors since the struct types are the same as
+    /// single-GPU). Refusal contracts in load_model_pp keep DFlash, CASK,
+    /// PFlash, VL and arch_id < 5 out of this branch.
+    pp: usize,
+    /// Owned multi-GPU orchestrator when `pp > 1`. The single-GPU path
+    /// continues to use the daemon's main `Gpu` directly.
+    pp_gpus: Option<Gpus>,
+    /// Per-device scratch when `pp > 1`. Replaces `q35_scratch`.
+    pp_scratch_set: Option<Qwen35ScratchSet>,
+    /// LA-layer → device map returned by `DeltaNetState::new_with_quant_multi`,
+    /// kept so `unload_model` and the reset handler can route per-layer
+    /// memsets to the correct device.
+    pp_dn_la_to_device: Option<Vec<u8>>,
     // Qwen3.5 state
     q35_config: Option<qwen35::Qwen35Config>,
     q35_weights: Option<qwen35::Qwen35Weights>,
@@ -565,7 +582,32 @@ fn main() {
                         Some("prefill_block must be > 0".to_string())
                     } else { None };
 
-                match load_model(path, max_seq, draft_path.as_deref(), kv_mode_override.as_deref(), &cask, &mut gpu) {
+                // Pipeline-parallel degree (Stage 7 of #58). Default 1 =
+                // single-GPU (no behavior change). pp > 1 routes through
+                // Gpus + *_multi paths and refuses VL / DFlash / CASK /
+                // PFlash at load time. v1 supports Qwen3.5 dense + MoE
+                // only — see load_model_pp for the arch_id check.
+                let pp = msg.get("params").and_then(|p| p.get("pp"))
+                    .and_then(|v| v.as_u64()).unwrap_or(1) as usize;
+                if pp > 1 {
+                    if draft_path.is_some() {
+                        let _ = writeln!(stdout, r#"{{"type":"error","message":"DFlash speculative decode requires pp=1 in v1; see issue #58 v1.1 roadmap"}}"#);
+                        let _ = stdout.flush();
+                        continue;
+                    }
+                    if cask.sidecar.is_some() {
+                        let _ = writeln!(stdout, r#"{{"type":"error","message":"CASK / TriAttention eviction requires pp=1 in v1; see issue #58 v1.1 roadmap"}}"#);
+                        let _ = stdout.flush();
+                        continue;
+                    }
+                    if pflash_drafter.is_some() || pflash_mode_str != "off" {
+                        let _ = writeln!(stdout, r#"{{"type":"error","message":"PFlash prefill compression requires pp=1 in v1; see issue #58 v1.1 roadmap"}}"#);
+                        let _ = stdout.flush();
+                        continue;
+                    }
+                }
+
+                match load_model(path, max_seq, draft_path.as_deref(), kv_mode_override.as_deref(), &cask, pp, &mut gpu) {
                     Ok(m) => {
                         let arch = match m.arch_id {
                             5 => "qwen3_5",
@@ -797,8 +839,35 @@ fn main() {
                 if let Some(ref mut m) = model {
                     m.seq_pos = 0;
                     m.conversation_tokens.clear();
-                    // Zero DeltaNet recurrent state (Qwen3.5)
-                    if let Some(ref dn) = m.dn_state {
+                    // Multi-GPU branch: route per-LA-layer memsets through
+                    // pp_dn_la_to_device so each buffer is zeroed on its
+                    // owning device. The single-GPU `gpu` parameter is left
+                    // alone — its scratch state isn't aliased to per-device
+                    // tensors when pp > 1.
+                    if m.pp > 1 {
+                        if let (Some(ref dn), Some(ref mut gpus), Some(ref la)) = (
+                            m.dn_state.as_ref(),
+                            m.pp_gpus.as_mut(),
+                            m.pp_dn_la_to_device.as_ref(),
+                        ) {
+                            for (i, s) in dn.s_matrices.iter().enumerate() {
+                                let g = &mut gpus.devices[la[i] as usize];
+                                let _ = g.bind_thread();
+                                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+                            }
+                            for (i, s) in dn.s_scales.iter().enumerate() {
+                                let g = &mut gpus.devices[la[i] as usize];
+                                let _ = g.bind_thread();
+                                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+                            }
+                            for (i, s) in dn.conv_states.iter().enumerate() {
+                                let g = &mut gpus.devices[la[i] as usize];
+                                let _ = g.bind_thread();
+                                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+                            }
+                        }
+                    } else if let Some(ref dn) = m.dn_state {
+                        // Zero DeltaNet recurrent state (Qwen3.5)
                         for s in &dn.s_matrices {
                             let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
                         }
@@ -883,6 +952,18 @@ fn main() {
                         continue;
                     }
                 };
+                // bench_prefill drives forward_prefill_batch / forward_scratch
+                // with the single-GPU `gpu` handle — those entry points panic
+                // when pp>1 because q35_scratch is None and the multi-GPU
+                // tensors live on Gpus instead. Refuse cleanly per snapshot
+                // review patch f253472. A pp>1 prefill bench is out of scope
+                // for v1.
+                if m.pp > 1 {
+                    let _ = writeln!(stdout,
+                        r#"{{"type":"error","message":"bench_prefill requires pp=1 (multi-GPU bench not implemented)"}}"#);
+                    let _ = stdout.flush();
+                    continue;
+                }
                 let n = msg.get("tokens").and_then(|v| v.as_u64()).unwrap_or(128) as usize;
                 // Guard physical_cap — reserve 32 slots of headroom so a subsequent
                 // generate request against the loaded model still has room. We guard
@@ -991,7 +1072,15 @@ fn main() {
     }
 }
 
-fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_override: Option<&str>, cask: &CaskConfig, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
+fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_override: Option<&str>, cask: &CaskConfig, pp: usize, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
+    if pp > 1 {
+        // Refusal contracts (DFlash, CASK sidecar) are enforced upstream in
+        // the "load" event handler so the operator gets a structured error
+        // before any HFQ open / weight allocation. By the time we get here
+        // with pp>1, draft_path is None and cask.sidecar is None.
+        let _ = (draft_path, cask);
+        return load_model_pp(path, max_seq, kv_mode_override, pp, gpu);
+    }
     // Per-load kv_mode (sent in load message params) overrides the env var.
     // Lets the CLI set size-aware defaults — e.g. Qwen3.5-27B prefers asym4
     // since layer-count compounding of asym3 noise flips argmax at decision
@@ -1285,6 +1374,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
 
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
+            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
             q35_config: Some(config), q35_weights: Some(weights), q35_scratch: Some(scratch),
             kv_cache: Some(kv), dn_state: Some(dn),
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
@@ -1311,6 +1401,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         let scratch = <Llama as Architecture>::new_state(gpu, &config)?;
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
+            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
             q35_config: None, q35_weights: None, q35_scratch: None,
             kv_cache: None, dn_state: None,
             llama_config: Some(config), llama_weights: Some(weights), llama_scratch: Some(scratch), llama_kv: Some(kv),
@@ -1322,6 +1413,106 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             dflash: None,
         })
     }
+}
+
+/// Multi-GPU pipeline-parallel load path (Stage 7 of #58). Refuses VL,
+/// non-Qwen3.5 architectures and (transitively, via the upstream "load"
+/// handler) DFlash, CASK and PFlash. Returns a `LoadedModel` with `pp_gpus`,
+/// `pp_scratch_set` and `pp_dn_la_to_device` populated; the daemon's primary
+/// `gpu` parameter is unused on this path. Eviction is refused at this layer
+/// because TriAttention/CASK/PFlash live on a single device and are not v1
+/// targets for pp>1 — physical_cap == max_seq accordingly.
+fn load_model_pp(
+    path: &str,
+    max_seq: usize,
+    kv_mode_override: Option<&str>,
+    pp: usize,
+    _gpu: &mut rdna_compute::Gpu,
+) -> Result<LoadedModel, String> {
+    let kv_mode = kv_mode_override
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| std::env::var("HIPFIRE_KV_MODE").unwrap_or_default());
+    let hfq = HfqFile::open(Path::new(path)).map_err(|e| format!("{e}"))?;
+    let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .ok_or("tokenizer not found")?;
+
+    if hfq.arch_id != 5 && hfq.arch_id != 6 {
+        return Err(format!(
+            "pp>1 supports Qwen3.5 dense (arch_id=5) and Qwen3.5-MoE / \
+             Qwen3.6-A3B (arch_id=6) only; got arch_id={}. LLaMA / Qwen3 \
+             dense (arch_id<5) is pp=1 only.",
+            hfq.arch_id
+        ));
+    }
+    if qwen35_vl::vision_config_from_hfq(&hfq).is_some()
+        && hfq.tensor_data("model.visual.patch_embed.proj.weight").is_some()
+    {
+        return Err("pp>1 does not support VL models in v1; see issue #58 v1.1 roadmap".into());
+    }
+
+    let config = qwen35::config_from_hfq(&hfq).ok_or("failed to read Qwen3.5 config")?;
+
+    let mut gpus = Gpus::init_uniform(pp, config.n_layers).map_err(|e| format!("{e}"))?;
+
+    let weights = qwen35::load_weights_multi(&hfq, &config, &mut gpus).map_err(|e| format!("{e}"))?;
+
+    // KV cache (asym3 default, q8/asym4/asym2 selectable). physical_cap ==
+    // max_seq on this path — eviction is refused at load.
+    let kv = match kv_mode.as_str() {
+        "q8" => llama::KvCache::new_gpu_q8_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "asym3" | "turbo3" | "turbo" | "auto" | "" => llama::KvCache::new_gpu_asym3_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        other => {
+            eprintln!("  KV cache: unrecognized '{other}', defaulting to asym3");
+            llama::KvCache::new_gpu_asym3_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?
+        }
+    };
+
+    // MoE state-quant rule mirrors the pp=1 path (Q8 drift on small hidden
+    // states); apply at the multi entry point so bit-equivalence with pp=1
+    // forward output holds when both run on the same model.
+    let dn_quant = if config.num_experts > 0 {
+        eprintln!("  DeltaNet state: FP32 (MoE model — Q8 drift mitigation)");
+        qwen35::StateQuant::FP32
+    } else {
+        qwen35::StateQuant::Q8
+    };
+    let (dn, la_to_device) =
+        DeltaNetState::new_with_quant_multi(&mut gpus, &config, dn_quant).map_err(|e| format!("{e}"))?;
+
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 128, max_seq).map_err(|e| format!("{e}"))?;
+
+    // ROCm 6.4.3 gotcha: enable_peer_access AFTER all allocations are live.
+    // See multi_gpu.rs::enable_peer_all docstring for the silent-success bug
+    // when the call precedes hipMalloc.
+    let _peer = gpus.enable_peer_all().map_err(|e| format!("enable_peer_all: {e}"))?;
+
+    eprintln!(
+        "  pp={pp} loaded: layer_to_device={:?}, output_device={}, peer_access={}",
+        gpus.layer_to_device, gpus.output_device, gpus.peer_access_enabled,
+    );
+
+    Ok(LoadedModel {
+        arch_id: hfq.arch_id,
+        pp,
+        pp_gpus: Some(gpus),
+        pp_scratch_set: Some(scratch_set),
+        pp_dn_la_to_device: Some(la_to_device),
+        q35_config: Some(config),
+        q35_weights: Some(weights),
+        q35_scratch: None,
+        kv_cache: Some(kv),
+        dn_state: Some(dn),
+        llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
+        vision_config: None, vision_weights: None,
+        tokenizer: Some(tokenizer),
+        seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None,
+        conversation_tokens: Vec::new(),
+        model_path: path.to_string(),
+        dflash: None,
+    })
 }
 
 /// Pre-screen all Qwen3.5/3.6 weight matrices for MMQ safety (#87).
@@ -1376,6 +1567,28 @@ fn screen_weights_qwen35(weights: &qwen35::Qwen35Weights, gpu: &mut rdna_compute
 }
 
 fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
+    // Multi-GPU branch (Stage 7 of #58). Frees per-device tensors through the
+    // Gpus orchestrator, then invalidates per-device caches so the next load
+    // can't inherit stale verdicts at recycled device addresses. Order
+    // matches the alloc order in load_model_pp reversed: scratch → kv → dn →
+    // weights, so each free targets a still-live owner.
+    if m.pp > 1 {
+        let mut gpus = m.pp_gpus.expect("pp>1 must carry pp_gpus");
+        if let Some(scratch_set) = m.pp_scratch_set { scratch_set.free_gpu_multi(&mut gpus); }
+        if let Some(kv) = m.kv_cache { kv.free_gpu_multi(&mut gpus); }
+        if let Some(dn) = m.dn_state {
+            let la_to_device = m.pp_dn_la_to_device.expect("pp>1 must carry la_to_device");
+            dn.free_gpu_multi(&mut gpus, &la_to_device);
+        }
+        if let Some(w) = m.q35_weights { w.free_gpu_multi(&mut gpus); }
+        for g in gpus.devices.iter_mut() {
+            g.invalidate_weight_caches();
+            g.invalidate_graph_state();
+            g.drain_pool();
+        }
+        let _ = gpu;
+        return;
+    }
     // DFlash state: draft weights have free_gpu; ring / snapshot / tape /
     // verify_scratch don't expose one — their GpuTensors / DeviceBuffers will
     // leak until daemon exit if the caller cycles load/unload mid-session.
@@ -2044,8 +2257,379 @@ fn generate_dflash(
     let _ = stdout.flush();
 }
 
+/// Multi-GPU pipeline-parallel AR decode (Stage 7 of #58). Mirrors the pp=1
+/// `generate` Qwen3.5 branch feature-for-feature: ChatFrame ChatML wrap,
+/// EosFilter UTF-8 streaming + strip-think + stop_at, LoopGuard n-gram
+/// detection, repeat penalty, attractor block on unclosed tool/think
+/// openers, max_think_tokens force-close, budget-alert nudge, ChatML \n
+/// trailer. Forward calls fan out to per-device tensors via
+/// `gpus.devices[dev]` and `scratch_set.per_device[dev]`; the final
+/// sample lives on `gpus.output_device`. DFlash, CASK, PFlash, VL and
+/// arch_id < 5 are refused upstream at load.
+#[allow(clippy::too_many_arguments)]
+fn generate_multi(
+    m: &mut LoadedModel,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    temp: f32,
+    top_p: f32,
+    max_tokens: usize,
+    repeat_penalty: f32,
+    _repeat_window: usize,
+    budget_alert_at_tok: usize,
+    budget_alert_text: &str,
+    max_think_tokens: usize,
+) {
+    let tokenizer = m.tokenizer.as_ref().unwrap();
+    let prompt_est = tokenizer.encode(prompt).len() + 20;
+    if m.seq_pos + prompt_est + max_tokens > m.max_seq {
+        eprintln!("[daemon] context full ({}/{}) — resetting conversation", m.seq_pos, m.max_seq);
+        m.seq_pos = 0;
+        m.conversation_tokens.clear();
+        if let (Some(ref dn), Some(ref mut gpus), Some(ref la)) = (
+            m.dn_state.as_ref(),
+            m.pp_gpus.as_mut(),
+            m.pp_dn_la_to_device.as_ref(),
+        ) {
+            for (i, s) in dn.s_matrices.iter().enumerate() {
+                let g = &mut gpus.devices[la[i] as usize];
+                let _ = g.bind_thread();
+                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for (i, s) in dn.s_scales.iter().enumerate() {
+                let g = &mut gpus.devices[la[i] as usize];
+                let _ = g.bind_thread();
+                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for (i, s) in dn.conv_states.iter().enumerate() {
+                let g = &mut gpus.devices[la[i] as usize];
+                let _ = g.bind_thread();
+                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+            }
+        }
+        if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
+    }
+
+    let im_end = tokenizer.encode("<|im_end|>");
+    let nl = tokenizer.encode("\n");
+    let q_tokens = tokenizer.encode(prompt);
+
+    // ChatML framing via the canonical hipfire_runtime::prompt_frame module.
+    // Identical to the pp=1 path so multi-turn behavior matches byte-for-byte
+    // when both paths run the same model on the same prompt history.
+    let new_tokens = hipfire_runtime::prompt_frame::ChatFrame {
+        tokenizer,
+        system: if m.seq_pos == 0 { system_prompt } else { None },
+        user: "",
+        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+        raw: false,
+    }
+    .build_with_user_tokens(&q_tokens);
+
+    let trailer = nl.len();
+    if m.seq_pos + new_tokens.len() + max_tokens + trailer > m.physical_cap {
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"request exceeds loaded KV budget: seq_pos={} + prefill={} + max_tokens={} + trailer={} > physical_cap={} — reload model with a larger max_seq"}}"#,
+            id, m.seq_pos, new_tokens.len(), max_tokens, trailer, m.physical_cap
+        );
+        let _ = stdout.flush();
+        return;
+    }
+
+    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    let tool_call_pair = match (
+        tokenizer.special_token_id("<tool_call>"),
+        tokenizer.special_token_id("</tool_call>"),
+    ) {
+        (Some(o), Some(c)) => Some((o, c)),
+        _ => None,
+    };
+    let think_pair = match (
+        tokenizer.special_token_id("<think>"),
+        tokenizer.special_token_id("</think>"),
+    ) {
+        (Some(o), Some(c)) => Some((o, c)),
+        _ => None,
+    };
+
+    let prefill_tokens = new_tokens.len();
+    let t0 = Instant::now();
+
+    let config = m.q35_config.as_ref().unwrap();
+    let weights = m.q35_weights.as_ref().unwrap();
+    let scratch_set = m.pp_scratch_set.as_ref().unwrap();
+    let kv = m.kv_cache.as_mut().unwrap();
+    let dn = m.dn_state.as_mut().unwrap();
+    let gpus = m.pp_gpus.as_mut().unwrap();
+
+    let dev_last = gpus.output_device;
+    let vocab_size = config.vocab_size;
+    let repeat_buf_cap = scratch_set.per_device[dev_last].repeat_buf.buf.size() / 4;
+
+    if let Err(e) = qwen35::forward_prefill_batch_multi(
+        gpus, weights, config, &new_tokens, m.seq_pos, kv, dn, scratch_set,
+    ) {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"forward_prefill_batch_multi: {}"}}"#, id, e);
+        let _ = stdout.flush();
+        return;
+    }
+    m.seq_pos += new_tokens.len();
+    m.conversation_tokens.extend_from_slice(&new_tokens);
+
+    // ngram scope: generated tokens only (matches pp=1).
+    let ngram_scope_start = m.conversation_tokens.len();
+
+    let mut rng_state: u32 = 0x13579BDFu32;
+
+    let attractor_pairs: Vec<(u32, u32)> = tool_call_pair
+        .into_iter()
+        .chain(think_pair.into_iter())
+        .collect();
+
+    // First sample on the output device.
+    let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
+    let mut blocked0: Vec<u32> = Vec::new();
+    sampler::collect_unclosed_attractor_blocks(
+        ngram_scope, &attractor_pairs, 20, 2, &mut blocked0,
+    );
+    let cfg0 = SamplerConfig {
+        temperature: temp,
+        top_p,
+        repeat_penalty,
+        repeat_window: repeat_buf_cap,
+        blocked_tokens: blocked0,
+    };
+    let tok0 = {
+        let s_last = &scratch_set.per_device[dev_last];
+        let g_last = &mut gpus.devices[dev_last];
+        sampler::sample(
+            g_last,
+            &s_last.logits,
+            &s_last.sample_buf,
+            &s_last.repeat_buf,
+            vocab_size,
+            ngram_scope,
+            &cfg0,
+            &mut rng_state,
+        )
+    };
+    let t_prefill = Instant::now();
+    let mut next_token = tok0;
+
+    let mut generated = 0usize;
+    let mut streamed_tokens: Vec<u32> = Vec::new();
+    let mut bytes_fed_to_filter = 0usize;
+    let mut filter = EosFilter::new(EosFilterConfig::default());
+    let mut alert_fired = false;
+    let mut think_count: usize = 0;
+    let mut prev_in_think: bool = false;
+    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_env();
+
+    while generated < max_tokens {
+        generated += 1;
+        m.conversation_tokens.push(next_token);
+        streamed_tokens.push(next_token);
+        let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
+        let new_bytes = &all_bytes[bytes_fed_to_filter..];
+        bytes_fed_to_filter = all_bytes.len();
+        if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
+            let text = std::str::from_utf8(&text_bytes).unwrap();
+            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+            let _ = stdout.flush();
+        }
+
+        if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, next_token, m.seq_pos, kv, dn, scratch_set) {
+            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"forward_scratch_multi decode: {}"}}"#, id, e);
+            let _ = stdout.flush();
+            return;
+        }
+        m.seq_pos += 1;
+
+        if next_token == config.eos_token { break; }
+        if im_end_token == Some(next_token) { break; }
+        if tokenizer.is_terminator(next_token) { break; }
+
+        // max_think_tokens enforcement: same decoded-text scan as pp=1.
+        if max_think_tokens > 0 {
+            let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
+            let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
+            let open_idx = raw_str.rfind("<think>");
+            let close_idx = raw_str.rfind("</think>");
+            let in_think = match (open_idx, close_idx) {
+                (Some(o), Some(c)) => o > c,
+                (Some(_), None) => true,
+                _ => false,
+            };
+            if in_think {
+                if !prev_in_think { think_count = 1; } else { think_count += 1; }
+            } else {
+                think_count = 0;
+            }
+            prev_in_think = in_think;
+
+            if in_think && think_count >= max_think_tokens {
+                let close_tokens = tokenizer.encode("</think>\n");
+                let budget_left = max_tokens.saturating_sub(generated);
+                let take = close_tokens.len().min(budget_left);
+                for &t in &close_tokens[..take] {
+                    if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, t, m.seq_pos, kv, dn, scratch_set) {
+                        eprintln!("[daemon] max_think close forward_scratch_multi: {}", e);
+                        break;
+                    }
+                    m.seq_pos += 1;
+                    m.conversation_tokens.push(t);
+                    streamed_tokens.push(t);
+                    let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
+                    let new_bytes = &all_bytes[bytes_fed_to_filter..];
+                    bytes_fed_to_filter = all_bytes.len();
+                    if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
+                        let text = std::str::from_utf8(&text_bytes).unwrap();
+                        let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                        let _ = stdout.flush();
+                    }
+                    generated += 1;
+                }
+                think_count = 0;
+                prev_in_think = false;
+                if generated >= max_tokens { break; }
+            }
+        }
+
+        // N-gram loop detector (token-side, no GPU work).
+        if let Some(hipfire_runtime::loop_guard::StopReason::NgramRepeat { count, .. }) =
+            loop_guard.check(&streamed_tokens)
+        {
+            let window_len = loop_guard.window_len(streamed_tokens.len());
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"info","id":"{}","message":"ngram loop detected (4gram repeated {}× in last {} tokens) — forcing EOS"}}"#,
+                id, count, window_len
+            );
+            let _ = stdout.flush();
+            break;
+        }
+
+        // Budget-alert injection: gated to inside an open <think> block.
+        if !alert_fired && budget_alert_at_tok > 0 && generated >= budget_alert_at_tok && !budget_alert_text.is_empty() {
+            alert_fired = true;
+            let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
+            let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
+            let in_think = match (raw_str.rfind("<think>"), raw_str.rfind("</think>")) {
+                (Some(o), Some(c)) => o > c,
+                (Some(_), None) => true,
+                _ => false,
+            };
+            if !in_think {
+                let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not inside an open <think> block"}}"#, id);
+                let _ = stdout.flush();
+                let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
+                let mut blocked: Vec<u32> = Vec::new();
+                sampler::collect_unclosed_attractor_blocks(ngram_scope, &attractor_pairs, 20, 2, &mut blocked);
+                let cfg = SamplerConfig {
+                    temperature: temp, top_p, repeat_penalty,
+                    repeat_window: repeat_buf_cap,
+                    blocked_tokens: blocked,
+                };
+                next_token = {
+                    let s_last = &scratch_set.per_device[dev_last];
+                    let g_last = &mut gpus.devices[dev_last];
+                    sampler::sample(g_last, &s_last.logits, &s_last.sample_buf, &s_last.repeat_buf, vocab_size, ngram_scope, &cfg, &mut rng_state)
+                };
+                continue;
+            }
+            let nudge_tokens = tokenizer.encode(budget_alert_text);
+            let budget_left = max_tokens.saturating_sub(generated);
+            let nudge_len = nudge_tokens.len().min(budget_left);
+            let need_kv = m.seq_pos + nudge_len + (max_tokens - generated - nudge_len) + nl.len();
+            if nudge_len > 0 && need_kv <= m.physical_cap {
+                for &tok in &nudge_tokens[..nudge_len] {
+                    m.conversation_tokens.push(tok);
+                    streamed_tokens.push(tok);
+                    let all_bytes2 = tokenizer.decode_bytes(&streamed_tokens);
+                    let new_bytes2 = &all_bytes2[bytes_fed_to_filter..];
+                    bytes_fed_to_filter = all_bytes2.len();
+                    if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes2) {
+                        let t = std::str::from_utf8(&text_bytes).unwrap();
+                        let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&t).unwrap_or_default());
+                        let _ = stdout.flush();
+                    }
+                    if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, tok, m.seq_pos, kv, dn, scratch_set) {
+                        eprintln!("[daemon] budget_alert forward_scratch_multi: {}", e);
+                        break;
+                    }
+                    m.seq_pos += 1;
+                    generated += 1;
+                }
+            } else if nudge_len < nudge_tokens.len() {
+                let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert clipped or skipped: nudge_len={} budget_left={}"}}"#, id, nudge_len, budget_left);
+                let _ = stdout.flush();
+            } else {
+                let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not enough KV headroom"}}"#, id);
+                let _ = stdout.flush();
+            }
+            if generated >= max_tokens { break; }
+        }
+
+        // Steady-state sample.
+        let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
+        let mut blocked: Vec<u32> = Vec::new();
+        sampler::collect_unclosed_attractor_blocks(ngram_scope, &attractor_pairs, 20, 2, &mut blocked);
+        let cfg = SamplerConfig {
+            temperature: temp, top_p, repeat_penalty,
+            repeat_window: repeat_buf_cap,
+            blocked_tokens: blocked,
+        };
+        next_token = {
+            let s_last = &scratch_set.per_device[dev_last];
+            let g_last = &mut gpus.devices[dev_last];
+            sampler::sample(g_last, &s_last.logits, &s_last.sample_buf, &s_last.repeat_buf, vocab_size, ngram_scope, &cfg, &mut rng_state)
+        };
+    }
+
+    // ChatML \n trailer so the next turn opens cleanly.
+    if im_end_token == Some(*m.conversation_tokens.last().unwrap_or(&0)) && !nl.is_empty() {
+        for &t in &nl {
+            if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, t, m.seq_pos, kv, dn, scratch_set) {
+                eprintln!("[daemon] trailer forward_scratch_multi: {}", e);
+                break;
+            }
+            m.seq_pos += 1;
+            m.conversation_tokens.push(t);
+        }
+    }
+
+    let t_end = Instant::now();
+    let total_s = t_end.duration_since(t0).as_secs_f64();
+    let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
+    let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
+    let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
+    let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens as f64 / prefill_s } else { 0.0 };
+    let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+    let _ = writeln!(
+        stdout,
+        r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1}}}"#,
+        id, generated, tok_s, prefill_tokens,
+        prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0
+    );
+    let _ = stdout.flush();
+}
+
 #[allow(clippy::too_many_arguments)]
 fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>) {
+    // Multi-GPU pipeline-parallel dispatch (Stage 7 of #58). pp>1 is refused
+    // at load when DFlash / CASK / PFlash / VL is requested, so this branch
+    // doesn't need to thread any of those args through.
+    if m.pp > 1 {
+        let _ = (gpu, pflash_state, pflash_cfg);
+        generate_multi(
+            m, stdout, id, prompt, system_prompt, temp, top_p, max_tokens,
+            repeat_penalty, repeat_window, budget_alert_at_tok, budget_alert_text, max_think_tokens,
+        );
+        return;
+    }
     // DFlash fast path -- only when a draft model is loaded AND temperature is
     // effectively 0 (DFlash is greedy-only in this integration). Skip the
     // normal AR sampling setup entirely.

--- a/crates/hipfire-runtime/examples/gpus_smoke.rs
+++ b/crates/hipfire-runtime/examples/gpus_smoke.rs
@@ -1,0 +1,103 @@
+//! Smoke test for `Gpus` orchestrator: init_uniform layer split, peer
+//! enable, boundary_copy + wait_boundary round-trip.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p hipfire-runtime --example gpus_smoke
+
+use hipfire_runtime::multi_gpu::Gpus;
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    println!("── Gpus::init_uniform(2, 24) ─────────────────────────────");
+    let mut gpus = Gpus::init_uniform(2, 24).expect("init_uniform");
+    assert_eq!(gpus.devices.len(), 2);
+    assert_eq!(gpus.layer_to_device.len(), 24);
+    assert_eq!(gpus.band_starts, vec![0, 12]);
+    assert_eq!(gpus.output_device, 1);
+    println!("  layer_to_device: {:?}", gpus.layer_to_device);
+    println!("  band_starts:     {:?}", gpus.band_starts);
+    println!("  output_device:   {}", gpus.output_device);
+
+    for layer in 0..12 {
+        assert_eq!(gpus.device_for_layer(layer), 0, "layer {layer} on dev 0");
+    }
+    for layer in 12..24 {
+        assert_eq!(gpus.device_for_layer(layer), 1, "layer {layer} on dev 1");
+    }
+    assert!(gpus.is_band_boundary(11), "layer 11 → 12 is a boundary");
+    assert!(!gpus.is_band_boundary(12), "layer 12 → 13 is not");
+    assert!(!gpus.is_band_boundary(23), "last layer has no successor");
+
+    println!("\n── allocate src/dst BEFORE enable_peer_all (ROCm gotcha) ─");
+    let n_elems = 1024usize;
+    let bytes = n_elems * 4;
+    let pattern: Vec<f32> = (0..n_elems).map(|i| i as f32 * 0.5).collect();
+
+    gpus.devices[0].bind_thread().expect("bind 0");
+    let src_t = gpus.devices[0]
+        .upload_f32(&pattern, &[n_elems])
+        .expect("upload src dev 0");
+    gpus.devices[1].bind_thread().expect("bind 1");
+    let dst_t = gpus.devices[1]
+        .zeros(&[n_elems], DType::F32)
+        .expect("zeros dst dev 1");
+
+    println!("\n── Gpus::enable_peer_all() ───────────────────────────────");
+    let peer_ok = gpus.enable_peer_all().expect("enable_peer_all");
+    assert!(peer_ok, "peer access should be bidirectional on 2× 7900 XTX");
+    assert!(gpus.peer_access_enabled);
+    println!("  peer_access_enabled = true");
+
+    println!("\n── boundary_copy 0→1 (null-stream path) ──────────────────");
+    let evt = gpus
+        .boundary_copy(0, 1, &src_t.buf, &dst_t.buf, bytes)
+        .expect("boundary_copy");
+    assert_eq!(evt.dst_dev, 1);
+    gpus.wait_boundary(evt).expect("wait_boundary");
+
+    let dst_host = gpus.devices[1].download_f32(&dst_t).expect("download dst");
+    assert_eq!(dst_host, pattern, "boundary_copy 0→1 byte-equality");
+    println!("  1024 f32 elements: byte-identical after boundary_copy + wait");
+
+    println!("\n── boundary_copy 1→0 (reverse direction, distinct pattern) ─");
+    // Going through a fresh upload (rather than memset(src,0) + reverse) avoids
+    // the ROCm 6.4.3 quirk where memset immediately followed by a peer read
+    // silently no-ops on the same page.
+    let reverse_pattern: Vec<f32> = (0..n_elems).map(|i| -(i as f32) * 0.25).collect();
+    gpus.devices[1].bind_thread().expect("bind 1 for upload reverse");
+    let bytes_view = unsafe {
+        std::slice::from_raw_parts(reverse_pattern.as_ptr() as *const u8, bytes)
+    };
+    gpus.devices[1]
+        .hip
+        .memcpy_htod(&dst_t.buf, bytes_view)
+        .expect("upload reverse pattern to dst");
+    let evt = gpus
+        .boundary_copy(1, 0, &dst_t.buf, &src_t.buf, bytes)
+        .expect("boundary_copy reverse");
+    gpus.wait_boundary(evt).expect("wait_boundary reverse");
+    let src_host = gpus.devices[0].download_f32(&src_t).expect("download src");
+    assert_eq!(
+        src_host, reverse_pattern,
+        "1→0 boundary_copy must carry reverse_pattern from dev 1 to dev 0"
+    );
+    println!("  reverse copy verified — dev 0 holds new pattern after 1→0");
+
+    gpus.devices[0].free_tensor(src_t).expect("free src");
+    gpus.devices[1].bind_thread().expect("bind 1 for free");
+    gpus.devices[1].free_tensor(dst_t).expect("free dst");
+
+    println!("\n── Gpus::single back-compat ──────────────────────────────");
+    drop(gpus); // release dev 0/1 before re-init for single
+    let solo = Gpu::init_with_device(0).expect("init solo");
+    let single = Gpus::single(solo, 24);
+    assert_eq!(single.devices.len(), 1);
+    assert_eq!(single.layer_to_device, vec![0u8; 24]);
+    assert_eq!(single.output_device, 0);
+    for layer in 0..24 {
+        assert_eq!(single.device_for_layer(layer), 0);
+        assert!(!single.is_band_boundary(layer), "no boundaries in PP=1");
+    }
+    println!("  PP=1 wrap: 24 layers all on dev 0, no band boundaries");
+
+    println!("\ngpus_smoke: PASS");
+}

--- a/crates/hipfire-runtime/examples/pp2_vram_probe.rs
+++ b/crates/hipfire-runtime/examples/pp2_vram_probe.rs
@@ -1,0 +1,155 @@
+//! Real-measurement VRAM probe for the multi-GPU PP=2 path. Loads the
+//! given model with `load_weights_multi`, builds `Qwen35ScratchSet` +
+//! `KvCache::new_gpu_asym3_capped_multi` + `DeltaNetState` (Q8), and
+//! reports per-card VRAM deltas at each stage. Output is a markdown
+//! table row suitable for `docs/multi-gpu.md`.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p hipfire-runtime \
+//!         --release --features deltanet --example pp2_vram_probe -- \
+//!         ~/.hipfire/models/qwen3.5-0.8b.mq4 [max_seq=4096]
+
+use hipfire_arch_qwen35::qwen35::{self, DeltaNetState, Qwen35ScratchSet, StateQuant};
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::KvCache;
+use hipfire_runtime::multi_gpu::Gpus;
+use std::path::Path;
+
+fn used_gb(gpus: &Gpus, baseline_free: &[(usize, usize)]) -> Vec<f64> {
+    (0..gpus.devices.len())
+        .map(|i| {
+            let (free, _) = gpus.devices[i].hip.get_vram_info().unwrap_or((0, 0));
+            (baseline_free[i].0 as f64 - free as f64) / 1e9
+        })
+        .collect()
+}
+
+fn fmt_per_card(label: &str, used: &[f64]) {
+    print!("{label:>16}:");
+    for (i, u) in used.iter().enumerate() {
+        print!("  dev{i}={u:6.3} GiB");
+    }
+    println!();
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("Usage: ... <model.mq4> [max_seq]");
+    let max_seq: usize = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4096);
+    let hfq = HfqFile::open(Path::new(&path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config_from_hfq");
+    eprintln!(
+        "{}: layers={}, dim={}, hidden={}, vocab={}, kv_heads={}, head_dim={}, max_seq={max_seq}",
+        Path::new(&path).file_name().and_then(|s| s.to_str()).unwrap_or("?"),
+        config.n_layers,
+        config.dim,
+        config.hidden_dim,
+        config.vocab_size,
+        config.n_kv_heads,
+        config.head_dim,
+    );
+
+    let mut gpus = Gpus::init_uniform(2, config.n_layers).expect("init_uniform");
+    let baseline_free: Vec<(usize, usize)> = (0..gpus.devices.len())
+        .map(|i| gpus.devices[i].hip.get_vram_info().unwrap_or((0, 0)))
+        .collect();
+    println!("\n── per-card VRAM deltas (PP=2 split) ─────────────────────");
+    let mut after = used_gb(&gpus, &baseline_free);
+    fmt_per_card("baseline", &after);
+
+    // Stage 1: weights via load_weights_multi
+    let weights = qwen35::load_weights_multi(&hfq, &config, &mut gpus).expect("load_weights_multi");
+    let after_weights = used_gb(&gpus, &baseline_free);
+    let weights_delta: Vec<f64> = after_weights
+        .iter()
+        .zip(after.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+    fmt_per_card("after weights", &after_weights);
+    fmt_per_card("Δ weights", &weights_delta);
+    after = after_weights;
+
+    // Stage 2: ScratchSet
+    let scratch_set =
+        Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 64, max_seq).expect("scratch");
+    let after_scratch = used_gb(&gpus, &baseline_free);
+    let scratch_delta: Vec<f64> = after_scratch
+        .iter()
+        .zip(after.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+    fmt_per_card("after scratch", &after_scratch);
+    fmt_per_card("Δ scratch", &scratch_delta);
+    after = after_scratch;
+
+    // Stage 3: KvCache asym3 capped
+    let kv = KvCache::new_gpu_asym3_capped_multi(
+        &mut gpus,
+        config.n_layers,
+        config.n_kv_heads,
+        config.head_dim,
+        max_seq,
+        max_seq,
+    )
+    .expect("kv asym3");
+    let after_kv = used_gb(&gpus, &baseline_free);
+    let kv_delta: Vec<f64> = after_kv.iter().zip(after.iter()).map(|(a, b)| a - b).collect();
+    fmt_per_card("after KV", &after_kv);
+    fmt_per_card("Δ KV", &kv_delta);
+    after = after_kv;
+
+    // Stage 4: DeltaNetState
+    let (dn, la_to_device) = DeltaNetState::new_with_quant_multi(&mut gpus, &config, StateQuant::Q8)
+        .expect("dn multi");
+    let after_dn = used_gb(&gpus, &baseline_free);
+    let dn_delta: Vec<f64> = after_dn.iter().zip(after.iter()).map(|(a, b)| a - b).collect();
+    fmt_per_card("after DN state", &after_dn);
+    fmt_per_card("Δ DN state", &dn_delta);
+
+    // Aggregate and emit a markdown row matching docs/multi-gpu.md schema:
+    //   model | quant | n_layers | dim | KV mode | ctx |
+    //   weights | KV | scratch | total | per-card PP=2 | fits 24 GB?
+    let weights_max = weights_delta.iter().cloned().fold(0.0_f64, f64::max);
+    let kv_max = kv_delta.iter().cloned().fold(0.0_f64, f64::max);
+    let scratch_dn_max = scratch_delta
+        .iter()
+        .zip(dn_delta.iter())
+        .map(|(s, d)| s + d)
+        .fold(0.0_f64, f64::max);
+    let total_max = after_dn.iter().cloned().fold(0.0_f64, f64::max);
+    let total_sum: f64 = after_dn.iter().sum();
+
+    let quant_tag = if path.contains(".mq4") { "mq4" } else if path.contains(".mq3") { "mq3" } else { "?" };
+    let model_tag = Path::new(&path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?");
+
+    println!("\n── markdown row ──────────────────────────────────────────");
+    println!(
+        "| {} | {} | {} | {} | asym3 | {} | {:.1} GB | {} MB | {} MB | {:.1} GB | {:.1} GB | {} |",
+        model_tag,
+        quant_tag,
+        config.n_layers,
+        config.dim,
+        max_seq,
+        total_sum,
+        (kv_max * 1000.0).round() as i64,
+        (scratch_dn_max * 1000.0).round() as i64,
+        total_sum,
+        total_max,
+        if total_max < 24.0 { "yes" } else { "tight" },
+    );
+    println!(
+        "(weights/card max={:.2} GB, kv/card max={:.3} GB, scratch+dn/card max={:.3} GB)",
+        weights_max, kv_max, scratch_dn_max,
+    );
+
+    // Cleanup
+    dn.free_gpu_multi(&mut gpus, &la_to_device);
+    kv.free_gpu_multi(&mut gpus);
+    scratch_set.free_gpu_multi(&mut gpus);
+    weights.free_gpu_multi(&mut gpus);
+    eprintln!("(freed)");
+}

--- a/crates/hipfire-runtime/examples/pp_parity.rs
+++ b/crates/hipfire-runtime/examples/pp_parity.rs
@@ -1,0 +1,137 @@
+//! Stage 6 smoke: PP=1 vs PP=2 token-stream parity on a real model.
+//! Loads qwen3.5:0.8b twice — once via the single-GPU forward_scratch
+//! and once via the multi-GPU forward_scratch_multi — and asserts the
+//! greedy token sequence matches for ≥ 100 decoded tokens (temp=0,
+//! same prompt token).
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p hipfire-runtime \
+//!         --release --features deltanet --example pp_parity -- \
+//!         ~/.hipfire/models/qwen3.5-0.8b.mq4
+
+use hipfire_arch_qwen35::qwen35::{
+    self, DeltaNetState, Qwen35Scratch, Qwen35ScratchSet, StateQuant,
+};
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::KvCache;
+use hipfire_runtime::multi_gpu::Gpus;
+use rdna_compute::Gpu;
+use std::path::Path;
+
+const N_TOKENS: usize = 100;
+const PROMPT_TOKEN: u32 = 1;
+
+fn argmax(logits: &[f32]) -> u32 {
+    let mut best_idx = 0u32;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i as u32;
+        }
+    }
+    best_idx
+}
+
+fn run_single_gpu(path: &str) -> Vec<u32> {
+    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpu = Gpu::init().expect("Gpu::init");
+    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let mut kv = KvCache::new_gpu_asym3_capped(
+        &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
+    )
+    .expect("kv");
+    let mut dn = DeltaNetState::new_with_quant(&mut gpu, &config, StateQuant::Q8).expect("dn");
+    let scratch = Qwen35Scratch::new_with_kv_max(&mut gpu, &config, 64, 4096).expect("scratch");
+
+    let mut tokens = Vec::with_capacity(N_TOKENS);
+    let mut tok = PROMPT_TOKEN;
+    for pos in 0..N_TOKENS {
+        qwen35::forward_scratch(&mut gpu, &weights, &config, tok, pos, &mut kv, &mut dn, &scratch)
+            .expect("forward_scratch");
+        let logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        tok = argmax(&logits);
+        tokens.push(tok);
+    }
+    // F4 (review): explicitly free + drain pool before returning, otherwise
+    // dev 0 stays VRAM-loaded into the next phase and the multi-GPU
+    // `Gpus::init_uniform` preflight_vram trips on the asymmetry. Without
+    // this, the parity smoke passes only on models small enough that the
+    // leak fits inside the 2 GiB tolerance.
+    scratch.free_gpu(&mut gpu);
+    dn.free_gpu(&mut gpu);
+    kv.free_gpu(&mut gpu);
+    weights.free_gpu(&mut gpu);
+    gpu.drain_pool();
+    tokens
+}
+
+fn run_multi_gpu(path: &str) -> Vec<u32> {
+    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpus = Gpus::init_uniform(2, config.n_layers).expect("init_uniform");
+    let weights =
+        qwen35::load_weights_multi(&hfq, &config, &mut gpus).expect("load_weights_multi");
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 64, 4096)
+        .expect("scratch_set");
+    let mut kv = KvCache::new_gpu_asym3_capped_multi(
+        &mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
+    )
+    .expect("kv multi");
+    let (mut dn, _la_to_device) =
+        DeltaNetState::new_with_quant_multi(&mut gpus, &config, StateQuant::Q8)
+            .expect("dn multi");
+    let _ = gpus.enable_peer_all().expect("enable_peer_all");
+
+    let dev_last = gpus.output_device;
+    let mut tokens = Vec::with_capacity(N_TOKENS);
+    let mut tok = PROMPT_TOKEN;
+    for pos in 0..N_TOKENS {
+        qwen35::forward_scratch_multi(
+            &mut gpus, &weights, &config, tok, pos, &mut kv, &mut dn, &scratch_set,
+        )
+        .expect("forward_scratch_multi");
+        let s_last = &scratch_set.per_device[dev_last];
+        let logits = gpus.devices[dev_last]
+            .download_f32(&s_last.logits)
+            .expect("download logits");
+        tok = argmax(&logits);
+        tokens.push(tok);
+    }
+    tokens
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("Usage: ... <model.mq4>");
+
+    println!("── PP=1 forward ──────────────────────────────────────────");
+    let tokens_pp1 = run_single_gpu(&path);
+    println!("PP=1 tokens (first 20): {:?}", &tokens_pp1[..20.min(tokens_pp1.len())]);
+
+    println!("\n── PP=2 forward ──────────────────────────────────────────");
+    let tokens_pp2 = run_multi_gpu(&path);
+    println!("PP=2 tokens (first 20): {:?}", &tokens_pp2[..20.min(tokens_pp2.len())]);
+
+    println!("\n── parity check ──────────────────────────────────────────");
+    if tokens_pp1 == tokens_pp2 {
+        println!("ALL {N_TOKENS} tokens identical between PP=1 and PP=2");
+        println!("\npp_parity: PASS");
+        return;
+    }
+    let first_diff = tokens_pp1
+        .iter()
+        .zip(tokens_pp2.iter())
+        .position(|(a, b)| a != b);
+    let n_match = first_diff.unwrap_or(N_TOKENS);
+    println!("matched {n_match}/{N_TOKENS} tokens before first divergence");
+    if let Some(i) = first_diff {
+        println!(
+            "first diff at idx {i}: PP=1={} PP=2={}",
+            tokens_pp1[i], tokens_pp2[i]
+        );
+        println!("PP=1 around: {:?}", &tokens_pp1[i.saturating_sub(2)..(i + 5).min(N_TOKENS)]);
+        println!("PP=2 around: {:?}", &tokens_pp2[i.saturating_sub(2)..(i + 5).min(N_TOKENS)]);
+    }
+    eprintln!("\npp_parity: FAIL");
+    std::process::exit(1);
+}

--- a/crates/hipfire-runtime/examples/pp_parity_chatml.rs
+++ b/crates/hipfire-runtime/examples/pp_parity_chatml.rs
@@ -162,6 +162,10 @@ fn run_multi_gpu(path: &str, prompt_tokens: &[u32]) -> (Vec<u32>, Vec<Vec<f32>>)
 }
 
 fn main() {
+    // Force deterministic WMMA reduction so parity holds regardless of
+    // whether the caller (pp-gate.sh) sets the var in the environment.
+    // PP FP16 reduction order is non-deterministic without this flag.
+    std::env::set_var("HIPFIRE_DETERMINISTIC", "1");
     let path = std::env::args().nth(1).expect("Usage: ... <model.mq4>");
     let hfq = HfqFile::open(Path::new(&path)).expect("open hfq");
     let tokenizer =

--- a/crates/hipfire-runtime/examples/pp_parity_chatml.rs
+++ b/crates/hipfire-runtime/examples/pp_parity_chatml.rs
@@ -1,0 +1,230 @@
+//! Extended pp parity: ChatML-wrapped prompt + multi-token prefill + top-K
+//! logit dump at the first divergence. Stage 6 pp_parity used a synthetic
+//! `tok=1` repeated input, which exercised decode-only steady state and
+//! sailed through 100/100. Real daemon flow runs through 15+ ChatML
+//! tokens of prefill — accumulating KV history that crosses the band
+//! boundary via hipMemcpyPeer. This binary mirrors that flow and prints
+//! both top-K's at the first argmax flip so we can tell roundoff from
+//! structural bug.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p hipfire-runtime \
+//!         --release --features deltanet --example pp_parity_chatml -- \
+//!         ~/.hipfire/models/qwen3.5-0.8b.mq4
+
+use hipfire_arch_qwen35::qwen35::{
+    self, DeltaNetState, Qwen35Scratch, Qwen35ScratchSet, StateQuant,
+};
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::KvCache;
+use hipfire_runtime::multi_gpu::Gpus;
+use hipfire_runtime::tokenizer::Tokenizer;
+use rdna_compute::Gpu;
+use std::path::Path;
+
+const N_DECODE: usize = 50;
+const TOP_K: usize = 5;
+const PROMPT: &str = "Write a one-sentence greeting.";
+
+fn argmax(logits: &[f32]) -> u32 {
+    let mut best_idx = 0u32;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i as u32;
+        }
+    }
+    best_idx
+}
+
+fn top_k(logits: &[f32], k: usize) -> Vec<(u32, f32)> {
+    let mut idx: Vec<usize> = (0..logits.len()).collect();
+    idx.sort_by(|&a, &b| logits[b].partial_cmp(&logits[a]).unwrap_or(std::cmp::Ordering::Equal));
+    idx.into_iter().take(k).map(|i| (i as u32, logits[i])).collect()
+}
+
+fn build_prompt_tokens(tok: &Tokenizer) -> Vec<u32> {
+    let im_start = tok.encode("<|im_start|>");
+    let im_end = tok.encode("<|im_end|>");
+    let nl = tok.encode("\n");
+    let user = tok.encode("user");
+    let asst = tok.encode("assistant");
+    let q = tok.encode(PROMPT);
+    let mut t = Vec::new();
+    t.extend_from_slice(&im_start);
+    t.extend_from_slice(&user);
+    t.extend_from_slice(&nl);
+    t.extend_from_slice(&q);
+    t.extend_from_slice(&im_end);
+    t.extend_from_slice(&nl);
+    t.extend_from_slice(&im_start);
+    t.extend_from_slice(&asst);
+    t.extend_from_slice(&nl);
+    t
+}
+
+fn run_single_gpu(path: &str, prompt_tokens: &[u32]) -> (Vec<u32>, Vec<Vec<f32>>) {
+    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpu = Gpu::init().expect("Gpu::init");
+    let weights = qwen35::load_weights(&hfq, &config, &mut gpu).expect("load_weights");
+    let mut kv = KvCache::new_gpu_asym3_capped(
+        &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
+    )
+    .expect("kv");
+    let mut dn = DeltaNetState::new_with_quant(&mut gpu, &config, StateQuant::Q8).expect("dn");
+    let scratch = Qwen35Scratch::new_with_kv_max(&mut gpu, &config, 64, 4096).expect("scratch");
+
+    // Per-token prefill (matches daemon pp=2 flow; pp=1 daemon uses
+    // forward_prefill_batch but per-token gives a fair pp comparison
+    // because pp=2 has no batched analogue yet — same kernel path).
+    let mut all_logits: Vec<Vec<f32>> = Vec::new();
+    for (i, &tok) in prompt_tokens.iter().enumerate() {
+        qwen35::forward_scratch(&mut gpu, &weights, &config, tok, i, &mut kv, &mut dn, &scratch)
+            .expect("forward_scratch prefill");
+    }
+    let mut tokens = Vec::with_capacity(N_DECODE);
+    let mut tok = {
+        let logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        let next = argmax(&logits);
+        all_logits.push(logits);
+        next
+    };
+    tokens.push(tok);
+    for step in 1..N_DECODE {
+        let pos = prompt_tokens.len() + step - 1;
+        qwen35::forward_scratch(&mut gpu, &weights, &config, tok, pos, &mut kv, &mut dn, &scratch)
+            .expect("forward_scratch decode");
+        let logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        tok = argmax(&logits);
+        tokens.push(tok);
+        all_logits.push(logits);
+    }
+    scratch.free_gpu(&mut gpu);
+    dn.free_gpu(&mut gpu);
+    kv.free_gpu(&mut gpu);
+    weights.free_gpu(&mut gpu);
+    gpu.drain_pool();
+    (tokens, all_logits)
+}
+
+fn run_multi_gpu(path: &str, prompt_tokens: &[u32]) -> (Vec<u32>, Vec<Vec<f32>>) {
+    let hfq = HfqFile::open(Path::new(path)).expect("open hfq");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpus = Gpus::init_uniform(2, config.n_layers).expect("init_uniform");
+    let weights =
+        qwen35::load_weights_multi(&hfq, &config, &mut gpus).expect("load_weights_multi");
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 64, 4096)
+        .expect("scratch_set");
+    let mut kv = KvCache::new_gpu_asym3_capped_multi(
+        &mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, 4096, 4096,
+    )
+    .expect("kv multi");
+    let (mut dn, _la_to_device) =
+        DeltaNetState::new_with_quant_multi(&mut gpus, &config, StateQuant::Q8)
+            .expect("dn multi");
+    let _ = gpus.enable_peer_all().expect("enable_peer_all");
+
+    let dev_last = gpus.output_device;
+    let mut all_logits: Vec<Vec<f32>> = Vec::new();
+    for (i, &tok) in prompt_tokens.iter().enumerate() {
+        qwen35::forward_scratch_multi(
+            &mut gpus, &weights, &config, tok, i, &mut kv, &mut dn, &scratch_set,
+        )
+        .expect("forward_scratch_multi prefill");
+    }
+    let mut tokens = Vec::with_capacity(N_DECODE);
+    let mut tok = {
+        let s_last = &scratch_set.per_device[dev_last];
+        let logits = gpus.devices[dev_last]
+            .download_f32(&s_last.logits)
+            .expect("download logits");
+        let next = argmax(&logits);
+        all_logits.push(logits);
+        next
+    };
+    tokens.push(tok);
+    for step in 1..N_DECODE {
+        let pos = prompt_tokens.len() + step - 1;
+        qwen35::forward_scratch_multi(
+            &mut gpus, &weights, &config, tok, pos, &mut kv, &mut dn, &scratch_set,
+        )
+        .expect("forward_scratch_multi decode");
+        let s_last = &scratch_set.per_device[dev_last];
+        let logits = gpus.devices[dev_last]
+            .download_f32(&s_last.logits)
+            .expect("download logits");
+        tok = argmax(&logits);
+        tokens.push(tok);
+        all_logits.push(logits);
+    }
+    (tokens, all_logits)
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("Usage: ... <model.mq4>");
+    let hfq = HfqFile::open(Path::new(&path)).expect("open hfq");
+    let tokenizer =
+        Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
+    let prompt_tokens = build_prompt_tokens(&tokenizer);
+    println!("prompt: {:?}  (len={})", PROMPT, prompt_tokens.len());
+
+    println!("\n── PP=1 (per-token prefill + decode) ──");
+    let (toks1, logits1) = run_single_gpu(&path, &prompt_tokens);
+    println!("PP=1 first 20: {:?}", &toks1[..20.min(toks1.len())]);
+
+    println!("\n── PP=2 (per-token prefill + decode) ──");
+    let (toks2, logits2) = run_multi_gpu(&path, &prompt_tokens);
+    println!("PP=2 first 20: {:?}", &toks2[..20.min(toks2.len())]);
+
+    println!("\n── parity ──");
+    let first_diff = toks1.iter().zip(toks2.iter()).position(|(a, b)| a != b);
+    match first_diff {
+        None => {
+            println!("ALL {N_DECODE} tokens identical.");
+            // Still report max abs logit delta and max top-1 margin.
+            let mut max_abs = 0f32;
+            let mut sum_abs = 0f32;
+            for (a, b) in logits1.iter().zip(logits2.iter()) {
+                for (x, y) in a.iter().zip(b.iter()) {
+                    let d = (x - y).abs();
+                    if d > max_abs { max_abs = d; }
+                    sum_abs += d;
+                }
+            }
+            let n = logits1.len() * logits1[0].len();
+            println!("max |Δlogit| = {:.3e}, mean |Δlogit| = {:.3e}", max_abs, sum_abs / n as f32);
+        }
+        Some(i) => {
+            println!("first diff at decode step {i}:");
+            println!("  PP=1 picked token {} ({:?})", toks1[i], tokenizer.decode_bytes(&[toks1[i]]));
+            println!("  PP=2 picked token {} ({:?})", toks2[i], tokenizer.decode_bytes(&[toks2[i]]));
+            let l1 = &logits1[i];
+            let l2 = &logits2[i];
+            let t1 = top_k(l1, TOP_K);
+            let t2 = top_k(l2, TOP_K);
+            println!("  PP=1 top-{TOP_K}:");
+            for (id, v) in &t1 {
+                println!("    {:>6}  {:>12.6}  {:?}", id, v, tokenizer.decode_bytes(&[*id]));
+            }
+            println!("  PP=2 top-{TOP_K}:");
+            for (id, v) in &t2 {
+                println!("    {:>6}  {:>12.6}  {:?}", id, v, tokenizer.decode_bytes(&[*id]));
+            }
+            let delta_top1 = (l1[toks1[i] as usize] - l2[toks1[i] as usize]).abs();
+            let delta_top2 = (l1[toks2[i] as usize] - l2[toks2[i] as usize]).abs();
+            println!("  |Δlogit| at PP=1 winner ({}): {:.3e}", toks1[i], delta_top1);
+            println!("  |Δlogit| at PP=2 winner ({}): {:.3e}", toks2[i], delta_top2);
+            // Margin = winner − runner-up on each side. Tiny margin + tiny
+            // |Δlogit| means we crossed an argmax razor's edge — diagnostic
+            // signature of pure floating-point accumulation, not a bug.
+            let margin1 = t1[0].1 - t1[1].1;
+            let margin2 = t2[0].1 - t2[1].1;
+            println!("  PP=1 top-1 margin: {:.3e}", margin1);
+            println!("  PP=2 top-1 margin: {:.3e}", margin2);
+        }
+    }
+
+    let common = toks1.iter().zip(toks2.iter()).take_while(|(a, b)| a == b).count();
+    println!("\nmatched {common}/{N_DECODE} decode tokens before divergence");
+}

--- a/crates/hipfire-runtime/examples/probe_wmma.rs
+++ b/crates/hipfire-runtime/examples/probe_wmma.rs
@@ -27,15 +27,13 @@ __global__ void probe_wmma(float* __restrict__ out) {
 }
 "#;
 
-    gpu.ensure_kernel("probe_wmma", src, "probe_wmma").unwrap();
+    gpu.ensure_kernel_public("probe_wmma", src, "probe_wmma").unwrap();
 
     let d_out = gpu.zeros(&[32 * 8], rdna_compute::DType::F32).unwrap();
-    let func = &gpu.functions["probe_wmma"];
-    let mut out_ptr = d_out.buf.as_ptr();
-    let mut params: Vec<*mut std::ffi::c_void> = vec![
-        &mut out_ptr as *mut _ as *mut std::ffi::c_void,
-    ];
-    unsafe { gpu.hip.launch_kernel(func, [1, 1, 1], [32, 1, 1], 0, gpu.stream_ref(), &mut params).unwrap(); }
+    let mut kernargs = hip_bridge::KernargBlob::new();
+    kernargs.push_ptr(d_out.buf.as_ptr());
+    gpu.launch_kernel_blob("probe_wmma", [1, 1, 1], [32, 1, 1], 0, kernargs.as_mut_slice())
+        .unwrap();
 
     let out = gpu.download_f32(&d_out).unwrap();
 

--- a/crates/hipfire-runtime/examples/test_qwen35_load.rs
+++ b/crates/hipfire-runtime/examples/test_qwen35_load.rs
@@ -84,6 +84,8 @@ fn main() {
             match layer {
                 qwen35::LayerWeights::DeltaNet(_) => eprint!("D"),
                 qwen35::LayerWeights::FullAttn(_) => eprint!("F"),
+                qwen35::LayerWeights::DeltaNetMoe(_) => eprint!("d"),
+                qwen35::LayerWeights::FullAttnMoe(_) => eprint!("f"),
             }
         }
         eprintln!("\nWeight loading: OK");

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod gguf;
 pub mod hfq;
 pub mod llama;
 pub mod loop_guard;
+pub mod multi_gpu;
 pub mod sampler;
 #[cfg(feature = "deltanet")]
 pub mod dflash;

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -2,6 +2,7 @@
 //! Supports loading from GGUF files and running inference.
 
 use crate::gguf::{GgmlType, GgufFile, TensorInfo};
+use crate::multi_gpu::Gpus;
 use hip_bridge::HipResult;
 use rdna_compute::{DType, Gpu, GpuTensor};
 use std::path::Path;
@@ -3028,6 +3029,350 @@ impl KvCache {
         gpu.hip.memcpy_htod_offset(&self.v_gpu[layer].buf, byte_offset, v_bytes)?;
         Ok(())
     }
+
+    // ── Multi-GPU constructors (Stage 5 of issue #58) ───────────────────
+    //
+    // Each `_multi` variant places the per-layer K/V slot on
+    // `gpus.devices[gpus.device_for_layer(i)]`. asym{2,3,4} variants
+    // additionally replicate the rotation tables to every device by
+    // populating `gpus.givens_cos_per_dev` / `gpus.givens_sin_per_dev`.
+    //
+    // The KvCache.givens_cos / .givens_sin fields stay `None` in multi mode
+    // — Stage 6 forward dispatch reads from the per-device replicas in
+    // `Gpus` instead.
+
+    /// Free all per-layer GPU tensors on their owning devices. Mirror of
+    /// `free_gpu` for the multi-GPU layout. Givens replicas stay owned by
+    /// `Gpus`; freeing them is the orchestrator's responsibility.
+    pub fn free_gpu_multi(self, gpus: &mut Gpus) {
+        for (i, t) in self.k_gpu.into_iter().enumerate() {
+            let dev_idx = gpus.device_for_layer(i);
+            let _ = gpus.devices[dev_idx].free_tensor(t);
+        }
+        for (i, t) in self.v_gpu.into_iter().enumerate() {
+            let dev_idx = gpus.device_for_layer(i);
+            let _ = gpus.devices[dev_idx].free_tensor(t);
+        }
+        for (i, t) in self.k_scales.into_iter().enumerate() {
+            let dev_idx = gpus.device_for_layer(i);
+            let _ = gpus.devices[dev_idx].free_tensor(t);
+        }
+        for (i, t) in self.v_scales.into_iter().enumerate() {
+            let dev_idx = gpus.device_for_layer(i);
+            let _ = gpus.devices[dev_idx].free_tensor(t);
+        }
+    }
+
+    pub fn new_gpu_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        let kv_dim = n_kv_heads * head_dim;
+        let cache_size = max_seq_len * kv_dim;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, cache_size, cache_size)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap: max_seq_len, n_kv_heads, head_dim, quantized: false, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_q4_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        let kv_dim = n_kv_heads * head_dim;
+        let bytes_per_head = 8 + head_dim / 2;
+        let bytes_per_pos = n_kv_heads * bytes_per_head;
+        let cache_bytes = max_seq_len * bytes_per_pos;
+        let cache_elems = (cache_bytes + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, cache_elems, cache_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap: max_seq_len, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_q8_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        Self::new_gpu_q8_capped_multi(gpus, n_layers, n_kv_heads, head_dim, max_seq_len, max_seq_len)
+    }
+
+    pub fn new_gpu_q8_capped_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let blocks_per_head = head_dim / 32;
+        let total_blocks = n_kv_heads * blocks_per_head;
+        let cache_bytes = physical_cap * total_blocks * 34;
+        let cache_elems = (cache_bytes + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, cache_elems, cache_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: true, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_int8c_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        let kv_dim = n_kv_heads * head_dim;
+        let bph = 8 + head_dim;
+        let bpp = n_kv_heads * bph;
+        let cache_bytes = max_seq_len * bpp;
+        let cache_elems = (cache_bytes + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, cache_elems, cache_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap: max_seq_len, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: true, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_hfq4kv_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        let kv_dim = n_kv_heads * head_dim;
+        let bytes_per_block = 8 + head_dim / 2;
+        let bytes_per_pos = n_kv_heads * bytes_per_block;
+        let cache_bytes = max_seq_len * bytes_per_pos;
+        let cache_elems = (cache_bytes + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, cache_elems, cache_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap: max_seq_len, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: true, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_hfq8_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        let kv_dim = n_kv_heads * head_dim;
+        let val_elems = (max_seq_len * kv_dim + 3) / 4;
+        let scale_elems = max_seq_len * n_kv_heads * 2;
+        let (k_gpu, v_gpu, k_scales, v_scales) =
+            alloc_kv_with_scales_per_layer_multi(gpus, n_layers, val_elems, val_elems, scale_elems, scale_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales, v_scales, kv_dim, max_seq: max_seq_len, physical_cap: max_seq_len, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_int8_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        let kv_dim = n_kv_heads * head_dim;
+        let val_elems = (max_seq_len * kv_dim + 3) / 4;
+        let scale_elems = max_seq_len * n_kv_heads;
+        let (k_gpu, v_gpu, k_scales, v_scales) =
+            alloc_kv_with_scales_per_layer_multi(gpus, n_layers, val_elems, val_elems, scale_elems, scale_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales, v_scales, kv_dim, max_seq: max_seq_len, physical_cap: max_seq_len, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: true, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_asym4_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        Self::new_gpu_asym4_capped_multi(gpus, n_layers, n_kv_heads, head_dim, max_seq_len, max_seq_len)
+    }
+
+    pub fn new_gpu_asym4_capped_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 128 || head_dim == 256, "asym4 requires head_dim=128 or 256");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + head_dim / 2;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_blocks_per_head = head_dim / 32;
+        let v_bpp = n_kv_heads * v_blocks_per_head * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, k_elems, v_elems)?;
+        replicate_givens_to_all_devices(gpus, head_dim / 2, 42)?;
+        Ok(Self {
+            k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim,
+            max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim,
+            quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false,
+            quant_asym4: true, quant_asym3: false, quant_asym2: false,
+            boundary_layers: 0, givens_cos: None, givens_sin: None,
+            layer_is_boundary: vec![], compact_offset: 0,
+        })
+    }
+
+    pub fn new_gpu_asym3_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        Self::new_gpu_asym3_capped_multi(gpus, n_layers, n_kv_heads, head_dim, max_seq_len, max_seq_len)
+    }
+
+    pub fn new_gpu_asym3_capped_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 256, "asym3 currently requires head_dim=256 (Qwen 3.5)");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + (head_dim * 3) / 8;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_blocks_per_head = head_dim / 32;
+        let v_bpp = n_kv_heads * v_blocks_per_head * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, k_elems, v_elems)?;
+        replicate_givens_to_all_devices(gpus, head_dim / 2, 42)?;
+        Ok(Self {
+            k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim,
+            max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim,
+            quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false,
+            quant_asym4: false, quant_asym3: true, quant_asym2: false,
+            boundary_layers: 0, givens_cos: None, givens_sin: None,
+            layer_is_boundary: vec![], compact_offset: 0,
+        })
+    }
+
+    pub fn new_gpu_asym2_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+    ) -> HipResult<Self> {
+        Self::new_gpu_asym2_capped_multi(gpus, n_layers, n_kv_heads, head_dim, max_seq_len, max_seq_len)
+    }
+
+    pub fn new_gpu_asym2_capped_multi(
+        gpus: &mut Gpus,
+        n_layers: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 128 || head_dim == 256, "asym2 requires head_dim=128 or 256");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + head_dim / 4;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_blocks_per_head = head_dim / 32;
+        let v_bpp = n_kv_heads * v_blocks_per_head * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi(gpus, n_layers, k_elems, v_elems)?;
+        replicate_givens_to_all_devices(gpus, head_dim / 2, 42)?;
+        Ok(Self {
+            k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim,
+            max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim,
+            quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false,
+            quant_asym4: false, quant_asym3: false, quant_asym2: true,
+            boundary_layers: 0, givens_cos: None, givens_sin: None,
+            layer_is_boundary: vec![], compact_offset: 0,
+        })
+    }
+}
+
+// ── Stage 5 helpers: per-device KV alloc + givens replication ────────
+
+fn alloc_kv_per_layer_multi(
+    gpus: &mut Gpus,
+    n_layers: usize,
+    k_elems: usize,
+    v_elems: usize,
+) -> HipResult<(Vec<GpuTensor>, Vec<GpuTensor>)> {
+    let mut k_gpu = Vec::with_capacity(n_layers);
+    let mut v_gpu = Vec::with_capacity(n_layers);
+    for i in 0..n_layers {
+        let dev_idx = gpus.device_for_layer(i);
+        let g = &mut gpus.devices[dev_idx];
+        k_gpu.push(g.zeros(&[k_elems], DType::F32)?);
+        v_gpu.push(g.zeros(&[v_elems], DType::F32)?);
+    }
+    Ok((k_gpu, v_gpu))
+}
+
+fn alloc_kv_with_scales_per_layer_multi(
+    gpus: &mut Gpus,
+    n_layers: usize,
+    k_elems: usize,
+    v_elems: usize,
+    k_scale_elems: usize,
+    v_scale_elems: usize,
+) -> HipResult<(Vec<GpuTensor>, Vec<GpuTensor>, Vec<GpuTensor>, Vec<GpuTensor>)> {
+    let mut k_gpu = Vec::with_capacity(n_layers);
+    let mut v_gpu = Vec::with_capacity(n_layers);
+    let mut k_scales = Vec::with_capacity(n_layers);
+    let mut v_scales = Vec::with_capacity(n_layers);
+    for i in 0..n_layers {
+        let dev_idx = gpus.device_for_layer(i);
+        let g = &mut gpus.devices[dev_idx];
+        k_gpu.push(g.zeros(&[k_elems], DType::F32)?);
+        v_gpu.push(g.zeros(&[v_elems], DType::F32)?);
+        k_scales.push(g.zeros(&[k_scale_elems], DType::F32)?);
+        v_scales.push(g.zeros(&[v_scale_elems], DType::F32)?);
+    }
+    Ok((k_gpu, v_gpu, k_scales, v_scales))
+}
+
+/// Asym{2,3,4} KV-rotation tables replicated to every device. Replaces any
+/// previous contents of `gpus.givens_*_per_dev`. Stage 6 forward dispatch
+/// reads `gpus.givens_*_per_dev[layer_to_device[i]]` per layer.
+fn replicate_givens_to_all_devices(
+    gpus: &mut Gpus,
+    n_blocks: usize,
+    seed: u32,
+) -> HipResult<()> {
+    let (cos_vals, sin_vals) = KvCache::gen_givens_angles(seed, n_blocks);
+    let cb: Vec<u8> = cos_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+    let sb: Vec<u8> = sin_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+
+    let prev_cos = std::mem::take(&mut gpus.givens_cos_per_dev);
+    let prev_sin = std::mem::take(&mut gpus.givens_sin_per_dev);
+    for (i, t) in prev_cos.into_iter().enumerate() {
+        if i < gpus.devices.len() { let _ = gpus.devices[i].free_tensor(t); }
+    }
+    for (i, t) in prev_sin.into_iter().enumerate() {
+        if i < gpus.devices.len() { let _ = gpus.devices[i].free_tensor(t); }
+    }
+
+    for dev_idx in 0..gpus.devices.len() {
+        let g = &mut gpus.devices[dev_idx];
+        let ct = g.alloc_tensor(&[n_blocks], DType::F32)?;
+        let st = g.alloc_tensor(&[n_blocks], DType::F32)?;
+        g.hip.memcpy_htod(&ct.buf, &cb)?;
+        g.hip.memcpy_htod(&st.buf, &sb)?;
+        gpus.givens_cos_per_dev.push(ct);
+        gpus.givens_sin_per_dev.push(st);
+    }
+    Ok(())
 }
 
 // attention_cpu removed — GPU attention is now used

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -18,18 +18,22 @@
 
 use hip_bridge::{
     DeviceBuffer, Event, HipError, HipResult,
-    HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
+    HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED, HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
 };
 use rdna_compute::{Gpu, GpuTensor};
 
-/// Stream-event handoff returned by `Gpus::boundary_copy`. The src stream
-/// records `completion` after the copy lands; `Gpus::wait_boundary` makes
-/// the dst stream wait on it before the next dispatch on dst_dev. The
-/// `Option` is consumed (set to `None`) by `wait_boundary` after
-/// `event_destroy`; if a `BoundaryEvent` is dropped without going through
-/// `wait_boundary`, the `Drop` impl logs a leak warning. The actual HIP
-/// event handle still leaks in that case — destroying it requires a HIP
-/// runtime reference we don't store.
+/// Stream-event handoff returned by `Gpus::boundary_copy`. When the src
+/// device has an active stream, `completion` holds a HIP event recorded
+/// after the async peer copy; `Gpus::wait_boundary` makes the dst stream
+/// wait on it. When the src device has no active stream, the sync
+/// `memcpy_peer` already serializes the copy on the host and `completion`
+/// is `None` — `wait_boundary` returns immediately in that case.
+///
+/// The `Option` is consumed (set to `None`) by `wait_boundary`; if a
+/// `BoundaryEvent` with `completion: Some` is dropped without going through
+/// `wait_boundary`, the `Drop` impl logs a leak warning. The HIP event
+/// handle leaks in that case — destroying it requires a runtime reference
+/// we don't store here.
 pub struct BoundaryEvent {
     pub dst_dev: usize,
     completion: Option<Event>,
@@ -178,6 +182,10 @@ impl Gpus {
                 }
                 match self.devices[i].hip.enable_peer_access(self.devices[j].device_id) {
                     Ok(()) => {}
+                    // ffi.rs already converts 704 → Ok(()); this arm is
+                    // belt-and-suspenders against ROCm versions where the
+                    // driver returns 704 through a different code path.
+                    Err(e) if e.code == HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED => {}
                     Err(e) if e.code == HIP_ERROR_PEER_ACCESS_UNSUPPORTED => {
                         all_ok = false;
                     }
@@ -238,30 +246,30 @@ impl Gpus {
             ));
         }
         let src_gpu = &self.devices[src_dev];
-        let dst_gpu = &self.devices[dst_dev];
         src_gpu.bind_thread()?;
-        let event = src_gpu.hip.event_create()?;
         let src_dev_id = src_gpu.device_id;
-        let dst_dev_id = dst_gpu.device_id;
-        let copy_result: HipResult<()> = match src_gpu.active_stream.as_ref() {
+        let dst_dev_id = self.devices[dst_dev].device_id;
+        match src_gpu.active_stream.as_ref() {
             Some(stream) => {
                 src_gpu.hip.memcpy_peer_async(
                     dst, dst_dev_id, src, src_dev_id, n_bytes, stream,
                 )?;
-                src_gpu.hip.event_record(&event, Some(stream))
+                let event = src_gpu.hip.event_create()?;
+                match src_gpu.hip.event_record(&event, Some(stream)) {
+                    Ok(()) => Ok(BoundaryEvent { dst_dev, completion: Some(event) }),
+                    Err(e) => {
+                        let _ = src_gpu.hip.event_destroy(event);
+                        Err(e)
+                    }
+                }
             }
             None => {
+                // Sync path: memcpy_peer blocks on host until the copy
+                // lands. No event needed — recording into the HIP null
+                // stream is fragile across ROCm versions; skip it and
+                // signal "already done" via completion: None.
                 src_gpu.hip.memcpy_peer(dst, dst_dev_id, src, src_dev_id, n_bytes)?;
-                src_gpu.hip.event_record(&event, None)
-            }
-        };
-        match copy_result {
-            Ok(()) => Ok(BoundaryEvent { dst_dev, completion: Some(event) }),
-            Err(e) => {
-                // Best-effort: destroy the freshly-created event before
-                // surfacing the original error to the caller.
-                let _ = src_gpu.hip.event_destroy(event);
-                Err(e)
+                Ok(BoundaryEvent { dst_dev, completion: None })
             }
         }
     }
@@ -269,7 +277,8 @@ impl Gpus {
     /// Stream-event handoff: makes dst's active stream (or null) wait on
     /// the completion event recorded by `boundary_copy`. Consumes the
     /// `BoundaryEvent` and destroys the underlying HIP event regardless
-    /// of the wait result.
+    /// of the wait result. If `completion` is `None` (sync copy already
+    /// serialized on host), returns immediately without touching HIP.
     pub fn wait_boundary(&self, mut evt: BoundaryEvent) -> HipResult<()> {
         if evt.dst_dev >= self.devices.len() {
             return Err(HipError::new(
@@ -281,9 +290,9 @@ impl Gpus {
                 ),
             ));
         }
-        let event = evt.completion.take().expect(
-            "BoundaryEvent::completion is Some until wait_boundary takes it",
-        );
+        let Some(event) = evt.completion.take() else {
+            return Ok(());
+        };
         let dst_gpu = &self.devices[evt.dst_dev];
         dst_gpu.bind_thread()?;
         let wait_result = if let Some(stream) = dst_gpu.active_stream.as_ref() {

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -1,0 +1,437 @@
+//! Multi-GPU pipeline-parallel orchestration. Layer bands, boundary copy,
+//! peer-access plumbing.
+//!
+//! # Threading invariant
+//!
+//! hipfire engine is **single-threaded for HIP work**. All `Gpu::*` methods
+//! must be called from the same OS thread for the lifetime of the daemon
+//! process. The `bind_thread()` helper assumes this.
+//!
+//! NOT supported in v1:
+//! - Calling `Gpu::*` from rayon/tokio worker threads.
+//! - HIP stream callbacks (`hipStreamAddCallback`) that touch `Gpu`.
+//!
+//! Future features adding background workers MUST:
+//! 1. Add `gpu.bind_thread()?;` as the FIRST statement on entry.
+//! 2. Run debug builds to catch silent mis-binds via the bind_thread invariant.
+//! 3. Pass the multi-GPU coherence gate.
+
+use hip_bridge::{
+    DeviceBuffer, Event, HipError, HipResult,
+    HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
+};
+use rdna_compute::{Gpu, GpuTensor};
+
+/// Stream-event handoff returned by `Gpus::boundary_copy`. The src stream
+/// records `completion` after the copy lands; `Gpus::wait_boundary` makes
+/// the dst stream wait on it before the next dispatch on dst_dev. The
+/// `Option` is consumed (set to `None`) by `wait_boundary` after
+/// `event_destroy`; if a `BoundaryEvent` is dropped without going through
+/// `wait_boundary`, the `Drop` impl logs a leak warning. The actual HIP
+/// event handle still leaks in that case — destroying it requires a HIP
+/// runtime reference we don't store.
+pub struct BoundaryEvent {
+    pub dst_dev: usize,
+    completion: Option<Event>,
+}
+
+impl Drop for BoundaryEvent {
+    fn drop(&mut self) {
+        if self.completion.is_some() {
+            eprintln!(
+                "WARN: BoundaryEvent for dst_dev={} dropped without wait_boundary — \
+                 HIP event handle leaked. Always pair boundary_copy with wait_boundary.",
+                self.dst_dev,
+            );
+        }
+    }
+}
+
+pub struct Gpus {
+    pub devices: Vec<Gpu>,
+    /// Per-layer device id, length = n_layers.
+    pub layer_to_device: Vec<u8>,
+    /// Index of the first layer of each band, length = n_devices.
+    pub band_starts: Vec<usize>,
+    pub peer_access_enabled: bool,
+    /// Variant 2 (Megatron/DeepSpeed/vLLM convention): `output_norm + lm_head`
+    /// live on `dev_last`, not on dev_0. Removes the final `s.x` cross-device
+    /// copy after the layer loop.
+    pub output_device: usize,
+    /// Per-device replicas of asym{2,3,4} KV rotation tables. Empty until
+    /// the KV cache constructor (Stage 5) populates them.
+    pub givens_cos_per_dev: Vec<GpuTensor>,
+    pub givens_sin_per_dev: Vec<GpuTensor>,
+}
+
+const DEFAULT_VRAM_TOLERANCE_GB: f64 = 2.0;
+
+impl Gpus {
+    /// Construct `n_devices` `Gpu` instances bound to logical IDs taken from
+    /// `HIPFIRE_DEVICES` (or the first N visible if unset). Layers are split
+    /// uniformly: max-min ≤ 1 layer per band. Pre-flight VRAM check enforces
+    /// arch match and bounded VRAM delta (override
+    /// `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB`, default 2 GiB).
+    pub fn init_uniform(n_devices: usize, n_layers: usize) -> HipResult<Self> {
+        if n_devices == 0 {
+            return Err(HipError::new(0, "init_uniform: n_devices must be >= 1"));
+        }
+        if n_layers < n_devices {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "init_uniform: n_layers ({n_layers}) < n_devices ({n_devices}) — \
+                     each device must own at least one layer",
+                ),
+            ));
+        }
+        let device_ids = resolve_device_ids(n_devices)?;
+        let devices = construct_devices(&device_ids)?;
+        preflight_vram(&devices)?;
+        let per_device = uniform_split_counts(n_devices, n_layers);
+        Self::from_parts(devices, per_device, n_layers)
+    }
+
+    /// Explicit escape hatch for asymmetric VRAM / hand-tuned splits. Same
+    /// pre-flight checks as `init_uniform`. `per_device` length determines
+    /// `n_devices`; sum determines `n_layers`.
+    pub fn init_layers(per_device: &[usize]) -> HipResult<Self> {
+        let n_devices = per_device.len();
+        if n_devices == 0 {
+            return Err(HipError::new(0, "init_layers: per_device must be non-empty"));
+        }
+        if per_device.contains(&0) {
+            return Err(HipError::new(0, "init_layers: each device must own ≥1 layer"));
+        }
+        let n_layers: usize = per_device.iter().sum();
+        let device_ids = resolve_device_ids(n_devices)?;
+        let devices = construct_devices(&device_ids)?;
+        preflight_vram(&devices)?;
+        Self::from_parts(devices, per_device.to_vec(), n_layers)
+    }
+
+    /// Reserved for v1.1 — automatic VRAM-weighted band assignment. For v1
+    /// use `init_layers(...)` with hand-computed counts.
+    pub fn init_vram_weighted(_n_devices: usize, _n_layers: usize) -> HipResult<Self> {
+        Err(HipError::new(
+            0,
+            "init_vram_weighted: scheduled for v1.1; use init_layers(per_device) instead",
+        ))
+    }
+
+    /// PP=1 back-compat path: wrap an existing single `Gpu` into a `Gpus`
+    /// with all layers on dev 0. `output_device = 0`.
+    pub fn single(gpu: Gpu, n_layers: usize) -> Self {
+        Self {
+            devices: vec![gpu],
+            layer_to_device: vec![0; n_layers],
+            band_starts: vec![0],
+            peer_access_enabled: false,
+            output_device: 0,
+            givens_cos_per_dev: Vec::new(),
+            givens_sin_per_dev: Vec::new(),
+        }
+    }
+
+    /// Bidirectional `hipDeviceEnablePeerAccess` between every pair of
+    /// devices. Returns `Ok(true)` if every leg succeeded; `Ok(false)` if
+    /// any pair reports `hipDeviceCanAccessPeer = 0` or
+    /// `hipErrorPeerAccessUnsupported = 217` — orchestrator falls back to
+    /// host-staged copies in that case. PP=1 short-circuits to `Ok(true)`.
+    ///
+    /// **MUST be called AFTER all peer-accessible allocations are live.**
+    /// On ROCm 6.4.3 / gfx1100 we observed that `hipDeviceEnablePeerAccess`
+    /// does not retroactively map allocations made after the enable call:
+    /// `hipMemcpyPeer` then silently returns `hipSuccess` while writing
+    /// nothing to dst. The supported flow is: `init_uniform` → load weights
+    /// → KV-cache alloc → `enable_peer_all` → forward. Without
+    /// `enable_peer_all`, peer copies still work via HIP's transparent
+    /// host-staging — slower, but correct.
+    ///
+    /// Partial-success state is sticky: hipDeviceDisablePeerAccess is not
+    /// wrapped, so pairs we already enabled stay enabled. We deliberately
+    /// keep iterating past a failed pair so that *capable* pairs in an
+    /// N≥3 topology still get peer-copy even when one edge is unsupported.
+    /// `Ok(false)` means "at least one pair could not be enabled"; the
+    /// global `peer_access_enabled` flag mirrors that. Functional impact
+    /// of a `false` return is small — `boundary_copy` falls through to
+    /// HIP's transparent host-staging on un-enabled pairs either way.
+    pub fn enable_peer_all(&mut self) -> HipResult<bool> {
+        let n = self.devices.len();
+        if n <= 1 {
+            self.peer_access_enabled = true;
+            return Ok(true);
+        }
+        let mut all_ok = true;
+        for i in 0..n {
+            self.devices[i].bind_thread()?;
+            for j in 0..n {
+                if i == j {
+                    continue;
+                }
+                if !self.devices[i]
+                    .hip
+                    .can_access_peer(self.devices[i].device_id, self.devices[j].device_id)?
+                {
+                    all_ok = false;
+                    continue;
+                }
+                match self.devices[i].hip.enable_peer_access(self.devices[j].device_id) {
+                    Ok(()) => {}
+                    Err(e) if e.code == HIP_ERROR_PEER_ACCESS_UNSUPPORTED => {
+                        all_ok = false;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+        self.peer_access_enabled = all_ok;
+        Ok(all_ok)
+    }
+
+    #[inline]
+    pub fn device_for_layer(&self, layer_idx: usize) -> usize {
+        self.layer_to_device[layer_idx] as usize
+    }
+
+    /// True when the layer at `layer_idx + 1` lives on a different device
+    /// than `layer_idx`. False at the last layer (no successor).
+    #[inline]
+    pub fn is_band_boundary(&self, layer_idx: usize) -> bool {
+        let next = layer_idx + 1;
+        next < self.layer_to_device.len()
+            && self.layer_to_device[next] != self.layer_to_device[layer_idx]
+    }
+
+    #[inline]
+    pub fn output_device(&self) -> usize {
+        self.output_device
+    }
+
+    /// Async cross-device copy. Enqueues `hipMemcpyPeerAsync` on the src
+    /// device's active stream (or null if unset) and records a completion
+    /// event the caller awaits via `wait_boundary` before issuing the next
+    /// dispatch on `dst_dev`. HIP transparently host-stages when peer
+    /// access is unavailable; correctness holds either way.
+    pub fn boundary_copy(
+        &self,
+        src_dev: usize,
+        dst_dev: usize,
+        src: &DeviceBuffer,
+        dst: &DeviceBuffer,
+        n_bytes: usize,
+    ) -> HipResult<BoundaryEvent> {
+        if src_dev == dst_dev {
+            return Err(HipError::new(
+                0,
+                "boundary_copy: src_dev == dst_dev (use memcpy_dtod instead)",
+            ));
+        }
+        if src_dev >= self.devices.len() || dst_dev >= self.devices.len() {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "boundary_copy: src_dev={src_dev} or dst_dev={dst_dev} out of \
+                     range (n_devices={})",
+                    self.devices.len(),
+                ),
+            ));
+        }
+        let src_gpu = &self.devices[src_dev];
+        let dst_gpu = &self.devices[dst_dev];
+        src_gpu.bind_thread()?;
+        let event = src_gpu.hip.event_create()?;
+        let src_dev_id = src_gpu.device_id;
+        let dst_dev_id = dst_gpu.device_id;
+        let copy_result: HipResult<()> = match src_gpu.active_stream.as_ref() {
+            Some(stream) => {
+                src_gpu.hip.memcpy_peer_async(
+                    dst, dst_dev_id, src, src_dev_id, n_bytes, stream,
+                )?;
+                src_gpu.hip.event_record(&event, Some(stream))
+            }
+            None => {
+                src_gpu.hip.memcpy_peer(dst, dst_dev_id, src, src_dev_id, n_bytes)?;
+                src_gpu.hip.event_record(&event, None)
+            }
+        };
+        match copy_result {
+            Ok(()) => Ok(BoundaryEvent { dst_dev, completion: Some(event) }),
+            Err(e) => {
+                // Best-effort: destroy the freshly-created event before
+                // surfacing the original error to the caller.
+                let _ = src_gpu.hip.event_destroy(event);
+                Err(e)
+            }
+        }
+    }
+
+    /// Stream-event handoff: makes dst's active stream (or null) wait on
+    /// the completion event recorded by `boundary_copy`. Consumes the
+    /// `BoundaryEvent` and destroys the underlying HIP event regardless
+    /// of the wait result.
+    pub fn wait_boundary(&self, mut evt: BoundaryEvent) -> HipResult<()> {
+        if evt.dst_dev >= self.devices.len() {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "wait_boundary: dst_dev={} out of range (n_devices={})",
+                    evt.dst_dev,
+                    self.devices.len(),
+                ),
+            ));
+        }
+        let event = evt.completion.take().expect(
+            "BoundaryEvent::completion is Some until wait_boundary takes it",
+        );
+        let dst_gpu = &self.devices[evt.dst_dev];
+        dst_gpu.bind_thread()?;
+        let wait_result = if let Some(stream) = dst_gpu.active_stream.as_ref() {
+            dst_gpu.hip.stream_wait_event(stream, &event)
+        } else {
+            // No dst stream: host-block on the event so the next null-stream
+            // dispatch on dst is ordered after the peer copy.
+            dst_gpu.hip.event_synchronize(&event)
+        };
+        let destroy_result = dst_gpu.hip.event_destroy(event);
+        wait_result.and(destroy_result)
+    }
+
+    fn from_parts(
+        devices: Vec<Gpu>,
+        per_device: Vec<usize>,
+        n_layers: usize,
+    ) -> HipResult<Self> {
+        debug_assert_eq!(per_device.iter().sum::<usize>(), n_layers);
+        debug_assert_eq!(per_device.len(), devices.len());
+        let n_devices = devices.len();
+        let mut layer_to_device = Vec::with_capacity(n_layers);
+        let mut band_starts = Vec::with_capacity(n_devices);
+        let mut cursor = 0;
+        for (dev_idx, &count) in per_device.iter().enumerate() {
+            band_starts.push(cursor);
+            for _ in 0..count {
+                layer_to_device.push(dev_idx as u8);
+            }
+            cursor += count;
+        }
+        Ok(Self {
+            devices,
+            layer_to_device,
+            band_starts,
+            peer_access_enabled: false,
+            output_device: n_devices - 1,
+            givens_cos_per_dev: Vec::new(),
+            givens_sin_per_dev: Vec::new(),
+        })
+    }
+}
+
+fn uniform_split_counts(n_devices: usize, n_layers: usize) -> Vec<usize> {
+    let base = n_layers / n_devices;
+    let rem = n_layers % n_devices;
+    (0..n_devices)
+        .map(|i| base + if i < rem { 1 } else { 0 })
+        .collect()
+}
+
+/// Resolve the device IDs to use. Logical IDs post-`HIP_VISIBLE_DEVICES`:
+/// `HIPFIRE_DEVICES=0,1` selects the first two HIP-visible devices. When
+/// unset, takes the first `n_devices` visible IDs.
+fn resolve_device_ids(n_devices: usize) -> HipResult<Vec<i32>> {
+    if let Ok(s) = std::env::var("HIPFIRE_DEVICES") {
+        let ids: Vec<i32> = s
+            .split(',')
+            .map(|p| p.trim())
+            .filter(|p| !p.is_empty())
+            .map(|p| p.parse::<i32>())
+            .collect::<Result<_, _>>()
+            .map_err(|e| HipError::new(0, &format!("HIPFIRE_DEVICES parse: {e}")))?;
+        if ids.len() < n_devices {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "HIPFIRE_DEVICES has {} ids but n_devices = {n_devices}",
+                    ids.len(),
+                ),
+            ));
+        }
+        return Ok(ids[..n_devices].to_vec());
+    }
+    Ok((0..n_devices as i32).collect())
+}
+
+fn construct_devices(ids: &[i32]) -> HipResult<Vec<Gpu>> {
+    let mut devices = Vec::with_capacity(ids.len());
+    for &id in ids {
+        devices.push(Gpu::init_with_device(id)?);
+    }
+    Ok(devices)
+}
+
+fn preflight_vram(devices: &[Gpu]) -> HipResult<()> {
+    if devices.is_empty() {
+        return Ok(());
+    }
+    let arch0 = devices[0].arch.clone();
+    let mut frees = Vec::with_capacity(devices.len());
+    for d in devices {
+        if d.arch != arch0 {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "preflight_vram: arch mismatch — dev 0 is {arch0}, dev {} is {}. \
+                     Mixed-arch is not supported in v1.",
+                    d.device_id, d.arch,
+                ),
+            ));
+        }
+        d.bind_thread()?;
+        let (free, _total) = d.hip.get_vram_info()?;
+        frees.push(free);
+    }
+    let max_free = *frees.iter().max().unwrap();
+    let min_free = *frees.iter().min().unwrap();
+    let delta_gb = (max_free - min_free) as f64 / 1e9;
+    let tol_gb = std::env::var("HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB")
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or(DEFAULT_VRAM_TOLERANCE_GB);
+    if delta_gb > tol_gb {
+        return Err(HipError::new(
+            0,
+            &format!(
+                "preflight_vram: VRAM delta {:.1} GiB exceeds tolerance {:.1} GiB. \
+                 Override via HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB or use init_layers().",
+                delta_gb, tol_gb,
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uniform_split_basic() {
+        assert_eq!(uniform_split_counts(2, 24), vec![12, 12]);
+        assert_eq!(uniform_split_counts(2, 25), vec![13, 12]);
+        assert_eq!(uniform_split_counts(3, 64), vec![22, 21, 21]);
+        assert_eq!(uniform_split_counts(4, 7), vec![2, 2, 2, 1]);
+    }
+
+    #[test]
+    fn uniform_split_invariants() {
+        for n_devices in 1..=6 {
+            for n_layers in n_devices..=80 {
+                let split = uniform_split_counts(n_devices, n_layers);
+                assert_eq!(split.iter().sum::<usize>(), n_layers);
+                let mn = *split.iter().min().unwrap();
+                let mx = *split.iter().max().unwrap();
+                assert!(mx - mn <= 1, "split {split:?} for {n_devices}/{n_layers}");
+            }
+        }
+    }
+}

--- a/crates/rdna-compute/examples/dual_gpu_smoke.rs
+++ b/crates/rdna-compute/examples/dual_gpu_smoke.rs
@@ -1,0 +1,145 @@
+//! Dual-GPU smoke: Gpu::init_with_device + bind_thread + per-device
+//! pointer ownership via hipPointerGetAttributes.
+//!
+//! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p rdna-compute --example dual_gpu_smoke
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let count = {
+        let probe = hip_bridge::HipRuntime::load().expect("load HIP runtime");
+        probe.device_count().expect("device_count")
+    };
+    println!("Visible devices: {count}");
+    assert!(
+        count >= 2,
+        "dual_gpu_smoke requires ≥2 visible devices (got {count}). Set HIP_VISIBLE_DEVICES=0,1"
+    );
+
+    println!("\n── init Gpu on dev 0 + dev 1 ──────────────────────────────");
+    let mut gpu0 = Gpu::init_with_device(0).expect("init dev 0");
+    assert_eq!(gpu0.device_id, 0, "gpu0.device_id should be 0");
+    let mut gpu1 = Gpu::init_with_device(1).expect("init dev 1");
+    assert_eq!(gpu1.device_id, 1, "gpu1.device_id should be 1");
+    println!("  gpu0: device_id={} arch={}", gpu0.device_id, gpu0.arch);
+    println!("  gpu1: device_id={} arch={}", gpu1.device_id, gpu1.arch);
+    assert_eq!(
+        gpu0.arch, gpu1.arch,
+        "this smoke test assumes homogeneous arch (got {} vs {})",
+        gpu0.arch, gpu1.arch
+    );
+
+    println!("\n── bind_thread alternation ────────────────────────────────");
+    gpu0.bind_thread().expect("bind 0");
+    assert_eq!(gpu0.hip.current_device().unwrap(), 0, "after bind on gpu0");
+    println!("  bind gpu0 → current_device=0");
+
+    gpu1.bind_thread().expect("bind 1");
+    assert_eq!(gpu1.hip.current_device().unwrap(), 1, "after bind on gpu1");
+    println!("  bind gpu1 → current_device=1");
+
+    gpu0.bind_thread().expect("bind 0 again");
+    assert_eq!(gpu0.hip.current_device().unwrap(), 0, "after re-bind on gpu0");
+    println!("  re-bind gpu0 → current_device=0 (cached path also exercised)");
+
+    println!("\n── tensor allocation + pointer_get_attributes ─────────────");
+
+    let vocab = 128usize;
+    let dim = 64usize;
+    let table0_data: Vec<f32> = (0..vocab * dim)
+        .map(|i| ((i % 17) as f32 - 8.0) * 0.01)
+        .collect();
+    gpu0.bind_thread().expect("bind 0 for upload");
+    let table0 = gpu0
+        .upload_f32(&table0_data, &[vocab, dim])
+        .expect("upload table on dev 0");
+    let attr_table0 = gpu0
+        .hip
+        .pointer_get_attributes(&table0.buf)
+        .expect("ptr-attr table0");
+    assert_eq!(attr_table0.device, 0, "table0 should live on dev 0");
+    println!("  table0 (vocab={vocab}, dim={dim}) on dev 0 — attr.device={}", attr_table0.device);
+
+    let out0 = gpu0.zeros(&[dim], DType::F32).expect("zeros out on dev 0");
+    let attr_out0 = gpu0.hip.pointer_get_attributes(&out0.buf).expect("ptr-attr out0");
+    assert_eq!(attr_out0.device, 0, "out0 should live on dev 0");
+
+    // Different pattern so misroutes are visible in the assert_ne! below.
+    let table1_data: Vec<f32> = (0..vocab * dim)
+        .map(|i| ((i % 13) as f32 - 6.0) * 0.02)
+        .collect();
+    gpu1.bind_thread().expect("bind 1 for upload");
+    let table1 = gpu1
+        .upload_f32(&table1_data, &[vocab, dim])
+        .expect("upload table on dev 1");
+    let attr_table1 = gpu1
+        .hip
+        .pointer_get_attributes(&table1.buf)
+        .expect("ptr-attr table1");
+    assert_eq!(attr_table1.device, 1, "table1 should live on dev 1");
+    println!("  table1 (vocab={vocab}, dim={dim}) on dev 1 — attr.device={}", attr_table1.device);
+
+    let out1 = gpu1.zeros(&[dim], DType::F32).expect("zeros out on dev 1");
+    let attr_out1 = gpu1.hip.pointer_get_attributes(&out1.buf).expect("ptr-attr out1");
+    assert_eq!(attr_out1.device, 1, "out1 should live on dev 1");
+
+    // ── embedding_lookup on each device ──────────────────────────────
+    println!("\n── embedding_lookup on each device ────────────────────────");
+    let token_id = 42u32;
+
+    gpu0.bind_thread().expect("bind 0 for lookup");
+    gpu0.embedding_lookup(&table0, &out0, token_id, dim)
+        .expect("lookup dev 0");
+    let out0_host = gpu0.download_f32(&out0).expect("download out0");
+    let row0_expected = &table0_data[(token_id as usize) * dim..(token_id as usize + 1) * dim];
+    assert_eq!(&out0_host, row0_expected, "dev 0 lookup row mismatch");
+    println!("  dev 0: looked up token {token_id} — first 4 elements: {:?}", &out0_host[..4]);
+
+    gpu1.bind_thread().expect("bind 1 for lookup");
+    gpu1.embedding_lookup(&table1, &out1, token_id, dim)
+        .expect("lookup dev 1");
+    let out1_host = gpu1.download_f32(&out1).expect("download out1");
+    let row1_expected = &table1_data[(token_id as usize) * dim..(token_id as usize + 1) * dim];
+    assert_eq!(&out1_host, row1_expected, "dev 1 lookup row mismatch");
+    println!("  dev 1: looked up token {token_id} — first 4 elements: {:?}", &out1_host[..4]);
+
+    // The two rows must differ — if they accidentally come back identical
+    // it would indicate dev_1 picked up dev_0's table (the multi-GPU
+    // corruption signature this whole audit is set up to catch).
+    assert_ne!(
+        out0_host, out1_host,
+        "dev 0 and dev 1 lookups returned identical rows — possible cross-device pointer mixup"
+    );
+
+    // ── Alternating allocations stress check ─────────────────────────
+    // Tight loop: bind 0, alloc, bind 1, alloc, bind 0, alloc … verify
+    // each allocation lands on the device we claimed it would. If
+    // bind_thread silently fails to switch, attr.device would lag the
+    // intended target.
+    println!("\n── alternating malloc stress (32 iterations) ──────────────");
+    for i in 0..32 {
+        let target = if i % 2 == 0 { &mut gpu0 } else { &mut gpu1 };
+        target.bind_thread().expect("bind in stress loop");
+        let t = target
+            .zeros(&[1024], DType::F32)
+            .expect("alloc in stress loop");
+        let attr = target.hip.pointer_get_attributes(&t.buf).expect("ptr-attr in loop");
+        assert_eq!(
+            attr.device, target.device_id,
+            "stress iter {i}: alloc landed on dev {} but expected {}",
+            attr.device, target.device_id
+        );
+        target.free_tensor(t).expect("free in stress loop");
+    }
+    println!("  all 32 alloc/free pairs landed on the correct device.");
+
+    // ── Cleanup ──────────────────────────────────────────────────────
+    gpu0.bind_thread().expect("bind 0 for cleanup");
+    gpu0.free_tensor(table0).expect("free table0");
+    gpu0.free_tensor(out0).expect("free out0");
+    gpu1.bind_thread().expect("bind 1 for cleanup");
+    gpu1.free_tensor(table1).expect("free table1");
+    gpu1.free_tensor(out1).expect("free out1");
+
+    println!("\ndual_gpu_smoke: PASS");
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -4,9 +4,16 @@
 use crate::compiler::KernelCompiler;
 use crate::kernels;
 use hip_bridge::{DeviceBuffer, HipResult, HipRuntime, Rocblas};
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::OnceLock;
+
+thread_local! {
+    /// Per-thread cache for `Gpu::bind_thread`. Sentinel `-1` forces the
+    /// first call to issue `hipSetDevice` even when the target id is 0.
+    static LAST_BOUND_DEVICE: Cell<i32> = const { Cell::new(-1) };
+}
 
 /// gfx1100 multi-row GEMV tile selector.
 /// HIPFIRE_GEMV_ROWS ∈ {1, 2, 4, 8}. Default 1 = single-row kernel (legacy).
@@ -230,6 +237,7 @@ impl DType {
 pub struct Gpu {
     pub hip: HipRuntime,
     pub arch: String,
+    pub device_id: i32,
     compiler: KernelCompiler,
     modules: HashMap<String, hip_bridge::Module>,
     functions: HashMap<String, hip_bridge::Function>,
@@ -377,6 +385,40 @@ impl Gpu {
         self.active_stream.as_ref()
     }
 
+    /// Bind this `Gpu`'s device on the calling thread. Cached via thread_local
+    /// — only issues `hipSetDevice` when the cached id changes.
+    #[inline]
+    pub fn bind_thread(&self) -> HipResult<()> {
+        if LAST_BOUND_DEVICE.with(|c| c.get()) != self.device_id {
+            self.hip.set_device(self.device_id)?;
+            LAST_BOUND_DEVICE.with(|c| c.set(self.device_id));
+        }
+        debug_assert_eq!(
+            self.hip.current_device()?,
+            self.device_id,
+            "bind_thread invariant: current device must match self.device_id",
+        );
+        Ok(())
+    }
+
+    /// `bind_thread` for `&mut self -> ()` and `Drop` contexts. Logs to
+    /// stderr on hipSetDevice failure instead of swallowing it silently;
+    /// no debug_assert (would risk panic-in-Drop on top of an unwinding
+    /// panic).
+    #[inline]
+    pub fn bind_thread_or_warn(&self) {
+        if LAST_BOUND_DEVICE.with(|c| c.get()) != self.device_id {
+            match self.hip.set_device(self.device_id) {
+                Ok(()) => LAST_BOUND_DEVICE.with(|c| c.set(self.device_id)),
+                Err(e) => eprintln!(
+                    "WARN: bind_thread_or_warn(dev {}) failed: {} — \
+                     subsequent ops run on the currently-bound device",
+                    self.device_id, e,
+                ),
+            }
+        }
+    }
+
     /// Drive the GPU to full DPM perf level before a perf-sensitive measurement.
     ///
     /// gfx1100 (and other RDNA cards) return to a low-power DPM state when
@@ -392,6 +434,7 @@ impl Gpu {
     /// mclk; the existing JITed `gemv_hfq4g256` kernel (available on any
     /// caller that has compiled a DFlash/Qwen3.5 model) stresses sclk.
     pub fn dpm_warmup(&mut self, secs: f32) -> HipResult<()> {
+        self.bind_thread()?;
         // 256 MB scratch — large enough to defeat L2 and tax the memory
         // controller. GDDR6 on the 7900 XTX is 24 GB so 256 MB is trivial.
         const SCRATCH_BYTES: usize = 256 * 1024 * 1024;
@@ -416,15 +459,27 @@ impl Gpu {
     }
 
     pub fn init() -> HipResult<Self> {
+        Self::init_with_device(0)
+    }
+
+    pub fn init_with_device(id: i32) -> HipResult<Self> {
         let hip = HipRuntime::load()?;
         let count = hip.device_count()?;
         if count == 0 {
             return Err(hip_bridge::HipError::new(0, "no GPU devices found"));
         }
-        hip.set_device(0)?;
+        if id < 0 || id >= count {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("device id {id} out of range (count={count})"),
+            ));
+        }
+        // set_device must precede try_init_rocblas — rocBLAS captures the
+        // currently-bound device into its handle.
+        hip.set_device(id)?;
 
-        let arch = hip.get_arch(0).unwrap_or_else(|_| "gfx1010".to_string());
-        let (vram_free, vram_total) = hip.get_vram_info().unwrap_or((0, 0));
+        let arch = hip.get_arch(id).unwrap_or_else(|_| "gfx1010".to_string());
+        let (_, vram_total) = hip.get_vram_info().unwrap_or((0, 0));
 
         // Check HIP runtime version matches GPU arch requirements
         let (hip_major, hip_minor) = hip.runtime_version().unwrap_or((0, 0));
@@ -438,13 +493,16 @@ impl Gpu {
             eprintln!("WARNING: HIP runtime {}.{} may not support {}. Minimum: {}.{}", hip_major, hip_minor, arch, min_major, min_minor);
             eprintln!("  Update your HIP runtime or kernels may fail to load.");
         }
-        eprintln!("GPU: {} ({:.1} GB VRAM, HIP {}.{})", arch, vram_total as f64 / 1e9, hip_major, hip_minor);
+        eprintln!("GPU dev {}: {} ({:.1} GB VRAM, HIP {}.{})", id, arch, vram_total as f64 / 1e9, hip_major, hip_minor);
 
         let compiler = KernelCompiler::new(&arch)?;
+
+        LAST_BOUND_DEVICE.with(|c| c.set(id));
 
         Ok(Self {
             hip,
             arch,
+            device_id: id,
             compiler,
             modules: HashMap::new(),
             functions: HashMap::new(),
@@ -503,6 +561,7 @@ impl Gpu {
     /// symbol missing, handle init fail), logs once and leaves `None`.
     /// Callers always fall back to the non-rocBLAS path.
     pub fn try_init_rocblas(&mut self) {
+        self.bind_thread_or_warn();
         if self.rocblas.is_some() { return; }
         let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
         let all_archs = std::env::var("HIPFIRE_ROCBLAS_ALL_ARCHS").ok().as_deref() == Some("1");
@@ -539,6 +598,7 @@ impl Gpu {
         w_fp16: &DeviceBuffer,
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         assert!(k % 256 == 0, "hfq4g256 dequant: K must be multiple of 256 (got {k})");
         self.ensure_kernel(
             "hfq4g256_dequantize_to_f16",
@@ -583,6 +643,7 @@ impl Gpu {
         y_fp32: &DeviceBuffer, // row-major [N × M]
         m: usize, n: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rocblas_gemm_hfq4_generic(w_fp16, x_fp16, y_fp32, m, n, k, 1.0, 0.0)
     }
 
@@ -596,6 +657,7 @@ impl Gpu {
         y_fp32: &DeviceBuffer,
         m: usize, n: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rocblas_gemm_hfq4_generic(w_fp16, x_fp16, y_fp32, m, n, k, 1.0, 1.0)
     }
 
@@ -631,6 +693,7 @@ impl Gpu {
     /// While capturing, dispatch methods that support it will use the blob
     /// launch path so that kernarg pointers survive until graph replay.
     pub fn begin_graph_capture(&mut self) -> HipResult<()> {
+        self.bind_thread()?;
         self.capture_blobs.clear();
         self.capture_mode = true;
         let stream = self.active_stream.as_ref()
@@ -640,6 +703,7 @@ impl Gpu {
 
     /// End capture, instantiate the graph for replay.
     pub fn end_graph_capture(&mut self) -> HipResult<()> {
+        self.bind_thread()?;
         self.capture_mode = false;
         let stream = self.active_stream.as_ref().unwrap();
         let graph = self.hip.stream_end_capture(stream)?;
@@ -651,6 +715,7 @@ impl Gpu {
 
     /// Replay the captured graph.
     pub fn graph_launch(&self) -> HipResult<()> {
+        self.bind_thread()?;
         let exec = self.graph_exec.as_ref().expect("no captured graph to replay");
         let stream = self.active_stream.as_ref().unwrap();
         self.hip.graph_launch(exec, stream)
@@ -658,6 +723,7 @@ impl Gpu {
 
     /// Destroy the captured graph and free all retained kernarg blobs.
     pub fn graph_destroy(&mut self) {
+        self.bind_thread_or_warn();
         if let Some(exec) = self.graph_exec.take() {
             let _ = self.hip.graph_exec_destroy(exec);
         }
@@ -686,14 +752,17 @@ impl Gpu {
     // becomes free.
 
     pub fn verify_has_graph(&self, b: usize) -> bool {
+        // bind_thread: skip — pure state query
         self.verify_graph_cache.contains_key(&b)
     }
 
     pub fn verify_needs_warmup(&self, b: usize) -> bool {
+        // bind_thread: skip — pure state query
         !self.verify_warmed_up.contains(&b)
     }
 
     pub fn verify_mark_warmup_done(&mut self, b: usize) {
+        // bind_thread: skip — pure state query
         self.verify_warmed_up.insert(b);
     }
 
@@ -701,6 +770,7 @@ impl Gpu {
     /// launch_maybe_blob calls will push their kernargs into `capture_blobs`,
     /// which is drained into the per-B cache entry on end_verify_graph_capture.
     pub fn begin_verify_graph_capture(&mut self, b: usize) -> HipResult<()> {
+        self.bind_thread()?;
         debug_assert!(self.verify_capturing_b.is_none(),
             "begin_verify_graph_capture: already capturing for b={:?}",
             self.verify_capturing_b);
@@ -717,6 +787,7 @@ impl Gpu {
     /// End capture, instantiate, stash into the per-B cache (taking ownership
     /// of the current capture_blobs).
     pub fn end_verify_graph_capture(&mut self) -> HipResult<()> {
+        self.bind_thread()?;
         let b = self.verify_capturing_b.take()
             .expect("end_verify_graph_capture without matching begin");
         self.capture_mode = false;
@@ -730,6 +801,7 @@ impl Gpu {
 
     /// Replay the cached verify graph for batch size `b`.
     pub fn verify_graph_launch(&self, b: usize) -> HipResult<()> {
+        self.bind_thread()?;
         let entry = self.verify_graph_cache.get(&b)
             .unwrap_or_else(|| panic!("no captured verify graph for b={}", b));
         let stream = self.active_stream.as_ref().unwrap();
@@ -738,11 +810,13 @@ impl Gpu {
 
     /// How many captured verify graphs are in the cache (for debug logs).
     pub fn verify_graph_count(&self) -> usize {
+        // bind_thread: skip — pure state query
         self.verify_graph_cache.len()
     }
 
     /// Destroy all cached verify graphs and their blobs.
     pub fn verify_graph_destroy_all(&mut self) {
+        self.bind_thread_or_warn();
         for (_, (graph, exec, _blobs)) in self.verify_graph_cache.drain() {
             let _ = self.hip.graph_exec_destroy(exec);
             let _ = self.hip.graph_destroy(graph);
@@ -759,18 +833,22 @@ impl Gpu {
     // ~192 kernel dispatches per replay.
 
     pub fn replay_has_graph(&self, n_steps: usize) -> bool {
+        // bind_thread: skip — pure state query
         self.replay_graph_cache.contains_key(&n_steps)
     }
 
     pub fn replay_needs_warmup(&self, n_steps: usize) -> bool {
+        // bind_thread: skip — pure state query
         !self.replay_warmed_up.contains(&n_steps)
     }
 
     pub fn replay_mark_warmup_done(&mut self, n_steps: usize) {
+        // bind_thread: skip — pure state query
         self.replay_warmed_up.insert(n_steps);
     }
 
     pub fn begin_replay_graph_capture(&mut self, n_steps: usize) -> HipResult<()> {
+        self.bind_thread()?;
         debug_assert!(self.replay_capturing_n.is_none(),
             "begin_replay_graph_capture: already capturing for n_steps={:?}",
             self.replay_capturing_n);
@@ -785,6 +863,7 @@ impl Gpu {
     }
 
     pub fn end_replay_graph_capture(&mut self) -> HipResult<()> {
+        self.bind_thread()?;
         let n_steps = self.replay_capturing_n.take()
             .expect("end_replay_graph_capture without matching begin");
         self.capture_mode = false;
@@ -797,6 +876,7 @@ impl Gpu {
     }
 
     pub fn replay_graph_launch(&self, n_steps: usize) -> HipResult<()> {
+        self.bind_thread()?;
         let entry = self.replay_graph_cache.get(&n_steps)
             .unwrap_or_else(|| panic!("no captured replay graph for n_steps={}", n_steps));
         let stream = self.active_stream.as_ref().unwrap();
@@ -804,10 +884,12 @@ impl Gpu {
     }
 
     pub fn replay_graph_count(&self) -> usize {
+        // bind_thread: skip — pure state query
         self.replay_graph_cache.len()
     }
 
     pub fn replay_graph_destroy_all(&mut self) {
+        self.bind_thread_or_warn();
         for (_, (graph, exec, _blobs)) in self.replay_graph_cache.drain() {
             let _ = self.hip.graph_exec_destroy(exec);
             let _ = self.hip.graph_destroy(graph);
@@ -830,6 +912,7 @@ impl Gpu {
         src_offset: usize,
         size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         if let Some(stream) = self.active_stream.as_ref() {
             self.hip.memcpy_dtod_async_at(dst, dst_offset, src, src_offset, size, stream)
         } else {
@@ -844,6 +927,7 @@ impl Gpu {
         src: &hip_bridge::DeviceBuffer,
         size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.memcpy_dtod_at_auto(dst, 0, src, 0, size)
     }
 
@@ -893,6 +977,7 @@ impl Gpu {
         source: &str,
         func_name: &str,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(module_name, source, func_name)
     }
 
@@ -915,6 +1000,7 @@ impl Gpu {
         shared_mem: u32,
         kernargs: &mut [u8],
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let func = self.functions.get(func_name).ok_or_else(|| {
             hip_bridge::HipError::new(0, &format!("launch_kernel_blob: function '{func_name}' not loaded"))
         })?;
@@ -997,6 +1083,7 @@ impl Gpu {
     /// `block_q8_1_mmq` layout. The scratch is ordered by [K/128 block, batch]
     /// so a 128-column batch tile is contiguous for each K tile.
     pub fn ensure_q8_1_mmq_x(&mut self, x: &GpuTensor, batch_size: usize, k: usize) -> HipResult<*mut c_void> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_hfq4g256_residual_mmq",
             kernels::GEMM_HFQ4G256_RESIDUAL_MMQ_SRC,
@@ -1059,6 +1146,7 @@ impl Gpu {
     /// Returns `true` if MMQ is safe for this weight, `false` if it should
     /// fall back to WMMA.
     pub fn mmq_screen_weight(&mut self, a_raw: &GpuTensor, m: usize, k: usize) -> bool {
+        self.bind_thread_or_warn();
         let key = a_raw.buf.as_ptr() as usize;
         if let Some(&safe) = self.mmq_screen_cache.get(&key) {
             return safe;
@@ -1202,6 +1290,7 @@ impl Gpu {
     /// Each entry is (module_name, source, func_name). Turbo kernels should have
     /// TURBO_COMMON_H already prepended in their source.
     pub fn precompile_kernels(&mut self, specs: &[(&str, &str, &str)]) -> HipResult<()> {
+        self.bind_thread()?;
         // Collect (name, source) pairs for the compiler batch, skipping already-loaded
         let batch: Vec<(&str, &str)> = specs.iter()
             .filter(|(_, _, func)| !self.functions.contains_key(*func))
@@ -1236,6 +1325,7 @@ impl Gpu {
     // ── Tensor allocation ───────────────────────────────────────
 
     pub fn alloc_tensor(&mut self, shape: &[usize], dtype: DType) -> HipResult<GpuTensor> {
+        self.bind_thread()?;
         let numel: usize = shape.iter().product();
         let byte_size = numel * dtype.size();
         let buf = self.pool.alloc(&self.hip, byte_size)?;
@@ -1247,6 +1337,7 @@ impl Gpu {
     }
 
     pub fn upload_f32(&mut self, data: &[f32], shape: &[usize]) -> HipResult<GpuTensor> {
+        self.bind_thread()?;
         let tensor = self.alloc_tensor(shape, DType::F32)?;
         let bytes = unsafe {
             std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
@@ -1256,6 +1347,7 @@ impl Gpu {
     }
 
     pub fn download_f32(&self, tensor: &GpuTensor) -> HipResult<Vec<f32>> {
+        self.bind_thread()?;
         let numel = tensor.numel();
         let mut data = vec![0.0f32; numel];
         let bytes = unsafe {
@@ -1266,6 +1358,7 @@ impl Gpu {
     }
 
     pub fn zeros(&mut self, shape: &[usize], dtype: DType) -> HipResult<GpuTensor> {
+        self.bind_thread()?;
         let tensor = self.alloc_tensor(shape, dtype)?;
         match self.active_stream.as_ref() {
             Some(stream) => self.hip.memset_async(&tensor.buf, 0, tensor.byte_size(), stream)?,
@@ -1283,6 +1376,7 @@ impl Gpu {
         token_id: u32,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let byte_offset = (token_id as usize) * dim * 4;
         let byte_size = dim * 4;
         self.hip.memcpy_dtod_offset(&output.buf, &table.buf, byte_offset, byte_size)
@@ -1297,6 +1391,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4lut", kernels::GEMV_Q4LUT_SRC, "gemv_q4lut")?;
         let func = &self.functions["gemv_q4lut"];
 
@@ -1325,6 +1420,7 @@ impl Gpu {
     pub fn gemv_q4wave(
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4wave", kernels::GEMV_Q4WAVE_SRC, "gemv_q4wave")?;
         let func = &self.functions["gemv_q4wave"];
         let mut a_ptr = a_raw.buf.as_ptr();
@@ -1344,6 +1440,7 @@ impl Gpu {
     pub fn gemv_q4as8(
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4as8", kernels::GEMV_Q4AS8_SRC, "gemv_q4as8")?;
         let func = &self.functions["gemv_q4as8"];
         let mut a_ptr = a_raw.buf.as_ptr();
@@ -1367,6 +1464,7 @@ impl Gpu {
         token_id: u32,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("embedding_q8", kernels::EMBEDDING_Q8_SRC, "embedding_q8")?;
         let func = &self.functions["embedding_q8"];
 
@@ -1396,6 +1494,7 @@ impl Gpu {
         token_id: u32,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("embedding_q4k", kernels::EMBEDDING_Q4K_SRC, "embedding_q4k")?;
         let func = &self.functions["embedding_q4k"];
 
@@ -1424,6 +1523,7 @@ impl Gpu {
         token_id: u32,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("embedding_hfq4g256", kernels::EMBEDDING_HFQ4G256_SRC, "embedding_hfq4g256")?;
         let func = &self.functions["embedding_hfq4g256"];
 
@@ -1458,6 +1558,7 @@ impl Gpu {
         n: usize,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "embedding_q8_batched",
             kernels::EMBEDDING_Q8_BATCHED_SRC,
@@ -1503,6 +1604,7 @@ impl Gpu {
         n: usize,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "embedding_hfq4g256_batched",
             kernels::EMBEDDING_HFQ4G256_BATCHED_SRC,
@@ -1543,6 +1645,7 @@ impl Gpu {
         token_id: u32,
         dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("embedding_hfq4g128", kernels::EMBEDDING_HFQ4G128_SRC, "embedding_hfq4g128")?;
         let func = &self.functions["embedding_hfq4g128"];
 
@@ -1565,6 +1668,7 @@ impl Gpu {
 
     /// Upload raw bytes to GPU (for quantized weights).
     pub fn upload_raw(&self, data: &[u8], shape: &[usize]) -> HipResult<GpuTensor> {
+        self.bind_thread()?;
         let buf = self.hip.malloc(data.len())?;
         self.hip.memcpy_htod(&buf, data)?;
         Ok(GpuTensor {
@@ -1575,6 +1679,7 @@ impl Gpu {
     }
 
     pub fn free_tensor(&mut self, tensor: GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.pool.free(tensor.buf);
         Ok(())
     }
@@ -1582,6 +1687,7 @@ impl Gpu {
     /// Drain the GPU memory pool. Actually calls hipFree on all pooled buffers.
     /// Call after model unload to return VRAM to the system.
     pub fn drain_pool(&mut self) {
+        self.bind_thread_or_warn();
         self.pool.drain(&self.hip);
     }
 
@@ -1595,6 +1701,7 @@ impl Gpu {
     ///     the rocBLAS prefill path (CDNA3-only). Owns GpuTensors, so the
     ///     entries are released back to the pool here.
     pub fn invalidate_weight_caches(&mut self) {
+        self.bind_thread_or_warn();
         self.mmq_screen_cache.clear();
         let shadows: Vec<GpuTensor> = self.fp16_shadow_cache.drain().map(|(_, t)| t).collect();
         for t in shadows {
@@ -1619,6 +1726,7 @@ impl Gpu {
     ///   * replay_graph_cache + replay_warmed_up + replay_capturing_n:
     ///     DFlash per-n_steps tape-replay graphs.
     pub fn invalidate_graph_state(&mut self) {
+        self.bind_thread_or_warn();
         self.graph_destroy();
         self.verify_graph_destroy_all();
         self.replay_graph_destroy_all();
@@ -1633,6 +1741,7 @@ impl Gpu {
         x: &GpuTensor,
         y: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv", kernels::GEMV_SRC, "gemv_f32")?;
         let func = &self.functions["gemv_f32"];
 
@@ -1685,6 +1794,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4k", kernels::GEMV_Q4K_SRC, "gemv_q4k")?;
         let func = &self.functions["gemv_q4k"];
 
@@ -1725,6 +1835,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq4g128", kernels::GEMV_HFQ4G128_SRC, "gemv_hfq4g128")?;
         let func = &self.functions["gemv_hfq4g128"];
 
@@ -1759,6 +1870,7 @@ impl Gpu {
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_hfq4g128", kernels::GEMM_HFQ4G128_SRC, "gemm_hfq4g128")?;
         let func = &self.functions["gemm_hfq4g128"];
         let mut a_ptr = a_raw.buf.as_ptr();
@@ -1783,6 +1895,7 @@ impl Gpu {
 
     /// HFQ2-G256 GEMV. K must be multiple of 256.
     pub fn gemv_hfq2g256(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq2g256", kernels::GEMV_HFQ2G256_SRC, "gemv_hfq2g256")?;
         let func = &self.functions["gemv_hfq2g256"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -1797,6 +1910,7 @@ impl Gpu {
 
     /// Lazily initialize MagnumQuant FWHT sign tables (256 floats each, seeds 42 and 1042).
     pub fn ensure_mq_signs(&mut self) -> HipResult<()> {
+        self.bind_thread()?;
         if self.mq_signs1.is_some() { return Ok(()); }
         fn gen_signs(seed: u32) -> Vec<f32> {
             let mut state = seed;
@@ -1832,6 +1946,7 @@ impl Gpu {
         signs1: &GpuTensor, signs2: &GpuTensor,
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_mq4g256", kernels::GEMV_MQ4G256_SRC, "gemv_mq4g256")?;
         let func = &self.functions["gemv_mq4g256"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -1864,6 +1979,7 @@ impl Gpu {
         k: usize,
         eps: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel(
             "fused_rmsnorm_mq_rotate",
@@ -1931,6 +2047,7 @@ impl Gpu {
         eps: f32,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel(
             "fused_rmsnorm_mq_rotate",
@@ -1990,6 +2107,7 @@ impl Gpu {
         x_rot: &GpuTensor,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel(
             "fused_silu_mul_mq_rotate",
@@ -2040,6 +2158,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel(
             "fused_silu_mul_mq_rotate",
@@ -2087,6 +2206,7 @@ impl Gpu {
     /// Exposed so callers can batch one rotation across multiple GEMVs that share x
     /// (e.g., Q/K/V projections all consume the same post-RMSNorm x).
     pub fn rotate_x_mq(&mut self, x: &GpuTensor, x_rot: &GpuTensor, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         // `mq_rotate_x` lives inside the `gemv_mq4g256` module — precompile
         // writes the .hsaco/.hash sidecar under that module name, so the
@@ -2128,6 +2248,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         // Same cache-key contract as `rotate_x_mq` — see comment there.
         self.ensure_kernel("gemv_mq4g256", kernels::GEMV_MQ4G256_SRC, "mq_rotate_x")?;
@@ -2173,6 +2294,7 @@ impl Gpu {
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         x_rot: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rotate_x_mq(x, x_rot, k)?;
         // MQ4 = FWHT-rotated HFQ4-G256. dot(rot(W), rot(x)) = dot(W, x).
         // Route through the arch-specific HFQ4 kernel (4x unroll on gfx1100, etc).
@@ -2184,6 +2306,7 @@ impl Gpu {
     pub fn gemv_mq4g256_prerotated(
         &mut self, a_raw: &GpuTensor, x_rot: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.gemv_hfq4g256(a_raw, x_rot, y, m, k)
     }
 
@@ -2194,6 +2317,7 @@ impl Gpu {
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         x_rot: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rotate_x_mq(x, x_rot, k)?;
         self.gemv_hfq3g256(a_raw, x_rot, y, m, k)
     }
@@ -2202,6 +2326,7 @@ impl Gpu {
     pub fn gemv_mq3g256_prerotated(
         &mut self, a_raw: &GpuTensor, x_rot: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.gemv_hfq3g256(a_raw, x_rot, y, m, k)
     }
 
@@ -2211,6 +2336,7 @@ impl Gpu {
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         x_rot: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rotate_x_mq(x, x_rot, k)?;
         self.gemv_hfq2g256(a_raw, x_rot, y, m, k)
     }
@@ -2219,6 +2345,7 @@ impl Gpu {
     pub fn gemv_mq2g256_prerotated(
         &mut self, a_raw: &GpuTensor, x_rot: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.gemv_hfq2g256(a_raw, x_rot, y, m, k)
     }
 
@@ -2227,6 +2354,7 @@ impl Gpu {
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         x_rot: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rotate_x_mq(x, x_rot, k)?;
         self.gemv_hfq6g256(a_raw, x_rot, y, m, k)
     }
@@ -2235,12 +2363,14 @@ impl Gpu {
     pub fn gemv_mq6g256_prerotated(
         &mut self, a_raw: &GpuTensor, x_rot: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.gemv_hfq6g256(a_raw, x_rot, y, m, k)
     }
 
     /// Standalone MQ8 rotate + INT8 quantize of x into internal `mq_x_q8`/`mq_x_scales`.
     /// After this, `gemv_mq8g256_prerotated` can be called multiple times with the same x.
     pub fn rotate_quantize_x_mq8(&mut self, x: &GpuTensor, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel("mq8_rotate_quantize_x", kernels::GEMV_MQ8G256_SRC, "mq8_rotate_quantize_x")?;
 
@@ -2269,6 +2399,7 @@ impl Gpu {
     pub fn gemv_mq8g256_prerotated(
         &mut self, a_raw: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_mq8g256", kernels::GEMV_MQ8G256_SRC, "gemv_mq8g256")?;
 
         let xq_ptr = self.mq_x_q8.as_ref().unwrap().as_ptr();
@@ -2291,6 +2422,7 @@ impl Gpu {
     pub fn gemv_mq8g256_with_rotate(
         &mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.rotate_quantize_x_mq8(x, k)?;
         self.gemv_mq8g256_prerotated(a_raw, y, m, k)
     }
@@ -2302,6 +2434,7 @@ impl Gpu {
     /// gfx9xx) produce byte-exact results against the RDNA3 baseline.
     /// Uses `launch_maybe_blob` for HIPFIRE_GRAPH=1 capture safety.
     pub fn gemv_hfq3g256(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         let (src, module) = kernels::gemv_hfq3g256_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfq3g256")?;
         let a_ptr = a_raw.buf.as_ptr();
@@ -2340,6 +2473,7 @@ impl Gpu {
         a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let (src, module) = kernels::gemv_hfq3g256_residual_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfq3g256_residual")?;
         let a_ptr = a_raw.buf.as_ptr();
@@ -2372,11 +2506,13 @@ impl Gpu {
     pub fn gemv_mq3g256_residual_prerotated(
         &mut self, a_raw: &GpuTensor, x_rot: &GpuTensor, y: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.gemv_hfq3g256_residual(a_raw, x_rot, y, m, k)
     }
 
     /// HFQ3-G128 GEMV. K must be multiple of 128. Finer granularity than G256.
     pub fn gemv_hfq3g128(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq3g128", kernels::GEMV_HFQ3G128_SRC, "gemv_hfq3g128")?;
         let func = &self.functions["gemv_hfq3g128"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -2391,6 +2527,7 @@ impl Gpu {
 
     /// HFQ2-G128 GEMV. K must be multiple of 128. Finer granularity than G256.
     pub fn gemv_hfq2g128(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq2g128", kernels::GEMV_HFQ2G128_SRC, "gemv_hfq2g128")?;
         let func = &self.functions["gemv_hfq2g128"];
         let mut ap = a_raw.buf.as_ptr(); let mut xp = x.buf.as_ptr(); let mut yp = y.buf.as_ptr();
@@ -2408,6 +2545,7 @@ impl Gpu {
     /// Used for wo and w_down in HFQ6 / MQ6 forward paths so the
     /// add_inplace_f32 follow-up launch can be elided.
     pub fn gemv_hfq6g256_residual(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq6g256_residual", kernels::GEMV_HFQ6G256_RESIDUAL_SRC, "gemv_hfq6g256_residual")?;
         let func = &self.functions["gemv_hfq6g256_residual"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -2422,6 +2560,7 @@ impl Gpu {
 
     /// HFQ6-G256 GEMV. K must be multiple of 256.
     pub fn gemv_hfq6g256(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq6g256", kernels::GEMV_HFQ6G256_SRC, "gemv_hfq6g256")?;
         let func = &self.functions["gemv_hfq6g256"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -2436,6 +2575,7 @@ impl Gpu {
 
     /// HFQ8-G256 GEMV. K must be multiple of 256.
     pub fn gemv_hfq8g256(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq8g256", kernels::GEMV_HFQ8G256_SRC, "gemv_hfq8g256")?;
         let func = &self.functions["gemv_hfq8g256"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -2450,6 +2590,7 @@ impl Gpu {
 
     /// HFQ4-G512 GEMV. K must be multiple of 512.
     pub fn gemv_hfq4g512(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq4g512", kernels::GEMV_HFQ4G512_SRC, "gemv_hfq4g512")?;
         let func = &self.functions["gemv_hfq4g512"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -2464,6 +2605,7 @@ impl Gpu {
 
     /// HFQ4-G1024 GEMV. K must be multiple of 1024.
     pub fn gemv_hfq4g1024(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_hfq4g1024", kernels::GEMV_HFQ4G1024_SRC, "gemv_hfq4g1024")?;
         let func = &self.functions["gemv_hfq4g1024"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
@@ -2485,6 +2627,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let (hfq4g256_src, hfq4g256_module) = kernels::gemv_hfq4g256_for_arch(&self.arch);
         self.ensure_kernel(hfq4g256_module, hfq4g256_src, "gemv_hfq4g256")?;
 
@@ -2581,6 +2724,7 @@ impl Gpu {
         q_m: usize, k_m: usize, v_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
@@ -2664,6 +2808,7 @@ impl Gpu {
         qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // gfx906/gfx908/gfx94x wave64-native path:
         // 2 rows per block, halves grid count vs wave32 kernel which wastes half
         // the wave slot. This kernel uses no MFMA, just FMA + shfl_down within
@@ -2751,6 +2896,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // CDNA3 MFMA path — 4 back-to-back rocBLAS calls. The last two
         // matrices (beta, alpha) are tiny (n_v_heads = 128 on A3B) so we
         // could skip them and stay on the GEMV path, but dispatching all
@@ -2911,6 +3057,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq4g256_fp16",
             kernels::GEMM_QKVZA_HFQ4G256_FP16_SRC,
@@ -2990,6 +3137,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq4g256_fp16_wave64",
             kernels::GEMM_QKVZA_HFQ4G256_FP16_WAVE64_SRC,
@@ -3070,6 +3218,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq4g256_dot2",
             kernels::GEMM_QKVZA_HFQ4G256_DOT2_SRC,
@@ -3146,6 +3295,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // CDNA3 MFMA path — 3 back-to-back rocBLAS calls for Q, K, V.
         if self.rocblas_arch_eligible()
             && batch_size >= self.rocblas_min_batch()
@@ -3287,6 +3437,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq4g256_fp16",
             kernels::GEMM_QKV_HFQ4G256_FP16_SRC,
@@ -3359,6 +3510,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq4g256_fp16_wave64",
             kernels::GEMM_QKV_HFQ4G256_FP16_WAVE64_SRC,
@@ -3431,6 +3583,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq4g256_dot2",
             kernels::GEMM_QKV_HFQ4G256_DOT2_SRC,
@@ -3500,6 +3653,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // CDNA3 MFMA path (task #130): two back-to-back rocBLAS calls against
         // the gate/up FP16 shadows. rocBLAS launch overhead is small compared
         // to the GEMM work at prefill batches, so fusing into a single
@@ -3622,6 +3776,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq4g256_dot2",
             kernels::GEMM_GATE_UP_HFQ4G256_DOT2_SRC,
@@ -3681,6 +3836,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq4g256_fp16",
             kernels::GEMM_GATE_UP_HFQ4G256_FP16_SRC,
@@ -3746,6 +3902,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq4g256_fp16_wave64",
             kernels::GEMM_GATE_UP_HFQ4G256_FP16_WAVE64_SRC,
@@ -3810,6 +3967,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_qkvza_hfq4g256_wmma", kernels::GEMM_QKVZA_HFQ4G256_WMMA_SRC, "gemm_qkvza_hfq4g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -3893,6 +4051,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_qkvza_hfq3g256_wmma_gfx12(
                 a_qkv, a_z, a_beta, a_alpha, x,
@@ -3980,6 +4139,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // Rotate batched x. mq_rotate_x_batched applies FWHT per-row.
         for b in 0..batch_size {
             let x_row = x.sub_offset(b * k, k);
@@ -4014,6 +4174,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq3g256_wmma_gfx12",
             kernels::GEMM_QKVZA_HFQ3G256_WMMA_GFX12_SRC,
@@ -4095,6 +4256,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq4g256_wmma_gfx12",
             kernels::GEMM_QKVZA_HFQ4G256_WMMA_GFX12_SRC,
@@ -4178,6 +4340,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_qkv_hfq4g256_wmma", kernels::GEMM_QKV_HFQ4G256_WMMA_SRC, "gemm_qkv_hfq4g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -4253,6 +4416,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_qkv_hfq3g256_wmma_gfx12(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
@@ -4330,6 +4494,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq4g256_wmma_gfx12",
             kernels::GEMM_QKV_HFQ4G256_WMMA_GFX12_SRC,
@@ -4406,6 +4571,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // HIPFIRE_GATE_UP_VARIANT=ldsx routes to the LDS-staged X variant
         // (Gate 1 microbench, opt-in only, default off). See
         // docs/perf-checkpoints/2026-05-01-gate-up-lds-x-share-plan.md.
@@ -4483,6 +4649,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq3g256_wmma_gfx12",
             kernels::GEMM_QKV_HFQ3G256_WMMA_GFX12_SRC,
@@ -4554,6 +4721,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_gate_up_hfq3g256_wmma_gfx12(
                 a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
@@ -4619,6 +4787,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq3g256_wmma_gfx12",
             kernels::GEMM_GATE_UP_HFQ3G256_WMMA_GFX12_SRC,
@@ -4687,6 +4856,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         for b in 0..batch_size {
             let x_row = x.sub_offset(b * k, k);
             let x_rot_row = x_rot.sub_offset(b * k, k);
@@ -4711,6 +4881,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq4g256_wmma_gfx12",
             kernels::GEMM_GATE_UP_HFQ4G256_WMMA_GFX12_SRC,
@@ -4791,6 +4962,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_hfq4g256_residual_wmma_gfx12",
             kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_GFX12_SRC,
@@ -4850,6 +5022,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let (src, module) = kernels::gemv_hfq4g256_residual_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfq4g256_residual")?;
 
@@ -4956,6 +5129,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemv_hfq4g256_residual_scaled",
             kernels::GEMV_HFQ4G256_RESIDUAL_SCALED_SRC,
@@ -5007,6 +5181,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemv_hfq4g256_residual_scaled",
             kernels::GEMV_HFQ4G256_RESIDUAL_SCALED_SRC,
@@ -5056,6 +5231,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemv_hfq4g256_residual_scaled",
             kernels::GEMV_HFQ4G256_RESIDUAL_SCALED_SRC,
@@ -5109,6 +5285,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemv_hfq4g256_residual_scaled",
             kernels::GEMV_HFQ4G256_RESIDUAL_SCALED_SRC,
@@ -5167,6 +5344,7 @@ impl Gpu {
         y_up:   &GpuTensor,   // [k_top × mi] — second half
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemv_hfq4g256_moe_gate_up",
             kernels::GEMV_HFQ4G256_MOE_GATE_UP_SRC,
@@ -5233,6 +5411,7 @@ impl Gpu {
         scales: [f32; 8],
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemv_hfq4g256_moe_down",
             kernels::GEMV_HFQ4G256_MOE_DOWN_SRC,
@@ -5294,6 +5473,7 @@ impl Gpu {
         n_exp: usize,
         norm_topk: bool,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "moe_softmax_topk_k8",
             kernels::MOE_SOFTMAX_TOPK_K8_SRC,
@@ -5387,6 +5567,7 @@ impl Gpu {
         y_up:   &GpuTensor,
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
@@ -5451,6 +5632,7 @@ impl Gpu {
         x_residual: &GpuTensor,
         m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
@@ -5514,6 +5696,7 @@ impl Gpu {
         norm_topk: bool,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "moe_softmax_topk_k8_batched",
             kernels::MOE_SOFTMAX_TOPK_K8_BATCHED_SRC,
@@ -5611,6 +5794,7 @@ impl Gpu {
         y_up:   &GpuTensor,
         m: usize, k: usize, k_top: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
@@ -5679,6 +5863,7 @@ impl Gpu {
         x_residual: &GpuTensor,
         m: usize, k: usize, k_top: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
@@ -5753,6 +5938,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // CDNA3 MFMA path — Y += X·W^T via rocBLAS with beta=1.
         if self.rocblas_arch_eligible()
             && batch_size >= self.rocblas_min_batch()
@@ -5886,6 +6072,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_hfq4g256_residual_fp16", kernels::GEMM_HFQ4G256_RESIDUAL_FP16_SRC, "gemm_hfq4g256_residual_fp16")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -5940,6 +6127,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_hfq4g256_residual_fp16_wave64", kernels::GEMM_HFQ4G256_RESIDUAL_FP16_WAVE64_SRC, "gemm_hfq4g256_residual_fp16_wave64")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -5992,6 +6180,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
         let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
             "gemm_hfq4g256_residual_mmq_full_add"
@@ -6064,6 +6253,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
         let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
             "gemm_hfq4g256_residual_mmq_full_set"
@@ -6136,6 +6326,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let kernel_name = if m % 128 == 0 && batch_size % 128 == 0 {
             "gemm_hfq4g256_residual_mmq_full_set"
         } else {
@@ -6209,6 +6400,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // Compile both kernels (convert + WMMA GEMM share the FP16 convert)
         // Kernel variant selection
         // MW16 path: dequant weights to FP16 per-call, then run no-dequant WMMA
@@ -6247,7 +6439,24 @@ impl Gpu {
         //   wmma   — base WMMA         (output-mapping bug — debug only)
         //   wmma2  — 2-wave block, 32 rows × 16 batch (output-mapping bug — debug only)
         let is_gfx115x = matches!(self.arch.as_str(), "gfx1150" | "gfx1151" | "gfx1152");
-        let auto_variant = if is_gfx115x && batch_size <= 16 {
+        // ksplit's atomicAdd reduction across K_SPLITS partials is fp-non-
+        // associative — order varies with warp scheduling, so output bytes
+        // drift between processes and between cold/hot runs. The drift is
+        // sub-argmax-margin per call but cascades on long greedy decode
+        // (>50 tokens). HIPFIRE_DETERMINISTIC=1 forces k2 (single-block
+        // K reduction) at the cost of ~33% perf on small-batch / small-M.
+        // Required when chasing multi-GPU parity: pp=1 vs pp=2 outputs
+        // can't be compared byte-for-byte when the underlying single-GPU
+        // path itself is non-deterministic.
+        // Cached — getenv on every decode token would re-parse 6× per layer
+        // × N layers per step. Read once at first dispatch.
+        static FORCE_DET: OnceLock<bool> = OnceLock::new();
+        let force_det = *FORCE_DET.get_or_init(|| {
+            std::env::var("HIPFIRE_DETERMINISTIC").ok().as_deref() == Some("1")
+        });
+        let auto_variant = if force_det {
+            "k2"
+        } else if is_gfx115x && batch_size <= 16 {
             "k2"
         } else if is_gfx115x && m < 8192 {
             "k2x32"
@@ -6347,6 +6556,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_hfq3g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
         }
@@ -6405,6 +6615,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_hfq3g256_residual_wmma_gfx12",
             kernels::GEMM_HFQ3G256_RESIDUAL_WMMA_GFX12_SRC,
@@ -6461,6 +6672,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         for b in 0..batch_size {
             let x_row = x.sub_offset(b * k, k);
             let x_rot_row = x_rot.sub_offset(b * k, k);
@@ -6535,6 +6747,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // CDNA3 MFMA path (task #130): when rocBLAS is loaded and batch is
         // big enough for the launch overhead to amortize, route through the
         // dequantize-once FP16 shadow + rocBLAS GEMM. Expected 20-100× over
@@ -6648,6 +6861,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         if !self.arch.starts_with("gfx11") {
             // No mw16 WMMA on non-RDNA3 — fall back to the scalar F32 GEMM.
             // This is slow but correct; non-gfx11 isn't the intended target.
@@ -6725,6 +6939,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let wmma_eligible = batch_size > 1
             && self.arch.starts_with("gfx11")
             && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
@@ -6758,6 +6973,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // WMMA eligibility: any arch with an MQ3 WMMA family ported. Today
         // that's gfx11 (RDNA3, _w32 builtin) and gfx12 (RDNA4, _w32_gfx12
         // builtin) — `gemm_hfq3g256_residual_wmma` dispatches internally to
@@ -6805,6 +7021,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
             // WMMA on gfx11+ (RDNA3): 16x16 tiled
@@ -6866,6 +7083,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_hfq6g256_residual_fp16", kernels::GEMM_HFQ6G256_RESIDUAL_FP16_SRC, "gemm_hfq6g256_residual_fp16")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -6918,6 +7136,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let (kernel_name, kernel_src, block_size, row_step) =
             ("gemm_hfq6g256_residual_wmma_k2", kernels::GEMM_HFQ6G256_RESIDUAL_WMMA_K2_SRC, 32u32, 16usize);
         self.ensure_kernel(kernel_name, kernel_src, kernel_name)?;
@@ -6974,6 +7193,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
             if has_wmma_f16_gfx12(&self.arch) {
@@ -7062,6 +7282,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq6g256_fp16",
             kernels::GEMM_QKVZA_HFQ6G256_FP16_SRC,
@@ -7141,6 +7362,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq6g256_dot2",
             kernels::GEMM_QKVZA_HFQ6G256_DOT2_SRC,
@@ -7205,6 +7427,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_qkvza_hfq6g256_wmma", kernels::GEMM_QKVZA_HFQ6G256_WMMA_SRC, "gemm_qkvza_hfq6g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -7286,6 +7509,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkvza_hfq6g256_wmma_gfx12",
             kernels::GEMM_QKVZA_HFQ6G256_WMMA_GFX12_SRC,
@@ -7370,6 +7594,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
             if has_wmma_f16_gfx12(&self.arch) {
@@ -7451,6 +7676,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq6g256_fp16",
             kernels::GEMM_QKV_HFQ6G256_FP16_SRC,
@@ -7523,6 +7749,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq6g256_dot2",
             kernels::GEMM_QKV_HFQ6G256_DOT2_SRC,
@@ -7581,6 +7808,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_qkv_hfq6g256_wmma", kernels::GEMM_QKV_HFQ6G256_WMMA_SRC, "gemm_qkv_hfq6g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -7655,6 +7883,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_qkv_hfq6g256_wmma_gfx12",
             kernels::GEMM_QKV_HFQ6G256_WMMA_GFX12_SRC,
@@ -7732,6 +7961,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
             if has_wmma_f16_gfx12(&self.arch) {
@@ -7806,6 +8036,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq6g256_fp16",
             kernels::GEMM_GATE_UP_HFQ6G256_FP16_SRC,
@@ -7871,6 +8102,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq6g256_dot2",
             kernels::GEMM_GATE_UP_HFQ6G256_DOT2_SRC,
@@ -7923,6 +8155,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_gate_up_hfq6g256_wmma", kernels::GEMM_GATE_UP_HFQ6G256_WMMA_SRC, "gemm_gate_up_hfq6g256_wmma")?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
@@ -7990,6 +8223,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gemm_gate_up_hfq6g256_wmma_gfx12",
             kernels::GEMM_GATE_UP_HFQ6G256_WMMA_GFX12_SRC,
@@ -8052,6 +8286,7 @@ impl Gpu {
     pub fn max_prob(
         &mut self, logits: &GpuTensor, result: &GpuTensor, vocab_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("max_prob", kernels::MAX_PROB_SRC, "max_prob")?;
         let func = &self.functions["max_prob"];
         let mut lp = logits.buf.as_ptr();
@@ -8076,6 +8311,7 @@ impl Gpu {
         yq: &GpuTensor, yk: &GpuTensor, yv: &GpuTensor,
         q_m: usize, k_m: usize, v_m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("fused_qkv_q4k", kernels::FUSED_QKV_Q4K_SRC, "fused_qkv_q4k")?;
         let func = &self.functions["fused_qkv_q4k"];
 
@@ -8120,6 +8356,7 @@ impl Gpu {
         y_gate: &GpuTensor, y_up: &GpuTensor,
         gate_m: usize, up_m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("fused_gate_up_q4k", kernels::FUSED_GATE_UP_Q4K_SRC, "fused_gate_up_q4k")?;
         let func = &self.functions["fused_gate_up_q4k"];
 
@@ -8158,6 +8395,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
         let y_ptr = y.buf.as_ptr();
@@ -8215,6 +8453,7 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         assert!(
             batch_size <= 16,
             "gemm_q8_0_batched: batch_size {batch_size} exceeds kernel MAX_BATCH=16"
@@ -8266,6 +8505,7 @@ impl Gpu {
         k: usize,
         row_stride: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let mut a_ptr = a_raw.buf.as_ptr();
         let mut x_ptr = x.buf.as_ptr();
         let mut y_ptr = y.buf.as_ptr();
@@ -8308,6 +8548,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q6k", kernels::GEMV_Q6K_SRC, "gemv_q6k")?;
         let func = &self.functions["gemv_q6k"];
 
@@ -8351,6 +8592,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4f16_g64", kernels::GEMV_Q4F16_G64_SRC, "gemv_q4f16_g64")?;
         let func = &self.functions["gemv_q4f16_g64"];
 
@@ -8391,6 +8633,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4f16_g64_wide", kernels::GEMV_Q4F16_G64_WIDE_SRC, "gemv_q4f16_g64_wide")?;
         let func = &self.functions["gemv_q4f16_g64_wide"];
 
@@ -8432,6 +8675,7 @@ impl Gpu {
         m: usize,
         k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemv_q4f16_g32", kernels::GEMV_Q4F16_G32_SRC, "gemv_q4f16_g32")?;
         let func = &self.functions["gemv_q4f16_g32"];
 
@@ -8472,6 +8716,7 @@ impl Gpu {
         n: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "argmax_f32_batched",
             kernels::ARGMAX_BATCHED_SRC,
@@ -8506,6 +8751,7 @@ impl Gpu {
 
     /// GPU-side argmax: returns index of max value. Avoids downloading full logits.
     pub fn argmax_f32(&mut self, data: &GpuTensor, n: usize) -> HipResult<u32> {
+        self.bind_thread()?;
         self.ensure_kernel("argmax_f32", kernels::ARGMAX_SRC, "argmax_f32")?;
         let func = &self.functions["argmax_f32"];
 
@@ -8545,6 +8791,7 @@ impl Gpu {
         out: &GpuTensor,
         eps: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("rmsnorm", kernels::RMSNORM_SRC, "rmsnorm_f32")?;
 
         let batch = if x.shape.len() > 1 { x.shape[0] } else { 1 };
@@ -8605,6 +8852,7 @@ impl Gpu {
         n_tokens: usize, n_heads: usize, head_dim: usize,
         layer_idx: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "triattn_accumulate",
             kernels::TRIATTN_ACCUMULATE_SRC,
@@ -8656,6 +8904,7 @@ impl Gpu {
         x: &GpuTensor, weight: &GpuTensor, out: &GpuTensor,
         batch: usize, n: usize, eps: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("rmsnorm", kernels::RMSNORM_SRC, "rmsnorm_f32")?;
 
         let mut x_ptr = x.buf.as_ptr();
@@ -8695,6 +8944,7 @@ impl Gpu {
 
     /// c = a + b (element-wise)
     pub fn add_f32(&mut self, a: &GpuTensor, b: &GpuTensor, c: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("add", kernels::ADD_SRC, "add_f32")?;
         let func = &self.functions["add_f32"];
 
@@ -8718,6 +8968,7 @@ impl Gpu {
 
     /// a += b (in-place element-wise add)
     pub fn add_inplace_f32(&mut self, a: &GpuTensor, b: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("add_inplace", kernels::ADD_INPLACE_SRC, "add_inplace_f32")?;
 
         let n = a.numel() as i32;
@@ -8750,6 +9001,7 @@ impl Gpu {
 
     /// c = a * b (element-wise)
     pub fn mul_f32(&mut self, a: &GpuTensor, b: &GpuTensor, c: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("mul", kernels::MUL_SRC, "mul_f32")?;
         let func = &self.functions["mul_f32"];
 
@@ -8777,6 +9029,7 @@ impl Gpu {
 
     /// out = silu(x)
     pub fn silu_f32(&mut self, x: &GpuTensor, out: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("silu", kernels::SILU_SRC, "silu_f32")?;
         let func = &self.functions["silu_f32"];
 
@@ -8798,6 +9051,7 @@ impl Gpu {
 
     /// out = silu(gate) * up — fused to avoid intermediate buffer
     pub fn silu_mul_f32(&mut self, gate: &GpuTensor, up: &GpuTensor, out: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("silu_mul", kernels::SILU_MUL_SRC, "silu_mul_f32")?;
 
         let n = gate.numel() as i32;
@@ -8833,6 +9087,7 @@ impl Gpu {
 
     /// In-place softmax over last dimension
     pub fn softmax_f32(&mut self, x: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("softmax", kernels::SOFTMAX_SRC, "softmax_f32")?;
 
         let rows = if x.shape.len() > 1 { x.shape[0] } else { 1 };
@@ -8880,6 +9135,7 @@ impl Gpu {
         head_dim: usize,
         freq_base: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("rope", kernels::ROPE_SRC, "rope_f32")?;
         let func = &self.functions["rope_f32"];
 
@@ -8924,6 +9180,7 @@ impl Gpu {
         &mut self, q: &GpuTensor, k: &GpuTensor, positions: &GpuTensor,
         n_heads_q: usize, n_heads_k: usize, head_dim: usize, freq_base: f32, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("rope_batched", kernels::ROPE_BATCHED_SRC, "rope_batched_f32")?;
         let func = &self.functions["rope_batched_f32"];
         let mut q_ptr = q.buf.as_ptr();
@@ -8968,6 +9225,7 @@ impl Gpu {
         head_dim: usize,
         max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention", kernels::ATTENTION_SRC, "attention_f32")?;
         let func = &self.functions["attention_f32"];
 
@@ -9029,6 +9287,7 @@ impl Gpu {
         head_dim: usize,
         max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let scale = 1.0f32 / (head_dim as f32).sqrt();
 
         // Choose chunk size: aim for 4-16 chunks
@@ -9117,6 +9376,7 @@ impl Gpu {
         y_gate: &GpuTensor, y_up: &GpuTensor,
         gate_m: usize, up_m: usize, k: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
@@ -9165,6 +9425,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, pos_buf: &DeviceBuffer,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_hfq4", kernels::KV_CACHE_WRITE_HFQ4_SRC, "kv_cache_write_hfq4")?;
         let func = &self.functions["kv_cache_write_hfq4"];
         let mut d = dst.buf.as_ptr(); let mut s = src.buf.as_ptr();
@@ -9184,6 +9445,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_hfq4_kv", kernels::ATTENTION_HFQ4_KV_SRC, "attention_hfq4_kv")?;
         let func = &self.functions["attention_hfq4_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -9210,6 +9472,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, pos_buf: &DeviceBuffer,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_int8c_f16", kernels::KV_CACHE_WRITE_INT8C_F16_SRC, "kv_cache_write_int8c_f16")?;
         let func = &self.functions["kv_cache_write_int8c_f16"];
         let mut d = dst.buf.as_ptr(); let mut s = src.buf.as_ptr(); let mut p = pos_buf.as_ptr();
@@ -9226,6 +9489,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_int8c_f16_kv", kernels::ATTENTION_INT8C_F16_KV_SRC, "attention_int8c_f16_kv")?;
         let func = &self.functions["attention_int8c_f16_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -9250,6 +9514,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, pos_buf: &DeviceBuffer,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_int8c", kernels::KV_CACHE_WRITE_INT8C_SRC, "kv_cache_write_int8c")?;
         let func = &self.functions["kv_cache_write_int8c"];
         let mut d = dst.buf.as_ptr(); let mut s = src.buf.as_ptr();
@@ -9269,6 +9534,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_int8c_kv", kernels::ATTENTION_INT8C_KV_SRC, "attention_int8c_kv")?;
         let func = &self.functions["attention_int8c_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -9294,6 +9560,7 @@ impl Gpu {
         &mut self, dst_data: &GpuTensor, dst_scales: &GpuTensor, src: &GpuTensor,
         pos_buf: &DeviceBuffer, n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_hfq8", kernels::KV_CACHE_WRITE_HFQ8_SRC, "kv_cache_write_hfq8")?;
         let func = &self.functions["kv_cache_write_hfq8"];
         let mut dd = dst_data.buf.as_ptr(); let mut ds = dst_scales.buf.as_ptr();
@@ -9315,6 +9582,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_hfq8_kv", kernels::ATTENTION_HFQ8_KV_SRC, "attention_hfq8_kv")?;
         let func = &self.functions["attention_hfq8_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -9343,6 +9611,7 @@ impl Gpu {
         &mut self, dst_vals: &GpuTensor, dst_scales: &GpuTensor, src: &GpuTensor,
         pos_buf: &DeviceBuffer, n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_int8", kernels::KV_CACHE_WRITE_INT8_SRC, "kv_cache_write_int8")?;
         let func = &self.functions["kv_cache_write_int8"];
         let mut dv = dst_vals.buf.as_ptr(); let mut ds = dst_scales.buf.as_ptr();
@@ -9364,6 +9633,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_int8_kv", kernels::ATTENTION_INT8_KV_SRC, "attention_int8_kv")?;
         let func = &self.functions["attention_int8_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -9393,6 +9663,7 @@ impl Gpu {
         &mut self, q: &GpuTensor, k: &GpuTensor, v: &GpuTensor, out: &GpuTensor,
         seq_len: usize, n_heads: usize, n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_causal_batched", kernels::ATTENTION_CAUSAL_BATCHED_SRC, "attention_causal_batched")?;
         let func = &self.functions["attention_causal_batched"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -9419,6 +9690,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, positions: &GpuTensor,
         n_kv_heads: usize, head_dim: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_q8_0_batched", kernels::KV_CACHE_WRITE_Q8_0_BATCHED_SRC, "kv_cache_write_q8_0_batched")?;
         let mut d = dst.buf.as_ptr(); let mut s = src.buf.as_ptr();
         let mut p = positions.buf.as_ptr();
@@ -9446,6 +9718,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, pos_buf: &DeviceBuffer,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_q8_0", kernels::KV_CACHE_WRITE_Q8_0_SRC, "kv_cache_write_q8_0")?;
         let d = dst.buf.as_ptr();
         let s = src.buf.as_ptr();
@@ -9499,6 +9772,7 @@ impl Gpu {
         max_ctx_len: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.attention_q8_0_kv_batched_masked(
             q, k_cache, v_cache, out, positions,
             n_heads, n_kv_heads, head_dim, max_seq, max_ctx_len, batch_size,
@@ -9537,6 +9811,7 @@ impl Gpu {
         block_start: usize,
         block_cols: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "attention_q8_0_kv_batched",
             kernels::ATTENTION_Q8_0_KV_BATCHED_SRC,
@@ -9612,6 +9887,7 @@ impl Gpu {
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         const TILE_SIZE: usize = 128;
         // Graph-safe: use max_tiles so the grid is position-independent.
         // The tile kernel exits early for tiles beyond actual seq_len.
@@ -9723,6 +9999,7 @@ impl Gpu {
         cos_theta: &GpuTensor, sin_theta: &GpuTensor,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // K: rotated 4-bit
         self.ensure_givens4_kernel(
             "kv_cache_write_asym_k_givens4",
@@ -9768,6 +10045,7 @@ impl Gpu {
         cos_theta: &GpuTensor, sin_theta: &GpuTensor,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel(
             "kv_cache_write_asym_k_givens3",
             kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC,
@@ -9995,6 +10273,7 @@ impl Gpu {
         cos_theta: &GpuTensor, sin_theta: &GpuTensor,
         n_kv_heads: usize, head_dim: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.launch_asym_k_batched(
             "kv_cache_write_asym_k_givens4_batched",
             kernels::KV_CACHE_WRITE_ASYM_K_GIVENS4_BATCHED_SRC,
@@ -10013,6 +10292,7 @@ impl Gpu {
         cos_theta: &GpuTensor, sin_theta: &GpuTensor,
         n_kv_heads: usize, head_dim: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.launch_asym_k_batched(
             "kv_cache_write_asym_k_givens2_batched",
             kernels::KV_CACHE_WRITE_ASYM_K_GIVENS2_BATCHED_SRC,
@@ -10033,6 +10313,7 @@ impl Gpu {
         max_seq: usize, max_ctx_len: usize, batch_size: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.attention_flash_asym4_batched_masked(
             q, k_cache, v_cache, out, positions, cos_theta, sin_theta,
             n_heads, n_kv_heads, head_dim, max_seq, max_ctx_len, batch_size, partials,
@@ -10056,6 +10337,7 @@ impl Gpu {
         block_start: usize,
         block_cols: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.launch_asym_flash_batched(
             "attention_flash_asym4_tile_batched",
             kernels::ATTENTION_FLASH_ASYM4_TILE_BATCHED_SRC,
@@ -10076,6 +10358,7 @@ impl Gpu {
         max_seq: usize, max_ctx_len: usize, batch_size: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.launch_asym_flash_batched(
             "attention_flash_asym2_tile_batched",
             kernels::ATTENTION_FLASH_ASYM2_TILE_BATCHED_SRC,
@@ -10095,6 +10378,7 @@ impl Gpu {
         cos_theta: &GpuTensor, sin_theta: &GpuTensor,
         n_kv_heads: usize, head_dim: usize, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         // K: batched 3-bit rotated write.
         self.ensure_givens4_kernel(
             "kv_cache_write_asym_k_givens3_batched",
@@ -10152,6 +10436,7 @@ impl Gpu {
         max_seq: usize, max_ctx_len: usize, batch_size: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.attention_flash_asym3_batched_masked(
             q, k_cache, v_cache, out, positions, cos_theta, sin_theta,
             n_heads, n_kv_heads, head_dim, max_seq, max_ctx_len, batch_size, partials,
@@ -10174,6 +10459,7 @@ impl Gpu {
         block_start: usize,
         block_cols: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.launch_asym_flash_batched(
             "attention_flash_asym3_tile_batched",
             kernels::ATTENTION_FLASH_ASYM3_TILE_BATCHED_SRC,
@@ -10193,6 +10479,7 @@ impl Gpu {
         seq_len_hint: usize, n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         const TILE_SIZE: usize = 128;
         let max_tiles = (max_seq + TILE_SIZE - 1) / TILE_SIZE;
         let actual_tiles = (seq_len_hint + TILE_SIZE - 1) / TILE_SIZE;
@@ -10285,6 +10572,7 @@ impl Gpu {
         cos_theta: &GpuTensor, sin_theta: &GpuTensor,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel(
             "kv_cache_write_asym_k_givens2",
             kernels::KV_CACHE_WRITE_ASYM_K_GIVENS2_SRC,
@@ -10328,6 +10616,7 @@ impl Gpu {
         seq_len_hint: usize, n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         const TILE_SIZE: usize = 128;
         let max_tiles = (max_seq + TILE_SIZE - 1) / TILE_SIZE;
         let actual_tiles = (seq_len_hint + TILE_SIZE - 1) / TILE_SIZE;
@@ -10423,6 +10712,7 @@ impl Gpu {
         seq_len_hint: usize, n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
         partials: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         const TILE_SIZE: usize = 128;
         let max_tiles = (max_seq + TILE_SIZE - 1) / TILE_SIZE;
         let actual_tiles = (seq_len_hint + TILE_SIZE - 1) / TILE_SIZE;
@@ -10514,6 +10804,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_q8_0_kv", kernels::ATTENTION_Q8_0_KV_SRC, "attention_q8_0_kv")?;
         let func = &self.functions["attention_q8_0_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -10557,6 +10848,7 @@ impl Gpu {
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
         cycle_counts: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_q8_0_kv_timed", kernels::ATTENTION_Q8_0_KV_TIMED_SRC, "attention_q8_0_kv_timed")?;
         let func = &self.functions["attention_q8_0_kv_timed"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -10610,6 +10902,7 @@ impl Gpu {
         p_q: f32,
         seq_len: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "triattn_score_q8",
             kernels::TRIATTN_SCORE_Q8_SRC,
@@ -10668,6 +10961,7 @@ impl Gpu {
         p_q: f32,
         seq_len: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel(
             "triattn_score_asym2",
             kernels::TRIATTN_SCORE_ASYM2_SRC,
@@ -10730,6 +11024,7 @@ impl Gpu {
         p_q: f32,
         seq_len: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel(
             "triattn_score_asym4",
             kernels::TRIATTN_SCORE_ASYM4_SRC,
@@ -10793,6 +11088,7 @@ impl Gpu {
         p_q: f32,
         seq_len: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel(
             "triattn_score_asym3",
             kernels::TRIATTN_SCORE_ASYM3_SRC,
@@ -10851,6 +11147,7 @@ impl Gpu {
         bytes_per_pos: usize,
         budget: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "kv_compact_gather",
             kernels::KV_COMPACT_GATHER_SRC,
@@ -10904,6 +11201,7 @@ impl Gpu {
         m: usize,
         budget: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "kv_fold_q8",
             kernels::KV_FOLD_Q8_SRC,
@@ -10949,6 +11247,7 @@ impl Gpu {
         src_indices: &GpuTensor, src_weights: &GpuTensor,
         n_kv: usize, head_dim: usize, m: usize, budget: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel("kv_fold_asym3", kernels::KV_FOLD_ASYM3_SRC, "kv_fold_asym3")?;
         let func = &self.functions["kv_fold_asym3"];
         let mut sp = src.buf.as_ptr();
@@ -10982,6 +11281,7 @@ impl Gpu {
         src_indices: &GpuTensor, src_weights: &GpuTensor,
         n_kv: usize, head_dim: usize, m: usize, budget: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel("kv_fold_asym4", kernels::KV_FOLD_ASYM4_SRC, "kv_fold_asym4")?;
         let func = &self.functions["kv_fold_asym4"];
         let mut sp = src.buf.as_ptr();
@@ -11015,6 +11315,7 @@ impl Gpu {
         src_indices: &GpuTensor, src_weights: &GpuTensor,
         n_kv: usize, head_dim: usize, m: usize, budget: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_givens4_kernel("kv_fold_asym2", kernels::KV_FOLD_ASYM2_SRC, "kv_fold_asym2")?;
         let func = &self.functions["kv_fold_asym2"];
         let mut sp = src.buf.as_ptr();
@@ -11046,6 +11347,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, pos_buf: &DeviceBuffer,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_q8", kernels::KV_CACHE_WRITE_Q8_SRC, "kv_cache_write_q8")?;
         let func = &self.functions["kv_cache_write_q8"];
         let mut d = dst.buf.as_ptr();
@@ -11069,6 +11371,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_q8kv", kernels::ATTENTION_Q8KV_SRC, "attention_q8kv")?;
         let func = &self.functions["attention_q8kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -11094,6 +11397,7 @@ impl Gpu {
         &mut self, dst: &GpuTensor, src: &GpuTensor, pos_buf: &DeviceBuffer,
         n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write_q4", kernels::KV_CACHE_WRITE_Q4_SRC, "kv_cache_write_q4")?;
         let func = &self.functions["kv_cache_write_q4"];
         let mut d = dst.buf.as_ptr();
@@ -11117,6 +11421,7 @@ impl Gpu {
         out: &GpuTensor, pos_buf: &DeviceBuffer, seq_len_hint: usize,
         n_heads: usize, n_kv_heads: usize, head_dim: usize, max_seq: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_q4kv", kernels::ATTENTION_Q4KV_SRC, "attention_q4kv")?;
         let func = &self.functions["attention_q4kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -11150,6 +11455,7 @@ impl Gpu {
         pos_buf: &DeviceBuffer,
         kv_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("kv_cache_write", kernels::KV_CACHE_WRITE_SRC, "kv_cache_write")?;
         let func = &self.functions["kv_cache_write"];
 
@@ -11194,6 +11500,7 @@ impl Gpu {
         repeat_window: usize,
         repeat_penalty: f32,
     ) -> HipResult<(u32, u32)> {
+        self.bind_thread()?;
         self.ensure_kernel("sample_top_p", kernels::SAMPLE_TOP_P_SRC, "sample_top_p")?;
         let func = &self.functions["sample_top_p"];
 
@@ -11254,6 +11561,7 @@ impl Gpu {
         repeat_window: usize,
         repeat_penalty: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("sample_top_p", kernels::SAMPLE_TOP_P_SRC, "sample_top_p")?;
         let func = &self.functions["sample_top_p"];
 
@@ -11305,6 +11613,7 @@ impl Gpu {
         &mut self, q: &GpuTensor, k: &GpuTensor, pos_buf: &hip_bridge::DeviceBuffer,
         n_heads_q: usize, n_heads_k: usize, head_dim: usize, n_rot: usize, freq_base: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("rope_partial_interleaved", kernels::ROPE_PARTIAL_INTERLEAVED_SRC, "rope_partial_interleaved_f32")?;
         let qp = q.buf.as_ptr(); let kp = k.buf.as_ptr();
         let pp = pos_buf.as_ptr();
@@ -11346,6 +11655,7 @@ impl Gpu {
         n_heads_q: usize, n_heads_k: usize, head_dim: usize, n_rot: usize,
         freq_base: f32, batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("rope_partial_interleaved_batched",
             kernels::ROPE_PARTIAL_INTERLEAVED_BATCHED_SRC,
             "rope_partial_interleaved_batched_f32")?;
@@ -11409,6 +11719,7 @@ impl Gpu {
         ratio: usize,
         head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("repeat_interleave_qk", kernels::REPEAT_INTERLEAVE_QK_SRC, "repeat_interleave_qk_f32")?;
         let qsp = q_src.buf.as_ptr();
         let ksp = k_src.buf.as_ptr();
@@ -11454,6 +11765,7 @@ impl Gpu {
         q_dst: &GpuTensor, k_dst: &GpuTensor,
         n_key_heads: usize, ratio: usize, head_dim: usize, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("repeat_interleave_qk_batched", kernels::REPEAT_INTERLEAVE_QK_BATCHED_SRC, "repeat_interleave_qk_f32_batched")?;
         let mut qsp = q_src.buf.as_ptr();
         let mut ksp = k_src.buf.as_ptr();
@@ -11498,6 +11810,7 @@ impl Gpu {
     /// Replaces per-head memcpy loop (n_heads × 2 ioctls → 1 dispatch).
     pub fn deinterleave_f32(&mut self, interleaved: &GpuTensor, out_a: &GpuTensor, out_b: &GpuTensor,
                             n_heads: usize, head_dim: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("deinterleave", kernels::DEINTERLEAVE_SRC, "deinterleave_f32")?;
         let inp = interleaved.buf.as_ptr();
         let ap = out_a.buf.as_ptr();
@@ -11536,6 +11849,7 @@ impl Gpu {
     /// batched prefill path.
     pub fn deinterleave_f32_batched(&mut self, interleaved: &GpuTensor, out_q: &GpuTensor, out_gate: &GpuTensor,
                                     n_heads: usize, head_dim: usize, n: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("deinterleave_batched", kernels::DEINTERLEAVE_BATCHED_SRC, "deinterleave_f32_batched")?;
         let mut inp = interleaved.buf.as_ptr();
         let mut qp = out_q.buf.as_ptr();
@@ -11572,6 +11886,7 @@ impl Gpu {
 
     #[cfg(feature = "deltanet")]
     pub fn sigmoid_f32(&mut self, x: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("sigmoid", kernels::SIGMOID_SRC, "sigmoid_f32")?;
         let func = &self.functions["sigmoid_f32"];
         let mut xp = x.buf.as_ptr();
@@ -11591,6 +11906,7 @@ impl Gpu {
     /// Softplus activation, in-place.
     #[cfg(feature = "deltanet")]
     pub fn softplus_f32(&mut self, x: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("softplus", kernels::SOFTPLUS_SRC, "softplus_f32")?;
         let func = &self.functions["softplus_f32"];
         let mut xp = x.buf.as_ptr();
@@ -11606,6 +11922,7 @@ impl Gpu {
     /// L2 normalization per head, in-place. One warp per head.
     #[cfg(feature = "deltanet")]
     pub fn l2_norm_f32(&mut self, x: &GpuTensor, n_heads: usize, head_dim: usize, eps: f32) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("l2_norm", kernels::L2_NORM_SRC, "l2_norm_f32")?;
         let func = &self.functions["l2_norm_f32"];
         let mut xp = x.buf.as_ptr();
@@ -11630,6 +11947,7 @@ impl Gpu {
         out: &GpuTensor,
         gate: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("sigmoid_mul", kernels::SIGMOID_MUL_SRC, "sigmoid_mul_f32")?;
         let mut op = out.buf.as_ptr();
         let mut gp = gate.buf.as_ptr();
@@ -11671,6 +11989,7 @@ impl Gpu {
         topk_buf: &GpuTensor,   // DType::F32 shape [2048] = 8192 bytes
         vocab_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("topk_logits", kernels::TOPK_LOGITS_SRC, "topk_logits_f32")?;
         let func = &self.functions["topk_logits_f32"];
         let mut lp = logits.buf.as_ptr();
@@ -11706,6 +12025,7 @@ impl Gpu {
         k: usize,
         b: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         assert!(k >= 1 && k <= 8, "topk_logsumexp_batched: K={} must be in [1,8]", k);
         self.ensure_kernel(
             "topk_logsumexp_batched",
@@ -11755,6 +12075,7 @@ impl Gpu {
         a_log: &GpuTensor,
         n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "fused_sigmoid_alpha_gate",
             kernels::FUSED_SIGMOID_ALPHA_GATE_SRC,
@@ -11800,6 +12121,7 @@ impl Gpu {
         n: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "fused_sigmoid_alpha_gate",
             kernels::FUSED_SIGMOID_ALPHA_GATE_SRC,
@@ -11852,6 +12174,7 @@ impl Gpu {
         q_scale: f32,
         eps: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "fused_qk_l2_norm_scale",
             kernels::FUSED_QK_L2_NORM_SCALE_SRC,
@@ -11900,6 +12223,7 @@ impl Gpu {
         eps: f32,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "fused_qk_l2_norm_scale",
             kernels::FUSED_QK_L2_NORM_SCALE_SRC,
@@ -11945,6 +12269,7 @@ impl Gpu {
         &mut self, output: &GpuTensor, input: &GpuTensor, weight: &GpuTensor,
         state: &GpuTensor, n_channels: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("conv1d_decode", kernels::CONV1D_DECODE_SRC, "conv1d_decode_f32")?;
         let func = &self.functions["conv1d_decode_f32"];
         let mut op = output.buf.as_ptr();
@@ -11968,6 +12293,7 @@ impl Gpu {
         &mut self, x: &GpuTensor, z: &GpuTensor, weight: &GpuTensor,
         out: &GpuTensor, n_heads: usize, head_dim: usize, eps: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gated_norm", kernels::GATED_NORM_SRC, "gated_norm_f32")?;
         let xp = x.buf.as_ptr();
         let zp = z.buf.as_ptr();
@@ -12006,6 +12332,7 @@ impl Gpu {
         n_heads: usize, head_dim: usize, eps: f32,
         batch_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gated_norm", kernels::GATED_NORM_SRC, "gated_norm_f32")?;
         let mut xp = x.buf.as_ptr();
         let mut zp = z.buf.as_ptr();
@@ -12048,6 +12375,7 @@ impl Gpu {
         state: &GpuTensor, output: &GpuTensor,
         n_tokens: usize, n_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gated_delta_net", kernels::GATED_DELTA_NET_SRC, "gated_delta_net_f32")?;
         let func = &self.functions["gated_delta_net_f32"];
         let mut qp = q.buf.as_ptr();
@@ -12080,6 +12408,7 @@ impl Gpu {
         s_q8: &GpuTensor, s_scales: &GpuTensor, output: &GpuTensor,
         n_tokens: usize, n_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gated_delta_net_q8", kernels::GATED_DELTA_NET_Q8_SRC, "gated_delta_net_q8")?;
         let qp = q.buf.as_ptr();
         let kp = k.buf.as_ptr();
@@ -12150,6 +12479,7 @@ impl Gpu {
         n_heads: usize,
         head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gated_delta_net_q8", kernels::GATED_DELTA_NET_Q8_SRC, "gated_delta_net_q8")?;
 
         let n_tiles = (128 / 4) as u32;
@@ -12237,6 +12567,7 @@ impl Gpu {
         n_heads: usize,
         head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "gated_delta_net_q8_tree",
             kernels::GATED_DELTA_NET_Q8_TREE_SRC,
@@ -12309,6 +12640,7 @@ impl Gpu {
         s_q4: &GpuTensor, s_scales: &GpuTensor, output: &GpuTensor,
         n_tokens: usize, n_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gated_delta_net_q4", kernels::GATED_DELTA_NET_Q4_SRC, "gated_delta_net_q4")?;
         let func = &self.functions["gated_delta_net_q4"];
         let mut qp = q.buf.as_ptr();
@@ -12339,6 +12671,7 @@ impl Gpu {
     pub fn alpha_gate_f32(
         &mut self, alpha: &GpuTensor, dt_bias: &GpuTensor, a_log: &GpuTensor, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("alpha_gate", kernels::ALPHA_GATE_SRC, "alpha_gate_f32")?;
         let func = &self.functions["alpha_gate_f32"];
         let mut ap = alpha.buf.as_ptr();
@@ -12361,6 +12694,7 @@ impl Gpu {
     /// Scale vector by constant: x[i] *= scale. Replaces 48µs CPU roundtrip.
     #[cfg(feature = "deltanet")]
     pub fn scale_f32(&mut self, x: &GpuTensor, scale: f32) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("scale_f32", kernels::SCALE_F32_SRC, "scale_f32")?;
         let func = &self.functions["scale_f32"];
         let n = x.numel();
@@ -12386,6 +12720,7 @@ impl Gpu {
     pub fn scaled_add_inplace_cpu_scalar_f32(
         &mut self, y: &GpuTensor, x: &GpuTensor, c: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "scaled_add_inplace",
             kernels::SCALED_ADD_INPLACE_SRC,
@@ -12424,6 +12759,7 @@ impl Gpu {
     pub fn scaled_add_inplace_gpu_scalar_f32(
         &mut self, y: &GpuTensor, x: &GpuTensor, c_buf: &GpuTensor,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "scaled_add_inplace",
             kernels::SCALED_ADD_INPLACE_SRC,
@@ -12460,6 +12796,7 @@ impl Gpu {
         &mut self, output: &GpuTensor, input: &GpuTensor, weight: &GpuTensor,
         state: &GpuTensor, n_channels: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("conv1d_silu", kernels::CONV1D_SILU_SRC, "conv1d_silu_f32")?;
         let func = &self.functions["conv1d_silu_f32"];
         let mut op = output.buf.as_ptr();
@@ -12497,6 +12834,7 @@ impl Gpu {
         k_dim: usize,
         v_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.conv1d_silu_split_f32_n(q_out, k_out, v_out, input, weight, state, k_dim, v_dim, 1)
     }
 
@@ -12518,6 +12856,7 @@ impl Gpu {
         v_dim: usize,
         n_tokens: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "conv1d_silu_split",
             kernels::CONV1D_SILU_SPLIT_SRC,
@@ -12588,6 +12927,7 @@ impl Gpu {
         v_dim: usize,
         n_tokens: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel(
             "conv1d_silu_split_tree",
             kernels::CONV1D_SILU_SPLIT_TREE_SRC,
@@ -12641,6 +12981,7 @@ impl Gpu {
         &mut self, logits: &GpuTensor, target_buf: &DeviceBuffer, loss_buf: &GpuTensor,
         vocab_size: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("cross_entropy_loss", kernels::CROSS_ENTROPY_LOSS_SRC, "cross_entropy_loss")?;
         let func = &self.functions["cross_entropy_loss"];
         let mut lp = logits.buf.as_ptr();
@@ -12663,6 +13004,7 @@ impl Gpu {
         &mut self, w: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_f16", kernels::GEMM_F16_SRC, "gemm_f16")?;
         let func = &self.functions["gemm_f16"];
         let mut wp = w.buf.as_ptr();
@@ -12689,6 +13031,7 @@ impl Gpu {
         &mut self, w: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_f16_wmma", kernels::GEMM_F16_WMMA_SRC, "gemm_f16_wmma")?;
         let func = &self.functions["gemm_f16_wmma"];
         let mut wp = w.buf.as_ptr();
@@ -12716,6 +13059,7 @@ impl Gpu {
         &mut self, w: &GpuTensor, x: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_f16_tiled", kernels::GEMM_F16_TILED_SRC, "gemm_f16_tiled")?;
         let func = &self.functions["gemm_f16_tiled"];
         let mut wp = w.buf.as_ptr();
@@ -12743,6 +13087,7 @@ impl Gpu {
         &mut self, w: &GpuTensor, x: &GpuTensor, bias: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_f16_bias", kernels::GEMM_F16_BIAS_SRC, "gemm_f16_bias")?;
         let func = &self.functions["gemm_f16_bias"];
         let mut wp = w.buf.as_ptr();
@@ -12770,6 +13115,7 @@ impl Gpu {
         &mut self, a: &GpuTensor, b: &GpuTensor, y: &GpuTensor,
         m: usize, k: usize, n: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gemm_f32_batched", kernels::GEMM_F32_SRC, "gemm_f32_batched")?;
         let func = &self.functions["gemm_f32_batched"];
         let mut ap = a.buf.as_ptr();
@@ -12794,6 +13140,7 @@ impl Gpu {
         &mut self, x: &GpuTensor, gamma: &GpuTensor, beta: &GpuTensor,
         out: &GpuTensor, batch: usize, n: usize, eps: f32,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("layernorm_f32", kernels::LAYERNORM_SRC, "layernorm_f32")?;
         let func = &self.functions["layernorm_f32"];
         let mut xp = x.buf.as_ptr();
@@ -12819,6 +13166,7 @@ impl Gpu {
 
     /// GELU tanh approximation (in-place capable if x == out)
     pub fn gelu_tanh_f32(&mut self, x: &GpuTensor, out: &GpuTensor, n: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("gelu_tanh_f32", kernels::GELU_TANH_SRC, "gelu_tanh_f32")?;
         let func = &self.functions["gelu_tanh_f32"];
         let mut xp = x.buf.as_ptr();
@@ -12835,6 +13183,7 @@ impl Gpu {
 
     /// Bias-add: x[batch, n] += bias[n] (in-place, broadcast over batch dim)
     pub fn bias_add_f32(&mut self, x: &GpuTensor, bias: &GpuTensor, batch: usize, n: usize) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("bias_add_f32", kernels::BIAS_ADD_SRC, "bias_add_f32")?;
         let func = &self.functions["bias_add_f32"];
         let mut xp = x.buf.as_ptr();
@@ -12856,6 +13205,7 @@ impl Gpu {
     pub fn transpose_f32(
         &mut self, src: &GpuTensor, dst: &GpuTensor, rows: usize, cols: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("transpose_f32", kernels::TRANSPOSE_SRC, "transpose_f32")?;
         let func = &self.functions["transpose_f32"];
         let mut sp = src.buf.as_ptr();
@@ -12878,6 +13228,7 @@ impl Gpu {
         &mut self, qkv: &GpuTensor, out: &GpuTensor,
         n: usize, hidden: usize, num_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("vit_attention_f32", kernels::VIT_ATTENTION_SRC, "vit_attention_f32")?;
         let func = &self.functions["vit_attention_f32"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -12911,6 +13262,7 @@ impl Gpu {
         &mut self, qkv: &GpuTensor, out: &GpuTensor,
         n: usize, hidden: usize, num_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("vit_attention_opt", kernels::VIT_ATTENTION_OPT_SRC, "vit_attention_opt")?;
         let func = &self.functions["vit_attention_opt"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -12953,6 +13305,7 @@ impl Gpu {
         q: &GpuTensor, k: &GpuTensor, v: &GpuTensor, out: &GpuTensor,
         b: usize, l: usize, n_heads: usize, n_kv_heads: usize, head_dim: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         self.ensure_kernel("attention_dflash_f32", kernels::ATTENTION_DFLASH_SRC, "attention_dflash_f32")?;
         let func = &self.functions["attention_dflash_f32"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
@@ -13002,6 +13355,7 @@ impl Gpu {
     /// weight quantization and KV cache type. Runs hipcc in parallel.
     #[cfg(feature = "deltanet")]
     pub fn precompile_qwen35(&mut self, weight_quant: &str, kv_type: &str, head_dim: usize) -> HipResult<()> {
+        self.bind_thread()?;
         // asym kernels #include "turbo_common.h" + "givens_common.h"; the
         // runtime dispatch path (see ensure_givens4_kernel) prepends the
         // header bodies and strips the #includes. We mirror that exactly so
@@ -13333,6 +13687,7 @@ impl Gpu {
         n_blocks: usize,
         last_pos: usize,
     ) -> HipResult<()> {
+        self.bind_thread()?;
         assert!(head_dim % 32 == 0, "head_dim must be a multiple of 32 for Q8 KV cache");
         assert!(n_blocks > 0 && block_size > 0 && n_pos > 0);
         assert!(last_pos < n_pos, "last_pos {last_pos} >= n_pos {n_pos}");
@@ -13381,6 +13736,7 @@ impl Gpu {
 
     /// Profile all compiled kernels: hardware caps + ISA metadata + occupancy.
     pub fn profile(&self) -> (crate::profiler::GpuCapability, Vec<crate::profiler::KernelProfile>) {
+        self.bind_thread_or_warn();
         let vram = self.hip.get_vram_info().map(|(_, t)| t as u64).unwrap_or(0);
         let cu_hint = self.hip
             .get_device_attribute(crate::profiler::HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, 0)
@@ -13394,5 +13750,17 @@ impl Gpu {
             self.compiler.compiled_kernels(),
             cu_hint,
         )
+    }
+}
+
+impl Drop for Gpu {
+    /// Defensive: bind owning device before any future per-field `Drop`
+    /// impls call `hipFree` etc. Uses `bind_thread_or_warn` to avoid
+    /// panic-in-Drop from `bind_thread`'s `debug_assert!`.
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+        self.bind_thread_or_warn();
     }
 }

--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -1,0 +1,202 @@
+# Multi-GPU Pipeline-Parallel
+
+**Status:** v1 feature-complete on `feat/multi-gpu-pp` branch — tracking
+issue [#58](https://github.com/Kaden-Schutt/hipfire/issues/58). Stages
+0–9 of the v2 plan are merged; refusal contracts (DFlash / VL / CASK +
+pp>1) are wired and validated. This doc is the source of truth for
+memory budget, deployment recipes, throughput, and known limitations.
+
+## Why PP
+
+hipfire on a single 24 GB card hits VRAM walls on:
+
+- 27B at `--max-ctx ≥ 16K` with `kv_mode=asym3` (`AGENTS.md:356`)
+- 35B-A3B at `--max-ctx ≥ 4K` with FP32 KV
+- hypothetical 80B-A3B at any context
+
+Pipeline-Parallel (PP) shards layers across N devices. Each device owns a contiguous "band"
+of consecutive layers. The residual stream `s.x` flows through the bands sequentially: dev_0
+runs layers `0..k1`, copies `s.x` to dev_1, dev_1 runs layers `k1..k2`, and so on. Final
+`output_norm + lm_head` run on the last device (dev_last) — its `s.logits` is read by the
+sampler in place.
+
+**What PP gives you on 2× 24 GB:**
+- Run 27B / 35B-A3B that don't fit on one card with extended context
+- Unlock max_ctx on 27B beyond single-GPU OOM limits
+- ~50-70% of single-GPU throughput on already-fitting models (sequential PP=2 is slower per token)
+
+**What PP does NOT give you:**
+- Faster multi-user serving — that's TP (tensor parallel), separate roadmap
+- Speedup on models that already fit on one card
+
+## Memory budget (per-card, PP=2)
+
+Numbers below are **measured** on 2× Radeon RX 7900 XTX (gfx1100, 25.8 GiB VRAM
+each) via `crates/hipfire-runtime/examples/pp2_vram_probe.rs` —
+`hipMemGetInfo` deltas captured at each allocation stage
+(`load_weights_multi`, `Qwen35ScratchSet`,
+`KvCache::new_gpu_asym3_capped_multi`, `DeltaNetState`). Per-card columns
+report the worst-of-two (the device that holds more — typically dev_last,
+which carries `output_norm + lm_head`). `total` is the sum across both cards.
+
+| Model | quant | n_layers | dim | KV mode | ctx | weights | KV/card | scratch+DN/card | total | per-card max | fits 24 GiB? |
+|-------|-------|----------|-----|---------|-----|---------|---------|-----------------|-------|--------------|--------------|
+| qwen3.5:0.8b | mq4 | 24 | 1024 | asym3 | 4096 | 1.3 GB | 50 MB | 8 MB | 1.3 GB | 0.7 GB | yes |
+| qwen3.5:4b | mq4 | 32 | 2560 | asym3 | 4096 | 4.0 GB | 134 MB | 15 MB | 4.0 GB | 2.0 GB | yes |
+| qwen3.5:9b | mq4 | 32 | 4096 | asym3 | 4096 | 5.6 GB | 134 MB | 19 MB | 5.6 GB | 2.8 GB | yes |
+| qwen3.5:9b | mq4 | 32 | 4096 | asym3 | 16K | 6.2 GB | 436 MB | 46 MB | 6.2 GB | 3.1 GB | yes |
+| qwen3.5:9b | mq3 | 32 | 4096 | asym3 | 4096 | 4.4 GB | 134 MB | 19 MB | 4.4 GB | 2.2 GB | yes |
+| qwen3.5:27b *(via 3.6 proxy)* | mq4 | 64 | 5120 | asym3 | 4096 | 15.5 GB | 268 MB | 42 MB | 15.5 GB | 7.8 GB | yes |
+| qwen3.5:27b *(via 3.6 proxy)* | mq4 | 64 | 5120 | asym3 | 16K | 16.8 GB | 872 MB | 80 MB | 16.8 GB | 8.4 GB | yes |
+| qwen3.5:27b | mq3 | 64 | 5120 | asym3 | 4096 | 12.6 GB | 268 MB | 40 MB | 12.6 GB | 6.3 GB | yes |
+| qwen3.5:27b | mq3 | 64 | 5120 | asym3 | 16K | 13.8 GB | 872 MB | 78 MB | 13.8 GB | 6.9 GB | yes |
+| qwen3.6:35b-a3b | mq4 | 40 | 2048 | asym3 | 4096 | 23.5 GB | 103 MB | 21 MB | 23.5 GB | 11.8 GB | yes |
+| (hypothetical) 80B-a3b | mq4 | 80 | 8192 | asym3 | 4096 | ~42 GB | ~250 MB | ~2 GB | ~44 GB | ~22 GB | estimate, tight |
+
+Notes:
+- `qwen3.5:27b mq4` rows use `qwen3.6:27b mq4` as a measurement proxy (same
+  `n_layers=64`, `dim=5120`, `head_dim=256`, `n_kv_heads=4` — VRAM-equivalent).
+  When `qwen3.5:27b mq4` lands as a downloadable artifact the rows can be
+  re-measured directly.
+- `qwen3.6:35b-a3b mq4` is the current-generation A3B; `qwen3.5:35b-a3b mq4`
+  ships local-only with the same MoE shape — measurement carries over.
+- The 80B row stays an estimate — no public artifact exists.
+- "scratch+DN/card" combines `Qwen35ScratchSet::per_device[i]` (residual
+  stream, attention/FFN scratch, flash partials, logits) and the
+  `DeltaNetState` slice owned by that device's LA-layer band.
+
+**Asymmetry under Variant 2 (lm_head on dev_last):**
+- dev_0 carries `token_embd`
+- dev_last carries `output_norm + lm_head`
+- Layer count shifts by ±1 for `n_layers % 2 != 0` (uniform split formula
+  `base + (i < rem ? 1 : 0)`)
+
+Probed on this hardware: per-card max < 24 GiB at every measured shape. The
+A3B model at 11.8 GB/card has the largest headroom consumer; everything
+else stays under 8.5 GB/card with 4 K context, under 9 GB/card at 16 K.
+
+To reproduce on your hardware:
+
+```sh
+HIP_VISIBLE_DEVICES=0,1 cargo run --release --features deltanet \
+    -p hipfire-runtime --example pp2_vram_probe -- \
+    ~/.hipfire/models/qwen3.5-9b.mq4 4096
+```
+
+## Deployment recipes
+
+The daemon takes a `pp` field in the load message (default `1` =
+single-GPU, identical behavior to pre-PP code paths):
+
+```sh
+# Filter to the two 7900 XTX (drop the iGPU)
+HIP_VISIBLE_DEVICES=0,1 hipfire run qwen3.5:27b --max-ctx 16384 "Hi"
+
+# Bypass the inherited `gemm_..._wmma_ksplit` non-determinism (k-split
+# atomicAdd reduction varies by warp scheduling — see commit f54ca71
+# and kernels/src/gemm_hfq4g256_residual_wmma_ksplit.hip:22). Required
+# for byte-equivalent output across processes / pp configurations.
+HIPFIRE_DETERMINISTIC=1 HIP_VISIBLE_DEVICES=0,1 hipfire run qwen3.5:9b "Hi"
+
+# Override uniform-VRAM tolerance (default 2 GiB; arches must match)
+HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB=4 hipfire run qwen3.5:27b "Hi"
+```
+
+Direct daemon JSON (driving without the CLI):
+
+```json
+{"type":"load","model":".../qwen3.5-27b.mq4","params":{"max_seq":16384,"pp":2}}
+```
+
+### Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `HIP_VISIBLE_DEVICES=0,1` | HIP runtime device filter (standard ROCm) |
+| `HIPFIRE_DETERMINISTIC=1` | Force k2 WMMA reduction (no atomicAdd) — bit-identical across processes/pp configs at ~33% perf cost on small-batch decode |
+| `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB=N` | Pre-flight VRAM-asymmetry tolerance for `Gpus::init_uniform` (default 2.0) |
+| `HIPFIRE_PREFILL_BATCHED=0` | Disable batched WMMA prefill (per-token fallback). Diagnostic for ksplit non-det isolation |
+| `HIPFIRE_PREFILL_MAX_BATCH=N` | Override per-chunk prefill batch (default `PREFILL_MAX_BATCH`); chunks > N split with peer-copy at boundary |
+| `HIPFIRE_WO_WMMA_VARIANT={k2,ksplit,k4,…}` | Manual override of the wo-residual GEMM variant — see `dispatch.rs` auto-dispatch |
+
+### Refusal matrix at load (`pp > 1`)
+
+| Feature | Behavior | Why |
+|---------|----------|-----|
+| arch_id ∈ {5, 6} (Qwen3.5 dense + MoE/A3B) | Accepted | Validated end-to-end |
+| arch_id = others (LLaMA / Qwen3) | Refused | Single-GPU only in v1 |
+| VL models (vision_config + vision tensors) | Refused | v1.1 |
+| DFlash draft (`draft` field set) | Refused | v1.1 — see `feedback_cask_mfold_dflash_broken.md` for the v1 ship-blocker |
+| CASK / TriAttention sidecar | Refused | Eviction context is single-device — v1.1 |
+
+## Throughput baseline (gfx1100 × 2)
+
+Measured on 2× Radeon RX 7900 XTX, ROCm 6.4.3, with
+`HIPFIRE_DETERMINISTIC=1` (bit-equivalent pp=1 ↔ pp=2 output).
+
+| Model | Prompt | pp=1 prefill | pp=2 prefill | pp=1 decode | pp=2 decode | pp=2/pp=1 decode |
+|-------|--------|--------------|--------------|-------------|-------------|------------------|
+| 0.8B mq4 | 22 tok | 838 tok/s | 588 tok/s | 332 tok/s | 227 tok/s | 68% |
+| 0.8B mq4 | 322 tok (chunked) | 6493 tok/s | 5490 tok/s | 315 tok/s | 212 tok/s | 67% |
+| 35B-A3B mq4 (MoE) | 15 tok | 331 tok/s | 258 tok/s | 142 tok/s | 97 tok/s | 68% |
+
+The pp=2 decode penalty is inherent to v1: per-token
+`forward_scratch_multi` pays one HIP launch per kernel per layer with
+no graph capture (vs pp=1 which captures + replays the AR-step graph
+after warmup). Pipelined decode + per-band graph capture lift this in
+v1.1.
+
+## Limitations (v1)
+
+Refused at load time:
+- `pp > 1` + DFlash speculative decode
+- `pp > 1` + CASK/TriAttention sidecar (eviction is single-device)
+- `pp > 1` + VL models (vision encoder is single-device)
+- `pp > 1` + arch_id ∉ {5, 6} (LLaMA / Qwen3 dense are pp=1 only)
+
+Architectural limits in v1:
+- Homogeneous arch only (`init_uniform` hard-fails on arch mismatch)
+- Uniform layer split — `init_layers(per_device)` is the manual escape hatch; `init_vram_weighted` stubbed
+- Per-token decode (no async stream pipeline / per-band graph capture) — v1.1
+- Pipelined prefill (chunk N+1 on dev_0 while chunk N processes on dev_1) — v1.1
+
+## Validation (Stage 9)
+
+```sh
+# Multi-GPU gate. Skips silently when fewer than 2 GPU visible.
+./scripts/pp-gate.sh
+
+# Just the parity smoke (no daemon end-to-end), faster
+./scripts/pp-gate.sh --skip-end-to-end
+
+# Underlying byte-equivalence example
+HIP_VISIBLE_DEVICES=0,1 cargo run --release --features deltanet \
+    -p hipfire-runtime --example pp_parity_chatml -- \
+    ~/.hipfire/models/qwen3.5-0.8b.mq4
+```
+
+The `pp-gate.sh` battery checks:
+1. Per-token `forward_scratch_multi` ≡ `forward_scratch` bit-exact (pp_parity_chatml)
+2. Daemon `pp=1` ≡ `pp=2` byte-identical with `HIPFIRE_DETERMINISTIC=1` (greedy ChatML)
+3. DFlash + pp=2 refusal at load
+4. CASK + pp=2 refusal at load
+
+A pre-commit hook calls `pp-gate.sh` automatically when staged files
+match the `multi_gpu|pp_|peer_access|pipeline|stages` hotspot regex.
+
+## Verifying peer access on your hardware
+
+```sh
+rocm-smi --showtopo            # weights, hops, link types
+rocm-smi --showtoponuma        # NUMA placement
+rocm-smi --showtopoaccess      # peer accessibility matrix
+```
+
+A `True` in every cell of `--showtopoaccess` for the cards you plan to use means peer-access
+should work. If not, hipfire falls back to host-staging via pinned buffers (slower but correct).
+
+## Open questions (will be filled in as Stages land)
+
+- DFlash + PP integration scope — pending maintainer guidance on issue #58
+- Whether mixed-arch should be soft-warn or hard-fail — currently hard-fail
+- API surface for `HIPFIRE_DEVICES` — current direction is logical IDs post-VISIBLE

--- a/docs/plans/multi-gpu-pp.md
+++ b/docs/plans/multi-gpu-pp.md
@@ -1,0 +1,390 @@
+# Multi-GPU Pipeline-Parallel (PP) Roadmap
+
+**Status:** Stages 1–9 implemented on `feat/multi-gpu-pp`
+**Author:** alpineQ (external contributor)
+**Date:** 2026-05-05
+**Target Release:** v0.2.0 (at maintainer discretion)
+**Related:** issue [#58](https://github.com/Kaden-Schutt/hipfire/issues/58),
+`docs/multi-gpu.md` (user-facing reference), `AGENTS.md` §threading,
+`CLAUDE.md` "Coherence Gate"
+
+---
+
+## 1. Objective
+
+Add Pipeline-Parallel (PP) inference over `n_devices` homogeneous AMD GPUs
+to the Qwen3.5 forward path. Layers are sharded into contiguous bands;
+the residual stream `s.x` flows through bands sequentially with a
+single cross-device copy per band boundary. `output_norm + lm_head`
+run on the last device (Variant 2 placement; matches Megatron / DeepSpeed
+/ vLLM convention) so the final residual never copies back to dev_0.
+
+**What v1 unlocks on 2× 24 GB:**
+
+- Run 27B / 35B-A3B with extended context that doesn't fit on a single
+  card (single-GPU 27B OOMs at `--max-ctx ≥ 16K` with `kv_mode=asym3`;
+  see `AGENTS.md:356`).
+- ~50-70 % of single-GPU throughput on already-fitting models. PP is
+  sequential — it does NOT speed up models that already fit on one card.
+  Multi-user serving needs TP, which is a separate roadmap.
+
+**Reference hardware for the contributor branch:** 2× 7900 XTX
+(gfx1100), Ryzen 9 9950X, NixOS, ROCm 6.4.3, peer access bidirectional
+via PCIe Gen4 (validated in Stage 1 — see `findings/` and
+`peer_smoke` example).
+
+---
+
+## 2. Why PP first
+
+This roadmap intentionally ships PP before TP:
+
+1. **Realistic first contribution.** PP is ~6 weeks median; TP from
+   scratch is multi-month with deeper kernel-side risk.
+2. **PP infrastructure is fundament for TP.** Multi-device FFI,
+   `Vec<Gpu>`, `bind_thread` audit, `output_device` plumbing — all of
+   it gets reused. TP layers on top.
+3. **PP is the right shape for memory-bound deployments.** Users
+   wanting 27B / 35B at extended context on consumer 2× 24 GB are PP-
+   shaped, not TP-shaped.
+
+---
+
+## 3. Architectural decisions
+
+### 3.1 Layer-band assignment (uniform split, escape hatch)
+
+Default — `Gpus::init_uniform(n_devices, n_layers)` — distributes
+layers contiguously with `base = n_layers / n_devices; rem = n_layers % n_devices;
+per_device[i] = base + (i < rem ? 1 : 0)` (max-min ≤ 1). Pre-flight VRAM
+check enforces homogeneous arch + bounded VRAM delta (default 2 GiB,
+override via `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB`).
+
+Asymmetric / mixed-VRAM systems use the explicit
+`Gpus::init_layers(per_device: &[usize])` escape hatch.
+`Gpus::init_vram_weighted(...)` is reserved for v1.1.
+
+### 3.2 `output_norm + lm_head` on dev_last (Variant 2)
+
+Convention adopted from Megatron-LM / DeepSpeed / vLLM. Removes the
+final cross-device copy of `s.x` back to dev_0 after the layer loop,
+and naturally balances the per-card weight footprint (dev_0 carries
+`token_embd`, dev_last carries `lm_head` — sizes match for symmetric
+vocabs).
+
+### 3.3 Boundary-copy primitive
+
+`Gpus::boundary_copy(src_dev, dst_dev, src, dst, n_bytes)` returns a
+`BoundaryEvent` (post-copy event recorded on the dst-device stream).
+Caller awaits via `Gpus::wait_boundary(evt)` before the next layer's
+dispatch on dst_dev. Modes:
+
+- **Peer mode** (default when peer access enabled): single
+  `hipMemcpyPeerAsync` on src-stream + post-copy event.
+- **Host-stage mode** (fallback): pinned host buffer + D2H async + event
+  sync + H2D async on dst-stream + post-copy event.
+
+Selection at `Gpus::enable_peer_all` time: bidirectional probe via
+`hipDeviceCanAccessPeer`, bidirectional enable via
+`hipDeviceEnablePeerAccess`. Any leg failing flips the orchestrator
+into host-stage mode globally (no mixed peer/host within a forward).
+
+### 3.4 Threading invariant
+
+hipfire engine is single-threaded for HIP work; `Gpu::bind_thread()` is
+a thread-local-cached `hipSetDevice` that runs at the entry of every
+non-trivial `Gpu::*` method. Stage 2b audits all 278 `pub fn` in
+`crates/rdna-compute/src/dispatch.rs` against a verify script
+(`scripts/verify-bind-thread.sh`) wired into `.githooks/pre-commit`.
+
+A module-level invariant doc in `crates/hipfire-runtime/src/multi_gpu.rs`
+enumerates what is **not** supported (rayon/tokio worker threads
+calling `Gpu::*`, HIP stream callbacks touching `Gpu`).
+
+### 3.5 Replicated globals
+
+Per-device replication (small, scratch-grade):
+
+- `givens_cos_per_dev`, `givens_sin_per_dev` — asym{2,3,4} KV rotation
+  tables (~2 KB × n_devices).
+
+KV cache and DeltaNet state are **partitioned** by `layer_to_device`,
+not replicated.
+
+---
+
+## 4. Scope (v1)
+
+### 4.1 In scope
+
+- 2-N device PP for the **Qwen3.5** decode + prefill paths
+  (`crates/hipfire-arch-qwen35/src/qwen35.rs`)
+- Homogeneous arch only (hard-fail on `gfx*` mismatch in `init_uniform`)
+- Peer access + bidirectional enable + host-stage fallback
+- Pre-flight VRAM check
+- `HIPFIRE_DEVICES` env var (logical IDs **post**-`HIP_VISIBLE_DEVICES`
+  filter — uphold ROCm convention; do not override visibility)
+- 14 KvCache constructors updated (`new_gpu`, `new_gpu_q4`, `new_gpu_q8`,
+  `new_gpu_q8_capped`, `new_gpu_int8`, `new_gpu_int8c`, `new_gpu_hfq4kv`,
+  `new_gpu_hfq8`, `new_gpu_asym{2,3,4}`, `new_gpu_asym{2,3,4}_capped`)
+- DFlash + `pp > 1` **refused at load time** (`"DFlash requires single-GPU
+  in v1; see issue #58 v1.1 roadmap"`)
+- CASK / TriAttention sidecar + `pp > 1` **refused at load time**
+- Spec decode + `pp > 1` **refused at load time** (deferred to v1.1)
+- `pp_parity` test: PP=1 ↔ PP=2 token sequence identical at temp=0
+  ≥ 100 tokens
+- `scripts/coherence-gate.sh --pp N` + new `scripts/pp-gate.sh` +
+  `scripts/verify-bind-thread.sh`
+
+### 4.2 Out of scope (v1)
+
+- Mixed-arch (separate sub-feature)
+- Llama-path multi-GPU (`crates/hipfire-runtime/src/llama.rs` decode loop)
+- VL path multi-GPU
+- DFlash + PP integration (v1.1+)
+- Spec decode + PP (v1.1)
+- Pipelined prefill (chunk N+1 on dev_0 while chunk N processes on dev_1) — v1.1
+- VRAM-weighted automatic split — v1.1
+- TP (tensor parallel) — separate roadmap
+- Stream rebind for rocBLAS handle — pre-existing tech debt; out as
+  separate PR after PP merge
+
+---
+
+## 5. Stages
+
+The branch `feat/multi-gpu-pp` is the umbrella; each Stage is a logical
+PR. Stage names below are the proposed PR branch / commit-prefix labels.
+
+### Stage 1 — `multi-gpu-pp-1-probing-ffi` (~2d, **shipped**)
+
+`crates/hip-bridge/src/{ffi.rs, lib.rs, error.rs}`,
+`crates/hip-bridge/examples/peer_smoke.rs`.
+
+- Add fn-pointer + `HipRuntime` methods: `hipGetDevice`,
+  `hipDeviceCanAccessPeer`, `hipDeviceEnablePeerAccess` (silently maps
+  `hipErrorPeerAccessAlreadyEnabled = 704` to `Ok`), `hipMemcpyPeer{,Async}`,
+  `hipPointerGetAttributes`.
+- New types: `MemoryType` enum (raw `u32` accessor for forward-compat),
+  `HipPointerAttribute` `repr(C)` mirroring ROCm 6.4.3 layout (6 fields,
+  including `allocationFlags`).
+- New error constants: `HIP_ERROR_PEER_ACCESS_{UNSUPPORTED,
+  ALREADY_ENABLED, NOT_ENABLED}`.
+- `peer_smoke` example: alloc on dev 0/1, `memcpy_peer` byte-equality
+  round-trip, `pointer_get_attributes` device verification,
+  bidirectional `enable_peer_access` idempotency check.
+
+**Validated on 2× 7900 XTX:** PASS, including 704 → Ok translation.
+
+### Stage 2 — split into 2a + 2b (~6-8d total)
+
+#### Stage 2a — `multi-gpu-pp-2a-device-binding` (~2d)
+
+`crates/rdna-compute/src/dispatch.rs:211,399`.
+
+- Add `pub device_id: i32` to `Gpu` struct.
+- Refactor `Gpu::init` → `Gpu::init_with_device(id: i32)` (no-arg
+  preserved as `Self::init_with_device(0)`); call `set_device(id)`
+  **before** `try_init_rocblas`.
+- Add `bind_thread()` helper: `thread_local! Cell<i32>` with sentinel
+  `-1`, `debug_assert_eq!` invariant against `current_device()`.
+- `impl Drop for Gpu` calls `bind_thread()` before resource free.
+- New example: `crates/rdna-compute/examples/dual_gpu_smoke.rs`.
+
+#### Stage 2b — `multi-gpu-pp-2b-bind-audit` (~4-6d)
+
+`crates/rdna-compute/src/dispatch.rs:355+`.
+
+- Audit all 278 `pub fn` in `impl Gpu`. Non-getter methods get
+  `self.bind_thread()?;` as the first statement; pure getters carry
+  an explicit `// bind_thread: skip — pure getter` whitelist comment.
+- New: `scripts/verify-bind-thread.sh` (greps `impl Gpu` and validates
+  invariant).
+- Wire `verify-bind-thread.sh` into `.githooks/pre-commit`.
+
+**Risk:** Medium-high. Silent mis-bind = malloc-on-wrong-device →
+corrupted activations. Mitigations: `debug_assert_eq!` in
+`bind_thread`, verify-script gate, single-GPU regression byte-equal.
+
+### Stage 3 — `multi-gpu-pp-3-gpus-type` (~2d)
+
+New: `crates/hipfire-runtime/src/multi_gpu.rs`.
+
+- `Gpus { devices, layer_to_device, band_starts, peer_access_enabled,
+  output_device, givens_cos_per_dev, givens_sin_per_dev }`.
+- `Gpus::init_uniform`, `Gpus::init_layers`, `Gpus::single`,
+  `Gpus::enable_peer_all`, `Gpus::device_for_layer`,
+  `Gpus::is_band_boundary`, `Gpus::output_device`,
+  `Gpus::boundary_copy`, `Gpus::wait_boundary`.
+- Pre-flight VRAM check (arch match, bounded delta, headroom > required
+  shard + scratch).
+- `HIPFIRE_VRAM_PROBE=1` debug print.
+
+### Stage 4 — `multi-gpu-pp-4-weight-load` (~3-4d)
+
+`crates/hipfire-arch-qwen35/src/qwen35.rs`.
+
+- Additive `load_weights_multi(hfq, config, gpus: &mut Gpus)`. Master's
+  `load_weights` (single-GPU) stays untouched — the helpers
+  (`load_token_embd_into`, `load_output_into`, `load_layer_into`) are
+  extracted but the master body inlines them verbatim, so pp=1
+  behavior is byte-equivalent.
+- `token_embd` → `gpus.devices[0]`; `output_norm` + `output / lm_head` →
+  `gpus.devices[gpus.output_device]`; per-layer weights →
+  `gpus.devices[gpus.device_for_layer(i)]`.
+- `Qwen35Weights::free_gpu_multi` mirrors per-device ownership.
+- Update `docs/multi-gpu.md` memory budget table from real measurements.
+
+### Stage 5 — `multi-gpu-pp-5-state-placement` (~4-5d)
+
+`crates/hipfire-arch-qwen35/src/qwen35.rs`,
+`crates/hipfire-runtime/src/llama.rs` (KvCache constructors),
+`crates/hipfire-arch-qwen35/src/speculative.rs` (signatures).
+
+- `Qwen35Scratch` → `Qwen35ScratchSet { per_device: Vec<Qwen35Scratch> }`.
+  `s.logits` lives on `dev_last` (Variant 2).
+- `DeltaNetState::new_with_quant_multi` accepts `gpus`; per-LA-layer state
+  placed by `layer_to_device`. Returns `(state, la_to_device)` for
+  daemon reset routing.
+- All 14 `KvCache::new_gpu*_multi` constructors updated to per-layer
+  device placement; asym{2,3,4} ctors use
+  `gpus.givens_*_per_dev[layer_to_device[i]]` instead of a single
+  global tensor.
+- Single-GPU constructors unchanged (`new_gpu*` without `_multi` suffix
+  retained for pp=1 path back-compat).
+
+### Stage 6 — `multi-gpu-pp-6-forward-decode` (~5-6d)
+
+`crates/hipfire-arch-qwen35/src/qwen35.rs` (`forward_scratch_multi`,
+`forward_scratch_layers_multi`).
+
+- Layer loop: `device_for_layer` lookup, boundary_copy + wait at band
+  boundary, per-device scratch dispatch.
+- Final `rmsnorm + lm_head` runs on `output_device`; no copy back.
+- Disable hipGraph capture when `gpus.devices.len() > 1`.
+- All 4 layer-type branches reproduced (DeltaNet, FullAttn,
+  DeltaNetMoe, FullAttnMoe) — no MoE-pp deferral.
+
+**Boundary-copy size in decode:** `dim × 4` bytes = 32 KB at dim=8192,
+~6-10 µs/copy on PCIe peer. Forward-shape audit (`findings/phase0-forward-shape.md`)
+confirms `s.x` is the only cross-band cross-layer buffer; per-layer
+scratch (`s.tmp`, `s.x_rot`, `s.dn_*`, `s.fa_*`, `s.flash_partials`,
+`s.gate_ffn`, `s.up`, `s.ffn_hidden`, `s.moe_x_rot`) lives entirely
+within one layer's body and does not cross boundaries.
+
+**Acceptance:**
+
+- PP=1 numeric byte-identical to current state.
+- PP=2 logits within 1e-4 of PP=1 on qwen3.5:0.8b.
+- `pp_parity` test: PP=1 and PP=2 with identical seed/prompt/temp=0
+  produce identical token sequence ≥ 100 tokens.
+
+### Stage 7 — `multi-gpu-pp-7-daemon` (~1.5d)
+
+`crates/hipfire-runtime/examples/daemon.rs`.
+
+- `Gpu::init()` → `Gpus::init_uniform(...) + enable_peer_all()`.
+- Read `pp` from load command JSON (default = `gpus.devices.len()`).
+- `HIPFIRE_DEVICES` env (post-VISIBLE filter).
+- Refuse `dflash + pp > 1`, `cask + pp > 1`, `spec_decode + pp > 1`.
+- `LoadedModel.pp_*` extension fields (`pp_gpus`, `pp_scratch_set`,
+  `la_to_device`, `pp_kv_cache`).
+- `generate_multi(...)` ports the full master `generate` feature set:
+  EosFilter, LoopGuard, PromptFrame, repeat_penalty, top_p sampler,
+  attractor block, max_think_tokens.
+- Sample/argmax reads `s.logits` from `gpus.devices[gpus.output_device]`.
+- Reset handler routes DeltaNetState memset through `la_to_device`.
+
+### Stage 8 — `multi-gpu-pp-8-prefill` (~2-3d)
+
+`crates/hipfire-arch-qwen35/src/qwen35.rs` (`PrefillBandCtx`,
+`forward_prefill_chunk` modification, `forward_prefill_batch_multi`).
+
+- Same band/boundary shape as Stage 6, applied to the prefill loop.
+- `forward_prefill_chunk` gains `band: Option<&PrefillBandCtx<'_>>`
+  parameter — `None` preserves byte-exact pp=1 behavior. All
+  master callers (`forward_prefill_batch`, `speculative.rs`,
+  `pflash.rs`) pass `None`.
+- Boundary-copy size: `batch_size × dim × 4` = 4 MB at batch=128
+  dim=8192, ~70-80 µs through peer.
+- Pipelined prefill (overlap chunk N+1 on dev_0 with chunk N on dev_1)
+  is **out of scope** for v1; v1.1 PR.
+
+### Stage 9 — `multi-gpu-pp-9-validation` (~1.5d)
+
+`scripts/coherence-gate.sh`, `scripts/pp-gate.sh` (new),
+`.githooks/pre-commit`,
+`crates/hipfire-arch-qwen35/tests/pp_parity.rs` (new),
+`crates/hipfire-runtime/examples/{pp_parity,pp_parity_chatml,pp2_vram_probe}.rs`
+(new),
+`docs/multi-gpu.md`,
+`tests/speed-baselines/gfx1100x2_pp.txt` (new).
+
+- `coherence-gate.sh --pp N`; for changes touching `multi_gpu.rs` or
+  forward, run with both `--pp 1` and `--pp 2`.
+- `pp-gate.sh` env-gates PP-specific tests on `HIPFIRE_HAVE_2_GPU=1`,
+  exits 0 with skip message when only 1 GPU is visible.
+- `.githooks/pre-commit` extends the HOTSPOT regex with
+  `pipeline|stages|multi_gpu|pp_|peer_access|forward_prefill_batch_multi|forward_scratch_multi|Gpus|init_uniform|init_layers|boundary_copy`.
+
+---
+
+## 6. Validation matrix
+
+| # | Test | Hardware | Command |
+|---|------|----------|---------|
+| 1 | Single-GPU regression | 1× any | `cargo test --workspace && ./scripts/coherence-gate.sh` |
+| 2 | PP=1 byte-identical | 1× any | `./scripts/coherence-gate.sh --pp 1` |
+| 3 | PP=2 numeric parity (0.8B) | 2× 7900 XTX | `./scripts/coherence-gate.sh --pp 2 --model qwen3.5:0.8b` |
+| 4 | PP=2 token-stream parity (9B) | 2× 7900 XTX | `HIPFIRE_HAVE_2_GPU=1 cargo test pp_parity --release` |
+| 5 | 27B + extended ctx unlock | 2× 7900 XTX | `HIPFIRE_DEVICES=0,1 hipfire run qwen3.5:27b --max-ctx 16384 "Hi"` |
+| 6 | 35B-A3B smoke | 2× 7900 XTX | `HIPFIRE_DEVICES=0,1 hipfire run qwen3.5:35b-a3b "Hi"` |
+| 7 | Perf baseline | 2× 7900 XTX | `HIPFIRE_DEVICES=0,1 hipfire bench qwen3.5:9b --runs 5` |
+| 8 | DFlash+PP refusal | any | `hipfire run --pp 2 --dflash on …` → expect clear error |
+| 9 | CASK+PP refusal | any | `hipfire run --pp 2 --cask on …` → expect clear error |
+| 10 | Pre-flight VRAM check | 2× any | `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB=0.1 hipfire run --pp 2 …` → expect clear refusal |
+
+---
+
+## 7. Critical files (cheat sheet)
+
+- `crates/hip-bridge/src/ffi.rs` — peer FFI (Stage 1, shipped)
+- `crates/rdna-compute/src/dispatch.rs:211,355,399` — `Gpu` struct,
+  init, 278 `pub fn` audit
+- `crates/hipfire-runtime/src/multi_gpu.rs` — `Gpus` orchestrator
+- `crates/hipfire-runtime/src/llama.rs` — 14 KvCache `*_multi` constructors
+- `crates/hipfire-arch-qwen35/src/qwen35.rs` — weights, scratch,
+  decode + prefill multi loops
+- `crates/hipfire-runtime/examples/daemon.rs` — daemon integration
+
+---
+
+## 8. Open questions for maintainer
+
+These are the four points raised in [issue #58](https://github.com/Kaden-Schutt/hipfire/issues/58)
+and re-stated here for permanence:
+
+1. **DFlash + PP scope.** v1 refuses the combination. Is that the right
+   call long-term, or should DFlash + PP land together in a v1.1 patch?
+2. **Mixed-arch policy.** v1 hard-fails `gfx*` mismatch. Soft-warn vs
+   hard-fail — preference?
+3. **API surface for `HIPFIRE_DEVICES`.** Current direction: logical IDs
+   post-`HIP_VISIBLE_DEVICES`. Alternative: re-use `HIP_VISIBLE_DEVICES`
+   semantics directly. Maintainer call.
+4. **Test gates.** Repo has no CI; `pp-gate.sh` runs locally on
+   `HIPFIRE_HAVE_2_GPU=1`. Sufficient, or should there be additional
+   instrumentation?
+
+---
+
+## 9. References
+
+- Issue [#58](https://github.com/Kaden-Schutt/hipfire/issues/58) —
+  multi-GPU roadmap
+- `docs/multi-gpu.md` — user-facing reference (memory budget table,
+  deployment recipes, limitations)
+- `docs/methodology/perf-benchmarking.md` — perf claim discipline
+- `CLAUDE.md` "Coherence Gate" — mandatory gate for forward-pass changes
+- `AGENTS.md` §threading — single-thread-for-HIP-work invariant
+- Megatron-LM, DeepSpeed, vLLM PP literature for Variant 2 placement
+  precedent

--- a/scripts/pp-gate.sh
+++ b/scripts/pp-gate.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Multi-GPU pipeline-parallel gate.
+#
+# Validates that pp>1 paths still match pp=1 byte-for-byte under the
+# deterministic flag. Skips silently when fewer than 2 HIP devices are
+# visible — that's the expected state in CI / single-GPU dev boxes, and
+# we don't want pp-gate to block commits that don't touch PP code.
+#
+# Three barriers (all skipped on <2 GPU):
+#
+#   1. pp_parity_chatml example — per-token forward_scratch{,_multi}
+#      bit-equivalence (50 decode tokens after ChatML prefill, asym3 KV).
+#      This is the floor: if forward_scratch_multi diverges from
+#      forward_scratch even with HIPFIRE_DETERMINISTIC=1, pp=2 is broken.
+#
+#   2. daemon pp=1 vs pp=2 byte-equivalence on dense 0.8B mq4 — the
+#      end-to-end smoke. Catches regressions in the load/prefill/decode/
+#      sample chain that the example doesn't exercise (top_p sampler,
+#      repeat penalty, attractor block, ChatML wrap, etc.). Run with
+#      HIPFIRE_DETERMINISTIC=1 to opt out of the inherited ksplit
+#      atomicAdd reduction non-det.
+#
+#   3. Refusal sanity — DFlash + pp=2 and CASK + pp=2 must still
+#      produce clean error messages at load. These are v1 contract
+#      promises (see plan v2 stages 7 + 9).
+#
+# Exit codes:
+#   0  passed, or skipped (<2 GPU)
+#   1  hard failure (parity broken, refusal missing, daemon panic)
+#   2  build / environment error
+#
+# Run by .githooks/pre-commit when staged diff touches multi_gpu.rs,
+# pp_*, peer_access, or other pipeline-related code.
+#
+# Manual invocation:
+#   ./scripts/pp-gate.sh            # full battery
+#   ./scripts/pp-gate.sh --skip-end-to-end   # parity example only
+
+set -u
+cd "$(dirname "$0")/.."
+
+SKIP_E2E=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skip-end-to-end) SKIP_E2E=1 ;;
+        -h|--help)
+            sed -n '3,33p' "$0"
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# ── ROCm env ────────────────────────────────────────────────────────────
+# Auto-source rocm-env.sh so HIP libraries land on the loader path on
+# NixOS-style hosts. No-op if already loaded.
+if [ -r "./scripts/rocm-env.sh" ]; then
+    # shellcheck disable=SC1091
+    . ./scripts/rocm-env.sh
+fi
+
+# ── GPU count detection ──────────────────────────────────────────────────
+# rocm-smi --showid prints multiple lines per GPU; count unique `GPU[N]`
+# tags. Fall back to HIP_VISIBLE_DEVICES string parsing for environments
+# without rocm-smi (rare).
+gpu_count=0
+if command -v rocm-smi >/dev/null 2>&1; then
+    gpu_count=$(rocm-smi --showid 2>/dev/null | grep -oE '^GPU\[[0-9]+\]' | sort -u | wc -l || true)
+fi
+if [ "$gpu_count" -eq 0 ] && [ -n "${HIP_VISIBLE_DEVICES:-}" ]; then
+    gpu_count=$(echo "$HIP_VISIBLE_DEVICES" | tr ',' '\n' | wc -l)
+fi
+
+if [ "$gpu_count" -lt 2 ]; then
+    echo "pp-gate: only $gpu_count GPU(s) visible — skipping"
+    exit 0
+fi
+
+# Export for the test runs. pp_parity_chatml + daemon pp=2 want both
+# devices visible; without this they'd see only $HIP_VISIBLE_DEVICES set
+# upstream (or all devices if unset). Pin to 0,1 — the dual-7900 XTX
+# layout this gate was sized for. Override via PP_GATE_DEVICES if the
+# host has more cards.
+export HIP_VISIBLE_DEVICES="${PP_GATE_DEVICES:-0,1}"
+export HIPFIRE_DETERMINISTIC=1
+
+EXE="./target/release/examples/daemon"
+EXAMPLES_DIR="./target/release/examples"
+MODEL="${HIPFIRE_PP_GATE_MODEL:-$HOME/.hipfire/models/qwen3.5-0.8b.mq4}"
+LOCK_SCRIPT="./scripts/gpu-lock.sh"
+
+if [ ! -f "$MODEL" ]; then
+    echo "pp-gate: model not found at $MODEL — skipping"
+    echo "         set HIPFIRE_PP_GATE_MODEL or install qwen3.5-0.8b.mq4"
+    exit 0
+fi
+
+# ── Rebuild ──────────────────────────────────────────────────────────────
+rebuild=0
+if [ ! -x "$EXE" ] || [ ! -x "$EXAMPLES_DIR/pp_parity_chatml" ]; then
+    rebuild=1
+else
+    # Post-0.1.20 modular topology: forward-pass + multi-GPU sources are
+    # split across hipfire-runtime (KvCache, Gpus, daemon) and
+    # hipfire-arch-qwen35 (qwen35 forward, prefill batch). Watch both.
+    for src in crates/hipfire-arch-qwen35/src/qwen35.rs \
+               crates/hipfire-runtime/src/llama.rs \
+               crates/hipfire-runtime/src/multi_gpu.rs \
+               crates/hipfire-runtime/examples/daemon.rs \
+               crates/hipfire-runtime/examples/pp_parity_chatml.rs \
+               crates/rdna-compute/src/dispatch.rs; do
+        if [ -f "$src" ] && [ "$src" -nt "$EXE" ]; then rebuild=1; break; fi
+    done
+fi
+if [ "$rebuild" -eq 1 ]; then
+    echo "pp-gate: rebuilding..."
+    if ! cargo build --release --features deltanet -p hipfire-runtime \
+            --example daemon --example pp_parity_chatml >&2; then
+        echo "pp-gate: build failed" >&2
+        exit 2
+    fi
+fi
+
+# ── GPU lock ─────────────────────────────────────────────────────────────
+# Only acquire if no caller has already taken it. Otherwise we'd
+# deadlock on the parent's lock — gpu_acquire polls indefinitely and
+# doesn't recognize a parent agent's reservation. Detection: lockfile
+# present at script start.
+if [ -r "$LOCK_SCRIPT" ] && [ ! -f /tmp/hipfire-gpu.lock ]; then
+    # shellcheck disable=SC1090
+    . "$LOCK_SCRIPT"
+    gpu_acquire "pp-gate" || { echo "could not acquire GPU lock" >&2; exit 2; }
+    trap 'gpu_release 2>/dev/null || true' EXIT
+fi
+
+fail=0
+say() { printf '\n── %s ──\n' "$1"; }
+
+# ── 1. pp_parity_chatml ─────────────────────────────────────────────────
+say "pp_parity_chatml (per-token forward bit-equivalence, 50 decode tokens)"
+if "$EXAMPLES_DIR/pp_parity_chatml" "$MODEL" 2>&1 | tee /tmp/pp-gate-parity.log | \
+   grep -qE 'ALL [0-9]+ tokens identical'; then
+    echo "PASS"
+else
+    echo "FAIL — see /tmp/pp-gate-parity.log"
+    fail=1
+fi
+
+if [ "$SKIP_E2E" -eq 1 ]; then
+    [ "$fail" -ne 0 ] && exit 1
+    echo
+    echo "pp-gate: parity-only mode passed."
+    exit 0
+fi
+
+# ── 2. daemon pp=1 vs pp=2 byte-equivalence ─────────────────────────────
+say "daemon pp=1 vs pp=2 byte-identical (greedy, ChatML, HIPFIRE_DETERMINISTIC=1)"
+gen_sha () {
+    local pp_arg="$1"
+    local params='{"max_seq":2048}'
+    [ "$pp_arg" = "2" ] && params='{"max_seq":2048,"pp":2}'
+    (printf '%s\n' \
+        '{"type":"load","model":"'"$MODEL"'","params":'"$params"'}' \
+        '{"type":"generate","id":"r1","prompt":"Write a one-sentence greeting.","temperature":0.0,"max_tokens":40}' \
+        '{"type":"unload"}'
+    ) | "$EXE" 2>/dev/null \
+      | grep '"text"' \
+      | python3 -c '
+import sys, json, hashlib
+toks = []
+for line in sys.stdin:
+    obj = json.loads(line.strip())
+    toks.append(obj["text"])
+print(hashlib.sha256("".join(toks).encode()).hexdigest()[:16])
+'
+}
+PP1_SHA=$(gen_sha 1)
+PP2_SHA=$(gen_sha 2)
+echo "pp=1: $PP1_SHA"
+echo "pp=2: $PP2_SHA"
+if [ -n "$PP1_SHA" ] && [ "$PP1_SHA" = "$PP2_SHA" ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    fail=1
+fi
+
+# ── 3. refusal contracts ─────────────────────────────────────────────────
+say "refusal: DFlash + pp=2 must error at load"
+DFLASH_REFUSAL=$( (printf '%s\n' \
+    '{"type":"load","model":"'"$MODEL"'","params":{"max_seq":2048,"pp":2,"draft":"/nonexistent.hfq"}}'
+) | "$EXE" 2>/dev/null | grep -c 'DFlash speculative decode requires pp=1' || true)
+if [ "$DFLASH_REFUSAL" -ge 1 ]; then echo "PASS"; else echo "FAIL"; fail=1; fi
+
+say "refusal: CASK + pp=2 must error at load"
+CASK_REFUSAL=$( (printf '%s\n' \
+    '{"type":"load","model":"'"$MODEL"'","params":{"max_seq":2048,"pp":2,"cask_sidecar":"/nonexistent.bin"}}'
+) | "$EXE" 2>/dev/null | grep -c 'CASK / TriAttention eviction requires pp=1' || true)
+if [ "$CASK_REFUSAL" -ge 1 ]; then echo "PASS"; else echo "FAIL"; fail=1; fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+    echo "pp-gate: FAIL"
+    exit 1
+fi
+echo "pp-gate: PASS"
+exit 0

--- a/scripts/verify-bind-thread.sh
+++ b/scripts/verify-bind-thread.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Verify that every pub fn in `impl Gpu` of dispatch.rs either calls
+# `self.bind_thread()?;` (or `let _ = self.bind_thread();`) as the first
+# statement, or carries a `// bind_thread: skip — <reason>` whitelist marker.
+#
+# Also runs a multi-GPU heuristic: anywhere `let g = &mut gpus.devices[X]`
+# appears, the first `g.<method>` call MUST NOT be `g.hip.<rawop>` (raw
+# HipRuntime methods bypass the bind_thread audit; if the first thing the
+# function does on `g` is a raw hipMalloc/memset/memcpy, the allocation
+# may land on a wrongly-bound device — see Stage 5 finding).
+#
+# Run by .githooks/pre-commit when dispatch.rs or any *_multi.rs is staged.
+
+set -eu
+
+FILE="${1:-crates/rdna-compute/src/dispatch.rs}"
+
+if [ ! -f "$FILE" ]; then
+    echo "verify-bind-thread: $FILE not found" >&2
+    exit 2
+fi
+
+python3 - "$FILE" <<'PYEOF'
+import re, sys
+from pathlib import Path
+
+WHITELIST_SPECIAL = {"init", "init_with_device", "bind_thread", "bind_thread_or_warn"}
+
+path = Path(sys.argv[1])
+lines = path.read_text().splitlines()
+
+impl_start = impl_end = None
+for i, l in enumerate(lines):
+    if l.startswith("impl Gpu {") and impl_start is None:
+        impl_start = i
+    elif impl_start is not None and l.startswith("impl Drop for Gpu"):
+        impl_end = i
+        break
+if impl_start is None or impl_end is None:
+    print("verify-bind-thread: impl Gpu boundaries not found", file=sys.stderr)
+    sys.exit(2)
+
+violations = []
+total = 0
+i = impl_start
+while i < impl_end:
+    m = re.match(r"^    pub fn (\w+)", lines[i])
+    if not m:
+        i += 1
+        continue
+    fn_name = m.group(1)
+    fn_line = i + 1
+    total += 1
+
+    if fn_name in WHITELIST_SPECIAL:
+        i += 1
+        continue
+
+    # Find body opener (line ending with ' {')
+    sig_end = i
+    while sig_end < impl_end:
+        s = lines[sig_end].rstrip()
+        if s.endswith("{") and not s.endswith("!{") and not s.endswith("::{"):
+            break
+        sig_end += 1
+    if sig_end >= impl_end:
+        violations.append((fn_line, fn_name, "body opener not found"))
+        i += 1
+        continue
+
+    # Walk first ~8 non-blank/non-doc body lines for the marker. Anchored
+    # patterns: marker must be the leading token on its line (catches
+    # "self.bind_thread() already" prose comments, etc.).
+    call_re = re.compile(r"^self\.bind_thread(?:_or_warn)?\(\)")
+    skip_re = re.compile(r"^//\s*bind_thread:\s*skip\b")
+    found = False
+    j = sig_end + 1
+    checked = 0
+    while j < impl_end and checked < 8:
+        s = lines[j].strip()
+        if s == "" or s.startswith("///"):
+            j += 1
+            continue
+        if call_re.match(s) or skip_re.match(s):
+            found = True
+            break
+        if s.startswith("//"):
+            j += 1
+            checked += 1
+            continue
+        # First real statement — if not bind_thread, the fn is non-compliant
+        break
+
+    if not found:
+        violations.append((fn_line, fn_name, "missing bind_thread"))
+
+    i = sig_end + 1
+
+if total == 0:
+    print(
+        "verify-bind-thread: regex matched zero `pub fn` in impl Gpu — "
+        "indentation changed or impl boundary moved. Audit is broken.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+if violations:
+    print(
+        f"verify-bind-thread: {len(violations)} of {total} pub fn in impl Gpu "
+        f"missing bind_thread:",
+        file=sys.stderr,
+    )
+    for ln, name, reason in violations[:20]:
+        print(f"  {path}:{ln}: {name} — {reason}", file=sys.stderr)
+    if len(violations) > 20:
+        print(f"  ... and {len(violations) - 20} more", file=sys.stderr)
+    print(
+        "\nFix: add `self.bind_thread()?;` (or `let _ = self.bind_thread();` for\n"
+        "non-HipResult fn) as the first statement, OR add a\n"
+        "`// bind_thread: skip — <reason>` comment for pure-state queries.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"verify-bind-thread: OK — {total} pub fn audited.")
+PYEOF
+
+# ─── Multi-GPU bind heuristic ─────────────────────────────────────────
+# Flag any `let <name> = &mut gpus.devices[X]` site whose first call on
+# `<name>` is a raw `<name>.hip.<rawop>` instead of either `<name>.bind_thread()`
+# or any other `<name>.<method>` (Gpu-method calls auto-bind via the Stage 2b
+# audit). Strict — to whitelist, add `// bind: pre-bound — <reason>` on the
+# `let` line.
+
+python3 - <<'PYEOF2'
+import re, sys, subprocess
+from pathlib import Path
+
+RAW_OPS = "malloc|memset|memcpy_htod|memcpy_dtoh|memcpy_dtod|memset_async|memcpy_htod_async|memcpy_dtoh_async|memcpy_dtod_async"
+LET_GPUS = re.compile(r"^\s*let\s+(\w+)\s*=\s*&mut\s+gpus\.devices\[")
+ALLOW_MARKER = re.compile(r"//\s*bind:\s*pre-bound\b")
+
+# Scope: scan all .rs files under crates/
+out = subprocess.check_output(
+    ["git", "ls-files", "crates/", "*.rs"], text=True
+).splitlines()
+
+violations = []
+for fpath in out:
+    if not fpath.endswith(".rs"):
+        continue
+    p = Path(fpath)
+    if not p.is_file():
+        continue
+    lines = p.read_text().splitlines()
+    for i, line in enumerate(lines):
+        m = LET_GPUS.match(line)
+        if not m:
+            continue
+        if ALLOW_MARKER.search(line):
+            continue
+        var = m.group(1)
+        # Patterns matched on each candidate line. Order of checks matters —
+        # `var.hip.<rawop>` and `var.bind_thread` are NOT also `var.<method>(`,
+        # so each is searched independently. Whichever matches first on the
+        # earliest non-blank line is the "first call on var".
+        hip_raw_re = re.compile(
+            rf"\b{re.escape(var)}\.hip\.(?:{RAW_OPS})\b"
+        )
+        bind_re = re.compile(rf"\b{re.escape(var)}\.bind_thread\b")
+        any_method_re = re.compile(rf"\b{re.escape(var)}\.(\w+)\(")
+
+        decision = None  # ("ok", line) | ("violation", line)
+        for j in range(i + 1, min(i + 26, len(lines))):
+            s = lines[j].strip()
+            if s == "" or s.startswith("//"):
+                continue
+            line_text = lines[j]
+            if hip_raw_re.search(line_text):
+                decision = ("violation", line_text)
+                break
+            if bind_re.search(line_text):
+                decision = ("ok", line_text)
+                break
+            if any_method_re.search(line_text):
+                decision = ("ok", line_text)
+                break
+            # Otherwise the line references var but neither calls a method nor
+            # routes through .hip — keep walking.
+        if decision and decision[0] == "violation":
+            violations.append((fpath, i + 1, var, decision[1].strip()))
+
+if violations:
+    print(
+        f"verify-multi-gpu-bind: {len(violations)} suspect raw HIP call(s) "
+        "in multi-GPU contexts:",
+        file=sys.stderr,
+    )
+    for fpath, line_no, var, snippet in violations[:20]:
+        print(f"  {fpath}:{line_no}: `{var}` → {snippet}", file=sys.stderr)
+    if len(violations) > 20:
+        print(f"  ... and {len(violations) - 20} more", file=sys.stderr)
+    print(
+        "\nIn each `let <name> = &mut gpus.devices[X]` block the first call on\n"
+        "`<name>` MUST be either `<name>.bind_thread()` or any non-`hip` Gpu\n"
+        "method (which auto-binds via the Stage 2b audit). Raw `<name>.hip.*`\n"
+        "lands on whatever device the host thread last bound — likely wrong\n"
+        "in multi-GPU paths. To accept the call site as already-bound, add\n"
+        "`// bind: pre-bound — <reason>` on the `let` line.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print("verify-multi-gpu-bind: OK")
+PYEOF2

--- a/tests/speed-baselines/gfx1100x2_pp.txt
+++ b/tests/speed-baselines/gfx1100x2_pp.txt
@@ -1,0 +1,50 @@
+# hipfire pp-gate baseline — 2× gfx1100 (Radeon RX 7900 XTX × 2)
+# Captured 2026-05-04 against commit on feat/multi-gpu-pp branch
+#   (Stage 9 close — pp-gate.sh + pp_parity.rs + docs ship).
+#
+# Config:
+#   - HIP_VISIBLE_DEVICES=0,1
+#   - HIPFIRE_DETERMINISTIC=1 (forces k2 wo-residual GEMM, k-split off
+#     for cross-process bit-equivalence; see commit f54ca71 + comments
+#     in kernels/src/gemm_hfq4g256_residual_wmma_ksplit.hip:22)
+#   - PP=2 layer split: uniform (init_uniform), Variant 2 placement
+#     (token_embd→dev 0, output_norm + lm_head→dev_last)
+#   - asym3 KV cache, max_seq=4096
+#
+# Tolerance: 0.05 (fail if any metric drops below baseline × (1 - tol)).
+#
+# Methodology:
+#   - Daemon driven via JSON IPC (mirrors what hipfire CLI sends)
+#   - Prefill numbers: 22-token greeting prompt (short — captures launch
+#     overhead) and 322-token list-spam prompt (chunked through
+#     PREFILL_MAX_BATCH=256, captures cross-band peer-copy overhead)
+#   - Decode: 40 tokens at temp=0.0, ChatML-wrapped, repeat_penalty=1.3
+#     defaults (matches daemon hot path, includes top_p sampler + scope
+#     upload)
+#
+# Floors below are conservative — measured numbers run higher in
+# practice. The pp-gate script asserts byte-equivalence between pp=1
+# and pp=2 outputs first; perf is a secondary gate run separately.
+
+# ─── 0.8B mq4 dense (24 layers split 12/12) ───────────────────────────
+0.8b_mq4_pp2_short_prefill_tok_s=550
+0.8b_mq4_pp2_short_decode_tok_s=200
+0.8b_mq4_pp2_long_prefill_tok_s=5200
+0.8b_mq4_pp2_long_decode_tok_s=200
+
+# ─── 4B mq4 dense (32 layers split 16/16) ─────────────────────────────
+4b_mq4_pp2_short_prefill_tok_s=350
+4b_mq4_pp2_short_decode_tok_s=110
+
+# ─── 35B-A3B mq4 MoE (40 layers split 20/20, num_experts=128, k_top=8) ─
+# The v1 stretch target — runs only with pp>=2 on 24 GB cards (~23.5 GB
+# weights total → 11.8 GB/card). Decode pays per-token forward_scratch_
+# multi overhead × MoE expert routing.
+35b_a3b_mq4_pp2_short_prefill_tok_s=240
+35b_a3b_mq4_pp2_short_decode_tok_s=90
+
+# ─── pp parity floor ─────────────────────────────────────────────────
+# Bit-exact pp=1 vs pp=2 across processes. Set by pp_parity_chatml +
+# pp-gate.sh on every commit that touches the multi_gpu/pp_/peer_access
+# hotspot bucket.
+pp_parity_50_decode_tokens_identical=1


### PR DESCRIPTION
## Summary

Pipeline-parallel inference over `n_devices` homogeneous AMD GPUs for the
Qwen3.5 family (dense + 3.5/3.6 A3B MoE). Layers shard into contiguous
bands; the residual stream `s.x` flows through bands sequentially with
one peer-copy per boundary. `output_norm + lm_head` execute on dev_last
(Variant 2 placement, matches Megatron / DeepSpeed / vLLM).

Default `pp = 1` is byte-identical to pre-PR behavior. Multi-GPU is
opt-in via the `pp` field in the daemon load message.

## What ships

- 11 commits, +5798 / -70 LOC, additive-only on master code paths.
- Tracking issue: #58.
- See `docs/multi-gpu.md` for memory budget, deployment recipes, env
  vars, refusal matrix, throughput baselines, peer-access verification.
- See `docs/plans/multi-gpu-pp.md` for stage-by-stage architecture
  rationale + open questions.

### Stages

| # | Scope |
|---|-------|
| 1 | `hip-bridge` peer-access FFI (`hipDeviceCanAccessPeer`, `hipMemcpyPeer{,Async}`, `hipPointerGetAttributes` + 704→Ok translation) |
| 2 | `rdna-compute` `Gpu::init_with_device(id)` + `bind_thread()` invariant on every public `Gpu::*` (286 fns audited via `scripts/verify-bind-thread.sh`) + `HIPFIRE_DETERMINISTIC` opt-out |
| 3 | `hipfire-runtime::multi_gpu` orchestrator (`Gpus`, `init_uniform`, `init_layers`, `enable_peer_all`, `boundary_copy`, `wait_boundary`) + 14 `KvCache::new_gpu*_multi` constructors |
| 4 | `hipfire-arch-qwen35` `load_weights_multi` + per-device `Qwen35ScratchSet` + `DeltaNetState::new_with_quant_multi` (returns `la_to_device` map for daemon reset routing) |
| 5 | `forward_scratch_multi` + `forward_scratch_layers_multi` (decode). All 4 layer-type branches: DeltaNet, FullAttn, DeltaNetMoe, FullAttnMoe |
| 6 | `forward_prefill_batch_multi` + `PrefillBandCtx`. The only invasive existing-fn modification: `forward_prefill_chunk` gains `band: Option<&PrefillBandCtx<'_>>` (`None` preserves byte-exact pp=1 behavior) |
| 7 | `daemon.rs` `LoadedModel.pp` + `generate_multi` (full feature port: EosFilter, LoopGuard, PromptFrame, repeat_penalty, top_p, attractor block, max_think_tokens) + refusal contracts |
| 8 | Examples (`pp_parity`, `pp_parity_chatml`, `pp2_vram_probe`, `gpus_smoke`, `peer_smoke`, `dual_gpu_smoke`) + `pp-gate.sh` 4-barrier battery + pre-commit hotspot regex |
| 9 | Docs (`docs/multi-gpu.md`, `docs/plans/multi-gpu-pp.md`) + `tests/speed-baselines/gfx1100x2_pp.txt` |

## Refusal matrix at load (`pp > 1`)

| Feature | Behavior |
|---------|----------|
| `arch_id ∈ {5, 6}` (Qwen3.5 dense + MoE/A3B) | Accepted |
| `arch_id` other (LLaMA / plain Qwen3) | Refused — single-GPU only in v1 |
| VL models | Refused — v1.1 |
| DFlash draft | Refused — v1.1 (eviction context single-device) |
| CASK / TriAttention sidecar | Refused — v1.1 |

## Validation

Reference hardware: 2× Radeon RX 7900 XTX (gfx1100), Ryzen 9 9950X,
NixOS, ROCm 6.4.3, peer access bidirectional via PCIe Gen4.

- `cargo build --workspace --release --all-targets` — clean.
- `cargo test --workspace --features deltanet` — 156 passed, 0 failed,
  4 hardware-gated `#[ignore]`d.
- `./scripts/verify-bind-thread.sh` — 286 pub fn audited, all pass.
- **`./scripts/pp-gate.sh` — 4/4 PASS:**
  1. `pp_parity_chatml` — per-token `forward_scratch_multi` ≡
     `forward_scratch` bit-exact, 50 decode tokens.
  2. Daemon `pp=1` ≡ `pp=2` byte-identical with `HIPFIRE_DETERMINISTIC=1`
     (sha256 `63f6060121d88269` on greedy ChatML completion).
  3. DFlash + `pp=2` refused at load.
  4. CASK + `pp=2` refused at load.
- `coherence-gate.sh` — no hard errors on 6 prompts (0.8B / 4B / 9B / 27B).
- Cross-process probe `50cee6c → HEAD` (9B mq4 decode):
  127.9 → 128.4 tok/s (+0.4 %, in noise). Branch is perf-neutral on the
  AR forward path.

### Methodology note

`scripts/pflash-baselines/gfx1100-2026-05-02.json` was captured on
maintainer hardware. On the contributor's gfx1100 it shows 5/12 drift
of 11–20 % on `*_baseline` 27B mq3 ≥16k metrics — both at the branch
base (`50cee6c`) and at HEAD. Same pattern at upstream/master
unchanged, so the drift is foreign-baseline noise, not a regression.
Verified by cross-process probe above.

## Throughput baseline (gfx1100 × 2, ROCm 6.4.3)

`HIPFIRE_DETERMINISTIC=1` → bit-equivalent pp=1 ↔ pp=2.

| Model | Prompt | pp=1 prefill | pp=2 prefill | pp=1 decode | pp=2 decode | pp=2/pp=1 decode |
|-------|--------|--------------|--------------|-------------|-------------|------------------|
| 0.8B mq4 | 22 tok | 838 tok/s | 588 tok/s | 332 tok/s | 227 tok/s | 68 % |
| 0.8B mq4 | 322 tok (chunked) | 6493 tok/s | 5490 tok/s | 315 tok/s | 212 tok/s | 67 % |
| 35B-A3B mq4 (MoE) | 15 tok | 331 tok/s | 258 tok/s | 142 tok/s | 97 tok/s | 68 % |

The pp=2 decode penalty is inherent to v1: per-token
`forward_scratch_multi` pays one HIP launch per kernel per layer with
no graph capture. Pipelined decode + per-band graph capture deferred
to v1.1 (see `docs/plans/multi-gpu-pp.md` §4.2).

## Architectural caveat

`Architecture` trait (`hipfire-runtime::arch`) signs on `&mut Gpu`
(single-GPU). Bring-up for `pp > 1` bypasses the trait and calls
`qwen35::load_weights_multi` directly from the daemon. Forward is
intentionally off-trait per `arch.rs:26-42`, so `forward_*_multi`
fits the existing pattern.

The `*_multi` variants are additive (mechanical clones with per-layer
device routing) rather than unified through `Option<&Gpus>`. This was
deliberate — the unified form requires a trait shape change that
breaks `hipfire-arch-llama`, `hipfire-arch-qwen35-vl`, and
`hipfire-arch-toy`, plus 80+ `forward_scratch` and 144+ `KvCache::new_gpu*`
call-site updates. Additive minimizes review surface and guarantees
pp=1 byte-equivalence by construction.

If preferred, a follow-up PR can: (a) unify `KvCache` constructors via
device-resolver closure, (b) refactor `load_weights` body through
extracted `load_*_into` helpers (interface unchanged), (c) extend the
`Architecture` trait with a defaulted `load_weights_multi` /
`new_state_multi`. `forward_scratch` unification is harder to justify
(hot path, byte-equivalence regression-prone) and probably stays
parallel.

## Out of scope (v1)

Refused at load with clear error:
- DFlash + pp>1 — eviction-context single-device, v1.1.
- CASK + pp>1 — same, v1.1.
- VL + pp>1 — vision encoder single-device, v1.1.
- Llama + pp>1, plain Qwen3 + pp>1 — single-GPU only in v1.

Architectural follow-ups:
- Pipelined decode + per-band graph capture (`forward_scratch_multi` is
  per-token sequential currently).
- Pipelined prefill (chunk N+1 on dev_0 while chunk N runs on dev_1).
- VRAM-weighted automatic split (`init_vram_weighted` is stubbed; manual
  escape hatch is `init_layers(per_device: &[usize])`).

## Open questions for maintainer

(Restated from #58 for permanence.)

1. **DFlash + PP scope** — v1 refuses. Is that the long-term call, or
   should DFlash + pp ship together in v1.1?
2. **Mixed-arch policy** — v1 hard-fails `gfx*` mismatch. Soft-warn vs
   hard-fail preference?
3. **`HIPFIRE_DEVICES` API surface** — currently logical IDs
   post-`HIP_VISIBLE_DEVICES`. Alternative: re-use
   `HIP_VISIBLE_DEVICES` semantics directly?
4. **CHANGELOG** — left unchanged in this PR. Maintainer adds the
   version + entry on merge.

## Test plan

- [ ] CI build clean
- [ ] `./scripts/pp-gate.sh` all 4 barriers PASS on 2-GPU host
- [ ] `./scripts/coherence-gate.sh` text-prompts pass
- [ ] Single-GPU regression: load any pp=1 model, generate — byte-identical
      to pre-PR behavior (verified locally; CI re-verification welcome)
- [ ] Refusal contracts: `pp=2 + draft=…` errors at load with
      `"DFlash requires single-GPU in v1; see issue #58 v1.1 roadmap"`
- [ ] On 1-GPU CI, `pp-gate.sh` exits 0 with skip message