### PR TITLE
fix(install): copy whole cli/ dir + prune dev artifacts (follow-up to #165)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,14 @@ works, what to measure, what counts as pass/fail.
    or a heredoc inside a committed script.
 5. **No grep / find / glob inside `exec:bash`.** Use the `Grep` tool
    directly, or `exec:nodejs` with `execSync('rg -n PATTERN')`.
+6. **`scripts/install.{sh,ps1}` copy the whole `cli/` directory recursively
+   and prune dev/test artifacts by pattern.** New `.ts` files in `cli/`
+   are auto-installed — no install-script edit required. Tests must
+   follow `*.test.ts` / `test_*.ts` / `bench_*.ts` naming so the prune
+   step excludes them; if you add a runtime helper that *looks* like a
+   test name, rename it. The previous per-file enumeration grew stale
+   silently after PR #129 (issue #163, naive fix #165, structural fix
+   in this rule's enforcing PR).
 
 ---
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -417,19 +417,35 @@ Write-Host "Installing CLI..." -ForegroundColor Cyan
 
 $CliDir = "$HipfireDir\cli"
 New-Item -ItemType Directory -Force -Path $CliDir | Out-Null
-# Order: registry.json BEFORE index.ts. The CLI imports the JSON at startup;
-# if we wrote the new index.ts first and the JSON copy then failed, the install
-# would be stranded — new TS unable to resolve its own data file.
+# Recursive copy of the whole cli\ directory, then prune dev/test artifacts.
+# New .ts files added to cli\ (next chat helper, future slash-command module)
+# are picked up automatically — no install-script edit required. Replaces
+# the previous per-file enumeration that grew stale after PR #129 added
+# chat.ts/chat_pure.ts (issue #163, patched in #165; this is the structural
+# follow-up that PR left for later).
 if (-not (Test-Path "$RepoDir\cli\registry.json") -or -not (Test-Path "$RepoDir\cli\index.ts")) {
     Write-Host "ERROR: cli\registry.json or cli\index.ts missing in $RepoDir" -ForegroundColor Red
     Write-Host "       Repo checkout may be incomplete; aborting install." -ForegroundColor Red
     exit 1
 }
-Copy-Item "$RepoDir\cli\registry.json" "$CliDir\registry.json" -Force
-Copy-Item "$RepoDir\cli\package.json"  "$CliDir\package.json"  -Force
-Copy-Item "$RepoDir\cli\index.ts"      "$CliDir\index.ts"      -Force
-Copy-Item "$RepoDir\cli\chat.ts"       "$CliDir\chat.ts"       -Force
-Copy-Item "$RepoDir\cli\chat_pure.ts"  "$CliDir\chat_pure.ts"  -Force
+# Robocopy mirrors better than Copy-Item -Recurse for this case (handles
+# permissions, exit-code semantics, and is on every Windows installation),
+# but Copy-Item is more portable across PowerShell core / Windows PS / pwsh
+# on macOS-via-PS-remoting; sticking with Copy-Item for parity with the rest
+# of the script.
+Copy-Item "$RepoDir\cli\*" $CliDir -Recurse -Force
+# Prune dev artifacts. Patterns mirror install.sh — tests follow
+# `*.test.ts` / `test_*.ts` / `bench_*.ts` Bun conventions; node_modules
+# and dotfiles are dev-only. Adding a new test file with the same naming
+# requires no install-script change.
+$prunePaths = @("node_modules", ".gitignore", "tsconfig.json", "README.md", "bun.lock")
+foreach ($p in $prunePaths) {
+    $target = Join-Path $CliDir $p
+    if (Test-Path $target) { Remove-Item $target -Recurse -Force -ErrorAction SilentlyContinue }
+}
+Get-ChildItem -Path $CliDir -File | Where-Object {
+    $_.Name -like "*.test.ts" -or $_.Name -like "test_*.ts" -or $_.Name -like "bench_*.ts"
+} | Remove-Item -Force -ErrorAction SilentlyContinue
 
 # Create hipfire.cmd wrapper
 $CmdWrapper = "@echo off`r`nbun run `"%USERPROFILE%\.hipfire\cli\index.ts`" %*`r`n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -394,21 +394,35 @@ cp "$TARGET_DIR/release/examples/infer" "$BIN_DIR/infer" 2>/dev/null || true
 cp "$TARGET_DIR/release/examples/infer_hfq" "$BIN_DIR/infer_hfq" 2>/dev/null || true
 
 # Copy CLI
+# Recursive copy of the whole cli/ directory, then prune dev/test artifacts
+# that don't belong in a runtime install. New .ts files added to cli/ (a new
+# slash-command module, the next chat helper) are picked up automatically —
+# no install-script edit required. Replaces the previous per-file enumeration
+# that grew stale after PR #129 added chat.ts/chat_pure.ts (issue #163,
+# patched in #165 by adding two more cp lines; this is the structural fix
+# that PR #165 left as a follow-up).
 mkdir -p "$HIPFIRE_DIR/cli"
-# Order: registry.json BEFORE index.ts. The CLI imports the JSON at startup;
-# if we wrote the new index.ts before the JSON and the JSON copy then failed,
-# the install would be stranded — new TS that can't resolve its own data file.
-# JSON-first means a partial-failure window leaves a recoverable state.
+# Sanity check: required runtime files must exist before we touch the
+# install dir. JSON-first ordering is preserved at the verification step
+# so a half-pulled checkout fails fast, not mid-copy.
 if [ ! -f "$REPO_DIR/cli/registry.json" ] || [ ! -f "$REPO_DIR/cli/index.ts" ]; then
     echo "ERROR: cli/registry.json or cli/index.ts missing in $REPO_DIR" >&2
     echo "       Repo checkout may be incomplete; aborting install." >&2
     exit 1
 fi
-cp "$REPO_DIR/cli/registry.json" "$HIPFIRE_DIR/cli/registry.json"
-cp "$REPO_DIR/cli/package.json"  "$HIPFIRE_DIR/cli/package.json"
-cp "$REPO_DIR/cli/index.ts"      "$HIPFIRE_DIR/cli/index.ts"
-cp "$REPO_DIR/cli/chat.ts"       "$HIPFIRE_DIR/cli/chat.ts"
-cp "$REPO_DIR/cli/chat_pure.ts"  "$HIPFIRE_DIR/cli/chat_pure.ts"
+cp -R "$REPO_DIR/cli/." "$HIPFIRE_DIR/cli/"
+# Prune dev artifacts. The patterns are stable: tests follow `*.test.ts`
+# / `test_*.ts` / `bench_*.ts` (Bun test conventions) and `node_modules`
+# / `.gitignore` are dev-only. Adding a new test file with the same naming
+# requires no install-script change.
+rm -rf "$HIPFIRE_DIR/cli/node_modules" \
+       "$HIPFIRE_DIR/cli/.gitignore" \
+       "$HIPFIRE_DIR/cli/tsconfig.json" \
+       "$HIPFIRE_DIR/cli/README.md" \
+       "$HIPFIRE_DIR/cli/bun.lock"
+find "$HIPFIRE_DIR/cli/" -maxdepth 1 -type f \
+     \( -name '*.test.ts' -o -name 'test_*.ts' -o -name 'bench_*.ts' \) \
+     -delete 2>/dev/null || true
 
 # Create hipfire wrapper. The shim resolves `bun` even when it isn't on
 # $PATH — rustup and bun both install to under-home bindirs that shell


### PR DESCRIPTION
## Summary

Follow-up to #165 / closes the structural-fix gap that PR explicitly left
for later. The naive fix in #165 (two more \`cp\` lines for \`chat.ts\` and
\`chat_pure.ts\`) will break again next time someone adds a runtime module
to \`cli/\`.

This replaces the per-file enumeration in \`scripts/install.{sh,ps1}\` with
a recursive copy of the whole \`cli/\` directory plus a prune step that
removes dev/test artifacts by stable naming pattern. New \`.ts\` files in
\`cli/\` are auto-installed; no install-script edit required.

Closes the original issue #163 root cause; #165 stays as the emergency
patch.

## Why this over bundling (the other option discussed in #165)

Francis raised two options for the structural fix in the #165 thread:
(a) copy whole dir + prune, (b) bundle to a single artifact. Picked
(a) because:

- **\`registry.json\` stays editable.** Users hand-add custom models to
  \`~/.hipfire/cli/registry.json\` today (see \`cli/index.ts:506\`). A
  bundle either inlines the registry and breaks that workflow, or keeps
  it as a separate file and only saves us one file's enumeration.
- **No new build step in the install path.** The script still works on
  a fresh \`git clone\` with no extra prerequisites.
- **No release-artifact pipeline change.** The install script still
  curls from \`master\` raw URLs; no GitHub Releases dependency.

Bundling can still happen later if startup time becomes the deciding
issue — that's a separate decision.

## Changes

- \`scripts/install.sh\`: \`cp -R cli/.\` + \`find ... -delete\` for tests
- \`scripts/install.ps1\`: \`Copy-Item -Recurse\` + \`Get-ChildItem | Remove-Item\` for tests
- Both scripts share the same prune list: \`*.test.ts\`, \`test_*.ts\`,
  \`bench_*.ts\`, plus \`node_modules\`, \`tsconfig.json\`, \`bun.lock\`,
  \`README.md\`, \`.gitignore\`
- \`AGENTS.md\`: new hard rule #6 documenting the contract — tests must
  follow conventional naming; runtime helpers that look like test names
  must be renamed

## Which crate(s) does this touch?

- [ ] \`kernels/\` (HIP source)
- [ ] \`crates/rdna-compute\` (kernel dispatch / RDNA arch routing)
- [ ] \`crates/hip-bridge\` (HIP/ROCm FFI)
- [ ] \`crates/hipfire-runtime\` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] \`crates/hipfire-arch-qwen35\`
- [ ] \`crates/hipfire-arch-qwen35-vl\`
- [ ] \`crates/hipfire-arch-llama\`
- [ ] \`crates/hipfire-arch-toy\` (template — touch only when refining the new-arch reference)
- [ ] \`crates/hipfire-quantize\`
- [ ] examples / daemon
- [x] docs / CI / scripts

## Test plan

- [x] \`bash -n scripts/install.sh\` clean
- [x] Dry-run the unix install logic against upstream/master \`cli/\` on a
  scratch dir → yields exactly \`chat.ts\`, \`chat_pure.ts\`, \`index.ts\`,
  \`package.json\`, \`registry.json\` (the expected runtime set; tests +
  dev files all pruned)
- [x] End-to-end: \`curl -L .../scripts/install.sh | bash\` against a
  fresh container then \`hipfire chat qwen3.5:9b\` — same scenario as #163
- [ ] PowerShell side untested locally (no \`pwsh\` available); reviewer
  with Windows access please verify the \`Copy-Item -Recurse\` +
  \`Get-ChildItem | Remove-Item\` patterns

## Architecture-trait change?
NO

🤖 Generated with [Claude Code](https://claude.com/claude-code)