### PR TITLE
feat: NixOS flake with dev shell, package, and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ curl -L https://raw.githubusercontent.com/Kaden-Schutt/hipfire/master/scripts/in
 For Windows, source builds, and verifying the install:
 [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
+## NixOS
+
+First-class support via Nix flake. See [docs/NIXOS.md](docs/NIXOS.md).
+
+```bash
+nix develop github:Kaden-Schutt/hipfire  # dev shell with Rust + ROCm + bun
+nix build github:Kaden-Schutt/hipfire    # build package
+```
+
+NixOS module:
+
+```nix
+{
+  inputs.hipfire.url = "github:Kaden-Schutt/hipfire";
+  # then in configuration.nix:
+  services.hipfire.enable = true;
+  services.hipfire.gpuTargets = [ "gfx1100" ];
+}
+```
+
 ## Inspiration: Lucebox
 
 hipfire's DFlash work was substantially shaped by Davide Ciffa's
@@ -100,6 +120,7 @@ the prefill MMQ redesign log is at
 | Page | Topic |
 |---|---|
 | [GETTING_STARTED.md](docs/GETTING_STARTED.md) | Install, first run, what to read next |
+| [NIXOS.md](docs/NIXOS.md) | NixOS flake, module, dev shell |
 | [CLI.md](docs/CLI.md) | Every subcommand, flags, file locations |
 | [MODELS.md](docs/MODELS.md) | Curated tags, BYO models, file extensions |
 | [QUANTIZE.md](docs/QUANTIZE.md) | `hipfire quantize` for HF / safetensors / GGUF |

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -954,7 +954,9 @@ class Engine {
 
   async start() {
     const exe = process.platform === "win32" ? ".exe" : "";
+    const envBin = process.env.HIPFIRE_DAEMON_BIN;
     const bins = [
+      ...(envBin ? [envBin] : []),
       resolve(__dirname, `../target/release/examples/daemon${exe}`),
       join(HIPFIRE_DIR, "bin", `daemon${exe}`),
     ];

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4479,7 +4479,9 @@ switch (cmd) {
     // ── 4. Daemon binary + models ──────────────────────────
     console.log("");
     const exe2 = process.platform === "win32" ? ".exe" : "";
+    const envBin2 = process.env.HIPFIRE_DAEMON_BIN;
     const daemonBins = [
+      ...(envBin2 ? [envBin2] : []),
       resolve(__dirname, `../target/release/examples/daemon${exe2}`),
       join(HIPFIRE_DIR, "bin", `daemon${exe2}`),
     ];

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -127,6 +127,59 @@ Your user must be in `video` and `render` groups:
 users.users.yourname.extraGroups = [ "video" "render" ];
 ```
 
+### Building from a specific branch or fork
+
+By default the module builds from the flake input (pinned in `flake.lock`).
+To build from a different branch, tag, commit, or fork:
+
+```nix
+# Build from a specific branch
+services.hipfire = {
+  enable = true;
+  gpuTargets = [ "gfx1100" ];
+  github.rev = "feat/cool-thing";
+  github.hash = "";  # build once — nix will print the correct hash
+};
+```
+
+```nix
+# Build from a fork
+services.hipfire = {
+  enable = true;
+  gpuTargets = [ "gfx1100" ];
+  github.owner = "my-username";
+  github.rev = "my-branch";
+  github.hash = "sha256-AAAA...";
+};
+```
+
+```nix
+# Build from a pinned commit
+services.hipfire = {
+  enable = true;
+  gpuTargets = [ "gfx1100" ];
+  github.rev = "abc123def456";
+  github.hash = "sha256-AAAA...";
+};
+```
+
+You can also pass an arbitrary source derivation directly:
+
+```nix
+services.hipfire = {
+  enable = true;
+  src = pkgs.fetchFromGitHub {
+    owner = "Kaden-Schutt";
+    repo = "hipfire";
+    rev = "v0.2.0";
+    hash = "sha256-AAAA...";
+  };
+};
+```
+
+**Tip:** Set `github.hash = ""` on the first build — Nix will error with
+the correct SRI hash to paste back in.
+
 ## GPU Targets
 
 | Arch | Card | Generation |
@@ -151,6 +204,11 @@ services.hipfire.gpuTargets = [ "gfx1100" "gfx1030" ];
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | bool | `false` | Enable the hipfire service |
+| `src` | path or null | `null` | Custom source derivation (overrides everything) |
+| `github.owner` | str | `"Kaden-Schutt"` | GitHub repo owner |
+| `github.repo` | str | `"hipfire"` | GitHub repo name |
+| `github.rev` | str or null | `null` | Branch, tag, or commit to fetch from GitHub |
+| `github.hash` | str | `""` | SRI hash of fetched source (required with `rev`) |
 | `gpuTargets` | list of str | `["gfx1100"]` | GPU architectures for kernel compilation |
 | `defaultModel` | str | `""` | Model to pre-warm on startup |
 | `temperature` | float | `0.3` | Sampling temperature |

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -4,7 +4,7 @@ hipfire has first-class NixOS support via a Nix flake.
 
 ## Prerequisites
 
-- NixOS 24.05+ or nixos-unstable
+- NixOS 25.11+ (or nixos-unstable)
 - AMD GPU with the `amdgpu` kernel module loaded
 - User in `video` and `render` groups (for non-service usage)
 
@@ -51,7 +51,7 @@ Add hipfire to your flake inputs and enable the service.
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     hipfire.url = "github:Kaden-Schutt/hipfire";
   };
 
@@ -78,18 +78,18 @@ services.hipfire = {
   enable = true;
   gpuTargets = [ "gfx1100" ];
 
-  # Global config (written to config.json)
-  settings = {
-    temperature = 0.3;
-    top_p = 0.8;
-    max_tokens = 512;
-    kv_cache = "asym3";
-    dflash_mode = "auto";
-    idle_timeout = 300;
-    default_model = "qwen3.5:9b";
-  };
+  # Inference settings
+  defaultModel = "qwen3.5:9b";
+  temperature = 0.3;
+  topP = 0.8;
+  maxTokens = 512;
+  maxSeq = 32768;
+  repeatPenalty = 1.05;
+  kvCache = "asym3";
+  dflashMode = "auto";
+  idleTimeout = 300;
 
-  # Per-model overrides (written to per_model_config.json)
+  # Per-model overrides (snake_case keys — these map directly to config.json)
   perModelSettings = {
     "qwen3.5:27b" = {
       max_seq = 16384;
@@ -146,6 +146,29 @@ Build kernels for multiple arches:
 services.hipfire.gpuTargets = [ "gfx1100" "gfx1030" ];
 ```
 
+## Module Options Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enable` | bool | `false` | Enable the hipfire service |
+| `gpuTargets` | list of str | `["gfx1100"]` | GPU architectures for kernel compilation |
+| `defaultModel` | str | `""` | Model to pre-warm on startup |
+| `temperature` | float | `0.3` | Sampling temperature |
+| `topP` | float | `0.8` | Nucleus sampling threshold |
+| `maxTokens` | int | `512` | Per-request token cap |
+| `maxSeq` | int | `32768` | KV cache capacity (tokens) |
+| `repeatPenalty` | float | `1.05` | Repetition penalty |
+| `kvCache` | str | `"auto"` | KV cache mode: auto/q8/asym4/asym3/asym2/turbo* |
+| `dflashMode` | enum | `"off"` | DFlash spec-decode: on/off/auto |
+| `idleTimeout` | int | `300` | Seconds before VRAM eviction (0 = never) |
+| `extraSettings` | attrs | `{}` | Additional config.json keys (snake_case) |
+| `perModelSettings` | attrs of attrs | `{}` | Per-model overrides (snake_case keys) |
+| `environment` | attrs of str | `{}` | Extra HIPFIRE_* env vars |
+| `modelDir` | str | `"/var/lib/hipfire/models"` | Model file directory |
+| `rocmSupport` | bool | `true` | Use nixpkgs ROCm libraries |
+| `userService` | bool | `false` | Run as user-level systemd service |
+| `port` | port | `11435` | API server port |
+
 ## ROCm Configuration
 
 ### Default: bundled nixpkgs ROCm
@@ -175,7 +198,7 @@ apply transparently.
 hipfire uses a layered config system. Precedence (lowest to highest):
 
 1. Engine defaults (hardcoded)
-2. `config.json` — set via `services.hipfire.settings`
+2. `config.json` — set via module options (`temperature`, `kvCache`, etc.)
 3. `per_model_config.json` — set via `services.hipfire.perModelSettings`
 4. Environment variables — set via `services.hipfire.environment`
 

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -1,0 +1,240 @@
+# NixOS
+
+hipfire has first-class NixOS support via a Nix flake.
+
+## Prerequisites
+
+- NixOS 24.05+ or nixos-unstable
+- AMD GPU with the `amdgpu` kernel module loaded
+- User in `video` and `render` groups (for non-service usage)
+
+Verify your GPU is visible:
+
+    ls /dev/kfd         # should exist
+    ls /dev/dri/        # should show renderD128+
+
+Detect your GPU architecture:
+
+    grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
+
+## Quick Start
+
+### Development shell
+
+Enter a shell with Rust, bun, hipcc, and ROCm tools:
+
+    nix develop github:Kaden-Schutt/hipfire
+
+This works with any hipfire checkout — the shell provides tools only,
+not the source tree:
+
+    nix develop github:Kaden-Schutt/hipfire
+    cd ~/my-hipfire-fork
+    cargo build --release --features deltanet --example daemon -p hipfire-runtime
+
+### Build from source
+
+    nix build github:Kaden-Schutt/hipfire
+    ./result/bin/hipfire run qwen3.5:9b "Hello"
+
+### Build kernels
+
+    nix build github:Kaden-Schutt/hipfire#hipfire-kernels
+
+## NixOS Module
+
+Add hipfire to your flake inputs and enable the service.
+
+### Minimal example
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hipfire.url = "github:Kaden-Schutt/hipfire";
+  };
+
+  outputs = { nixpkgs, hipfire, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        hipfire.nixosModules.default
+        {
+          nixpkgs.overlays = [ hipfire.overlays.default ];
+          services.hipfire.enable = true;
+          services.hipfire.gpuTargets = [ "gfx1100" ];
+        }
+      ];
+    };
+  };
+}
+```
+
+### Full example
+
+```nix
+services.hipfire = {
+  enable = true;
+  gpuTargets = [ "gfx1100" ];
+
+  # Global config (written to config.json)
+  settings = {
+    temperature = 0.3;
+    top_p = 0.8;
+    max_tokens = 512;
+    kv_cache = "asym3";
+    dflash_mode = "auto";
+    idle_timeout = 300;
+    default_model = "qwen3.5:9b";
+  };
+
+  # Per-model overrides (written to per_model_config.json)
+  perModelSettings = {
+    "qwen3.5:27b" = {
+      max_seq = 16384;
+      kv_cache = "q8";
+      dflash_mode = "on";
+    };
+  };
+
+  # Extra env vars (highest precedence)
+  environment = {
+    HIPFIRE_NORMALIZE_PROMPT = "1";
+  };
+
+  modelDir = "/var/lib/hipfire/models";
+};
+```
+
+### Desktop / user-service mode
+
+For single-user desktop setups, use a user-level systemd service:
+
+```nix
+services.hipfire = {
+  enable = true;
+  userService = true;
+  gpuTargets = [ "gfx1100" ];
+};
+```
+
+Manage with `systemctl --user start hipfire`, `systemctl --user status hipfire`.
+
+Your user must be in `video` and `render` groups:
+
+```nix
+users.users.yourname.extraGroups = [ "video" "render" ];
+```
+
+## GPU Targets
+
+| Arch | Card | Generation |
+|------|------|-----------|
+| gfx906 | Vega 20 / MI50 | GCN5 |
+| gfx908 | MI100 | CDNA |
+| gfx1010 | RX 5700 XT | RDNA1 |
+| gfx1030 | RX 6800 XT | RDNA2 |
+| gfx1100 | RX 7900 XTX | RDNA3 |
+| gfx1151 | Strix Halo | RDNA3.5 |
+| gfx1200 | Radeon R9700 | RDNA4 |
+| gfx1201 | RX 9070 XT | RDNA4 |
+
+Build kernels for multiple arches:
+
+```nix
+services.hipfire.gpuTargets = [ "gfx1100" "gfx1030" ];
+```
+
+## ROCm Configuration
+
+### Default: bundled nixpkgs ROCm
+
+hipfire uses `rocmPackages.clr` from nixpkgs by default.
+`LD_LIBRARY_PATH` is injected automatically via wrapper scripts.
+
+### Bring your own ROCm
+
+```nix
+services.hipfire = {
+  rocmSupport = false;
+  environment = {
+    LD_LIBRARY_PATH = "/opt/rocm/lib";
+  };
+};
+```
+
+### Custom ROCm version via overlay
+
+Override `rocmPackages` in your nixpkgs overlay. The hipfire package
+and module reference `rocmPackages.clr` generically, so overlays
+apply transparently.
+
+## Configuration
+
+hipfire uses a layered config system. Precedence (lowest to highest):
+
+1. Engine defaults (hardcoded)
+2. `config.json` — set via `services.hipfire.settings`
+3. `per_model_config.json` — set via `services.hipfire.perModelSettings`
+4. Environment variables — set via `services.hipfire.environment`
+
+For the full list of config keys, see [CONFIG.md](CONFIG.md).
+
+### Environment variables (interactive use)
+
+For interactive usage outside the systemd service (`hipfire run`, `hipfire chat`),
+set `HIPFIRE_*` variables in your shell profile:
+
+```bash
+# ~/.bashrc or equivalent
+export HIPFIRE_KV_MODE=asym3
+export HIPFIRE_NORMALIZE_PROMPT=1
+```
+
+These only affect the current user's shell sessions, not the systemd service.
+
+## Troubleshooting
+
+### "libamdhip64.so not found"
+
+The HIP runtime library is missing. If using bundled ROCm (`rocmSupport = true`),
+verify `rocmPackages.clr` is available:
+
+    nix build nixpkgs#rocmPackages.clr
+
+If using bring-your-own, check your `LD_LIBRARY_PATH`:
+
+    ls -la /opt/rocm/lib/libamdhip64.so*
+
+### "Permission denied" on /dev/kfd
+
+Your user needs `video` and `render` group membership:
+
+```nix
+users.users.yourname.extraGroups = [ "video" "render" ];
+```
+
+Then rebuild and relogin.
+
+### "No AMD GPU detected"
+
+Check that the amdgpu kernel module is loaded:
+
+    lsmod | grep amdgpu
+
+On NixOS, ensure firmware is available:
+
+```nix
+hardware.firmware = [ pkgs.linux-firmware ];
+# or for AMD specifically:
+hardware.amdgpu.initrd.enable = true;  # NixOS 24.05+
+```
+
+### Kernel pre-compilation fails
+
+Ensure hipcc version matches your GPU target. Check with:
+
+    hipcc --version
+
+gfx1200/gfx1201 requires ROCm 6.4+, gfx1151 requires ROCm 7.2+.

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -209,7 +209,7 @@ services.hipfire.gpuTargets = [ "gfx1100" "gfx1030" ];
 | `github.repo` | str | `"hipfire"` | GitHub repo name |
 | `github.rev` | str or null | `null` | Branch, tag, or commit to fetch from GitHub |
 | `github.hash` | str | `""` | SRI hash of fetched source (required with `rev`) |
-| `gpuTargets` | list of str | `["gfx1100"]` | GPU architectures for kernel compilation |
+| `gpuTargets` | list of str | `[]` (required) | GPU architectures for kernel compilation |
 | `defaultModel` | str | `""` | Model to pre-warm on startup |
 | `temperature` | float | `0.3` | Sampling temperature |
 | `topP` | float | `0.8` | Nucleus sampling threshold |

--- a/docs/NIXOS.md
+++ b/docs/NIXOS.md
@@ -77,6 +77,7 @@ Add hipfire to your flake inputs and enable the service.
 services.hipfire = {
   enable = true;
   gpuTargets = [ "gfx1100" ];
+  openFirewall = true;  # opens port 11435
 
   # Inference settings
   defaultModel = "qwen3.5:9b";
@@ -204,6 +205,7 @@ services.hipfire.gpuTargets = [ "gfx1100" "gfx1030" ];
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | bool | `false` | Enable the hipfire service |
+| `openFirewall` | bool | `false` | Open the API port in the firewall |
 | `src` | path or null | `null` | Custom source derivation (overrides everything) |
 | `github.owner` | str | `"Kaden-Schutt"` | GitHub repo owner |
 | `github.repo` | str | `"hipfire"` | GitHub repo name |

--- a/docs/superpowers/plans/2026-05-07-nixos-packaging.md
+++ b/docs/superpowers/plans/2026-05-07-nixos-packaging.md
@@ -1,0 +1,1032 @@
+# NixOS Packaging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide first-class NixOS support via a Nix flake with dev shell, package derivation, kernel compilation, NixOS module, and documentation.
+
+**Architecture:** Single `flake.nix` at repo root wiring together four Nix files under `nix/`. The daemon has no CLI flags — all config flows through the Bun CLI (`hipfire serve`) which spawns the daemon and communicates via JSON IPC over stdin/stdout. Kernels live relative to the daemon binary at `<binary_dir>/kernels/compiled/<arch>/`. The NixOS module runs `hipfire serve` as a systemd service with `HOME` set to manage config/PID/model paths.
+
+**Tech Stack:** Nix flakes, `rustPlatform.buildRustPackage`, `rust-overlay`, `rocmPackages`, `makeWrapper`, systemd
+
+**Spec:** `docs/superpowers/specs/2026-05-07-nixos-packaging-design.md`
+
+---
+
+### File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `flake.nix` | Inputs, outputs, wiring |
+| Create | `nix/package.nix` | Rust binary derivation |
+| Create | `nix/kernels.nix` | GPU kernel compilation |
+| Create | `nix/dev-shell.nix` | Development environment |
+| Create | `nix/module.nix` | NixOS module (`services.hipfire`) |
+| Create | `docs/NIXOS.md` | User-facing installation guide |
+| Modify | `README.md:43-52` | Add NixOS section after Install |
+
+---
+
+### Task 1: Create `flake.nix`
+
+**Files:**
+- Create: `flake.nix`
+
+- [ ] **Step 1: Write `flake.nix`**
+
+```nix
+{
+  description = "hipfire — LLM inference for AMD RDNA GPUs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        hipfire = pkgs.callPackage ./nix/package.nix {
+          rocmSupport = true;
+        };
+
+        hipfire-kernels = pkgs.callPackage ./nix/kernels.nix {
+          gpuTargets = [ "gfx1100" ];
+        };
+      in
+      {
+        packages = {
+          default = hipfire;
+          inherit hipfire hipfire-kernels;
+        };
+
+        devShells.default = pkgs.callPackage ./nix/dev-shell.nix {
+          rust-bin = pkgs.rust-bin;
+          rocmSupport = true;
+        };
+      }
+    ) // {
+      nixosModules.default = import ./nix/module.nix;
+
+      overlays.default = final: prev: {
+        hipfire = final.callPackage ./nix/package.nix {
+          rocmSupport = true;
+        };
+        hipfire-kernels = final.callPackage ./nix/kernels.nix {
+          gpuTargets = [ "gfx1100" ];
+        };
+      };
+    };
+}
+```
+
+- [ ] **Step 2: Verify flake parses**
+
+Run: `nix flake check --no-build 2>&1 | head -20`
+
+Expected: No syntax errors. May warn about missing `nix/*.nix` files — that's fine, we create them next.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add flake.nix
+git commit -m "feat(nix): add flake.nix skeleton with inputs and outputs"
+```
+
+---
+
+### Task 2: Create `nix/package.nix`
+
+**Files:**
+- Create: `nix/package.nix`
+
+- [ ] **Step 1: Write `nix/package.nix`**
+
+```nix
+{ lib
+, rustPlatform
+, rocmPackages
+, bun
+, makeWrapper
+, rocmSupport ? true
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hipfire";
+  version = "0.1.20";
+
+  src = lib.cleanSource ./..;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  # The main binaries are cargo [[example]] targets, not [[bin]].
+  # We need a custom build/install phase.
+  buildPhase = ''
+    runHook preBuild
+    cargo build --release --features deltanet \
+      --example daemon --example infer --example infer_hfq \
+      -p hipfire-runtime
+    runHook postBuild
+  '';
+
+  # Skip default install (no [[bin]] targets exist)
+  dontCargoInstall = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install daemon and inference binaries
+    mkdir -p $out/bin
+    cp target/release/examples/daemon $out/bin/hipfire-daemon-unwrapped
+    cp target/release/examples/infer $out/bin/hipfire-infer 2>/dev/null || true
+    cp target/release/examples/infer_hfq $out/bin/hipfire-infer-hfq 2>/dev/null || true
+
+    # Wrap daemon with LD_LIBRARY_PATH for libamdhip64.so dlopen
+    makeWrapper $out/bin/hipfire-daemon-unwrapped $out/bin/hipfire-daemon \
+      ${lib.optionalString rocmSupport
+        "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
+
+    # Install CLI (TypeScript, invoked via bun)
+    mkdir -p $out/share/hipfire/cli
+    cp -r cli/. $out/share/hipfire/cli/
+    # Remove dev artifacts from CLI
+    rm -rf $out/share/hipfire/cli/node_modules \
+           $out/share/hipfire/cli/.gitignore \
+           $out/share/hipfire/cli/tsconfig.json \
+           $out/share/hipfire/cli/bun.lock
+    find $out/share/hipfire/cli/ -maxdepth 1 -type f \
+         \( -name '*.test.ts' -o -name 'test_*.ts' -o -name 'bench_*.ts' \) \
+         -delete 2>/dev/null || true
+
+    # Create hipfire CLI wrapper
+    # The CLI spawns the daemon binary — it looks for it at:
+    #   1. ~/.hipfire/bin/daemon  2. alongside the CLI  3. in PATH
+    # We set HIPFIRE_DAEMON_BIN so the CLI finds our wrapped daemon.
+    makeWrapper ${bun}/bin/bun $out/bin/hipfire \
+      --add-flags "run $out/share/hipfire/cli/index.ts" \
+      --set HIPFIRE_DAEMON_BIN $out/bin/hipfire-daemon \
+      ${lib.optionalString rocmSupport
+        "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "LLM inference for AMD RDNA GPUs";
+    homepage = "https://github.com/Kaden-Schutt/hipfire";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "hipfire";
+  };
+}
+```
+
+**Note:** The CLI discovers the daemon binary in several ways. We set
+`HIPFIRE_DAEMON_BIN` as the env var — **this must be verified during
+implementation**. If the CLI doesn't support this env var, we need to either:
+(a) add it to `cli/index.ts` (small patch), or (b) symlink the daemon to
+`$out/share/hipfire/cli/../bin/daemon` matching the expected relative layout.
+Check `cli/index.ts` for how `bin` is resolved (look for `daemon` spawn path).
+
+- [ ] **Step 2: Test that the derivation evaluates**
+
+Run: `nix eval .#packages.x86_64-linux.default.name 2>&1`
+
+Expected: `"hipfire-0.1.20"` (or eval error pointing to a fixable issue).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nix/package.nix
+git commit -m "feat(nix): add package derivation for hipfire binary + CLI"
+```
+
+---
+
+### Task 3: Create `nix/kernels.nix`
+
+**Files:**
+- Create: `nix/kernels.nix`
+
+- [ ] **Step 1: Write `nix/kernels.nix`**
+
+```nix
+{ lib
+, stdenv
+, rocmPackages
+, gpuTargets ? [ "gfx1100" ]
+}:
+
+stdenv.mkDerivation {
+  pname = "hipfire-kernels";
+  version = "0.1.20";
+
+  src = lib.cleanSource ./..;
+
+  nativeBuildInputs = [
+    rocmPackages.clr           # provides hipcc
+    rocmPackages.llvm.clang    # HIP compilation toolchain
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$TMPDIR
+    bash scripts/compile-kernels.sh ${lib.concatStringsSep " " gpuTargets}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/kernels/compiled
+    for arch in ${lib.concatStringsSep " " gpuTargets}; do
+      if [ -d "kernels/compiled/$arch" ]; then
+        cp -r "kernels/compiled/$arch" "$out/kernels/compiled/"
+      fi
+    done
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Pre-compiled GPU kernels for hipfire";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+}
+```
+
+- [ ] **Step 2: Test that the derivation evaluates**
+
+Run: `nix eval .#packages.x86_64-linux.hipfire-kernels.name 2>&1`
+
+Expected: `"hipfire-kernels-0.1.20"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nix/kernels.nix
+git commit -m "feat(nix): add kernel compilation derivation"
+```
+
+---
+
+### Task 4: Create `nix/dev-shell.nix`
+
+**Files:**
+- Create: `nix/dev-shell.nix`
+
+- [ ] **Step 1: Write `nix/dev-shell.nix`**
+
+```nix
+{ lib
+, mkShell
+, rust-bin
+, rocmPackages
+, bun
+, pkg-config
+, rocmSupport ? true
+}:
+
+mkShell {
+  name = "hipfire-dev";
+
+  nativeBuildInputs = [
+    (rust-bin.stable.latest.default.override {
+      extensions = [ "rust-src" "rust-analyzer" ];
+    })
+    bun
+    pkg-config
+  ] ++ lib.optionals rocmSupport [
+    rocmPackages.clr
+    rocmPackages.rocm-smi
+    rocmPackages.rocminfo
+  ];
+
+  LD_LIBRARY_PATH = lib.optionalString rocmSupport
+    "${rocmPackages.clr}/lib";
+
+  shellHook = ''
+    echo "hipfire dev shell"
+    echo "  rust: $(rustc --version)"
+    echo "  bun:  $(bun --version)"
+    ${lib.optionalString rocmSupport ''
+      echo "  hip:  $(hipcc --version 2>&1 | head -1)"
+    ''}
+  '';
+}
+```
+
+- [ ] **Step 2: Test that the dev shell evaluates**
+
+Run: `nix eval .#devShells.x86_64-linux.default.name 2>&1`
+
+Expected: `"hipfire-dev"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nix/dev-shell.nix
+git commit -m "feat(nix): add development shell with Rust, bun, ROCm"
+```
+
+---
+
+### Task 5: Create `nix/module.nix`
+
+**Files:**
+- Create: `nix/module.nix`
+
+- [ ] **Step 1: Write `nix/module.nix`**
+
+```nix
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.hipfire;
+  configJson = pkgs.writeText "hipfire-config.json"
+    (builtins.toJSON cfg.settings);
+  perModelConfigJson = pkgs.writeText "hipfire-per-model-config.json"
+    (builtins.toJSON cfg.perModelSettings);
+
+  # Build the hipfire package with the user's rocmSupport choice
+  hipfirePkg = cfg.package.override {
+    rocmSupport = cfg.rocmSupport;
+  };
+
+  hipfireKernelsPkg = cfg.kernelsPackage.override {
+    gpuTargets = cfg.gpuTargets;
+  };
+
+  # Home directory for the service
+  homeDir = if cfg.userService then "$HOME" else "/var/lib/hipfire";
+
+  # LD_LIBRARY_PATH for ROCm
+  rocmLdPath = lib.optionalString cfg.rocmSupport
+    "LD_LIBRARY_PATH=${pkgs.rocmPackages.clr}/lib";
+
+  # Merged environment for systemd
+  envList =
+    (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment)
+    ++ lib.optionals cfg.rocmSupport [
+      "LD_LIBRARY_PATH=${pkgs.rocmPackages.clr}/lib"
+    ];
+in
+{
+  options.services.hipfire = {
+
+    enable = lib.mkEnableOption "hipfire inference daemon";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.hipfire;
+      defaultText = lib.literalExpression "pkgs.hipfire";
+      description = "The hipfire package to use.";
+    };
+
+    kernelsPackage = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.hipfire-kernels;
+      defaultText = lib.literalExpression "pkgs.hipfire-kernels";
+      description = "Pre-compiled GPU kernels package.";
+    };
+
+    gpuTargets = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "gfx1100" ];
+      example = [ "gfx1100" "gfx1030" ];
+      description = ''
+        GPU architectures to compile kernels for.
+        Detect yours: grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
+      '';
+    };
+
+    rocmSupport = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Use nixpkgs ROCm libraries (rocmPackages.clr).
+        Set to false to provide your own libamdhip64.so via environment.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 11435;
+      description = "Port for the OpenAI-compatible API server.";
+    };
+
+    modelDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/hipfire/models";
+      description = "Directory containing model files.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = {
+        temperature = 0.3;
+        top_p = 0.8;
+        max_tokens = 512;
+      };
+      description = ''
+        Global configuration written to config.json.
+        See docs/CONFIG.md for all available keys.
+      '';
+    };
+
+    perModelSettings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.attrs;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "qwen3.5:27b" = {
+            max_seq = 16384;
+            kv_cache = "q8";
+          };
+        }
+      '';
+      description = ''
+        Per-model config overrides written to per_model_config.json.
+        Keys are model tags, values are config attrsets.
+      '';
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''
+        { HIPFIRE_KV_MODE = "asym3"; }
+      '';
+      description = "Extra environment variables (HIPFIRE_*) for the daemon.";
+    };
+
+    userService = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Run as a user-level systemd service (systemctl --user)
+        instead of a system service. No dedicated user is created.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "hipfire";
+      description = "User to run the daemon as (system mode only).";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "hipfire";
+      description = "Group to run the daemon as (system mode only).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+
+    # ── System service mode ──────────────────────────────────
+    (lib.mkIf (!cfg.userService) {
+
+      users.users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        extraGroups = [ "video" "render" ];
+        home = "/var/lib/hipfire";
+        createHome = true;
+      };
+      users.groups.${cfg.group} = { };
+
+      # Write config files into the service home on activation
+      systemd.services.hipfire-setup = {
+        description = "hipfire config setup";
+        wantedBy = [ "multi-user.target" ];
+        before = [ "hipfire-precompile.service" "hipfire.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = cfg.user;
+          Group = cfg.group;
+        };
+        script = ''
+          mkdir -p /var/lib/hipfire/.hipfire/bin
+          mkdir -p ${cfg.modelDir}
+          cp -f ${configJson} /var/lib/hipfire/.hipfire/config.json
+          cp -f ${perModelConfigJson} /var/lib/hipfire/.hipfire/per_model_config.json
+
+          # Symlink daemon binary so the CLI can find it at ~/.hipfire/bin/daemon
+          ln -sf ${hipfirePkg}/bin/hipfire-daemon /var/lib/hipfire/.hipfire/bin/daemon
+
+          # Symlink pre-compiled kernels next to the daemon
+          ln -sfn ${hipfireKernelsPkg}/kernels /var/lib/hipfire/.hipfire/bin/kernels
+        '';
+      };
+
+      # Pre-compile any missing kernels on activation
+      systemd.services.hipfire-precompile = {
+        description = "hipfire GPU kernel pre-compilation";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "hipfire-setup.service" ];
+        before = [ "hipfire.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = cfg.user;
+          Group = cfg.group;
+          Environment = envList;
+        };
+        script = ''
+          export HOME=/var/lib/hipfire
+          ${hipfirePkg}/bin/hipfire-daemon --precompile || true
+        '';
+      };
+
+      # Main daemon service
+      systemd.services.hipfire = {
+        description = "hipfire inference daemon";
+        after = [ "network.target" "hipfire-precompile.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${hipfirePkg}/bin/hipfire serve -d";
+          Restart = "on-failure";
+          RestartSec = 5;
+          User = cfg.user;
+          Group = cfg.group;
+          Environment = envList ++ [
+            "HOME=/var/lib/hipfire"
+            "HIPFIRE_PORT=${toString cfg.port}"
+          ];
+          # Hardening
+          ProtectSystem = "strict";
+          ReadWritePaths = [ cfg.modelDir "/var/lib/hipfire" ];
+          NoNewPrivileges = true;
+          DeviceAllow = [ "/dev/kfd rw" "/dev/dri/renderD128 rw" ];
+        };
+      };
+    })
+
+    # ── User service mode ────────────────────────────────────
+    (lib.mkIf cfg.userService {
+
+      systemd.user.services.hipfire-setup = {
+        description = "hipfire config setup (user)";
+        wantedBy = [ "default.target" ];
+        before = [ "hipfire.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          mkdir -p $HOME/.hipfire/bin
+          mkdir -p ${cfg.modelDir}
+          cp -f ${configJson} $HOME/.hipfire/config.json
+          cp -f ${perModelConfigJson} $HOME/.hipfire/per_model_config.json
+          ln -sf ${hipfirePkg}/bin/hipfire-daemon $HOME/.hipfire/bin/daemon
+          ln -sfn ${hipfireKernelsPkg}/kernels $HOME/.hipfire/bin/kernels
+        '';
+      };
+
+      systemd.user.services.hipfire = {
+        description = "hipfire inference daemon (user)";
+        after = [ "hipfire-setup.service" ];
+        wantedBy = [ "default.target" ];
+        serviceConfig = {
+          ExecStart = "${hipfirePkg}/bin/hipfire serve -d";
+          Restart = "on-failure";
+          RestartSec = 5;
+          Environment = envList ++ [
+            "HIPFIRE_PORT=${toString cfg.port}"
+          ];
+        };
+      };
+    })
+  ]);
+}
+```
+
+**Important implementation notes:**
+- The daemon has NO CLI flags except `--precompile`. The CLI (`hipfire serve`)
+  manages config, spawns the daemon, and handles HTTP.
+- Config files are written to `~/.hipfire/` (the CLI reads from `HOME`).
+- The daemon binary is symlinked to `~/.hipfire/bin/daemon` where the CLI
+  expects to find it.
+- Kernel directory is symlinked to `~/.hipfire/bin/kernels/` (the daemon looks
+  for kernels relative to its binary at `<binary_dir>/kernels/compiled/<arch>/`).
+- `HIPFIRE_PORT` env var needs verification — check if `cli/index.ts` reads it.
+  If not, the port must be set in `config.json` under the `port` key (which the
+  setup service already handles via `cfg.settings`).
+
+- [ ] **Step 2: Test that the module evaluates**
+
+Run: `nix eval .#nixosModules.default --apply 'x: builtins.typeOf x' 2>&1`
+
+Expected: `"lambda"` (it's a function, as NixOS modules should be).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add nix/module.nix
+git commit -m "feat(nix): add NixOS module with system and user service modes"
+```
+
+---
+
+### Task 6: Create `docs/NIXOS.md`
+
+**Files:**
+- Create: `docs/NIXOS.md`
+
+- [ ] **Step 1: Write `docs/NIXOS.md`**
+
+```markdown
+# NixOS
+
+hipfire has first-class NixOS support via a Nix flake.
+
+## Prerequisites
+
+- NixOS 24.05+ or nixos-unstable
+- AMD GPU with the `amdgpu` kernel module loaded
+- User in `video` and `render` groups (for non-service usage)
+
+Verify your GPU is visible:
+
+    ls /dev/kfd         # should exist
+    ls /dev/dri/        # should show renderD128+
+
+Detect your GPU architecture:
+
+    grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
+
+## Quick Start
+
+### Development shell
+
+Enter a shell with Rust, bun, hipcc, and ROCm tools:
+
+    nix develop github:Kaden-Schutt/hipfire
+
+This works with any hipfire checkout — the shell provides tools only,
+not the source tree:
+
+    nix develop github:Kaden-Schutt/hipfire
+    cd ~/my-hipfire-fork
+    cargo build --release --features deltanet --example daemon -p hipfire-runtime
+
+### Build from source
+
+    nix build github:Kaden-Schutt/hipfire
+    ./result/bin/hipfire run qwen3.5:9b "Hello"
+
+### Build kernels
+
+    nix build github:Kaden-Schutt/hipfire#hipfire-kernels
+
+## NixOS Module
+
+Add hipfire to your flake inputs and enable the service.
+
+### Minimal example
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hipfire.url = "github:Kaden-Schutt/hipfire";
+  };
+
+  outputs = { nixpkgs, hipfire, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        hipfire.nixosModules.default
+        {
+          nixpkgs.overlays = [ hipfire.overlays.default ];
+          services.hipfire.enable = true;
+          services.hipfire.gpuTargets = [ "gfx1100" ];
+        }
+      ];
+    };
+  };
+}
+```
+
+### Full example
+
+```nix
+services.hipfire = {
+  enable = true;
+  gpuTargets = [ "gfx1100" ];
+
+  # Global config (written to config.json)
+  settings = {
+    temperature = 0.3;
+    top_p = 0.8;
+    max_tokens = 512;
+    kv_cache = "asym3";
+    dflash_mode = "auto";
+    port = 11435;
+    idle_timeout = 300;
+    default_model = "qwen3.5:9b";
+  };
+
+  # Per-model overrides (written to per_model_config.json)
+  perModelSettings = {
+    "qwen3.5:27b" = {
+      max_seq = 16384;
+      kv_cache = "q8";
+      dflash_mode = "on";
+    };
+  };
+
+  # Extra env vars (highest precedence)
+  environment = {
+    HIPFIRE_NORMALIZE_PROMPT = "1";
+  };
+
+  modelDir = "/var/lib/hipfire/models";
+};
+```
+
+### Desktop / user-service mode
+
+For single-user desktop setups, use a user-level systemd service:
+
+```nix
+services.hipfire = {
+  enable = true;
+  userService = true;
+  gpuTargets = [ "gfx1100" ];
+};
+```
+
+Manage with `systemctl --user start hipfire`, `systemctl --user status hipfire`.
+
+Your user must be in `video` and `render` groups:
+
+```nix
+users.users.yourname.extraGroups = [ "video" "render" ];
+```
+
+## GPU Targets
+
+| Arch | Card | Generation |
+|------|------|-----------|
+| gfx906 | Vega 20 / MI50 | GCN5 |
+| gfx908 | MI100 | CDNA |
+| gfx1010 | RX 5700 XT | RDNA1 |
+| gfx1030 | RX 6800 XT | RDNA2 |
+| gfx1100 | RX 7900 XTX | RDNA3 |
+| gfx1151 | Strix Halo | RDNA3.5 |
+| gfx1200 | Radeon R9700 | RDNA4 |
+| gfx1201 | RX 9070 XT | RDNA4 |
+
+Build kernels for multiple arches:
+
+```nix
+services.hipfire.gpuTargets = [ "gfx1100" "gfx1030" ];
+```
+
+## ROCm Configuration
+
+### Default: bundled nixpkgs ROCm
+
+hipfire uses `rocmPackages.clr` from nixpkgs by default.
+`LD_LIBRARY_PATH` is injected automatically via wrapper scripts.
+
+### Bring your own ROCm
+
+```nix
+services.hipfire = {
+  rocmSupport = false;
+  environment = {
+    LD_LIBRARY_PATH = "/opt/rocm/lib";
+  };
+};
+```
+
+### Custom ROCm version via overlay
+
+Override `rocmPackages` in your nixpkgs overlay. The hipfire package
+and module reference `rocmPackages.clr` generically, so overlays
+apply transparently.
+
+## Configuration
+
+hipfire uses a layered config system. Precedence (lowest to highest):
+
+1. Engine defaults (hardcoded)
+2. `config.json` — set via `services.hipfire.settings`
+3. `per_model_config.json` — set via `services.hipfire.perModelSettings`
+4. Environment variables — set via `services.hipfire.environment`
+
+For the full list of config keys, see [CONFIG.md](CONFIG.md).
+
+### Environment variables (interactive use)
+
+For interactive usage outside the systemd service (`hipfire run`, `hipfire chat`),
+set `HIPFIRE_*` variables in your shell profile:
+
+```bash
+# ~/.bashrc or equivalent
+export HIPFIRE_KV_MODE=asym3
+export HIPFIRE_NORMALIZE_PROMPT=1
+```
+
+These only affect the current user's shell sessions, not the systemd service.
+
+## Troubleshooting
+
+### "libamdhip64.so not found"
+
+The HIP runtime library is missing. If using bundled ROCm (`rocmSupport = true`),
+verify `rocmPackages.clr` is available:
+
+    nix build nixpkgs#rocmPackages.clr
+
+If using bring-your-own, check your `LD_LIBRARY_PATH`:
+
+    ls -la /opt/rocm/lib/libamdhip64.so*
+
+### "Permission denied" on /dev/kfd
+
+Your user needs `video` and `render` group membership:
+
+```nix
+users.users.yourname.extraGroups = [ "video" "render" ];
+```
+
+Then rebuild and relogin.
+
+### "No AMD GPU detected"
+
+Check that the amdgpu kernel module is loaded:
+
+    lsmod | grep amdgpu
+
+On NixOS, ensure firmware is available:
+
+```nix
+hardware.firmware = [ pkgs.linux-firmware ];
+# or for AMD specifically:
+hardware.amdgpu.initrd.enable = true;  # NixOS 24.05+
+```
+
+### Kernel pre-compilation fails
+
+Ensure hipcc version matches your GPU target. Check with:
+
+    hipcc --version
+
+gfx1200/gfx1201 requires ROCm 6.4+, gfx1151 requires ROCm 7.2+.
+```
+
+- [ ] **Step 2: Verify doc renders**
+
+Run: `head -5 docs/NIXOS.md`
+
+Expected: The title and first lines of the doc.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/NIXOS.md
+git commit -m "docs: add NixOS installation and configuration guide"
+```
+
+---
+
+### Task 7: Add NixOS section to README.md
+
+**Files:**
+- Modify: `README.md:52` (insert after the Install section's closing line)
+
+- [ ] **Step 1: Add NixOS section to README.md**
+
+Insert after line 52 (`[docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).`) and before line 54 (`## Inspiration: Lucebox`):
+
+```markdown
+
+## NixOS
+
+First-class support via Nix flake. See [docs/NIXOS.md](docs/NIXOS.md).
+
+```bash
+nix develop github:Kaden-Schutt/hipfire  # dev shell with Rust + ROCm + bun
+nix build github:Kaden-Schutt/hipfire    # build package
+```
+
+NixOS module:
+
+```nix
+{
+  inputs.hipfire.url = "github:Kaden-Schutt/hipfire";
+  # then in configuration.nix:
+  services.hipfire.enable = true;
+  services.hipfire.gpuTargets = [ "gfx1100" ];
+}
+```
+
+```
+
+- [ ] **Step 2: Add NIXOS.md to the Documentation table**
+
+In the Documentation table (around line 112 after insertion), add a row:
+
+```markdown
+| [NIXOS.md](docs/NIXOS.md) | NixOS flake, module, dev shell |
+```
+
+Insert after the `GETTING_STARTED.md` row.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add NixOS section to README"
+```
+
+---
+
+### Task 8: Verify flake builds end-to-end
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run `nix flake check`**
+
+Run: `nix flake check 2>&1 | tail -20`
+
+Expected: No errors. Warnings about unchecked packages are acceptable.
+
+- [ ] **Step 2: Test dev shell enters**
+
+Run: `nix develop --command bash -c 'echo "rust: $(rustc --version); bun: $(bun --version)"'`
+
+Expected: Prints Rust and bun versions.
+
+- [ ] **Step 3: Test package build (may take several minutes)**
+
+Run: `nix build .#default 2>&1 | tail -10`
+
+Expected: Builds successfully, creates `./result/bin/hipfire` and `./result/bin/hipfire-daemon`.
+
+- [ ] **Step 4: Test kernel build**
+
+Run: `nix build .#hipfire-kernels 2>&1 | tail -10`
+
+Expected: Builds kernels for default arch, creates `./result/kernels/compiled/gfx1100/`.
+
+- [ ] **Step 5: Verify binary runs**
+
+Run: `./result/bin/hipfire --help 2>&1 | head -10`
+
+Expected: hipfire CLI help output.
+
+- [ ] **Step 6: Commit lock file**
+
+```bash
+git add flake.lock
+git commit -m "chore(nix): add flake.lock"
+```
+
+---
+
+### Task 9: Verify daemon binary discovery
+
+**Files:** Potentially modify `cli/index.ts` if `HIPFIRE_DAEMON_BIN` env var is not supported.
+
+- [ ] **Step 1: Check how CLI finds the daemon binary**
+
+Read `cli/index.ts` and search for how the daemon binary path is resolved.
+Look for references to `daemon`, `bin`, spawn/exec calls.
+
+- [ ] **Step 2: If `HIPFIRE_DAEMON_BIN` is not supported, add it**
+
+In `cli/index.ts`, find the daemon binary resolution logic and add:
+
+```typescript
+// Check HIPFIRE_DAEMON_BIN env var first (for Nix and other package managers)
+const daemonBin = process.env.HIPFIRE_DAEMON_BIN
+  || path.join(hipfireDir, "bin", "daemon");
+```
+
+Use the existing code style and insert at the appropriate location.
+
+- [ ] **Step 3: If changes were made, test the CLI still works**
+
+Run: `HIPFIRE_DAEMON_BIN=./target/release/examples/daemon bun run cli/index.ts --help 2>&1 | head -5`
+
+Expected: CLI help output.
+
+- [ ] **Step 4: Commit if changes were made**
+
+```bash
+git add cli/index.ts
+git commit -m "feat(cli): support HIPFIRE_DAEMON_BIN env var for packaged installs"
+```

--- a/docs/superpowers/specs/2026-05-07-nixos-packaging-design.md
+++ b/docs/superpowers/specs/2026-05-07-nixos-packaging-design.md
@@ -1,0 +1,251 @@
+# NixOS Packaging Design
+
+**Date:** 2026-05-07
+**Status:** Approved
+**Scope:** Nix flake (dev shell + package + NixOS module) + documentation
+
+## Overview
+
+Provide first-class NixOS support for hipfire via a single `flake.nix` at the
+repo root. Users get three entry points:
+
+1. `nix develop` — full dev shell (Rust, bun, ROCm, hipcc)
+2. `nix build` — produces the hipfire package (daemon + CLI + kernels)
+3. `nixosModules.default` — declarative `services.hipfire` system configuration
+
+## File Layout
+
+```
+flake.nix              # inputs, outputs, wiring
+flake.lock
+nix/
+  package.nix          # hipfire binary derivation
+  kernels.nix          # GPU kernel compilation derivation
+  dev-shell.nix        # development shell
+  module.nix           # NixOS module (services.hipfire)
+docs/
+  NIXOS.md             # user-facing installation & configuration guide
+README.md              # add short NixOS section pointing to docs/NIXOS.md
+```
+
+## Flake Inputs
+
+```nix
+inputs = {
+  nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  rust-overlay.url = "github:oxalica/rust-overlay";
+  flake-utils.url = "github:numtide/flake-utils";
+};
+```
+
+## Flake Outputs
+
+- `packages.${system}.default` — hipfire package
+- `packages.${system}.hipfire-kernels` — pre-compiled GPU kernels
+- `devShells.${system}.default` — development shell
+- `nixosModules.default` — NixOS module
+- `overlays.default` — for overlay-based consumption
+
+## Package Derivation (`nix/package.nix`)
+
+Uses `rustPlatform.buildRustPackage`.
+
+**Build inputs:**
+- Rust toolchain (from nixpkgs, not overlay — overlay is dev-shell only)
+- `makeWrapper` for LD_LIBRARY_PATH injection
+
+**Parameters:**
+- `rocmSupport ? true` — wire ROCm libs into wrapper's LD_LIBRARY_PATH
+- `gpuTargets ? [ "gfx1100" ]` — passed to kernel derivation
+
+**Install outputs:**
+- `$out/bin/hipfire-daemon` — wrapped daemon binary
+- `$out/bin/hipfire` — bun wrapper invoking CLI
+- `$out/share/hipfire/cli/` — TypeScript CLI files
+
+**Runtime dependency:** `libamdhip64.so` resolved via `makeWrapper --prefix
+LD_LIBRARY_PATH` when `rocmSupport = true`. hipfire uses bare-soname dlopen
+(`libamdhip64.so`, `.so.7`, `.so.6`, `.so.5`) — no env var override exists on
+Linux, so the wrapper approach is required on NixOS.
+
+**Cargo build flags:**
+```
+cargo build --release --features deltanet \
+  --example daemon --example infer --example infer_hfq \
+  -p hipfire-runtime
+```
+
+## Kernel Derivation (`nix/kernels.nix`)
+
+Separate derivation — kernels need `hipcc` at build time but the Rust binary
+does not.
+
+**Build inputs:**
+- `rocmPackages.clr` (provides hipcc)
+- `rocmPackages.llvm.clang`
+
+**Parameters:**
+- `gpuTargets ? [ "gfx1100" ]` — architectures to compile for
+
+**Build phase:** Invokes existing `scripts/compile-kernels.sh` with the target
+list. The script handles variant-tag resolution, wave64/wave32 selection, and
+parallel compilation.
+
+**Output:** `$out/kernels/compiled/{arch}/*.hsaco` + `.hash` files.
+
+## Dev Shell (`nix/dev-shell.nix`)
+
+Provides the full development environment. Does NOT depend on the hipfire source
+tree — works with any checkout/fork.
+
+**Contents:**
+- Rust stable (via rust-overlay) with rust-src + rust-analyzer
+- Bun (CLI runtime)
+- pkg-config
+- When `rocmSupport = true`: rocmPackages.clr, rocm-smi, rocminfo
+- `LD_LIBRARY_PATH` set for dlopen during `cargo run`
+
+**Usage with different repos:**
+```bash
+nix develop github:Kaden-Schutt/hipfire
+cd ~/my-hipfire-fork
+cargo build --release
+```
+
+## NixOS Module (`nix/module.nix`)
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enable` | bool | false | Enable hipfire service |
+| `package` | package | pkgs.hipfire | Package to use |
+| `kernelsPackage` | package | pkgs.hipfire-kernels | Pre-compiled kernels |
+| `gpuTargets` | listOf str | ["gfx1100"] | GPU architectures |
+| `rocmSupport` | bool | true | Use nixpkgs ROCm libs |
+| `port` | port | 11435 | API listen port |
+| `modelDir` | path | /var/lib/hipfire/models | Model directory |
+| `settings` | attrs | {temperature=0.3, ...} | Global config.json |
+| `perModelSettings` | attrsOf attrs | {} | Per-model overrides |
+| `environment` | attrsOf str | {} | HIPFIRE_* env vars |
+| `userService` | bool | false | User-level systemd unit |
+| `user` | str | "hipfire" | Daemon user (system mode) |
+| `group` | str | "hipfire" | Daemon group (system mode) |
+
+### System Mode (default)
+
+- Creates dedicated `hipfire` user in `video` + `render` groups
+- `systemd.services.hipfire-precompile` — oneshot, runs `daemon --precompile`
+  on activation (before main service)
+- `systemd.services.hipfire` — long-running daemon
+- Hardened: `ProtectSystem=strict`, `NoNewPrivileges=true`,
+  `DeviceAllow=/dev/kfd rw, /dev/dri/* rw`
+- `ReadWritePaths` includes `modelDir` and `/var/lib/hipfire`
+
+### User Service Mode (`userService = true`)
+
+- Creates `systemd.user.services.hipfire` (managed via `systemctl --user`)
+- No dedicated user/group created
+- User must be in `video` + `render` groups themselves
+- Models default to `~/.hipfire/models`
+
+### Config File Generation
+
+- `settings` attrset -> `config.json` (via `pkgs.writeText` + `builtins.toJSON`)
+- `perModelSettings` attrset -> `per_model_config.json`
+- `environment` attrset -> systemd `Environment=` lines
+- Precedence: engine defaults < config.json < per_model_config.json < env vars
+
+### Daemon CLI Flags
+
+**TODO (verify during implementation):** Confirm actual daemon flags for:
+- `--port` (or is it positional / config-only?)
+- `--models` / `--model-dir`
+- `--config` (path to config.json)
+- `--kernels` (path to compiled kernels)
+
+If the daemon reads config.json from `~/.hipfire/` by default, the service may
+need to set `HOME=/var/lib/hipfire` or use an env var to redirect.
+
+## ROCm Dependency Handling
+
+Three modes:
+
+1. **Bundled (default):** `rocmSupport = true` — uses `rocmPackages.clr` from
+   nixpkgs. `LD_LIBRARY_PATH` injected via wrapper/systemd env.
+
+2. **Bring your own:** `rocmSupport = false` — no ROCm from nixpkgs. User sets
+   `LD_LIBRARY_PATH` manually or via `services.hipfire.environment`.
+
+3. **Custom ROCm overlay:** User overrides `rocmPackages` in their nixpkgs
+   overlay to use a different ROCm version. The flake's package/module
+   references `rocmPackages.clr` generically, so overlays just work.
+
+## GPU Target Configuration
+
+Supported architectures (from install.sh):
+| Arch | Card | Generation |
+|------|------|-----------|
+| gfx906 | Vega 20 | GCN5 |
+| gfx908 | MI100 | CDNA |
+| gfx1010 | RX 5700 XT | RDNA1 |
+| gfx1030 | RX 6800 XT | RDNA2 |
+| gfx1100 | RX 7900 XTX | RDNA3 |
+| gfx1151 | Strix Halo | RDNA3.5 |
+| gfx1200 | Radeon R9700 | RDNA4 |
+| gfx1201 | RX 9070 XT | RDNA4 |
+
+`gpuTargets` accepts any subset. Kernels are compiled only for listed arches.
+Detection command: `grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties`
+
+## Documentation (`docs/NIXOS.md`)
+
+Covers:
+- Prerequisites (NixOS version, AMD GPU, firmware, kernel module)
+- Quick start (nix develop, nix build, flake input)
+- NixOS module usage with examples (minimal, full, desktop mode)
+- GPU target configuration with detection instructions
+- Configuration (settings, perModelSettings, environment, precedence)
+- ROCm dependency modes (bundled, BYOD, overlay)
+- Dev shell usage (including different repo/fork workflow)
+- Building from source inside dev shell
+- Troubleshooting (libamdhip64 not found, /dev/kfd permissions, firmware, hipcc mismatch)
+- Environment variables (document that interactive HIPFIRE_* vars go in shell profile)
+
+## README.md Addition
+
+Short section:
+```markdown
+## NixOS
+
+hipfire has first-class NixOS support via a Nix flake. See [docs/NIXOS.md](docs/NIXOS.md).
+
+Quick start:
+```bash
+nix develop github:Kaden-Schutt/hipfire  # dev shell
+nix build github:Kaden-Schutt/hipfire    # build package
+```
+
+For NixOS module usage:
+```nix
+{
+  inputs.hipfire.url = "github:Kaden-Schutt/hipfire";
+
+  # In your configuration.nix:
+  services.hipfire.enable = true;
+  services.hipfire.gpuTargets = [ "gfx1100" ];
+}
+```
+```
+
+## Open Questions (resolve during implementation)
+
+1. **Daemon CLI flags** — verify exact flag names for port, model dir, config
+   path, and kernel path by reading the daemon example source.
+2. **Home directory assumption** — the CLI reads `~/.hipfire/config.json`. In
+   system service mode, need to either set `HOME=/var/lib/hipfire` or symlink.
+3. **Bun in Nix** — verify `pkgs.bun` is available in nixos-unstable and works
+   for the CLI. If not, bundle via fetchurl or use the bun flake.
+4. **Cargo examples as binaries** — `rustPlatform.buildRustPackage` may need a
+   custom `buildPhase`/`installPhase` since the main binaries are `[[example]]`
+   targets, not `[[bin]]`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778123869,
+        "narHash": "sha256-hV9D8ET33kXjdoMXBT2bwM/j8WQM1SP/dVKZtjQKhAQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "592e5dedf04f0eaff1ed0f01ce5db7407d9fc7be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "hipfire — LLM inference for AMD RDNA GPUs";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -20,6 +20,7 @@
           rocmSupport = true;
         };
 
+        # Default target; override via services.hipfire.gpuTargets in NixOS module
         hipfire-kernels = pkgs.callPackage ./nix/kernels.nix {
           gpuTargets = [ "gfx1100" ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    let lib = nixpkgs.lib; in
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ (import rust-overlay) ];
@@ -18,6 +19,8 @@
 
         hipfire = pkgs.callPackage ./nix/package.nix {
           rocmSupport = true;
+          src = lib.cleanSource ./.;
+          cargoLockFile = ./Cargo.lock;
         };
 
         # Default target; override via services.hipfire.gpuTargets in NixOS module
@@ -42,6 +45,8 @@
       overlays.default = final: prev: {
         hipfire = final.callPackage ./nix/package.nix {
           rocmSupport = true;
+          src = lib.cleanSource ./.;
+          cargoLockFile = ./Cargo.lock;
         };
         hipfire-kernels = final.callPackage ./nix/kernels.nix {
           gpuTargets = [ "gfx1100" ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "hipfire — LLM inference for AMD RDNA GPUs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        hipfire = pkgs.callPackage ./nix/package.nix {
+          rocmSupport = true;
+        };
+
+        hipfire-kernels = pkgs.callPackage ./nix/kernels.nix {
+          gpuTargets = [ "gfx1100" ];
+        };
+      in
+      {
+        packages = {
+          default = hipfire;
+          inherit hipfire hipfire-kernels;
+        };
+
+        devShells.default = pkgs.callPackage ./nix/dev-shell.nix {
+          rust-bin = pkgs.rust-bin;
+          rocmSupport = true;
+        };
+      }
+    ) // {
+      nixosModules.default = import ./nix/module.nix;
+
+      overlays.default = final: prev: {
+        hipfire = final.callPackage ./nix/package.nix {
+          rocmSupport = true;
+        };
+        hipfire-kernels = final.callPackage ./nix/kernels.nix {
+          gpuTargets = [ "gfx1100" ];
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "hipfire — LLM inference for AMD RDNA GPUs";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,13 @@
           cargoLockFile = ./Cargo.lock;
         };
 
-        # Default target; override via services.hipfire.gpuTargets in NixOS module
+        # Default to no precompiled kernels — daemon JIT-compiles on first
+        # use. Override via `services.hipfire.gpuTargets` in NixOS module
+        # (e.g. `lib.mkForce [ "gfx1010" ]`) or pass an override to
+        # `hipfire-kernels` in your own flake. Empty default avoids the
+        # silent footgun where 5700-XT users build gfx1100 kernels.
         hipfire-kernels = pkgs.callPackage ./nix/kernels.nix {
-          gpuTargets = [ "gfx1100" ];
+          gpuTargets = [];
         };
       in
       {
@@ -49,7 +53,7 @@
           cargoLockFile = ./Cargo.lock;
         };
         hipfire-kernels = final.callPackage ./nix/kernels.nix {
-          gpuTargets = [ "gfx1100" ];
+          gpuTargets = [];  # JIT by default; override per-host
         };
       };
     };

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -1,0 +1,36 @@
+{ lib
+, mkShell
+, rust-bin
+, rocmPackages
+, bun
+, pkg-config
+, rocmSupport ? true
+}:
+
+mkShell {
+  name = "hipfire-dev";
+
+  nativeBuildInputs = [
+    (rust-bin.stable.latest.default.override {
+      extensions = [ "rust-src" "rust-analyzer" ];
+    })
+    bun
+    pkg-config
+  ] ++ lib.optionals rocmSupport [
+    rocmPackages.clr
+    rocmPackages.rocm-smi
+    rocmPackages.rocminfo
+  ];
+
+  LD_LIBRARY_PATH = lib.optionalString rocmSupport
+    "${rocmPackages.clr}/lib";
+
+  shellHook = ''
+    echo "hipfire dev shell"
+    echo "  rust: $(rustc --version)"
+    echo "  bun:  $(bun --version)"
+    ${lib.optionalString rocmSupport ''
+      echo "  hip:  $(hipcc --version 2>&1 | head -1)"
+    ''}
+  '';
+}

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -22,8 +22,18 @@ mkShell {
     rocmPackages.rocminfo
   ];
 
+  # Match package.nix + module.nix runtime closure: clr alone is not
+  # enough — the daemon dlopens libamdhip64 / rocm-runtime / rocm-comgr /
+  # rocprofiler-register at startup. Without the full set, `nix develop`
+  # cannot run the daemon ("no ROCm-capable device detected" at
+  # initialization). lib.makeLibraryPath stitches the lib/ subdirs.
   LD_LIBRARY_PATH = lib.optionalString rocmSupport
-    "${rocmPackages.clr}/lib";
+    (lib.makeLibraryPath [
+      rocmPackages.clr
+      rocmPackages.rocm-runtime
+      rocmPackages.rocm-comgr
+      rocmPackages.rocprofiler-register
+    ]);
 
   shellHook = ''
     echo "hipfire dev shell"

--- a/nix/kernels.nix
+++ b/nix/kernels.nix
@@ -4,11 +4,15 @@
 , gpuTargets ? [ "gfx1100" ]
 }:
 
+let
+  src = lib.cleanSource ./..;
+  cargoToml = builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"));
+in
 stdenv.mkDerivation {
   pname = "hipfire-kernels";
-  version = "0.1.20";
+  version = cargoToml.workspace.package.version or cargoToml.package.version;
 
-  src = lib.cleanSource ./..;
+  inherit src;
 
   nativeBuildInputs = [
     rocmPackages.clr
@@ -18,7 +22,11 @@ stdenv.mkDerivation {
   buildPhase = ''
     runHook preBuild
     export HOME=$TMPDIR
-    bash scripts/compile-kernels.sh ${lib.concatStringsSep " " gpuTargets}
+    # Allow partial failures — some kernels are arch-specific and won't
+    # compile for every target. The daemon JIT-compiles missing kernels.
+    bash scripts/compile-kernels.sh ${lib.concatStringsSep " " gpuTargets} || {
+      echo "WARNING: some kernels failed to compile (see above). Daemon will JIT-compile them on first use."
+    }
     runHook postBuild
   '';
 

--- a/nix/kernels.nix
+++ b/nix/kernels.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, rocmPackages
+, gpuTargets ? [ "gfx1100" ]
+}:
+
+stdenv.mkDerivation {
+  pname = "hipfire-kernels";
+  version = "0.1.20";
+
+  src = lib.cleanSource ./..;
+
+  nativeBuildInputs = [
+    rocmPackages.clr
+    rocmPackages.llvm.clang
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$TMPDIR
+    bash scripts/compile-kernels.sh ${lib.concatStringsSep " " gpuTargets}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/kernels/compiled
+    for arch in ${lib.concatStringsSep " " gpuTargets}; do
+      if [ -d "kernels/compiled/$arch" ]; then
+        cp -r "kernels/compiled/$arch" "$out/kernels/compiled/"
+      fi
+    done
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Pre-compiled GPU kernels for hipfire";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/nix/kernels.nix
+++ b/nix/kernels.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , rocmPackages
-, gpuTargets ? [ "gfx1100" ]
+, gpuTargets ? []
 }:
 
 let

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -62,6 +62,12 @@ in
 
     enable = lib.mkEnableOption "hipfire inference daemon";
 
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the API port in the firewall.";
+    };
+
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.hipfire;
@@ -295,6 +301,10 @@ in
 
     # Expose the CLI globally so `hipfire pull`, `hipfire diag`, etc. work
     { environment.systemPackages = [ hipfirePkg ]; }
+
+    (lib.mkIf cfg.openFirewall {
+      networking.firewall.allowedTCPPorts = [ cfg.port ];
+    })
 
     # ── System service mode ──────────────────────────────────
     (lib.mkIf (!cfg.userService) {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -22,7 +22,23 @@ let
   perModelConfigJson = pkgs.writeText "hipfire-per-model-config.json"
     (builtins.toJSON cfg.perModelSettings);
 
-  hipfirePkg = cfg.package;
+  # Resolve source: explicit src > github.rev > package default
+  effectiveSrc =
+    if cfg.src != null then cfg.src
+    else if cfg.github.rev != null then
+      pkgs.fetchFromGitHub {
+        owner = cfg.github.owner;
+        repo = cfg.github.repo;
+        rev = cfg.github.rev;
+        hash = cfg.github.hash;
+      }
+    else null;
+
+  hipfirePkg =
+    if effectiveSrc != null then
+      cfg.package.override { src = effectiveSrc; cargoLockFile = "${effectiveSrc}/Cargo.lock"; }
+    else
+      cfg.package;
   hipfireKernelsPkg =
     if cfg.kernelsPackage == pkgs.hipfire-kernels
     then cfg.kernelsPackage.override { gpuTargets = cfg.gpuTargets; }
@@ -44,6 +60,51 @@ in
       default = pkgs.hipfire;
       defaultText = lib.literalExpression "pkgs.hipfire";
       description = "The hipfire package to use.";
+    };
+
+    src = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Custom source tree for building hipfire. Overrides the package's
+        default source. Set this directly, or use the github.* options
+        for convenience.
+      '';
+    };
+
+    github = {
+      owner = lib.mkOption {
+        type = lib.types.str;
+        default = "Kaden-Schutt";
+        description = "GitHub repository owner.";
+      };
+
+      repo = lib.mkOption {
+        type = lib.types.str;
+        default = "hipfire";
+        description = "GitHub repository name.";
+      };
+
+      rev = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "master";
+        description = ''
+          Git revision to build from (branch name, tag, or commit hash).
+          When set, fetches the source from GitHub instead of using the
+          local flake source. Takes precedence unless src is also set.
+        '';
+      };
+
+      hash = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        example = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        description = ''
+          SRI hash of the fetched source. Required when github.rev is set.
+          Set to "" and build once to get the correct hash from the error.
+        '';
+      };
     };
 
     kernelsPackage = lib.mkOption {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,8 +47,14 @@ let
 
   envList =
     (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment)
+    ++ [ "HIPFIRE_MODELS_DIR=${cfg.modelDir}" ]
     ++ lib.optionals cfg.rocmSupport [
-      "LD_LIBRARY_PATH=${pkgs.rocmPackages.clr}/lib"
+      "LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
+        pkgs.rocmPackages.clr
+        pkgs.rocmPackages.rocm-runtime
+        pkgs.rocmPackages.rocm-comgr
+        pkgs.rocmPackages.rocprofiler-register
+      ]}"
     ];
 in
 {
@@ -236,7 +242,10 @@ in
     modelDir = lib.mkOption {
       type = lib.types.str;
       default = "/var/lib/hipfire/models";
-      description = "Directory containing model files.";
+      description = ''
+        Directory containing model files (.mq4, .hfq6, etc.).
+        The CLI and daemon resolve models from this path via HIPFIRE_MODELS_DIR.
+      '';
     };
 
     environment = lib.mkOption {
@@ -283,6 +292,9 @@ in
         '';
       }];
     }
+
+    # Expose the CLI globally so `hipfire pull`, `hipfire diag`, etc. work
+    { environment.systemPackages = [ hipfirePkg ]; }
 
     # ── System service mode ──────────────────────────────────
     (lib.mkIf (!cfg.userService) {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -362,6 +362,7 @@ in
         description = "hipfire inference daemon";
         after = [ "network.target" "hipfire-precompile.service" ];
         wantedBy = [ "multi-user.target" ];
+        path = lib.optionals cfg.rocmSupport [ pkgs.rocmPackages.clr ];
         serviceConfig = {
           ExecStart = "${hipfirePkg}/bin/hipfire serve";
           Restart = "on-failure";
@@ -405,6 +406,7 @@ in
         description = "hipfire inference daemon (user)";
         after = [ "hipfire-setup.service" ];
         wantedBy = [ "default.target" ];
+        path = lib.optionals cfg.rocmSupport [ pkgs.rocmPackages.clr ];
         serviceConfig = {
           ExecStart = "${hipfirePkg}/bin/hipfire serve";
           Restart = "on-failure";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -10,9 +10,10 @@ let
     (builtins.toJSON cfg.perModelSettings);
 
   hipfirePkg = cfg.package;
-  hipfireKernelsPkg = cfg.kernelsPackage.override {
-    gpuTargets = cfg.gpuTargets;
-  };
+  hipfireKernelsPkg =
+    if cfg.kernelsPackage == pkgs.hipfire-kernels
+    then cfg.kernelsPackage.override { gpuTargets = cfg.gpuTargets; }
+    else cfg.kernelsPackage;
 
   envList =
     (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment)
@@ -202,7 +203,7 @@ in
           ProtectSystem = "strict";
           ReadWritePaths = [ cfg.modelDir "/var/lib/hipfire" ];
           NoNewPrivileges = true;
-          PrivateDevices = true;
+          DevicePolicy = "closed";
           DeviceAllow = [ "/dev/kfd rw" "/dev/dri rw" "/dev/dri/* rw" ];
         };
       };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -10,7 +10,9 @@ let
     (builtins.toJSON cfg.perModelSettings);
 
   hipfirePkg = cfg.package;
-  hipfireKernelsPkg = cfg.kernelsPackage;
+  hipfireKernelsPkg = cfg.kernelsPackage.override {
+    gpuTargets = cfg.gpuTargets;
+  };
 
   envList =
     (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment)
@@ -178,7 +180,9 @@ in
         };
         script = ''
           export HOME=/var/lib/hipfire
-          ${hipfirePkg}/bin/hipfire-daemon --precompile || true
+          if ! ${hipfirePkg}/bin/hipfire-daemon --precompile; then
+            echo "WARNING: kernel pre-compilation failed (exit $?). Daemon will JIT-compile on first request." >&2
+          fi
         '';
       };
 
@@ -198,7 +202,8 @@ in
           ProtectSystem = "strict";
           ReadWritePaths = [ cfg.modelDir "/var/lib/hipfire" ];
           NoNewPrivileges = true;
-          DeviceAllow = [ "/dev/kfd rw" "/dev/dri/renderD128 rw" ];
+          PrivateDevices = true;
+          DeviceAllow = [ "/dev/kfd rw" "/dev/dri rw" "/dev/dri/* rw" ];
         };
       };
     })

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,240 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.hipfire;
+
+  settingsWithPort = cfg.settings // { port = cfg.port; };
+  configJson = pkgs.writeText "hipfire-config.json"
+    (builtins.toJSON settingsWithPort);
+  perModelConfigJson = pkgs.writeText "hipfire-per-model-config.json"
+    (builtins.toJSON cfg.perModelSettings);
+
+  hipfirePkg = cfg.package;
+  hipfireKernelsPkg = cfg.kernelsPackage;
+
+  envList =
+    (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.environment)
+    ++ lib.optionals cfg.rocmSupport [
+      "LD_LIBRARY_PATH=${pkgs.rocmPackages.clr}/lib"
+    ];
+in
+{
+  options.services.hipfire = {
+
+    enable = lib.mkEnableOption "hipfire inference daemon";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.hipfire;
+      defaultText = lib.literalExpression "pkgs.hipfire";
+      description = "The hipfire package to use.";
+    };
+
+    kernelsPackage = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.hipfire-kernels;
+      defaultText = lib.literalExpression "pkgs.hipfire-kernels";
+      description = "Pre-compiled GPU kernels package.";
+    };
+
+    gpuTargets = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "gfx1100" ];
+      example = [ "gfx1100" "gfx1030" ];
+      description = ''
+        GPU architectures to compile kernels for.
+        Detect yours: grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
+      '';
+    };
+
+    rocmSupport = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Use nixpkgs ROCm libraries (rocmPackages.clr).
+        Set to false to provide your own libamdhip64.so via environment.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 11435;
+      description = "Port for the OpenAI-compatible API server.";
+    };
+
+    modelDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/hipfire/models";
+      description = "Directory containing model files.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = {
+        temperature = 0.3;
+        top_p = 0.8;
+        max_tokens = 512;
+      };
+      description = ''
+        Global configuration written to config.json.
+        See docs/CONFIG.md for all available keys.
+        Note: the 'port' key is managed by services.hipfire.port.
+      '';
+    };
+
+    perModelSettings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.attrs;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "qwen3.5:27b" = {
+            max_seq = 16384;
+            kv_cache = "q8";
+          };
+        }
+      '';
+      description = ''
+        Per-model config overrides written to per_model_config.json.
+        Keys are model tags, values are config attrsets.
+      '';
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''
+        { HIPFIRE_KV_MODE = "asym3"; }
+      '';
+      description = "Extra environment variables (HIPFIRE_*) for the daemon.";
+    };
+
+    userService = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Run as a user-level systemd service (systemctl --user)
+        instead of a system service. No dedicated user is created.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "hipfire";
+      description = "User to run the daemon as (system mode only).";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "hipfire";
+      description = "Group to run the daemon as (system mode only).";
+    };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+
+    # ── System service mode ──────────────────────────────────
+    (lib.mkIf (!cfg.userService) {
+
+      users.users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        extraGroups = [ "video" "render" ];
+        home = "/var/lib/hipfire";
+        createHome = true;
+      };
+      users.groups.${cfg.group} = { };
+
+      systemd.services.hipfire-setup = {
+        description = "hipfire config setup";
+        wantedBy = [ "multi-user.target" ];
+        before = [ "hipfire-precompile.service" "hipfire.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = cfg.user;
+          Group = cfg.group;
+        };
+        script = ''
+          mkdir -p /var/lib/hipfire/.hipfire/bin
+          mkdir -p ${lib.escapeShellArg cfg.modelDir}
+          cp -f ${configJson} /var/lib/hipfire/.hipfire/config.json
+          cp -f ${perModelConfigJson} /var/lib/hipfire/.hipfire/per_model_config.json
+          ln -sf ${hipfirePkg}/bin/hipfire-daemon /var/lib/hipfire/.hipfire/bin/daemon
+          ln -sfn ${hipfireKernelsPkg}/kernels /var/lib/hipfire/.hipfire/bin/kernels
+        '';
+      };
+
+      systemd.services.hipfire-precompile = {
+        description = "hipfire GPU kernel pre-compilation";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "hipfire-setup.service" ];
+        before = [ "hipfire.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = cfg.user;
+          Group = cfg.group;
+          Environment = envList;
+        };
+        script = ''
+          export HOME=/var/lib/hipfire
+          ${hipfirePkg}/bin/hipfire-daemon --precompile || true
+        '';
+      };
+
+      systemd.services.hipfire = {
+        description = "hipfire inference daemon";
+        after = [ "network.target" "hipfire-precompile.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${hipfirePkg}/bin/hipfire serve";
+          Restart = "on-failure";
+          RestartSec = 5;
+          User = cfg.user;
+          Group = cfg.group;
+          Environment = envList ++ [
+            "HOME=/var/lib/hipfire"
+          ];
+          ProtectSystem = "strict";
+          ReadWritePaths = [ cfg.modelDir "/var/lib/hipfire" ];
+          NoNewPrivileges = true;
+          DeviceAllow = [ "/dev/kfd rw" "/dev/dri/renderD128 rw" ];
+        };
+      };
+    })
+
+    # ── User service mode ────────────────────────────────────
+    (lib.mkIf cfg.userService {
+
+      systemd.user.services.hipfire-setup = {
+        description = "hipfire config setup (user)";
+        wantedBy = [ "default.target" ];
+        before = [ "hipfire.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          mkdir -p $HOME/.hipfire/bin
+          mkdir -p ${lib.escapeShellArg cfg.modelDir}
+          cp -f ${configJson} $HOME/.hipfire/config.json
+          cp -f ${perModelConfigJson} $HOME/.hipfire/per_model_config.json
+          ln -sf ${hipfirePkg}/bin/hipfire-daemon $HOME/.hipfire/bin/daemon
+          ln -sfn ${hipfireKernelsPkg}/kernels $HOME/.hipfire/bin/kernels
+        '';
+      };
+
+      systemd.user.services.hipfire = {
+        description = "hipfire inference daemon (user)";
+        after = [ "hipfire-setup.service" ];
+        wantedBy = [ "default.target" ];
+        serviceConfig = {
+          ExecStart = "${hipfirePkg}/bin/hipfire serve";
+          Restart = "on-failure";
+          RestartSec = 5;
+          Environment = envList;
+        };
+      };
+    })
+  ]);
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -3,6 +3,7 @@
 let
   cfg = config.services.hipfire;
 
+
   # Build config.json from typed options — camelCase NixOS options → snake_case JSON keys
   configAttrs = {
     port = cfg.port;
@@ -116,11 +117,16 @@ in
 
     gpuTargets = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "gfx1100" ];
+      default = [ ];
       example = [ "gfx1100" "gfx1030" ];
       description = ''
-        GPU architectures to compile kernels for.
-        Detect yours: grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
+        GPU architectures to compile kernels for. Must be set explicitly —
+        Nix cannot probe hardware at evaluation time.
+
+        Detect yours:
+          rocminfo 2>/dev/null | grep -oP 'amdgcn-amd-amdhsa--\K\S+' | sort -u
+        or:
+          grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
       '';
     };
 
@@ -265,6 +271,18 @@ in
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
+
+    {
+      assertions = [{
+        assertion = cfg.gpuTargets != [ ];
+        message = ''
+          services.hipfire.gpuTargets is empty. Set it to your GPU architecture(s).
+          Detect yours by running:
+            rocminfo 2>/dev/null | grep -oP 'amdgcn-amd-amdhsa--\K\S+' | sort -u
+          Example: services.hipfire.gpuTargets = [ "gfx1100" ];
+        '';
+      }];
+    }
 
     # ── System service mode ──────────────────────────────────
     (lib.mkIf (!cfg.userService) {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -3,9 +3,22 @@
 let
   cfg = config.services.hipfire;
 
-  settingsWithPort = cfg.settings // { port = cfg.port; };
+  # Build config.json from typed options — camelCase NixOS options → snake_case JSON keys
+  configAttrs = {
+    port = cfg.port;
+    default_model = cfg.defaultModel;
+    temperature = cfg.temperature;
+    top_p = cfg.topP;
+    max_tokens = cfg.maxTokens;
+    max_seq = cfg.maxSeq;
+    repeat_penalty = cfg.repeatPenalty;
+    kv_cache = cfg.kvCache;
+    dflash_mode = cfg.dflashMode;
+    idle_timeout = cfg.idleTimeout;
+  } // cfg.extraSettings;
+
   configJson = pkgs.writeText "hipfire-config.json"
-    (builtins.toJSON settingsWithPort);
+    (builtins.toJSON configAttrs);
   perModelConfigJson = pkgs.writeText "hipfire-per-model-config.json"
     (builtins.toJSON cfg.perModelSettings);
 
@@ -59,31 +72,80 @@ in
       '';
     };
 
+    # ── Inference settings (written to config.json) ──────────
+
     port = lib.mkOption {
       type = lib.types.port;
       default = 11435;
       description = "Port for the OpenAI-compatible API server.";
     };
 
-    modelDir = lib.mkOption {
+    defaultModel = lib.mkOption {
       type = lib.types.str;
-      default = "/var/lib/hipfire/models";
-      description = "Directory containing model files.";
+      default = "";
+      example = "qwen3.5:27b";
+      description = "Model to pre-warm on startup. Empty = none.";
     };
 
-    settings = lib.mkOption {
-      type = lib.types.attrs;
-      default = {
-        temperature = 0.3;
-        top_p = 0.8;
-        max_tokens = 512;
-      };
+    temperature = lib.mkOption {
+      type = lib.types.float;
+      default = 0.3;
+      description = "Sampling temperature.";
+    };
+
+    topP = lib.mkOption {
+      type = lib.types.float;
+      default = 0.8;
+      description = "Nucleus sampling threshold.";
+    };
+
+    maxTokens = lib.mkOption {
+      type = lib.types.int;
+      default = 512;
+      description = "Per-request token cap.";
+    };
+
+    maxSeq = lib.mkOption {
+      type = lib.types.int;
+      default = 32768;
+      description = "KV cache physical capacity (tokens).";
+    };
+
+    repeatPenalty = lib.mkOption {
+      type = lib.types.float;
+      default = 1.05;
+      description = "Repetition penalty. Keep conservative — 1.3+ causes MQ4 gibberish at low temp.";
+    };
+
+    kvCache = lib.mkOption {
+      type = lib.types.str;
+      default = "auto";
+      example = "asym3";
+      description = "KV cache quantization mode: auto / q8 / asym4 / asym3 / asym2 / turbo / turbo4 / turbo3 / turbo2.";
+    };
+
+    dflashMode = lib.mkOption {
+      type = lib.types.enum [ "on" "off" "auto" ];
+      default = "off";
+      description = "DFlash speculative decode: on / off / auto.";
+    };
+
+    idleTimeout = lib.mkOption {
+      type = lib.types.int;
+      default = 300;
+      description = "Seconds before evicting loaded model from VRAM. 0 = never.";
+    };
+
+    extraSettings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = { };
       description = ''
-        Global configuration written to config.json.
-        See docs/CONFIG.md for all available keys.
-        Note: the 'port' key is managed by services.hipfire.port.
+        Additional config.json keys (snake_case) not covered by dedicated options.
+        These are merged last and can override typed options.
       '';
     };
+
+    # ── Per-model overrides ──────────────────────────────────
 
     perModelSettings = lib.mkOption {
       type = lib.types.attrsOf lib.types.attrs;
@@ -98,8 +160,16 @@ in
       '';
       description = ''
         Per-model config overrides written to per_model_config.json.
-        Keys are model tags, values are config attrsets.
+        Keys are model tags, values are config attrsets (snake_case keys).
       '';
+    };
+
+    # ── Runtime / service options ────────────────────────────
+
+    modelDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/hipfire/models";
+      description = "Directory containing model files.";
     };
 
     environment = lib.mkOption {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -41,7 +41,12 @@ rustPlatform.buildRustPackage {
     cp target/release/examples/daemon $out/bin/hipfire-daemon-unwrapped
     makeWrapper $out/bin/hipfire-daemon-unwrapped $out/bin/hipfire-daemon \
       ${lib.optionalString rocmSupport
-        "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
+        "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+          rocmPackages.clr
+          rocmPackages.rocm-runtime
+          rocmPackages.rocm-comgr
+          rocmPackages.rocprofiler-register
+        ]}"}
 
     # Install other binaries
     cp target/release/examples/infer $out/bin/hipfire-infer 2>/dev/null || true
@@ -65,7 +70,12 @@ rustPlatform.buildRustPackage {
       --add-flags "run $out/share/hipfire/cli/index.ts" \
       --set HIPFIRE_DAEMON_BIN $out/bin/hipfire-daemon \
       ${lib.optionalString rocmSupport
-        "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
+        "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+          rocmPackages.clr
+          rocmPackages.rocm-runtime
+          rocmPackages.rocm-comgr
+          rocmPackages.rocprofiler-register
+        ]}"}
 
     runHook postInstall
   '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,14 +4,16 @@
 , bun
 , makeWrapper
 , rocmSupport ? true
+, src ? lib.cleanSource ./..
+, cargoLockFile ? ../Cargo.lock
 }:
 
 rustPlatform.buildRustPackage {
   pname = "hipfire";
   version = "0.1.20";
 
-  src = lib.cleanSource ./..;
-  cargoLock.lockFile = ../Cargo.lock;
+  inherit src;
+  cargoLock.lockFile = cargoLockFile;
   doCheck = false;  # tests require GPU
 
   # The main binaries are cargo [[example]] targets, not [[bin]].

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -53,16 +53,11 @@ rustPlatform.buildRustPackage {
          \( -name '*.test.ts' -o -name 'test_*.ts' -o -name 'bench_*.ts' \) \
          -delete 2>/dev/null || true
 
-    # Create symlink so CLI finds daemon via its relative path resolution:
-    # CLI __dirname = $out/share/hipfire/cli/
-    # CLI checks: resolve(__dirname, "../target/release/examples/daemon")
-    # = $out/share/hipfire/target/release/examples/daemon
-    mkdir -p $out/share/hipfire/target/release/examples
-    ln -s $out/bin/hipfire-daemon $out/share/hipfire/target/release/examples/daemon
-
     # Create hipfire CLI wrapper
+    # HIPFIRE_DAEMON_BIN tells the CLI where to find the wrapped daemon
     makeWrapper ${bun}/bin/bun $out/bin/hipfire \
       --add-flags "run $out/share/hipfire/cli/index.ts" \
+      --set HIPFIRE_DAEMON_BIN $out/bin/hipfire-daemon \
       ${lib.optionalString rocmSupport
         "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,9 +8,12 @@
 , cargoLockFile ? ../Cargo.lock
 }:
 
+let
+  cargoToml = builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"));
+in
 rustPlatform.buildRustPackage {
   pname = "hipfire";
-  version = "0.1.20";
+  version = cargoToml.workspace.package.version or cargoToml.package.version;
 
   inherit src;
   cargoLock.lockFile = cargoLockFile;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,79 @@
+{ lib
+, rustPlatform
+, rocmPackages
+, bun
+, makeWrapper
+, rocmSupport ? true
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hipfire";
+  version = "0.1.20";
+
+  src = lib.cleanSource ./..;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  # The main binaries are cargo [[example]] targets, not [[bin]].
+  buildPhase = ''
+    runHook preBuild
+    cargo build --release --features deltanet \
+      --example daemon --example infer --example infer_hfq \
+      -p hipfire-runtime
+    runHook postBuild
+  '';
+
+  dontCargoInstall = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    # Install and wrap daemon binary with LD_LIBRARY_PATH for libamdhip64.so dlopen
+    cp target/release/examples/daemon $out/bin/hipfire-daemon-unwrapped
+    makeWrapper $out/bin/hipfire-daemon-unwrapped $out/bin/hipfire-daemon \
+      ${lib.optionalString rocmSupport
+        "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
+
+    # Install other binaries
+    cp target/release/examples/infer $out/bin/hipfire-infer 2>/dev/null || true
+    cp target/release/examples/infer_hfq $out/bin/hipfire-infer-hfq 2>/dev/null || true
+
+    # Install CLI (TypeScript, invoked via bun)
+    mkdir -p $out/share/hipfire/cli
+    cp -r cli/. $out/share/hipfire/cli/
+    # Remove dev artifacts
+    rm -rf $out/share/hipfire/cli/node_modules \
+           $out/share/hipfire/cli/.gitignore \
+           $out/share/hipfire/cli/tsconfig.json \
+           $out/share/hipfire/cli/bun.lock
+    find $out/share/hipfire/cli/ -maxdepth 1 -type f \
+         \( -name '*.test.ts' -o -name 'test_*.ts' -o -name 'bench_*.ts' \) \
+         -delete 2>/dev/null || true
+
+    # Create symlink so CLI finds daemon via its relative path resolution:
+    # CLI __dirname = $out/share/hipfire/cli/
+    # CLI checks: resolve(__dirname, "../target/release/examples/daemon")
+    # = $out/share/hipfire/target/release/examples/daemon
+    mkdir -p $out/share/hipfire/target/release/examples
+    ln -s $out/bin/hipfire-daemon $out/share/hipfire/target/release/examples/daemon
+
+    # Create hipfire CLI wrapper
+    makeWrapper ${bun}/bin/bun $out/bin/hipfire \
+      --add-flags "run $out/share/hipfire/cli/index.ts" \
+      ${lib.optionalString rocmSupport
+        "--prefix LD_LIBRARY_PATH : ${rocmPackages.clr}/lib"}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "LLM inference for AMD RDNA GPUs";
+    homepage = "https://github.com/Kaden-Schutt/hipfire";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "hipfire";
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,6 +12,7 @@ rustPlatform.buildRustPackage {
 
   src = lib.cleanSource ./..;
   cargoLock.lockFile = ../Cargo.lock;
+  doCheck = false;  # tests require GPU
 
   # The main binaries are cargo [[example]] targets, not [[bin]].
   buildPhase = ''

--- a/scripts/compile-kernels.sh
+++ b/scripts/compile-kernels.sh
@@ -25,9 +25,9 @@ echo "Source: $SRC_DIR"
 echo "Architectures: ${ARCHS[*]}"
 echo "Parallel jobs: $JOBS"
 
-# Variant-tag regex: matches .gfxNNNN. (chip, e.g. .gfx1201.) and .gfxNN.
-# (family, e.g. .gfx12.). Files matching this are treated as overrides for
-# their parent name, not as independent kernels.
+# Variant-tag regex: matches .gfxNNNN.hip (chip, e.g. .gfx1201.hip) and
+# .gfxNN.hip (family, e.g. .gfx12.hip). Files matching this are treated as
+# overrides for their parent name, not as independent kernels.
 VARIANT_TAG_RE='\.gfx[0-9]+\.hip$'
 
 # ── Phase 1: enumerate jobs ──────────────────────────────────────────────
@@ -67,7 +67,7 @@ for arch in "${ARCHS[@]}"; do
         # gfx906-specific kernels (sdot4 dp4a, etc.) only build on gfx906.
         if [ "$arch" != "gfx906" ]; then
             case "$name" in
-                *_gfx906)
+                *_gfx906|*_gfx906_*|*_dp4a)
                     echo "  - $name SKIP (gfx906-only)"
                     continue
                     ;;


### PR DESCRIPTION
## Summary

- Add `flake.nix` with dev shell (`nix develop`), package derivation (`nix build`), and NixOS module (`services.hipfire`)
- Pre-compiled GPU kernels as a separate derivation (`nix build .#hipfire-kernels`) with configurable `gpuTargets`
- ROCm support toggle — bundled nixpkgs ROCm by default, bring-your-own option
- System and user service modes with systemd hardening
- `HIPFIRE_DAEMON_BIN` env var for CLI daemon discovery in packaged installs
- Full docs at `docs/NIXOS.md` + README section

## Files

```
flake.nix, flake.lock
nix/package.nix, nix/kernels.nix, nix/dev-shell.nix, nix/module.nix
docs/NIXOS.md, README.md (updated)
cli/index.ts (+2 lines: HIPFIRE_DAEMON_BIN support)
```

## Verified on NixOS 25.11 (Strix Halo gfx1151)

- `nix flake check` passes
- `nix develop` provides Rust 1.95, Bun 1.3, HIP 7.2
- `nix build` produces working daemon + CLI
- `hipfire --help`, `hipfire diag` work from Nix package
- Installed system-wide via overlay, tested end-to-end

## Test plan

- [x] `nix flake check` — all outputs evaluate
- [x] `nix develop` — shell with Rust, bun, hipcc
- [x] `nix build` — produces hipfire CLI + daemon with ROCm wrappers
- [x] `hipfire diag` — detects GPU, HIP version, driver
- [x] NixOS rebuild with overlay — package installs system-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)