### PR TITLE
feat(gfx906): HFQ6/MQ6 Phase A — wave64 + dp4a kernel stack (+41% decode, +248% prefill)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -5381,6 +5381,10 @@ fn run_fa_layer_body(
     let fa3_same_dtype = layer.wk.gpu_dtype == dt && layer.wv.gpu_dtype == dt;
     let fused_fa3_mq4 = fa3_same_dtype && (dt == DType::MQ4G256 || dt == DType::HFQ4G256);
     let fused_fa3_lloyd_mq3 = fa3_same_dtype && dt == DType::MQ3G256Lloyd;
+    // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+    let fused_fa3_hfq6 = fa3_same_dtype
+        && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
+        && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
     if fused_fa3_mq4 {
         let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
         gpu.fused_qkv_hfq4g256(
@@ -5393,6 +5397,15 @@ fn run_fa_layer_body(
     } else if fused_fa3_lloyd_mq3 {
         let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
         gpu.fused_qkv_mq3g256_lloyd(
+            &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+            eff_x,
+            &s.fa_q_full, &s.fa_k, &s.fa_v,
+            layer.wq.m, layer.wk.m, layer.wv.m,
+            layer.wq.k,
+        )?;
+    } else if fused_fa3_hfq6 {
+        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+        gpu.fused_qkv_hfq6g256_dp4a(
             &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
             eff_x,
             &s.fa_q_full, &s.fa_k, &s.fa_v,
@@ -5514,6 +5527,10 @@ fn run_fa_layer_body(
     let same_dtype = layer.w_up.gpu_dtype == dt_g;
     let fused_gu_mq4 = same_dtype && (dt_g == DType::MQ4G256 || dt_g == DType::HFQ4G256);
     let fused_gu_lloyd_mq3 = same_dtype && dt_g == DType::MQ3G256Lloyd;
+    // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+    let fused_gu_hfq6 = same_dtype
+        && (dt_g == DType::MQ6G256 || dt_g == DType::HFQ6G256)
+        && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
     if fused_gu_mq4 {
         let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
         gpu.fused_gate_up_hfq4g256(
@@ -5526,6 +5543,15 @@ fn run_fa_layer_body(
     } else if fused_gu_lloyd_mq3 {
         let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
         gpu.fused_gate_up_mq3g256_lloyd(
+            &layer.w_gate.buf, &layer.w_up.buf,
+            eff_x,
+            &s.gate_ffn, &s.up,
+            layer.w_gate.m, layer.w_up.m,
+            layer.w_gate.k,
+        )?;
+    } else if fused_gu_hfq6 {
+        let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+        gpu.fused_gate_up_hfq6g256_dp4a(
             &layer.w_gate.buf, &layer.w_up.buf,
             eff_x,
             &s.gate_ffn, &s.up,
@@ -5646,6 +5672,10 @@ fn forward_scratch_layers(
                     && layer.w_alpha.gpu_dtype == dt;
                 let fused_la4_mq4 = la4_same_dtype && (dt == DType::MQ4G256 || dt == DType::HFQ4G256);
                 let fused_la4_lloyd_mq3 = la4_same_dtype && dt == DType::MQ3G256Lloyd;
+                // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+                let fused_la4_hfq6 = la4_same_dtype
+                    && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
+                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
                 if fused_la4_mq4 {
                     // MQ4: x_rot is Some(rotated x); HF4: x_rot is None and
                     // s.tmp holds the plain rmsnormed x from the fallback path.
@@ -5666,6 +5696,18 @@ fn forward_scratch_layers(
                         None => &s.tmp,
                     };
                     gpu.fused_qkvza_mq3g256_lloyd(
+                        &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
+                        eff_x,
+                        &s.dn_qkv, &s.dn_z, &s.dn_beta, &s.dn_alpha,
+                        layer.wqkv.m, layer.wz.m, layer.w_beta.m, layer.w_alpha.m,
+                        layer.wqkv.k,
+                    )?;
+                } else if fused_la4_hfq6 {
+                    let eff_x = match x_rot {
+                        Some(xr) => xr,
+                        None => &s.tmp,
+                    };
+                    gpu.fused_qkvza_hfq6g256_dp4a(
                         &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
                         eff_x,
                         &s.dn_qkv, &s.dn_z, &s.dn_beta, &s.dn_alpha,
@@ -5761,6 +5803,10 @@ fn forward_scratch_layers(
                 let same_dtype = layer.w_up.gpu_dtype == dt_g;
                 let fused_gu_mq4 = same_dtype && (dt_g == DType::MQ4G256 || dt_g == DType::HFQ4G256);
                 let fused_gu_lloyd_mq3 = same_dtype && dt_g == DType::MQ3G256Lloyd;
+                // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+                let fused_gu_hfq6 = same_dtype
+                    && (dt_g == DType::MQ6G256 || dt_g == DType::HFQ6G256)
+                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
                 if fused_gu_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -5779,6 +5825,15 @@ fn forward_scratch_layers(
                         None => &s.tmp,
                     };
                     gpu.fused_gate_up_mq3g256_lloyd(
+                        &layer.w_gate.buf, &layer.w_up.buf,
+                        eff_x,
+                        &s.gate_ffn, &s.up,
+                        layer.w_gate.m, layer.w_up.m,
+                        layer.w_gate.k,
+                    )?;
+                } else if fused_gu_hfq6 {
+                    let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                    gpu.fused_gate_up_hfq6g256_dp4a(
                         &layer.w_gate.buf, &layer.w_up.buf,
                         eff_x,
                         &s.gate_ffn, &s.up,
@@ -5816,6 +5871,10 @@ fn forward_scratch_layers(
                 let fa3_same_dtype = layer.wk.gpu_dtype == dt && layer.wv.gpu_dtype == dt;
                 let fused_fa3_mq4 = fa3_same_dtype && (dt == DType::MQ4G256 || dt == DType::HFQ4G256);
                 let fused_fa3_lloyd_mq3 = fa3_same_dtype && dt == DType::MQ3G256Lloyd;
+                // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+                let fused_fa3_hfq6 = fa3_same_dtype
+                    && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
+                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
                 if fused_fa3_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -5834,6 +5893,15 @@ fn forward_scratch_layers(
                         None => &s.tmp,
                     };
                     gpu.fused_qkv_mq3g256_lloyd(
+                        &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                        eff_x,
+                        &s.fa_q_full, &s.fa_k, &s.fa_v,
+                        layer.wq.m, layer.wk.m, layer.wv.m,
+                        layer.wq.k,
+                    )?;
+                } else if fused_fa3_hfq6 {
+                    let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                    gpu.fused_qkv_hfq6g256_dp4a(
                         &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
                         eff_x,
                         &s.fa_q_full, &s.fa_k, &s.fa_v,
@@ -5972,6 +6040,10 @@ fn forward_scratch_layers(
                 let same_dtype = layer.w_up.gpu_dtype == dt_g;
                 let fused_gu_mq4 = same_dtype && (dt_g == DType::MQ4G256 || dt_g == DType::HFQ4G256);
                 let fused_gu_lloyd_mq3 = same_dtype && dt_g == DType::MQ3G256Lloyd;
+                // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+                let fused_gu_hfq6 = same_dtype
+                    && (dt_g == DType::MQ6G256 || dt_g == DType::HFQ6G256)
+                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
                 if fused_gu_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -5990,6 +6062,15 @@ fn forward_scratch_layers(
                         None => &s.tmp,
                     };
                     gpu.fused_gate_up_mq3g256_lloyd(
+                        &layer.w_gate.buf, &layer.w_up.buf,
+                        eff_x,
+                        &s.gate_ffn, &s.up,
+                        layer.w_gate.m, layer.w_up.m,
+                        layer.w_gate.k,
+                    )?;
+                } else if fused_gu_hfq6 {
+                    let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                    gpu.fused_gate_up_hfq6g256_dp4a(
                         &layer.w_gate.buf, &layer.w_up.buf,
                         eff_x,
                         &s.gate_ffn, &s.up,
@@ -6147,6 +6228,10 @@ fn forward_scratch_layers(
                 let fa3_same_dtype = layer.wk.gpu_dtype == dt && layer.wv.gpu_dtype == dt;
                 let fused_fa3_mq4 = fa3_same_dtype && (dt == DType::MQ4G256 || dt == DType::HFQ4G256);
                 let fused_fa3_lloyd_mq3 = fa3_same_dtype && dt == DType::MQ3G256Lloyd;
+                // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
+                let fused_fa3_hfq6 = fa3_same_dtype
+                    && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
+                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
                 if fused_fa3_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -6165,6 +6250,15 @@ fn forward_scratch_layers(
                         None => &s.tmp,
                     };
                     gpu.fused_qkv_mq3g256_lloyd(
+                        &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                        eff_x,
+                        &s.fa_q_full, &s.fa_k, &s.fa_v,
+                        layer.wq.m, layer.wk.m, layer.wv.m,
+                        layer.wq.k,
+                    )?;
+                } else if fused_fa3_hfq6 {
+                    let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
+                    gpu.fused_qkv_hfq6g256_dp4a(
                         &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
                         eff_x,
                         &s.fa_q_full, &s.fa_k, &s.fa_v,

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -3326,9 +3326,31 @@ fn run_dflash_draft_for_logits(
             let _ = gpu.free_tensor(rotated);
             r2
         }
+        rdna_compute::DType::HFQ6G256 => {
+            // Phase A.4: HFQ6 lm_head batched via gemm_hfq6g256_batched_lmhead
+            // (which zeros Y then dispatches the dp4a residual on gfx906 or
+            // WMMA / FP16 fallbacks elsewhere).
+            gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
+            )
+        }
+        rdna_compute::DType::MQ6G256 => {
+            let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
+            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            if let Err(e) = r1 {
+                let _ = gpu.free_tensor(rotated);
+                let _ = gpu.free_tensor(logits_batch);
+                return Err(e);
+            }
+            let r2 = gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
+            );
+            let _ = gpu.free_tensor(rotated);
+            r2
+        }
         _ => Err(hip_bridge::HipError::new(
             0,
-            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256/MQ3G256)",
+            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256/MQ3G256/HFQ6G256/MQ6G256)",
         )),
     };
     if let Err(e) = gemm_result {
@@ -3463,9 +3485,29 @@ fn run_dflash_draft_for_topk_gpu(
             let _ = gpu.free_tensor(rotated);
             r2
         }
+        rdna_compute::DType::HFQ6G256 => {
+            // Phase A.4: HFQ6 lm_head batched.
+            gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
+            )
+        }
+        rdna_compute::DType::MQ6G256 => {
+            let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
+            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            if let Err(e) = r1 {
+                let _ = gpu.free_tensor(rotated);
+                let _ = gpu.free_tensor(logits_batch);
+                return Err(e);
+            }
+            let r2 = gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
+            );
+            let _ = gpu.free_tensor(rotated);
+            r2
+        }
         _ => Err(hip_bridge::HipError::new(
             0,
-            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256/MQ3G256)",
+            "ddtree: unsupported target.output dtype (need Q8/HFQ4G256/MQ4G256/MQ3G256/HFQ6G256/MQ6G256)",
         )),
     };
     if let Err(e) = gemm_result {

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -2084,7 +2084,9 @@ fn verify_dflash_block_inner(
         rdna_compute::DType::Q8_0
         | rdna_compute::DType::HFQ4G256
         | rdna_compute::DType::MQ4G256
-        | rdna_compute::DType::MQ3G256 => true,
+        | rdna_compute::DType::MQ3G256
+        | rdna_compute::DType::HFQ6G256
+        | rdna_compute::DType::MQ6G256 => true,
         _ => false,
     };
 
@@ -2092,7 +2094,7 @@ fn verify_dflash_block_inner(
         let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
         // Q8_0 gemm_q8_0_batched has a hard MAX_BATCH=16 in the kernel, so
         // tree-verify blocks exceeding 16 (budget + 1 > 16) need chunking.
-        // MQ4/HFQ4 kernels have no such cap — they take the single-shot path.
+        // MQ4/HFQ4/HFQ6/MQ6 kernels have no such cap — they take the single-shot path.
         match w_out.gpu_dtype {
             rdna_compute::DType::Q8_0 => {
                 const Q8_LM_MAX: usize = 16;
@@ -2130,6 +2132,23 @@ fn verify_dflash_block_inner(
                 let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
                 gpu.rotate_x_mq_batched(&final_hidden, &rot, w_out.k, b)?;
                 gpu.gemm_hfq3g256_batched_lmhead(
+                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
+                )?;
+            }
+            rdna_compute::DType::HFQ6G256 => {
+                // Phase A.4: gfx906 dp4a path for HFQ6 lm_head batched.
+                gpu.gemm_hfq6g256_batched_lmhead(
+                    &w_out.buf, &final_hidden, &logits_batch, w_out.m, w_out.k, b,
+                )?;
+            }
+            rdna_compute::DType::MQ6G256 => {
+                // Phase A.4: rotate-then-batched lm_head for MQ6.
+                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                    "verify_scratch.rot undersized for MQ6 lm_head: b*k={} > max_n*hidden_k={}",
+                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
+                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+                gpu.rotate_x_mq_batched(&final_hidden, &rot, w_out.k, b)?;
+                gpu.gemm_hfq6g256_batched_lmhead(
                     &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
                 )?;
             }
@@ -2616,7 +2635,11 @@ pub fn spec_step_dflash(
     let w_out = &target.weights.output;
     let use_batched_gemm = matches!(
         w_out.gpu_dtype,
-        rdna_compute::DType::HFQ4G256 | rdna_compute::DType::MQ4G256 | rdna_compute::DType::MQ3G256,
+        rdna_compute::DType::HFQ4G256
+        | rdna_compute::DType::MQ4G256
+        | rdna_compute::DType::MQ3G256
+        | rdna_compute::DType::HFQ6G256
+        | rdna_compute::DType::MQ6G256,
     );
     let use_q8_staged = matches!(w_out.gpu_dtype, rdna_compute::DType::Q8_0);
     if use_batched_gemm || use_q8_staged {
@@ -2657,6 +2680,20 @@ pub fn spec_step_dflash(
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
                 gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
                 gpu.gemm_hfq3g256_batched_lmhead(
+                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
+                )?;
+            }
+            rdna_compute::DType::HFQ6G256 => {
+                gpu.gemm_hfq6g256_batched_lmhead(
+                    &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
+                )?;
+            }
+            rdna_compute::DType::MQ6G256 => {
+                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                    "verify_scratch.rot undersized for MQ6 draft lm_head");
+                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                gpu.gemm_hfq6g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -8772,6 +8772,11 @@ impl Gpu {
             if has_wmma_f16(&self.arch) {
                 return self.gemm_qkvza_hfq6g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
+            // gfx906: wave64+dp4a batched fused (Phase A.3, plan v3.2.3 §5.1
+            // item 3). Pre-quantize x to Q8_1 and dispatch the dp4a kernel.
+            if gemv_dp4a_enabled(&self.arch) {
+                return self.gemm_qkvza_hfq6g256_wave64_dp4a(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
+            }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
             if has_dot2_f32_f16(&self.arch) {
@@ -8923,6 +8928,83 @@ impl Gpu {
     /// RDNA2 (gfx1011/1012/1030-1032) fast path using `amd_mixed_dot`.
     /// One instruction per half2 dot with FP32 accumulation — 1.2-1.5× over FP16 packed.
     #[allow(clippy::too_many_arguments)]
+    /// gfx906 wave64+dp4a batched 4-way fused QKVZA GEMM. Phase A.3
+    /// (plan v3.2.3 §5.1 item 3). Uses Q8_1 activation pre-quantize
+    /// (shared with A.1c GEMV-shape dp4a kernels) and HFQ6 6-bit
+    /// unsigned weight unpack.
+    pub fn gemm_qkvza_hfq6g256_wave64_dp4a(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+
+        self.ensure_kernel(
+            "gemm_qkvza_hfq6g256_wave64_dp4a",
+            kernels::GEMM_QKVZA_HFQ6G256_WAVE64_DP4A_SRC,
+            "gemm_qkvza_hfq6g256_wave64_dp4a",
+        )?;
+
+        let aq = a_qkv.buf.as_ptr();
+        let az = a_z.buf.as_ptr();
+        let ab = a_beta.buf.as_ptr();
+        let aa = a_alpha.buf.as_ptr();
+        let yq = y_qkv.buf.as_ptr();
+        let yz = y_z.buf.as_ptr();
+        let yb = y_beta.buf.as_ptr();
+        let ya = y_alpha.buf.as_ptr();
+        let qkv_m_val = qkv_m as i32;
+        let z_m_val = z_m as i32;
+        let beta_m_val = beta_m as i32;
+        let alpha_m_val = alpha_m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aq as *const _ as *mut c_void,
+            &az as *const _ as *mut c_void,
+            &ab as *const _ as *mut c_void,
+            &aa as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yq as *const _ as *mut c_void,
+            &yz as *const _ as *mut c_void,
+            &yb as *const _ as *mut c_void,
+            &ya as *const _ as *mut c_void,
+            &qkv_m_val as *const _ as *mut c_void,
+            &z_m_val as *const _ as *mut c_void,
+            &beta_m_val as *const _ as *mut c_void,
+            &alpha_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        const BATCH_TILE: usize = 8;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let total_m = (qkv_m + z_m + beta_m + alpha_m) as u32;
+        let grid_x = (total_m + 1) / 2;
+
+        self.launch_maybe_blob(
+            "gemm_qkvza_hfq6g256_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xq);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(qkv_m_val); b.push_i32(z_m_val);
+                b.push_i32(beta_m_val); b.push_i32(alpha_m_val);
+                b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        )
+    }
+
     pub fn gemm_qkvza_hfq6g256_dot2(
         &mut self,
         a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
@@ -9173,6 +9255,10 @@ impl Gpu {
             if has_wmma_f16(&self.arch) {
                 return self.gemm_qkv_hfq6g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
+            // gfx906: wave64+dp4a batched fused (Phase A.3).
+            if gemv_dp4a_enabled(&self.arch) {
+                return self.gemm_qkv_hfq6g256_wave64_dp4a(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+            }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
             if has_dot2_f32_f16(&self.arch) {
@@ -9310,6 +9396,74 @@ impl Gpu {
     /// RDNA2 (gfx1011/1012/1030-1032) fast path using `amd_mixed_dot`.
     /// One instruction per half2 dot with FP32 accumulation — 1.2-1.5× over FP16 packed.
     #[allow(clippy::too_many_arguments)]
+    /// gfx906 wave64+dp4a batched 3-way fused QKV GEMM. Phase A.3
+    /// (plan v3.2.3 §5.1 item 3). Sibling of qkvza_wave64_dp4a.
+    pub fn gemm_qkv_hfq6g256_wave64_dp4a(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+
+        self.ensure_kernel(
+            "gemm_qkv_hfq6g256_wave64_dp4a",
+            kernels::GEMM_QKV_HFQ6G256_WAVE64_DP4A_SRC,
+            "gemm_qkv_hfq6g256_wave64_dp4a",
+        )?;
+
+        let aq = a_q.buf.as_ptr();
+        let ak = a_k.buf.as_ptr();
+        let av = a_v.buf.as_ptr();
+        let yq = y_q.buf.as_ptr();
+        let yk = y_k.buf.as_ptr();
+        let yv = y_v.buf.as_ptr();
+        let q_m_val = q_m as i32;
+        let k_m_val = k_m as i32;
+        let v_m_val = v_m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aq as *const _ as *mut c_void,
+            &ak as *const _ as *mut c_void,
+            &av as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yq as *const _ as *mut c_void,
+            &yk as *const _ as *mut c_void,
+            &yv as *const _ as *mut c_void,
+            &q_m_val as *const _ as *mut c_void,
+            &k_m_val as *const _ as *mut c_void,
+            &v_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        const BATCH_TILE: usize = 8;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let total_m = (q_m + k_m + v_m) as u32;
+        let grid_x = (total_m + 1) / 2;
+
+        self.launch_maybe_blob(
+            "gemm_qkv_hfq6g256_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xq);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        )
+    }
+
     pub fn gemm_qkv_hfq6g256_dot2(
         &mut self,
         a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
@@ -9540,6 +9694,10 @@ impl Gpu {
             if has_wmma_f16(&self.arch) {
                 return self.gemm_gate_up_hfq6g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
+            // gfx906: wave64+dp4a batched fused (Phase A.3).
+            if gemv_dp4a_enabled(&self.arch) {
+                return self.gemm_gate_up_hfq6g256_wave64_dp4a(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
+            }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
             if has_dot2_f32_f16(&self.arch) {
@@ -9663,6 +9821,66 @@ impl Gpu {
     /// RDNA2 (gfx1011/1012/1030-1032) fast path using `amd_mixed_dot`.
     /// One instruction per half2 dot with FP32 accumulation — 1.2-1.5× over FP16 packed.
     #[allow(clippy::too_many_arguments)]
+    /// gfx906 wave64+dp4a batched 2-way fused gate+up GEMM. Phase A.3.
+    pub fn gemm_gate_up_hfq6g256_wave64_dp4a(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+
+        self.ensure_kernel(
+            "gemm_gate_up_hfq6g256_wave64_dp4a",
+            kernels::GEMM_GATE_UP_HFQ6G256_WAVE64_DP4A_SRC,
+            "gemm_gate_up_hfq6g256_wave64_dp4a",
+        )?;
+
+        let agate = a_gate.buf.as_ptr();
+        let aup = a_up.buf.as_ptr();
+        let ygate = y_gate.buf.as_ptr();
+        let yup = y_up.buf.as_ptr();
+        let gate_m_val = gate_m as i32;
+        let up_m_val = up_m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &agate as *const _ as *mut c_void,
+            &aup as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &ygate as *const _ as *mut c_void,
+            &yup as *const _ as *mut c_void,
+            &gate_m_val as *const _ as *mut c_void,
+            &up_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        const BATCH_TILE: usize = 8;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let total_m = (gate_m + up_m) as u32;
+        let grid_x = (total_m + 1) / 2;
+
+        self.launch_maybe_blob(
+            "gemm_gate_up_hfq6g256_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(agate); b.push_ptr(aup); b.push_ptr(xq);
+                b.push_ptr(ygate); b.push_ptr(yup);
+                b.push_i32(gate_m_val); b.push_i32(up_m_val);
+                b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        )
+    }
+
     pub fn gemm_gate_up_hfq6g256_dot2(
         &mut self,
         a_gate: &GpuTensor, a_up: &GpuTensor,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -57,7 +57,7 @@ fn gemv_rows_override() -> Option<u32> {
 /// Default-on for gfx906 only. Override with HIPFIRE_GEMV_DP4A={0,1}.
 /// fused_qkv / fused_qkvza ports are pending; same lever, same
 /// estimated +1-2 % per kernel.
-fn gemv_dp4a_enabled(arch: &str) -> bool {
+pub fn gemv_dp4a_enabled(arch: &str) -> bool {
     static CACHE: OnceLock<Option<bool>> = OnceLock::new();
     let override_ = *CACHE.get_or_init(|| {
         std::env::var("HIPFIRE_GEMV_DP4A").ok().and_then(|v| match v.as_str() {
@@ -3532,6 +3532,183 @@ impl Gpu {
     }
 
     // HFQ2 GEMV dispatch already exists at line ~521 from the HFQ family
+
+    /// gfx906 dp4a-port — see fused_gate_up_hfq6g256_wave64_dp4a.hip for
+    /// the math derivation. Plan §3.1.1 item 3 / v3.2.2 §5.1 item 1c.
+    pub fn fused_qkv_hfq6g256_dp4a(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, 1, k)?;
+
+        self.ensure_kernel(
+            "fused_qkv_hfq6g256_wave64_dp4a",
+            kernels::FUSED_QKV_HFQ6G256_WAVE64_DP4A_SRC,
+            "fused_qkv_hfq6g256_wave64_dp4a",
+        )?;
+
+        let aq = a_q.buf.as_ptr();
+        let ak = a_k.buf.as_ptr();
+        let av = a_v.buf.as_ptr();
+        let yq = y_q.buf.as_ptr();
+        let yk = y_k.buf.as_ptr();
+        let yv = y_v.buf.as_ptr();
+        let q_m_val = q_m as i32;
+        let k_m_val = k_m as i32;
+        let v_m_val = v_m as i32;
+        let k_val = k as i32;
+        let total = (q_m + k_m + v_m) as u32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aq as *const _ as *mut c_void,
+            &ak as *const _ as *mut c_void,
+            &av as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yq as *const _ as *mut c_void,
+            &yk as *const _ as *mut c_void,
+            &yv as *const _ as *mut c_void,
+            &q_m_val as *const _ as *mut c_void,
+            &k_m_val as *const _ as *mut c_void,
+            &v_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+        ];
+
+        self.launch_maybe_blob(
+            "fused_qkv_hfq6g256_wave64_dp4a",
+            [(total + 1) / 2, 1, 1], [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av); b.push_ptr(xq);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val);
+                b.push_i32(v_m_val); b.push_i32(k_val);
+                b
+            },
+        )
+    }
+
+    /// gfx906 dp4a-port — 4-output deltanet QKV preamble.
+    pub fn fused_qkvza_hfq6g256_dp4a(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, 1, k)?;
+
+        self.ensure_kernel(
+            "fused_qkvza_hfq6g256_wave64_dp4a",
+            kernels::FUSED_QKVZA_HFQ6G256_WAVE64_DP4A_SRC,
+            "fused_qkvza_hfq6g256_wave64_dp4a",
+        )?;
+
+        let aqkv = a_qkv.buf.as_ptr();
+        let az = a_z.buf.as_ptr();
+        let ab = a_beta.buf.as_ptr();
+        let aa = a_alpha.buf.as_ptr();
+        let yqkv = y_qkv.buf.as_ptr();
+        let yz = y_z.buf.as_ptr();
+        let yb = y_beta.buf.as_ptr();
+        let ya = y_alpha.buf.as_ptr();
+        let qkv_m_val = qkv_m as i32;
+        let z_m_val = z_m as i32;
+        let beta_m_val = beta_m as i32;
+        let alpha_m_val = alpha_m as i32;
+        let k_val = k as i32;
+        let total = (qkv_m + z_m + beta_m + alpha_m) as u32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aqkv as *const _ as *mut c_void,
+            &az as *const _ as *mut c_void,
+            &ab as *const _ as *mut c_void,
+            &aa as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yqkv as *const _ as *mut c_void,
+            &yz as *const _ as *mut c_void,
+            &yb as *const _ as *mut c_void,
+            &ya as *const _ as *mut c_void,
+            &qkv_m_val as *const _ as *mut c_void,
+            &z_m_val as *const _ as *mut c_void,
+            &beta_m_val as *const _ as *mut c_void,
+            &alpha_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+        ];
+
+        self.launch_maybe_blob(
+            "fused_qkvza_hfq6g256_wave64_dp4a",
+            [(total + 1) / 2, 1, 1], [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aqkv); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xq);
+                b.push_ptr(yqkv); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(qkv_m_val); b.push_i32(z_m_val);
+                b.push_i32(beta_m_val); b.push_i32(alpha_m_val);
+                b.push_i32(k_val);
+                b
+            },
+        )
+    }
+
+    /// gfx906 dp4a-port — 2-output FFN gate+up projection.
+    pub fn fused_gate_up_hfq6g256_dp4a(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, 1, k)?;
+
+        self.ensure_kernel(
+            "fused_gate_up_hfq6g256_wave64_dp4a",
+            kernels::FUSED_GATE_UP_HFQ6G256_WAVE64_DP4A_SRC,
+            "fused_gate_up_hfq6g256_wave64_dp4a",
+        )?;
+
+        let agate = a_gate.buf.as_ptr();
+        let aup = a_up.buf.as_ptr();
+        let ygate = y_gate.buf.as_ptr();
+        let yup = y_up.buf.as_ptr();
+        let gate_m_val = gate_m as i32;
+        let up_m_val = up_m as i32;
+        let k_val = k as i32;
+        let total = (gate_m + up_m) as u32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &agate as *const _ as *mut c_void,
+            &aup as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &ygate as *const _ as *mut c_void,
+            &yup as *const _ as *mut c_void,
+            &gate_m_val as *const _ as *mut c_void,
+            &up_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+        ];
+
+        self.launch_maybe_blob(
+            "fused_gate_up_hfq6g256_wave64_dp4a",
+            [(total + 1) / 2, 1, 1], [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(agate); b.push_ptr(aup); b.push_ptr(xq);
+                b.push_ptr(ygate); b.push_ptr(yup);
+                b.push_i32(gate_m_val); b.push_i32(up_m_val);
+                b.push_i32(k_val);
+                b
+            },
+        )
+    }
 
     /// 3-way fused HFQ4-G256 projection — cross-arch.
     ///

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -8515,10 +8515,67 @@ impl Gpu {
     // HFQ6-G256 GEMM variants (residual, fused)
     // ========================================================================
 
+    /// gfx906 wave64+dp4a batched residual GEMM for HFQ6/MQ6.
+    /// Phase A.2 (plan v3.2.3 §5.1 item 2). Pre-quantizes x to Q8_1 and
+    /// dispatches the dp4a kernel; output is residual `+=` semantics.
+    ///
+    /// Math identity: same as the fused-GEMV dp4a kernels (plan §2.2
+    /// Option A — HFQ6 unsigned weights, no zp shift correction).
+    pub fn gemm_hfq6g256_residual_wave64_dp4a(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+
+        self.ensure_kernel(
+            "gemm_hfq6g256_residual_wave64_dp4a",
+            kernels::GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC,
+            "gemm_hfq6g256_residual_wave64_dp4a",
+        )?;
+
+        let a_ptr = a_raw.buf.as_ptr();
+        let y_ptr = y.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &a_ptr as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &y_ptr as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        const BATCH_TILE: usize = 8;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let grid_x = ((m as u32) + 1) / 2;
+
+        self.launch_maybe_blob(
+            "gemm_hfq6g256_residual_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(xq); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        )
+    }
+
     /// Batched HFQ6-G256 GEMM with fused residual add:
     ///   for b in 0..batch_size: y[b][row] += A[row] · x[b]
     ///
-    /// Auto-selects: gfx11 -> WMMA, else -> FP16 packed, fallback -> FP32 scalar.
+    /// Auto-selects: gfx11 -> WMMA, gfx906 -> dp4a (Phase A.2),
+    /// else -> FP16 packed, fallback -> FP32 scalar.
     pub fn gemm_hfq6g256_residual(
         &mut self,
         a_raw: &GpuTensor,
@@ -8534,6 +8591,12 @@ impl Gpu {
             // WMMA on gfx11+ (RDNA3): 16x16 tiled
             if self.arch.starts_with("gfx11") {
                 return self.gemm_hfq6g256_residual_wmma(a_raw, x, y, m, k, batch_size);
+            }
+            // gfx906: dp4a + wave64 batched residual (Phase A.2, plan v3.2.3
+            // §5.1 item 2). Pre-quantize x to Q8_1 and dispatch the dp4a
+            // kernel. Mirror of the HFQ4 sibling pattern at gemm_hfq4g256_wave64_dp4a.
+            if gemv_dp4a_enabled(&self.arch) {
+                return self.gemm_hfq6g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
             }
             // FP16 packed on all other RDNA
             return self.gemm_hfq6g256_residual_fp16(a_raw, x, y, m, k, batch_size);

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3275,8 +3275,6 @@ impl Gpu {
     /// add_inplace_f32 follow-up launch can be elided.
     pub fn gemv_hfq6g256_residual(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
         self.bind_thread()?;
-        self.ensure_kernel("gemv_hfq6g256_residual", kernels::GEMV_HFQ6G256_RESIDUAL_SRC, "gemv_hfq6g256_residual")?;
-        let func = &self.functions["gemv_hfq6g256_residual"];
         let mut a_ptr = a_raw.buf.as_ptr(); let mut x_ptr = x.buf.as_ptr(); let mut y_ptr = y.buf.as_ptr();
         let mut m_val = m as i32; let mut k_val = k as i32;
         let mut params: Vec<*mut c_void> = vec![
@@ -3284,6 +3282,24 @@ impl Gpu {
             &mut y_ptr as *mut _ as *mut c_void, &mut m_val as *mut _ as *mut c_void,
             &mut k_val as *mut _ as *mut c_void,
         ];
+
+        // Wave64-native fast path (gfx906/908/94x): 2 rows per block, halves
+        // grid.x. Mirrors the HFQ4 sibling at line ~5378. Plan §3.1.1 item 2
+        // (gfx906-mq6-mq8-port.md v3.2.1). Byte-exact with the wave32 base
+        // since each warp's 32-lane reduction stays in-warp.
+        if has_wave64_native(&self.arch) {
+            self.ensure_kernel(
+                "gemv_hfq6g256_residual_wave64",
+                kernels::GEMV_HFQ6G256_RESIDUAL_WAVE64_SRC,
+                "gemv_hfq6g256_residual_wave64",
+            )?;
+            let func = &self.functions["gemv_hfq6g256_residual_wave64"];
+            let grid = ((m as u32) + 1) / 2;
+            return unsafe { self.hip.launch_kernel(func, [grid, 1, 1], [64, 1, 1], 0, self.stream_ref(), &mut params) };
+        }
+
+        self.ensure_kernel("gemv_hfq6g256_residual", kernels::GEMV_HFQ6G256_RESIDUAL_SRC, "gemv_hfq6g256_residual")?;
+        let func = &self.functions["gemv_hfq6g256_residual"];
         unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 0, self.stream_ref(), &mut params) }
     }
 

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3285,15 +3285,24 @@ impl Gpu {
 
         // Wave64-native fast path (gfx906/908/94x): 2 rows per block, halves
         // grid.x. Mirrors the HFQ4 sibling at line ~5378. Plan §3.1.1 item 2
-        // (gfx906-mq6-mq8-port.md v3.2.1). Byte-exact with the wave32 base
-        // since each warp's 32-lane reduction stays in-warp.
+        // (gfx906-mq6-mq8-port.md v3.2.1 + v3.2.2). Byte-exact with the
+        // wave32 base since each warp's 32-lane reduction stays in-warp.
+        // ILP-prefetch variant gates on gemv_prefetch_enabled(arch) — default
+        // on for gfx906 (Phase A.1b, mirror of HFQ4 +4.8% lever from `3ef127d`).
         if has_wave64_native(&self.arch) {
-            self.ensure_kernel(
-                "gemv_hfq6g256_residual_wave64",
-                kernels::GEMV_HFQ6G256_RESIDUAL_WAVE64_SRC,
-                "gemv_hfq6g256_residual_wave64",
-            )?;
-            let func = &self.functions["gemv_hfq6g256_residual_wave64"];
+            let (kname, ksrc): (&str, &str) = if gemv_prefetch_enabled(&self.arch) {
+                (
+                    "gemv_hfq6g256_residual_wave64_prefetch",
+                    kernels::GEMV_HFQ6G256_RESIDUAL_WAVE64_PREFETCH_SRC,
+                )
+            } else {
+                (
+                    "gemv_hfq6g256_residual_wave64",
+                    kernels::GEMV_HFQ6G256_RESIDUAL_WAVE64_SRC,
+                )
+            };
+            self.ensure_kernel(kname, ksrc, kname)?;
+            let func = &self.functions[kname];
             let grid = ((m as u32) + 1) / 2;
             return unsafe { self.hip.launch_kernel(func, [grid, 1, 1], [64, 1, 1], 0, self.stream_ref(), &mut params) };
         }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -55,8 +55,8 @@ fn gemv_rows_override() -> Option<u32> {
 /// prefetch win on gemv_residual. Coherence gate clean.
 ///
 /// Default-on for gfx906 only. Override with HIPFIRE_GEMV_DP4A={0,1}.
-/// fused_qkv / fused_qkvza ports are pending; same lever, same
-/// estimated +1-2 % per kernel.
+/// fused_qkv / fused_qkvza ports for HFQ4 (PR #167) and HFQ6 (PR #187)
+/// have shipped; this lever now toggles every fused dp4a path together.
 pub fn gemv_dp4a_enabled(arch: &str) -> bool {
     static CACHE: OnceLock<Option<bool>> = OnceLock::new();
     let override_ = *CACHE.get_or_init(|| {
@@ -8481,7 +8481,9 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // gfx906: dp4a residual + zero-init Y for `=` semantics.
-        if batch_size > 1 && gemv_dp4a_enabled(&self.arch) {
+        // Skip in capture mode (the residual kernel calls ensure_q8_1_mmq_x
+        // which launches an internal quantize kernel — matches HFQ4 sibling).
+        if batch_size > 1 && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
             match self.active_stream.as_ref() {
                 Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
                 None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
@@ -8643,7 +8645,10 @@ impl Gpu {
             // gfx906: dp4a + wave64 batched residual (Phase A.2, plan v3.2.3
             // §5.1 item 2). Pre-quantize x to Q8_1 and dispatch the dp4a
             // kernel. Mirror of the HFQ4 sibling pattern at gemm_hfq4g256_wave64_dp4a.
-            if gemv_dp4a_enabled(&self.arch) {
+            // Skip in capture mode: ensure_q8_1_mmq_x launches an internal
+            // quantize kernel that the captured graph may not record (matches
+            // gemm_hfq4g256_dp4a's `&& !self.capture_mode` guard at line ~7889).
+            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
                 return self.gemm_hfq6g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
             }
             // FP16 packed on all other RDNA
@@ -8822,7 +8827,9 @@ impl Gpu {
             }
             // gfx906: wave64+dp4a batched fused (Phase A.3, plan v3.2.3 §5.1
             // item 3). Pre-quantize x to Q8_1 and dispatch the dp4a kernel.
-            if gemv_dp4a_enabled(&self.arch) {
+            // Skip in capture mode (Q8_1 quantize launch must be reachable
+            // from captured graph or pre-baked) — matches HFQ4 sibling pattern.
+            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
                 return self.gemm_qkvza_hfq6g256_wave64_dp4a(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -9304,7 +9311,8 @@ impl Gpu {
                 return self.gemm_qkv_hfq6g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // gfx906: wave64+dp4a batched fused (Phase A.3).
-            if gemv_dp4a_enabled(&self.arch) {
+            // Skip in capture mode (Q8_1 quantize) — matches HFQ4 sibling.
+            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
                 return self.gemm_qkv_hfq6g256_wave64_dp4a(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
@@ -9743,7 +9751,8 @@ impl Gpu {
                 return self.gemm_gate_up_hfq6g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // gfx906: wave64+dp4a batched fused (Phase A.3).
-            if gemv_dp4a_enabled(&self.arch) {
+            // Skip in capture mode (Q8_1 quantize) — matches HFQ4 sibling.
+            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
                 return self.gemm_gate_up_hfq6g256_wave64_dp4a(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -8462,6 +8462,54 @@ impl Gpu {
         self.gemm_hfq4g256(a_raw, x, y, m, k, batch_size)
     }
 
+    /// HFQ6-G256 sister of `gemm_hfq4g256_batched_lmhead`. Phase A.4
+    /// (plan v3.2.3 §5.1 item 4). On gfx906 uses the dp4a residual GEMM
+    /// (Phase A.2) with a zero-init of Y, mirroring the HFQ4 WMMA pattern
+    /// at line 8019-8022. Lets the residual `+=` collapse to `=` semantics
+    /// without needing a separate non-residual kernel.
+    ///
+    /// Caller is responsible for FWHT-rotating x first when the weights
+    /// are MQ6 (FWHT-rotated at quant time).
+    pub fn gemm_hfq6g256_batched_lmhead(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        // gfx906: dp4a residual + zero-init Y for `=` semantics.
+        if batch_size > 1 && gemv_dp4a_enabled(&self.arch) {
+            match self.active_stream.as_ref() {
+                Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
+                None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
+            }
+            return self.gemm_hfq6g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
+        }
+        // gfx11+: WMMA residual + zero-init.
+        let wmma_eligible = batch_size > 1
+            && self.arch.starts_with("gfx11")
+            && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
+            && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
+        if wmma_eligible {
+            self.fp16_x_source_ptr = std::ptr::null_mut();
+            match self.active_stream.as_ref() {
+                Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
+                None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
+            }
+            return self.gemm_hfq6g256_residual_wmma(a_raw, x, y, m, k, batch_size);
+        }
+        // Fallback: use the residual dispatcher with zero-init Y. This
+        // routes to fp16-packed or scalar depending on arch.
+        match self.active_stream.as_ref() {
+            Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
+            None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
+        }
+        self.gemm_hfq6g256_residual(a_raw, x, y, m, k, batch_size)
+    }
+
     /// HFQ3-G256 sister of `gemm_hfq4g256_batched_lmhead`. Same FP16-X cache
     /// stomp + zero-init of Y, then `gemm_hfq3g256_residual_wmma` to compute
     /// y[b][row] = A[row] · x[b]. Used by `dflash::gemm_dispatch` for MQ3

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -238,6 +238,12 @@ pub const FUSED_GATE_UP_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../
 pub const FUSED_QKV_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/fused_qkv_hfq6g256_wave64_dp4a.hip");
 pub const FUSED_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/fused_qkvza_hfq6g256_wave64_dp4a.hip");
 
+/// Phase A.2 (plan v3.2.3 §5.1 item 2): wave64+dp4a batched residual
+/// GEMM for HFQ6/MQ6 prefill. Mirror of `gemm_hfq4g256_wave64_dp4a.hip`
+/// with HFQ6 6-bit unpack and `+=` residual write semantic. Used for
+/// per-layer wo + w_down at B>1.
+pub const GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_hfq6g256_residual_wave64_dp4a.hip");
+
 
 /// HFQ3-G256: flat 3-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][96B data] = 104 bytes per 256 weights (0.41 B/w).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -230,6 +230,14 @@ pub const GEMV_HFQ6G256_RESIDUAL_WAVE64_SRC: &str = include_str!("../../../kerne
 /// Default-on for gfx906 via `gemv_prefetch_enabled(arch)`.
 pub const GEMV_HFQ6G256_RESIDUAL_WAVE64_PREFETCH_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6g256_residual_wave64_prefetch.hip");
 
+/// gfx906 wave64+dp4a fused single-token GEMVs for HFQ6/MQ6 — the
+/// Phase A.1c headline lever. Mirror of HFQ4 fused-dp4a family; uses
+/// sdot4 with HFQ6's 6-bit unsigned weights (no zp shift correction).
+/// Plan §3.1.1 item 3 / v3.2.2 §5.1 item 1c.
+pub const FUSED_GATE_UP_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/fused_gate_up_hfq6g256_wave64_dp4a.hip");
+pub const FUSED_QKV_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/fused_qkv_hfq6g256_wave64_dp4a.hip");
+pub const FUSED_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/fused_qkvza_hfq6g256_wave64_dp4a.hip");
+
 
 /// HFQ3-G256: flat 3-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][96B data] = 104 bytes per 256 weights (0.41 B/w).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -217,6 +217,13 @@ pub const GEMV_HFQ8G256_SRC: &str = include_str!("../../../kernels/src/gemv_hfq8
 pub const GEMV_HFQ6G256_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6g256.hip");
 pub const GEMV_HFQ6G256_RESIDUAL_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6g256_residual.hip");
 
+/// Wave64-native HFQ6-G256 residual GEMV. Mirror of the HFQ4 sibling
+/// (`gemv_hfq4g256_residual_wave64.hip`) with 6-bit unpack from
+/// `gemv_hfq6g256_residual.hip`. Used for HFQ6/MQ6 `wo` and `w_down`
+/// projections on wave64-native arches (gfx906/908/94x). Plan §3.1.1
+/// item 2 (gfx906-mq6-mq8-port.md v3.2.1).
+pub const GEMV_HFQ6G256_RESIDUAL_WAVE64_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6g256_residual_wave64.hip");
+
 
 /// HFQ3-G256: flat 3-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][96B data] = 104 bytes per 256 weights (0.41 B/w).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -224,6 +224,12 @@ pub const GEMV_HFQ6G256_RESIDUAL_SRC: &str = include_str!("../../../kernels/src/
 /// item 2 (gfx906-mq6-mq8-port.md v3.2.1).
 pub const GEMV_HFQ6G256_RESIDUAL_WAVE64_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6g256_residual_wave64.hip");
 
+/// Wave64-native HFQ6-G256 residual GEMV with software-pipelined
+/// across-quad weight prefetch. Mirror of `gemv_hfq4g256_residual_wave64_prefetch.hip`.
+/// Plan §3.1.1 item 2 / v3.2.2 §5.1 item 1b (the ILP-prefetch lever).
+/// Default-on for gfx906 via `gemv_prefetch_enabled(arch)`.
+pub const GEMV_HFQ6G256_RESIDUAL_WAVE64_PREFETCH_SRC: &str = include_str!("../../../kernels/src/gemv_hfq6g256_residual_wave64_prefetch.hip");
+
 
 /// HFQ3-G256: flat 3-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][96B data] = 104 bytes per 256 weights (0.41 B/w).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -244,6 +244,15 @@ pub const FUSED_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../ke
 /// per-layer wo + w_down at B>1.
 pub const GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_hfq6g256_residual_wave64_dp4a.hip");
 
+/// Phase A.3 (plan v3.2.3 §5.1 item 3): wave64+dp4a batched fused
+/// GEMMs for HFQ6/MQ6 prefill. Sibling of A.2 with multi-output row
+/// routing (qkvza 4-way, qkv 3-way, gate_up 2-way). Overwrite output
+/// semantics — caller fuses residual at the wo + w_down sites via
+/// gemm_hfq6g256_residual_wave64_dp4a (Phase A.2).
+pub const GEMM_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq6g256_wave64_dp4a.hip");
+pub const GEMM_QKV_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq6g256_wave64_dp4a.hip");
+pub const GEMM_GATE_UP_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq6g256_wave64_dp4a.hip");
+
 
 /// HFQ3-G256: flat 3-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][96B data] = 104 bytes per 256 weights (0.41 B/w).

--- a/crates/rdna-compute/src/lib.rs
+++ b/crates/rdna-compute/src/lib.rs
@@ -8,5 +8,5 @@ pub mod profile;
 pub mod profiler;
 
 pub use compiler::KernelCompiler;
-pub use dispatch::{DType, Gpu, GpuTensor};
+pub use dispatch::{gemv_dp4a_enabled, DType, Gpu, GpuTensor};
 pub use kernels::GEMV_SRC;

--- a/kernels/src/fused_gate_up_hfq6g256_wave64_dp4a.hip
+++ b/kernels/src/fused_gate_up_hfq6g256_wave64_dp4a.hip
@@ -1,0 +1,156 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// dp4a-port of fused_gate_up_hfq6g256_wave64. Activations are
+// pre-quantized to Q8_1 (block_q8_1_mmq layout, see
+// kernels/src/gemm_hfq4g256_residual_mmq.hip:31). Weights stay
+// HFQ6-G256 (6-bit unsigned + per-256-group fp32 scale + zp).
+//
+// Plan §2.2 Option A: HFQ6 weights are unsigned q ∈ [0, 63]. No
+// (n - 8) shift — the values fit in signed int8 cleanly because
+// q < 128. So the dp4a path uses sdot4 with unsigned-positive int8
+// lanes on the weight side and signed int8 on the activation side,
+// and the math identity is:
+//
+//   sum_k (sc * q_k + zp) * x_k
+// = sc * sum_k(q_k * x_k) + zp * sum_k(x_k)
+// =      ^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^
+//        sdot4-able        zp * sum_x (no shift correction)
+//
+// And with x quantized as x_k ≈ d_x * x_int8_k per Q8_1 sub-block:
+//   = sc * d_x * sum_k(q_k_packed_int8 · x_int8_packed) + zp * sum_x
+//
+// Per-sub-block contribution:
+//   acc += sc * d_x * sumi_dp4a + zp * sum_x_subblock * 0.25
+//
+// (The 0.25 weight on sum_x is because each Q8_1 sub-block's sum_x
+// covers 32 K-elements while each lane only covers 8 — the 32-lane
+// reduction recovers the per-sub-block term exactly.)
+//
+// Lane mapping inside one HFQ6-G256 group (256 K-elements):
+//   lane l owns K-elements [8l, 8l+7]
+//   sub-block s(l) = l/4   (8 sub-blocks total: 4 in block A, 4 in B)
+//   block      b(l) = l/16   (0 = block A, 1 = block B)
+//   in-block sub  = (l/4) % 4
+//
+// HFQ6 weight: 8 weights = 6 bytes per thread per group. Bytes are
+// loaded individually (not as a single u32) because byte_off = lane*6
+// is not dword-aligned for half the lanes. Compiler coalesces the
+// 6 byte-loads into the natural alignment.
+
+#define QK8_1 32
+
+struct block_q8_1_mmq {
+    half2 ds4[4];           // (d, sum_x) per 32-K sub-block, 4 sub-blocks/block
+    int8_t qs[4 * QK8_1];   // 128 int8 K-elements per block
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void fused_gate_up_hfq6g256_wave64_dp4a(
+    const char* __restrict__ A_gate,
+    const char* __restrict__ A_up,
+    const block_q8_1_mmq* __restrict__ Xq,   // K/128 blocks
+    float* __restrict__ y_gate,
+    float* __restrict__ y_up,
+    int gate_m, int up_m, int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = gate_m + up_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* y;
+    int local_row;
+    if (gid < gate_m) {
+        A = A_gate; y = y_gate; local_row = gid;
+    } else {
+        A = A_up; y = y_up; local_row = gid - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)local_row * groups_per_row * 200;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block = (lane / 4) % 4;     // ds4[i] index, 0..3
+    const int block_within_group = lane / 16;    // 0 (A) or 1 (B)
+    const int qs_byte_off = 8 * (lane % 16);     // 0,8,16,...,120
+
+    float acc = 0.0f;
+
+    // One HFQ6 group per outer iter.
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        // Load this lane's 6 weight bytes.
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        // 6-bit unpack: 8 weights from 6 bytes (4 weights per 3 bytes).
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        // Pack 4 weights per int (each weight ∈ [0, 63] fits in lower
+        // 6 bits of an int8 lane; high bit zero → reads as positive
+        // signed int8 for sdot4).
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        // Pick the right Q8_1 block (A or B) for this lane.
+        // HFQ6 group g spans Q8_1 blocks (2g, 2g+1) — same as HFQ4
+        // since the activation Q8_1 layout is keyed off K-element
+        // count, not weight quant format.
+        const int kblock = 2 * g + block_within_group;
+        const block_q8_1_mmq* xb = Xq + kblock;
+
+        const int* xqs = (const int*)(xb->qs + qs_byte_off);
+        const int xq_a = xqs[0];
+        const int xq_b = xqs[1];
+
+        // sdot4: signed int8 lanes. Weights are in [0, 63] (positive
+        // signed) so the multiplication is mathematically identical
+        // to an unsigned 6-bit × signed int8 product.
+        int sumi = 0;
+        sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+        sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+        const half2 ds = xb->ds4[sub_in_block];
+        const float2 dsf = __half22float2(ds);
+        const float d_x = dsf.x;
+        const float sum_x = dsf.y;
+
+        // Per-sub-block contribution: HFQ6 has no zp shift correction
+        // (vs HFQ4's zp + 8*sc) because weights are unsigned-positive.
+        acc += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        acc += __shfl_down(acc, offset);
+    }
+
+    if (lane == 0) y[local_row] = acc;
+}

--- a/kernels/src/fused_qkv_hfq6g256_wave64_dp4a.hip
+++ b/kernels/src/fused_qkv_hfq6g256_wave64_dp4a.hip
@@ -1,0 +1,117 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// dp4a-port of fused_qkv_hfq6g256_wave64. Same math + lane-mapping
+// invariants as fused_gate_up_hfq6g256_wave64_dp4a.hip — see that file
+// for the derivation. This kernel adds Q+K+V routing (3 output
+// matrices instead of 2). Activations pre-quantized to Q8_1
+// (block_q8_1_mmq layout, see kernels/src/gemm_hfq4g256_residual_mmq.hip:31).
+//
+// Plan §2.2 Option A: HFQ6 weights are unsigned q ∈ [0, 63], no
+// shift. zp_eff = zp (no +8*sc correction).
+
+#define QK8_1 32
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void fused_qkv_hfq6g256_wave64_dp4a(
+    const char*  __restrict__ A_q,
+    const char*  __restrict__ A_k,
+    const char*  __restrict__ A_v,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float*       __restrict__ y_q,
+    float*       __restrict__ y_k,
+    float*       __restrict__ y_v,
+    int q_m, int k_m, int v_m,
+    int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = q_m + k_m + v_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* y;
+    int row;
+    if (gid < q_m) {
+        A = A_q; y = y_q; row = gid;
+    } else if (gid < q_m + k_m) {
+        A = A_k; y = y_k; row = gid - q_m;
+    } else {
+        A = A_v; y = y_v; row = gid - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 200;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+        const block_q8_1_mmq* xb = Xq + kblock;
+
+        const int* xqs = (const int*)(xb->qs + qs_byte_off);
+        const int xq_a = xqs[0];
+        const int xq_b = xqs[1];
+
+        int sumi = 0;
+        sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+        sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+        const half2 ds = xb->ds4[sub_in_block];
+        const float2 dsf = __half22float2(ds);
+        const float d_x = dsf.x;
+        const float sum_x = dsf.y;
+
+        acc += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] = acc;
+}

--- a/kernels/src/fused_qkvza_hfq6g256_wave64_dp4a.hip
+++ b/kernels/src/fused_qkvza_hfq6g256_wave64_dp4a.hip
@@ -1,0 +1,120 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// dp4a-port of fused_qkvza_hfq6g256_wave64 (4-output deltanet QKV
+// preamble: qkv + z + beta + alpha). Math + lane-mapping invariants
+// match fused_gate_up_hfq6g256_wave64_dp4a.hip; only the row-routing
+// prologue differs (4 output matrices instead of 2).
+//
+// Plan §2.2 Option A: HFQ6 weights are unsigned q ∈ [0, 63], no
+// shift. zp_eff = zp (no +8*sc correction).
+
+#define QK8_1 32
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void fused_qkvza_hfq6g256_wave64_dp4a(
+    const char*  __restrict__ A_qkv,
+    const char*  __restrict__ A_z,
+    const char*  __restrict__ A_beta,
+    const char*  __restrict__ A_alpha,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float*       __restrict__ y_qkv,
+    float*       __restrict__ y_z,
+    float*       __restrict__ y_beta,
+    float*       __restrict__ y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* y;
+    int row;
+    if (gid < qkv_m) {
+        A = A_qkv;   y = y_qkv;   row = gid;
+    } else if (gid < qkv_m + z_m) {
+        A = A_z;     y = y_z;     row = gid - qkv_m;
+    } else if (gid < qkv_m + z_m + beta_m) {
+        A = A_beta;  y = y_beta;  row = gid - (qkv_m + z_m);
+    } else {
+        A = A_alpha; y = y_alpha; row = gid - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 200;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+        const block_q8_1_mmq* xb = Xq + kblock;
+
+        const int* xqs = (const int*)(xb->qs + qs_byte_off);
+        const int xq_a = xqs[0];
+        const int xq_b = xqs[1];
+
+        int sumi = 0;
+        sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+        sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+        const half2 ds = xb->ds4[sub_in_block];
+        const float2 dsf = __half22float2(ds);
+        const float d_x = dsf.x;
+        const float sum_x = dsf.y;
+
+        acc += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] = acc;
+}

--- a/kernels/src/gemm_gate_up_hfq6g256_wave64_dp4a.hip
+++ b/kernels/src/gemm_gate_up_hfq6g256_wave64_dp4a.hip
@@ -1,0 +1,126 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a batched 2-way fused gate+up GEMM for HFQ6/MQ6, gfx906.
+// FFN preamble at B>1.
+//
+// Sibling of gemm_qkvza_hfq6g256_wave64_dp4a.hip with 2-way row-routing.
+// Same math + lane-mapping. Plan §3.2.3 §5.1 item 3 (Phase A.3).
+
+#define QK8_1 32
+#define BATCH_TILE 8
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_gate_up_hfq6g256_wave64_dp4a(
+    const char*  __restrict__ A_gate,
+    const char*  __restrict__ A_up,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float*       __restrict__ Y_gate,
+    float*       __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = gate_m + up_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* Y;
+    int row;
+    int out_stride;
+    if (gid < gate_m) {
+        A = A_gate; Y = Y_gate; row = gid;            out_stride = gate_m;
+    } else {
+        A = A_up;   Y = Y_up;   row = gid - gate_m;   out_stride = up_m;
+    }
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+        }
+    }
+
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) Y[(long long)(batch_start + b) * out_stride + row] = val;
+    }
+}

--- a/kernels/src/gemm_hfq6g256_residual_wave64_dp4a.hip
+++ b/kernels/src/gemm_hfq6g256_residual_wave64_dp4a.hip
@@ -1,0 +1,136 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a port of gemm_hfq6g256_residual. Activations pre-quantized
+// to Q8_1 (block_q8_1_mmq layout, kblock-major: [K/128 * batch_size]).
+// Weights stay HFQ6-G256 (6-bit unsigned + per-256-group fp32 scale + zp).
+//
+// Combines three reference patterns:
+//   - Wave64 topology + Q8_1 lookup pattern from gemm_hfq4g256_wave64_dp4a.hip
+//   - 6-bit unpack from fused_gate_up_hfq6g256_wave64_dp4a.hip
+//   - Residual `+=` write semantic from gemm_hfq6g256_residual.hip
+//
+// Plan §3.1 v3.2.3 §5.1 item 2 (Phase A.2). Targets the per-layer wo +
+// w_down at B>1, the prefill batched-residual surface that doesn't
+// route through the (not-yet-ported-for-HFQ6) MMQ family.
+//
+// Math identity is the same as the fused dp4a GEMVs (HFQ6 unsigned,
+// no zp shift):
+//   acc[b] += sc * d_x[b] * sumi_dp4a + zp * sum_x[b] * 0.25f
+//
+// Topology mirrors gemm_hfq4g256_wave64_dp4a:
+//   block = [64, 1, 1]   = 2 warps, each handles 1 row (warp_id = row offset)
+//   grid  = [(M+1)/2, ceil(N/BATCH_TILE), 1]
+//   BATCH_TILE = 8 tokens per WG, accumulators acc[BATCH_TILE]
+//
+// Output write semantic: `Y[...] += val` (residual fuse), unlike the
+// HFQ4 sibling's `Y[...] = val` (overwrite).
+
+#define QK8_1 32
+#define BATCH_TILE 8
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_hfq6g256_residual_wave64_dp4a(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,   // kblock-major: [K/128 * N]
+    float* __restrict__ y,                   // [batch_size, M]
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int row = blockIdx.x * 2 + warp_id;
+    if (row >= M) return;
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        // Lane's 8 weights from 6 bytes (HFQ6 6-bit unpack).
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        // Pack 4 weights per int (each ∈ [0, 63] fits signed int8).
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        // Per-batch-token loop. Each iteration loads its own activation
+        // slice from kblock-major Xq.
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+        }
+    }
+
+    // Reduce + residual write-back.
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) y[(long long)(batch_start + b) * M + row] += val;
+    }
+}

--- a/kernels/src/gemm_qkv_hfq6g256_wave64_dp4a.hip
+++ b/kernels/src/gemm_qkv_hfq6g256_wave64_dp4a.hip
@@ -1,0 +1,131 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a batched 3-way fused QKV GEMM for HFQ6/MQ6, gfx906.
+// FullAttention preamble (Q + K + V) at B>1.
+//
+// Sibling of gemm_qkvza_hfq6g256_wave64_dp4a.hip with 3-way row-routing
+// instead of 4-way. Same math + lane-mapping. Plan §3.2.3 §5.1 item 3
+// (Phase A.3).
+
+#define QK8_1 32
+#define BATCH_TILE 8
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_qkv_hfq6g256_wave64_dp4a(
+    const char*  __restrict__ A_q,
+    const char*  __restrict__ A_k,
+    const char*  __restrict__ A_v,
+    const block_q8_1_mmq* __restrict__ Xq,
+    float*       __restrict__ Y_q,
+    float*       __restrict__ Y_k,
+    float*       __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = q_m + k_m + v_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* Y;
+    int row;
+    int out_stride;
+    if (gid < q_m) {
+        A = A_q; Y = Y_q; row = gid;                              out_stride = q_m;
+    } else if (gid < q_m + k_m) {
+        A = A_k; Y = Y_k; row = gid - q_m;                         out_stride = k_m;
+    } else {
+        A = A_v; Y = Y_v; row = gid - q_m - k_m;                    out_stride = v_m;
+    }
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+        }
+    }
+
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) Y[(long long)(batch_start + b) * out_stride + row] = val;
+    }
+}

--- a/kernels/src/gemm_qkvza_hfq6g256_wave64_dp4a.hip
+++ b/kernels/src/gemm_qkvza_hfq6g256_wave64_dp4a.hip
@@ -1,0 +1,149 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a batched 4-way fused qkvza GEMM for HFQ6/MQ6, gfx906.
+// DeltaNet preamble (qkv + z + beta + alpha) at B>1.
+//
+// Combines:
+//   - 4-way row-routing prologue from gemm_qkvza_hfq6g256.hip (wave32 baseline)
+//   - Wave64 topology + Q8_1 lookup + dp4a inner loop from
+//     gemm_hfq6g256_residual_wave64_dp4a.hip (Phase A.2)
+//   - HFQ6 6-bit unpack + Q8_1 packing identical to fused_qkvza_hfq6g256_wave64_dp4a.hip
+//
+// Plan §3.2.3 §5.1 item 3 (Phase A.3). Fires when batch_size > 1 and
+// gemv_dp4a_enabled(arch) — i.e. gfx906 prefill + DFlash verify.
+//
+// Output semantics: y[b][row] = acc (overwrite), matching the HFQ4
+// batched-fused convention. Residual is only fused at the wo + w_down
+// sites which use gemm_hfq6g256_residual_wave64_dp4a (Phase A.2).
+
+#define QK8_1 32
+#define BATCH_TILE 8
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_qkvza_hfq6g256_wave64_dp4a(
+    const char*  __restrict__ A_qkv,
+    const char*  __restrict__ A_z,
+    const char*  __restrict__ A_beta,
+    const char*  __restrict__ A_alpha,
+    const block_q8_1_mmq* __restrict__ Xq,    // kblock-major: [K/128 * batch_size]
+    float*       __restrict__ Y_qkv,           // [batch_size, qkv_m]
+    float*       __restrict__ Y_z,
+    float*       __restrict__ Y_beta,
+    float*       __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    if (gid >= total_m) return;
+
+    // Route to target matrix + output stride.
+    const char* A;
+    float* Y;
+    int row;
+    int out_stride;
+    if (gid < qkv_m) {
+        A = A_qkv;   Y = Y_qkv;   row = gid;                                out_stride = qkv_m;
+    } else if (gid < qkv_m + z_m) {
+        A = A_z;     Y = Y_z;     row = gid - qkv_m;                         out_stride = z_m;
+    } else if (gid < qkv_m + z_m + beta_m) {
+        A = A_beta;  Y = Y_beta;  row = gid - (qkv_m + z_m);                  out_stride = beta_m;
+    } else {
+        A = A_alpha; Y = Y_alpha; row = gid - (qkv_m + z_m + beta_m);          out_stride = alpha_m;
+    }
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int byte_off = lane * 6;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 200;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+
+        // 8 weights from 6 bytes (HFQ6 6-bit unpack).
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+        const unsigned char b0 = dp[byte_off];
+        const unsigned char b1 = dp[byte_off + 1];
+        const unsigned char b2 = dp[byte_off + 2];
+        const unsigned char b3 = dp[byte_off + 3];
+        const unsigned char b4 = dp[byte_off + 4];
+        const unsigned char b5 = dp[byte_off + 5];
+
+        const unsigned int q0 = b0 & 63;
+        const unsigned int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        const unsigned int q2 = (b1 >> 4) | ((b2 & 3)  << 4);
+        const unsigned int q3 = b2 >> 2;
+        const unsigned int q4 = b3 & 63;
+        const unsigned int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        const unsigned int q6 = (b4 >> 4) | ((b5 & 3)  << 4);
+        const unsigned int q7 = b5 >> 2;
+
+        const int int_a = (int)((q0 & 0xFF)
+                              | ((q1 & 0xFF) << 8)
+                              | ((q2 & 0xFF) << 16)
+                              | ((q3 & 0xFF) << 24));
+        const int int_b = (int)((q4 & 0xFF)
+                              | ((q5 & 0xFF) << 8)
+                              | ((q6 & 0xFF) << 16)
+                              | ((q7 & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        // Per-batch-token loop.
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp * sum_x * 0.25f;
+        }
+    }
+
+    // Reduce + write-back. Overwrite semantics for the fused-projection
+    // family (caller adds residual at wo + w_down sites separately).
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) Y[(long long)(batch_start + b) * out_stride + row] = val;
+    }
+}

--- a/kernels/src/gemv_hfq6g256_residual_wave64.hip
+++ b/kernels/src/gemv_hfq6g256_residual_wave64.hip
@@ -1,0 +1,134 @@
+#include <hip/hip_runtime.h>
+
+// Wave64-native counterpart to gemv_hfq6g256_residual for gfx906 / CDNA1+ /
+// CDNA3 (anywhere `has_wave64_native` returns true). The wave32 base kernel
+// runs at half throughput on a wave64-native arch because half the wave's
+// lanes mask out per pyramid `__shfl_down`.
+//
+// block=[64,1,1] packs two rows per block (one per warp); grid halves from
+// M to (M + 1) / 2. Each warp's 32-lane reduction is byte-exact with the
+// wave32 base kernel's pyramid (lane 0 per warp writes output; the
+// `__shfl_down` chain stays within the 32-lane warp).
+//
+// Mirror of `gemv_hfq4g256_residual_wave64.hip`'s structure with HFQ6's
+// 6-bit unpack from `gemv_hfq6g256_residual.hip`. Per-thread footprint
+// is 8 weights = 6 bytes (4 weights per 3 bytes packing), wider than
+// HFQ4's 4 bytes per thread; expect ~10–15 % higher VGPR usage. If
+// occupancy regresses, dial back to `__launch_bounds__(64, N)` with
+// smaller N, or split the 4-quad accumulator into 2.
+//
+// Identical math to gemv_hfq6g256_residual: per-group dequant
+// `acc += (scale * q + zero) * x[k]` for k ∈ [0..7] per thread per group,
+// plus 4-accumulator interleave (q ∈ {0,1,2,3} pyramid) when
+// groups_per_row >= 4. Output line uses `+=` to fuse the residual add.
+
+extern "C" __global__ void gemv_hfq6g256_residual_wave64(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int row = blockIdx.x * 2 + warp_id;
+    if (row >= M) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int byte_off = lane * 6;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    // 6-bit unpack: 8 weights = 48 bits = 6 bytes per thread per group.
+    //   q0 = b0 & 63
+    //   q1 = (b0 >> 6) | ((b1 & 0xF) << 2)
+    //   q2 = (b1 >> 4) | ((b2 & 3)  << 4)
+    //   q3 = b2 >> 2
+    //   q4..q7: same pattern on bytes 3..5
+    #define UNPACK_AND_DOG(gp, sc, zp, b, a) do {                                      \
+        const unsigned char* _data = (const unsigned char*)(gp + 8);                   \
+        unsigned char _b0 = _data[byte_off];                                            \
+        unsigned char _b1 = _data[byte_off + 1];                                        \
+        unsigned char _b2 = _data[byte_off + 2];                                        \
+        unsigned char _b3 = _data[byte_off + 3];                                        \
+        unsigned char _b4 = _data[byte_off + 4];                                        \
+        unsigned char _b5 = _data[byte_off + 5];                                        \
+        int _q0 = _b0 & 63;                                                             \
+        int _q1 = (_b0 >> 6) | ((_b1 & 0xF) << 2);                                      \
+        int _q2 = (_b1 >> 4) | ((_b2 & 3)  << 4);                                       \
+        int _q3 = _b2 >> 2;                                                             \
+        int _q4 = _b3 & 63;                                                             \
+        int _q5 = (_b3 >> 6) | ((_b4 & 0xF) << 2);                                      \
+        int _q6 = (_b4 >> 4) | ((_b5 & 3)  << 4);                                       \
+        int _q7 = _b5 >> 2;                                                             \
+        (a) += (sc * (float)_q0 + zp) * x[(b)]                                          \
+             + (sc * (float)_q1 + zp) * x[(b) + 1]                                      \
+             + (sc * (float)_q2 + zp) * x[(b) + 2]                                      \
+             + (sc * (float)_q3 + zp) * x[(b) + 3]                                      \
+             + (sc * (float)_q4 + zp) * x[(b) + 4]                                      \
+             + (sc * (float)_q5 + zp) * x[(b) + 5]                                      \
+             + (sc * (float)_q6 + zp) * x[(b) + 6]                                      \
+             + (sc * (float)_q7 + zp) * x[(b) + 7];                                     \
+    } while(0)
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 200;
+        const char* gp1 = gp0 + 200;
+        const char* gp2 = gp1 + 200;
+        const char* gp3 = gp2 + 200;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        int base = g * 256 + lane * 8;
+
+        UNPACK_AND_DOG(gp0, sc0, zp0, base,       acc0);
+        UNPACK_AND_DOG(gp1, sc1, zp1, base + 256, acc1);
+        UNPACK_AND_DOG(gp2, sc2, zp2, base + 512, acc2);
+        UNPACK_AND_DOG(gp3, sc3, zp3, base + 768, acc3);
+    }
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 200;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        int base = g * 256 + lane * 8;
+        UNPACK_AND_DOG(gp, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 200;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        int base = g * 256 + lane * 8;
+        UNPACK_AND_DOG(gp, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 200;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        int base = g * 256 + lane * 8;
+        UNPACK_AND_DOG(gp, sc, zp, base, acc2);
+    }
+    #undef UNPACK_AND_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] += acc;   // each warp's lane 0 writes its row
+}

--- a/kernels/src/gemv_hfq6g256_residual_wave64_prefetch.hip
+++ b/kernels/src/gemv_hfq6g256_residual_wave64_prefetch.hip
@@ -1,0 +1,219 @@
+#include <hip/hip_runtime.h>
+
+// Software-pipelined variant of gemv_hfq6g256_residual_wave64. Identical
+// math; the only structural change is across-quad weight prefetch — quad
+// q+1's packed bytes + scales/zeros are issued *before* quad q's compute
+// chain runs, so the L2 fills overlap with the FMA chain instead of
+// stalling the load unit each iteration.
+//
+// Mirror of gemv_hfq4g256_residual_wave64_prefetch.hip's structure with
+// HFQ6's 6-bit unpack and wider per-thread footprint:
+//   HFQ4: 4 bytes/thread/group (1 dword)
+//   HFQ6: 6 bytes/thread/group (1.5 dwords; loaded as 2 separate u32s
+//                               with a partial-byte tail)
+//
+// Layout / topology unchanged from the non-prefetched wave64 sibling:
+// block=[64,1,1], 2 rows/WG (warp_id=0,1), 4-quad interleave with 4
+// accumulators. Bit-exact with the non-prefetched base modulo IEEE FMA
+// reordering tolerance.
+//
+// VGPR cost: HFQ4 sibling is 29 VGPR base, ~41-44 VGPR with prefetch.
+// HFQ6's wider unpack + slightly larger packed footprint should land
+// ~46-50 VGPR — still 5 waves/SIMD on gfx906 (granule cap 64-VGPR for
+// 5 waves). If occupancy regresses below 5, dial back to a 2-quad
+// pipeline depth (split into pairs).
+
+extern "C" __global__ void gemv_hfq6g256_residual_wave64_prefetch(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int row = blockIdx.x * 2 + warp_id;
+    if (row >= M) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int byte_off = lane * 6;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    // 6-bit unpack from 6 bytes into 8 weights, dequant + FMA against x[].
+    // Same arithmetic as gemv_hfq6g256_residual_wave64.hip's UNPACK_AND_DOG.
+    #define UNPACK_AND_DOG(b0, b1, b2, b3, b4, b5, sc, zp, base, a) do {           \
+        int _q0 = (b0) & 63;                                                        \
+        int _q1 = ((b0) >> 6) | (((b1) & 0xF) << 2);                                \
+        int _q2 = ((b1) >> 4) | (((b2) & 3)  << 4);                                 \
+        int _q3 = (b2) >> 2;                                                        \
+        int _q4 = (b3) & 63;                                                        \
+        int _q5 = ((b3) >> 6) | (((b4) & 0xF) << 2);                                \
+        int _q6 = ((b4) >> 4) | (((b5) & 3)  << 4);                                 \
+        int _q7 = (b5) >> 2;                                                        \
+        (a) += (sc * (float)_q0 + zp) * x[(base)]                                   \
+             + (sc * (float)_q1 + zp) * x[(base) + 1]                               \
+             + (sc * (float)_q2 + zp) * x[(base) + 2]                               \
+             + (sc * (float)_q3 + zp) * x[(base) + 3]                               \
+             + (sc * (float)_q4 + zp) * x[(base) + 4]                               \
+             + (sc * (float)_q5 + zp) * x[(base) + 5]                               \
+             + (sc * (float)_q6 + zp) * x[(base) + 6]                               \
+             + (sc * (float)_q7 + zp) * x[(base) + 7];                              \
+    } while (0)
+
+    // Load all 4 groups of quad q_idx into the staged registers.
+    // Each group: 4 bytes scale + 4 bytes zero + 6 bytes packed at byte_off.
+    //
+    // The 6 packed bytes per group could be loaded as a single u32 + u16
+    // when (byte_off & 3) == 2, or as 6 individual byte loads. We use a
+    // u32 + u16 load approach: u32 covers bytes [0..3], u16 covers
+    // [4..5]. byte_off = lane * 6 ∈ {0, 6, 12, 18, 24, 30, 36, 42, 48, 54,
+    // 60, 66, 72, 78, 84, 90, 96, 102, 108, 114, 120, 126, 132, 138, 144,
+    // 150, 156, 162, 168, 174, 180, 186}. (byte_off & 3) cycles {0,2,0,2,...},
+    // so half the lanes naturally u32-align and the other half are
+    // 2-byte aligned. Both are dword-fast on gfx906.
+    //
+    // We just use 6 byte-loads per group via uchar* — the compiler can
+    // coalesce these into the natural alignment. This matches the
+    // non-prefetched sibling's pattern; benchmarking will tell us if
+    // moving to u32+u16 explicit loads buys anything.
+    #define LOAD_QUAD(q_idx,                                                       \
+                      sc0v, zp0v, sc1v, zp1v, sc2v, zp2v, sc3v, zp3v,              \
+                      b00, b01, b02, b03, b04, b05,                                \
+                      b10, b11, b12, b13, b14, b15,                                \
+                      b20, b21, b22, b23, b24, b25,                                \
+                      b30, b31, b32, b33, b34, b35)                                \
+        do {                                                                       \
+            const int g_ = (q_idx) << 2;                                           \
+            const char* gp0_ = row_ptr + g_ * 200;                                 \
+            const char* gp1_ = gp0_ + 200;                                         \
+            const char* gp2_ = gp1_ + 200;                                         \
+            const char* gp3_ = gp2_ + 200;                                         \
+            (sc0v) = __builtin_bit_cast(float, *(const unsigned int*)(gp0_));      \
+            (zp0v) = __builtin_bit_cast(float, *(const unsigned int*)(gp0_ + 4));  \
+            (sc1v) = __builtin_bit_cast(float, *(const unsigned int*)(gp1_));      \
+            (zp1v) = __builtin_bit_cast(float, *(const unsigned int*)(gp1_ + 4));  \
+            (sc2v) = __builtin_bit_cast(float, *(const unsigned int*)(gp2_));      \
+            (zp2v) = __builtin_bit_cast(float, *(const unsigned int*)(gp2_ + 4));  \
+            (sc3v) = __builtin_bit_cast(float, *(const unsigned int*)(gp3_));      \
+            (zp3v) = __builtin_bit_cast(float, *(const unsigned int*)(gp3_ + 4));  \
+            const unsigned char* d0_ = (const unsigned char*)(gp0_ + 8);            \
+            const unsigned char* d1_ = (const unsigned char*)(gp1_ + 8);            \
+            const unsigned char* d2_ = (const unsigned char*)(gp2_ + 8);            \
+            const unsigned char* d3_ = (const unsigned char*)(gp3_ + 8);            \
+            (b00) = d0_[byte_off];     (b01) = d0_[byte_off + 1];                  \
+            (b02) = d0_[byte_off + 2]; (b03) = d0_[byte_off + 3];                  \
+            (b04) = d0_[byte_off + 4]; (b05) = d0_[byte_off + 5];                  \
+            (b10) = d1_[byte_off];     (b11) = d1_[byte_off + 1];                  \
+            (b12) = d1_[byte_off + 2]; (b13) = d1_[byte_off + 3];                  \
+            (b14) = d1_[byte_off + 4]; (b15) = d1_[byte_off + 5];                  \
+            (b20) = d2_[byte_off];     (b21) = d2_[byte_off + 1];                  \
+            (b22) = d2_[byte_off + 2]; (b23) = d2_[byte_off + 3];                  \
+            (b24) = d2_[byte_off + 4]; (b25) = d2_[byte_off + 5];                  \
+            (b30) = d3_[byte_off];     (b31) = d3_[byte_off + 1];                  \
+            (b32) = d3_[byte_off + 2]; (b33) = d3_[byte_off + 3];                  \
+            (b34) = d3_[byte_off + 4]; (b35) = d3_[byte_off + 5];                  \
+        } while (0)
+
+    if (quads > 0) {
+        // Prologue: load quad 0 into the staged registers.
+        float sc0, zp0, sc1, zp1, sc2, zp2, sc3, zp3;
+        unsigned char b00, b01, b02, b03, b04, b05;
+        unsigned char b10, b11, b12, b13, b14, b15;
+        unsigned char b20, b21, b22, b23, b24, b25;
+        unsigned char b30, b31, b32, b33, b34, b35;
+        LOAD_QUAD(0, sc0, zp0, sc1, zp1, sc2, zp2, sc3, zp3,
+                  b00, b01, b02, b03, b04, b05,
+                  b10, b11, b12, b13, b14, b15,
+                  b20, b21, b22, b23, b24, b25,
+                  b30, b31, b32, b33, b34, b35);
+
+        // Steady state: compute(q) then prefetch(q+1) into next-iter regs.
+        for (int q = 0; q < quads - 1; q++) {
+            float n_sc0, n_zp0, n_sc1, n_zp1, n_sc2, n_zp2, n_sc3, n_zp3;
+            unsigned char n_b00, n_b01, n_b02, n_b03, n_b04, n_b05;
+            unsigned char n_b10, n_b11, n_b12, n_b13, n_b14, n_b15;
+            unsigned char n_b20, n_b21, n_b22, n_b23, n_b24, n_b25;
+            unsigned char n_b30, n_b31, n_b32, n_b33, n_b34, n_b35;
+            LOAD_QUAD(q + 1,
+                      n_sc0, n_zp0, n_sc1, n_zp1, n_sc2, n_zp2, n_sc3, n_zp3,
+                      n_b00, n_b01, n_b02, n_b03, n_b04, n_b05,
+                      n_b10, n_b11, n_b12, n_b13, n_b14, n_b15,
+                      n_b20, n_b21, n_b22, n_b23, n_b24, n_b25,
+                      n_b30, n_b31, n_b32, n_b33, n_b34, n_b35);
+
+            int base = (q << 2) * 256 + lane * 8;
+            UNPACK_AND_DOG(b00, b01, b02, b03, b04, b05, sc0, zp0, base,         acc0);
+            UNPACK_AND_DOG(b10, b11, b12, b13, b14, b15, sc1, zp1, base + 256,   acc1);
+            UNPACK_AND_DOG(b20, b21, b22, b23, b24, b25, sc2, zp2, base + 512,   acc2);
+            UNPACK_AND_DOG(b30, b31, b32, b33, b34, b35, sc3, zp3, base + 768,   acc3);
+
+            sc0 = n_sc0; zp0 = n_zp0; sc1 = n_sc1; zp1 = n_zp1;
+            sc2 = n_sc2; zp2 = n_zp2; sc3 = n_sc3; zp3 = n_zp3;
+            b00 = n_b00; b01 = n_b01; b02 = n_b02; b03 = n_b03; b04 = n_b04; b05 = n_b05;
+            b10 = n_b10; b11 = n_b11; b12 = n_b12; b13 = n_b13; b14 = n_b14; b15 = n_b15;
+            b20 = n_b20; b21 = n_b21; b22 = n_b22; b23 = n_b23; b24 = n_b24; b25 = n_b25;
+            b30 = n_b30; b31 = n_b31; b32 = n_b32; b33 = n_b33; b34 = n_b34; b35 = n_b35;
+        }
+
+        // Epilogue: compute the last quad whose data was prefetched.
+        {
+            int base = ((quads - 1) << 2) * 256 + lane * 8;
+            UNPACK_AND_DOG(b00, b01, b02, b03, b04, b05, sc0, zp0, base,         acc0);
+            UNPACK_AND_DOG(b10, b11, b12, b13, b14, b15, sc1, zp1, base + 256,   acc1);
+            UNPACK_AND_DOG(b20, b21, b22, b23, b24, b25, sc2, zp2, base + 512,   acc2);
+            UNPACK_AND_DOG(b30, b31, b32, b33, b34, b35, sc3, zp3, base + 768,   acc3);
+        }
+    }
+    #undef LOAD_QUAD
+
+    // Tail (1-3 trailing groups, no prefetch — too few iterations to amortize).
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 200;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8);
+        unsigned char b0 = d[byte_off],     b1 = d[byte_off + 1];
+        unsigned char b2 = d[byte_off + 2], b3 = d[byte_off + 3];
+        unsigned char b4 = d[byte_off + 4], b5 = d[byte_off + 5];
+        int base = g * 256 + lane * 8;
+        UNPACK_AND_DOG(b0, b1, b2, b3, b4, b5, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 200;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8);
+        unsigned char b0 = d[byte_off],     b1 = d[byte_off + 1];
+        unsigned char b2 = d[byte_off + 2], b3 = d[byte_off + 3];
+        unsigned char b4 = d[byte_off + 4], b5 = d[byte_off + 5];
+        int base = g * 256 + lane * 8;
+        UNPACK_AND_DOG(b0, b1, b2, b3, b4, b5, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 200;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* d = (const unsigned char*)(gp + 8);
+        unsigned char b0 = d[byte_off],     b1 = d[byte_off + 1];
+        unsigned char b2 = d[byte_off + 2], b3 = d[byte_off + 3];
+        unsigned char b4 = d[byte_off + 4], b5 = d[byte_off + 5];
+        int base = g * 256 + lane * 8;
+        UNPACK_AND_DOG(b0, b1, b2, b3, b4, b5, sc, zp, base, acc2);
+    }
+    #undef UNPACK_AND_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] += acc;
+}


### PR DESCRIPTION
## Summary

Closes the gfx906 / HFQ6 / MQ6 perf gap by porting the wave64 + dp4a kernel family that PR #158 shipped for HFQ4. Six new kernels + dispatch + arch wiring across 6 commits. **Both decode and prefill substantially improved on Qwen 3.5/3.6 at MI50 (gfx906)**, mirror of the HFQ4 stack. mq6 was previously running on the wave32 / FP16-packed paths with no gfx906-specific optimization.

> **Sequencing:** this PR ships **Phase A only**. A follow-up PR (B.1 + B.2 + v3.2.7) is on `feat/gfx906-hfq6-hfq8-analysis` and depends on this one. Phase B closes the remaining 3.65× mq4-vs-mq6 gap to **0.94× of mq4 parity** via MMQ-streaming + DFlash unlock; sequenced after #187 merges to keep review surface manageable.

## Headline numbers

5-run fresh-process median per `AGENTS.md §5`. Per-quant bench protocol matches the bench-cold harness (`scripts/bench-cold.sh`): asym3 KV, `HIPFIRE_GRAPH=1`, `HIPFIRE_DPM_WARMUP_SECS=10`, deterministic 0..N-1 fake-prompt seed.

| Workload | Pre-Phase-A (wave32) | Post-Phase-A | Δ |
|---|---:|---:|---:|
| 9B mq6 decode pp32 | 31.1 tok/s | **44.0** | **+41.5%** |
| 9B mq6 decode pp128 | 30.3 | **42.6** | **+40.6%** |
| 9B mq6 prefill pp32 | 46.3 | **157.4** | **+240%** (3.4×) |
| 9B mq6 prefill pp128 | 46.7 | **162.6** | **+248%** (3.5×) |
| 27B mq6 decode pp32 | 10.2 | **15.3** | **+50.0%** |
| 27B mq6 decode pp128 | 10.1 | **15.0** | **+48.5%** |
| 27B mq6 prefill pp32 | 13.5 | **46.4** | **+244%** (3.4×) |
| 27B mq6 prefill pp128 | 13.5 | **47.1** | **+249%** (3.5×) |

Spread ≤ 1.5 % on every measurement; deterministic.

## mq4-vs-mq6 prefill gap

| Stage | mq4 9B pp128 | mq6 9B pp128 | Ratio |
|---|---:|---:|---:|
| Pre-Phase-A | 593.8 | 46.7 | 12.7× |
| **Post-Phase-A** | **593.8** | **162.6** | **3.65×** |

mq6 has structurally 1.47× more weight bytes than mq4 (200 vs 136 B/group), so the bandwidth-bound floor is ~1.47×. Phase A closes the gap from 12.7× → 3.65×, leaving ~2.5× of "kernel-architecture" gap remaining — that's MMQ-streaming territory, addressed in the **follow-up PR** which closes the gap to 1.07× (within 6 % of mq4 parity).

## What's in this PR

Six commits, sequenced as layered improvements:

1. **A.1a** (`239666c`) — `gemv_hfq6g256_residual_wave64.hip`: wave64 mirror of the HFQ4 sibling. +3% decode (matches HFQ4 reference's +3.2% on MI300X per `166451d`).
2. **A.1b** (`8ab8ab1`) — `gemv_hfq6g256_residual_wave64_prefetch.hip`: software-pipelined ILP-prefetch on the wave64 residual GEMV. +1-3% decode cumulative.
3. **A.1c** (`4cb6763`) — `fused_{gate_up,qkv,qkvza}_hfq6g256_wave64_dp4a.hip`: dp4a-on-fused-GEMVs trio (FFN gate+up, FA QKV, DN QKVZA preambles). **+35-40% decode** — the dominant decode lever.
4. **A.2** (`4ca9bfc`) — `gemm_hfq6g256_residual_wave64_dp4a.hip`: dp4a on the batched residual GEMM (per-layer wo + w_down at B>1). +30% prefill.
5. **A.3** (`94643cb`) — `gemm_{gate_up,qkv,qkvza}_hfq6g256_wave64_dp4a.hip`: dp4a-on-batched-fused-GEMMs trio. **+162-171% prefill** over A.2 — the dominant prefill lever.
6. **A.4** (`61d99a8`) — `gemm_hfq6g256_batched_lmhead` Rust wrapper + `speculative.rs` `try_batched` extension to cover HFQ6/MQ6 (closing a perf miss documented in earlier audit work). No new kernel — reuses A.2's residual kernel with zero-init Y.
7. **A.review** (`5768fe4`) — three-way review (self / glm5 / gemini) follow-ups: capture_mode guards on 5 HFQ6 dp4a sites, DDTree HFQ6/MQ6 dispatch arms, stale comment.

Kernel files added (9 .hip, ~1500 lines): the GEMV-shape trio (A.1c), the GEMM-shape singles (A.2), the GEMM-shape trio (A.3), and the wave64 residual + prefetch GEMVs (A.1a, A.1b).

## Math identity (HFQ6 vs HFQ4 dp4a)

HFQ6 weights are unsigned `q ∈ [0, 63]`. Plan §2.2 Option A: no `(n - 8)` shift correction needed (unlike HFQ4's nibbles). Math:
```
acc += sc * d_x * sumi_dp4a + zp * sum_x * 0.25
```
The 0.25 factor distributes Q8_1's per-sub-block `sum_x` (32 K-elements) across the 4 lanes that share each sub-block (lanes own 8 K-elements each); the 32-lane warp reduction recovers the per-sub-block term exactly. Identical pattern to `fused_*_hfq4g256_wave64_dp4a.hip` minus the `+ 8.0f * sc` correction.

## Coherence

`scripts/coherence-gate.sh` passed at HEAD `5768fe4` — 7/7 SHORT_TESTS rows green:

```
qwen3.5-0.8b.mq4 / cap          status: OK
qwen3.5-4b.mq4   / code         status: OK
qwen3.5-9b.mq4   / reason       status: OK    (mq4 unaffected — gated paths)
qwen3.5-9b.mq4   / tool-call    status: OK
qwen3.5-9b.mq3   / reason-mq3   status: OK    (mq3 unaffected)
qwen3.5-27b.mq3  / cap-mq3-27b  status: OK
qwen3.5-9b.mq6   / reason-mq6   status: OK    (the new dp4a paths)
```

mq6 gate output is structured fluent reasoning, correctly arrives at "9 are left" on the canonical sheep prompt. mq4/mq3 rows confirm zero regression on the gated paths.

In-gate decode tok/s for `qwen3.5-9b.mq6 / reason-mq6`: **41.4 tok/s** (matches bench-cold's 42.6 within noise).

Math byte-equivalent to the wave32 / FP16-packed baseline modulo IEEE FMA reordering + Q8_1 quantization noise (same noise floor PR #158 validated for HFQ4 dp4a paths, NRMSE ≤ 0.30%).

## Architecture / dispatch gating

All Phase A paths are gated on `gemv_dp4a_enabled(arch)` (default-on for `gfx906` only) within the existing arch-aware dispatchers (`gemm_qkvza_hfq6g256`, `gemm_qkv_hfq6g256`, `gemm_gate_up_hfq6g256`, `gemm_hfq6g256_residual`). Other archs continue WMMA / dot2 / FP16 fallbacks with no change.

Promoted `gemv_dp4a_enabled` to `pub` in `crates/rdna-compute/src/dispatch.rs` and re-exported from the crate so the arch crate can use it for compile-time arch gating in qwen35.rs (3 call sites for fused FA QKV, LA QKVZA, FFN gate_up; 1 call site for MoE FA QKV).

## Build verification

```
hipcc --genco --offload-arch=gfx906 -O3 -I/opt/rocm/include kernels/src/<kernel>.hip
```
All 9 new kernels compile clean on **gfx906**. The dp4a kernels (A.1c trio, A.2, A.3 trio, A.4-via-A.2) require `dot1-insts` which is gfx906/CDNA-only. Kernel-source builds **fail** on gfx1100/gfx1201 with `error: '__builtin_amdgcn_sdot4' needs target feature dot1-insts` — same constraint as the existing `fused_*_hfq4g256_wave64_dp4a.hip` family. The runtime `gemv_dp4a_enabled` gate correctly restricts dispatch to gfx906 only.

The wave64 ports (A.1a, A.1b) build clean on **gfx906, gfx1100, gfx1201** because they use plain `__shfl_down`. Gated on `has_wave64_native` (gfx906/908/94x) for runtime dispatch.

## What's NOT in this PR (covered in follow-up)

- **No MMQ-streaming port for HFQ6** — Phase B.2, follow-up PR. Closes the remaining 3.65× mq4-vs-mq6 prefill gap to 1.07× via small-tile dp4a-MMQ streaming (mirror of `gemm_hfq4g256_residual_mmq_gfx906_x{N}` from PR #158).
- **No BT propagation** — Phase B.1, follow-up PR. +14.5 % from doubling BATCH_TILE on the dp4a kernels.
- **No DFlash mq6 spec-decode unlock** — v3.2.7 follow-up. 4.74 → 15.05 tok/s decode at 27B mq6 via lifting the capture_mode gate on MMQ branches.
- **No MoE-indexed kernels for HFQ6**. Out of scope; only relevant for A3B+MQ6 workloads which don't ship today.
- **No changes to MQ4 / HFQ4 paths**. All Phase A code is gated by dtype + `gemv_dp4a_enabled(arch)`.
- **No silent-corruption-gap fixes**. Earlier audit work flagged 22 missing matchers in qwen35.rs (MQ8/MQ2 zero coverage, MQ3 missing from MoE-batched bodies). Tracked separately as upstream issue #179 + PR #115 comment; not part of this PR.

## Test plan

- [x] `cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4` (clean)
- [x] `hipcc --genco --offload-arch=gfx906 -O3 -I/opt/rocm/include` for all 9 new kernels (clean)
- [x] `bench_qwen35_mq4 qwen3.5-9b.mq6` 5-run fresh-process median (numbers above)
- [x] `bench_qwen35_mq4 qwen3.6-27b.mq6` 5-run fresh-process median (numbers above)
- [x] `scripts/coherence-gate.sh` (7/7 PASS, mq4/mq3/mq6 all coherent)
- [x] `scripts/audit-dispatch-coverage.sh` reports same 22 gaps as before — Phase A doesn't introduce new dispatch-coverage gaps, all pre-existing (MQ2/MQ8 latent, MQ3 MoE-batched issue #179)
- [x] mq4 zero-regression sanity (mq4 paths gated; gate decode tok/s in-gate at 56.5 vs bench-cold 57 ✓)

## Refs

- PR #158 (`afb84bd`): the HFQ4 sibling wave64 + dp4a + MMQ work this PR mirrors
- PR #186 (`ee0fac6`): sister PR — standalone `gemv_mq8g256.hip` sudot4→sdot4 buildability fix (already merged)
- HFQ4 dp4a attribution data from `docs/perf-checkpoints/2026-05-05-gfx906-decode-investigation.md` informed the per-lever calibration
- **Follow-up PR (Phase B + v3.2.7)** — branch `feat/gfx906-hfq6-hfq8-analysis`. Closes mq6/mq4 gap to 1.07×, unlocks DFlash mq6 spec-decode at 3.18× via capture-mode fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)