### PR TITLE
WIP: hetero PFlash+DFlash — PR2 drafter device pinning + PR3 cross-card coord (in progress)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -1343,6 +1343,20 @@ impl HiddenStateRingBuffer {
         self.head = 0;
         self.written = 0;
     }
+
+    /// Free all GPU tensors owned by this ring. Caller MUST pass the same
+    /// `Gpu` instance the ring was allocated from — under hetero PFlash+DFlash
+    /// (PR3 step 2) the ring lives on the drafter Gpu, so unload_model must
+    /// route the free through `dflash_drafter_gpu` rather than the target.
+    /// Freeing on the wrong device leaks the allocations.
+    pub fn free_gpu(self, gpu: &mut Gpu) {
+        for t in self.layer_bufs {
+            let _ = gpu.free_tensor(t);
+        }
+        for t in self.staging_bufs {
+            let _ = gpu.free_tensor(t);
+        }
+    }
 }
 
 /// Single-pass argmax for token sampling. Not SIMD-optimized — the logit
@@ -2272,6 +2286,21 @@ pub fn scatter_hidden_block_to_interleaved(
     let row_bytes = hidden * 4;
     let start_slot = (head + max_pos - block_size) % max_pos;
 
+    // PR3 step 2 hetero hardening: at long prompts (≥ ~10K BPE tokens with
+    // num_extract=5 → 50K+ memcpys), the AMD HIP runtime accumulates an
+    // internal `Command` object chain proportional to memcpy count. The
+    // chain releases linked-list-style via `Command::terminate() →
+    // ReferenceCountedObject::release() → Command::releaseResources()
+    // → terminate()` recursion. At ~10K rows × 5 extracts = 50K commands,
+    // the recursive release blows the main thread's 8 MB stack on the
+    // FIRST subsequent kernel launch (in our case spec_step_dflash's
+    // first cycle). Verified via core-dump backtrace: 50K identical
+    // frames in libamdhip64.so.
+    //
+    // Workaround: periodically `device_synchronize()` to drain the
+    // command chain. Fence at every CHAIN_DRAIN_INTERVAL rows × num_extract
+    // memcpys so the chain stays bounded.
+    const CHAIN_DRAIN_INTERVAL: usize = 1024;
     for r in 0..n_rows {
         let slot = (start_slot + r) % max_pos;
         let dst_row = dst_row_offset + r;
@@ -2287,6 +2316,17 @@ pub fn scatter_hidden_block_to_interleaved(
                 row_bytes,
             )?;
         }
+        // Drain the HIP command chain periodically (see comment above the loop).
+        if (r + 1) % CHAIN_DRAIN_INTERVAL == 0 {
+            gpu.hip.device_synchronize()?;
+        }
+    }
+    // Final drain only if any pending memcpys haven't been drained by the
+    // periodic fence above. Skip the unconditional sync on short prompts
+    // (n_rows < CHAIN_DRAIN_INTERVAL) so single-card / short-context cycles
+    // don't pay an extra device_synchronize that adds nothing.
+    if n_rows > 0 && n_rows % CHAIN_DRAIN_INTERVAL != 0 {
+        gpu.hip.device_synchronize()?;
     }
     Ok(())
 }
@@ -2401,7 +2441,8 @@ pub fn download_hidden_block(
 /// full cumulative context (the default, distribution-preserving path).
 #[allow(clippy::too_many_arguments)]
 pub fn spec_step_dflash(
-    gpu: &mut Gpu,
+    target_gpu: &mut Gpu,
+    mut drafter_gpu: Option<&mut Gpu>,
     target: &mut ModelSlot,
     draft_weights: &DflashWeights,
     draft_cfg: &DflashConfig,
@@ -2424,6 +2465,27 @@ pub fn spec_step_dflash(
     repeat_penalty: f32,
     repeat_window: usize,
 ) -> HipResult<SpecStepResult> {
+    // Hetero PFlash+DFlash (PR3 step 2): when `drafter_gpu` is `Some`, drafter
+    // weights / scratch / hidden_rb live on a separate HIP device. Drafter
+    // kernels must launch on the drafter Gpu's HIP context (its module cache
+    // is the only one that has the kernels' GPU-side modules loaded — calling
+    // them through target_gpu's context crashes with hipErrorInvalidImage).
+    //
+    // Convention used below:
+    //   - target-side blocks (target weights / KV / dn_state / verify_scratch)
+    //     run with `target_gpu.bind_thread()` current.
+    //   - drafter-side blocks (draft_weights / draft_scratch / hidden_rb-local
+    //     scatter) run with `drafter_gpu.bind_thread()` current — or the same
+    //     gpu in single-card mode where `drafter_gpu` is None.
+    //   - peer access between target and drafter is enabled bidirectionally
+    //     at load time (daemon.rs::load_model), so cross-device memcpys and
+    //     incidental cross-device pointer reads inside kernels work without
+    //     any per-call setup.
+    //
+    // Single-card mode (drafter_gpu = None) is byte-identical to the pre-PR3
+    // path: every "drafter" block reuses target_gpu, bind_thread is a no-op
+    // via the thread-local cache, and we skip the cross-device synchronizes.
+    let split_mode = drafter_gpu.is_some();
     // Effective block size for THIS step. Usually `draft_cfg.block_size`
     // (what the draft was trained at, 16 for Qwen3.5-*-DFlash) but a caller
     // doing adaptive-B based on rolling τ can shrink to save per-iter cost.
@@ -2445,8 +2507,20 @@ pub fn spec_step_dflash(
     // and stream-ordered launches have a non-null stream to ride on. Without
     // this, the lm_head pre-zero memsets in dispatch.rs:4475/4545 fall through
     // to the sync hipMemset path (~46 hot calls/cycle on 27B).
-    if gpu.active_stream.is_none() {
-        gpu.active_stream = Some(gpu.hip.stream_create()?);
+    //
+    // In hetero (split_mode) we initialize streams on BOTH gpus — drafter
+    // kernels need a non-null stream on drafter_gpu's context for the same
+    // memset_async fast path; otherwise the stream-gated async fallthrough in
+    // commit_staging_to_ring / write_rows_to_staging breaks.
+    if target_gpu.active_stream.is_none() {
+        target_gpu.active_stream = Some(target_gpu.hip.stream_create()?);
+    }
+    if let Some(d) = drafter_gpu.as_deref_mut() {
+        if d.active_stream.is_none() {
+            d.bind_thread()?;
+            d.active_stream = Some(d.hip.stream_create()?);
+            target_gpu.bind_thread()?;
+        }
     }
 
     assert!(b >= 2, "dflash block size must be ≥ 2");
@@ -2470,7 +2544,7 @@ pub fn spec_step_dflash(
     // of Instant::now() calls.
     let phase_on = std::env::var("HIPFIRE_SPEC_PHASES").ok().as_deref() == Some("1");
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_spec_start = std::time::Instant::now();
     let mut t_phase = t_spec_start;
@@ -2521,28 +2595,40 @@ pub fn spec_step_dflash(
             }
         }
     } else {
-    // ── 2. noise_embedding = target.embed_tokens(block) written directly
-    // into draft_scratch.x on GPU (no host round-trip). Target and draft
-    // share the same Gpu, so the embedding lookup can target the draft's
-    // scratch buffer. Avoids 16 × D2H + one H2D per iter (~1 ms saved).
-    for (i, &tok) in block.iter().enumerate() {
-        let dst = draft_scratch.x.sub_offset(i * h, h);
-        match target.weights.embd_format {
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
-                gpu.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
-                gpu.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
-                gpu.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::F32 => {
-                gpu.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
-            }
-            _ => panic!("dflash: unsupported target embedding format for noise lookup"),
+    // ── Drafter-bound section (§2 embedding, §3 positions, §4 draft_forward) ──
+    //
+    // In hetero (split_mode), drafter weights / scratch live on a different
+    // HIP device than the target. The embedding lookup writes into
+    // `draft_scratch.x` (drafter memory) and reads `target.weights.token_embd`
+    // via peer access; the draft forward runs entirely against drafter
+    // weights/scratch. Both must launch on drafter_gpu's HIP context.
+    {
+        let drafter: &mut Gpu = match drafter_gpu.as_mut() {
+            Some(d) => &mut **d,
+            None => &mut *target_gpu,
+        };
+        if split_mode {
+            drafter.bind_thread()?;
         }
-    }
+        // ── 2. embedding lookup on drafter context ──
+        for (i, &tok) in block.iter().enumerate() {
+            let dst = draft_scratch.x.sub_offset(i * h, h);
+            match target.weights.embd_format {
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
+                    drafter.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
+                    drafter.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
+                    drafter.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::F32 => {
+                    drafter.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
+                }
+                _ => panic!("dflash: unsupported target embedding format for noise lookup"),
+            }
+        }
 
     // ── 3. Position arrays + optional context slice ─────────────────────
     // Q positions: the absolute positions of the block slots,
@@ -2609,7 +2695,7 @@ pub fn spec_step_dflash(
     // noise_embedding = None: we wrote embeddings directly into
     // draft_scratch.x above via D2D (no host round-trip).
     dflash::draft_forward(
-        gpu,
+        drafter,
         draft_weights,
         draft_cfg,
         None,
@@ -2620,6 +2706,24 @@ pub fn spec_step_dflash(
         effective_ctx_len,
         draft_scratch,
     )?;
+
+    // Drain drafter's stream so the next (target-bound) lm_head GEMM sees
+    // a coherent draft_scratch.x via peer read. Skipped in single-card mode
+    // — kernels submitted on the same device order naturally on the same
+    // null-stream / active_stream.
+    if split_mode {
+        drafter.hip.device_synchronize()?;
+    }
+    } // drafter borrow ends — target_gpu reusable below
+
+    // ── Target-bound section (§5 lm_head + §6 verify) ───────────────────
+    // Switch the calling thread to target's HIP context for the rest of
+    // the cycle. The lm_head GEMM reads target.weights.output (target
+    // memory) and writes verify_scratch.logits (target memory); reads
+    // draft_scratch.x cross-device via peer access.
+    if split_mode {
+        target_gpu.bind_thread()?;
+    }
 
     // ── 5. Apply target.lm_head to draft hidden positions 1..B ──────────
     // Fast path: a single batched GEMM against target.weights.output over
@@ -2658,10 +2762,10 @@ pub fn spec_step_dflash(
 
         match w_out.gpu_dtype {
             rdna_compute::DType::Q8_0 => {
-                gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)?;
+                target_gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)?;
             }
             rdna_compute::DType::HFQ4G256 => {
-                gpu.gemm_hfq4g256_batched_lmhead(
+                target_gpu.gemm_hfq4g256_batched_lmhead(
                     &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }
@@ -2669,8 +2773,8 @@ pub fn spec_step_dflash(
                 assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
                     "verify_scratch.rot undersized for draft lm_head");
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq4g256_batched_lmhead(
+                target_gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                target_gpu.gemm_hfq4g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }
@@ -2678,13 +2782,13 @@ pub fn spec_step_dflash(
                 assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
                     "verify_scratch.rot undersized for MQ3 draft lm_head");
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq3g256_batched_lmhead(
+                target_gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                target_gpu.gemm_hfq3g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }
             rdna_compute::DType::HFQ6G256 => {
-                gpu.gemm_hfq6g256_batched_lmhead(
+                target_gpu.gemm_hfq6g256_batched_lmhead(
                     &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }
@@ -2692,8 +2796,8 @@ pub fn spec_step_dflash(
                 assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
                     "verify_scratch.rot undersized for MQ6 draft lm_head");
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq6g256_batched_lmhead(
+                target_gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                target_gpu.gemm_hfq6g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
             }
@@ -2702,7 +2806,7 @@ pub fn spec_step_dflash(
 
         if use_temp_sampling {
             // Full D2H of (B-1)×vocab logits, CPU softmax+sample.
-            let host_logits = gpu.download_f32(&logits_batch)?;
+            let host_logits = target_gpu.download_f32(&logits_batch)?;
             debug_assert_eq!(host_logits.len(), batch * vocab);
             draft_softmaxes.reserve(batch);
             for i in 0..batch {
@@ -2720,7 +2824,7 @@ pub fn spec_step_dflash(
             // so draft and target pick from the same reshaped distribution.
             // Keeps spec-decode aligned (τ doesn't collapse from mismatched
             // argmaxes — both sides see identical -inf logits on banned toks).
-            let host_logits = gpu.download_f32(&logits_batch)?;
+            let host_logits = target_gpu.download_f32(&logits_batch)?;
             debug_assert_eq!(host_logits.len(), batch * vocab);
             let mut row = vec![0f32; vocab];
             for i in 0..batch {
@@ -2736,13 +2840,13 @@ pub fn spec_step_dflash(
         } else {
             // GPU argmax over (B-1) rows — one kernel, small D2H.
             let argmax_buf = verify_scratch.argmax.sub_offset(0, batch);
-            gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, batch)?;
+            target_gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, batch)?;
             let mut host_idx = vec![0i32; batch];
             {
                 let bytes: &mut [u8] = unsafe {
                     std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, batch * 4)
                 };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
+                target_gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
             }
             for &idx in &host_idx {
                 drafted.push(idx as u32);
@@ -2752,8 +2856,8 @@ pub fn spec_step_dflash(
         // Fallback: per-row weight_gemv loop.
         for i in 1..b {
             let hidden_row = draft_scratch.x.sub_offset(i * h, h);
-            llama::weight_gemv(gpu, w_out, &hidden_row, &target.scratch.logits)?;
-            let logits = gpu.download_f32(&target.scratch.logits)?;
+            llama::weight_gemv(target_gpu, w_out, &hidden_row, &target.scratch.logits)?;
+            let logits = target_gpu.download_f32(&target.scratch.logits)?;
             debug_assert_eq!(logits.len(), vocab);
             if use_temp_sampling {
                 let mut probs = Vec::with_capacity(vocab);
@@ -2784,7 +2888,7 @@ pub fn spec_step_dflash(
     }
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_draft_end = std::time::Instant::now();
 
@@ -2834,7 +2938,7 @@ pub fn spec_step_dflash(
     // per-LA-layer (q, k, v, α, β) innovation tape so the rollback can
     // replay just the GDN recurrence for `accept+1` steps without
     // re-running the target.
-    target_snap.save_from(&target.dn_state, gpu)?;
+    target_snap.save_from(&target.dn_state, target_gpu)?;
     // Mutable variable to allow both verify capture + rollback replay usage.
     let mut gdn_tape_opt = gdn_tape;
     // MoE targets can't populate the tape: forward_prefill_batch_with_pbs's
@@ -2854,18 +2958,18 @@ pub fn spec_step_dflash(
     }
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_verify_start = std::time::Instant::now();
     let verify_out = verify_dflash_block(
-        gpu, target, &block, position, hidden_rb,
+        target_gpu, target, &block, position, hidden_rb,
         gdn_tape_opt.as_deref_mut(),
         use_temp_sampling || host_path_active,  // full target logits needed for rejection sampling, RP, or n-gram block
         verify_scratch,
     )?;
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_verify_end = std::time::Instant::now();
 
@@ -3041,7 +3145,7 @@ pub fn spec_step_dflash(
     debug_assert_eq!(committed_count, accept_len + 2);
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_accept_end = std::time::Instant::now();
 
@@ -3084,7 +3188,12 @@ pub fn spec_step_dflash(
     let rows_to_keep = accept_len + 1;
     if ctx_slice.is_some() {
         // ctx_slice path: CPU shadow still required for the window slice.
-        let hidden_block = download_hidden_block(gpu, hidden_rb, b)?;
+        // hidden_rb lives on drafter memory in hetero mode; the d2h read
+        // works either way thanks to peer access (hipMemcpy across peer-
+        // enabled devices), so we leave the read on target_gpu's context
+        // here. ctx_slice is a diagnostic-only path — not in the production
+        // hot loop.
+        let hidden_block = download_hidden_block(target_gpu, hidden_rb, b)?;
         target_hidden_host.extend_from_slice(&hidden_block[..rows_to_keep * ne * h]);
     } else {
         // Fast path: scatter straight from hidden_rb into draft scratch on GPU.
@@ -3094,14 +3203,41 @@ pub fn spec_step_dflash(
         // `rows_to_keep` (= accept+1) of those. Pass block_size=b so the
         // scatter function aligns to the verify-block origin, not the
         // ring tail.
-        scatter_hidden_block_to_interleaved(
-            gpu,
-            hidden_rb,
-            &draft_scratch.target_hidden,
-            position,
-            b,
-            rows_to_keep,
-        )?;
+        //
+        // Both `hidden_rb` and `draft_scratch.target_hidden` live on the
+        // drafter Gpu in hetero mode. The scatter is a chain of D2D
+        // memcpys; in single-card mode it stays on target_gpu, in hetero
+        // we bind drafter so the memcpys execute on the drafter device's
+        // context (their src AND dst are drafter-local — no peer hop). We
+        // also need to drain target_gpu's stream first so verify's writes
+        // into hidden_rb (peer writes from target context) are visible
+        // before drafter starts reading them.
+        if split_mode {
+            target_gpu.hip.device_synchronize()?;
+        }
+        {
+            let drafter: &mut Gpu = match drafter_gpu.as_mut() {
+                Some(d) => &mut **d,
+                None => &mut *target_gpu,
+            };
+            if split_mode {
+                drafter.bind_thread()?;
+            }
+            scatter_hidden_block_to_interleaved(
+                drafter,
+                hidden_rb,
+                &draft_scratch.target_hidden,
+                position,
+                b,
+                rows_to_keep,
+            )?;
+            if split_mode {
+                drafter.hip.device_synchronize()?;
+            }
+        }
+        if split_mode {
+            target_gpu.bind_thread()?;
+        }
         // Keep draft_forward's incremental-upload tracker in sync so any future
         // ctx_slice=Some call in the same session doesn't try to re-upload what
         // GPU already has; and so the assertion-in-draft path stays coherent.
@@ -3119,7 +3255,7 @@ pub fn spec_step_dflash(
     }
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_scatter_end = std::time::Instant::now();
 
@@ -3129,10 +3265,10 @@ pub fn spec_step_dflash(
     // draft tokens). The bonus token is NOT replayed — it will be
     // block[0] of the next iter. This keeps the invariant that before each
     // verify, target state is at position `start` (= pre-verify position).
-    target_snap.restore_to(&mut target.dn_state, gpu)?;
+    target_snap.restore_to(&mut target.dn_state, target_gpu)?;
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
     }
     let t_restore_end = std::time::Instant::now();
     // Tape-replay path (0.1.7 perf): if a GdnTape was captured during verify,
@@ -3148,12 +3284,12 @@ pub fn spec_step_dflash(
     // batched call instead of (accept+1) sequential decodes.
     if let Some(tape) = gdn_tape_opt.as_deref() {
         tape.replay_gdn(
-            gpu, &target.weights, &target.config, &mut target.dn_state, accept_len + 1,
+            target_gpu, &target.weights, &target.config, &mut target.dn_state, accept_len + 1,
         )?;
     } else {
         let replay_tokens = &committed[..accept_len + 1];
         qwen35::forward_prefill_batch(
-            gpu,
+            target_gpu,
             &target.weights,
             &target.config,
             replay_tokens,
@@ -3170,7 +3306,7 @@ pub fn spec_step_dflash(
     // `position + accept_len + 1`) as part of that iter's block[0] forward.
 
     if phase_on {
-        gpu.hip.device_synchronize()?;
+        target_gpu.hip.device_synchronize()?;
         let t_end = std::time::Instant::now();
         let us_draft   = t_draft_end.duration_since(t_spec_start).as_micros();
         let us_ngram   = t_verify_start.duration_since(t_draft_end).as_micros();

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -3513,9 +3513,15 @@ fn run_dflash_draft_for_logits(
 ///
 /// Returns `(top_tokens, top_log_probs)` each of size `(b-1) * k` in
 /// row-major order (same convention as `ddtree::topk_from_logits`).
+///
+/// Hetero (split_mode = drafter_gpu.is_some()): embedding lookup + DFlash
+/// draft forward run on drafter; lm_head GEMM + GPU top-K + D2H run on
+/// target_gpu (target.weights.output is local there). Mirrors the drafter/
+/// target split in `spec_step_dflash` step 2.
 #[allow(clippy::too_many_arguments)]
 fn run_dflash_draft_for_topk_gpu(
-    gpu: &mut Gpu,
+    target_gpu: &mut Gpu,
+    mut drafter_gpu: Option<&mut Gpu>,
     target: &ModelSlot,
     draft_weights: &DflashWeights,
     draft_cfg: &DflashConfig,
@@ -3531,33 +3537,12 @@ fn run_dflash_draft_for_topk_gpu(
     let ne = draft_cfg.num_extract();
     let vocab = target.config.vocab_size;
     let mask_token = draft_cfg.mask_token_id;
+    let split_mode = drafter_gpu.is_some();
     assert!(b >= 2, "dflash draft: b must be ≥ 2");
     assert!(k >= 1 && k <= 8, "topk k={} must be in [1, 8]", k);
 
-    // Step 1-3: identical to run_dflash_draft_for_logits — embed, positions,
-    // draft forward. Duplicating the small glue to avoid a refactor risk;
-    // this path is shipped after. (Could factor out, but the savings is <50
-    // lines and the call site is stable.)
     let mut block: Vec<u32> = vec![mask_token; b];
     block[0] = seed_token;
-    for (i, &tok) in block.iter().enumerate() {
-        let dst = draft_scratch.x.sub_offset(i * h, h);
-        match target.weights.embd_format {
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
-                gpu.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
-                gpu.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
-                gpu.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::F32 => {
-                gpu.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
-            }
-            _ => panic!("ddtree draft: unsupported target embedding format"),
-        }
-    }
     let effective_ctx_len = match ctx_slice {
         Some(n) => n.min(position),
         None => position,
@@ -3568,22 +3553,65 @@ fn run_dflash_draft_for_topk_gpu(
     let th_offset = ctx_start * ne * h;
     let th_slice: &[f32] = &target_hidden_host[th_offset..];
 
-    dflash::draft_forward(
-        gpu,
-        draft_weights,
-        draft_cfg,
-        None,
-        Some(th_slice),
-        &positions_q,
-        &positions_k,
-        b,
-        effective_ctx_len,
-        draft_scratch,
-    )?;
+    // ── Drafter-bound section (embedding + DFlash draft forward) ──
+    {
+        let drafter: &mut Gpu = match drafter_gpu.as_mut() {
+            Some(d) => &mut **d,
+            None => &mut *target_gpu,
+        };
+        if split_mode {
+            drafter.bind_thread()?;
+        }
+        for (i, &tok) in block.iter().enumerate() {
+            let dst = draft_scratch.x.sub_offset(i * h, h);
+            match target.weights.embd_format {
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
+                    drafter.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
+                    drafter.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
+                    drafter.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::F32 => {
+                    drafter.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
+                }
+                _ => panic!("ddtree draft: unsupported target embedding format"),
+            }
+        }
+        dflash::draft_forward(
+            drafter,
+            draft_weights,
+            draft_cfg,
+            None,
+            Some(th_slice),
+            &positions_q,
+            &positions_k,
+            b,
+            effective_ctx_len,
+            draft_scratch,
+        )?;
+        // Drain drafter so the next (target-bound) lm_head GEMM sees a
+        // coherent draft_scratch.x via peer read. Skipped in single-card
+        // mode — kernels submitted on the same device order naturally.
+        if split_mode {
+            drafter.hip.device_synchronize()?;
+        }
+    } // drafter borrow ends — target_gpu reusable below
+
+    // ── Target-bound section (lm_head + GPU top-K + D2H) ──
+    // The lm_head reads target.weights.output (target memory) and writes
+    // logits_batch (target memory); reads draft_scratch.x cross-device via
+    // peer access in hetero mode.
+    if split_mode {
+        target_gpu.bind_thread()?;
+    }
 
     // Step 4: lm_head → [batch × vocab] logits (GPU-resident).
     let batch = b - 1;
     let hidden_rows = draft_scratch.x.sub_offset(h, batch * h);
+    let gpu = target_gpu;
     let logits_batch = gpu.alloc_tensor(&[batch * vocab], rdna_compute::DType::F32)?;
     let w_out = &target.weights.output;
     let gemm_result = match w_out.gpu_dtype {
@@ -4040,7 +4068,8 @@ pub fn spec_step_ddtree(
 /// τ wins (+40–46% on creative/essay) into wall-clock wins.
 #[allow(clippy::too_many_arguments)]
 pub fn spec_step_ddtree_batched(
-    gpu: &mut Gpu,
+    target_gpu: &mut Gpu,
+    drafter_gpu: Option<&mut Gpu>,
     target: &mut ModelSlot,
     draft_weights: &DflashWeights,
     draft_cfg: &DflashConfig,
@@ -4088,9 +4117,14 @@ pub fn spec_step_ddtree_batched(
     // ── 1+2. GPU-resident draft + per-row top-K + log-sum-exp ────────────
     // Keeps logits on device; returns only (b-1) × k indices + log-probs
     // to the host. Replaces the prior 15 MB D2H + CPU sort pair (~34 ms)
-    // with an on-device top-K (~µs) plus a ~480 byte D2H.
+    // with an on-device top-K (~µs) plus a ~480 byte D2H. In hetero mode
+    // the drafter half (embedding + DFlash forward) launches on
+    // drafter_gpu's HIP context; the target half (lm_head + top-K + D2H)
+    // launches on target_gpu — and the thread is left bound to target on
+    // return so the rest of the function uses target_gpu via `gpu`.
     let (top_tokens, top_log_probs) = run_dflash_draft_for_topk_gpu(
-        gpu,
+        target_gpu,
+        drafter_gpu,
         target,
         draft_weights,
         draft_cfg,
@@ -4102,6 +4136,7 @@ pub fn spec_step_ddtree_batched(
         b,
         tree_topk,
     )?;
+    let gpu = target_gpu;
 
     let t_draft = t_all.elapsed();
     let t_topk = t_draft; // fused with draft now
@@ -4617,7 +4652,8 @@ pub struct Phase2Snapshots<'a> {
 /// (this function uses `target_snap` + `path_c_phase2` snapshots instead).
 #[cfg(feature = "deltanet")]
 pub fn spec_step_ddtree_path_c(
-    gpu: &mut Gpu,
+    target_gpu: &mut Gpu,
+    drafter_gpu: Option<&mut Gpu>,
     target: &mut ModelSlot,
     draft_weights: &DflashWeights,
     draft_cfg: &DflashConfig,
@@ -4650,8 +4686,11 @@ pub fn spec_step_ddtree_path_c(
     );
 
     // ── 1+2. GPU-resident draft + per-row top-K (identical to batched path) ──
+    // Hetero: drafter half on drafter_gpu, lm_head/top-K on target. Returns
+    // with thread bound to target.
     let (top_tokens, top_log_probs) = run_dflash_draft_for_topk_gpu(
-        gpu,
+        target_gpu,
+        drafter_gpu,
         target,
         draft_weights,
         draft_cfg,
@@ -4663,6 +4702,7 @@ pub fn spec_step_ddtree_path_c(
         b,
         tree_topk,
     )?;
+    let gpu = target_gpu;
 
     // ── 3. Build the DDTree ───────────────────────────────────────────────
     let tree = hipfire_runtime::ddtree::build_ddtree_tree_with_cutoff(

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1869,28 +1869,10 @@ fn load_dflash_state(
     // to know whether a dedicated drafter device was opened by load_model.
     let drafter_pinned = drafter_gpu.is_some();
 
-    // PR3 step 2 refusal: ddtree + cross-card spec-decode is not yet wired
-    // up. spec_step_ddtree_batched / spec_step_ddtree_path_c still take a
-    // single `gpu: &mut Gpu` and run their drafter forwards through that
-    // context, which crashes when drafter weights/scratch live on a
-    // different device. Refuse cleanly at load — and BEFORE allocating any
-    // drafter VRAM — rather than letting it blow up at the first decode
-    // cycle. Plain chain-mode (`spec_step_dflash`) is the supported hetero
-    // path in step 2; ddtree hetero is a follow-on.
-    let ddtree_budget_raw = std::env::var("HIPFIRE_DDTREE_BUDGET")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(0);
-    if ddtree_budget_raw > 0 && drafter_pinned {
-        return Err(
-            "ddtree + cross-card spec-decode not yet supported \
-             (HIPFIRE_DDTREE_BUDGET set together with HIPFIRE_DFLASH_DRAFTER_DEVICE). \
-             Unset one of them. Chain-mode DFlash with HIPFIRE_DFLASH_DRAFTER_DEVICE \
-             is the supported hetero path in PR3 step 2."
-                .to_string(),
-        );
-    }
+    // PR3 step 4: ddtree + cross-card spec-decode is now wired through
+    // spec_step_ddtree_batched / spec_step_ddtree_path_c (drafter half
+    // routes via `drafter_gpu: Option<&mut Gpu>` mirroring
+    // spec_step_dflash). drafter_pinned no longer blocks DDTree.
 
     let hfq = HfqFile::open(Path::new(draft_path)).map_err(|e| format!("open draft: {e}"))?;
     let draft_config = DflashConfig::from_hfq(&hfq).ok_or("parse DflashConfig")?;
@@ -2409,7 +2391,9 @@ fn generate_dflash(
                     None
                 };
                 spec_step_ddtree_path_c(
-                    gpu, &mut target, &df.draft_weights, &df.draft_config,
+                    gpu,
+                    drafter_gpu_owned.as_mut(),
+                    &mut target, &df.draft_weights, &df.draft_config,
                     &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
                     &mut df.target_snap, &mut df.gdn_tape, &df.verify_scratch,
                     position, seed_token,
@@ -2420,7 +2404,9 @@ fn generate_dflash(
                 )
             } else {
                 spec_step_ddtree_batched(
-                    gpu, &mut target, &df.draft_weights, &df.draft_config,
+                    gpu,
+                    drafter_gpu_owned.as_mut(),
+                    &mut target, &df.draft_weights, &df.draft_config,
                     &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
                     &mut df.target_snap, &mut dd.post_seed_snap, &mut df.gdn_tape,
                     &dd.scratch, &df.verify_scratch,

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -355,6 +355,13 @@ struct LoadedModel {
     model_path: String,
     // DFlash speculative decoding state (populated when load supplied a draft).
     dflash: Option<DflashState>,
+    /// PR2 (hetero PFlash+DFlash PRD step 2): when env var
+    /// `HIPFIRE_DFLASH_DRAFTER_DEVICE=N` is set at load time, this holds a
+    /// dedicated `Gpu` instance bound to HIP device N. PR2 only opens the
+    /// instance and stores it; PR3 (cross-card spec-decode coordination)
+    /// will route drafter ops here. None when env unset — drafter shares
+    /// the target's Gpu (current single-card behavior preserved).
+    dflash_drafter_gpu: Option<rdna_compute::Gpu>,
 }
 
 /// Print a friendly, user-actionable message when Gpu::init fails. Matches
@@ -1392,6 +1399,54 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                 }
             }
         } else { None };
+
+        // ── PR2 (hetero PFlash+DFlash PRD): drafter device pinning ──────
+        //
+        // `HIPFIRE_DFLASH_DRAFTER_DEVICE=N` opens a separate `Gpu` instance
+        // bound to HIP device N for the DFlash drafter. Empty / unset / no
+        // draft → preserve current behavior (drafter shares the target's
+        // Gpu). PR2 only opens the instance and stores it in
+        // `LoadedModel.dflash_drafter_gpu`; PR3 routes drafter ops onto
+        // that instance. Until PR3 lands, setting this env opens a Gpu
+        // that is allocated but unused — that's intentional: it lets PR2
+        // be reviewed in isolation without breaking the existing single-
+        // Gpu DFlash path.
+        //
+        // Preflight: device id must be in `[0, hip.device_count())`. The
+        // HIP runtime returns a clear error if it's out of range, so we
+        // surface that as a load failure rather than silently downgrading.
+        let dflash_drafter_gpu: Option<rdna_compute::Gpu> = match (
+            draft_path,
+            std::env::var("HIPFIRE_DFLASH_DRAFTER_DEVICE")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        ) {
+            (Some(_), Some(dev_str)) => match dev_str.parse::<i32>() {
+                Ok(dev) => match rdna_compute::Gpu::init_with_device(dev) {
+                    Ok(g) => {
+                        eprintln!(
+                            "  DFlash drafter pinned to HIP device {} ({}, {} MiB VRAM)",
+                            dev,
+                            g.arch,
+                            g.hip.get_vram_info().map(|(_, t)| t / (1024 * 1024)).unwrap_or(0),
+                        );
+                        Some(g)
+                    }
+                    Err(e) => {
+                        return Err(format!(
+                            "HIPFIRE_DFLASH_DRAFTER_DEVICE={dev}: failed to open Gpu: {e}",
+                        ));
+                    }
+                },
+                Err(e) => {
+                    return Err(format!(
+                        "HIPFIRE_DFLASH_DRAFTER_DEVICE={dev_str}: not a valid device id (parse error: {e})",
+                    ));
+                }
+            },
+            _ => None,
+        };
+
         // Optional DFlash draft: load the draft model's weights + a fresh set
         // of per-cycle scratch buffers (hidden ring, verify scratch, GdnTape,
         // DeltaNetSnapshot) sized for the target's max_seq. If the draft file
@@ -1431,6 +1486,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             conversation_tokens: Vec::new(),
             model_path: path.to_string(),
             dflash,
+            dflash_drafter_gpu,
         })
     } else {
         // Qwen3 / LLaMA — no eviction supported on this path (TriAttention needs
@@ -1458,6 +1514,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             conversation_tokens: Vec::new(),
             model_path: path.to_string(),
             dflash: None,
+            dflash_drafter_gpu: None,
         })
     }
 }
@@ -1586,6 +1643,7 @@ fn load_model_pp(
         conversation_tokens: Vec::new(),
         model_path: path.to_string(),
         dflash: None,
+        dflash_drafter_gpu: None,
     })
 }
 
@@ -1671,6 +1729,16 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     if let Some(df) = m.dflash {
         df.draft_weights.free_gpu(gpu);
         df.draft_scratch.free_gpu(gpu);
+    }
+    // PR2: drop the dedicated drafter Gpu instance if one was opened by
+    // HIPFIRE_DFLASH_DRAFTER_DEVICE. Drop releases the HIP device handle
+    // and any tensors still owned by the Gpu's pool. PR2 has no tensors
+    // on the drafter Gpu yet (drafter weights/scratch still on `gpu`
+    // until PR3), so this is essentially a handle close.
+    if let Some(_drafter_gpu) = m.dflash_drafter_gpu {
+        // Drop runs Gpu's destructor which frees pool + closes the
+        // device. No explicit free needed beyond letting it fall out of
+        // scope, but binding to a local makes the intent explicit.
     }
     // Free eviction context (centers + scratch tensors) if active.
     if let Some(ev) = m.eviction { ev.free_gpu(gpu); }

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1415,7 +1415,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // Preflight: device id must be in `[0, hip.device_count())`. The
         // HIP runtime returns a clear error if it's out of range, so we
         // surface that as a load failure rather than silently downgrading.
-        let dflash_drafter_gpu: Option<rdna_compute::Gpu> = match (
+        let mut dflash_drafter_gpu: Option<rdna_compute::Gpu> = match (
             draft_path,
             std::env::var("HIPFIRE_DFLASH_DRAFTER_DEVICE")
                 .ok()
@@ -1458,7 +1458,30 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             // `max_seq` so eviction's smaller buffer caps VRAM: a 128K-advertised
             // model with physical_cap=896 allocates an 896-slot ring, not 128K.
             // Without eviction, physical_cap == max_seq so the behavior matches.
-            match load_dflash_state(dp, physical_cap, &config, &dn, gpu) {
+            //
+            // PR3: when `dflash_drafter_gpu` is `Some`, drafter weights/scratch/
+            // hidden_rb allocate on that device instead of the target Gpu. Peer
+            // access between target and drafter must be enabled (we do that
+            // bidirectionally below if drafter device is set).
+            if let Some(d) = dflash_drafter_gpu.as_mut() {
+                let target_dev = gpu.device_id;
+                let drafter_dev = d.device_id;
+                // Bidirectional peer-access enable. Target context already
+                // current (we are inside load_model's body). Drafter side
+                // requires bind_thread before enabling peer access from there.
+                if target_dev != drafter_dev {
+                    if let Ok(true) = gpu.hip.can_access_peer(target_dev, drafter_dev) {
+                        let _ = gpu.hip.enable_peer_access(drafter_dev);
+                    }
+                    let _ = d.bind_thread();
+                    if let Ok(true) = d.hip.can_access_peer(drafter_dev, target_dev) {
+                        let _ = d.hip.enable_peer_access(target_dev);
+                    }
+                    // Restore target context for the rest of load_model.
+                    let _ = gpu.bind_thread();
+                }
+            }
+            match load_dflash_state(dp, physical_cap, &config, &dn, gpu, dflash_drafter_gpu.as_mut()) {
                 Ok(state) => {
                     eprintln!(
                         "  DFlash draft loaded: {} (layers={}, hidden={}, block={})",
@@ -1774,12 +1797,31 @@ fn load_dflash_state(
     target_config: &qwen35::Qwen35Config,
     target_dn: &DeltaNetState,
     gpu: &mut rdna_compute::Gpu,
+    drafter_gpu: Option<&mut rdna_compute::Gpu>,
 ) -> Result<DflashState, String> {
     let hfq = HfqFile::open(Path::new(draft_path)).map_err(|e| format!("open draft: {e}"))?;
     let draft_config = DflashConfig::from_hfq(&hfq).ok_or("parse DflashConfig")?;
-    let draft_weights = DflashWeights::load(gpu, &hfq, &draft_config).map_err(|e| format!("load weights: {e}"))?;
+
+    // PR3: when `drafter_gpu` is `Some`, drafter weights + scratch + hidden_rb
+    // live on the dedicated drafter device. The big buffers — `target_hidden`
+    // (l × ne × h × 4) and `mq_x_rot` (same size) — together comprise the
+    // bulk of DFlash scratch (~5 GB on 16K, ~10 GB on 32K). Routing them off
+    // the target Gpu is what makes 27B + DFlash fit on a single 24 GB card
+    // again — modulo peer-access overhead between cards on the verify path.
+    //
+    // `target_snap`, `gdn_tape`, and `verify_scratch` stay on the target Gpu:
+    // they are populated during the target's prefill forward (which runs on
+    // the target Gpu) and read during verify (also target Gpu). Drafter
+    // forward reads them via peer access when needed. This split mirrors the
+    // PRD's component map: drafter-private state on drafter Gpu, target-
+    // adjacent state on target Gpu, peer-access glue at the boundary.
+    let alloc_gpu: &mut rdna_compute::Gpu = match drafter_gpu {
+        Some(d) => d,
+        None => gpu,
+    };
+    let draft_weights = DflashWeights::load(alloc_gpu, &hfq, &draft_config).map_err(|e| format!("load weights: {e}"))?;
     let draft_scratch = DflashScratch::new_with_mq(
-        gpu, &draft_config, draft_config.block_size, ctx_capacity, draft_weights.has_mq,
+        alloc_gpu, &draft_config, draft_config.block_size, ctx_capacity, draft_weights.has_mq,
     ).map_err(|e| format!("draft scratch: {e}"))?;
 
     // Hidden ring: one row per target-layer selected by the draft config,
@@ -1787,7 +1829,7 @@ fn load_dflash_state(
     // one block fits without aliasing. Cheap (< 100 MB) next to the draft
     // weights themselves.
     let hidden_rb = HiddenStateRingBuffer::new(
-        gpu,
+        alloc_gpu,
         target_config.n_layers,
         draft_config.num_extract(),
         draft_config.hidden,

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1466,19 +1466,65 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             if let Some(d) = dflash_drafter_gpu.as_mut() {
                 let target_dev = gpu.device_id;
                 let drafter_dev = d.device_id;
-                // Bidirectional peer-access enable. Target context already
-                // current (we are inside load_model's body). Drafter side
-                // requires bind_thread before enabling peer access from there.
+                // Bidirectional peer-access enable.
+                //
+                // PR3 step 2 fix: `Gpu::init_with_device(drafter_dev)` left the
+                // calling thread bound to the DRAFTER device (it issued
+                // hipSetDevice + LAST_BOUND_DEVICE=drafter as part of init).
+                // The pre-step-2 PR2 code then called
+                // `gpu.hip.enable_peer_access(drafter_dev)` on the (silently
+                // mis-bound) thread, which enabled drafter→drafter peer access
+                // — a no-op or error swallowed by `let _ =`. Result: target →
+                // drafter peer writes (e.g. target's verify forward writing
+                // hidden_rb under hetero) faulted asynchronously and the GPU
+                // aborted at the next sync.
+                //
+                // Fix: explicitly `gpu.bind_thread()` before each direction to
+                // guarantee the calling-thread device matches the source side
+                // of `enable_peer_access`. Surface errors via `eprintln!`
+                // instead of swallowing — silent failure here corrupts step 2's
+                // entire correctness story.
                 if target_dev != drafter_dev {
-                    if let Ok(true) = gpu.hip.can_access_peer(target_dev, drafter_dev) {
-                        let _ = gpu.hip.enable_peer_access(drafter_dev);
+                    // Direction 1: target → drafter (kernels on target context
+                    // can read/write drafter VRAM by direct address).
+                    if let Err(e) = gpu.bind_thread() {
+                        eprintln!("  hetero peer-access: bind target failed: {e}");
                     }
-                    let _ = d.bind_thread();
-                    if let Ok(true) = d.hip.can_access_peer(drafter_dev, target_dev) {
-                        let _ = d.hip.enable_peer_access(target_dev);
+                    match gpu.hip.can_access_peer(target_dev, drafter_dev) {
+                        Ok(true) => {
+                            if let Err(e) = gpu.hip.enable_peer_access(drafter_dev) {
+                                eprintln!("  hetero peer-access target→drafter: {e}");
+                            } else {
+                                eprintln!("  hetero peer-access target({target_dev})→drafter({drafter_dev}): enabled");
+                            }
+                        }
+                        Ok(false) => eprintln!(
+                            "  hetero peer-access target({target_dev})→drafter({drafter_dev}): NOT supported by HIP runtime"
+                        ),
+                        Err(e) => eprintln!("  hetero peer-access can_access_peer t→d: {e}"),
+                    }
+                    // Direction 2: drafter → target (kernels on drafter context
+                    // can read/write target VRAM by direct address).
+                    if let Err(e) = d.bind_thread() {
+                        eprintln!("  hetero peer-access: bind drafter failed: {e}");
+                    }
+                    match d.hip.can_access_peer(drafter_dev, target_dev) {
+                        Ok(true) => {
+                            if let Err(e) = d.hip.enable_peer_access(target_dev) {
+                                eprintln!("  hetero peer-access drafter→target: {e}");
+                            } else {
+                                eprintln!("  hetero peer-access drafter({drafter_dev})→target({target_dev}): enabled");
+                            }
+                        }
+                        Ok(false) => eprintln!(
+                            "  hetero peer-access drafter({drafter_dev})→target({target_dev}): NOT supported by HIP runtime"
+                        ),
+                        Err(e) => eprintln!("  hetero peer-access can_access_peer d→t: {e}"),
                     }
                     // Restore target context for the rest of load_model.
-                    let _ = gpu.bind_thread();
+                    if let Err(e) = gpu.bind_thread() {
+                        eprintln!("  hetero peer-access: restore target failed: {e}");
+                    }
                 }
             }
             match load_dflash_state(dp, physical_cap, &config, &dn, gpu, dflash_drafter_gpu.as_mut()) {
@@ -1744,24 +1790,43 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
         let _ = gpu;
         return;
     }
-    // DFlash state: draft weights have free_gpu; ring / snapshot / tape /
-    // verify_scratch don't expose one — their GpuTensors / DeviceBuffers will
-    // leak until daemon exit if the caller cycles load/unload mid-session.
-    // Acceptable for the daemon since unload is rare and the weights are the
-    // bulk of the VRAM anyway.
+    // DFlash state. Under PR3 step 1 + 2 the split is:
+    //   - draft_weights, draft_scratch, hidden_rb live on the dedicated
+    //     drafter Gpu when `dflash_drafter_gpu` is `Some`. Free them via
+    //     that Gpu so its allocation pool actually shrinks.
+    //   - target_snap, gdn_tape, verify_scratch were allocated on `gpu`
+    //     (target). They still don't expose free_gpu — they leak until
+    //     daemon exit if the caller cycles load/unload mid-session, same
+    //     as before this PR.
+    //
+    // Single-card mode (drafter_gpu = None) preserves the prior behavior:
+    // weights + scratch + ring all freed on the target gpu.
     if let Some(df) = m.dflash {
-        df.draft_weights.free_gpu(gpu);
-        df.draft_scratch.free_gpu(gpu);
-    }
-    // PR2: drop the dedicated drafter Gpu instance if one was opened by
-    // HIPFIRE_DFLASH_DRAFTER_DEVICE. Drop releases the HIP device handle
-    // and any tensors still owned by the Gpu's pool. PR2 has no tensors
-    // on the drafter Gpu yet (drafter weights/scratch still on `gpu`
-    // until PR3), so this is essentially a handle close.
-    if let Some(_drafter_gpu) = m.dflash_drafter_gpu {
-        // Drop runs Gpu's destructor which frees pool + closes the
-        // device. No explicit free needed beyond letting it fall out of
-        // scope, but binding to a local makes the intent explicit.
+        if let Some(mut drafter_gpu) = m.dflash_drafter_gpu {
+            // Bind drafter for the per-tensor frees so the underlying
+            // hipFree calls reach the right device's allocator.
+            let _ = drafter_gpu.bind_thread();
+            df.draft_weights.free_gpu(&mut drafter_gpu);
+            df.draft_scratch.free_gpu(&mut drafter_gpu);
+            df.hidden_rb.free_gpu(&mut drafter_gpu);
+            drafter_gpu.invalidate_weight_caches();
+            drafter_gpu.invalidate_graph_state();
+            drafter_gpu.drain_pool();
+            // Restore the calling thread to target before subsequent target-
+            // side frees below run on the wrong device.
+            let _ = gpu.bind_thread();
+            // drafter_gpu falls out of scope here — Gpu::Drop closes the
+            // device handle and releases any remaining pooled allocations.
+        } else {
+            df.draft_weights.free_gpu(gpu);
+            df.draft_scratch.free_gpu(gpu);
+            df.hidden_rb.free_gpu(gpu);
+        }
+    } else if let Some(_drafter_gpu) = m.dflash_drafter_gpu {
+        // No dflash state but a drafter Gpu was opened — reachable only via
+        // load_dflash_state's early ddtree+hetero refusal, which fires BEFORE
+        // any drafter VRAM is allocated. Dropping the Gpu closes the device
+        // handle; nothing else needs to be freed.
     }
     // Free eviction context (centers + scratch tensors) if active.
     if let Some(ev) = m.eviction { ev.free_gpu(gpu); }
@@ -1799,6 +1864,34 @@ fn load_dflash_state(
     gpu: &mut rdna_compute::Gpu,
     drafter_gpu: Option<&mut rdna_compute::Gpu>,
 ) -> Result<DflashState, String> {
+    // Capture before we move `drafter_gpu` into the alloc_gpu match below.
+    // Used by the ddtree+hetero refusal check further down — we still need
+    // to know whether a dedicated drafter device was opened by load_model.
+    let drafter_pinned = drafter_gpu.is_some();
+
+    // PR3 step 2 refusal: ddtree + cross-card spec-decode is not yet wired
+    // up. spec_step_ddtree_batched / spec_step_ddtree_path_c still take a
+    // single `gpu: &mut Gpu` and run their drafter forwards through that
+    // context, which crashes when drafter weights/scratch live on a
+    // different device. Refuse cleanly at load — and BEFORE allocating any
+    // drafter VRAM — rather than letting it blow up at the first decode
+    // cycle. Plain chain-mode (`spec_step_dflash`) is the supported hetero
+    // path in step 2; ddtree hetero is a follow-on.
+    let ddtree_budget_raw = std::env::var("HIPFIRE_DDTREE_BUDGET")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0);
+    if ddtree_budget_raw > 0 && drafter_pinned {
+        return Err(
+            "ddtree + cross-card spec-decode not yet supported \
+             (HIPFIRE_DDTREE_BUDGET set together with HIPFIRE_DFLASH_DRAFTER_DEVICE). \
+             Unset one of them. Chain-mode DFlash with HIPFIRE_DFLASH_DRAFTER_DEVICE \
+             is the supported hetero path in PR3 step 2."
+                .to_string(),
+        );
+    }
+
     let hfq = HfqFile::open(Path::new(draft_path)).map_err(|e| format!("open draft: {e}"))?;
     let draft_config = DflashConfig::from_hfq(&hfq).ok_or("parse DflashConfig")?;
 
@@ -1819,6 +1912,14 @@ fn load_dflash_state(
         Some(d) => d,
         None => gpu,
     };
+    // PR3 step 2: hipMalloc in `alloc_gpu.alloc_tensor` and the upload helpers
+    // honor the CURRENTLY BOUND device, not `alloc_gpu.device_id`. With the
+    // step-1 peer-access setup ending bound to target, the draft allocations
+    // would land on target memory while DflashWeights / DflashScratch tracked
+    // them as drafter — silent device mismatch that survives only because
+    // peer access masks the cross-device pointers. Make the binding explicit
+    // here so the malloc target matches `alloc_gpu`.
+    alloc_gpu.bind_thread().map_err(|e| format!("bind alloc_gpu: {e}"))?;
     let draft_weights = DflashWeights::load(alloc_gpu, &hfq, &draft_config).map_err(|e| format!("load weights: {e}"))?;
     let draft_scratch = DflashScratch::new_with_mq(
         alloc_gpu, &draft_config, draft_config.block_size, ctx_capacity, draft_weights.has_mq,
@@ -1836,6 +1937,13 @@ fn load_dflash_state(
         ctx_capacity + draft_config.block_size,
         hipfire_arch_qwen35::qwen35::PREFILL_MAX_BATCH.max(draft_config.block_size),
     ).map_err(|e| format!("hidden_rb: {e}"))?;
+
+    // Switch back to target before allocating target-side state (target_snap,
+    // gdn_tape, verify_scratch). Same reason as the bind above: hipMalloc on
+    // the wrong device would land these on drafter memory.
+    if drafter_pinned {
+        gpu.bind_thread().map_err(|e| format!("bind target post draft alloc: {e}"))?;
+    }
 
     let target_snap = DeltaNetSnapshot::new_for(gpu, target_dn).map_err(|e| format!("target_snap: {e}"))?;
 
@@ -1878,6 +1986,8 @@ fn load_dflash_state(
             }
         },
     };
+    // (ddtree+hetero refusal already fired at the top of load_dflash_state,
+    // before any drafter VRAM was allocated.)
     let scratch_max_n = if ddtree_budget_env > 0 {
         std::cmp::max(draft_config.block_size, 1 + ddtree_budget_env)
     } else {
@@ -2060,6 +2170,13 @@ fn generate_dflash(
         for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
         for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
     }
+    // PR3 step 2: take the drafter Gpu out of LoadedModel for the
+    // duration of the decode loop. spec_step_dflash needs `Option<&mut Gpu>`
+    // for the drafter; taking ownership here avoids split-borrow conflicts
+    // with `m.dflash` and lets us re-borrow on every cycle via `.as_mut()`.
+    // We restore it back into `m.dflash_drafter_gpu` on every exit path
+    // below so subsequent requests see the same pinned device.
+    let mut drafter_gpu_owned: Option<rdna_compute::Gpu> = m.dflash_drafter_gpu.take();
     let df = m.dflash.as_mut().unwrap();
     df.target_hidden_host.clear();
     df.draft_scratch.reset_upload_tracking();
@@ -2082,6 +2199,7 @@ fn generate_dflash(
             let _ = stdout.flush();
             m.q35_weights = Some(weights); m.kv_cache = Some(kv_cache);
             m.dn_state = Some(dn_state); m.q35_scratch = Some(scratch);
+            m.dflash_drafter_gpu = drafter_gpu_owned;
             return;
         }
     };
@@ -2118,6 +2236,7 @@ fn generate_dflash(
         m.kv_cache = Some(target.kv_cache);
         m.dn_state = Some(target.dn_state);
         m.q35_scratch = Some(target.scratch);
+        m.dflash_drafter_gpu = drafter_gpu_owned;
         return;
     }
     if m.eviction.is_none() && prompt_tokens.len() + max_tokens + df.block_size > ctx_capacity {
@@ -2131,6 +2250,7 @@ fn generate_dflash(
         m.kv_cache = Some(target.kv_cache);
         m.dn_state = Some(target.dn_state);
         m.q35_scratch = Some(target.scratch);
+        m.dflash_drafter_gpu = drafter_gpu_owned;
         return;
     }
 
@@ -2147,6 +2267,7 @@ fn generate_dflash(
         m.kv_cache = Some(target.kv_cache);
         m.dn_state = Some(target.dn_state);
         m.q35_scratch = Some(target.scratch);
+        m.dflash_drafter_gpu = drafter_gpu_owned;
         return;
     }
     // Prime the draft's GPU target_hidden buffer from the prompt rows so the
@@ -2173,6 +2294,7 @@ fn generate_dflash(
             m.kv_cache = Some(target.kv_cache);
             m.dn_state = Some(target.dn_state);
             m.q35_scratch = Some(target.scratch);
+            m.dflash_drafter_gpu = drafter_gpu_owned;
             return;
         }
     };
@@ -2310,7 +2432,9 @@ fn generate_dflash(
             }
         } else {
             spec_step_dflash(
-                gpu, &mut target, &df.draft_weights, &df.draft_config,
+                gpu,
+                drafter_gpu_owned.as_mut(),
+                &mut target, &df.draft_weights, &df.draft_config,
                 &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
                 &mut df.target_snap, &df.verify_scratch,
                 position, seed_token,
@@ -2404,6 +2528,14 @@ fn generate_dflash(
         if hit_eos || think_cap_hit { break; }
     }
 
+    // PR3 step 2: defensively re-bind target before handing control back
+    // to the daemon's outer loop. spec_step_dflash flips the thread to
+    // drafter for §2-§4 and back; on a successful cycle it ends bound to
+    // target, but if an inner kernel errored via `?` the bind could be
+    // left on drafter. The daemon's next request expects target bound, so
+    // force the cache back to target here. No-op in single-card mode.
+    let _ = gpu.bind_thread();
+
     // Put target state back on LoadedModel so the next request sees fresh
     // (reset) state. We zero DN/kv on entry anyway, but we still need the
     // ownership back.
@@ -2411,6 +2543,9 @@ fn generate_dflash(
     m.kv_cache = Some(target.kv_cache);
     m.dn_state = Some(target.dn_state);
     m.q35_scratch = Some(target.scratch);
+    // Restore the dedicated drafter Gpu (was taken at the top of generate_dflash
+    // for borrow-disjoint access during the decode loop).
+    m.dflash_drafter_gpu = drafter_gpu_owned;
     m.seq_pos = position;
     m.conversation_tokens = emitted.clone();
 

--- a/crates/hipfire-runtime/examples/dflash_spec_demo.rs
+++ b/crates/hipfire-runtime/examples/dflash_spec_demo.rs
@@ -1147,6 +1147,7 @@ fn main() {
                 };
                 speculative::spec_step_ddtree_path_c(
                     &mut gpu,
+                    None,                       // single-card example: no drafter_gpu
                     &mut target,
                     &draft_weights,
                     &draft_cfg,
@@ -1167,6 +1168,7 @@ fn main() {
             } else if ddtree_batched {
                 speculative::spec_step_ddtree_batched(
                     &mut gpu,
+                    None,                       // single-card example: no drafter_gpu
                     &mut target,
                     &draft_weights,
                     &draft_cfg,

--- a/crates/hipfire-runtime/examples/dflash_spec_demo.rs
+++ b/crates/hipfire-runtime/examples/dflash_spec_demo.rs
@@ -1209,6 +1209,7 @@ fn main() {
         } else {
             speculative::spec_step_dflash(
                 &mut gpu,
+                None,                  // drafter_gpu — demo is single-card only
                 &mut target,
                 &draft_weights,
                 &draft_cfg,

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -651,11 +651,21 @@ fn upload_slice_i32(gpu: &Gpu, dst: &GpuTensor, data: &[i32]) -> HipResult<()> {
 /// Run one draft forward over `block_size` positions with `ctx_len` cached
 /// context rows.
 ///
+/// `gpu` is the **drafter** device — the Gpu instance that owns
+/// `weights` and `scratch`. The caller MUST have already bound this device
+/// on the calling thread (`gpu.bind_thread()`); every kernel launched here
+/// goes through this Gpu's HIP context and module cache. Under hetero
+/// PFlash+DFlash (PR3 step 2) this is the dedicated drafter device when
+/// `HIPFIRE_DFLASH_DRAFTER_DEVICE=N` is set, else it's the target's Gpu
+/// (single-card mode is byte-identical to the pre-PR3 behavior).
+///
 /// `noise_embedding`: if `Some`, uploaded into `scratch.x` before the forward.
 ///     If `None`, the caller must have already filled `scratch.x` with B × hidden
 ///     F32 embeddings — this avoids the target→host→draft round-trip in the
-///     spec-decode hot loop (both target and draft share the same GPU, so
-///     D2D copies into `scratch.x` suffice).
+///     spec-decode hot loop. In single-card mode the embedding lookup writes
+///     directly via D2D from target weights into drafter scratch; in hetero
+///     mode it crosses the peer-access boundary (memory still ends up in
+///     `scratch.x` on the drafter Gpu).
 /// `target_hidden`: if `Some`, uploaded into `scratch.target_hidden`.
 ///     If `None`, the caller must have already filled `scratch.target_hidden`
 ///     with `ctx_len × num_extract × hidden` F32 rows.

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -15220,6 +15220,21 @@ impl Gpu {
         self.ensure_kernel("attention_dflash_f32", kernels::ATTENTION_DFLASH_SRC, "attention_dflash_f32")?;
         let func = &self.functions["attention_dflash_f32"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
+        // Tiled online-softmax (FlashAttention-style). LDS layout:
+        //   tile_scores[tile_size] + ws[block_size] + out_run[head_dim]
+        //
+        // tile_size is chosen to keep LDS ≤ 56 KB (8 KB margin under gfx1100's
+        // 64 KB hard limit for kernel launch overhead). Single-tile case
+        // (l ≤ tile_size) is mathematically equivalent to the prior
+        // single-pass softmax up to FP order; multi-tile carries (max, sum,
+        // out) running state across tiles. Replaces the prior `scores[L]`
+        // allocation that overflowed LDS at l > ~16128.
+        let block_size = std::cmp::min(256, std::cmp::max(l, head_dim)) as u32;
+        let block_size = block_size.next_power_of_two();
+        const LDS_BUDGET_F32: usize = 14_336; // 56 KB / 4 bytes
+        let fixed = block_size as usize + head_dim;
+        let max_tile_room = LDS_BUDGET_F32.saturating_sub(fixed);
+        let tile_size = std::cmp::min(l.max(1), max_tile_room.max(1));
         let mut qp = q.buf.as_ptr();
         let mut kp = k.buf.as_ptr();
         let mut vp = v.buf.as_ptr();
@@ -15230,6 +15245,7 @@ impl Gpu {
         let mut nkv = n_kv_heads as i32;
         let mut hd = head_dim as i32;
         let mut sc = scale;
+        let mut ts = tile_size as i32;
         let mut params: Vec<*mut c_void> = vec![
             &mut qp as *mut _ as *mut c_void,
             &mut kp as *mut _ as *mut c_void,
@@ -15241,11 +15257,9 @@ impl Gpu {
             &mut nkv as *mut _ as *mut c_void,
             &mut hd as *mut _ as *mut c_void,
             &mut sc as *mut _ as *mut c_void,
+            &mut ts as *mut _ as *mut c_void,
         ];
-        let block_size = std::cmp::min(256, std::cmp::max(l, head_dim)) as u32;
-        let block_size = block_size.next_power_of_two();
-        // Shared: scores[L] + workspace[block_size]
-        let shared_mem = ((l + block_size as usize) * 4) as u32;
+        let shared_mem = ((tile_size + block_size as usize + head_dim) * 4) as u32;
         unsafe {
             self.hip.launch_kernel(
                 func,

--- a/kernels/src/attention_dflash.hip
+++ b/kernels/src/attention_dflash.hip
@@ -3,8 +3,7 @@
 // Each query position attends to ALL key/value positions (non-causal,
 // bidirectional). Supports GQA where n_heads > n_kv_heads. Q/K/V are
 // separate buffers — K can be longer than Q. Grid: [n_heads, B, 1],
-// one block per (head, query-position). Block size is chosen to cover
-// max(L, head_dim). Shared mem: L scores + block_size workspace.
+// one block per (head, query-position).
 //
 // Layout (row-major, flat):
 //   q    : [B  * n_heads    * head_dim]
@@ -13,6 +12,16 @@
 //   out  : [B  * n_heads    * head_dim]
 //
 // rep = n_heads / n_kv_heads (must divide evenly).
+//
+// PR3 step 2 follow-up: this is a tiled online-softmax (FlashAttention-style)
+// implementation. Replaces the prior single-pass `scores[L]` allocation that
+// overflowed gfx1100/RDNA3's 64 KB LDS budget at L > ~16128. With tiling,
+// LDS = (tile_size + block_size + head_dim) * 4 bytes — independent of L.
+// Single-tile case (tile_size = L when L ≤ tile_size) is mathematically
+// equivalent to the prior kernel up to FP non-associativity in the same
+// reduce trees. Multi-tile case carries a running (max, sum, output)
+// triplet across tiles, mathematically identical to single-pass softmax
+// modulo FP order.
 
 #include <hip/hip_runtime.h>
 
@@ -22,7 +31,8 @@ extern "C" __global__ void attention_dflash_f32(
     const float* __restrict__ v,
     float* __restrict__ out,
     int B, int L, int n_heads, int n_kv_heads, int head_dim,
-    float scale
+    float scale,
+    int tile_size
 ) {
     extern __shared__ float sdata[];
     int head = blockIdx.x;
@@ -36,68 +46,103 @@ extern "C" __global__ void attention_dflash_f32(
     int q_stride = n_heads * head_dim;
     int kv_stride = n_kv_heads * head_dim;
 
-    float* scores = sdata;               // [L]
-    float* ws = sdata + L;               // [blockDim.x]
+    // LDS layout: [tile_scores[tile_size]] [ws[nthreads]] [out_run[head_dim]]
+    float* tile_scores = sdata;                                // [tile_size]
+    float* ws          = sdata + tile_size;                    // [nthreads]
+    float* out_run     = sdata + tile_size + nthreads;         // [head_dim]
 
     const float* q_ptr = q + qi * q_stride + head * head_dim;
 
-    // Phase 1: scores[j] = dot(Q[qi,head], K[j,kv_head]) * scale, tracking max.
-    float local_max = -1e30f;
-    for (int j = tid; j < L; j += nthreads) {
-        const float* k_ptr = k + j * kv_stride + kv_head * head_dim;
-        float dot = 0.0f;
-        for (int d = 0; d < head_dim; ++d) {
-            dot += q_ptr[d] * k_ptr[d];
-        }
-        float s = dot * scale;
-        scores[j] = s;
-        if (s > local_max) local_max = s;
-    }
-
-    // Block-wide max reduce.
-    ws[tid] = local_max;
-    __syncthreads();
-    for (int s = nthreads / 2; s > 0; s >>= 1) {
-        if (tid < s) {
-            float a = ws[tid];
-            float b = ws[tid + s];
-            ws[tid] = a > b ? a : b;
-        }
-        __syncthreads();
-    }
-    float max_val = ws[0];
-    __syncthreads();
-
-    // Phase 2: exp(score - max), tracking sum.
-    float local_sum = 0.0f;
-    for (int j = tid; j < L; j += nthreads) {
-        float e = expf(scores[j] - max_val);
-        scores[j] = e;
-        local_sum += e;
-    }
-    ws[tid] = local_sum;
-    __syncthreads();
-    for (int s = nthreads / 2; s > 0; s >>= 1) {
-        if (tid < s) ws[tid] += ws[tid + s];
-        __syncthreads();
-    }
-    float sum_val = ws[0];
-    __syncthreads();
-
-    // Normalize.
-    float inv_sum = 1.0f / sum_val;
-    for (int j = tid; j < L; j += nthreads) {
-        scores[j] *= inv_sum;
-    }
-    __syncthreads();
-
-    // Phase 3: out[qi, head, :] = sum_j scores[j] * V[j, kv_head, :]
-    float* out_ptr = out + qi * q_stride + head * head_dim;
+    // Initialize running output to 0.
     for (int d = tid; d < head_dim; d += nthreads) {
-        float val = 0.0f;
-        for (int j = 0; j < L; ++j) {
-            val += scores[j] * v[j * kv_stride + kv_head * head_dim + d];
+        out_run[d] = 0.0f;
+    }
+    __syncthreads();
+
+    // Online-softmax running state.
+    float m_run = -1e30f;  // running max of all scores seen so far
+    float l_run = 0.0f;    // running sum of exp(scores - m_run)
+
+    int n_tiles = (L + tile_size - 1) / tile_size;
+    for (int t = 0; t < n_tiles; ++t) {
+        int tile_start = t * tile_size;
+        int tile_len = L - tile_start;
+        if (tile_len > tile_size) tile_len = tile_size;
+
+        // Phase A: compute scores for this tile, track tile-local max.
+        float local_max = -1e30f;
+        for (int j = tid; j < tile_len; j += nthreads) {
+            int abs_j = tile_start + j;
+            const float* k_ptr = k + abs_j * kv_stride + kv_head * head_dim;
+            float dot = 0.0f;
+            for (int d = 0; d < head_dim; ++d) {
+                dot += q_ptr[d] * k_ptr[d];
+            }
+            float s = dot * scale;
+            tile_scores[j] = s;
+            if (s > local_max) local_max = s;
         }
-        out_ptr[d] = val;
+        ws[tid] = local_max;
+        __syncthreads();
+        for (int s = nthreads / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                float a = ws[tid];
+                float b = ws[tid + s];
+                ws[tid] = a > b ? a : b;
+            }
+            __syncthreads();
+        }
+        float tile_max = ws[0];
+        __syncthreads();
+
+        // Phase B: rescale running state to the new global max.
+        //   m_new   = max(m_run, tile_max)
+        //   alpha   = exp(m_run - m_new)             (= 1 if m_run won, < 1 otherwise)
+        //   l_new   = alpha * l_run + sum_j exp(score_j - m_new)
+        //   out_new = alpha * out_run + sum_j exp(score_j - m_new) * V[j]
+        // First tile (m_run = -inf): alpha = exp(-inf - finite) = 0, so the
+        // running state correctly reduces to fresh-tile contribution.
+        float m_new = m_run > tile_max ? m_run : tile_max;
+        float alpha = expf(m_run - m_new);
+
+        // Convert tile_scores in place to exp(score - m_new), summing.
+        float local_sum = 0.0f;
+        for (int j = tid; j < tile_len; j += nthreads) {
+            float e = expf(tile_scores[j] - m_new);
+            tile_scores[j] = e;
+            local_sum += e;
+        }
+        ws[tid] = local_sum;
+        __syncthreads();
+        for (int s = nthreads / 2; s > 0; s >>= 1) {
+            if (tid < s) ws[tid] += ws[tid + s];
+            __syncthreads();
+        }
+        float tile_sum = ws[0];
+        __syncthreads();
+
+        // Update running denominator.
+        l_run = alpha * l_run + tile_sum;
+
+        // Update running output: each thread updates the head_dim slots it owns.
+        for (int d = tid; d < head_dim; d += nthreads) {
+            float scaled_old = alpha * out_run[d];
+            float contrib = 0.0f;
+            for (int j = 0; j < tile_len; ++j) {
+                int abs_j = tile_start + j;
+                contrib += tile_scores[j] * v[abs_j * kv_stride + kv_head * head_dim + d];
+            }
+            out_run[d] = scaled_old + contrib;
+        }
+        __syncthreads();
+
+        m_run = m_new;
+    }
+
+    // Finalize: out = out_run / l_run.
+    float* out_ptr = out + qi * q_stride + head * head_dim;
+    float inv_l = 1.0f / l_run;
+    for (int d = tid; d < head_dim; d += nthreads) {
+        out_ptr[d] = out_run[d] * inv_l;
     }
 }

--- a/kernels/src/attention_dflash.hip
+++ b/kernels/src/attention_dflash.hip
@@ -124,15 +124,52 @@ extern "C" __global__ void attention_dflash_f32(
         // Update running denominator.
         l_run = alpha * l_run + tile_sum;
 
-        // Update running output: each thread updates the head_dim slots it owns.
-        for (int d = tid; d < head_dim; d += nthreads) {
-            float scaled_old = alpha * out_run[d];
-            float contrib = 0.0f;
-            for (int j = 0; j < tile_len; ++j) {
+        // Phase C: V accumulation. Earlier revision used `for d = tid;
+        // d < head_dim; d += nthreads`, which left half the workgroup idle
+        // when nthreads > head_dim (the typical case: nthreads=256,
+        // head_dim=128). Now split the j-range across `nthreads /
+        // head_dim` partitions so all 256 threads do useful work.
+        //
+        // Thread `tid` owns:
+        //   d_local = tid % head_dim
+        //   j_part  = tid / head_dim          (0 .. j_parts-1)
+        // and accumulates the slice [j_part * span, (j_part+1) * span) of
+        // the j-loop. We reduce per-d partials through ws[] and then a
+        // single thread per d updates out_run[d].
+        //
+        // When nthreads ≤ head_dim the original 1-partition path is exactly
+        // recovered (j_parts=1, span=tile_len, every active thread does
+        // the full loop). The reduction step also degrades cleanly: with
+        // j_parts=1 there is no inter-partition combine, just a single
+        // scaled_old + ws[tid] write.
+        int j_parts = nthreads / head_dim;
+        if (j_parts < 1) j_parts = 1;
+        int d_local = tid % head_dim;
+        int j_part  = tid / head_dim;
+        int span    = (tile_len + j_parts - 1) / j_parts;
+        int j_start = j_part * span;
+        int j_end   = j_start + span;
+        if (j_end > tile_len) j_end = tile_len;
+        // Idle lanes: tid where j_part * head_dim ≥ nthreads (impossible
+        // here) or where j_start ≥ tile_len (small tile_len). Their partial
+        // is 0 and contributes nothing to the reduction.
+        float partial = 0.0f;
+        if (j_part < j_parts && j_start < tile_len) {
+            for (int j = j_start; j < j_end; ++j) {
                 int abs_j = tile_start + j;
-                contrib += tile_scores[j] * v[abs_j * kv_stride + kv_head * head_dim + d];
+                partial += tile_scores[j] * v[abs_j * kv_stride + kv_head * head_dim + d_local];
             }
-            out_run[d] = scaled_old + contrib;
+        }
+        ws[tid] = partial;
+        __syncthreads();
+        // One thread per d_local sums across j_parts and writes out_run.
+        if (tid < head_dim) {
+            float scaled_old = alpha * out_run[tid];
+            float sum_partials = 0.0f;
+            for (int p = 0; p < j_parts; ++p) {
+                sum_partials += ws[tid + p * head_dim];
+            }
+            out_run[tid] = scaled_old + sum_partials;
         }
         __syncthreads();
 


### PR DESCRIPTION
## Status: closing this draft

Closing without merge after a follow-up perf investigation that turned up a structurally better lever (native MTP) and one optimization worth carving out as a smaller, narrower PR.

## What landed on this branch through PR3 step 2 (already covered in earlier comment)

- `041436b` PR2 drafter device pinning
- `41fa1e2` PR3 step 1 — DFlash allocations routed to `drafter_gpu`
- `1083d48` tiled online-softmax for `attention_dflash_f32` (LDS-overflow fix at L ≥ 16128)
- `c098323` PR3 step 2 — `bind_thread` routing for cross-card spec-decode

Functional milestone (correctness): 27B + DFlash on a single 24 GB consumer card at 16K canonical, coherent prose at τ=1.78, 11.4 tok/s decode.

## What I tried on top after that comment, and what came of it

| Commit | Result |
|---|---|
| `b80e85b` perf(kernel): full-workgroup V-accumulation in `attention_dflash_f32` Phase C | ✅ Clean +33% on `attn_kernel` time at 16K hetero. No τ regression. Worth keeping. |
| ~~`6ba16a2` `HIPFIRE_DFLASH_ATTN_WINDOW` — drafter-side sliding window~~ | ❌ **Reverted via rebase.** Cut drafter context to last W positions, which knocked τ from 1.74 → 1.45. The cycle-wall reduction looked like a tok/s win in isolation but per-token throughput went **below AR-only baseline** (30 ms/token vs AR 25.6). Net negative once you account for the τ loss. Wrong lever. |
| `62890e0` PR3 step 4 — DDTree + cross-card hetero spec-decode | Structural plumbing: drafter_gpu routing through `spec_step_ddtree_batched` / `spec_step_ddtree_path_c`, removes the load-time refusal block. DDTree+hetero now runs cleanly. **Doesn't itself unlock a throughput win** at 16K — peaks at ~25 tok/s on Wikipedia prose, still below AR. |

## The honest perf picture at the same 16K canonical (qwen3.6-27b.mq4, prompt md5 `d21eb…`)

| Setup | decode tok/s | τ | per-token |
|---|---|---|---|
| hipfire AR-only (single card) | **39.0** | n/a | 25.6 ms |
| hipfire DFlash hetero, this branch's best (W=2048, no DDTree) | 20.2 | 1.48 | 49 ms |
| hipfire DFlash hetero, this branch's best (W=96 + DDTree path_c B=4) | 33.0 | 1.45 | 30 ms |
| llama.cpp + Qwen3.6 native MTP, `--spec-draft-n-max=8` | **45.4** | 3.5 | 22 ms |

**Native MTP is the lever the user wants** at 16K Wikipedia prose: it's the only configuration here that actually beats AR (+16%), and it's been right there all along in the source weights as `mtp.*` tensors that the hipfire quantizer currently strips.

I also tried `feat/sliding-window-fa` locally as an alternative (#78 — Lucebox PR #26 port). At 16K, target-side window doesn't deliver the 3.48× the Lucebox bench claims at 60K — got ~37 tok/s at W=512, comparable to plain AR. The Lucebox win materializes when target FA itself is the dominant cost, which kicks in at very long context (60K+), not at 16K.

## Why I'm closing rather than asking for review

The hetero DFlash direction in this branch is a correctness milestone (27B at 16K on a single 24 GB card, no OOM, coherent output) but it doesn't translate to a throughput win against AR on this workload. The structural answer (native MTP integration) is a different code-path discussion than this PR is scoped for, and `b80e85b` deserves to land independently of all the hetero plumbing — it's a kernel improvement that benefits any DFlash setup on gfx1100 once the tiled `attention_dflash_f32` (`1083d48`) is in.

Carving the kernel work out to a narrow PR.

## Reproducibility

All numbers above are 3-run means on the canonical Wikipedia 16K prompt (md5 `d21ebdd2e3204c1788a7f2681d60c38a`), Qwen3.6-27B mq4 + qwen36-27b-dflash-mq4 drafter on 2× RX 7900 XTX (gfx1100), MAX_TOK=128. llama.cpp built from this fork's HIP target with `--spec-type mtp --spec-draft-n-max 8`.