### PR TITLE
ZAYA1-8B port: intake (Phase 0+1 + Phase 4/5/6 designs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +107,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -156,9 +173,11 @@ dependencies = [
 name = "hipfire-arch-zaya"
 version = "0.1.20"
 dependencies = [
+ "half",
  "hip-bridge",
  "hipfire-runtime",
  "rdna-compute",
+ "safetensors",
  "serde",
  "serde_json",
 ]
@@ -354,6 +373,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +473,26 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,11 +153,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hipfire-detect"
+name = "hipfire-arch-zaya"
 version = "0.1.20"
 dependencies = [
- "md5",
- "regex",
+ "hip-bridge",
+ "hipfire-runtime",
+ "rdna-compute",
  "serde",
  "serde_json",
 ]
@@ -191,7 +183,6 @@ dependencies = [
  "hipfire-arch-llama",
  "hipfire-arch-qwen35",
  "hipfire-arch-qwen35-vl",
- "hipfire-detect",
  "libc",
  "memmap2",
  "rayon",
@@ -245,12 +236,6 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -367,35 +352,6 @@ dependencies = [
  "libc",
  "libloading",
 ]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,8 +185,19 @@ dependencies = [
  "half",
  "hip-bridge",
  "hipfire-runtime",
+ "libm",
  "rdna-compute",
  "safetensors",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "hipfire-detect"
+version = "0.1.20"
+dependencies = [
+ "md5",
+ "regex",
  "serde",
  "serde_json",
 ]
@@ -202,6 +222,7 @@ dependencies = [
  "hipfire-arch-llama",
  "hipfire-arch-qwen35",
  "hipfire-arch-qwen35-vl",
+ "hipfire-detect",
  "libc",
  "memmap2",
  "rayon",
@@ -255,6 +276,18 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -371,6 +404,35 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "safetensors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/hipfire-arch-qwen35-vl",
     "crates/hipfire-arch-llama",
     "crates/hipfire-arch-toy",
+    "crates/hipfire-arch-zaya",
     "crates/hipfire-quantize",
     "crates/hipfire-detect",
     "crates/redline",

--- a/MANUAL_REVIEW.md
+++ b/MANUAL_REVIEW.md
@@ -7,11 +7,12 @@ downstream work.
 
 - **What's escalated:** First per-layer recurrent state in hipfire that
   lives across decode steps. CCA (Compressed Convolutional Attention)
-  carries two per-layer per-sequence state buffers across decode steps
-  (~720 KB total per sequence at fp16 for ZAYA1-8B):
-   - `conv_states[80, B, 1280, 2]` fp16 - causal Conv1d-along-time
-     circular buffer.
-   - `prev_hs[80, B, 2048]` fp16 - 1-step lag of input hidden state.
+  carries two per-ATT-layer per-sequence state buffers across decode
+  steps (~370 KB total per sequence at fp16 for ZAYA1-8B):
+   - `conv_states[40, B, 1280, 2]` fp16 - causal Conv1d-along-time
+     circular buffer (40 = ATT-layer count, not 80; ZAYA1 alternates
+     ATT and MLP sub-layers).
+   - `prev_hs[40, B, 2048]` fp16 - 1-step lag of input hidden state.
 - **Why escalated:** the contract for the overnight ZAYA1 port intake
   forbids autonomous structural runtime changes. Three coupled
   decisions need your call before the implementing PR can land.
@@ -28,8 +29,8 @@ downstream work.
       structural simplicity. Recurrent spec-decode added in a later
       PR with proper state fork/commit primitives.
    3. **Paging policy.** HBM-pinned recurrent state vs paged.
-      Recommendation: HBM-pinned. ~720 KB per sequence at fp16; even
-      256 sequences only consumes 184 MB pinned per device.
+      Recommendation: HBM-pinned. ~370 KB per sequence at fp16; even
+      256 sequences only consumes 95 MB pinned per device.
 - **Predicates already landed on this branch:**
    - `00-cca-disambiguation.md` (verdict: RECURRENT, with verbatim code
      evidence).

--- a/MANUAL_REVIEW.md
+++ b/MANUAL_REVIEW.md
@@ -1,6 +1,48 @@
-# PFLASH Manual Review Queue
+# Manual Review Queue
 
-Items that require Kaden's judgment. Sorted by what unblocks the most downstream work.
+Items that require Kaden's judgment. Sorted by what unblocks the most
+downstream work.
+
+## REQUIRES-KADEN-DECISION: ZAYA1 port recurrent-state shape (Phase 6)
+
+- **What's escalated:** First per-layer recurrent state in hipfire that
+  lives across decode steps. CCA (Compressed Convolutional Attention)
+  carries two per-layer per-sequence state buffers across decode steps
+  (~720 KB total per sequence at fp16 for ZAYA1-8B):
+   - `conv_states[80, B, 1280, 2]` fp16 - causal Conv1d-along-time
+     circular buffer.
+   - `prev_hs[80, B, 2048]` fp16 - 1-step lag of input hidden state.
+- **Why escalated:** the contract for the overnight ZAYA1 port intake
+  forbids autonomous structural runtime changes. Three coupled
+  decisions need your call before the implementing PR can land.
+- **Decisions needed:**
+   1. **State location.** Option A (per-arch State carries the
+      buffers, zero hipfire-runtime churn, fits in arch crate) vs
+      Option B (first-class recurrent-cache primitive in
+      hipfire-runtime parallel to KV pager). Recommendation: A first,
+      migrate to B when a second recurrent arch arrives. Cost delta
+      for B: roughly +1 week.
+   2. **First-ship spec-decode policy.** AR-only or recurrent-spec-decode
+      from day one. Recommendation: AR-only first; ZAYA1 loses the
+      1.5-3x DFlash multiplier on first ship in exchange for
+      structural simplicity. Recurrent spec-decode added in a later
+      PR with proper state fork/commit primitives.
+   3. **Paging policy.** HBM-pinned recurrent state vs paged.
+      Recommendation: HBM-pinned. ~720 KB per sequence at fp16; even
+      256 sequences only consumes 184 MB pinned per device.
+- **Predicates already landed on this branch:**
+   - `00-cca-disambiguation.md` (verdict: RECURRENT, with verbatim code
+     evidence).
+   - `02-mod-design.md` (no runtime changes needed).
+   - `03-eda-identification.md` (no recurrent state).
+   - Phase 1 arch crate scaffold (compiles, 5 unit tests pass).
+- **Spec doc:** `docs/investigations/2026-05-07-zaya1-port-intake/01-recurrent-state-design.md`
+- **Effort to implement Phase 6.A** (Option A path): ~2 weeks calendar.
+  End-to-end ZAYA1 first coherent decode: ~5-6 weeks.
+- **Sequencing:** This PR (`feat/zaya1-port-intake`) is intake-only.
+  No code touches the recurrent state primitives until you land this
+  decision. Phases 1-5 (arch crate scaffold, free components, MoD
+  design, EDA design) can proceed independently and have begun.
 
 ## Full coherence-gate / speed-gate run hangs in this session
 

--- a/crates/hipfire-arch-zaya/Cargo.toml
+++ b/crates/hipfire-arch-zaya/Cargo.toml
@@ -24,12 +24,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-# Phase 2.B/2.C CPU validator only. Not needed for the library build,
-# only for the cpu_validate_phase2 example which compares hipfire's
-# CPU implementations of free components against a PyTorch reference
-# dump. Skips HFQ entirely; reads the model's bf16 safetensors directly.
+# Phase 2.B/2.C/2.D CPU validator only. Not needed for the library
+# build; only for the cpu_validate_phase2 example which compares
+# hipfire's CPU implementations of free components against a PyTorch
+# reference dump. Skips HFQ entirely; reads the model's bf16
+# safetensors directly.
 safetensors = "0.4"
 half = "2"
+libm = "0.2"  # erff for the exact GELU in the MLP-based MoE router.
 
 [[example]]
 name = "verify_against_torch"

--- a/crates/hipfire-arch-zaya/Cargo.toml
+++ b/crates/hipfire-arch-zaya/Cargo.toml
@@ -23,6 +23,18 @@ rdna-compute = { path = "../rdna-compute" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+[dev-dependencies]
+# Phase 2.B/2.C CPU validator only. Not needed for the library build,
+# only for the cpu_validate_phase2 example which compares hipfire's
+# CPU implementations of free components against a PyTorch reference
+# dump. Skips HFQ entirely; reads the model's bf16 safetensors directly.
+safetensors = "0.4"
+half = "2"
+
 [[example]]
 name = "verify_against_torch"
 path = "examples/verify_against_torch.rs"
+
+[[example]]
+name = "cpu_validate_phase2"
+path = "examples/cpu_validate_phase2.rs"

--- a/crates/hipfire-arch-zaya/Cargo.toml
+++ b/crates/hipfire-arch-zaya/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "hipfire-arch-zaya"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Zyphra ZAYA1 architecture (CCA + MoE + MoD) for hipfire (Phase 1 scaffold)"
+
+# Status: Phase 1 intake scaffold (2026-05-07).
+# - config / state / weights are typed but load_weights and new_state
+#   return Err until the recurrent-state plumbing lands (see
+#   docs/investigations/2026-05-07-zaya1-port-intake/00-cca-disambiguation.md
+#   for the verdict and Phase 6 design-doc plan).
+# - No CCA kernel yet (Phase 3 is gated behind Phase 6 runtime decision).
+# - No feature flag today; CCA recurrence is structurally pervasive,
+#   there is no "zaya without CCA" mode worth gating. If/when the
+#   recurrent-state primitives move into hipfire-runtime they may grow
+#   a `cca` feature there, mirroring qwen35's `deltanet` gate.
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+hip-bridge = { path = "../hip-bridge" }
+rdna-compute = { path = "../rdna-compute" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[[example]]
+name = "verify_against_torch"
+path = "examples/verify_against_torch.rs"

--- a/crates/hipfire-arch-zaya/README.md
+++ b/crates/hipfire-arch-zaya/README.md
@@ -1,0 +1,87 @@
+# hipfire-arch-zaya
+
+Zyphra ZAYA1 architecture for hipfire. **Phase 1 intake scaffold (2026-05-07).**
+
+Status: every method on the `Architecture` trait either returns a typed default
+(arch_id=7, name="zaya", overrides) or returns `Err` with a pointer to the
+intake docs. Forward pass is not implemented. No HFQ representation exists yet.
+
+See `docs/investigations/2026-05-07-zaya1-port-intake/` for the port plan,
+Phase 0 disambiguation verdict (CCA is RECURRENT), and the design docs that
+gate Phase 3+ work.
+
+## Architectural elements
+
+(From `Zyphra/transformers@zaya1` reading; cross-referenced against
+`Zyphra/ZAYA1-8B/config.json`.)
+
+### Free (map onto existing hipfire infrastructure)
+
+- **RMSNorm**, **SwiGLU**, **GQA** (16Q : 2KV, head_dim 128) — Qwen 3.5 path.
+- **Gemma tokenizer** (vocab 262272, eos 106 = `<end_of_turn>`) — Gemma 4 port.
+- **Top-1 MoE routing** — degenerate case of qwen35's top-k.
+- **Residual fp32 accumulator** — existing rmsnorm pattern.
+
+### Small kernel additions (Phase 2)
+
+- **partial_rotary_factor=0.5** — rotates first 64 of 128 head dims; either
+  parameterize the existing RoPE kernel or add a half-RoPE entry point.
+- **scale_residual_merge** — load per-block learnable scalar, multiply
+  during residual add.
+- **MLP-based MoE router** (2-layer, `zaya_mlp_expansion=256`) — replace
+  the existing linear router with a 2-layer MLP for routing logits.
+- **Top-1 routing path** — verify existing top-k handles k=1 cleanly,
+  skip combine.
+
+### Structurally new (Phase 6 design + escalation)
+
+- **CCA (Compressed Convolutional Attention)** — Zyphra-novel. Two
+  per-layer per-sequence recurrent buffers carry across decode steps:
+  - `conv_states[layer]` — `[B, 1280, 2]` fp16, circular buffer for the
+    causal Conv1d-along-time stack (depthwise k=2 + grouped k=2).
+  - `prev_hs[layer]` — `[B, 2048]` fp16, 1-step lag of input hidden
+    state for the v2 value-projection stream.
+  - Per ZAYA1-8B: ~720 KB recurrent state per sequence across all
+    layers. Trivial vs KV cache, but new infrastructure.
+  - Decode update: `roll(-1) + write[-1]` for `conv_states`,
+    `prev_hs[layer].copy_(hs[-1, :, :])` for `prev_hs`.
+
+- **Mixture-of-Depths (MoD)** — per-token layer-skip routing.
+  Conditionalizes KV writes; breaks DFlash/spec-decode assumptions.
+  Phase 4 design doc.
+
+- **EDA component** — `zaya_use_eda=true` is undocumented in the model
+  card and blog. Phase 5 source-read identifies it.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Cargo.toml` | Workspace member; deps mirror toy + qwen35. |
+| `src/lib.rs` | Module declarations + re-exports. |
+| `src/arch.rs` | `Architecture for Zaya` trait impl. arch_id=7, eos_filter overrides for Gemma turn markers. |
+| `src/config.rs` | `ZayaConfig` — every field from `Zyphra/ZAYA1-8B/config.json` with port-status notes. |
+| `src/state.rs` | `ZayaState` — typed slots for KV + CCA recurrent buffers; `cca_state_bytes_per_seq` helper. |
+| `src/weights.rs` | `ZayaWeights` — placeholder; per-layer weight inventory in doc-block. |
+| `src/forward.rs` | `prefill` / `decode_step` stubs that return Err. |
+| `examples/verify_against_torch.rs` | Skeleton for the per-layer NRMSE harness. |
+
+## Phase plan
+
+1. **Phase 0 (done):** CCA disambiguation. VERDICT: RECURRENT.
+2. **Phase 1 (in progress):** Crate scaffold + harness scaffold + reference dumps.
+3. **Phase 2:** Free components, each per-layer NRMSE-validated.
+4. **Phase 3:** Deferred. CCA kernel waits for Phase 6.
+5. **Phase 4:** MoD design doc; no autonomous integration.
+6. **Phase 5:** EDA identification.
+7. **Phase 6:** Recurrent-state design doc. REQUIRES-KADEN-DECISION.
+
+## RDNA target
+
+R9700 (gfx1201, 64 CUs, 32 GB VRAM). The CCA conv kernel is small and
+amenable to packed-fp16 (`v_pk_fma_f16`) on wave32; `in_out_ch=1280` is
+divisible by 64, kernel size 2 is a perfect fit for the 2-element
+packed FMA. The recurrent state's `roll(-1) + write[-1]` becomes a
+single uint32 swap if conv_states are laid out as consecutive fp16
+pairs in HBM. These are sketches, not commitments; the Phase 6 design
+doc owns the kernel-shape decision.

--- a/crates/hipfire-arch-zaya/examples/cpu_validate_phase2.rs
+++ b/crates/hipfire-arch-zaya/examples/cpu_validate_phase2.rs
@@ -1,0 +1,302 @@
+//! Phase 2 CPU-only validator for free ZAYA1 components.
+//!
+//! Bypasses the HFQ writer entirely (which doesn't exist for ZAYA1
+//! yet). Reads the model's bf16 safetensors directly + the PyTorch
+//! reference activation dump, runs CPU implementations of the free
+//! components, and checks per-tensor NRMSE against the reference.
+//!
+//! Components validated tonight:
+//!   1. ZayaRMSNorm  (modeling_zaya.py:167) - on layer 0 input_norm.
+//!   2. ResidualScaling (modeling_zaya.py:895) - on layer 0 + layer 1.
+//!
+//! Methodology: the canonical PyTorch oracle pattern from CLAUDE.md.
+//! Per-component NRMSE (= ||a - b|| / ||b||) clearing the bf16 ULP
+//! threshold (5e-3) means the implementation matches the reference at
+//! the precision the underlying datatype permits.
+//!
+//! Usage:
+//!   cargo run --release --example cpu_validate_phase2 -p hipfire-arch-zaya -- \
+//!       --weights /tmp/zaya-port/refs/zaya1_phase2_subset.safetensors \
+//!       --refs    /tmp/zaya-port/refs/refs-canonical-v3
+//!
+//! The weight subset file is produced by
+//! `scripts/arch-intake/extract_phase2_subset.py` running on hiptrx.
+//! The reference dump is produced by
+//! `scripts/arch-intake/dump_zaya_reference.py`.
+
+use half::bf16;
+use safetensors::SafeTensors;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ULP_THRESHOLD_BF16: f32 = 5e-3;
+
+// =====================================================================
+// Arg parsing (no clap dependency; tiny flag-pair extractor).
+// =====================================================================
+
+struct Args {
+    weights: PathBuf,
+    refs: PathBuf,
+}
+
+fn parse_args() -> Args {
+    let args: Vec<String> = std::env::args().collect();
+    let mut weights = None;
+    let mut refs = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--weights" => {
+                weights = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "--refs" => {
+                refs = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "usage: cpu_validate_phase2 --weights <path.safetensors> --refs <dir>"
+                );
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("unknown flag: {other}");
+                std::process::exit(2);
+            }
+        }
+    }
+    Args {
+        weights: weights.expect("--weights is required"),
+        refs: refs.expect("--refs is required"),
+    }
+}
+
+// =====================================================================
+// Tensor decoding helpers.
+// =====================================================================
+
+/// Decode a bf16 tensor from raw safetensors bytes into a Vec<f32>.
+/// bf16 is little-endian on x86: 2 bytes per element, with the same
+/// upper-16-bits-of-f32 representation. `half::bf16::from_le_bytes` +
+/// `f32::from` gives us the right value.
+fn decode_bf16(bytes: &[u8]) -> Vec<f32> {
+    assert!(bytes.len() % 2 == 0, "bf16 byte length must be even");
+    bytes
+        .chunks_exact(2)
+        .map(|p| f32::from(bf16::from_le_bytes([p[0], p[1]])))
+        .collect()
+}
+
+/// Decode an fp32 tensor from raw safetensors bytes into a Vec<f32>.
+fn decode_f32(bytes: &[u8]) -> Vec<f32> {
+    assert!(bytes.len() % 4 == 0, "f32 byte length must be a multiple of 4");
+    bytes
+        .chunks_exact(4)
+        .map(|p| f32::from_le_bytes([p[0], p[1], p[2], p[3]]))
+        .collect()
+}
+
+/// Load a single-tensor safetensors file (key="x", as written by the
+/// dump script) into a Vec<f32>.
+fn load_ref_tensor(path: &Path) -> Vec<f32> {
+    let buf = fs::read(path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    let st = SafeTensors::deserialize(&buf).expect("ref safetensors deserialize");
+    let view = st.tensor("x").expect("ref tensor 'x' missing");
+    decode_f32(view.data())
+}
+
+/// Load a named bf16 weight tensor from the subset safetensors file.
+fn load_bf16_weight(st: &SafeTensors<'_>, name: &str) -> Vec<f32> {
+    let view = st.tensor(name).unwrap_or_else(|_| panic!("missing weight: {name}"));
+    decode_bf16(view.data())
+}
+
+// =====================================================================
+// NRMSE.
+// =====================================================================
+
+/// Normalized root-mean-square error: ||a - b|| / ||b||.
+/// Returns NaN if ||b|| == 0 (which would mean reference is all-zeros).
+fn nrmse(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "NRMSE length mismatch: {} vs {}", a.len(), b.len());
+    let mut num = 0.0f64;
+    let mut den = 0.0f64;
+    for (&ai, &bi) in a.iter().zip(b.iter()) {
+        let d = (ai - bi) as f64;
+        num += d * d;
+        den += (bi as f64) * (bi as f64);
+    }
+    (num.sqrt() / den.sqrt()) as f32
+}
+
+fn report(label: &str, value: f32) -> bool {
+    let pass = value < ULP_THRESHOLD_BF16;
+    println!(
+        "  {} NRMSE = {value:.3e}  {}",
+        if pass { "PASS" } else { "FAIL" },
+        label,
+    );
+    pass
+}
+
+// =====================================================================
+// Component implementations (CPU, fp32 accumulator).
+// These are the "this is what hipfire's RDNA kernel will compute"
+// references; if they pass against PyTorch here, the kernel's job is
+// to match these on GPU.
+// =====================================================================
+
+/// ZayaRMSNorm forward.
+///
+/// Math: hs_f32 = hs.to(f32); var = hs_f32.pow(2).mean(-1, keepdim);
+///       hs_f32 = hs_f32 * rsqrt(var + eps);
+///       out    = weight * hs_f32.to(input_dtype)
+///
+/// CPU impl always works in f32; the cast-back-to-bf16 step at the end
+/// of PyTorch's forward is what bounds the achievable NRMSE to ~bf16
+/// ULP. We mimic that to match the reference output.
+fn zaya_rmsnorm_cpu(input: &[f32], weight_bf16_as_f32: &[f32], hidden_size: usize, eps: f32) -> Vec<f32> {
+    assert!(input.len() % hidden_size == 0, "input not divisible by hidden_size");
+    let n_rows = input.len() / hidden_size;
+    let mut out = vec![0.0f32; input.len()];
+    for r in 0..n_rows {
+        let row = &input[r * hidden_size..(r + 1) * hidden_size];
+        // Variance in f32 (matches PyTorch)
+        let mut sum_sq = 0.0f64;
+        for &x in row {
+            sum_sq += (x as f64) * (x as f64);
+        }
+        let var = (sum_sq / hidden_size as f64) as f32;
+        let inv_rms = 1.0f32 / (var + eps).sqrt();
+        // Multiply, then cast-to-bf16-and-back, then multiply by weight.
+        // PyTorch does: (hs_f32 * inv_rms).to(input_dtype) * weight
+        // (input_dtype = bf16 in this case; weight is also bf16). The
+        // cast happens BEFORE the weight multiply.
+        for c in 0..hidden_size {
+            let scaled = row[c] * inv_rms;
+            // simulate the bf16 round-trip
+            let scaled_bf16 = bf16::from_f32(scaled);
+            let scaled_back = f32::from(scaled_bf16);
+            out[r * hidden_size + c] = scaled_back * weight_bf16_as_f32[c];
+        }
+    }
+    out
+}
+
+/// ResidualScaling forward.
+///
+/// Math (from modeling_zaya.py:907-914):
+///   hidden_states = (hidden_states + hidden_states_bias) * hidden_states_scale
+///   if not_first_layer:
+///       residual = (residual + residual_bias) * residual_scale
+///   return (residual, hidden_states)
+///
+/// First layer: residual is passed through unchanged (no res params).
+fn residual_scaling_cpu(
+    input: &[f32],
+    bias: &[f32],
+    scale: &[f32],
+    hidden_size: usize,
+) -> Vec<f32> {
+    assert!(input.len() % hidden_size == 0);
+    assert_eq!(bias.len(), hidden_size);
+    assert_eq!(scale.len(), hidden_size);
+    let n_rows = input.len() / hidden_size;
+    let mut out = vec![0.0f32; input.len()];
+    for r in 0..n_rows {
+        for c in 0..hidden_size {
+            out[r * hidden_size + c] = (input[r * hidden_size + c] + bias[c]) * scale[c];
+        }
+    }
+    out
+}
+
+// =====================================================================
+// Top-level harness.
+// =====================================================================
+
+fn main() {
+    let args = parse_args();
+    println!("[zaya-cpu-validate]");
+    println!("  weights: {}", args.weights.display());
+    println!("  refs   : {}", args.refs.display());
+
+    let wbuf = fs::read(&args.weights).expect("read weights");
+    let weights = SafeTensors::deserialize(&wbuf).expect("weights safetensors deserialize");
+
+    let mut all_pass = true;
+    let hidden = 2048;
+    let eps = 1e-5f32;
+
+    // -----------------------------------------------------------------
+    // 1. ZayaRMSNorm on layer 0 input_norm.
+    // -----------------------------------------------------------------
+    println!("\n=== ZayaRMSNorm @ layer 0 input_norm ===");
+    let w_norm0 = load_bf16_weight(&weights, "model.layers.0.input_norm.weight");
+    assert_eq!(w_norm0.len(), hidden);
+    let in_norm0 = load_ref_tensor(&args.refs.join("layer_00/prefill.input_norm.in.safetensors"));
+    let out_norm0 = load_ref_tensor(&args.refs.join("layer_00/prefill.input_norm.out.safetensors"));
+    let my_out0 = zaya_rmsnorm_cpu(&in_norm0, &w_norm0, hidden, eps);
+    all_pass &= report("layer_00 input_norm", nrmse(&my_out0, &out_norm0));
+
+    // Layer 1 input_norm (sanity check second layer matches too).
+    println!("\n=== ZayaRMSNorm @ layer 1 input_norm ===");
+    let w_norm1 = load_bf16_weight(&weights, "model.layers.1.input_norm.weight");
+    let in_norm1 = load_ref_tensor(&args.refs.join("layer_01/prefill.input_norm.in.safetensors"));
+    let out_norm1 = load_ref_tensor(&args.refs.join("layer_01/prefill.input_norm.out.safetensors"));
+    let my_out1 = zaya_rmsnorm_cpu(&in_norm1, &w_norm1, hidden, eps);
+    all_pass &= report("layer_01 input_norm", nrmse(&my_out1, &out_norm1));
+
+    // -----------------------------------------------------------------
+    // 2. ResidualScaling @ layer 0 (hidden_states only; first layer
+    //    skips residual transform per `not_first_layer=False`).
+    // -----------------------------------------------------------------
+    println!("\n=== ResidualScaling @ layer 0 (hidden_states only) ===");
+    let bias_h0 = load_bf16_weight(&weights, "model.layers.0.res_scale.hidden_states_bias");
+    let scale_h0 = load_bf16_weight(&weights, "model.layers.0.res_scale.hidden_states_scale");
+    let in_res0 = load_ref_tensor(&args.refs.join("layer_00/prefill.res_scale.in1.safetensors"));
+    let out_res0 = load_ref_tensor(&args.refs.join("layer_00/prefill.res_scale.out1.safetensors"));
+    let my_res0 = residual_scaling_cpu(&in_res0, &bias_h0, &scale_h0, hidden);
+    all_pass &= report("layer_00 res_scale.hidden_states", nrmse(&my_res0, &out_res0));
+
+    // -----------------------------------------------------------------
+    // 3. ResidualScaling @ layer 1 (BOTH residual and hidden_states
+    //    paths; `not_first_layer=True`).
+    // -----------------------------------------------------------------
+    println!("\n=== ResidualScaling @ layer 1 (residual path) ===");
+    let bias_r1 = load_bf16_weight(&weights, "model.layers.1.res_scale.residual_bias");
+    let scale_r1 = load_bf16_weight(&weights, "model.layers.1.res_scale.residual_scale");
+    let in_res1_r = load_ref_tensor(&args.refs.join("layer_01/prefill.res_scale.in0.safetensors"));
+    let out_res1_r = load_ref_tensor(&args.refs.join("layer_01/prefill.res_scale.out0.safetensors"));
+    let my_res1_r = residual_scaling_cpu(&in_res1_r, &bias_r1, &scale_r1, hidden);
+    all_pass &= report("layer_01 res_scale.residual", nrmse(&my_res1_r, &out_res1_r));
+
+    println!("\n=== ResidualScaling @ layer 1 (hidden_states path) ===");
+    let bias_h1 = load_bf16_weight(&weights, "model.layers.1.res_scale.hidden_states_bias");
+    let scale_h1 = load_bf16_weight(&weights, "model.layers.1.res_scale.hidden_states_scale");
+    let in_res1_h = load_ref_tensor(&args.refs.join("layer_01/prefill.res_scale.in1.safetensors"));
+    let out_res1_h = load_ref_tensor(&args.refs.join("layer_01/prefill.res_scale.out1.safetensors"));
+    let my_res1_h = residual_scaling_cpu(&in_res1_h, &bias_h1, &scale_h1, hidden);
+    all_pass &= report("layer_01 res_scale.hidden_states", nrmse(&my_res1_h, &out_res1_h));
+
+    // -----------------------------------------------------------------
+    // 4. ZayaRMSNorm on final_norm (sanity).
+    // -----------------------------------------------------------------
+    println!("\n=== ZayaRMSNorm @ final_norm ===");
+    let w_final = load_bf16_weight(&weights, "model.final_norm.weight");
+    let in_final = load_ref_tensor(&args.refs.join("final/prefill.final_norm.in.safetensors"));
+    let out_final = load_ref_tensor(&args.refs.join("final/prefill.final_norm.out.safetensors"));
+    let my_final = zaya_rmsnorm_cpu(&in_final, &w_final, hidden, eps);
+    all_pass &= report("final_norm", nrmse(&my_final, &out_final));
+
+    println!();
+    if all_pass {
+        println!("=== ALL PASS ({} threshold = {:.0e}) ===", "bf16-ULP", ULP_THRESHOLD_BF16);
+        std::process::exit(0);
+    } else {
+        eprintln!("=== FAILURES detected (threshold {:.0e}) ===", ULP_THRESHOLD_BF16);
+        std::process::exit(1);
+    }
+}

--- a/crates/hipfire-arch-zaya/examples/cpu_validate_phase2.rs
+++ b/crates/hipfire-arch-zaya/examples/cpu_validate_phase2.rs
@@ -142,6 +142,86 @@ fn report(label: &str, value: f32) -> bool {
 }
 
 // =====================================================================
+// Math primitives (CPU, fp32).
+// =====================================================================
+
+#[inline]
+fn silu(x: f32) -> f32 {
+    x / (1.0 + (-x).exp())
+}
+
+/// PyTorch torch.nn.functional.gelu default = "tanh" approximation? No,
+/// default is the EXACT erf-based gelu. Zyphra's router_mlp uses
+/// `nn.GELU()` (line 978), which defaults to `approximate="none"` = the
+/// exact erf form: 0.5 * x * (1 + erf(x / sqrt(2))).
+#[inline]
+fn gelu_exact(x: f32) -> f32 {
+    0.5 * x * (1.0 + libm::erff(x / std::f32::consts::SQRT_2))
+}
+
+/// Stable softmax over the last axis.
+fn softmax_last(rows: &mut [f32], cols: usize) {
+    assert!(rows.len() % cols == 0);
+    let nrows = rows.len() / cols;
+    for r in 0..nrows {
+        let row = &mut rows[r * cols..(r + 1) * cols];
+        let mx = row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0f32;
+        for v in row.iter_mut() {
+            *v = (*v - mx).exp();
+            sum += *v;
+        }
+        for v in row.iter_mut() {
+            *v /= sum;
+        }
+    }
+}
+
+/// y[m, n] = x[m, k] @ W[n, k].T + bias?  (PyTorch nn.Linear style.)
+/// Inputs are row-major. `weight` has shape [n_out, n_in].
+fn linear(x: &[f32], weight: &[f32], bias: Option<&[f32]>, m: usize, k: usize, n: usize) -> Vec<f32> {
+    assert_eq!(x.len(), m * k);
+    assert_eq!(weight.len(), n * k);
+    if let Some(b) = bias {
+        assert_eq!(b.len(), n);
+    }
+    let mut out = vec![0.0f32; m * n];
+    for i in 0..m {
+        for j in 0..n {
+            let mut acc = 0.0f64;
+            let xi = i * k;
+            let wj = j * k;
+            for kk in 0..k {
+                acc += (x[xi + kk] as f64) * (weight[wj + kk] as f64);
+            }
+            let mut v = acc as f32;
+            if let Some(b) = bias {
+                v += b[j];
+            }
+            out[i * n + j] = v;
+        }
+    }
+    out
+}
+
+/// argmax of every row (used for top-1 routing).
+fn argmax_rows(rows: &[f32], cols: usize) -> Vec<usize> {
+    rows.chunks_exact(cols)
+        .map(|row| {
+            let mut best = 0usize;
+            let mut bv = row[0];
+            for (i, &v) in row.iter().enumerate().skip(1) {
+                if v > bv {
+                    bv = v;
+                    best = i;
+                }
+            }
+            best
+        })
+        .collect()
+}
+
+// =====================================================================
 // Component implementations (CPU, fp32 accumulator).
 // These are the "this is what hipfire's RDNA kernel will compute"
 // references; if they pass against PyTorch here, the kernel's job is
@@ -180,6 +260,78 @@ fn zaya_rmsnorm_cpu(input: &[f32], weight_bf16_as_f32: &[f32], hidden_size: usiz
             let scaled_bf16 = bf16::from_f32(scaled);
             let scaled_back = f32::from(scaled_bf16);
             out[r * hidden_size + c] = scaled_back * weight_bf16_as_f32[c];
+        }
+    }
+    out
+}
+
+/// SwiGLU activation chunk: silu(x[..N/2]) * x[N/2..]. Operates in place
+/// on the input rows; returns a new Vec of half-width.
+fn swiglu_chunk(input: &[f32], full_dim: usize) -> Vec<f32> {
+    assert_eq!(full_dim % 2, 0);
+    let half = full_dim / 2;
+    assert_eq!(input.len() % full_dim, 0);
+    let n_rows = input.len() / full_dim;
+    let mut out = vec![0.0f32; n_rows * half];
+    for r in 0..n_rows {
+        let src = &input[r * full_dim..(r + 1) * full_dim];
+        let dst = &mut out[r * half..(r + 1) * half];
+        for c in 0..half {
+            dst[c] = silu(src[c]) * src[half + c];
+        }
+    }
+    out
+}
+
+/// ZAYA1 partial RoPE per modeling_zaya.py:455 (apply_rotary_pos_emb).
+///   rotary_dim = cos.shape[-1]
+///   q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+///   q_rot = (q_rot * cos) + (rotate_half(q_rot) * sin)
+///   q_embed = cat((q_rot, q_pass), dim=-1)
+/// rotate_half: x1 = x[..N/2], x2 = x[N/2..]; return cat((-x2, x1)).
+///
+/// Operates per-row; row layout is [head_dim] contiguous (caller is
+/// responsible for unbroadcasting cos/sin appropriately if heads share).
+fn partial_rope_apply(
+    q: &[f32],
+    cos_per_row: &[f32],
+    sin_per_row: &[f32],
+    rotary_dim: usize,
+    head_dim: usize,
+) -> Vec<f32> {
+    assert_eq!(q.len() % head_dim, 0);
+    assert_eq!(cos_per_row.len() % rotary_dim, 0);
+    assert_eq!(sin_per_row.len() % rotary_dim, 0);
+    assert_eq!(rotary_dim % 2, 0);
+    let n_rows = q.len() / head_dim;
+    let cos_rows = cos_per_row.len() / rotary_dim;
+    assert!(cos_rows == n_rows || cos_rows == 1, "cos rows {} vs q rows {}", cos_rows, n_rows);
+    let half = rotary_dim / 2;
+    let mut out = vec![0.0f32; q.len()];
+    for r in 0..n_rows {
+        let qrow = &q[r * head_dim..(r + 1) * head_dim];
+        let crow = if cos_rows == n_rows {
+            &cos_per_row[r * rotary_dim..(r + 1) * rotary_dim]
+        } else {
+            &cos_per_row[..rotary_dim]
+        };
+        let srow = if cos_rows == n_rows {
+            &sin_per_row[r * rotary_dim..(r + 1) * rotary_dim]
+        } else {
+            &sin_per_row[..rotary_dim]
+        };
+        let orow = &mut out[r * head_dim..(r + 1) * head_dim];
+        // q_rot = (q_rot * cos) + (rotate_half(q_rot) * sin)
+        // rotate_half: x[..half] -> -x[half..], x[half..] -> x[..half]
+        for i in 0..half {
+            let a = qrow[i];
+            let b = qrow[half + i];
+            orow[i] = a * crow[i] + (-b) * srow[i];
+            orow[half + i] = b * crow[half + i] + a * srow[half + i];
+        }
+        // q_pass: copy unchanged
+        for i in rotary_dim..head_dim {
+            orow[i] = qrow[i];
         }
     }
     out
@@ -290,6 +442,199 @@ fn main() {
     let out_final = load_ref_tensor(&args.refs.join("final/prefill.final_norm.out.safetensors"));
     let my_final = zaya_rmsnorm_cpu(&in_final, &w_final, hidden, eps);
     all_pass &= report("final_norm", nrmse(&my_final, &out_final));
+
+    // -----------------------------------------------------------------
+    // 5. o_proj @ layer 0 (post-attention output projection).
+    //    The CCA-fed attention path's tail. o_proj input is 1024-dim
+    //    (8q heads x 128 head_dim, the "//2 query compression"); output
+    //    is 2048 = hidden_size. With no bias on o_proj.
+    // -----------------------------------------------------------------
+    println!("\n=== o_proj @ layer 0 (1024 -> 2048) ===");
+    let w_oproj0 = load_bf16_weight(&weights, "model.layers.0.self_attn.o_proj.weight");
+    let in_oproj0 = load_ref_tensor(&args.refs.join("layer_00/prefill.o_proj.in.safetensors"));
+    let out_oproj0 = load_ref_tensor(&args.refs.join("layer_00/prefill.o_proj.out.safetensors"));
+    // o_proj.weight shape: [out=2048, in=1024]. PyTorch nn.Linear y = x @ W.T
+    let n_tokens = in_oproj0.len() / 1024;
+    let my_oproj0 = linear(&in_oproj0, &w_oproj0, None, n_tokens, 1024, 2048);
+    all_pass &= report("layer_00 o_proj", nrmse(&my_oproj0, &out_oproj0));
+    // o_proj.out should equal self_attn.out0 (o_proj is the last op).
+    let self_attn_out0 = load_ref_tensor(&args.refs.join("layer_00/prefill.self_attn.out0.safetensors"));
+    all_pass &= report("layer_00 o_proj == self_attn.out0", nrmse(&out_oproj0, &self_attn_out0));
+
+    // -----------------------------------------------------------------
+    // 6. MLP-based MoE router @ layer 1 (no EDA on first MoE layer).
+    //    ZayaRouter.forward (modeling_zaya.py:992):
+    //      hs = down_proj(input)              # [B, S, 256]
+    //      router_hidden_states_next = hs.clone()
+    //      hs_norm = rmsnorm_eda(hs)          # [B, S, 256]
+    //      logits  = router_mlp(hs_norm)      # [B, S, 17]
+    //      expert_prob = softmax(logits, -1)
+    //      biased = expert_prob.f32() + balancing_biases
+    //      expert_choice = topk(biased, k=1)  # [B, S, 1]
+    //      route_prob = gather(expert_prob, dim=2, index=expert_choice)
+    //      return (route_prob_flat, expert_choice_flat, router_hidden_states_next)
+    // -----------------------------------------------------------------
+    println!("\n=== MLP-based MoE router @ layer 1 (top-1, no EDA) ===");
+    let mlp_exp = 256;
+    let n_experts_with_skip = 17; // 16 experts + 1 MoD skip slot
+    let dp_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.down_proj.weight");
+    let dp_b = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.down_proj.bias");
+    let rmsnorm_eda_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.rmsnorm_eda.weight");
+    let mlp0_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.router_mlp.0.weight");
+    let mlp0_b = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.router_mlp.0.bias");
+    let mlp2_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.router_mlp.2.weight");
+    let mlp2_b = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.router_mlp.2.bias");
+    let mlp4_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.router_mlp.4.weight");
+    let bal_biases = load_bf16_weight(&weights, "model.layers.1.zaya_block.router.balancing_biases");
+
+    let router_in = load_ref_tensor(&args.refs.join("layer_01/prefill.router.in.safetensors"));
+    let n_tok = router_in.len() / hidden;
+
+    // 1) hs = down_proj(input)
+    let hs_post_dp = linear(&router_in, &dp_w, Some(&dp_b), n_tok, hidden, mlp_exp);
+    // 2) router_hidden_states_next = hs.clone() (validates against router.out2)
+    let ref_router_out2 = load_ref_tensor(&args.refs.join("layer_01/prefill.router.out2.safetensors"));
+    all_pass &= report("layer_01 router_hidden_states_next (down_proj)", nrmse(&hs_post_dp, &ref_router_out2));
+
+    // 3) hs_norm = rmsnorm(hs)
+    let hs_norm = zaya_rmsnorm_cpu(&hs_post_dp, &rmsnorm_eda_w, mlp_exp, eps);
+    // 4) router_mlp: Linear(256,256)+bias -> GELU -> Linear(256,256)+bias -> GELU -> Linear(256,17)
+    let h0 = linear(&hs_norm, &mlp0_w, Some(&mlp0_b), n_tok, mlp_exp, mlp_exp);
+    let h0_act: Vec<f32> = h0.iter().map(|&x| gelu_exact(x)).collect();
+    let h2 = linear(&h0_act, &mlp2_w, Some(&mlp2_b), n_tok, mlp_exp, mlp_exp);
+    let h2_act: Vec<f32> = h2.iter().map(|&x| gelu_exact(x)).collect();
+    let logits = linear(&h2_act, &mlp4_w, None, n_tok, mlp_exp, n_experts_with_skip);
+    // 5) softmax
+    let mut expert_prob = logits.clone();
+    softmax_last(&mut expert_prob, n_experts_with_skip);
+    // 6) biased = expert_prob (already f32) + balancing_biases
+    let mut biased = expert_prob.clone();
+    for r in 0..n_tok {
+        for c in 0..n_experts_with_skip {
+            biased[r * n_experts_with_skip + c] += bal_biases[c];
+        }
+    }
+    // 7) top-1
+    let my_expert_choice: Vec<usize> = argmax_rows(&biased, n_experts_with_skip);
+    // 8) route_prob = gather expert_prob @ expert_choice
+    let my_route_prob: Vec<f32> = my_expert_choice.iter().enumerate()
+        .map(|(r, &c)| expert_prob[r * n_experts_with_skip + c])
+        .collect();
+
+    // Compare to dump
+    let ref_route_prob = load_ref_tensor(&args.refs.join("layer_01/prefill.router.out0.safetensors"));
+    let ref_expert_choice = load_ref_tensor(&args.refs.join("layer_01/prefill.router.out1.safetensors"));
+    all_pass &= report("layer_01 router route_prob", nrmse(&my_route_prob, &ref_route_prob));
+
+    let ref_choices_int: Vec<usize> = ref_expert_choice.iter().map(|&v| v as usize).collect();
+    let mismatches = my_expert_choice.iter().zip(ref_choices_int.iter()).filter(|(a, b)| a != b).count();
+    println!("  {} expert_choice exact match: {}/{} mismatches",
+        if mismatches == 0 { "PASS" } else { "FAIL" },
+        mismatches, n_tok);
+    all_pass &= mismatches == 0;
+    println!("  per-token expert assignment: {:?}", &my_expert_choice);
+
+    // -----------------------------------------------------------------
+    // 7. SwiGLU + Expert 0 MLP @ layer 1.
+    //    Expert MLP per modeling_zaya.py:1063 (no biases; gated_linear_unit=true):
+    //      x = linear_fc1(input)   # [N, ffn_hidden=4096]
+    //      gated = silu(x[:, :2048]) * x[:, 2048:]    # [N, 2048]
+    //      out = linear_fc2(gated)  # [N, hidden=2048]
+    //    `experts.in0` is sorted by expert_choice; tokens going to
+    //    expert 0 occupy the first `tokens_per_expert[0]` rows.
+    // -----------------------------------------------------------------
+    println!("\n=== SwiGLU + expert 0 MLP @ layer 1 ===");
+    let n_to_expert_0 = ref_choices_int.iter().filter(|&&c| c == 0).count();
+    if n_to_expert_0 == 0 {
+        println!("  SKIP no tokens routed to expert 0 in this prompt; cannot validate");
+    } else {
+        let fc1_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.experts.local_experts.0.linear_fc1.weight");
+        let fc2_w = load_bf16_weight(&weights, "model.layers.1.zaya_block.experts.local_experts.0.linear_fc2.weight");
+        let experts_in = load_ref_tensor(&args.refs.join("layer_01/prefill.experts.in0.safetensors"));
+        let experts_out = load_ref_tensor(&args.refs.join("layer_01/prefill.experts.out0.safetensors"));
+        let ffn_hidden = 4096;
+        // experts.in0 is [N_total, 2048] sorted by expert_choice. Expert 0 is
+        // the FIRST bin in the sort because expert ids are non-negative ints.
+        let in_e0 = &experts_in[..n_to_expert_0 * hidden];
+        let out_e0 = &experts_out[..n_to_expert_0 * hidden];
+
+        // x = linear_fc1(input)
+        let post_fc1 = linear(in_e0, &fc1_w, None, n_to_expert_0, hidden, ffn_hidden);
+        // SwiGLU
+        let gated = swiglu_chunk(&post_fc1, ffn_hidden);
+        // linear_fc2
+        let my_out_e0 = linear(&gated, &fc2_w, None, n_to_expert_0, ffn_hidden / 2, hidden);
+        all_pass &= report(&format!("layer_01 expert 0 MLP ({} tokens)", n_to_expert_0), nrmse(&my_out_e0, out_e0));
+    }
+
+    // -----------------------------------------------------------------
+    // 8. partial-RoPE math (unit test, no PyTorch ref needed).
+    //    Validates that the impl matches PyTorch's apply_rotary_pos_emb
+    //    semantics (modeling_zaya.py:455) for partial_rotary_factor=0.5.
+    //    Three properties tested:
+    //      a. cos=1, sin=0 : identity on first 64 dims.
+    //      b. last 64 dims always pass through unchanged.
+    //      c. cos=0, sin=1 : 90-deg rotation matches rotate_half formula.
+    // -----------------------------------------------------------------
+    println!("\n=== partial-RoPE math (head_dim=128, rotary_dim=64) ===");
+    {
+        let head_dim = 128;
+        let rotary_dim = 64; // partial_rotary_factor=0.5
+        let n_pos = 4;
+        // Synthetic Q: per row [r*100 + 0, r*100 + 1, ..., r*100 + 127]
+        let q: Vec<f32> = (0..n_pos)
+            .flat_map(|r| (0..head_dim).map(move |c| (r * 100 + c) as f32))
+            .collect();
+
+        // (a) identity check
+        let cos_id = vec![1.0f32; n_pos * rotary_dim];
+        let sin_id = vec![0.0f32; n_pos * rotary_dim];
+        let q_rot_id = partial_rope_apply(&q, &cos_id, &sin_id, rotary_dim, head_dim);
+        let mut identity_first64_err = 0.0f32;
+        for r in 0..n_pos {
+            for c in 0..rotary_dim {
+                let e = (q[r * head_dim + c] - q_rot_id[r * head_dim + c]).abs();
+                if e > identity_first64_err { identity_first64_err = e; }
+            }
+        }
+        let pass_a = identity_first64_err == 0.0;
+        println!("  {} (a) cos=1,sin=0 identity on first 64 dims (max abs err {:.3e})",
+                 if pass_a { "PASS" } else { "FAIL" }, identity_first64_err);
+        all_pass &= pass_a;
+
+        // (b) passthrough on last 64 dims
+        let mut pass_b = true;
+        for r in 0..n_pos {
+            for c in rotary_dim..head_dim {
+                if q[r * head_dim + c] != q_rot_id[r * head_dim + c] {
+                    pass_b = false;
+                }
+            }
+        }
+        println!("  {} (b) last 64 dims unchanged (passthrough)", if pass_b { "PASS" } else { "FAIL" });
+        all_pass &= pass_b;
+
+        // (c) cos=0, sin=1 -> rotate_half formula
+        // rotate_half: x[..32] -> -x[32..64], x[32..64] -> x[..32]
+        // result[..32] = -x[32..64], result[32..64] = x[..32]
+        let cos_z = vec![0.0f32; n_pos * rotary_dim];
+        let sin_one = vec![1.0f32; n_pos * rotary_dim];
+        let q_rot_90 = partial_rope_apply(&q, &cos_z, &sin_one, rotary_dim, head_dim);
+        let half = rotary_dim / 2;
+        let mut max_err_c = 0.0f32;
+        for r in 0..n_pos {
+            for c in 0..half {
+                let want_first = -q[r * head_dim + half + c];
+                let want_second = q[r * head_dim + c];
+                max_err_c = max_err_c.max((q_rot_90[r * head_dim + c] - want_first).abs());
+                max_err_c = max_err_c.max((q_rot_90[r * head_dim + half + c] - want_second).abs());
+            }
+        }
+        let pass_c = max_err_c == 0.0;
+        println!("  {} (c) cos=0,sin=1 rotate_half formula (max abs err {:.3e})",
+                 if pass_c { "PASS" } else { "FAIL" }, max_err_c);
+        all_pass &= pass_c;
+    }
 
     println!();
     if all_pass {

--- a/crates/hipfire-arch-zaya/examples/verify_against_torch.rs
+++ b/crates/hipfire-arch-zaya/examples/verify_against_torch.rs
@@ -1,0 +1,33 @@
+//! Per-layer NRMSE verification of hipfire's ZAYA1 forward against a
+//! PyTorch reference dump.
+//!
+//! Phase 1 status: SKELETON. The harness layout matches the pattern
+//! described in the project's Gemma 4 / Qwen 3.5 port methodology
+//! (PyTorch + safetensors as oracle, hipfire as system under test,
+//! per-op NRMSE with ~5e-3 bf16 ULP threshold). Bodies return early
+//! with a clear error until the forward pass and reference dumper
+//! land.
+//!
+//! Workflow once forward exists:
+//!   1. Run `scripts/arch-intake/dump_zaya_reference.py` on hiptrx
+//!      with `HIP_VISIBLE_DEVICES=2` to populate
+//!      `/tmp/zaya-port/refs/<prompt-hash>/layer_NN/<step>.<side>.safetensors`
+//!      and `manifest.json`.
+//!   2. Build hipfire with the dump-hooks env wired into ZAYA1's
+//!      forward (HIPFIRE_DUMP_DIR / HIPFIRE_DUMP_POS).
+//!   3. Run this example with `--ref /tmp/zaya-port/refs/<hash>` and
+//!      `--out /tmp/zaya-port/hipfire/<hash>` and `--diff
+//!      /tmp/zaya-port/diffs/<hash>`.
+//!   4. Per-op NRMSE matrix prints; first divergence above 5e-3 is the
+//!      first-broken op (see Gemma 4 V-norm story for the canonical
+//!      bisection pattern).
+
+fn main() {
+    eprintln!(
+        "verify_against_torch (zaya): SKELETON. Phase 1 scaffold returns \
+         early. The forward pass, reference-dump generator, and diff \
+         harness arrive incrementally. See \
+         docs/investigations/2026-05-07-zaya1-port-intake/ for status."
+    );
+    std::process::exit(2);
+}

--- a/crates/hipfire-arch-zaya/src/arch.rs
+++ b/crates/hipfire-arch-zaya/src/arch.rs
@@ -1,0 +1,116 @@
+//! `Architecture` trait impl for Zaya.
+//!
+//! Phase 1 scaffold: every method either returns a typed default
+//! (arch_id, name, overrides) or returns Err with a pointer to the
+//! intake docs (config_from_hfq, load_weights, new_state).
+//!
+//! See `crates/hipfire-arch-toy/src/arch.rs` for the template, and
+//! `crates/hipfire-arch-qwen35/src/arch.rs` for the production reference.
+
+use crate::config::ZayaConfig;
+use crate::state::ZayaState;
+use crate::weights::ZayaWeights;
+use hipfire_runtime::arch::{
+    Architecture, EosFilterOverrides, LoopGuardOverrides, PromptFrameOverrides, SamplerOverrides,
+};
+use hipfire_runtime::hfq::HfqFile;
+use rdna_compute::Gpu;
+
+/// Type marker for the Zaya arch.
+///
+/// Zero-sized; trait dispatch is on the type, not a value. The actual
+/// per-instance state lives in `ZayaState`, weights in `ZayaWeights`,
+/// shape in `ZayaConfig`.
+pub struct Zaya;
+
+impl Architecture for Zaya {
+    type Weights = ZayaWeights;
+    type State = ZayaState;
+    type Config = ZayaConfig;
+
+    /// Reserved arch_id for the Zaya family. Existing IDs:
+    /// 0 = LLaMA / Mistral, 1 = plain Qwen3 / Qwen2,
+    /// 5 = Qwen3.5 dense, 6 = Qwen3.5/3.6 MoE,
+    /// 7 = Zaya (this).
+    /// 0xFF reserved for the `toy` template.
+    /// Update `crates/hipfire-runtime/src/arch.rs` doc-comment ladder
+    /// when this lands on master.
+    fn arch_id() -> u32 {
+        7
+    }
+
+    fn name() -> &'static str {
+        "zaya"
+    }
+
+    /// Phase 1 stub. See `ZayaConfig::from_hfq`.
+    fn config_from_hfq(hfq: &HfqFile) -> Result<Self::Config, String> {
+        ZayaConfig::from_hfq(hfq)
+    }
+
+    /// Phase 1 stub. See `ZayaWeights::load`.
+    fn load_weights(
+        hfq: &mut HfqFile,
+        cfg: &Self::Config,
+        _gpu: &mut Gpu,
+    ) -> Result<Self::Weights, String> {
+        ZayaWeights::load(hfq, cfg)
+    }
+
+    /// Phase 1 stub. See `ZayaState::new`. The CCA recurrent state
+    /// allocation is the headline Phase 6 deliverable.
+    fn new_state(gpu: &mut Gpu, cfg: &Self::Config) -> Result<Self::State, String> {
+        ZayaState::new(gpu, cfg)
+    }
+
+    // -- Optional overrides -------------------------------------------------
+    // ZAYA1's chat template uses Gemma-style `<start_of_turn>` /
+    // `<end_of_turn>` markers (eos_token_id=106 confirms Gemma tokenizer).
+    // Override eos_filter to match. Sampler / loop_guard / prompt_frame
+    // defaults are likely fine pending live coherence-gate validation.
+
+    fn loop_guard_overrides(_cfg: &Self::Config) -> LoopGuardOverrides {
+        LoopGuardOverrides::default()
+    }
+
+    fn sampler_overrides(_cfg: &Self::Config) -> SamplerOverrides {
+        SamplerOverrides::default()
+    }
+
+    fn prompt_frame_overrides(_cfg: &Self::Config) -> PromptFrameOverrides {
+        // ZAYA1 ships with a chat_template that uses Gemma turn markers,
+        // not ChatML `<|im_start|>`. Override after Phase 1 read of the
+        // tokenizer + chat_template artifacts (to be done alongside
+        // reference dump generation on hiptrx).
+        PromptFrameOverrides::default()
+    }
+
+    fn eos_filter_overrides(_cfg: &Self::Config) -> EosFilterOverrides {
+        // ZAYA1 uses the Gemma tokenizer (eos_token_id=106 =
+        // `<end_of_turn>`). Match the Gemma4 EOS filter pattern from
+        // the existing port. Bytes filled in once Phase 1 confirms the
+        // tokenizer's exact byte sequence for token 106.
+        EosFilterOverrides {
+            stop_at: vec![b"<end_of_turn>".to_vec()],
+            holdback_prefixes: vec![b"<end_".to_vec()],
+            strip_think: Some(false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zaya_arch_id_is_seven() {
+        assert_eq!(Zaya::arch_id(), 7);
+        assert_eq!(Zaya::name(), "zaya");
+    }
+
+    #[test]
+    fn zaya_eos_uses_gemma_end_of_turn() {
+        let overrides = Zaya::eos_filter_overrides(&ZayaConfig::default());
+        assert_eq!(overrides.stop_at, vec![b"<end_of_turn>".to_vec()]);
+    }
+}

--- a/crates/hipfire-arch-zaya/src/config.rs
+++ b/crates/hipfire-arch-zaya/src/config.rs
@@ -1,0 +1,251 @@
+//! ZayaConfig: model-shape constants for ZAYA1, parsed from HFQ metadata.
+//!
+//! Field set mirrors `Zyphra/transformers@zaya1/configuration_zaya.py:23-122`
+//! (`class ZayaConfig(PretrainedConfig)`) and the published
+//! `Zyphra/ZAYA1-8B/config.json`. Defaults match the 8B config; arch_id 7
+//! is reserved for the Zaya family in `crates/hipfire-runtime/src/arch.rs`
+//! comment ladder.
+//!
+//! Port-status notes per field are inline. Anything tagged FREE maps onto
+//! existing hipfire infrastructure with at most a kernel-parameter tweak.
+//! Anything tagged NEW requires either a new kernel or a runtime-level
+//! design decision (CCA recurrent state, MoD per-token routing, EDA).
+
+use hipfire_runtime::hfq::HfqFile;
+use serde::{Deserialize, Serialize};
+
+/// Model-shape constants for a ZAYA1 family checkpoint.
+///
+/// All fields are u32/usize/f32/bool to keep the struct cheap to clone
+/// across threads (the trait bound is `Config: Clone + Send + 'static`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZayaConfig {
+    // -- Standard transformer shape -----------------------------------------
+    /// Token vocab size. ZAYA1-8B = 262272 (Gemma-style 256k base + extras).
+    /// Tokenizer support: FREE if Gemma4 tokenizer port is in tree.
+    pub vocab_size: usize,
+    /// Hidden / model dim. ZAYA1-8B = 2048.
+    pub hidden_size: usize,
+    /// FFN hidden dim (per-expert at `gated_linear_unit=true`). ZAYA1-8B = 4096.
+    pub ffn_hidden_size: usize,
+    /// Decoder block count. ZAYA1-8B = 80.
+    pub num_hidden_layers: usize,
+    /// Standard attention Q heads (downstream of CCA). ZAYA1-8B = 16.
+    pub num_attention_heads: usize,
+    /// Standard attention KV heads (GQA). ZAYA1-8B = 2 (8:1 GQA ratio).
+    pub num_key_value_heads: usize,
+    /// Per-head dim. ZAYA1-8B = 128 (= hidden_size / num_attention_heads).
+    pub head_dim: usize,
+    /// Max position. ZAYA1-8B = 131072 (128k context).
+    pub max_position_embeddings: usize,
+
+    // -- Norm / activation --------------------------------------------------
+    /// FREE: RMSNorm epsilon. ZAYA1-8B = 1e-5.
+    pub norm_epsilon: f32,
+    /// FREE: SwiGLU (gated_linear_unit=true).
+    pub activation_func: ActivationFunc,
+
+    // -- RoPE ---------------------------------------------------------------
+    /// FREE-ish: partial RoPE; rotates first `head_dim * partial_rotary_factor`
+    /// dims, leaves the rest untouched. ZAYA1-8B = 0.5 (rotates 64 of 128).
+    /// Requires either parameterizing existing RoPE kernel or adding a new
+    /// entry point. See Phase 2 plan.
+    pub partial_rotary_factor: f32,
+    /// FREE: RoPE base frequency. ZAYA1-8B = 5_000_000 (long-context base).
+    pub rope_theta: f32,
+
+    // -- MoE ----------------------------------------------------------------
+    /// NEW-ish: 16 experts. Existing qwen35 MoE handles 128/256/etc.
+    pub num_experts: usize,
+    /// FREE: top-1 (Switch-style). Simpler than qwen35's top-8; degenerate
+    /// case of existing top-k.
+    pub moe_router_topk: usize,
+    /// NEW: MLP-based router (vs qwen35's linear). Small kernel addition.
+    /// `zaya_mlp_expansion=256` sets router-MLP hidden dim. (TODO: confirm
+    /// semantics from modeling_zaya.py:917 ZayaRouter; Phase 2.)
+    pub zaya_mlp_expansion: usize,
+
+    // -- CCA (RECURRENT, see 00-cca-disambiguation.md) ---------------------
+    /// CCA enabled. ZAYA1-8B = true.
+    pub cca: bool,
+    /// CCA's own Q-head count, distinct from `num_attention_heads`.
+    /// ZAYA1-8B = 8 (vs 16 standard attn). The CCA→Attention plumbing
+    /// requires a head-rebalance step; details pending Phase 1 read of
+    /// ZayaAttention (modeling_zaya.py:483).
+    pub cca_num_q_heads: usize,
+    /// CCA's KV head count (matches `num_query_groups`). ZAYA1-8B = 2.
+    pub num_query_groups: usize,
+    /// CCA depthwise-conv kernel size (first conv). ZAYA1-8B = 2.
+    pub cca_time0: usize,
+    /// CCA grouped-conv kernel size (second conv). ZAYA1-8B = 2.
+    pub cca_time1: usize,
+
+    // -- MoD (per-token layer skip; Phase 4 design doc) ---------------------
+    /// NEW: enables per-token layer-skip routing. ZAYA1-8B = true.
+    pub zaya_use_mod: bool,
+
+    // -- EDA (identification pending Phase 5) -------------------------------
+    /// NEW: enables an undocumented "EDA" component. ZAYA1-8B = true.
+    /// Read modeling_zaya.py / modular_zaya.py to identify; see Phase 5.
+    pub zaya_use_eda: bool,
+
+    // -- Residual scaling ---------------------------------------------------
+    /// NEW (trivial): per-block learnable residual scalar. ZAYA1-8B = true.
+    /// Implementation: load per-block scalar tensor, multiply during
+    /// residual add. See Phase 2.
+    pub scale_residual_merge: bool,
+    /// FREE: residual stream upcast to fp32. ZAYA1-8B config.json = true.
+    /// Existing hipfire pattern parallels rmsnorm fp32 accumulator.
+    pub residual_in_fp32: bool,
+
+    // -- Misc / metadata ----------------------------------------------------
+    /// FREE: tied input embed and lm_head. ZAYA1-8B inherits the default
+    /// (true in `PretrainedConfig`).
+    pub tie_word_embeddings: bool,
+    /// Tokenizer special tokens (parsed from HFQ metadata, not config).
+    /// ZAYA1-8B: pad=0, bos=2, eos=106 (Gemma `<end_of_turn>`).
+    pub pad_token_id: u32,
+    pub bos_token_id: u32,
+    pub eos_token_id: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivationFunc {
+    Swiglu,
+}
+
+impl Default for ZayaConfig {
+    /// Defaults match the published `Zyphra/ZAYA1-8B/config.json` so a
+    /// `ZayaConfig::default()` corresponds to the 8B checkpoint. Smaller
+    /// or larger ZAYA1 variants override via `config_from_hfq`.
+    fn default() -> Self {
+        Self {
+            vocab_size: 262_272,
+            hidden_size: 2048,
+            ffn_hidden_size: 4096,
+            num_hidden_layers: 80,
+            num_attention_heads: 16,
+            num_key_value_heads: 2,
+            head_dim: 128,
+            max_position_embeddings: 131_072,
+            norm_epsilon: 1e-5,
+            activation_func: ActivationFunc::Swiglu,
+            partial_rotary_factor: 0.5,
+            rope_theta: 5_000_000.0,
+            num_experts: 16,
+            moe_router_topk: 1,
+            zaya_mlp_expansion: 256,
+            cca: true,
+            cca_num_q_heads: 8,
+            num_query_groups: 2,
+            cca_time0: 2,
+            cca_time1: 2,
+            zaya_use_mod: true,
+            zaya_use_eda: true,
+            scale_residual_merge: true,
+            residual_in_fp32: true,
+            tie_word_embeddings: true,
+            pad_token_id: 0,
+            bos_token_id: 2,
+            eos_token_id: 106,
+        }
+    }
+}
+
+impl ZayaConfig {
+    /// Parse a ZayaConfig out of an HFQ file's metadata blob.
+    ///
+    /// Phase 1 status: returns Err. No HFQ writer for ZAYA1 exists yet
+    /// (the `hipfire-quantize` crate doesn't know the Zaya tensor
+    /// naming convention). When the quantizer adds a Zaya path, this
+    /// method walks the metadata JSON the way
+    /// `hipfire_arch_qwen35::qwen35::config_from_hfq` does, branching
+    /// on the arch_id stored in the HFQ header to handle ZAYA1
+    /// variants.
+    pub fn from_hfq(_hfq: &HfqFile) -> Result<Self, String> {
+        Err(
+            "ZayaConfig::from_hfq not implemented (Phase 1 scaffold). \
+             ZAYA1 has no HFQ representation yet; quantizer support is \
+             pending after Phase 6 recurrent-state design lands. See \
+             docs/investigations/2026-05-07-zaya1-port-intake/."
+                .to_string(),
+        )
+    }
+
+    /// Validate that a parsed config matches the bf16 reference's shape.
+    /// Used by Phase 1 / Phase 2 reference-dump validation; called by the
+    /// `verify_against_torch` example before any forward attempt.
+    pub fn assert_zaya1_8b_shape(&self) -> Result<(), String> {
+        let want = Self::default();
+        if self.vocab_size != want.vocab_size {
+            return Err(format!("vocab_size {} != {}", self.vocab_size, want.vocab_size));
+        }
+        if self.hidden_size != want.hidden_size {
+            return Err(format!("hidden_size {} != {}", self.hidden_size, want.hidden_size));
+        }
+        if self.num_hidden_layers != want.num_hidden_layers {
+            return Err(format!(
+                "num_hidden_layers {} != {}",
+                self.num_hidden_layers, want.num_hidden_layers
+            ));
+        }
+        if self.num_attention_heads != want.num_attention_heads
+            || self.num_key_value_heads != want.num_key_value_heads
+            || self.head_dim != want.head_dim
+        {
+            return Err(format!(
+                "attn shape {}q/{}kv/{}d != {}q/{}kv/{}d",
+                self.num_attention_heads,
+                self.num_key_value_heads,
+                self.head_dim,
+                want.num_attention_heads,
+                want.num_key_value_heads,
+                want.head_dim,
+            ));
+        }
+        if self.partial_rotary_factor != want.partial_rotary_factor {
+            return Err(format!(
+                "partial_rotary_factor {} != {}",
+                self.partial_rotary_factor, want.partial_rotary_factor
+            ));
+        }
+        if self.num_experts != want.num_experts || self.moe_router_topk != want.moe_router_topk {
+            return Err(format!(
+                "MoE topology {}exp/top-{} != {}exp/top-{}",
+                self.num_experts,
+                self.moe_router_topk,
+                want.num_experts,
+                want.moe_router_topk
+            ));
+        }
+        if !self.cca || !self.zaya_use_mod || !self.zaya_use_eda {
+            return Err(format!(
+                "feature flags off (cca={}, mod={}, eda={}); ZAYA1-8B has all on",
+                self.cca, self.zaya_use_mod, self.zaya_use_eda
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_zaya1_8b_shape() {
+        let cfg = ZayaConfig::default();
+        cfg.assert_zaya1_8b_shape().expect("default must match published 8B config");
+    }
+
+    #[test]
+    fn from_hfq_returns_err_in_phase1() {
+        // `from_hfq` is a stub today; smoke-test that it returns Err so
+        // anyone wiring it into the daemon fails loudly rather than
+        // silently constructing a default config from a real HFQ file.
+        // (HfqFile construction itself requires a real file, so this
+        // test stays as a documentation marker rather than a runnable
+        // assertion until quantizer support lands.)
+    }
+}

--- a/crates/hipfire-arch-zaya/src/forward.rs
+++ b/crates/hipfire-arch-zaya/src/forward.rs
@@ -1,0 +1,55 @@
+//! ZAYA1 forward-pass entry points (stubs).
+//!
+//! Phase 1 status: declarations only. Bodies return Err. Real forward
+//! lands incrementally:
+//!   - Phase 2: free components (config, RMSNorm, SwiGLU, GQA reuse,
+//!     partial-RoPE, scale_residual_merge, MLP router, top-1).
+//!   - Phase 6 decision: where the CCA recurrent-state primitive lives.
+//!   - Phase 3 (later): CCA scalar reference + HIP kernel.
+//!   - Phase 4 (later): MoD per-token routing (gen-loop change).
+//!
+//! Forward signatures intentionally NOT on the Architecture trait
+//! (per `hipfire-runtime::arch` doc-block: forward-pass dispatch is
+//! static and arch-specific). The runtime's daemon calls these via the
+//! concrete `Zaya` type.
+
+use crate::state::ZayaState;
+use crate::weights::ZayaWeights;
+use rdna_compute::Gpu;
+
+/// Prefill: process a prompt of length S, populate the KV cache and the
+/// CCA recurrent buffers (`conv_states`, `prev_hs`) such that the next
+/// `decode_step` can pick up coherently.
+///
+/// Returns the next-token logits over the vocab.
+pub fn prefill(
+    _gpu: &mut Gpu,
+    _weights: &ZayaWeights,
+    _state: &mut ZayaState,
+    _input_ids: &[u32],
+) -> Result<Vec<f32>, String> {
+    Err(
+        "ZAYA1 prefill not implemented (Phase 1 scaffold). Free \
+         components land in Phase 2; CCA forward in Phase 3 after \
+         Phase 6 design doc. See docs/investigations/2026-05-07-zaya1-port-intake/."
+            .to_string(),
+    )
+}
+
+/// Single decode step: takes one new token id, advances the recurrent
+/// state and KV cache by one position, returns the next-token logits.
+///
+/// MoD per-token layer-skip routing (Phase 4) lives inside this function;
+/// the call site does not see whether a token skipped layers.
+pub fn decode_step(
+    _gpu: &mut Gpu,
+    _weights: &ZayaWeights,
+    _state: &mut ZayaState,
+    _input_id: u32,
+) -> Result<Vec<f32>, String> {
+    Err(
+        "ZAYA1 decode_step not implemented (Phase 1 scaffold). See \
+         docs/investigations/2026-05-07-zaya1-port-intake/."
+            .to_string(),
+    )
+}

--- a/crates/hipfire-arch-zaya/src/lib.rs
+++ b/crates/hipfire-arch-zaya/src/lib.rs
@@ -1,0 +1,33 @@
+//! hipfire-arch-zaya: Zyphra ZAYA1 architecture for hipfire (Phase 1 scaffold).
+//!
+//! Status: intake scaffold landed 2026-05-07 on `feat/zaya1-port-intake`.
+//! Implements the [`hipfire_runtime::arch::Architecture`] trait surface
+//! with stubs that return `Err` from the load and state-alloc paths.
+//! Real loading + forward come after the recurrent-state design lands
+//! (Phase 6 of the intake contract).
+//!
+//! See docs/investigations/2026-05-07-zaya1-port-intake/ for the port plan,
+//! Phase 0 disambiguation verdict (CCA is RECURRENT), and the implication
+//! that hipfire-runtime grows a per-layer recurrent-state primitive before
+//! ZAYA1 can run end-to-end.
+//!
+//! Architectural elements (from Zyphra/transformers@zaya1):
+//!   - CCA (Compressed Convolutional Attention) with two per-layer
+//!     state buffers per sequence: `conv_states` and `prev_hs`.
+//!   - Standard GQA attention downstream of CCA's Q/K/V outputs.
+//!   - 16-expert MoE, top-1 routing, MLP-based router.
+//!   - MoD (Mixture-of-Depths) per-token layer-skip routing.
+//!   - partial_rotary_factor=0.5 (NeoX/GPT-J-style half-RoPE).
+//!   - scale_residual_merge (learnable per-block residual scalar).
+//!   - EDA component (zaya_use_eda=true; identification pending Phase 5).
+
+pub mod arch;
+pub mod config;
+pub mod forward;
+pub mod state;
+pub mod weights;
+
+pub use arch::Zaya;
+pub use config::ZayaConfig;
+pub use state::ZayaState;
+pub use weights::ZayaWeights;

--- a/crates/hipfire-arch-zaya/src/state.rs
+++ b/crates/hipfire-arch-zaya/src/state.rs
@@ -17,17 +17,22 @@ use rdna_compute::Gpu;
 
 /// Per-decode GPU scratch for a single ZAYA1 sequence.
 ///
-/// Field shapes (for ZAYA1-8B, num_layers=80, hidden_size=2048):
-///   - `kv_cache_bytes`: standard KV cache, sized by max context. Owned
-///     by the runtime's existing KV pager (placeholder field today).
-///   - `cca_conv_states`: `[num_layers, B, in_out_ch=1280, conv_kernel_size=2]`
-///     fp16. Per-step roll-and-write update from
-///     `ZayaDynamicCache.update_conv_state`. ~205 KB per sequence.
-///   - `cca_prev_hs`: `[num_layers, B, hidden_size=2048]` fp16. Per-step
-///     overwrite from `prev_hs[layer].copy_(hs[-1, :, :])`. ~328 KB per
-///     sequence.
+/// ZAYA1's `num_hidden_layers=80` is the alternating ATT+MLP sub-layer
+/// count (40 ATT + 40 MLP, even/odd interleave). Only the 40 ATT
+/// sub-layers carry CCA state.
 ///
-/// Total CCA recurrent state per sequence: ~533 KB at fp16. Trivial vs
+/// Field shapes (for ZAYA1-8B, num_attn_layers=40, hidden_size=2048):
+///   - `kv_cache_bytes`: standard KV cache, sized by max context, lives
+///     on the 40 ATT layers. Owned by the runtime's existing KV pager
+///     (placeholder field today).
+///   - `cca_conv_states`: `[num_attn_layers, B, in_out_ch=1280, conv_kernel_size=2]`
+///     fp16. Per-step roll-and-write update from
+///     `ZayaDynamicCache.update_conv_state`. ~200 KB per sequence.
+///   - `cca_prev_hs`: `[num_attn_layers, B, hidden_size=2048]` fp16.
+///     Per-step overwrite from `prev_hs[layer].copy_(hs[-1, :, :])`.
+///     ~164 KB per sequence.
+///
+/// Total CCA recurrent state per sequence: ~370 KB at fp16. Trivial vs
 /// KV cache; large vs nothing. Fits comfortably in a single HBM block.
 ///
 /// RDNA ISA notes (gfx1201 R9700 target):
@@ -75,13 +80,17 @@ impl ZayaState {
     /// Compute the per-sequence CCA recurrent state size in bytes.
     /// Used by the Phase 6 design doc to size the runtime allocator
     /// budget regardless of which option lands.
+    ///
+    /// ZAYA1 alternates ATT and MLP sub-layers; only ATT layers carry
+    /// CCA state. Strict alternation is assumed: count = num_hidden_layers / 2.
     pub fn cca_state_bytes_per_seq(cfg: &ZayaConfig) -> usize {
         let dtype_bytes = 2; // fp16, per ZayaDynamicCache default
+        let num_attn_layers = cfg.num_hidden_layers / 2;
         let in_out_ch = cfg.cca_num_q_heads * cfg.head_dim
             + cfg.num_query_groups * cfg.head_dim;
         let conv_kernel_size = cfg.cca_time0.max(cfg.cca_time1); // both =2 in 8B
-        let conv = cfg.num_hidden_layers * in_out_ch * conv_kernel_size * dtype_bytes;
-        let prev_hs = cfg.num_hidden_layers * cfg.hidden_size * dtype_bytes;
+        let conv = num_attn_layers * in_out_ch * conv_kernel_size * dtype_bytes;
+        let prev_hs = num_attn_layers * cfg.hidden_size * dtype_bytes;
         conv + prev_hs
     }
 
@@ -99,13 +108,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cca_state_bytes_8b_under_1mb() {
+    fn cca_state_bytes_8b_under_500kb() {
         let cfg = ZayaConfig::default();
         let bytes = ZayaState::cca_state_bytes_per_seq(&cfg);
-        // Expected for 8B (80 layers, in_out_ch=1280, kernel=2, hidden=2048):
-        //   conv:    80 * 1280 * 2 * 2 = 409_600
-        //   prev_hs: 80 * 2048 * 2     = 327_680
-        //   total = 737_280 = ~720 KB
-        assert!(bytes > 700_000 && bytes < 800_000, "got {bytes} bytes");
+        // Expected for 8B (40 ATT layers, in_out_ch=1280, kernel=2, hidden=2048):
+        //   conv:    40 * 1280 * 2 * 2 = 204_800
+        //   prev_hs: 40 * 2048 * 2     = 163_840
+        //   total = 368_640 = ~360 KB
+        assert!(bytes > 350_000 && bytes < 400_000, "got {bytes} bytes");
     }
 }

--- a/crates/hipfire-arch-zaya/src/state.rs
+++ b/crates/hipfire-arch-zaya/src/state.rs
@@ -1,0 +1,111 @@
+//! ZayaState: per-decode GPU scratch for ZAYA1.
+//!
+//! Holds the standard KV cache PLUS the two CCA recurrent state buffers
+//! (`conv_states`, `prev_hs`) per layer per sequence. The recurrent
+//! buffers are the load-bearing structural addition vs every prior
+//! hipfire arch (qwen35 hybrid LA aside).
+//!
+//! Phase 1 status: TYPED FIELDS ONLY. `new` returns Err — actual GPU
+//! allocation lands after Phase 6 design doc resolves whether recurrent
+//! state lives in `hipfire-runtime` (Option B) or stays per-arch in this
+//! crate's State (Option A). See
+//! docs/investigations/2026-05-07-zaya1-port-intake/00-cca-disambiguation.md
+//! for the trade-off.
+
+use crate::config::ZayaConfig;
+use rdna_compute::Gpu;
+
+/// Per-decode GPU scratch for a single ZAYA1 sequence.
+///
+/// Field shapes (for ZAYA1-8B, num_layers=80, hidden_size=2048):
+///   - `kv_cache_bytes`: standard KV cache, sized by max context. Owned
+///     by the runtime's existing KV pager (placeholder field today).
+///   - `cca_conv_states`: `[num_layers, B, in_out_ch=1280, conv_kernel_size=2]`
+///     fp16. Per-step roll-and-write update from
+///     `ZayaDynamicCache.update_conv_state`. ~205 KB per sequence.
+///   - `cca_prev_hs`: `[num_layers, B, hidden_size=2048]` fp16. Per-step
+///     overwrite from `prev_hs[layer].copy_(hs[-1, :, :])`. ~328 KB per
+///     sequence.
+///
+/// Total CCA recurrent state per sequence: ~533 KB at fp16. Trivial vs
+/// KV cache; large vs nothing. Fits comfortably in a single HBM block.
+///
+/// RDNA ISA notes (gfx1201 R9700 target):
+///   - in_out_ch=1280 is divisible by 64 → wave32 × 2-VGPR-per-lane
+///     packed-fp16 covers it in 20 lane-groups.
+///   - conv_kernel_size=2 means each output position is a 2-element MAC
+///     per channel; ideal for v_pk_fma_f16 packed math.
+///   - Roll(-1) + write[-1] becomes a single uint32 swap if we lay the
+///     two time slots out as consecutive fp16 pairs in HBM.
+pub struct ZayaState {
+    pub config: ZayaConfig,
+
+    // -- KV cache ----------------------------------------------------------
+    /// Placeholder. Real impl threads through `hipfire-runtime`'s KV pager.
+    pub kv_cache_bytes: usize,
+
+    // -- CCA recurrent state -----------------------------------------------
+    /// Total bytes for `conv_states` across all layers, computed from cfg.
+    pub cca_conv_states_bytes: usize,
+    /// Total bytes for `prev_hs` across all layers, computed from cfg.
+    pub cca_prev_hs_bytes: usize,
+    /// `has_previous_state` flag from `ZayaDynamicCache`. False until the
+    /// first decode step writes the cache. Toggled by the forward pass.
+    pub has_previous_state: bool,
+}
+
+impl ZayaState {
+    /// Allocate per-sequence GPU scratch for ZAYA1.
+    ///
+    /// Phase 1 status: returns Err. The recurrent-state allocation
+    /// strategy is the headline Phase 6 deliverable; do not silently
+    /// allocate anything until that decision lands.
+    pub fn new(_gpu: &mut Gpu, _cfg: &ZayaConfig) -> Result<Self, String> {
+        Err(
+            "ZayaState::new not implemented (Phase 1 scaffold). The CCA \
+             recurrent state's GPU layout is the Phase 6 deliverable; \
+             see docs/investigations/2026-05-07-zaya1-port-intake/. Two \
+             options under consideration: extend per-arch State (Option A) \
+             vs first-class recurrent-cache primitive in hipfire-runtime \
+             (Option B). Decision REQUIRES-KADEN-DECISION."
+                .to_string(),
+        )
+    }
+
+    /// Compute the per-sequence CCA recurrent state size in bytes.
+    /// Used by the Phase 6 design doc to size the runtime allocator
+    /// budget regardless of which option lands.
+    pub fn cca_state_bytes_per_seq(cfg: &ZayaConfig) -> usize {
+        let dtype_bytes = 2; // fp16, per ZayaDynamicCache default
+        let in_out_ch = cfg.cca_num_q_heads * cfg.head_dim
+            + cfg.num_query_groups * cfg.head_dim;
+        let conv_kernel_size = cfg.cca_time0.max(cfg.cca_time1); // both =2 in 8B
+        let conv = cfg.num_hidden_layers * in_out_ch * conv_kernel_size * dtype_bytes;
+        let prev_hs = cfg.num_hidden_layers * cfg.hidden_size * dtype_bytes;
+        conv + prev_hs
+    }
+
+    /// Reset both recurrent buffers to zero (matches
+    /// `ZayaDynamicCache.reset()` semantics). Called by the daemon on
+    /// session end / context reset.
+    pub fn reset_cca(&mut self) {
+        self.has_previous_state = false;
+        // Real impl zeroes the GPU buffers via `gpu.memset(...)`.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cca_state_bytes_8b_under_1mb() {
+        let cfg = ZayaConfig::default();
+        let bytes = ZayaState::cca_state_bytes_per_seq(&cfg);
+        // Expected for 8B (80 layers, in_out_ch=1280, kernel=2, hidden=2048):
+        //   conv:    80 * 1280 * 2 * 2 = 409_600
+        //   prev_hs: 80 * 2048 * 2     = 327_680
+        //   total = 737_280 = ~720 KB
+        assert!(bytes > 700_000 && bytes < 800_000, "got {bytes} bytes");
+    }
+}

--- a/crates/hipfire-arch-zaya/src/weights.rs
+++ b/crates/hipfire-arch-zaya/src/weights.rs
@@ -1,0 +1,51 @@
+//! ZayaWeights: GPU-resident model weights for ZAYA1.
+//!
+//! Phase 1 status: TYPE STUB. `load` returns Err; per-layer weight
+//! tensors are unspecified pending HFQ-side quantizer support and the
+//! Phase 6 recurrent-state plumbing decision.
+//!
+//! Per-layer weight inventory (from Zyphra/transformers@zaya1
+//! modeling_zaya.py:1197 ZayaBlock):
+//!   - CCA: linear_q, linear_k, val_proj1, val_proj2, conv_qk[0], conv_qk[1],
+//!          temp (per-kv-head scalar)
+//!   - Standard attention: q_proj, k_proj, v_proj, o_proj (16q/2kv layout)
+//!   - Norms: 4× RMSNorm per block (pre-CCA, pre-attn, pre-mlp, pre-mod-router?)
+//!     Exact set TBD by Phase 1 read of ZayaBlock.
+//!   - MoE: 16× expert FFN (gate/up/down per expert, SwiGLU), MLP router
+//!     (2-layer with `zaya_mlp_expansion=256` hidden), shared expert(?)
+//!   - MoD: per-block top-k token-router weights (Phase 4)
+//!   - Residual scaling: per-block learnable scalar (`scale_residual_merge`)
+//!   - EDA: TBD pending Phase 5
+//! Plus model-global: token_embed (262272 × 2048), final_norm, lm_head
+//! (tied to embed per `tie_word_embeddings=true`).
+
+use crate::config::ZayaConfig;
+use hipfire_runtime::hfq::HfqFile;
+
+/// Per-decode model weights for ZAYA1.
+///
+/// Phase 1: opaque placeholder. Real fields populate as forward-pass
+/// kernels come online (Phase 2 free components, then Phase 3/6 CCA).
+pub struct ZayaWeights {
+    pub config: ZayaConfig,
+    /// Total bytes uploaded (for accounting; populated by `load`).
+    pub uploaded_bytes: usize,
+}
+
+impl ZayaWeights {
+    /// Load ZAYA1 weights from an HFQ file.
+    ///
+    /// Phase 1 status: returns Err. The HFQ representation for ZAYA1
+    /// requires (a) the quantizer learning the Zaya tensor naming
+    /// convention from the safetensors checkpoint, and (b) any new
+    /// quant-format slots the recurrent state's fp16 conv_states /
+    /// prev_hs need. Both pending Phase 6 decisions.
+    pub fn load(_hfq: &mut HfqFile, _cfg: &ZayaConfig) -> Result<Self, String> {
+        Err(
+            "ZayaWeights::load not implemented (Phase 1 scaffold). HFQ \
+             representation for ZAYA1 pending quantizer support; see \
+             docs/investigations/2026-05-07-zaya1-port-intake/."
+                .to_string(),
+        )
+    }
+}

--- a/docs/investigations/2026-05-07-zaya1-port-intake/00-cca-disambiguation.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/00-cca-disambiguation.md
@@ -144,7 +144,7 @@ grep -nE "Conv1d|conv_states|prev_hs|has_previous_state|update_conv_state"
 ### What's structurally new
 
 1. **First per-layer recurrent state in hipfire.** Existing infra (Qwen 3.5 DeltaNet linear-attention path is the closest analogue, but DeltaNet's recurrence is folded into the LA forward signature, not externalized as a stateful cache the way CCA does).
-2. **State allocation:** 80 layers × (1280 × 2 + 2048) = 80 × 4608 = ~370k elems per sequence at fp16 = ~740 KB per sequence. Trivial vs KV cache. But it needs a home.
+2. **State allocation:** ZAYA1 alternates ATT layers and MLP layers; only the 40 ATT layers carry CCA. So total: 40 layers × (1280 × 2 + 2048) = 40 × 4608 = ~184k elems per sequence at fp16 = ~370 KB per sequence. (Earlier draft of this doc claimed 80 layers × ... = ~740 KB; corrected after Phase 1 empirical layer-structure probe on hiptrx confirmed `model.layers[i]` alternates `ZayaDecoderATTLayer` (even idx) with `ZayaDecoderMLPLayer` (odd idx), so `num_hidden_layers=80` really means 40 ATT + 40 MLP, not 80 attention blocks.) Still trivial vs KV cache. But it needs a home.
 3. **State carry:** every decode step reads `conv_states[layer]` and `prev_hs[layer]`, computes new outputs, writes both back. The `roll(-1) + write [-1]` semantic for `conv_states` is a circular buffer; on RDNA we'd implement as a small persistent HBM tensor or a single-line LDS-resident buffer per layer.
 4. **State reset** on session end / context reset (`reset()` zeroes both buffers).
 

--- a/docs/investigations/2026-05-07-zaya1-port-intake/00-cca-disambiguation.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/00-cca-disambiguation.md
@@ -1,0 +1,188 @@
+# 00 - CCA Disambiguation
+
+**Date:** 2026-05-07
+**Branch:** `feat/zaya1-port-intake`
+**Source:** `Zyphra/transformers@zaya1` (cloned at `/tmp/zaya-port/source-reads/zyphra-transformers`)
+**Files read:** `src/transformers/models/zaya/{configuration_zaya.py, modeling_zaya.py}`
+
+## Verdict
+
+**RECURRENT.**
+
+CCA carries two per-layer per-sequence state buffers across decode steps. This is unambiguous from the source: the cache class explicitly allocates them, the forward explicitly reads and writes them in the generation branch, and the operator is structurally a stateful causal Conv1d-along-time fused with a 1-step hidden-state delay for the value path.
+
+The earlier reading (HF model card, blog post) that suggested CCA was attention-only was incomplete; the recurrence is not described in the marketing material but is plainly visible in the modeling code.
+
+`mamba_cache_dtype: float32` in `config.json` is **dead config** - zero references across the entire `zaya/` module - but the recurrence it suggests is real, just stored at fp16 (Python default) by the actual cache class.
+
+## Evidence
+
+### Two state buffers, allocated per-layer
+
+`modeling_zaya.py:187-229` - `ZayaDynamicCache(DynamicCache)`:
+
+```python
+class ZayaDynamicCache(DynamicCache):
+    """Cache that includes both the KV cache and the CCA cache."""
+
+    def __init__(self, config: ZayaConfig, batch_size: int, dtype: torch.dtype = torch.float16, ...):
+        ...
+        self.conv_kernel_size = 2
+        self.num_layers = config.num_hidden_layers
+        self.latent_k_dim = num_k_heads * head_dim                # 2 * 128 = 256
+        self.latent_q_dim = num_q_heads * head_dim                # 8 * 128 = 1024  (note: cca_num_q_heads, not num_attention_heads)
+        self.in_out_ch = self.latent_k_dim + self.latent_q_dim    # 1280
+        self.has_previous_state = False
+
+        self.conv_states = torch.zeros(
+            self.num_layers, batch_size, self.in_out_ch, self.conv_kernel_size,
+            device=device, dtype=dtype,
+        )                                                         # [80, B, 1280, 2]
+
+        self.prev_hs = torch.zeros(
+            self.num_layers, batch_size, config.hidden_size,
+            device=device, dtype=dtype,
+        )                                                         # [80, B, 2048]
+```
+
+The cache docstring is the smoking gun: "Cache that includes **both** the KV cache and the CCA cache." Standard KV is inherited from `DynamicCache`; the CCA cache is `conv_states + prev_hs` added on top.
+
+### Cache update is per-step, time-rolling
+
+`modeling_zaya.py:231-237`:
+
+```python
+def update_conv_state(self, layer_idx: int, new_conv_state: torch.Tensor) -> torch.Tensor:
+    if not self.has_previous_state:
+        # Prefill: install the conv-warm window from the tail of the prompt
+        self.conv_states[layer_idx] = new_conv_state.to(self.conv_states.device)
+    else:
+        # Decode: shift left by 1 (drop oldest), write current step at [-1]
+        self.conv_states[layer_idx] = self.conv_states[layer_idx].roll(shifts=-1, dims=-1)
+        self.conv_states[layer_idx][:, :, -1] = new_conv_state[:, 0, :].to(self.conv_states.device)
+    return self.conv_states[layer_idx]
+```
+
+This is a textbook circular-buffer update for a causal 1D conv with persistent state. Identical in pattern to Mamba's conv state caching, just smaller (kernel=2 → 1 cached step instead of kernel=4 → 3).
+
+### CCA forward reads + writes both buffers in the decode branch
+
+`modeling_zaya.py:359-368` (decode = `has_previous_state` branch):
+
+```python
+if past_key_values.has_previous_state:
+    # Generation
+    qk_packed0 = qk_packed0.transpose(0, 1)                                  # [B, 1, H]
+    qk_packed0_cached = past_key_values.conv_states[self.layer_number]       # [B, H, 2]
+    qk_packed0_cat = torch.cat([qk_packed0_cached, qk_packed0.transpose(1, 2)], dim=-1)  # [B, H, 3]
+    qk_packed3 = self.conv_qk(qk_packed0_cat).permute(2, 0, 1)               # [S, B, E]
+    qk_packed0_cache = past_key_values.update_conv_state(
+        layer_idx=self.layer_number, new_conv_state=qk_packed0
+    )                                                                        # rolls cache
+```
+
+`modeling_zaya.py:409-415` (the v2 / `prev_hs` half):
+
+```python
+if past_key_values is not None:
+    if past_key_values.has_previous_state:
+        # Generation
+        hs_d = past_key_values.prev_hs[self.layer_number].clone()  # [B, H]
+        hs_d = hs_d.unsqueeze(0)                                   # [1, B, H]
+    past_key_values.prev_hs[self.layer_number].copy_(hs[-1, :, :])  # writeback (always at decode)
+```
+
+Two distinct recurrences in one operator:
+
+1. **Conv state** - last `conv_kernel_size - 1 = 1` step of post-projection QK (concatenated 1280-dim), used to compose the conv1d input for the next step.
+2. **`prev_hs`** - last step's input hidden state, used as the "delayed" stream for `val_proj2(hs_d)` (the v2 half of the value projection).
+
+### Convs are along the SEQUENCE axis (not channel)
+
+`modeling_zaya.py:289-308` - the conv stack:
+
+```python
+in_out_ch = self.latent_k_dim + self.latent_q_dim   # 1280
+self.conv_qk = nn.Sequential(
+    nn.Conv1d(in_channels=in_out_ch, out_channels=in_out_ch,
+              kernel_size=self.cca_time0, groups=in_out_ch, padding=0, stride=1),     # depthwise, k=2
+    nn.Conv1d(in_channels=in_out_ch, out_channels=in_out_ch,
+              kernel_size=self.cca_time1, groups=(num_kv_heads + num_q_heads),         # grouped (10 groups), k=2
+              padding=0, stride=1),
+)
+```
+
+The prefill path makes this explicit (`modeling_zaya.py:385-394`):
+
+```python
+qk_packed1 = qk_packed0.permute(1, 2, 0)                  # [S, B, E] -> [B, E, S]   (channels=E, length=S)
+qk_packed2 = F.pad(qk_packed1, (self.total_padding, 0))   # left-pad ONLY (causal)
+qk_packed3 = self.conv_qk(qk_packed2).permute(2, 0, 1)    # back to [S, B, E]
+```
+
+`F.pad(..., (total_padding, 0))` left-pads on the LAST dim (sequence). Two stacked k=2 convs → effective kernel = 3 over time. So each output position is a function of the current and the previous 2 positions of QK projections.
+
+### Cross-reference: why earlier grep missed it
+
+```
+grep -nE "mamba|ssm|recurrent|scan|conv1d|state\.copy_|state_in|past_state|\.cache_params"
+   modeling_zaya.py modular_zaya.py configuration_zaya.py
+   → ZERO matches
+```
+
+The keywords for THIS recurrence are different. The right query was:
+
+```
+grep -nE "Conv1d|conv_states|prev_hs|has_previous_state|update_conv_state"
+   → modeling_zaya.py: 4 + N hits (CCA constructor, cache class, forward decode branch)
+```
+
+`mamba_cache_dtype` (singular field in config) returns zero hits across the module - confirmed dead. The Zaya cache class allocates fp16 by default and never consults that config field.
+
+## Implications for hipfire-runtime
+
+### What's structurally new
+
+1. **First per-layer recurrent state in hipfire.** Existing infra (Qwen 3.5 DeltaNet linear-attention path is the closest analogue, but DeltaNet's recurrence is folded into the LA forward signature, not externalized as a stateful cache the way CCA does).
+2. **State allocation:** 80 layers × (1280 × 2 + 2048) = 80 × 4608 = ~370k elems per sequence at fp16 = ~740 KB per sequence. Trivial vs KV cache. But it needs a home.
+3. **State carry:** every decode step reads `conv_states[layer]` and `prev_hs[layer]`, computes new outputs, writes both back. The `roll(-1) + write [-1]` semantic for `conv_states` is a circular buffer; on RDNA we'd implement as a small persistent HBM tensor or a single-line LDS-resident buffer per layer.
+4. **State reset** on session end / context reset (`reset()` zeroes both buffers).
+
+### What this breaks for hipfire
+
+1. **Speculative decoding (DFlash, MTP):** drafter and target both run CCA forward, both must have a coherent recurrent state. Parallel speculation across N candidate tokens means N parallel possible state advances; on rollback, state must be restored. This is the same problem Mamba speculative decoding solves; non-trivial.
+2. **KV pager:** the existing pager only knows about KV. If a sequence is paged out, conv_states + prev_hs must travel with it.
+3. **Multi-GPU sharding:** if layers are pipeline-sharded across devices (PP), each device owns its layers' recurrent state - already the natural shard axis. If layers are tensor-sharded (TP within a layer), conv_states is sharded along its channel dim (1280) which decomposes cleanly per-head.
+4. **Multi-batch / continuous batching:** state is per-sequence per-layer, must be allocated and reset alongside KV pages.
+
+### What's contained in the arch crate
+
+- The CCA forward op itself (the conv kernels, the L2-norm-and-scale, the v1/v2 mixing).
+- Math is straightforward; the "novelty" is structural (state plumbing), not arithmetic. The conv is k=2 depthwise + k=2 grouped over a 1280-channel × short-time window - small enough to run as a single fused HIP kernel per decode step.
+
+### What requires hipfire-runtime changes (per contract: REQUIRES-KADEN-DECISION)
+
+- A new state container in `hipfire-runtime` parallel to KV. Either:
+  - **Option A** - extend the existing `State` per-arch type (already on the `Architecture` trait at `crates/hipfire-runtime/src/arch.rs:44`) to carry recurrent buffers as opaque per-arch state. Per-arch crate owns shape/dtype; runtime only allocates and reset-zeros via trait methods. **Lower runtime churn.**
+  - **Option B** - first-class "recurrent cache" abstraction in `hipfire-runtime` parallel to KV cache, with paging/sharding/spec-decode hooks. **Higher payoff, more design surface.**
+- Spec-decode policy: either **gate ZAYA1 to AR-only** (simplest, ships) or design state-fork/merge primitives.
+- Wire `state.reset()` into the session-end / chat-template-reset path.
+
+### Sequencing recommendation for the rest of tonight
+
+Per the contract's RECURRENT branch:
+
+- **Phase 1** (foundations) - proceed: arch crate scaffolding, intake harness, PyTorch reference dumps. The recurrent state shapes are now known and can be modeled in `Self::State`.
+- **Phase 2** (free components) - proceed: config parse, RMSNorm/SwiGLU/GQA reuse, partial-RoPE 0.5, scale_residual_merge, MLP router, top-1 routing. None of these touch CCA.
+- **Phase 3 (CCA kernel)** - **DO NOT start tonight.** Per contract.
+- **Phase 4 (MoD design doc)** - proceed.
+- **Phase 5 (EDA identification)** - proceed.
+- **Phase 6 (recurrent-state design doc)** - **headline deliverable.** Author with Option A vs Option B comparison and a recommended path. Flag REQUIRES-KADEN-DECISION.
+
+### Side-finding to flag for Phase 1
+
+CCA's `cca_num_q_heads = 8` is **distinct from** the standard attention's `num_attention_heads = 16`. CCA's forward returns `query: [B, S, 8*128] = [B, S, 1024]`, `key: [B, S, 2*128] = [B, S, 256]`, `value: [B, S, 2*128] = [B, S, 256]`. The downstream `ZayaAttention` (line 483) then does 16-head attention. How does the 8-head CCA Q project up to 16-head attention input? Either repeat-interleave (treating 8 CCA heads as 8 "groups" doubled) or a learned projection inside `ZayaAttention`. Read in Phase 1 before writing the arch crate's forward signature.
+
+## Confidence
+
+**High.** The cache class explicitly says "CCA cache," the forward explicitly reads + writes per-layer state in the generation branch, and the update semantics match a textbook circular conv buffer. There is no plausible reading where CCA is stateless.

--- a/docs/investigations/2026-05-07-zaya1-port-intake/01-recurrent-state-design.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/01-recurrent-state-design.md
@@ -18,8 +18,11 @@ The state being placed:
 | `conv_states` | `[in_out_ch=1280, conv_kernel_size=2]` | fp16 | roll(-1) + write at [-1] |
 | `prev_hs` | `[hidden_size=2048]` | fp16 | overwrite (1-step lag of input hs) |
 
-For ZAYA1-8B (80 layers): ~720 KB per sequence at fp16. No KV-pager-scale
-allocation; comfortably HBM-resident.
+For ZAYA1-8B: ~370 KB per sequence at fp16. (40 ATT layers carry CCA;
+the other 40 are MLP layers and have no CCA state. ZAYA1's
+`num_hidden_layers=80` is total sub-layer count, alternating ATT/MLP;
+per Phase 1 layer-structure probe.) No KV-pager-scale allocation;
+comfortably HBM-resident.
 
 This is the **first per-layer recurrent state in hipfire** that lives
 across decode steps (qwen35's DeltaNet recurrence is folded into the LA

--- a/docs/investigations/2026-05-07-zaya1-port-intake/01-recurrent-state-design.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/01-recurrent-state-design.md
@@ -1,0 +1,287 @@
+# 01 - CCA Recurrent-State Design
+
+**Date:** 2026-05-07
+**Branch:** `feat/zaya1-port-intake`
+**Status:** REQUIRES-KADEN-DECISION (see MANUAL_REVIEW.md)
+**Predicates:** 00-cca-disambiguation.md (verdict: RECURRENT), 02-mod-design.md (no
+runtime changes needed), 03-eda-identification.md (no recurrent state)
+
+## What this doc decides
+
+Where the CCA recurrent state lives in hipfire. Two coherent options
+follow; neither is wrong, but their long-term shape differs.
+
+The state being placed:
+
+| Buffer | Per-layer shape (per seq) | Dtype | Update semantic |
+|---|---|---|---|
+| `conv_states` | `[in_out_ch=1280, conv_kernel_size=2]` | fp16 | roll(-1) + write at [-1] |
+| `prev_hs` | `[hidden_size=2048]` | fp16 | overwrite (1-step lag of input hs) |
+
+For ZAYA1-8B (80 layers): ~720 KB per sequence at fp16. No KV-pager-scale
+allocation; comfortably HBM-resident.
+
+This is the **first per-layer recurrent state in hipfire** that lives
+across decode steps (qwen35's DeltaNet recurrence is folded into the LA
+forward signature; never externalized as a runtime concept).
+
+## Two options
+
+### Option A: per-arch State carries the recurrent buffers
+
+ZayaState owns the buffers; allocation, update, reset are
+arch-private. The runtime sees only an opaque `Self::State` per the
+`Architecture` trait. No new abstractions in hipfire-runtime.
+
+**Pros:**
+- Zero hipfire-runtime churn. PR fits in `hipfire-arch-zaya/` plus the
+  per-arch HFQ format growth (or a new metadata field) for the conv
+  state shapes.
+- Doesn't lock in a shape for a recurrent-cache abstraction before we
+  see what other recurrent archs (Mamba2, SSM hybrids, RWKV) actually
+  need. Keeps the experimentation surface in the per-arch crate.
+- Easy to delete if ZAYA1 is retired; runtime never grew the slot.
+
+**Cons:**
+- Reuses no infrastructure. Spec-decode, paging, multi-GPU sharding
+  all become per-arch concerns instead of per-runtime.
+- Two recurrent arches (this one and a hypothetical next) duplicate
+  the buffer-management code.
+- The arch crate ends up doing GPU allocation it would otherwise
+  delegate to a pager.
+
+### Option B: first-class recurrent-cache abstraction in hipfire-runtime
+
+Mirror the existing KV-cache abstraction with a parallel
+"recurrent cache" primitive: per-sequence per-layer typed slots,
+allocation via the runtime's pager, update-semantic registered by the
+arch crate (roll-and-write here, but other patterns possible), reset on
+session end, paging-aware, sharding-aware.
+
+**Pros:**
+- Spec-decode, paging, sharding gain a uniform place to handle
+  recurrent state. When DFlash/MTP comes online for ZAYA1 it can use
+  the existing fork/merge primitives by design.
+- Future recurrent arches (Mamba2, SSM) cost zero new runtime code.
+- Reset / migration / serialization for sessions becomes a runtime
+  concern, not arch-private.
+
+**Cons:**
+- Larger PR, more design surface to get right. The first abstraction
+  attempt almost always shapes the next one wrong; we'd be designing
+  for a population of one.
+- Locks in a shape before we know what other recurrent archs need.
+  Mamba2's selective scan has different update semantics; CCA's
+  roll-and-write is a special case.
+- Slower to ship.
+
+## Recommendation
+
+**Option A first. Migrate to Option B after the second recurrent arch
+arrives.** Concretely:
+
+1. Phase 6.A (this PR; estimated 1-2 weeks): land Option A with the
+   recurrent buffers in `ZayaState`. Restrict spec-decode for ZAYA1
+   to AR-only on first ship (small, explicit comment in the daemon).
+   Paging: hold ZAYA1 sequences in HBM in their entirety (no paging
+   mode) on first ship; the recurrent state is small enough that
+   paging adds complexity without payoff.
+
+2. Phase 6.B (deferred until a second recurrent arch): when Mamba2
+   or SSM lands, pull the buffers and update semantics out of
+   `ZayaState` into a runtime primitive whose first user is ZAYA1.
+   By then we will have seen what semantics generalize.
+
+This is the same shape the engine modularization PRD took for
+`speculative.rs` and `pflash.rs`: live in the arch crate today,
+generalize when the second user arrives.
+
+## Detailed Phase 6.A plan (Option A, this branch)
+
+### State allocation
+
+`ZayaState::new(gpu, cfg)` allocates two device buffers per sequence
+during session creation:
+
+```rust
+let conv_states = gpu.alloc_zero_fp16(
+    cfg.num_hidden_layers * cfg.batch_size *
+    (cfg.cca_num_q_heads + cfg.num_query_groups) * cfg.head_dim *
+    max(cfg.cca_time0, cfg.cca_time1)
+)?;
+let prev_hs = gpu.alloc_zero_fp16(
+    cfg.num_hidden_layers * cfg.batch_size * cfg.hidden_size
+)?;
+```
+
+Shape choice: keep both as flat fp16 slabs with explicit per-layer
+strides. The `roll(-1) + write[-1]` semantic for conv_states becomes a
+single uint32 swap per channel if `conv_kernel_size = 2` is laid out
+as two consecutive fp16 slots.
+
+### Per-step update kernel
+
+One fused HIP kernel per layer's CCA forward, called from the per-arch
+forward path:
+
+```c
+// pseudo: per-channel update
+__global__ void cca_advance_state(
+    const half2* qk_packed_new,   // [B, in_out_ch/2]   new step's QK proj
+    half2*       conv_states,     // [B, in_out_ch/2]   was [B, ch, 2] viewed as packed
+    const half*  hs_input,        // [B, hidden_size]   current step's input hidden state
+    half*        prev_hs,         // [B, hidden_size]
+    int B, int in_out_ch, int hidden_size
+) {
+    // For each lane in wave32 (gfx1201):
+    //   - Load 2 fp16 channels packed as half2 from conv_states (= old [t-1, t])
+    //   - Shift: new_state.x = old_state.y; new_state.y = qk_packed_new
+    //   - Store back: conv_states[lane] = new_state
+    // For prev_hs: copy current hs into prev_hs (separate kernel or fused tail).
+}
+```
+
+Wave32-friendly because `in_out_ch/2 = 640` divides cleanly into
+`640 / 32 = 20` lane-groups. fp16 packed math is two ops per lane per
+update.
+
+The conv1d output is computed in a separate kernel that consumes
+`conv_states` directly (read the [t-1, t] pair, multiply by depthwise
+weights, accumulate). The grouped second conv operates on the result.
+
+### Spec-decode story
+
+First ship: **gate ZAYA1 to AR-only.** Add `Self::supports_spec_decode()
+-> false` (or equivalent) on the trait, default true, override here
+returning false.
+
+Why: drafter and target sharing CCA conv state across N parallel
+candidate tokens means N parallel possible state advances; rollback on
+rejection requires reverting the conv state. The roll(-1) operation is
+not cheap to invert without a save/restore. In Phase 6.B / future PRs,
+add a `state.fork(N)` / `state.commit(idx)` primitive for general
+spec-decode of recurrent archs.
+
+This is a real cost: ZAYA1 loses the 1.5-3x DFlash multiplier. The
+acceptable trade is "AR-only ship now, recurrent spec-decode later."
+
+### Paging story
+
+First ship: **no paging for ZAYA1 sequences.** The recurrent state is
+small (~720 KB per sequence) but its update semantic doesn't compose
+with the LRU eviction the existing KV pager does. A paged-out
+sequence's conv_states can't roll forward without being resident.
+
+Long-term: pin the recurrent state in HBM even when the KV cache is
+paged out. The 720 KB is ~0.07% of an R9700's 32 GB; even 256
+sequences only consumes 184 MB pinned.
+
+### Multi-GPU sharding
+
+Pipeline parallel (PP): natural fit. Each GPU owns a layer range; the
+recurrent state for those layers lives on that GPU. The `prev_hs`
+boundary travel between PP stages is one extra `[B, hidden_size]`
+fp16 send per decode step (negligible vs the residual stream that
+already crosses).
+
+Tensor parallel (TP) within a layer: `conv_states` shards along its
+channel dim (`in_out_ch=1280`); each shard owns its 1/N slice of the
+1280 channels. The depthwise+grouped conv is locality-friendly (each
+output channel is a function of its own channel's history). TP shards
+the prev_hs along the residual stream's existing shard axis.
+
+### Migration path
+
+Existing arches (qwen35, llama, gemma) gain a no-op `State` slot for
+the recurrent buffer; their `new_state` continues to allocate zero
+recurrent bytes. The `Architecture` trait does NOT grow new methods
+(forward stays static, recurrent state is owned per-arch). Zero impact
+on existing arch crates.
+
+When Phase 6.B comes, the recurrent-cache primitive moves into
+`hipfire-runtime::recurrent_cache` and `ZayaState` grows a borrow into
+it. Other arches still allocate zero bytes there; the primitive is
+opt-in by per-arch crate.
+
+### Reset semantics
+
+`ZayaState::reset_cca(&mut self)` zeroes both buffers and sets
+`has_previous_state = false`. The runtime's session-end / clear-cache
+path calls this alongside KV reset. No new runtime entry point needed;
+the existing `Architecture::reset_state(state)` (TODO: confirm this
+exists; if not, add as part of this PR) covers it.
+
+## Effort estimate
+
+| Sub-task | Effort |
+|---|---|
+| ZayaState allocation + reset (Option A) | 1-2 days |
+| CCA conv-state advance kernel + tests | 3-5 days |
+| CCA prev_hs writeback (fused or separate) | 1 day |
+| ZAYA1 spec-decode opt-out (1-line override) | 1 hour |
+| Per-layer NRMSE pass on CCA output (vs ref) | 2-3 days |
+| Documentation + PR review iteration | 2-3 days |
+| **Total Phase 6.A** | **~2 weeks** |
+
+This assumes Phase 0-5 deliverables already landed (which they will
+when this PR's predecessors merge). It does NOT include:
+- HFQ writer for ZAYA1 (separate work, ~3-5 days).
+- Final ZayaAttention plumbing for the 8q->16q head rebalance (Phase 1
+  open question; ~1 day once read).
+- MoD impl (~3-5 days, Phase 4 plan).
+- EDA impl (~half-day, Phase 5 plan).
+
+End-to-end ZAYA1 first-token: ~3-4 weeks calendar from this branch's
+state. End-to-end coherent decode + bench: ~5-6 weeks.
+
+## RDNA-aware design points (per user clarification)
+
+The user explicitly called out: respect the prescribed model arch AND
+target RDNA hardware respecting its ISA. Specific commitments:
+
+1. **Wave32 first.** All CCA kernels target gfx1201's wave32 default,
+   not wave64. The depthwise k=2 conv with `in_out_ch=1280` divides
+   cleanly into 1280/32 = 40 wave-groups for the per-channel update.
+
+2. **Packed fp16 (`v_pk_fma_f16`).** The conv1d's k=2 multiply-add per
+   channel is exactly the shape of one packed fp16 FMA. Two fp16 weights
+   in `<2 x fp16>` × two history slots in `<2 x fp16>` = one
+   `v_pk_fma_f16` issue, accumulating into the output.
+
+3. **LDS-resident state for hot loop.** During a multi-token decode
+   chunk (e.g. spec-decode candidate evaluation, when re-enabled), the
+   conv_states for the layers being processed can sit in LDS with bank
+   conflict-free strides. 720 KB total state for ZAYA1-8B fits in a
+   single CU's LDS (gfx1201 has 96 KB LDS per CU; sequence-state per
+   layer is ~9 KB so a few layers can live in LDS at once).
+
+4. **No SHL+OR composition tricks.** The roll(-1)+write[-1] semantic
+   is a single uint32 swap when conv_states are laid out as
+   `(channel, time)` packed pairs. No extra ALU.
+
+5. **gfx1201 wmma-SAFE.** No matrix-unit code in CCA; the conv is too
+   small for wmma. The downstream attention (post-CCA) reuses the
+   existing FA path which already targets gfx1201.
+
+These are sketches, not commitments. The actual kernel layout falls
+out during impl; this section is here to set the bar.
+
+## REQUIRES-KADEN-DECISION
+
+Two decisions to confirm before Phase 6.A merges:
+
+1. **Option A vs B, this PR**. Recommendation Option A; happy to flip
+   to B if you want to invest now. (Cost delta: roughly +1 week.)
+
+2. **First-ship spec-decode policy: AR-only or block-mode-spec?**
+   Recommendation AR-only first. The recurrent-spec-decode design
+   landed properly takes care; cheap stub today buys ZAYA1 ship.
+
+3. **Paging policy**: HBM-pinned per-sequence vs paged. Recommendation
+   HBM-pinned, given the small per-sequence footprint (~720 KB at
+   bf16 / fp16) and the un-page-friendly update semantic.
+
+Other items in the design above (kernel choices, Wave32 vs Wave64,
+LDS layout, multi-GPU shard axis) are implementer's call; this doc
+captures the proposal but does not require approval before code
+starts on those items.

--- a/docs/investigations/2026-05-07-zaya1-port-intake/02-mod-design.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/02-mod-design.md
@@ -1,0 +1,187 @@
+# 02 - Mixture-of-Depths (MoD) Design
+
+**Date:** 2026-05-07
+**Branch:** `feat/zaya1-port-intake`
+**Source:** `Zyphra/transformers@zaya1` `modeling_zaya.py:1197-1280` (ZayaBlock),
+`917-1048` (ZayaRouter)
+
+## TL;DR
+
+The contract treated MoD as a structural concern (per-token layer-skip,
+breaks DFlash/spec-decode, conditionalized KV writes). After reading
+the implementation: **Zyphra's MoD is much friendlier than the spec
+suggested.** It is implemented as `num_experts + 1` (the +1 = skip slot)
+plus a sort-and-skip-last-bin pattern in the MoE dispatcher. Skip
+tokens get `y = x * route_prob_skip`, then continue through the
+residual add. **MoD touches zero KV state and zero attention compute.**
+
+This is the lightweight implementation option from the contract's
+Phase 4 menu, not the heavy compaction option, and it is what Zyphra
+shipped. Recommendation: implement straightforward; no spec-decode
+incompatibility, no gen-loop changes, no KV conditionalization.
+
+## How Zyphra implements MoD
+
+### Router side (ZayaRouter)
+
+```python
+self.use_mod = bool(getattr(config, "zaya_use_mod", False))
+self.num_experts = (num_moe_experts + 1) if self.use_mod else num_moe_experts  # +1 skip
+...
+self.balancing_biases[-1] = -1.0   # bias the router AWAY from skip
+```
+
+The router has one extra "expert" slot reserved for skip. With
+`moe_router_topk=1` (ZAYA1-8B), each token picks exactly one expert.
+That choice can be the skip slot (last index), which means the token
+elects to bypass MoE compute for this layer.
+
+The `-1.0` balancing bias on the skip slot prevents it from dominating;
+without it the router would learn to route everything to skip (free
+loss reduction since the residual stream survives).
+
+### MoE side (ZayaBlock.forward)
+
+```python
+sorted_indices, sort_order = torch.sort(indices_flat)
+tokens_per_expert = torch.bincount(sorted_indices, minlength=self.router.num_experts)
+sorted_hidden_states = hidden_states_flat[sort_order]
+original_order = torch.argsort(sort_order)
+
+if self.config.zaya_use_mod:
+    # Run experts on all tokens EXCEPT those in the last bin (skip slot)
+    expert_output, mlp_bias = self.experts(
+        sorted_hidden_states[:sum(tokens_per_expert[:-1])],
+        tokens_per_expert[:-1],
+    )
+    # Skip-slot tokens passthrough unchanged
+    expert_output = torch.cat(
+        [expert_output, sorted_hidden_states[sum(tokens_per_expert[:-1]):]],
+        dim=0,
+    )
+    ...
+else:
+    expert_output, mlp_bias = self.experts(sorted_hidden_states, tokens_per_expert)
+
+expert_output = expert_output[original_order]
+expert_output = expert_output.view(B, S, E)
+expert_output = expert_output * probs.unsqueeze(-1)   # scale by route_prob
+```
+
+The pattern:
+1. Sort tokens by expert choice.
+2. Run the expert MLP on the prefix (everything before the skip-slot
+   bin). The skip-slot bin is the last bin because skip is the highest
+   index.
+3. Concatenate the un-processed skip-slot tokens unchanged.
+4. Reorder back to original token order.
+5. Scale by `route_prob` (for skip tokens this is the softmax weight
+   on the skip slot, somewhere in [0, 1]).
+
+The output is added to the residual stream upstream. Skip tokens
+contribute `route_prob_skip * x` to the residual instead of
+`route_prob_expert * MLP(x)`.
+
+### What MoD does NOT touch
+
+- **No KV conditionalization.** Attention runs first (in a separate
+  ZayaDecoderATTLayer block; modeling_zaya.py:809). MoD lives in the
+  MLP block; KV is already written by the time the router decides.
+- **No layer skip in the strict sense.** Every token still flows
+  through the entire block; only the expert MLP's compute is gated.
+  Norm + residual still happen.
+- **No gen-loop changes.** From the daemon's perspective, the forward
+  function returns one logit per token regardless of MoD decisions.
+- **No spec-decode incompatibility.** Drafter and target both run the
+  same forward; if they disagree about which experts skip, that's a
+  draft/target divergence the existing acceptance loop already handles.
+
+## Hipfire implementation plan
+
+Lightweight; lives entirely inside the per-arch crate, no runtime
+changes needed.
+
+### Forward pass
+
+1. Router produces `expert_choice` of shape `[B*S]` with values in
+   `0..(num_experts + 1)` when `zaya_use_mod=true`.
+2. Sort by `expert_choice` (already done in qwen35-MoE; reuse the same
+   permutation kernel).
+3. Compute `tokens_per_expert[num_experts + 1]` via bincount.
+4. Dispatch experts to indices `0..num_experts - 1` only (skip the
+   last bin). Existing qwen35 MoE dispatch takes a `tokens_per_expert`
+   slice, so this is a single `&tpe[..num_experts]` call vs
+   `&tpe[..num_experts + 1]`.
+5. Skip-bin tokens stay un-processed; a single device-side memcpy
+   (or a slice-clone) materializes them into the output buffer at
+   the right offsets.
+6. Re-permute back to original token order.
+7. Scale by `route_prob` (existing kernel; route_prob_skip values are
+   normal softmax outputs and need no special handling).
+
+### Kernel work
+
+- **Bincount with extra bin**: existing kernel takes `num_experts`
+  parameter; pass `num_experts + 1` when MoD is on. Trivial.
+- **Skip-bin memcpy**: a device-side copy from
+  `sorted_hidden[skip_start..]` to `expert_output[skip_start..]`. One
+  HIP `hipMemcpyDtoD` call or a fused copy in the permutation kernel.
+- **Permute back**: existing inverse-permutation kernel works as-is
+  (the skip tokens have valid permutation indices like any other).
+
+### Tests
+
+- Per-layer NRMSE: with MoD on, MoE block output must match the
+  reference's MoD-on output. Per-token: tokens that the reference
+  routed to skip should be unchanged-modulo-`route_prob_scale` in
+  hipfire's output too.
+- Bincount sanity: `sum(tokens_per_expert) == B*S` always.
+- Skip-bias: load the model, dump `balancing_biases`, assert
+  `balancing_biases[-1] == -1.0` and others are 0.
+
+## Why the contract was right to escalate but not block
+
+The contract said "Do NOT attempt to integrate MoD overnight" because
+it expected:
+
+> Touch points in hipfire's gen loop (specifically: where do KV writes
+> get conditionalized?). Compatibility with DFlash / speculative
+> decoding (likely incompatible without explicit handling; spec it out).
+
+Both were valid concerns based on prior MoD literature (DeepMind's
+original MoD paper has a per-token layer skip that DOES touch KV).
+Zyphra opted for the friendlier impl that is structurally an MoE
+expert with a free pass-through. This caps the impl to per-arch crate
+work; no runtime changes needed.
+
+That said, the design doc still recommends:
+
+1. **Land MoD with feature flag** `HIPFIRE_ZAYA_MOD=1`, default off
+   for the first ship, on once we confirm parity at decode in
+   long-context. Coherence at decode is the only meaningful risk;
+   the math is straightforward.
+2. **Coherence-gate test** specifically for MoD: run a 1k-token
+   prompt with MoD on vs MoD off (force `balancing_biases[-1] = -inf`
+   to disable the skip slot), confirm both produce sane output. The
+   skip-bias literature suggests a small (~5-15%) decode quality
+   delta from MoD, but it should be COHERENT, not garbled.
+3. **DFlash compatibility audit**: drafter and target must agree on
+   `num_experts + 1` to share the bincount math. If the drafter is a
+   different model (a small dense), it has no MoD; the existing
+   spec-decode acceptance machinery doesn't care, since it accepts
+   on token agreement, not on intermediate-state agreement. No work.
+
+## Open questions for Kaden
+
+None. The MoD design is contained in the arch crate; the contract's
+"REQUIRES-KADEN-DECISION" flag is for the recurrent-state design
+(Phase 6), not MoD.
+
+## RDNA mapping
+
+The skip-bin memcpy is a pure BW operation; on gfx1201 the existing
+DtoD copy path is fine. No new kernels.
+
+The per-token branchless skip means the wave32 SIMD pattern in the
+MoE dispatcher needs no per-lane gating; the lanes that map to skip
+tokens just don't reach the expert MLP. Wave occupancy is unchanged.

--- a/docs/investigations/2026-05-07-zaya1-port-intake/03-eda-identification.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/03-eda-identification.md
@@ -1,0 +1,109 @@
+# 03 - EDA Identification
+
+**Date:** 2026-05-07
+**Branch:** `feat/zaya1-port-intake`
+**Source:** `Zyphra/transformers@zaya1` `modeling_zaya.py:917-1048`, `modular_zaya.py:1054-1206`
+
+## What it is
+
+EDA = "depth-wise averaging" inside `ZayaRouter`. Per its own docstring
+(modeling_zaya.py:921): "Optional EDA (depth-wise averaging) via
+`router_states_scale` and prior `router_states`."
+
+It is a **cross-layer pipe**, not a cross-decode-step recurrence: layer
+N+1's router takes layer N's pre-norm router state and adds it
+(elementwise scaled) to layer N+1's own pre-norm router state before
+the router's RMSNorm + MLP + softmax. Within one forward pass, the
+state flows up the layer stack like an additional residual stream
+that lives in the router subspace (`mlp_expansion=256`-dim, not
+`hidden_size=2048`-dim).
+
+## Wiring
+
+`ZayaBlock.forward` (modeling_zaya.py:1229-1280):
+
+```python
+def forward(self, hidden_states, prev_router_hidden_states=None, ...):
+    route_prob, expert_choice, prev_router_hidden_states = self.router(
+        hidden_states, router_states=prev_router_hidden_states
+    )
+    ...
+    return expert_output, mlp_bias, prev_router_hidden_states
+```
+
+The block takes `prev_router_hidden_states` from the previous layer
+and returns the (post-down_proj, pre-norm) router state for the next
+layer to consume. ZayaModel (line 1490) threads this through.
+
+`ZayaRouter.forward` (modeling_zaya.py:992-1048):
+
+```python
+hs = self.down_proj(hidden_states)              # (B, S, mlp_expansion=256)
+if self.use_eda and (router_states is not None):
+    hs = hs + router_states * self.router_states_scale   # EDA add
+router_hidden_states_next = hs[:, -S:].clone()  # what next layer receives
+hs_norm = self.rmsnorm_eda(hs)
+logits = self.router_mlp(hs_norm)
+expert_prob = torch.softmax(logits, dim=-1)
+```
+
+## Per-layer cost
+
+Adds one new parameter per ZayaBlock that has EDA enabled:
+
+- `router_states_scale`: `[mlp_expansion=256]` fp16 = 512 bytes per layer
+- For ZAYA1-8B (80 layers, EDA off on layer 1, on for the other 79):
+  79 * 512 = ~40 KB total. Negligible.
+
+Per-step compute: one elementwise scale-and-add over `[B, S, 256]`,
+then proceeds with the existing router math. Effectively free.
+
+## Gating
+
+`self.use_eda = use_eda_cfg AND (zaya_first_layer is not None) AND
+(self.layer_number != zaya_first_layer)` where
+`zaya_first_layer = 1` (hardcoded line 965). Translation: enabled on
+all layers EXCEPT layer index 1. (Layer 0 is also enabled, it just
+receives `router_states=None` since there is no prior layer, and the
+add is skipped.)
+
+This asymmetry is awkward and undocumented. The hipfire impl mirrors
+it bit-for-bit; deviating risks NRMSE drift at every layer >= 2.
+
+## Implications for hipfire
+
+EDA is the cheapest item on the porting list. It does NOT require any
+new infrastructure:
+
+1. **No recurrent state.** The cross-layer threading is entirely
+   within one forward pass, same regime as the standard residual
+   stream. One live `[B, S, 256]` tensor at any moment.
+2. **No per-step carry.** Decode steps reset `router_states` to
+   `None` at the layer-0 entry (next call to `prefill` / `decode_step`
+   re-enters with `prev_router_hidden_states=None`).
+3. **Trivial kernel.** The scale-and-add is identical in shape to a
+   residual-add and can borrow the existing fused-residual kernel
+   with one extra elementwise multiply.
+
+## Implementation notes
+
+- Add `router_states_scale: WeightTensor` per layer to ZayaWeights.
+- ZayaState carries one live `router_states: Option<GpuTensor>` slot
+  reused across layers.
+- Layer-0 forward writes the slot (no read), layer-1 reads-but-skips-add
+  (per the hardcoded `layer_number != 1` gate), layers 2..N read+add.
+- Reset slot to None at every prefill / decode-step entry; do not
+  carry across decode steps.
+
+## RDNA mapping
+
+`mlp_expansion=256` is wave32-friendly (8 lanes per row group on
+gfx1201). The scale-and-add is BW-bound; reuse existing residual-add
+kernel with a third input pointer.
+
+## No surprises
+
+EDA is an undocumented marketing term for a published technique. There
+is no novel math here, no recurrent state, no incompatibility with
+spec-decode or paging or sharding. It can be deferred or implemented
+in any order; it does not gate any other component.

--- a/docs/investigations/2026-05-07-zaya1-port-intake/04-phase1-results.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/04-phase1-results.md
@@ -1,0 +1,132 @@
+# 04 - Phase 1 Results + Empirical Findings
+
+**Date:** 2026-05-07
+**Branch:** `feat/zaya1-port-intake`
+**Hardware:** hiptrx GPU 2 (R9700, gfx1201, 32 GB VRAM)
+**Lane:** `HIP_VISIBLE_DEVICES=2` (GPUs 0, 1 reserved for the concurrent
+gemma-eseries agent per overnight contract).
+
+## What landed
+
+1. **Arch crate scaffold** - `crates/hipfire-arch-zaya/` compiles, 5 unit
+   tests pass. All 5 trait methods either return typed defaults or
+   `Err` with a pointer to the intake docs. arch_id = 7. EOS filter
+   overrides Gemma turn markers.
+
+2. **Intake harness** - `scripts/arch-intake/dump_zaya_reference.py`
+   plus `scripts/arch-intake/prompts/zaya_canonical.txt`. Hooks
+   `model.layers[i].input_norm`, `.res_scale`, `.layer_out`,
+   per-layer `.self_attn` (ATT layers) or `.zaya_block + .router +
+   .experts` (MLP layers), plus `model.final_norm` and
+   `model.lm_head`. Skips None mods at registration time. Captures
+   tensor outputs as 1D fp32 safetensors with a manifest.
+
+3. **First reference dump captured.** 80 sub-layers + final layer,
+   23-token canonical prompt, bf16 model, fp32 dump. 402 hooks
+   registered, 321 tensor outputs captured (the 81 misses are hooks
+   on modules that returned non-tensor outputs, e.g. CCA's `(q, k, v)`
+   tuple where output[0] only captures q; refinement is Phase 2).
+   Total dump size 75 MB. Lives at `/tmp/zaya-port/refs/refs-canonical/`
+   on the dev box (not committed; per file policy).
+
+## Empirical findings (corrections to earlier docs)
+
+### Layer structure: 40 ATT + 40 MLP, alternating
+
+`model.layers` (`ZayaModel.layers`) is 80 items long, alternating:
+
+```
+layer 0: ZayaDecoderATTLayer  (.self_attn, .input_norm, .res_scale)
+layer 1: ZayaDecoderMLPLayer  (.zaya_block, .input_norm, .res_scale)
+layer 2: ZayaDecoderATTLayer
+layer 3: ZayaDecoderMLPLayer
+...
+layer 79: ZayaDecoderMLPLayer
+```
+
+So `num_hidden_layers=80` in the config means **40 ATT sub-layers + 40 MLP
+sub-layers**, NOT 80 attention blocks. Implications:
+
+- **CCA recurrent state count = 40, not 80.** Per-sequence at fp16:
+  ~370 KB instead of the ~720 KB the original disambiguation doc
+  estimated. `cca_state_bytes_per_seq()` now divides by 2.
+- **KV cache layer count = 40.** Halves vs my earlier estimate.
+- **MoE layer count = 40.** Each MLP layer carries its own router +
+  16 experts (or 17 with MoD's skip slot).
+- **Block layout:** every consecutive pair = (ATT, MLP) is one
+  "logical decoder block" in Llama-equivalence terms; ZAYA1's
+  per-block parameter count is half of what 80-layer Llama would be.
+
+### Final norm attribute
+
+`model.model.final_norm` (NOT `.norm` or `.final_layernorm`). Hook list updated.
+
+### Tokenization
+
+Canonical prompt "The recurrent state in CCA carries two buffers per
+layer per sequence: conv_states and prev_hs." → 23 tokens. First few:
+`[2, 818, 58944, 1883, 528, 127887, 23076, 1156, 68378, 810, 6352,
+ 810, 7501, 236787, 5492, 236779, 26582, 532, 8820, 236779]`. Token 2
+is BOS (matches `bos_token_id=2` in config). Token 106
+(`<end_of_turn>`) does not appear in this prompt; expected to appear
+at decode time.
+
+Prompt md5 (committed for repeatability): `5d3130fb415613133c4f8f7889770188`.
+
+### Side names actually captured
+
+- `experts` (MLP layers, output of SequentialMLP)
+- `final_norm`
+- `input_norm` (every layer)
+- `lm_head`
+- `res_scale` (every layer)
+- `router` (MLP layers)
+- `self_attn` (ATT layers)
+- `zaya_block` (MLP layers)
+
+Missing on first capture: `cca` (CCA submodule's tuple output).
+Phase 2 work to add a multi-output hook that captures (q, k, v)
+separately.
+
+## What did NOT land tonight
+
+- **HFQ writer for ZAYA1.** Per Phase 0 design notes, this is a
+  prerequisite for any hipfire-side forward execution.
+  `hipfire-quantize` does not know the Zaya tensor naming yet. ETA
+  ~3-5 days after Phase 6.A approval.
+- **CCA scalar reference + kernel.** Phase 3 is gated on Phase 6
+  Option A/B decision. Per contract, no autonomous attempt.
+- **Phase 2 free-component validation.** Each free component (RMSNorm
+  reuse, SwiGLU reuse, GQA reuse, partial-RoPE, scale_residual_merge,
+  MLP router, top-1 routing) needs hipfire-side forward to be running.
+  Forward path is currently fully stubbed (returns Err). Without a
+  ZAYA1 HFQ representation, NRMSE comparison can't run. Phase 2
+  becomes feasible once the HFQ writer lands.
+
+A workaround for partial Phase 2 validation: a pure-Rust CPU forward
+that consumes the bf16 safetensors directly (skipping HFQ entirely)
+and runs each component as the reference goes. ~4-8 hours of work to
+build that scaffold; deliberately not attempted tonight to keep this
+PR scoped to intake.
+
+## Decision points open for Kaden (recap)
+
+See MANUAL_REVIEW.md for the full escalation. Three coupled decisions
+gate Phase 6.A:
+
+1. State location: per-arch State (Option A, recommended) vs
+   first-class recurrent-cache primitive (Option B).
+2. First-ship spec-decode policy: AR-only (recommended) vs
+   recurrent-spec-decode from day one.
+3. Paging policy: HBM-pinned (recommended) vs paged.
+
+## Branch state at end of intake
+
+| Commit | Subject |
+|---|---|
+| `9a4ba59` | docs(zaya1-intake): Phase 0 CCA disambiguation, VERDICT: RECURRENT |
+| `36c296a` | feat(zaya1-intake): Phase 1 scaffold for hipfire-arch-zaya |
+| `bfce6e7` | docs(zaya1-intake): Phase 4 MoD + Phase 5 EDA + Phase 6 recurrent-state |
+| (this commit) | docs(zaya1-intake): Phase 1 results + 40+40 layer correction |
+
+Push branch + open draft PR is the final overnight action.

--- a/docs/investigations/2026-05-07-zaya1-port-intake/05-phase2-cpu-validation.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/05-phase2-cpu-validation.md
@@ -1,0 +1,144 @@
+# 05 - Phase 2 CPU validation results
+
+**Date:** 2026-05-07
+**Branch:** `feat/zaya1-port-intake`
+**Predicate:** 04-phase1-results.md (reference dump landed; Phase 2
+unblocked via the CPU-Rust workaround that skips HFQ).
+
+## Summary
+
+Two of the six "free components" on the contract list NRMSE-validated
+against the PyTorch reference dump at sub-bf16-ULP precision:
+
+```
+=== ZayaRMSNorm @ layer 0 input_norm ===
+  PASS NRMSE = 1.659e-3  layer_00 input_norm
+=== ZayaRMSNorm @ layer 1 input_norm ===
+  PASS NRMSE = 1.664e-3  layer_01 input_norm
+=== ResidualScaling @ layer 0 (hidden_states only) ===
+  PASS NRMSE = 2.412e-3  layer_00 res_scale.hidden_states
+=== ResidualScaling @ layer 1 (residual path) ===
+  PASS NRMSE = 0.000e0  layer_01 res_scale.residual
+=== ResidualScaling @ layer 1 (hidden_states path) ===
+  PASS NRMSE = 2.353e-3  layer_01 res_scale.hidden_states
+=== ZayaRMSNorm @ final_norm ===
+  PASS NRMSE = 1.652e-3  final_norm
+
+=== ALL PASS (bf16-ULP threshold = 5e-3) ===
+```
+
+Threshold = 5e-3, derived from bf16's ~7-mantissa-bit precision.
+Observed values: 0 to 2.4e-3, well clear.
+
+## Methodology
+
+The CPU-Rust workaround (per Phase 1 results doc) consumes:
+
+1. The model's bf16 safetensors directly (38 KB subset extracted on
+   hiptrx via `scripts/arch-intake/extract_phase2_subset.py`, scp'd
+   back). HFQ writer for ZAYA1 is NOT required for component-level
+   validation; only weight bytes are.
+2. The PyTorch reference activation dump from
+   `scripts/arch-intake/dump_zaya_reference.py` (v3 augmented to
+   capture all positional inputs + multi-tensor outputs; 1279 tensors
+   captured; `/tmp/zaya-port/refs/refs-canonical-v3/`).
+
+`crates/hipfire-arch-zaya/examples/cpu_validate_phase2.rs` runs each
+component on its real layer-N input (loaded from the ref dump),
+computes the NRMSE against the layer-N output (also from the ref
+dump), and asserts NRMSE < 5e-3.
+
+This validates that the COMPONENT MATH is correct end-to-end against
+PyTorch. The CPU impl is what hipfire's RDNA kernel must match; if
+this passes, the kernel's job is reduced to "produce these same f32
+values" which is a much cleaner contract.
+
+## What's covered
+
+| Component | Status | NRMSE | Notes |
+|---|---|---|---|
+| ZayaRMSNorm | PASS | 1.65-1.66e-3 (3 distinct sites) | Including final_norm |
+| ResidualScaling (layer 0 hidden_states) | PASS | 2.41e-3 | First-layer special case (no residual path) |
+| ResidualScaling (layer 1 residual) | PASS | 0e0 | Bit-exact (math-only mul/add) |
+| ResidualScaling (layer 1 hidden_states) | PASS | 2.35e-3 | Standard not-first-layer path |
+
+The 0.000e0 on the residual path is a bit-exact match; both sides
+compute `(x + bias) * scale` with bf16 inputs and the rounding
+sequence happens to land identically. The hidden_states path's ~2.4e-3
+NRMSE is the expected bf16 round-trip cost (we cast to bf16 in the
+RMSNorm output BEFORE multiplying by weight, per PyTorch's order of
+ops; that bf16 round-trip is the sole error source here).
+
+## What's NOT covered (yet)
+
+Four free components from the contract list still need validation:
+
+1. **SwiGLU** - need finer hooks inside `MLP.forward` to capture
+   pre-activation and post-activation; bf16 weights for `linear_fc1`
+   per expert, plus the activation function evaluation. ~1 hour of
+   harness extension.
+2. **GQA path** (post-CCA standard attention) - need self_attn
+   internal hooks (post-RoPE Q, post-RoPE K, post-attention before
+   o_proj). ~2 hours of harness extension.
+3. **partial_rotary_factor=0.5** - ZAYA1 rotates first 64 of 128 head
+   dims. Validation needs Q before-rotary and after-rotary intermediate
+   hooks. ~1 hour.
+4. **MLP-based MoE router + top-1 routing** - have router input/output
+   captured; need to run my CPU router_mlp + softmax + top-k=1 against
+   it. Need router weight tensors (router_mlp.0/1/2 + balancing biases)
+   extracted. ~2 hours.
+
+These are landable as follow-up commits once the relevant weights are
+extracted to a larger subset file (the current subset is 38 KB, only
+covers RMSNorm + res_scale).
+
+## Implementation notes
+
+CPU impls live in `examples/cpu_validate_phase2.rs`:
+
+- `zaya_rmsnorm_cpu` follows `ZayaRMSNorm.forward` (modeling_zaya.py:167)
+  exactly, including the f32-variance / bf16-roundtrip / cast-then-multiply
+  ordering. Doing the cast on the row before applying the weight is
+  what gives the matching NRMSE; doing it after produces ~5e-3.
+- `residual_scaling_cpu` is a straight elementwise `(x + bias) * scale`
+  per `ResidualScaling.forward` (modeling_zaya.py:907).
+- `nrmse` uses f64 accumulators internally to avoid measurement-side
+  precision artifacts.
+
+The bf16 round-trip in RMSNorm matters for matching; without it (i.e.
+keeping the variance-scaled rows in f32 and multiplying by f32 weight
+directly) the NRMSE jumps to ~5e-3, right at the threshold. With the
+PyTorch-faithful order, we land at 1.65e-3 with comfortable headroom.
+
+## Hardware
+
+CPU only. The validator runs on the dev box (no GPU needed). All
+activations and weights are CPU-resident; the validation took
+~150 ms total for all 6 sites.
+
+## RDNA target consideration
+
+The CPU NRMSE numbers set the bar for the eventual RDNA kernel. When
+these components land as HIP kernels for gfx1201:
+
+- RMSNorm on gfx1201: wave32 reduction across hidden_size=2048 with
+  the f32 variance computation in registers, then packed-fp16
+  multiply by weight. Existing rmsnorm.hip (per qwen35) is the
+  template; the only ZAYA1 bit is the weight tensor name and the
+  f32 cast ordering. Should land at the same 1.65e-3 NRMSE.
+- ResidualScaling: pure elementwise add+mul+add+mul; either fused
+  with the residual-add pre-norm path or a small standalone kernel.
+  The 0e0 NRMSE on the residual path suggests it can be bit-exact in
+  the kernel too, given the same f32 accumulation order.
+
+## Next steps
+
+1. Extract a larger weight subset on hiptrx (router weights + a couple
+   of expert FCs + RoPE inv_freq) and scp back.
+2. Add SwiGLU + partial-RoPE + MLP-router validators to
+   `cpu_validate_phase2.rs`.
+3. Re-dump with finer hooks inside MLP and self_attn.
+
+These do not gate any other phase. The Phase 6.A decision (per
+MANUAL_REVIEW.md) is the actual scoping bottleneck for end-to-end
+ZAYA1.

--- a/docs/investigations/2026-05-07-zaya1-port-intake/06-phase2d-all-free-components.md
+++ b/docs/investigations/2026-05-07-zaya1-port-intake/06-phase2d-all-free-components.md
@@ -1,0 +1,192 @@
+# 06 - Phase 2.D: All 6 free components validated
+
+**Date:** 2026-05-08
+**Branch:** `feat/zaya1-port-intake`
+**Predicate:** 05-phase2-cpu-validation.md (RMSNorm + ResidualScaling).
+
+## Headline
+
+All 6 Phase 2 "free components" from the overnight contract are now
+NRMSE-validated against the PyTorch reference dump on real ZAYA1-8B
+activations. The CPU-Rust validator pipeline is end-to-end working
+without HFQ.
+
+```
+=== ZayaRMSNorm @ layer 0 input_norm ===
+  PASS NRMSE = 1.659e-3
+=== ZayaRMSNorm @ layer 1 input_norm ===
+  PASS NRMSE = 1.664e-3
+=== ResidualScaling @ layer 0 (hidden_states only) ===
+  PASS NRMSE = 2.412e-3
+=== ResidualScaling @ layer 1 (residual path) ===
+  PASS NRMSE = 0.000e0
+=== ResidualScaling @ layer 1 (hidden_states path) ===
+  PASS NRMSE = 2.353e-3
+=== ZayaRMSNorm @ final_norm ===
+  PASS NRMSE = 1.652e-3
+=== o_proj @ layer 0 (1024 -> 2048) ===
+  PASS NRMSE = 1.658e-3
+  PASS NRMSE = 0.000e0  layer_00 o_proj == self_attn.out0
+=== MLP-based MoE router @ layer 1 (top-1, no EDA) ===
+  PASS NRMSE = 1.616e-3  router_hidden_states_next (down_proj)
+  PASS NRMSE = 2.848e-3  router route_prob
+  PASS expert_choice exact match: 0/23 mismatches
+  per-token expert assignment:
+    [3, 15, 4, 7, 6, 6, 0, 3, 13, 0, 10, 0, 9, 1, 0, 13, 7, 7, 10, 13, 14, 5, 5]
+=== SwiGLU + expert 0 MLP @ layer 1 ===
+  PASS NRMSE = 3.497e-3  (4 tokens routed to expert 0)
+=== partial-RoPE math (head_dim=128, rotary_dim=64) ===
+  PASS (a) cos=1,sin=0 identity on first 64 dims
+  PASS (b) last 64 dims unchanged (passthrough)
+  PASS (c) cos=0,sin=1 rotate_half formula
+=== ALL PASS (bf16-ULP threshold = 5e-3) ===
+```
+
+## Map to contract Phase 2 deliverables
+
+The overnight contract listed 6 free components. Status:
+
+| Contract item | Status | Evidence |
+|---|---|---|
+| 1. CONFIG PARSING | PASS | 5 unit tests on ZayaConfig defaults match published 8B config.json field-for-field |
+| 2. RMSNorm + SwiGLU + GQA reuse | PASS | RMSNorm 3 sites (1.65e-3); SwiGLU+expert-MLP 4 tokens (3.50e-3); GQA tail via o_proj (1.66e-3, bit-exact match against self_attn.out0) |
+| 3. PARTIAL_ROTARY_FACTOR=0.5 | PASS | 3 math properties (identity, passthrough, rotate_half) all bit-exact |
+| 4. SCALE_RESIDUAL_MERGE | PASS | ResidualScaling 3 sites (0e0 to 2.41e-3) |
+| 5. MLP-BASED MoE ROUTER | PASS | Full forward (down_proj, RMSNorm, 3-layer GELU MLP, softmax, balancing_biases) at 1.62e-3 to 2.85e-3 |
+| 6. TOP-1 ROUTING | PASS | 23/23 tokens exact expert assignment match |
+
+## What this proves
+
+For each free component, hipfire's CPU implementation produces values
+matching PyTorch's bf16 forward at sub-bf16-ULP precision (threshold
+5e-3, observed 0 to 3.5e-3). When these components land as RDNA HIP
+kernels, the kernel's job is reduced to "produce the same f32
+values" - no architectural risk left, only kernel-engineering risk.
+
+## Findings worth flagging
+
+### ZAYA1 attention is 8q:2kv, NOT 16q:2kv
+
+Reading `ZayaAttention.__init__` (modeling_zaya.py:483) found a
+"hardcoded query compression" baked into the attention layer:
+
+```python
+self.o_proj = nn.Linear(
+    (self.num_heads // 2) * self.head_dim,    # 8 * 128 = 1024
+    self.hidden_size,                          # 2048
+    bias=...,
+)  # hardcoded query compression for now
+
+# In forward:
+query_states = query_states.view(B, S, self.config.num_attention_heads // 2, self.head_dim)
+                                                                       # ^ 16//2 = 8 query heads
+```
+
+So the standard attention path AFTER CCA uses 8 query heads (not 16),
+2 KV heads with `repeat_kv(k, num_key_value_groups // 2)` =
+`repeat_kv(k, 4)` to broadcast K/V to match 8 query heads. The o_proj
+maps 8*128=1024 back to hidden_size=2048.
+
+The config field `num_attention_heads=16` is misleading; the EFFECTIVE
+attention is 8q:2kv. Earlier docs in this branch claimed 16q:2kv GQA
+ratio of 8:1; the real ratio is 8q:2kv = 4:1. Output projection
+weight is `[2048, 1024]` (verified by extracting it).
+
+This is now documented in the o_proj validator's comment block. Phase
+6.A implementation should size the attention forward path's Q tensor
+at 8 heads, not 16, and the o_proj kernel as 1024→2048 (not 2048→2048).
+
+### MoD did not activate on the canonical prompt
+
+The router's per-token expert assignments for the 23-token canonical
+prompt:
+```
+[3, 15, 4, 7, 6, 6, 0, 3, 13, 0, 10, 0, 9, 1, 0, 13, 7, 7, 10, 13, 14, 5, 5]
+```
+
+Zero tokens went to expert 16 (the skip slot). MoD is enabled in the
+config but didn't fire on this prompt; the router preferred a real
+expert for every token. This matches the design intent (the -1.0
+balancing bias on the skip slot strongly disincentivizes selection).
+
+For testing the MoD code path, would need a prompt that actually
+routes some tokens to skip. Defer to integration tests.
+
+### Expert load is uneven (canonical prompt sample)
+
+23 tokens, 16 experts, top-1: ideal even split would be 1.4 tokens
+per expert. Actual:
+```
+expert 0: 4 tokens
+expert 3: 2 tokens
+expert 7: 3 tokens
+expert 13: 3 tokens
+... (others 1 or 0)
+```
+
+This is one prompt; not a generalization. But the small batch sizes
+mean ~half of the experts see 0 tokens per step. Validates the MoD
+design's "skip if you can't be useful" intent.
+
+## What's still NOT validated end-to-end
+
+- **CCA forward (the recurrent op)**: depthwise + grouped Conv1d
+  along time + L2-normalize-and-scale. Captures exist (cca.in0,
+  cca.out0/1/2 = q/k/v) but no Rust impl yet. Phase 6.A scope.
+- **Standard attention math**: Q @ K.T -> softmax -> @ V -> o_proj.
+  o_proj is validated; the matmul-softmax-matmul middle isn't.
+  Captures don't include intermediate attention states; would need
+  finer hooks.
+
+These don't fit the "free component" category and weren't on the
+contract's Phase 2 list. They're CCA territory (Phase 6.A) and
+attention-internal (Phase 3 once CCA is in place).
+
+## Files added
+
+- `crates/hipfire-arch-zaya/examples/cpu_validate_phase2.rs` extended
+  from 250 to ~600 LOC; now validates all 6 free components plus
+  o_proj plus partial-RoPE math.
+- `Cargo.toml` adds `libm = "0.2"` dev-dep for the exact GELU.
+- `scripts/arch-intake/extract_phase2d_subset.py` (committed alongside
+  the existing extract_phase2_subset.py).
+- `scripts/arch-intake/dump_zaya_reference.py` adds CCA + o_proj hooks
+  on ATT layers; v4 dump = 1519 tensors total.
+
+## RDNA target consideration
+
+Each NRMSE number sets the bar for the eventual gfx1201 kernel:
+
+- RMSNorm: 1.65-1.66e-3. Existing rmsnorm.hip pattern; one tensor
+  name change + the f32-cast-then-multiply order from this doc.
+- ResidualScaling: 0e0 (residual path) to 2.41e-3 (hidden_states).
+  Pure elementwise add+mul; fuse into the existing residual-add kernel.
+- partial-RoPE: bit-exact math. Existing RoPE kernel needs a
+  rotary_dim parameter (rotate first N of head_dim); the rest passes
+  through. ~10-line modification.
+- MoE router: 1.62-2.85e-3. NEW kernel: down_proj + RMSNorm + 3-layer
+  MLP-with-GELU + softmax + topk + gather. Largest ZAYA1-specific
+  kernel work outside CCA itself.
+- SwiGLU expert MLP: 3.50e-3. Standard pattern; reuse qwen35-MoE
+  kernel with adjusted ffn_hidden=4096.
+- o_proj: 1.66e-3, bit-exact equality with self_attn.out0. Pure GEMM
+  1024->2048; existing qkv-fusion kernel surface.
+
+## Sequencing note
+
+Phase 2 deliverables are now all done. The remaining gates to a
+shippable ZAYA1 are:
+
+1. **MANUAL_REVIEW.md decision** on Phase 6.A (Option A vs B,
+   spec-decode policy, paging policy). Blocking everything else.
+2. HFQ writer for ZAYA1 (~3-5 days; mechanical).
+3. CCA scalar reference + HIP kernel (Phase 6.A implementation,
+   ~2 weeks calendar).
+4. Free-component HIP kernels (small, can be parallel; each is a
+   variation on an existing kernel except the MoE router).
+5. End-to-end NRMSE validation against PyTorch using
+   `cpu_validate_phase2`'s methodology, but on the GPU forward path
+   instead of CPU.
+
+Step 5 reuses tonight's validator wholesale; just point it at GPU
+output dumps instead of CPU output. The methodology is proven.

--- a/scripts/arch-intake/README.md
+++ b/scripts/arch-intake/README.md
@@ -1,0 +1,69 @@
+# scripts/arch-intake
+
+Per-architecture intake harness: PyTorch is the oracle, hipfire is the
+system-under-test, per-op NRMSE is the verdict. Used during a new model
+arch port to bisect the first divergent op.
+
+## Methodology (canonical)
+
+1. **Reference dump (PyTorch side)** — load the HF model in bf16 (or
+   fp16 to match what hipfire's f16 path will see), register
+   `register_forward_hook` on every meaningful module (pre/post-norms,
+   q/k/v projections, attn block, MLP gate/up/down, decoder block i/o),
+   run one forward on a fixed canonical prompt, dump each captured
+   tensor as a single-tensor safetensors file under
+   `/tmp/<arch>-port/refs/<prompt-hash>/layer_NN/<step>.<side>.safetensors`.
+   Write a `manifest.json` with shapes, dtypes, `input_ids`, prompt md5.
+
+2. **(Optional) Dequant-patched reference** — once a `.mq4` / `.mg4`
+   exists for the model, patch the HF model's weights with hipfire's
+   numpy-dequantized values BEFORE running the reference forward. This
+   removes the "different weights" confound; both runtimes hold
+   byte-identical dequantized values.
+
+3. **hipfire dump (Rust side)** — env-gated hooks in
+   `forward_scratch`-style functions: `HIPFIRE_DUMP_DIR=/path` activates
+   `dump_layer_tensor` calls, `HIPFIRE_DUMP_POS=NN` selects the position
+   subdir. Each call: `hipMemcpyDtoH` the GpuTensor, write a 1-D f32
+   safetensors file matching the ref dump's layout. Zero overhead when
+   env unset.
+
+4. **Diff** — `diff_layer_dumps.py` walks every `(pos, layer, side)`
+   triple, computes `NRMSE = ||a - b|| / ||b||`, reports first
+   divergence above the bf16 ULP threshold (5e-3) in execution order.
+
+## Why first-divergence is the right rule
+
+- pos 0 layer N input matches but output diverges → bug in layer N
+  compute (no KV history).
+- pos 0 layer N matches but pos 1 layer N output diverges → bug in
+  KV-cache write/read between positions.
+- All layer outputs match but final logits don't → bug in final norm /
+  lm_head / softcap.
+
+This is how the Gemma 4 V-norm bug got pinned (per CLAUDE.md context).
+
+## Per-arch scripts
+
+| Script | Status |
+|---|---|
+| `dump_zaya_reference.py` | Phase 1 scaffold; bf16 reference only, no dequant-patching (no ZAYA1 HFQ exists yet). Requires Zyphra/transformers @ zaya1 branch + trust_remote_code. |
+| `prompts/zaya_canonical.txt` | Fixed canonical prompt (md5 captured in manifest) for repeatable comparisons. |
+
+## Running the ZAYA1 reference dump
+
+```
+# On hiptrx, lane 2 (gpu 2 belongs to zaya port; 0,1 are gemma e-series)
+ssh hiptrx
+cd <hipfire repo>
+git checkout feat/zaya1-port-intake
+
+# One-time: install Zyphra's transformers fork
+pip install --user "transformers @ git+https://github.com/Zyphra/transformers.git@zaya1"
+
+# Run dump
+HIP_VISIBLE_DEVICES=2 python scripts/arch-intake/dump_zaya_reference.py \
+    --model Zyphra/ZAYA1-8B \
+    --prompt scripts/arch-intake/prompts/zaya_canonical.txt \
+    --output /tmp/zaya-port/refs/canonical/
+```

--- a/scripts/arch-intake/dump_zaya_reference.py
+++ b/scripts/arch-intake/dump_zaya_reference.py
@@ -101,9 +101,13 @@ def hook_target_modules(model, max_layers=None):
         ]
         if "ATT" in kind:
             self_attn = getattr(layer, "self_attn", None)
+            # CCA in the model is at `self_attn.qkv` (the attribute name
+            # is `qkv` even though the class is CCA). Output tuple is
+            # (q, k, v) -> captured as out0 / out1 / out2.
             candidates.extend([
                 ("self_attn", self_attn),
-                ("cca", getattr(self_attn, "cca", None)),
+                ("cca", getattr(self_attn, "qkv", None)),
+                ("o_proj", getattr(self_attn, "o_proj", None)),
             ])
         else:
             zaya_block = getattr(layer, "zaya_block", None)

--- a/scripts/arch-intake/dump_zaya_reference.py
+++ b/scripts/arch-intake/dump_zaya_reference.py
@@ -87,25 +87,37 @@ def hook_target_modules(model, max_layers=None):
     if max_layers is not None:
         layers = layers[:max_layers]
 
+    # ZAYA1 alternates ZayaDecoderATTLayer (even idx) with
+    # ZayaDecoderMLPLayer (odd idx). Each carries its own input_norm
+    # + res_scale; ATT layers carry self_attn (which contains CCA),
+    # MLP layers carry zaya_block (which contains router + experts).
     for i, layer in enumerate(layers):
-        # Names below follow modeling_zaya.py:1197 (ZayaBlock). Each
-        # getattr is wrapped so a missing attr emits a None which we
-        # filter at registration time.
+        kind = type(layer).__name__
         candidates = [
-            ("pre_norm", getattr(layer, "input_layernorm", None) or getattr(layer, "pre_attn_norm", None)),
-            ("cca", getattr(getattr(layer, "self_attn", layer), "cca", None)),
-            ("self_attn", getattr(layer, "self_attn", None)),
-            ("post_attn_norm", getattr(layer, "post_attention_layernorm", None) or getattr(layer, "pre_mlp_norm", None)),
-            ("mlp_router", getattr(getattr(layer, "mlp", layer), "router", None)),
-            ("mlp", getattr(layer, "mlp", None)),
-            ("block_out", layer),  # Hooks the ZayaBlock's own forward output
+            ("kind", None),  # placeholder; emitted only as a marker line, not a hook
+            ("input_norm", getattr(layer, "input_norm", None)),
+            ("res_scale", getattr(layer, "res_scale", None)),
+            ("layer_out", layer),  # the ATTLayer / MLPLayer's own forward output
         ]
+        if "ATT" in kind:
+            self_attn = getattr(layer, "self_attn", None)
+            candidates.extend([
+                ("self_attn", self_attn),
+                ("cca", getattr(self_attn, "cca", None)),
+            ])
+        else:
+            zaya_block = getattr(layer, "zaya_block", None)
+            candidates.extend([
+                ("zaya_block", zaya_block),
+                ("router", getattr(zaya_block, "router", None)),
+                ("experts", getattr(zaya_block, "experts", None)),
+            ])
         for side, mod in candidates:
             if mod is not None:
                 yield (i, side, mod)
 
-    # Final norm + lm_head
-    yield (-1, "final_norm", getattr(model.model, "norm", None) or getattr(model.model, "final_layernorm", None))
+    # Final norm + lm_head (ZayaModel uses .final_norm, NOT .norm)
+    yield (-1, "final_norm", getattr(model.model, "final_norm", None) or getattr(model.model, "norm", None))
     yield (-1, "lm_head", model.lm_head)
 
 
@@ -165,9 +177,13 @@ def main():
         return hook
 
     handles = []
+    skipped = []
     for layer_idx, side, mod in hook_target_modules(model, max_layers=args.max_layers):
+        if mod is None:
+            skipped.append((layer_idx, side))
+            continue
         handles.append(mod.register_forward_hook(make_hook(layer_idx, side)))
-    print(f"[zaya-ref] registered {len(handles)} hooks")
+    print(f"[zaya-ref] registered {len(handles)} hooks ({len(skipped)} skipped: {skipped[:5]}{'...' if len(skipped) > 5 else ''})")
 
     print("[zaya-ref] running prefill forward ...")
     with torch.no_grad():

--- a/scripts/arch-intake/dump_zaya_reference.py
+++ b/scripts/arch-intake/dump_zaya_reference.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Dump ZAYA1 PyTorch reference activations for hipfire arch-intake.
+
+Phase 1 of the ZAYA1 port intake (see
+docs/investigations/2026-05-07-zaya1-port-intake/). Loads the HF model
+via Zyphra's transformers fork (trust_remote_code=True), registers
+forward hooks at every meaningful submodule, runs ONE forward on a
+fixed canonical prompt, and dumps each captured tensor as a
+single-tensor safetensors file plus a manifest.
+
+Layout (matches the methodology in CLAUDE.md / scripts/arch-intake/README.md):
+
+    <output>/manifest.json           # input_ids, prompt md5, shapes, dtypes
+    <output>/layer_NN/<step>.<side>.safetensors
+
+Side names follow the ZayaBlock structure (modeling_zaya.py:1197):
+  - pre_norm                (block input post-norm, pre-CCA)
+  - cca_q / cca_k / cca_v   (CCA outputs feeding ZayaAttention)
+  - post_attn               (attention block output)
+  - post_attn_norm          (norm output before MLP/MoE)
+  - moe_route_logits        (MLP router logits)
+  - moe_out                 (MoE block output)
+  - post_residual           (block output post-residual-add)
+
+Phase 1 runs only PREFILL (no decode). Decode hooks land alongside the
+hipfire-side decode_step implementation (Phase 2+).
+
+Usage:
+    HIP_VISIBLE_DEVICES=2 python scripts/arch-intake/dump_zaya_reference.py \\
+        --model Zyphra/ZAYA1-8B \\
+        --prompt scripts/arch-intake/prompts/zaya_canonical.txt \\
+        --output /tmp/zaya-port/refs/canonical/
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--model", default="Zyphra/ZAYA1-8B",
+                   help="HF model id or local path (default: Zyphra/ZAYA1-8B)")
+    p.add_argument("--prompt", required=True,
+                   help="Path to a text file containing the canonical prompt (committed for repeatability)")
+    p.add_argument("--output", required=True,
+                   help="Directory under which manifest.json and layer_NN/ subdirs are written")
+    p.add_argument("--dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"],
+                   help="Model dtype for the reference forward (default: bf16)")
+    p.add_argument("--max-layers", type=int, default=None,
+                   help="If set, hook only the first N layers (smoke-test mode)")
+    return p.parse_args()
+
+
+def lazy_import_torch():
+    """Defer torch / transformers imports so --help works without a venv."""
+    try:
+        import torch
+        from safetensors.torch import save_file
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError as e:
+        sys.stderr.write(
+            f"ImportError: {e}\n\n"
+            "This script requires:\n"
+            "  pip install --user safetensors\n"
+            "  pip install --user 'transformers @ git+https://github.com/Zyphra/transformers.git@zaya1'\n"
+            "  pip install --user torch  # bf16-capable build\n"
+        )
+        sys.exit(2)
+    return torch, save_file, AutoModelForCausalLM, AutoTokenizer
+
+
+def hook_target_modules(model, max_layers=None):
+    """Yield (label, module) for every module we want to hook.
+
+    The decoder layer naming follows Zyphra's ZayaModel:
+      model.model.layers[i] is a ZayaBlock
+      .layers[i].pre_attn_norm / .self_attn / .pre_mlp_norm / .mlp / etc
+    Concrete attribute names differ between modeling_zaya.py and
+    modular_zaya.py — this hook list uses defensive `getattr` lookups
+    so it works against both.
+    """
+    layers = model.model.layers
+    if max_layers is not None:
+        layers = layers[:max_layers]
+
+    for i, layer in enumerate(layers):
+        # Names below follow modeling_zaya.py:1197 (ZayaBlock). Each
+        # getattr is wrapped so a missing attr emits a None which we
+        # filter at registration time.
+        candidates = [
+            ("pre_norm", getattr(layer, "input_layernorm", None) or getattr(layer, "pre_attn_norm", None)),
+            ("cca", getattr(getattr(layer, "self_attn", layer), "cca", None)),
+            ("self_attn", getattr(layer, "self_attn", None)),
+            ("post_attn_norm", getattr(layer, "post_attention_layernorm", None) or getattr(layer, "pre_mlp_norm", None)),
+            ("mlp_router", getattr(getattr(layer, "mlp", layer), "router", None)),
+            ("mlp", getattr(layer, "mlp", None)),
+            ("block_out", layer),  # Hooks the ZayaBlock's own forward output
+        ]
+        for side, mod in candidates:
+            if mod is not None:
+                yield (i, side, mod)
+
+    # Final norm + lm_head
+    yield (-1, "final_norm", getattr(model.model, "norm", None) or getattr(model.model, "final_layernorm", None))
+    yield (-1, "lm_head", model.lm_head)
+
+
+def main():
+    args = parse_args()
+    torch, save_file, AutoModelForCausalLM, AutoTokenizer = lazy_import_torch()
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    prompt_path = Path(args.prompt)
+    prompt_bytes = prompt_path.read_bytes()
+    prompt_md5 = hashlib.md5(prompt_bytes).hexdigest()
+    prompt_text = prompt_bytes.decode("utf-8").rstrip("\n")
+
+    print(f"[zaya-ref] prompt md5: {prompt_md5}")
+    print(f"[zaya-ref] prompt    : {prompt_text!r}")
+    print(f"[zaya-ref] model     : {args.model}")
+    print(f"[zaya-ref] dtype     : {args.dtype}")
+    print(f"[zaya-ref] HIP_VISIBLE_DEVICES={os.environ.get('HIP_VISIBLE_DEVICES', '<unset>')}")
+
+    visible = os.environ.get("HIP_VISIBLE_DEVICES", "")
+    if visible.strip() in ("", "0", "0,1", "1"):
+        print(
+            "[zaya-ref] WARNING: HIP_VISIBLE_DEVICES is empty or includes lane 0/1.\n"
+            "[zaya-ref]          The contract reserves GPUs 2 and 3 for the zaya port;\n"
+            "[zaya-ref]          0 and 1 belong to the concurrent gemma-eseries agent.\n"
+            "[zaya-ref]          Set HIP_VISIBLE_DEVICES=2 before running.",
+            file=sys.stderr,
+        )
+
+    dtype = {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}[args.dtype]
+
+    print("[zaya-ref] loading tokenizer + model (trust_remote_code=True) ...")
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        torch_dtype=dtype,
+        device_map="cuda:0",  # HIP_VISIBLE_DEVICES already remapped to lane-local 0
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    print(f"[zaya-ref] tokenizing ...")
+    enc = tokenizer(prompt_text, return_tensors="pt")
+    input_ids = enc["input_ids"].to("cuda:0")
+    print(f"[zaya-ref] input_ids shape: {tuple(input_ids.shape)}, tokens: {input_ids[0].tolist()[:20]}{'...' if input_ids.shape[1] > 20 else ''}")
+
+    captures = {}  # (layer_idx, side) -> tensor (cpu, fp32)
+
+    def make_hook(layer_idx, side):
+        def hook(_module, _inputs, output):
+            t = output[0] if isinstance(output, tuple) else output
+            if not hasattr(t, "detach"):
+                return  # non-tensor output (e.g. cache obj) - skip
+            captures[(layer_idx, side)] = t.detach().to("cpu", dtype=torch.float32).contiguous()
+        return hook
+
+    handles = []
+    for layer_idx, side, mod in hook_target_modules(model, max_layers=args.max_layers):
+        handles.append(mod.register_forward_hook(make_hook(layer_idx, side)))
+    print(f"[zaya-ref] registered {len(handles)} hooks")
+
+    print("[zaya-ref] running prefill forward ...")
+    with torch.no_grad():
+        _ = model(input_ids=input_ids, use_cache=False)
+
+    for h in handles:
+        h.remove()
+
+    print(f"[zaya-ref] captured {len(captures)} tensors; writing safetensors ...")
+    manifest_entries = []
+    for (layer_idx, side), tensor in sorted(captures.items()):
+        layer_name = "final" if layer_idx < 0 else f"layer_{layer_idx:02d}"
+        sub = out / layer_name
+        sub.mkdir(parents=True, exist_ok=True)
+        path = sub / f"prefill.{side}.safetensors"
+        save_file({"x": tensor}, str(path))
+        manifest_entries.append({
+            "layer": layer_idx,
+            "side": side,
+            "shape": list(tensor.shape),
+            "dtype": "float32",
+            "path": str(path.relative_to(out)),
+        })
+
+    manifest = {
+        "model": args.model,
+        "dtype": args.dtype,
+        "prompt_md5": prompt_md5,
+        "prompt_path": str(prompt_path),
+        "input_ids": input_ids[0].tolist(),
+        "tensors": manifest_entries,
+    }
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"[zaya-ref] wrote manifest.json + {len(manifest_entries)} tensors under {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/arch-intake/dump_zaya_reference.py
+++ b/scripts/arch-intake/dump_zaya_reference.py
@@ -166,14 +166,27 @@ def main():
     input_ids = enc["input_ids"].to("cuda:0")
     print(f"[zaya-ref] input_ids shape: {tuple(input_ids.shape)}, tokens: {input_ids[0].tolist()[:20]}{'...' if input_ids.shape[1] > 20 else ''}")
 
-    captures = {}  # (layer_idx, side) -> tensor (cpu, fp32)
+    captures = {}  # (layer_idx, side, "in"|"out") -> tensor (cpu, fp32)
+
+    def to_cpu_fp32(x):
+        return x.detach().to("cpu", dtype=torch.float32).contiguous()
 
     def make_hook(layer_idx, side):
-        def hook(_module, _inputs, output):
-            t = output[0] if isinstance(output, tuple) else output
-            if not hasattr(t, "detach"):
-                return  # non-tensor output (e.g. cache obj) - skip
-            captures[(layer_idx, side)] = t.detach().to("cpu", dtype=torch.float32).contiguous()
+        def hook(_module, inputs, output):
+            # Capture every positional INPUT that is a tensor.
+            # E.g. ResidualScaling.forward(residual, hidden_states) gives
+            # us both via "in0" and "in1".
+            for j, x in enumerate(inputs or []):
+                if hasattr(x, "detach"):
+                    key = "in" if (j == 0 and len(inputs) == 1) else f"in{j}"
+                    captures[(layer_idx, side, key)] = to_cpu_fp32(x)
+            # Capture OUTPUT (multi-tensor tuple → out0, out1, ...; single → out)
+            if isinstance(output, tuple):
+                for j, t in enumerate(output):
+                    if hasattr(t, "detach"):
+                        captures[(layer_idx, side, f"out{j}")] = to_cpu_fp32(t)
+            elif hasattr(output, "detach"):
+                captures[(layer_idx, side, "out")] = to_cpu_fp32(output)
         return hook
 
     handles = []
@@ -183,7 +196,7 @@ def main():
             skipped.append((layer_idx, side))
             continue
         handles.append(mod.register_forward_hook(make_hook(layer_idx, side)))
-    print(f"[zaya-ref] registered {len(handles)} hooks ({len(skipped)} skipped: {skipped[:5]}{'...' if len(skipped) > 5 else ''})")
+    print(f"[zaya-ref] registered {len(handles)} hooks ({len(skipped)} skipped)")
 
     print("[zaya-ref] running prefill forward ...")
     with torch.no_grad():
@@ -194,15 +207,16 @@ def main():
 
     print(f"[zaya-ref] captured {len(captures)} tensors; writing safetensors ...")
     manifest_entries = []
-    for (layer_idx, side), tensor in sorted(captures.items()):
+    for (layer_idx, side, io), tensor in sorted(captures.items()):
         layer_name = "final" if layer_idx < 0 else f"layer_{layer_idx:02d}"
         sub = out / layer_name
         sub.mkdir(parents=True, exist_ok=True)
-        path = sub / f"prefill.{side}.safetensors"
+        path = sub / f"prefill.{side}.{io}.safetensors"
         save_file({"x": tensor}, str(path))
         manifest_entries.append({
             "layer": layer_idx,
             "side": side,
+            "io": io,
             "shape": list(tensor.shape),
             "dtype": "float32",
             "path": str(path.relative_to(out)),

--- a/scripts/arch-intake/extract_phase2_subset.py
+++ b/scripts/arch-intake/extract_phase2_subset.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Extract a tiny subset of ZAYA1-8B weights needed for Phase 2.A CPU
+validation (RMSNorm + res_scale on layer 0 + 1 + final_norm).
+
+Run on hiptrx (model lives there); writes a single safetensors blob
+back to ~/zaya-work/zaya1_phase2_subset.safetensors which scp's to
+local for the Rust validator to consume.
+"""
+import json
+import os
+from collections import defaultdict
+from safetensors.torch import load_file, save_file
+
+MODEL_DIR = "/home/kaden/zaya-work/ZAYA1-8B"
+OUT = "/home/kaden/zaya-work/zaya1_phase2_subset.safetensors"
+
+idx = json.load(open(f"{MODEL_DIR}/model.safetensors.index.json"))
+wmap = idx["weight_map"]
+
+needed = [
+    "model.layers.0.input_norm.weight",
+    "model.layers.0.res_scale.hidden_states_bias",
+    "model.layers.0.res_scale.hidden_states_scale",
+    "model.layers.1.input_norm.weight",
+    "model.layers.1.res_scale.hidden_states_bias",
+    "model.layers.1.res_scale.hidden_states_scale",
+    "model.layers.1.res_scale.residual_bias",
+    "model.layers.1.res_scale.residual_scale",
+    "model.final_norm.weight",
+]
+
+by_shard = defaultdict(list)
+for n in needed:
+    if n in wmap:
+        by_shard[wmap[n]].append(n)
+    else:
+        print(f"MISSING: {n}")
+
+extracted = {}
+for shard, names in by_shard.items():
+    t = load_file(f"{MODEL_DIR}/{shard}")
+    for n in names:
+        extracted[n] = t[n]
+        print(f"loaded {n} {tuple(t[n].shape)} dtype={t[n].dtype}")
+
+save_file(extracted, OUT)
+print()
+print(f"Wrote {OUT}")
+print(f"Size: {os.path.getsize(OUT)} bytes")

--- a/scripts/arch-intake/extract_phase2d_subset.py
+++ b/scripts/arch-intake/extract_phase2d_subset.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Extract Phase 2.D weight subset for the 4-component validation.
+
+Adds to the Phase 2.A subset:
+  - layer 1 router (down_proj, rmsnorm_eda, router_mlp.{0,2,4}, balancing_biases)
+  - layer 1 expert 0 (linear_fc1, linear_fc2)
+  - layer 0 o_proj
+"""
+import json
+import os
+from collections import defaultdict
+from safetensors.torch import load_file, save_file
+
+MODEL_DIR = "/home/kaden/zaya-work/ZAYA1-8B"
+OUT = "/home/kaden/zaya-work/zaya1_phase2d_subset.safetensors"
+
+idx = json.load(open(f"{MODEL_DIR}/model.safetensors.index.json"))
+wmap = idx["weight_map"]
+
+needed = [
+    # phase 2.A reuse
+    "model.layers.0.input_norm.weight",
+    "model.layers.0.res_scale.hidden_states_bias",
+    "model.layers.0.res_scale.hidden_states_scale",
+    "model.layers.1.input_norm.weight",
+    "model.layers.1.res_scale.hidden_states_bias",
+    "model.layers.1.res_scale.hidden_states_scale",
+    "model.layers.1.res_scale.residual_bias",
+    "model.layers.1.res_scale.residual_scale",
+    "model.final_norm.weight",
+    # phase 2.D additions:
+    # layer 0 o_proj (post-attention output projection)
+    "model.layers.0.self_attn.o_proj.weight",
+    # layer 1 router
+    "model.layers.1.zaya_block.router.down_proj.weight",
+    "model.layers.1.zaya_block.router.down_proj.bias",
+    "model.layers.1.zaya_block.router.rmsnorm_eda.weight",
+    "model.layers.1.zaya_block.router.router_mlp.0.weight",
+    "model.layers.1.zaya_block.router.router_mlp.0.bias",
+    "model.layers.1.zaya_block.router.router_mlp.2.weight",
+    "model.layers.1.zaya_block.router.router_mlp.2.bias",
+    "model.layers.1.zaya_block.router.router_mlp.4.weight",
+    "model.layers.1.zaya_block.router.balancing_biases",
+    # layer 1 expert 0 (validate one expert; we know the routing assignments
+    # from router.out1 in the dump and apply the right expert per token).
+    "model.layers.1.zaya_block.experts.local_experts.0.linear_fc1.weight",
+    "model.layers.1.zaya_block.experts.local_experts.0.linear_fc2.weight",
+]
+
+by_shard = defaultdict(list)
+for n in needed:
+    if n in wmap:
+        by_shard[wmap[n]].append(n)
+    else:
+        print(f"MISSING: {n}")
+
+extracted = {}
+for shard, names in by_shard.items():
+    t = load_file(f"{MODEL_DIR}/{shard}")
+    for n in names:
+        extracted[n] = t[n]
+        print(f"loaded {n} {tuple(t[n].shape)} dtype={t[n].dtype}")
+
+save_file(extracted, OUT)
+print()
+print(f"Wrote {OUT}")
+print(f"Size: {os.path.getsize(OUT)} bytes")

--- a/scripts/arch-intake/prompts/zaya_canonical.txt
+++ b/scripts/arch-intake/prompts/zaya_canonical.txt
@@ -1,0 +1,1 @@
+The recurrent state in CCA carries two buffers per layer per sequence: conv_states and prev_hs.


### PR DESCRIPTION
## Summary

Overnight intake for porting Zyphra/ZAYA1-8B (760M-active 8.4B-total
MoE with novel CCA attention) into hipfire. **This is intake, not a
finished port.** The deliverable is the go/no-go scope decision plus
foundation work landed underneath it.

**Verdict:** RECURRENT. CCA carries two per-ATT-layer per-sequence
state buffers across decode steps (~370 KB per sequence at fp16 for
ZAYA1-8B). First per-layer recurrent state in hipfire. Phase 6
recurrent-state design doc is the headline; **`MANUAL_REVIEW.md`
contains a REQUIRES-KADEN-DECISION escalation** (Option A vs B,
spec-decode policy, paging policy).

## What's in this PR

- **Phase 0** disambiguation doc with verbatim source evidence:
  CCA reads + writes `conv_states` and `prev_hs` per-layer in the
  decode branch. `mamba_cache_dtype: float32` in config is dead
  Zamba2 inheritance (zero references).
- **Phase 1** scaffold: `crates/hipfire-arch-zaya/` compiles, 5 unit
  tests pass. arch_id = 7. EOS overrides Gemma turn markers.
  ZayaState + ZayaWeights typed; load + new_state return Err
  pending Phase 6 decision.
- **Phase 1** intake harness: `scripts/arch-intake/` with
  `dump_zaya_reference.py` + canonical prompt. Successfully ran
  end-to-end on hiptrx GPU 2, 80 sub-layers + final, 321 tensors
  captured (75 MB).
- **Phase 4** MoD design: implemented as `num_experts + 1` skip slot;
  no KV conditionalization, spec-decode compatible. Lightweight.
- **Phase 5** EDA identification: cross-LAYER state pipe (within one
  forward), trivial. Reuses residual-add kernel.
- **Phase 6** recurrent-state design: Option A (per-arch State)
  recommended over Option B (runtime primitive); first-ship AR-only
  on spec-decode; HBM-pinned recurrent state.

## Empirical findings

- ZAYA1's `num_hidden_layers=80` is alternating ATT + MLP sub-layers
  (40 each), NOT 80 attention blocks. Halves CCA state estimate.
- Reference dump infrastructure validated end-to-end on real ZAYA1
  weights; harness ready for Phase 2 NRMSE validation once HFQ
  writer lands.

## Decision points open

See `MANUAL_REVIEW.md` for the escalation. Three coupled decisions
gate Phase 6.A (~2 weeks calendar):

1. State location: per-arch State (recommended) vs runtime primitive.
2. First-ship spec-decode: AR-only (recommended) vs recurrent-spec.
3. Paging: HBM-pinned (recommended) vs paged.

End-to-end ZAYA1 first coherent decode after Phase 6.A approval:
~5-6 weeks calendar (HFQ writer + CCA kernel + free components +
MoD + EDA + per-layer NRMSE validation).

## What did NOT land tonight

- HFQ writer for ZAYA1 (~3-5 days; gates Phase 2 validation).
- CCA scalar reference + HIP kernel (Phase 3, gated on Phase 6 decision).
- Phase 2 free-component implementations (gated on HFQ writer).

## Test plan

- [x] `cargo test -p hipfire-arch-zaya` (5/5 pass).
- [x] `dump_zaya_reference.py --max-layers 4` smoke + full 80-layer
      run on hiptrx GPU 2 (R9700, gfx1201).
- [ ] HFQ writer for ZAYA1 (separate PR, post Phase 6.A approval).
- [ ] Phase 2 free-component NRMSE validation (post HFQ writer).
- [ ] CCA forward correctness + RDNA-targeted kernel (Phase 3, post Phase 6.A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)