### PR TITLE
fix(quantizer): Q8 router default for MoE — fixes #171

### DIFF
--- a/crates/hipfire-quantize/src/gguf_input.rs
+++ b/crates/hipfire-quantize/src/gguf_input.rs
@@ -412,6 +412,63 @@ fn dequant_q4_k(data: &[u8], n: usize) -> Vec<f32> {
     out
 }
 
+fn dequant_q5_k(data: &[u8], n: usize) -> Vec<f32> {
+    let block_size = 256;
+    let block_bytes = 176;
+    let nblocks = (n + block_size - 1) / block_size;
+    let mut out = vec![0.0f32; n];
+    for b in 0..nblocks {
+        let off = b * block_bytes;
+        if off + block_bytes > data.len() {
+            break;
+        }
+        let d = f16_to_f32(u16::from_le_bytes([data[off], data[off + 1]]));
+        let dmin = f16_to_f32(u16::from_le_bytes([data[off + 2], data[off + 3]]));
+
+        // 12-byte packed scales/mins — same layout as Q4_K
+        let sc_data = &data[off + 4..off + 16];
+        let mut scales = [0u8; 8];
+        let mut mins = [0u8; 8];
+        for i in 0..4 {
+            scales[i] = sc_data[i] & 63;
+            mins[i] = sc_data[4 + i] & 63;
+        }
+        for i in 0..4 {
+            scales[4 + i] = (sc_data[8 + i] & 0xF) | ((sc_data[i] >> 6) << 4);
+            mins[4 + i] = (sc_data[8 + i] >> 4) | ((sc_data[4 + i] >> 6) << 4);
+        }
+
+        // 32 bytes of high bits (1 bit per element), then 128 bytes of low nibbles
+        let qh = &data[off + 16..off + 48];
+        let ql = &data[off + 48..off + 176];
+
+        for group in 0..4 {
+            let sb_even = group * 2;
+            let sb_odd = group * 2 + 1;
+            let sc_even = d * scales[sb_even] as f32;
+            let m_even = dmin * mins[sb_even] as f32;
+            let sc_odd = d * scales[sb_odd] as f32;
+            let m_odd = dmin * mins[sb_odd] as f32;
+            for l in 0..32 {
+                let byte = ql[group * 32 + l];
+                let hbit = ((qh[l] >> group) & 1) as u8;
+                let hbit2 = ((qh[l] >> (group + 4)) & 1) as u8;
+                let idx_even = b * block_size + group * 64 + l;
+                let idx_odd = idx_even + 32;
+                if idx_even < n {
+                    let q = ((byte & 0x0F) | (hbit << 4)) as f32;
+                    out[idx_even] = q * sc_even - m_even;
+                }
+                if idx_odd < n {
+                    let q = (((byte >> 4) & 0x0F) | (hbit2 << 4)) as f32;
+                    out[idx_odd] = q * sc_odd - m_odd;
+                }
+            }
+        }
+    }
+    out
+}
+
 fn dequant_q6_k(data: &[u8], n: usize) -> Vec<f32> {
     let block_size = 256;
     let block_bytes = 210;
@@ -480,6 +537,7 @@ pub fn tensor_to_f32(info: &TensorInfo, data: &[u8]) -> Vec<f32> {
         GgmlType::Q4_0 => dequant_q4_0(data, n),
         GgmlType::Q8_0 => dequant_q8_0(data, n),
         GgmlType::Q4K => dequant_q4_k(data, n),
+        GgmlType::Q5K => dequant_q5_k(data, n),
         GgmlType::Q6K => dequant_q6_k(data, n),
         other => panic!(
             "GGUF tensor type {:?} not implemented (tensor: {})",

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1701,6 +1701,7 @@ fn main() {
     let use_mq3g256 = format == "mq3" || format == "mq3g256";
     let use_mq2g256 = format == "mq2" || format == "mq2g256";
     let use_hfq6 = format == "hfq6" || format == "hfq6g256" || format == "hf6";
+    let q8_router_flag = args.iter().any(|a| a == "--q8-router");
 
     // ── Sub-4-bit guards (2026-04-30 sweep) ─────────────────────────────
     // MQ2 with the current uniform 4-level codebook collapses at every
@@ -1790,6 +1791,11 @@ fn main() {
     };
     eprintln!("Architecture: {arch_str} (id={arch_id})");
     let is_moe = arch_id == 6;
+    // Q8 router: always on for MoE models. 4-bit router quantization destroys
+    // routing precision on precision-sensitive models (Qwen3.6-A3B: 152/256
+    // expert rows drop below 0.99 cosine similarity at HFQ4G256). Cost: ~0.05%
+    // model size. See github.com/Kaden-Schutt/hipfire/issues/171.
+    let q8_router = is_moe || q8_router_flag;
     if is_moe {
         eprintln!("  MoE detected — will split 3D expert tensors per-expert before quantization.");
     }
@@ -1906,7 +1912,10 @@ fn main() {
             let signs1 = gen_fwht_signs(42, 256);
             let signs2 = gen_fwht_signs(1042, 256);
             let inner_k = inner_shape[1] as usize;
-            let supports_mq4 = inner_k % 256 == 0;
+            let supports_g256 = inner_k % 256 == 0;
+            let expert_mq6 = use_mq6g256 && supports_g256;
+            let expert_hfq6 = use_hfq6 && supports_g256;
+            let expert_hfq4 = use_hfq4g256 && supports_g256;
 
             // Parallelize across the 256 expert slices via rayon. Each slice
             // dequant→FWHT→quant→pack is a CPU-bound, self-contained job.
@@ -1920,7 +1929,16 @@ fn main() {
                 let slice_off = x * inner_bytes;
                 let slice = &raw_data[slice_off..slice_off + inner_bytes];
                 let f32_slice = to_f32(slice, &dtype);
-                let (quantized, qt, gs) = if supports_mq4 {
+                let (quantized, qt, gs) = if expert_mq6 {
+                    let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
+                    (q, QuantType::MQ6G256, 256u32)
+                } else if expert_hfq6 {
+                    let q = quantize_hfq6g256(&f32_slice);
+                    (q, QuantType::HFQ6G256, 256u32)
+                } else if expert_hfq4 {
+                    let q = quantize_hfq4g256(&f32_slice);
+                    (q, QuantType::HFQ4G256, 256u32)
+                } else if supports_g256 {
                     let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
                     (q, QuantType::MQ4G256, 256u32)
                 } else {
@@ -1937,7 +1955,7 @@ fn main() {
             }).collect();
             quantized_params += inner_n as u64 * n_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
-            let label = if supports_mq4 { "MQ4G256" } else { "HFQ4G128" };
+            let label = if expert_mq6 { "MQ6G256" } else if expert_hfq6 { "HFQ6G256" } else if expert_hfq4 { "HFQ4G256" } else if supports_g256 { "MQ4G256" } else { "HFQ4G128" };
             let bytes_per = new_tensors.first().map(|t| t.data.len()).unwrap_or(0);
             eprintln!("  {label:>8}: {parent_owned}{{0..{n_experts}}}.{base_owned}.weight {:?} (×{n_experts} experts || {:.1} KB/expert, parallel)",
                 inner_shape, bytes_per as f64 / 1024.0);
@@ -2067,6 +2085,11 @@ fn main() {
                     let q = quantize_q8f16(&f32_data);
                     (q, QuantType::Q8F16, 32u32, "Q8_F16")
                 }
+            } else if q8_router && is_q8_tensor(name) {
+                // Q8 router for MoE: keep mlp.gate.weight and
+                // shared_expert_gate.weight at Q8 regardless of --format.
+                let q = quantize_q8f16(&f32_data);
+                (q, QuantType::Q8F16, 32u32, "Q8_F16")
             } else if use_mq4g256 && is_embed {
                 let q = quantize_q8f16(&f32_data);
                 (q, QuantType::Q8F16, 32u32, "Q8_F16")


### PR DESCRIPTION
## Summary

- **Always quantize MoE router weights at Q8** (`mlp.gate.weight`, `mlp.shared_expert_gate.weight`) regardless of `--format`. The `is_q8_tensor` guard existed but only fired in `q8-mixed`/`q8-fast` modes — now it fires for all MoE models (`num_experts > 0`).
- Add `dequant_q5_k()` for GGUF Q5K tensor support
- Add `--format hfq4`/`hfq6` support for MoE expert weights (was MQ4/MQ6-only)
- Add `--q8-router` explicit flag (redundant for MoE, useful for non-MoE)

## Root cause

4-bit quantization of the 256×2048 router weight destroys routing precision: 152/256 expert rows drop below 0.99 cosine similarity at HFQ4G256 (3× worse MSE than Q4_K_M). This flips top-8 expert selection, cascading into structural attractors across 40 MoE layers.

## Evidence

llama.cpp parity test confirmed attractors are hipfire-specific (not model fragility):

| Format | Router | Unique words | Verdict |
|---|---|---|---|
| MQ4 (4-bit router) | 4-bit | 14% | **ATTRACTOR** |
| **MQ4 + Q8 router** | **8-bit** | **46%** | **CLEAN** |
| HFQ4 (4-bit router) | 4-bit | 10% | **ATTRACTOR** |
| **HFQ4 + Q8 router** | **8-bit** | **42%** | **CLEAN** |
| **HFQ6** | **6-bit** | **70%** | **CLEAN** |
| Q4_K_M (llama.cpp) | mixed-6bit | 58% | CLEAN |

Cost: ~10 MB on 18 GB model (0.05%). No perf impact.

## Test plan

- [x] MQ4 + Q8 router: clean on 3.6-A3B code review prompt (greedy, RP=1.05)
- [x] HFQ4 + Q8 router: clean on same prompt
- [x] HFQ6: clean on same prompt
- [x] 3.5-A3B MQ4 (no Q8 router): still clean (fa0592d was sufficient for 3.5)
- [x] Coherence gate `--full`: all models pass (0 hard errors), 3.5-A3B and 3.6-A3B both coherent on sheep prompt with re-quantized MQ4 models
- [x] 122B-A10B: re-quantized from original safetensors with Q8 router. **CLEAN** — 59.9% unique words, coherent code review (487 tok, self-EOS). Previous 4-bit router baseline was borderline (54.7% unique, mild tail repetition).

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)