### PR TITLE
fix(qwen35): symmetric MQ3-in-MoE refusal across prefill paths (#179)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1818,20 +1818,25 @@ fn ffn_all_mq4_for_moe(ffn: &MoeFfnWeights) -> bool {
         && ffn.experts.iter().all(|e| e.gate_up.gpu_dtype == DType::MQ4G256)
 }
 
-/// Detect any MQ3G256 weight inside a MoE FFN block (router, shared expert
-/// gate/up/down, shared_expert_gate router-mix scalar, or any routed
-/// expert's gate_up/down). The MoE batched FFN kernels assume HFQ4-layout
-/// (136 B/group); an MQ3 weight (104 B/group) would dispatch with the wrong
-/// stride. Used by the captured-prefill defense-in-depth check.
+/// Detect any MQ3G256 / MQ3G256Lloyd weight inside a MoE FFN block (router,
+/// shared expert gate/up/down, shared_expert_gate router-mix scalar, or any
+/// routed expert's gate_up/down). The MoE batched FFN kernels assume HFQ4
+/// layout (136 B/group); an MQ3 weight (104 B/group) or Lloyd-MQ3 weight
+/// (112 B/group) would dispatch with the wrong stride. Used by the
+/// captured-prefill and non-captured-prefill defense-in-depth checks.
+///
+/// Mirrors `is_mq3_any` in `forward_prefill_batch_single_chunk_captured`
+/// (line 3325) so both cross-checks treat plain and Lloyd-MQ3 identically.
 fn moe_ffn_has_mq3(ffn: &MoeFfnWeights) -> bool {
-    ffn.router.gpu_dtype == DType::MQ3G256
-        || ffn.shared_expert_gate.gpu_dtype == DType::MQ3G256
-        || ffn.shared_expert.gate.gpu_dtype == DType::MQ3G256
-        || ffn.shared_expert.up.gpu_dtype == DType::MQ3G256
-        || ffn.shared_expert.down.gpu_dtype == DType::MQ3G256
+    let is_mq3_any = |dt: DType| matches!(dt, DType::MQ3G256 | DType::MQ3G256Lloyd);
+    is_mq3_any(ffn.router.gpu_dtype)
+        || is_mq3_any(ffn.shared_expert_gate.gpu_dtype)
+        || is_mq3_any(ffn.shared_expert.gate.gpu_dtype)
+        || is_mq3_any(ffn.shared_expert.up.gpu_dtype)
+        || is_mq3_any(ffn.shared_expert.down.gpu_dtype)
         || ffn.experts.iter().any(|e|
-            e.gate_up.gpu_dtype == DType::MQ3G256
-            || e.down.gpu_dtype == DType::MQ3G256)
+            is_mq3_any(e.gate_up.gpu_dtype)
+            || is_mq3_any(e.down.gpu_dtype))
 }
 
 /// Zero-alloc MoE decode for the scratch path. `scratch.moe_*` fields must
@@ -3389,12 +3394,12 @@ pub fn forward_prefill_batch_single_chunk_captured(
     );
     if mq3_in_moe {
         return Err(hip_bridge::HipError::new(0,
-            "forward_prefill_batch_single_chunk_captured: model has MQ3G256 \
-             weights inside a MoE/A3B layer (DeltaNetMoe or FullAttnMoe). The \
-             MoE batched prefill branches dispatch through HFQ4-layout kernels \
-             and would memory-fault on the 104-vs-136 byte stride. Use an MQ4 \
-             quantization for MoE/A3B targets, or wait for the MQ3 MoE \
-             branches to land."
+            "forward_prefill_batch_single_chunk_captured: model has MQ3G256 / \
+             MQ3G256Lloyd weights inside a MoE/A3B layer (DeltaNetMoe or \
+             FullAttnMoe). The MoE batched prefill branches dispatch through \
+             HFQ4-layout kernels and would memory-fault on the 104/112-vs-136 \
+             byte stride. Use an MQ4 quantization for MoE/A3B targets, or wait \
+             for the MQ3 MoE branches to land."
         ));
     }
     if mq3_in_dense && !arch_has_wmma {
@@ -3532,6 +3537,49 @@ pub fn forward_prefill_batch_with_pbs(
     let n = tokens.len();
     if n == 0 {
         return Ok(());
+    }
+
+    // Cross-path safety: refuse MQ3 / MQ3-Lloyd weights inside any MoE
+    // layer (attention OR FFN), mirroring the captured-path guard at
+    // `forward_prefill_batch_single_chunk_captured` (line 3367+). Without
+    // this, the eligibility check below would admit a hybrid model with
+    // (e.g.) MQ3 attention + MQ4 MoE FFN onto the batched path, where the
+    // MoE-batched LA/FA bodies would misroute: the QKV matcher drops MQ3
+    // and the wo path is hardcoded to `gemm_hfq4g256_residual` regardless
+    // of `layer.wo.gpu_dtype`. The result is a 104/112 vs 136 byte stride
+    // mismatch and silent-corruption fluent-looking output. Issue #179
+    // documents the matcher half of this; the wo half was uncovered in
+    // review. Wiring both correctly (plus Lloyd) is tracked separately
+    // (see followup issue) — until then we hard-error here so all three
+    // entry points (daemon-DFlash setup, captured prefill, non-captured
+    // prefill) reject MQ3+MoE consistently.
+    let is_mq3_any = |dt: DType| matches!(dt, DType::MQ3G256 | DType::MQ3G256Lloyd);
+    let mq3_in_moe = weights.layers.iter().any(|lw| match lw {
+        LayerWeights::DeltaNetMoe(l) =>
+            is_mq3_any(l.wqkv.gpu_dtype)
+                || is_mq3_any(l.wz.gpu_dtype)
+                || is_mq3_any(l.w_beta.gpu_dtype)
+                || is_mq3_any(l.w_alpha.gpu_dtype)
+                || is_mq3_any(l.wo.gpu_dtype)
+                || moe_ffn_has_mq3(&l.ffn),
+        LayerWeights::FullAttnMoe(l) =>
+            is_mq3_any(l.wq.gpu_dtype)
+                || is_mq3_any(l.wk.gpu_dtype)
+                || is_mq3_any(l.wv.gpu_dtype)
+                || is_mq3_any(l.wo.gpu_dtype)
+                || moe_ffn_has_mq3(&l.ffn),
+        _ => false,
+    });
+    if mq3_in_moe {
+        return Err(hip_bridge::HipError::new(0,
+            "forward_prefill_batch: model has MQ3G256 / MQ3G256Lloyd weights \
+             inside a MoE/A3B layer (DeltaNetMoe or FullAttnMoe). The MoE \
+             batched prefill branches dispatch through HFQ4-layout kernels \
+             (QKV matcher drops MQ3; wo path is hardcoded MQ4) and would \
+             produce silent corruption from the 104/112-vs-136 byte stride \
+             mismatch. Use an MQ4 quantization for MoE/A3B targets, or wait \
+             for the MQ3 MoE branches to land (see followup issue)."
+        ));
     }
 
     // Tree-verify mode sanity checks — the downstream path can't silently
@@ -4931,12 +4979,16 @@ fn forward_prefill_chunk(
                 // only the FFN differs. Duplicated inline for now — can
                 // be factored into a `prefill_la_body_batched` helper
                 // when dense and MoE LA paths are proven byte-exact.
-                // GAP NOTE: this matcher is missing plain DType::MQ3G256 (upstream
-                // issue #179) and DType::MQ3G256Lloyd / MQ2G256Lloyd. Currently
-                // dead code — moe_ffn_all_mq4 (line 3707) keeps non-MQ4 MoE
-                // layers off the batched path. Re-evaluate this comment when
-                // touching is_batchable_la or moe_ffn_all_mq4. See
-                // docs/plans/mq-lloyd-batched-prefill-followup.md.
+                // This body is unreachable for MQ3 / MQ3-Lloyd weights —
+                // the upstream `mq3_in_moe` guard at the top of
+                // `forward_prefill_batch_with_pbs` rejects any MoE layer
+                // with MQ3/Lloyd-MQ3 weights anywhere (attention OR FFN),
+                // mirroring the captured-path guard at line 3367+. So
+                // `layer.wqkv.gpu_dtype` is restricted to MQ4G256 / HFQ4G256
+                // / MQ6G256 / HFQ6G256 here. Adding MQ3 to the matcher AND
+                // the QKV dispatch is insufficient — the wo path below
+                // (line 5072) is hardcoded MQ4 too — so the all-or-nothing
+                // wiring lives in a separate PR (see followup issue).
                 let is_mq = matches!(layer.wqkv.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
                 let is_6bit = matches!(layer.wqkv.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
 
@@ -5088,10 +5140,16 @@ fn forward_prefill_chunk(
                 // MoE path is proven byte-exact.
                 let kv_dim = config.n_kv_heads * config.head_dim;
                 let q_dim = config.n_heads * config.head_dim;
-                // GAP NOTE: this matcher is missing plain DType::MQ3G256 (upstream
-                // issue #179) and DType::MQ3G256Lloyd / MQ2G256Lloyd. Currently
-                // dead code — moe_ffn_all_mq4 keeps non-MQ4 MoE off the batched
-                // path. See docs/plans/mq-lloyd-batched-prefill-followup.md.
+                // This body is unreachable for MQ3 / MQ3-Lloyd weights —
+                // the upstream `mq3_in_moe` guard at the top of
+                // `forward_prefill_batch_with_pbs` rejects any MoE layer
+                // with MQ3/Lloyd-MQ3 weights anywhere (attention OR FFN),
+                // mirroring the captured-path guard at line 3367+. So
+                // `layer.wq.gpu_dtype` is restricted to MQ4G256 / HFQ4G256
+                // / MQ6G256 / HFQ6G256 here. Adding MQ3 to the matcher AND
+                // the QKV dispatch is insufficient — the wo path below
+                // (line 5320) is hardcoded MQ4 too — so the all-or-nothing
+                // wiring lives in a separate PR (see followup issue).
                 let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
                 let qkv_is_6bit = matches!(layer.wq.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
 


### PR DESCRIPTION
## Summary

Closes the captured-vs-non-captured prefill gate asymmetry that issue #179 surfaced via its matcher gap. Mirrors the existing `mq3_in_moe` guard from `forward_prefill_batch_single_chunk_captured` (`qwen35.rs:3367+`) onto `forward_prefill_batch_with_pbs` so all three entry points — daemon DFlash setup, captured prefill, non-captured prefill — refuse MQ3 / MQ3-Lloyd weights inside MoE layers consistently. Also fixes `moe_ffn_has_mq3` to cover `MQ3G256Lloyd`, mirroring the dense `is_mq3_any` cross-check at line 3325.

The narrow matcher fix originally proposed in #179 was found to be unsafe during multi-reviewer audit (Claude / Gemini / GLM-5):

1. The `wo` paths at `qwen35.rs:5072` (LA) and `5320` (FA) call `gemm_hfq4g256_residual` regardless of `layer.wo.gpu_dtype`, with an inline comment "Eligibility gate ensured layer.wo is MQ4" that's wrong (`is_batchable_la` admits MQ3 wo on gfx11+). A model with MQ3 wq/wk/wv would also have MQ3 wo, so wiring only the QKV side narrows but does not close the silent-corruption window.
2. The eligibility check admits MQ3 attention on gfx11+, and `moe_ffn_all_mq4` only checks FFN dtypes — so the in-scope hybrid case (MQ3 attn + MQ4 MoE FFN) passes eligibility, hits the partially-broken bodies, and silently corrupts.

So the matcher fix would convert a fully-broken-and-out-of-reach path into a partially-broken-and-in-reach one. This PR closes the gate instead, leaving the proper wiring (matchers + wo dispatch + Lloyd + FFN body + helper extraction + coherence-gate row) for #209 when a real MQ3 / Lloyd-MQ3 MoE model exists to test against.

## What's in the diff

- `forward_prefill_batch_with_pbs`: scan layers for any `MQ3G256` / `MQ3G256Lloyd` weight inside `DeltaNetMoe` / `FullAttnMoe` (attention or FFN); hard-error with a parallel message to the captured-path guard.
- `moe_ffn_has_mq3`: factored to use `is_mq3_any` (covers MQ3G256 + MQ3G256Lloyd).
- Captured-path error message updated to mention `MQ3G256Lloyd` (since the helper now catches it).
- `GAP NOTE` comments in both MoE bodies replaced — the original ones claimed `moe_ffn_all_mq4` made the matchers "dead code" but that's wrong (it gates FFN, not attention). New text accurately describes the new reachability story.

## No behaviour change for the current model zoo

Every shipped MoE/A3B model is MQ4 (largest is `qwen3.6-35b-a3b.mq4`). The change only affects models that don't exist yet but would have silently corrupted on load + prefill.

## Pre-commit gate

Bypassed with `--no-verify` and explicit maintainer authorization. The 4B MQ4 decode bench shows -10.2% vs baseline 178.0 (current 159.8), but bench-verified that **master without this PR's changes also gives 159.8** — pre-existing DPM/thermal drift documented in `docs/methodology/perf-benchmarking.md` (±10-15% within-session noise band on gfx1100). This commit is a safety guard at prefill entry that provably cannot affect the per-token decode path.

## Test plan

- [x] `cargo check -p hipfire-arch-qwen35` — clean (no new warnings).
- [x] `cargo check --workspace` — clean.
- [x] Cross-process bench on 4B MQ4 (gen_tok_s=159.8) confirms decode regression is pre-existing, not caused by the guard.
- [ ] Verify on reviewer's machine that current MQ4 MoE inference (e.g. `qwen3.6-35b-a3b.mq4`) is unaffected — guard's `mq3_in_moe` scan returns false for an all-MQ4 model and short-circuits the new check before any allocation.
- [ ] Optional: load a hand-crafted MQ3-attention + MQ4-FFN MoE blob (if anyone has one) and confirm the new error message fires cleanly with the right HIP error code path.

## Follow-up

#209 tracks the proper MQ3 + MoE wiring (matchers + wo + Lloyd + FFN body + helper extraction + coherence-gate row). The trigger is either (a) a real MQ3 / Lloyd-MQ3 MoE model getting quantized, or (b) MQ4-Lloyd (#182) landing and someone wanting Lloyd-MoE — at which point all six checklist items must land in the same PR per the all-together-or-none rule in `docs/plans/mq-lloyd-batched-prefill-followup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
