### PR TITLE
fix(agentic-gate): VRAM-headroom skip for undersized hosts

### DIFF
--- a/scripts/agentic-gate.sh
+++ b/scripts/agentic-gate.sh
@@ -37,9 +37,14 @@
 #   2 - build / env / detector-self-check failure
 #
 # Skip semantics (CI-safe):
-#   - Both A3B models absent      -> exit 0 with SKIPPED message
-#   - One model absent            -> run the present one's cells, log skip
-#   - HIPFIRE_SKIP_AGENTIC_GATE=1 -> exit 0 immediately
+#   - Both A3B models absent           -> exit 0 with SKIPPED message
+#   - One model absent                 -> run the present one's cells, log skip
+#   - Model exceeds host VRAM          -> treat as absent (path-blank); skips
+#                                         silently otherwise → zero-token hard-fail
+#   - HIPFIRE_SKIP_AGENTIC_GATE=1      -> exit 0 immediately
+#   - HIPFIRE_AGENTIC_GATE_NO_VRAM_CHECK=1 -> bypass VRAM-headroom skip
+#                                            (e.g., registry minimums too conservative
+#                                            for your host)
 #
 # Report destination: /tmp/agentic-gate-<timestamp>.md (or $HIPFIRE_AGENTIC_GATE_OUT)
 
@@ -156,9 +161,84 @@ PI_SYS="benchmarks/prompts/agentic_pi_system.txt"
 HERMES_SYS="benchmarks/prompts/agentic_hermes_system.txt"
 USER_READ="benchmarks/prompts/agentic_user_read.txt"
 
-# Skip-on-absence: both models missing -> exit 0
+# ---- VRAM headroom check ---------------------------------------------------
+# Models declare min_vram_gb in cli/registry.json. If the host can't meet
+# that minimum, the model loads but silently OOMs during prefill and emits
+# zero tokens (looks like a tool-call regression — it isn't). Treat such
+# models as absent so the existing skip path covers this case too.
+#
+# Threshold semantics: min_vram_gb is interpreted as a strict floor expressed
+# in GiB (1024^3). Daemon overhead (KV cache, graph capture, scratch) is
+# assumed pre-included in the registry value — A3B-35B is an 18.7 GB blob
+# but declares min_vram_gb=22, i.e. ~3.3 GiB margin. We do NOT add a
+# secondary +1 GB headroom because (a) it'd compound, and (b) the registry
+# is the single source of truth for "needs N GiB". Comparison is in bytes
+# to avoid GiB-truncation false-positives on cards that report slightly
+# under their advertised size (e.g. a 24 GB card reading 23.98 GiB).
+#
+# Disable with HIPFIRE_AGENTIC_GATE_NO_VRAM_CHECK=1 (e.g., on hosts where
+# the registry minimums are conservative).
+REGISTRY="cli/registry.json"
+# Multi-card systems take the max VRAM across all DRM cards. iGPUs report
+# zero / a sliver, so max correctly picks the dGPU. On dual-dGPU hosts this
+# is optimistic — we don't know which card the daemon will use.
+VRAM_BYTES=0
+for f in /sys/class/drm/card*/device/mem_info_vram_total; do
+    [ -r "$f" ] || continue
+    v="$(cat "$f" 2>/dev/null)" || continue
+    [ "$v" -gt "$VRAM_BYTES" ] && VRAM_BYTES="$v"
+done
+VRAM_GB=$(( VRAM_BYTES / 1073741824 ))
+if [ "$VRAM_BYTES" -eq 0 ] && [ "${HIPFIRE_AGENTIC_GATE_NO_VRAM_CHECK:-0}" != "1" ]; then
+    echo "agentic-gate: VRAM detection unavailable (no /sys/class/drm/card*/device/mem_info_vram_total) - skipping VRAM check"
+fi
+
+model_fits_vram() {
+    local model_path="$1"
+    [ "${HIPFIRE_AGENTIC_GATE_NO_VRAM_CHECK:-0}" = "1" ] && return 0
+    [ -f "$REGISTRY" ] || return 0
+    [ "$VRAM_BYTES" -gt 0 ] || return 0
+    # python3 is a hard script-wide dep (self-check + JSONL builder). No guard.
+
+    local fname min_gb min_bytes
+    fname="$(basename "$model_path")"
+    min_gb="$(python3 -c '
+import json, sys
+fname = sys.argv[1]
+with open(sys.argv[2]) as fh:
+    data = json.load(fh)
+for entry in data.get("models", {}).values():
+    if isinstance(entry, dict) and entry.get("file") == fname:
+        v = entry.get("min_vram_gb")
+        if v is not None:
+            print(v)
+        break
+' "$fname" "$REGISTRY" 2>/dev/null)"
+    [ -n "$min_gb" ] || return 0
+
+    min_bytes=$(( min_gb * 1073741824 ))
+    if [ "$VRAM_BYTES" -lt "$min_bytes" ]; then
+        echo "agentic-gate: $fname needs ${min_gb} GB VRAM, host has ${VRAM_GB} GB - skipping cell"
+        return 1
+    fi
+    return 0
+}
+
+# Path-blank when over budget so the existing `[ -f "$A3B_..." ]` checks
+# downstream naturally treat these models as absent (`[ -f "" ]` is false).
+A3B_35_VRAM_SKIP=0
+A3B_36_VRAM_SKIP=0
+if [ -f "$A3B_35" ] && ! model_fits_vram "$A3B_35"; then A3B_35=""; A3B_35_VRAM_SKIP=1; fi
+if [ -f "$A3B_36" ] && ! model_fits_vram "$A3B_36"; then A3B_36=""; A3B_36_VRAM_SKIP=1; fi
+
+# Skip-on-absence: both models missing -> exit 0. Distinguish absent-on-disk
+# from skipped-for-VRAM so the operator can tell which case fired.
 if [ ! -f "$A3B_35" ] && [ ! -f "$A3B_36" ]; then
-    echo "agentic-gate: A3B models absent ($A3B_35, $A3B_36) - SKIPPED"
+    if [ "$A3B_35_VRAM_SKIP" = "1" ] || [ "$A3B_36_VRAM_SKIP" = "1" ]; then
+        echo "agentic-gate: all A3B models absent or exceed host VRAM (${VRAM_GB} GB) - SKIPPED"
+    else
+        echo "agentic-gate: A3B models absent ($MODELS_DIR/qwen3.{5,6}-35b-a3b.mq4) - SKIPPED"
+    fi
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Adds a registry-driven VRAM-headroom check to `scripts/agentic-gate.sh`. Models whose `min_vram_gb` exceeds the host's reported VRAM are path-blanked so the existing skip-on-absence path covers them — no more zero-token HARD_FAIL on undersized hosts blocking pure-docs commits via the pre-commit hook.
- VRAM read from `/sys/class/drm/card*/device/mem_info_vram_total` (kernel-canonical, no extra deps); registry lookup via inline `python3` (already a hard dep of this script).
- Comparison runs in **bytes** rather than truncated GiB, so a 24 GB card reading 23.98 GiB doesn't false-positive against a `min_vram_gb=24` model.

## Threshold semantics (decision recorded in code comment)

`min_vram_gb` is treated as a strict floor expressed in GiB ($1024^3$). Daemon overhead is assumed pre-included in the registry value — A3B-35B is an 18.7 GB blob declaring `min_vram_gb=22`, so ~3.3 GiB of margin is already baked in. We do **not** add a secondary +1 GB headroom because (a) it'd compound, and (b) the registry should be the single source of truth.

## Escape hatches

- `HIPFIRE_AGENTIC_GATE_NO_VRAM_CHECK=1` — bypass entirely (hosts where the registry minimums are too conservative).
- Non-AMD / non-Linux hosts (no DRM sysfs nodes): one-line diagnostic + fall through (no false-skip).

## Deviations from the issue's proposed patch

- **`python3` instead of `jq`.** The proposed patch's `jq` path soft-falls-through on hosts without `jq` installed — including the issue reporter's own host. `python3` is already a hard dep of `agentic-gate.sh` (used by `--self-check` and the JSONL builder), so no new dep, and the fix actually engages on the discovery box.
- **`rocminfo` evaluated and rejected.** rocminfo's per-agent pool tree is fiddly to walk in awk for marginal accuracy gain over sysfs, which gives the same byte count straight from the kernel.
- **Distinguished absent-on-disk vs VRAM-skip in the final SKIPPED message.** Operators can tell which case fired without re-running.

## Test plan

- [x] `bash -n scripts/agentic-gate.sh` — clean syntax
- [x] **VRAM-skip path:** 7900 XT (~19 GiB) with qwen3.6-35b-a3b.mq4 present and `min_vram_gb=22` → emits per-model skip message + `all A3B models absent or exceed host VRAM (19 GB) - SKIPPED`, exit 0
- [x] **Absent path:** both A3B models missing → unchanged wording showing actual paths, exit 0
- [x] **Escape hatch:** `HIPFIRE_AGENTIC_GATE_NO_VRAM_CHECK=1` → gate proceeds past skip on undersized host
- [ ] **Fits path:** would need a host with ≥22 GiB; unverified in this PR
- [ ] **No-sysfs path:** needs a non-AMD-Linux host; unverified, but the diagnostic line code path is trivial

## Followups (separate issues, per #198)

- Daemon should surface a clean error on alloc failure rather than returning zero tokens. The gate fix is a workaround; the engine bug deserves its own issue.
- `qwen3.5:35b-a3b` HF publication or clearer LOCAL-ONLY signaling.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)