### PR TITLE
feat(quantize): adaptive cosim + K-map alternating mode (#196 step 2)

### DIFF
--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1281,13 +1281,316 @@ fn quantize_hfq4g128(f32_data: &[f32]) -> Vec<u8> {
     output
 }
 
+// ─── Dequantization (for adaptive cosim) ────────────────────────────────────
+
+/// Dequantize MQ4-G256: unpack 4-bit nibbles, apply scale+min, inverse FWHT.
+fn dequant_mq4g256(data: &[u8], n: usize, signs1: &[f32], signs2: &[f32]) -> Vec<f32> {
+    let block_bytes = 136;
+    let n_blocks = (n + 255) / 256;
+    let mut out = vec![0.0f32; n];
+    for b in 0..n_blocks {
+        let off = b * block_bytes;
+        let scale = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+        let min_val = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
+        let mut group = [0.0f32; 256];
+        for i in 0..128 {
+            let byte = data[off + 8 + i];
+            group[2 * i] = (byte & 0x0F) as f32 * scale + min_val;
+            group[2 * i + 1] = (byte >> 4) as f32 * scale + min_val;
+        }
+        // Inverse FWHT (self-inverse with same signs)
+        cpu_fwht_256(&mut group, signs2, signs1);
+        let start = b * 256;
+        let end = (start + 256).min(n);
+        out[start..end].copy_from_slice(&group[..end - start]);
+    }
+    out
+}
+
+/// Dequantize MQ6-G256: unpack 6-bit values, apply scale+min, inverse FWHT.
+fn dequant_mq6g256(data: &[u8], n: usize, signs1: &[f32], signs2: &[f32]) -> Vec<f32> {
+    let block_bytes = 200;
+    let n_blocks = (n + 255) / 256;
+    let mut out = vec![0.0f32; n];
+    for b in 0..n_blocks {
+        let off = b * block_bytes;
+        let scale = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+        let min_val = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
+        let mut group = [0.0f32; 256];
+        for i in (0..256).step_by(4) {
+            let byte_off = off + 8 + (i / 4) * 3;
+            let b0 = data[byte_off];
+            let b1 = data[byte_off + 1];
+            let b2 = data[byte_off + 2];
+            group[i]     = (b0 & 0x3F) as f32 * scale + min_val;
+            group[i + 1] = (((b0 >> 6) | (b1 << 2)) & 0x3F) as f32 * scale + min_val;
+            group[i + 2] = (((b1 >> 4) | (b2 << 4)) & 0x3F) as f32 * scale + min_val;
+            group[i + 3] = (b2 >> 2) as f32 * scale + min_val;
+        }
+        // Inverse FWHT (self-inverse with same signs)
+        cpu_fwht_256(&mut group, signs2, signs1);
+        let start = b * 256;
+        let end = (start + 256).min(n);
+        out[start..end].copy_from_slice(&group[..end - start]);
+    }
+    out
+}
+
+/// Dequantize HFQ4-G256: unpack 4-bit nibbles, apply scale+min (no rotation).
+fn dequant_hfq4g256(data: &[u8], n: usize) -> Vec<f32> {
+    let block_bytes = 136;
+    let n_blocks = (n + 255) / 256;
+    let mut out = vec![0.0f32; n];
+    for b in 0..n_blocks {
+        let off = b * block_bytes;
+        let scale = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+        let min_val = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
+        let start = b * 256;
+        let end = (start + 256).min(n);
+        for i in 0..128 {
+            let byte = data[off + 8 + i];
+            let idx_lo = start + 2 * i;
+            let idx_hi = start + 2 * i + 1;
+            if idx_lo < end {
+                out[idx_lo] = (byte & 0x0F) as f32 * scale + min_val;
+            }
+            if idx_hi < end {
+                out[idx_hi] = (byte >> 4) as f32 * scale + min_val;
+            }
+        }
+    }
+    out
+}
+
+/// Dequantize HFQ6-G256: unpack 6-bit values, apply scale+min (no rotation).
+fn dequant_hfq6g256(data: &[u8], n: usize) -> Vec<f32> {
+    let block_bytes = 200;
+    let n_blocks = (n + 255) / 256;
+    let mut out = vec![0.0f32; n];
+    for b in 0..n_blocks {
+        let off = b * block_bytes;
+        let scale = f32::from_le_bytes(data[off..off + 4].try_into().unwrap());
+        let min_val = f32::from_le_bytes(data[off + 4..off + 8].try_into().unwrap());
+        let start = b * 256;
+        let end = (start + 256).min(n);
+        for i in (0..256).step_by(4) {
+            let byte_off = off + 8 + (i / 4) * 3;
+            let b0 = data[byte_off];
+            let b1 = data[byte_off + 1];
+            let b2 = data[byte_off + 2];
+            let vals = [
+                (b0 & 0x3F) as f32 * scale + min_val,
+                (((b0 >> 6) | (b1 << 2)) & 0x3F) as f32 * scale + min_val,
+                (((b1 >> 4) | (b2 << 4)) & 0x3F) as f32 * scale + min_val,
+                (b2 >> 2) as f32 * scale + min_val,
+            ];
+            for j in 0..4 {
+                let idx = start + i + j;
+                if idx < end {
+                    out[idx] = vals[j];
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Cosine similarity between two f32 slices.
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+    let mut dot = 0.0f64;
+    let mut norm_a = 0.0f64;
+    let mut norm_b = 0.0f64;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot += x as f64 * y as f64;
+        norm_a += (x as f64) * (x as f64);
+        norm_b += (y as f64) * (y as f64);
+    }
+    let denom = (norm_a * norm_b).sqrt();
+    if denom == 0.0 { 1.0 } else { dot / denom }
+}
+
+/// Quantize-and-measure result for adaptive promotion.
+struct AdaptiveResult {
+    data: Vec<u8>,
+    quant_type: QuantType,
+    group_size: u32,
+    label: &'static str,
+    cosim: f64,
+    promotions: usize,
+}
+
+/// Try quantizing at base level, then promote up the ladder until cosim >= threshold.
+/// Returns the quantized data at the best level found within max_promotions steps.
+///
+/// `base_format` is one of: "mq2", "mq3", "mq4", "hfq2", "hfq3", "hfq4".
+/// Only call this for tensors with k_dim % 256 == 0 (G256 formats).
+fn try_adaptive_promote(
+    f32_data: &[f32],
+    base_format: &str,
+    threshold: f64,
+    max_promotions: usize,
+    signs1: &[f32],
+    signs2: &[f32],
+) -> AdaptiveResult {
+    let n = f32_data.len();
+
+    // Define the promotion ladder per base format.
+    // Each entry: (quantize_fn, dequant_fn, QuantType, group_size, label)
+    let ladder: Vec<(
+        Box<dyn Fn(&[f32]) -> Vec<u8>>,
+        Box<dyn Fn(&[u8], usize) -> Vec<f32>>,
+        QuantType,
+        u32,
+        &'static str,
+    )> = match base_format {
+        "mq2" => {
+            let s1a = signs1.to_vec(); let s2a = signs2.to_vec();
+            let s1b = signs1.to_vec(); let s2b = signs2.to_vec();
+            let s1c = signs1.to_vec(); let s2c = signs2.to_vec();
+            let s1d = signs1.to_vec(); let s2d = signs2.to_vec();
+            let s1e = signs1.to_vec(); let s2e = signs2.to_vec();
+            let s1f = signs1.to_vec(); let s2f = signs2.to_vec();
+            vec![
+                (Box::new(move |d: &[f32]| quantize_mq2g256(d, &s1a, &s2a)),
+                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]), // no dequant for mq2 yet — will fail cosim
+                 QuantType::MQ2G256, 256, "MQ2G256"),
+                (Box::new(move |d: &[f32]| quantize_mq3g256(d, &s1b, &s2b)),
+                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+                 QuantType::MQ3G256, 256, "MQ3G256"),
+                (Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1c, &s2c)),
+                 Box::new(move |d: &[u8], n: usize| dequant_mq4g256(d, n, &s1d, &s2d)),
+                 QuantType::MQ4G256, 256, "MQ4G256"),
+                (Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1e, &s2e)),
+                 Box::new(move |d: &[u8], n: usize| dequant_mq6g256(d, n, &s1f, &s2f)),
+                 QuantType::MQ6G256, 256, "MQ6G256"),
+            ]
+        }
+        "mq3" => {
+            let s1a = signs1.to_vec(); let s2a = signs2.to_vec();
+            let s1b = signs1.to_vec(); let s2b = signs2.to_vec();
+            let s1c = signs1.to_vec(); let s2c = signs2.to_vec();
+            let s1d = signs1.to_vec(); let s2d = signs2.to_vec();
+            vec![
+                (Box::new(move |d: &[f32]| quantize_mq3g256(d, &s1a, &s2a)),
+                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+                 QuantType::MQ3G256, 256, "MQ3G256"),
+                (Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1b, &s2b)),
+                 Box::new(move |d: &[u8], n: usize| dequant_mq4g256(d, n, &s1c, &s2c)),
+                 QuantType::MQ4G256, 256, "MQ4G256"),
+                (Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1d, &s2d)),
+                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+                 QuantType::MQ6G256, 256, "MQ6G256"),
+            ]
+        }
+        "mq4" => {
+            let s1a = signs1.to_vec(); let s2a = signs2.to_vec();
+            let s1b = signs1.to_vec(); let s2b = signs2.to_vec();
+            let s1c = signs1.to_vec(); let s2c = signs2.to_vec();
+            let s1d = signs1.to_vec(); let s2d = signs2.to_vec();
+            vec![
+                (Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1a, &s2a)),
+                 Box::new(move |d: &[u8], n: usize| dequant_mq4g256(d, n, &s1b, &s2b)),
+                 QuantType::MQ4G256, 256, "MQ4G256"),
+                (Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1c, &s2c)),
+                 Box::new(move |d: &[u8], n: usize| dequant_mq6g256(d, n, &s1d, &s2d)),
+                 QuantType::MQ6G256, 256, "MQ6G256"),
+                (Box::new(|d: &[f32]| quantize_q8f16(d)),
+                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]), // Q8 is terminal — no dequant needed
+                 QuantType::Q8F16, 32, "Q8_F16"),
+            ]
+        }
+        "hfq2" => vec![
+            (Box::new(|d: &[f32]| quantize_hfq2g256(d)),
+             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+             QuantType::HFQ2G256, 256, "HFQ2G256"),
+            (Box::new(|d: &[f32]| quantize_hfq3g256(d)),
+             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+             QuantType::HFQ3G256, 256, "HFQ3G256"),
+            (Box::new(|d: &[f32]| quantize_hfq4g256(d)),
+             Box::new(|d: &[u8], n: usize| dequant_hfq4g256(d, n)),
+             QuantType::HFQ4G256, 256, "HFQ4G256"),
+            (Box::new(|d: &[f32]| quantize_hfq6g256(d)),
+             Box::new(|d: &[u8], n: usize| dequant_hfq6g256(d, n)),
+             QuantType::HFQ6G256, 256, "HFQ6G256"),
+        ],
+        "hfq3" => vec![
+            (Box::new(|d: &[f32]| quantize_hfq3g256(d)),
+             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+             QuantType::HFQ3G256, 256, "HFQ3G256"),
+            (Box::new(|d: &[f32]| quantize_hfq4g256(d)),
+             Box::new(|d: &[u8], n: usize| dequant_hfq4g256(d, n)),
+             QuantType::HFQ4G256, 256, "HFQ4G256"),
+            (Box::new(|d: &[f32]| quantize_hfq6g256(d)),
+             Box::new(|d: &[u8], n: usize| dequant_hfq6g256(d, n)),
+             QuantType::HFQ6G256, 256, "HFQ6G256"),
+        ],
+        "hfq4" => vec![
+            (Box::new(|d: &[f32]| quantize_hfq4g256(d)),
+             Box::new(|d: &[u8], n: usize| dequant_hfq4g256(d, n)),
+             QuantType::HFQ4G256, 256, "HFQ4G256"),
+            (Box::new(|d: &[f32]| quantize_hfq6g256(d)),
+             Box::new(|d: &[u8], n: usize| dequant_hfq6g256(d, n)),
+             QuantType::HFQ6G256, 256, "HFQ6G256"),
+            (Box::new(|d: &[f32]| quantize_q8f16(d)),
+             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
+             QuantType::Q8F16, 32, "Q8_F16"),
+        ],
+        _ => panic!("unsupported base format for adaptive: {base_format}"),
+    };
+
+    let mut best_data = Vec::new();
+    let mut best_qt = ladder[0].2;
+    let mut best_gs = ladder[0].3;
+    let mut best_label = ladder[0].4;
+    let mut best_cosim = 0.0f64;
+    let mut promotions = 0usize;
+
+    // Walk the ladder: base level + up to max_promotions steps
+    let max_idx = (1 + max_promotions).min(ladder.len());
+    for (i, (quantize_fn, dequant_fn, qt, gs, label)) in ladder.iter().enumerate() {
+        if i >= max_idx { break; }
+        let quantized = quantize_fn(f32_data);
+        best_data = quantized;
+        best_qt = *qt;
+        best_gs = *gs;
+        best_label = label;
+        promotions = i;
+
+        // Terminal level (Q8) — no dequant needed, accept unconditionally
+        if *qt == QuantType::Q8F16 {
+            best_cosim = 1.0;
+            break;
+        }
+
+        let reconstructed = dequant_fn(&best_data, n);
+        if reconstructed.is_empty() {
+            // No dequant available for this level — promote unconditionally
+            continue;
+        }
+        let cs = cosine_similarity(f32_data, &reconstructed);
+        best_cosim = cs;
+        if cs >= threshold {
+            break;
+        }
+    }
+
+    AdaptiveResult {
+        data: best_data,
+        quant_type: best_qt,
+        group_size: best_gs,
+        label: best_label,
+        cosim: best_cosim,
+        promotions,
+    }
+}
+
 // ─── HFQ File Format ────────────────────────────────────────────────────────
 
 const HFQ_MAGIC: &[u8; 4] = b"HFQM";
 const HFQ_VERSION: u32 = 1;
 
 #[repr(u8)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum QuantType {
     Q4F16G64 = 0,
     F16 = 1,
@@ -2257,6 +2560,17 @@ fn main() {
     // help ONLY (never on dense)" by default.
     let kmap_dense = args.iter().any(|a| a == "--kmap-dense");
 
+    // ── Adaptive cosim override (alternative to K-map) ──────────────────
+    let adaptive = args.iter().any(|a| a == "--adaptive");
+    let cosim_threshold: f64 = args.iter().position(|a| a == "--cosim-threshold")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0.9995);
+    let max_promotions: usize = args.iter().position(|a| a == "--max-promotions")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2);
+
     // ── Sub-4-bit guards (2026-04-30 sweep) ─────────────────────────────
     // MQ2 with the current uniform 4-level codebook collapses at every
     // model size validated locally (0.8B / 4B / 9B Qwen 3.5 → multilingual
@@ -2387,6 +2701,13 @@ fn main() {
     if is_moe {
         eprintln!("  MoE detected — will split 3D expert tensors per-expert before quantization.");
     }
+    if adaptive && !no_kmap && (is_moe || kmap_dense) {
+        eprintln!("error: --adaptive and K-map are mutually exclusive. Use --no-kmap with --adaptive.");
+        std::process::exit(1);
+    }
+    if adaptive {
+        eprintln!("Adaptive cosim: threshold={cosim_threshold}, max_promotions={max_promotions}");
+    }
 
     // Extract layer count for K-map edge-layer promotion.
     // Qwen3.5+ nests config under "text_config"; try both paths.
@@ -2491,6 +2812,8 @@ fn main() {
     let mut total_quant_error = 0.0f64;
     let mut max_quant_error = 0.0f32;
     let mut _n_quant_groups = 0u64;
+    let mut adaptive_total = 0u64;
+    let mut adaptive_promoted = 0u64;
 
     let include_vision = std::env::args().any(|a| a == "--include-vision");
     let vision_quant = std::env::args().position(|a| a == "--vision-quant")
@@ -2570,6 +2893,15 @@ fn main() {
             let parent_owned = parent.to_string();
             let inner_shape_clone = inner_shape.clone();
             let base_owned = base_name.to_string();
+            let expert_adaptive = adaptive && !kmap_promote && supports_g256;
+            let expert_base_fmt = if use_mq4g256 || use_mq4_mq6exp { "mq4" }
+                else if use_mq3g256 { "mq3" }
+                else if use_mq2g256 { "mq2" }
+                else if use_hfq4g256 { "hfq4" }
+                else if use_hfq3g256 { "hfq3" }
+                else if use_hfq2g256 { "hfq2" }
+                else { "" };
+            let expert_promote_count = std::sync::atomic::AtomicU64::new(0);
             let mut new_tensors: Vec<HfqTensor> = (0..n_experts).into_par_iter().map(|x| {
                 let slice_off = x * inner_bytes;
                 let slice = &raw_data[slice_off..slice_off + inner_bytes];
@@ -2583,6 +2915,15 @@ fn main() {
                 } else if expert_hfq4 {
                     let q = quantize_hfq4g256(&f32_slice);
                     (q, QuantType::HFQ4G256, 256u32)
+                } else if expert_adaptive && !expert_base_fmt.is_empty() {
+                    let ar = try_adaptive_promote(
+                        &f32_slice, expert_base_fmt, cosim_threshold, max_promotions,
+                        &signs1, &signs2,
+                    );
+                    if ar.promotions > 0 {
+                        expert_promote_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    (ar.data, ar.quant_type, ar.group_size)
                 } else if supports_g256 {
                     let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
                     (q, QuantType::MQ4G256, 256u32)
@@ -2599,6 +2940,14 @@ fn main() {
                     spilled_len: 0,
                 }
             }).collect();
+            let n_expert_promoted = expert_promote_count.load(std::sync::atomic::Ordering::Relaxed);
+            if expert_adaptive && n_expert_promoted > 0 {
+                eprintln!("  PROMOTE: {parent_owned}{{..}}.{base_owned}.weight: {n_expert_promoted}/{n_experts} experts promoted");
+                adaptive_promoted += n_expert_promoted;
+            }
+            if expert_adaptive {
+                adaptive_total += n_experts as u64;
+            }
             quantized_params += inner_n as u64 * n_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
             let label = if expert_mq6 { "MQ6G256" } else if expert_hfq6 { "HFQ6G256" } else if expert_hfq4 { "HFQ4G256" } else if supports_g256 { "MQ4G256" } else { "HFQ4G128" };
@@ -2709,6 +3058,51 @@ fn main() {
                     let q = quantize_q8f16(&f32_data);
                     (q, QuantType::Q8F16, 32u32, "Q8_F16")
                 }
+            } else if adaptive {
+            // ── Adaptive cosim override ───────────────────────────────────
+            let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
+            let base_fmt = if use_mq4g256 || use_mq4_mq6exp { "mq4" }
+                else if use_mq3g256 { "mq3" }
+                else if use_mq2g256 { "mq2" }
+                else if use_hfq4g256 { "hfq4" }
+                else if use_hfq3g256 { "hfq3" }
+                else if use_hfq2g256 { "hfq2" }
+                else { "" };
+            if !base_fmt.is_empty() && k_dim % 256 == 0 {
+                let signs1 = gen_fwht_signs(42, 256);
+                let signs2 = gen_fwht_signs(1042, 256);
+                let is_embed = name.contains("embed_tokens");
+                if is_embed {
+                    let q = quantize_q8f16(&f32_data);
+                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                } else {
+                    let ar = try_adaptive_promote(
+                        &f32_data, base_fmt, cosim_threshold, max_promotions,
+                        &signs1, &signs2,
+                    );
+                    adaptive_total += 1;
+                    if ar.promotions > 0 {
+                        adaptive_promoted += 1;
+                        eprintln!("  PROMOTE: {} {}->{} (cosim={:.6} < {:.4})",
+                            name, base_fmt.to_uppercase(), ar.label, ar.cosim, cosim_threshold);
+                    }
+                    (ar.data, ar.quant_type, ar.group_size, ar.label)
+                }
+            } else {
+                // Non-G256 or unsupported format — fall through to normal path
+                let q = if k_dim % 128 == 0 {
+                    quantize_hfq4g128(&f32_data)
+                } else {
+                    quantize_q4f16_g64(&f32_data)
+                };
+                let (qt, gs, lbl) = if k_dim % 128 == 0 {
+                    (QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                } else {
+                    (QuantType::Q4F16G64, 64u32, "Q4_F16")
+                };
+                (q, qt, gs, lbl)
+            }
+
             } else {
             // QuantLevel::Base — existing format-specific logic below
 
@@ -3105,6 +3499,9 @@ fn main() {
     eprintln!("  Mean quant error: {mean_quant_error:.8}");
     eprintln!("  Max quant error:  {max_quant_error:.8}");
     eprintln!("  Output size:      {:.1} MB", total_bytes as f64 / 1e6);
+    if adaptive && adaptive_total > 0 {
+        eprintln!("  Adaptive:         {adaptive_promoted}/{adaptive_total} tensors promoted");
+    }
 
     // Write .hfq file
     eprintln!("\nWriting: {}", output_path.display());
@@ -3249,5 +3646,126 @@ mod tests {
         assert_eq!(kmap_resolve("blk.0.attn_q.weight", 64, false), QuantLevel::Promote6);
         assert_eq!(kmap_resolve("blk.63.ffn_gate.weight", 64, false), QuantLevel::Promote6);
         assert_eq!(kmap_resolve("blk.30.ffn_gate.weight", 64, false), QuantLevel::Base);
+    }
+
+    // ── Adaptive cosim tests ─────────────────────────────────────────────
+
+    #[test]
+    fn cosim_identical_vectors() {
+        let a = vec![1.0, 2.0, 3.0, 4.0];
+        assert!((cosine_similarity(&a, &a) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosim_orthogonal_vectors() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cosim_zero_vector_returns_one() {
+        let a = vec![0.0, 0.0, 0.0];
+        let b = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn dequant_mq4_roundtrip() {
+        let signs1 = gen_fwht_signs(42, 256);
+        let signs2 = gen_fwht_signs(1042, 256);
+        // Generate test data: 512 floats (2 blocks)
+        let data: Vec<f32> = (0..512).map(|i| (i as f32 * 0.01) - 2.56).collect();
+        let quantized = quantize_mq4g256(&data, &signs1, &signs2);
+        let reconstructed = dequant_mq4g256(&quantized, 512, &signs1, &signs2);
+        assert_eq!(reconstructed.len(), 512);
+        let cs = cosine_similarity(&data, &reconstructed);
+        // MQ4 with FWHT should have decent cosim (> 0.99)
+        assert!(cs > 0.99, "MQ4 roundtrip cosim too low: {cs}");
+    }
+
+    #[test]
+    fn dequant_mq6_roundtrip() {
+        let signs1 = gen_fwht_signs(42, 256);
+        let signs2 = gen_fwht_signs(1042, 256);
+        let data: Vec<f32> = (0..256).map(|i| (i as f32 * 0.01) - 1.28).collect();
+        let quantized = quantize_mq6g256(&data, &signs1, &signs2);
+        let reconstructed = dequant_mq6g256(&quantized, 256, &signs1, &signs2);
+        assert_eq!(reconstructed.len(), 256);
+        let cs = cosine_similarity(&data, &reconstructed);
+        // MQ6 should be better than MQ4
+        assert!(cs > 0.999, "MQ6 roundtrip cosim too low: {cs}");
+    }
+
+    #[test]
+    fn dequant_hfq4_roundtrip() {
+        let data: Vec<f32> = (0..256).map(|i| (i as f32 * 0.01) - 1.28).collect();
+        let quantized = quantize_hfq4g256(&data);
+        let reconstructed = dequant_hfq4g256(&quantized, 256);
+        assert_eq!(reconstructed.len(), 256);
+        let cs = cosine_similarity(&data, &reconstructed);
+        assert!(cs > 0.99, "HFQ4 roundtrip cosim too low: {cs}");
+    }
+
+    #[test]
+    fn dequant_hfq6_roundtrip() {
+        let data: Vec<f32> = (0..256).map(|i| (i as f32 * 0.01) - 1.28).collect();
+        let quantized = quantize_hfq6g256(&data);
+        let reconstructed = dequant_hfq6g256(&quantized, 256);
+        assert_eq!(reconstructed.len(), 256);
+        let cs = cosine_similarity(&data, &reconstructed);
+        assert!(cs > 0.999, "HFQ6 roundtrip cosim too low: {cs}");
+    }
+
+    #[test]
+    fn adaptive_no_promotion_when_cosim_high() {
+        let signs1 = gen_fwht_signs(42, 256);
+        let signs2 = gen_fwht_signs(1042, 256);
+        // Uniform data quantizes well — should not promote
+        let data: Vec<f32> = (0..256).map(|i| i as f32 / 256.0).collect();
+        let ar = try_adaptive_promote(&data, "mq4", 0.99, 2, &signs1, &signs2);
+        assert_eq!(ar.promotions, 0);
+        assert_eq!(ar.quant_type, QuantType::MQ4G256);
+    }
+
+    #[test]
+    fn adaptive_promotes_when_threshold_above_base_cosim() {
+        let signs1 = gen_fwht_signs(42, 256);
+        let signs2 = gen_fwht_signs(1042, 256);
+        // Generate data, quantize at MQ4, measure its actual cosim, then set
+        // threshold just above that to force promotion.
+        let data: Vec<f32> = (0..256).map(|i| (i as f32 * 0.1) - 12.8).collect();
+        let q = quantize_mq4g256(&data, &signs1, &signs2);
+        let recon = dequant_mq4g256(&q, 256, &signs1, &signs2);
+        let base_cosim = cosine_similarity(&data, &recon);
+        // Set threshold above base cosim to guarantee promotion
+        let threshold = base_cosim + 0.0001;
+        let ar = try_adaptive_promote(&data, "mq4", threshold, 2, &signs1, &signs2);
+        assert!(ar.promotions > 0, "expected promotion: base cosim={base_cosim}, threshold={threshold}");
+        // Should promote to MQ6
+        assert_eq!(ar.quant_type, QuantType::MQ6G256);
+    }
+
+    #[test]
+    fn adaptive_respects_max_promotions() {
+        let signs1 = gen_fwht_signs(42, 256);
+        let signs2 = gen_fwht_signs(1042, 256);
+        // Pathological data with max_promotions=0 should not promote
+        let mut data = vec![0.001f32; 256];
+        data[0] = 1000.0;
+        let ar = try_adaptive_promote(&data, "mq4", 0.99999, 0, &signs1, &signs2);
+        assert_eq!(ar.promotions, 0);
+        assert_eq!(ar.quant_type, QuantType::MQ4G256);
+    }
+
+    #[test]
+    fn adaptive_ladder_hfq4() {
+        let data: Vec<f32> = (0..256).map(|i| i as f32 / 256.0).collect();
+        let signs1 = gen_fwht_signs(42, 256);
+        let signs2 = gen_fwht_signs(1042, 256);
+        let ar = try_adaptive_promote(&data, "hfq4", 0.99, 2, &signs1, &signs2);
+        // Well-behaved data should stay at HFQ4
+        assert_eq!(ar.promotions, 0);
+        assert_eq!(ar.quant_type, QuantType::HFQ4G256);
     }
 }

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -2633,18 +2633,19 @@ fn main() {
     // help ONLY (never on dense)" by default.
     let kmap_dense = args.iter().any(|a| a == "--kmap-dense");
     // K-map mode: 0=default, 1=alternating (ffn_down every 3rd + edge), 2=typed (ffn_down+attn_v everywhere)
+    // K-map mode: 0=full (all candidates promoted), 1=alternating (edge + every 3rd),
+    // 2=typed (ffn_down+attn_v everywhere). Default: alternating — same PPL as full
+    // at 17% less model size on MoE (22.9 vs 27.7 GB, PPL 8K: 19.96 vs 20.07).
     let kmap_mode: u8 = args.iter().position(|a| a == "--kmap-mode")
         .and_then(|i| args.get(i + 1))
         .map(|v| match v.as_str() {
-            "default" | "0" => 0,
+            "full" | "0" => 0,
             "alternating" | "alt" | "1" => 1,
             "typed" | "2" => 2,
-            _ => { eprintln!("warning: unknown --kmap-mode '{v}', using default"); 0 }
+            _ => { eprintln!("warning: unknown --kmap-mode '{v}', using alternating"); 1 }
         })
-        .unwrap_or(0);
-    if kmap_mode > 0 {
-        eprintln!("K-map mode: {}", match kmap_mode { 1 => "alternating", 2 => "typed", _ => "default" });
-    }
+        .unwrap_or(1);
+    eprintln!("K-map mode: {}", match kmap_mode { 0 => "full", 1 => "alternating", 2 => "typed", _ => "unknown" });
 
     // ── Adaptive cosim override (alternative to K-map) ──────────────────
     let adaptive = args.iter().any(|a| a == "--adaptive");

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1666,12 +1666,30 @@ fn parse_layer_idx(name: &str) -> Option<usize> {
     None
 }
 
+/// llama.cpp-style alternating promotion: edge layers always promoted,
+/// middle layers promoted every `stride` layers. Returns true if the layer
+/// at `idx` should be promoted given `n_layers` total.
+fn is_positional_promote(idx: usize, n_layers: usize, stride: usize) -> bool {
+    if n_layers == 0 || stride == 0 { return false; }
+    // Edge layers: first 2 + last 2
+    if idx < 2 || idx >= n_layers.saturating_sub(2) { return true; }
+    // Middle: every `stride` layers, offset from first non-edge layer
+    (idx - 2) % stride == 0
+}
+
 /// Resolve the quantization level for a tensor based on its name, the model's
 /// layer count, and whether the model is MoE. See spec for rule ordering.
+///
+/// `kmap_mode`: 0 = default, 1 = alternating (ffn_down every 3rd middle layer),
+/// 2 = typed (promote ffn_down + attn_v everywhere, skip gate/up).
 ///
 /// Note: In the safetensors path, norms/biases are filtered by `should_quantize()`
 /// before this function is called. Rules 1-2 exist for the GGUF path and completeness.
 fn kmap_resolve(name: &str, n_layers: usize, is_moe: bool) -> QuantLevel {
+    kmap_resolve_mode(name, n_layers, is_moe, 0)
+}
+
+fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -> QuantLevel {
     // Rule 1: norms, biases, 1D (GGUF path mainly)
     if name.contains("norm") || name.contains("bias") {
         return QuantLevel::F16;
@@ -1694,10 +1712,54 @@ fn kmap_resolve(name: &str, n_layers: usize, is_moe: bool) -> QuantLevel {
 
     // Rule 4: MoE expert FFN weights
     if is_moe && name.contains("mlp.experts.") {
+        if kmap_mode == 1 {
+            // Alternating: promote expert groups only in positional layers
+            if let Some(idx) = parse_layer_idx(name) {
+                if is_positional_promote(idx, n_layers, 3) {
+                    return QuantLevel::Promote6;
+                }
+                return QuantLevel::Base;
+            }
+        }
         return QuantLevel::Promote6;
     }
 
-    // Rule 5: edge layers (first 2 + last 2)
+    // Mode 2 (typed): promote ffn_down and attn_v everywhere, skip gate/up
+    if kmap_mode == 2 {
+        let is_down = name.contains("down_proj") || name.contains("ffn_down");
+        let is_v = name.contains("v_proj") || name.contains("attn_v");
+        if is_down || is_v {
+            return QuantLevel::Promote6;
+        }
+        // Edge layers: promote everything
+        if n_layers > 0 {
+            if let Some(idx) = parse_layer_idx(name) {
+                if idx < 2 || idx >= n_layers.saturating_sub(2) {
+                    return QuantLevel::Promote6;
+                }
+            }
+        }
+        return QuantLevel::Base;
+    }
+
+    // Mode 1 (alternating): ffn_down in edge + every 3rd middle layer
+    if kmap_mode == 1 {
+        let is_down = name.contains("down_proj") || name.contains("ffn_down");
+        if n_layers > 0 {
+            if let Some(idx) = parse_layer_idx(name) {
+                if is_down && is_positional_promote(idx, n_layers, 3) {
+                    return QuantLevel::Promote6;
+                }
+                // Edge layers: all tensors (attn+FFN)
+                if idx < 2 || idx >= n_layers.saturating_sub(2) {
+                    return QuantLevel::Promote6;
+                }
+            }
+        }
+        return QuantLevel::Base;
+    }
+
+    // Rule 5 (default mode 0): edge layers (first 2 + last 2)
     if n_layers > 0 {
         if let Some(idx) = parse_layer_idx(name) {
             if idx < 2 || idx >= n_layers.saturating_sub(2) {
@@ -2332,7 +2394,7 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
         for info in &gguf.tensors {
             let out_name = gguf_to_safetensors_name(&info.name)
                 .unwrap_or_else(|| info.name.clone());
-            let level = kmap_resolve(&out_name, n_layers, is_moe);
+            let level = kmap_resolve_mode(&out_name, n_layers, is_moe, 0); // GGUF: default mode only
             match level {
                 QuantLevel::F16 => counts[0] += 1,
                 QuantLevel::Q8 => counts[1] += 1,
@@ -2570,6 +2632,19 @@ fn main() {
     // ppl_kmap_20260508.md). Maintainer directive 2026-05-08: "intends to
     // help ONLY (never on dense)" by default.
     let kmap_dense = args.iter().any(|a| a == "--kmap-dense");
+    // K-map mode: 0=default, 1=alternating (ffn_down every 3rd + edge), 2=typed (ffn_down+attn_v everywhere)
+    let kmap_mode: u8 = args.iter().position(|a| a == "--kmap-mode")
+        .and_then(|i| args.get(i + 1))
+        .map(|v| match v.as_str() {
+            "default" | "0" => 0,
+            "alternating" | "alt" | "1" => 1,
+            "typed" | "2" => 2,
+            _ => { eprintln!("warning: unknown --kmap-mode '{v}', using default"); 0 }
+        })
+        .unwrap_or(0);
+    if kmap_mode > 0 {
+        eprintln!("K-map mode: {}", match kmap_mode { 1 => "alternating", 2 => "typed", _ => "default" });
+    }
 
     // ── Adaptive cosim override (alternative to K-map) ──────────────────
     let adaptive = args.iter().any(|a| a == "--adaptive");
@@ -2712,12 +2787,13 @@ fn main() {
     if is_moe {
         eprintln!("  MoE detected — will split 3D expert tensors per-expert before quantization.");
     }
-    if adaptive && !no_kmap && (is_moe || kmap_dense) {
-        eprintln!("error: --adaptive and K-map are mutually exclusive. Use --no-kmap with --adaptive.");
-        std::process::exit(1);
-    }
+    let kmap_active = !no_kmap && (is_moe || kmap_dense);
     if adaptive {
-        eprintln!("Adaptive cosim: threshold={cosim_threshold}, max_promotions={max_promotions}");
+        if kmap_active {
+            eprintln!("Adaptive cosim + K-map: K-map defines promotion groups, adaptive gates activation (threshold={cosim_threshold})");
+        } else {
+            eprintln!("Adaptive cosim: threshold={cosim_threshold}, max_promotions={max_promotions}");
+        }
     }
 
     // Extract layer count for K-map edge-layer promotion.
@@ -2792,7 +2868,7 @@ fn main() {
         let mut map = HashMap::new();
         let mut counts = [0u32; 4]; // F16, Q8, Promote6, Base
         for (name, _fi) in &all_tensors {
-            let level = kmap_resolve(name, n_layers, is_moe);
+            let level = kmap_resolve_mode(name, n_layers, is_moe, kmap_mode);
             match level {
                 QuantLevel::F16 => counts[0] += 1,
                 QuantLevel::Q8 => counts[1] += 1,
@@ -2891,7 +2967,36 @@ fn main() {
             // (e.g. "...mlp.experts.gate_up_proj") contains "mlp.experts."
             // so kmap_resolve rule 4 matches it. The kmap HashMap was built
             // from all_tensors which has these parent names as keys.
-            let kmap_promote = kmap.get(*name) == Some(&QuantLevel::Promote6);
+            let kmap_promote_raw = kmap.get(*name) == Some(&QuantLevel::Promote6);
+            // When --adaptive gates K-map, probe the expert group before promoting.
+            // If all experts pass raw cosim threshold, skip promotion.
+            let kmap_promote = if kmap_promote_raw && adaptive && supports_g256 {
+                use rayon::prelude::*;
+                let fail_count = std::sync::atomic::AtomicU64::new(0);
+                (0..n_experts).into_par_iter().for_each(|x| {
+                    let slice_off = x * inner_bytes;
+                    let slice = &raw_data[slice_off..slice_off + inner_bytes];
+                    let f32_slice = to_f32(slice, &meta.dtype);
+                    let q = quantize_hfq4g256(&f32_slice);
+                    let d = dequant_hfq4g256(&q, f32_slice.len());
+                    let cs = cosine_similarity(&f32_slice, &d);
+                    if cs < cosim_threshold {
+                        fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                });
+                let n_fail = fail_count.load(std::sync::atomic::Ordering::Relaxed);
+                adaptive_total += 1;
+                if n_fail > 0 {
+                    adaptive_promoted += 1;
+                    eprintln!("  PROMOTE: {parent}{{..}}.{base_name}.weight: {n_fail}/{n_experts} experts below cosim — promoting group");
+                    true
+                } else {
+                    eprintln!("  SKIP:    {parent}{{..}}.{base_name}.weight: all {n_experts} experts pass cosim — keeping base");
+                    false
+                }
+            } else {
+                kmap_promote_raw
+            };
             let expert_mq6 = (use_mq6g256 || use_mq4_mq6exp || (kmap_promote && use_mq4g256)) && supports_g256;
             let expert_hfq6 = (use_hfq6 || (kmap_promote && use_hfq4g256)) && supports_g256;
             let expert_hfq4 = use_hfq4g256 && !kmap_promote && supports_g256;
@@ -2904,7 +3009,7 @@ fn main() {
             let parent_owned = parent.to_string();
             let inner_shape_clone = inner_shape.clone();
             let base_owned = base_name.to_string();
-            let expert_adaptive = adaptive && !kmap_promote && supports_g256;
+            let expert_adaptive = adaptive && !kmap_promote && !kmap_promote_raw && supports_g256;
             let expert_base_fmt = if use_mq4g256 || use_mq4_mq6exp { "mq4" }
                 else if use_mq3g256 { "mq3" }
                 else if use_mq2g256 { "mq2" }
@@ -3063,9 +3168,41 @@ fn main() {
                     .collect();
                 (f16_bytes, QuantType::F16, 0u32, "F16")
             } else if kmap_level == QuantLevel::Promote6 {
-                // K-map says promote to 6-bit
+                // K-map says promote to 6-bit.
+                // When --adaptive is active, gate by raw cosim: only promote if
+                // the tensor's raw HFQ4 cosim is below threshold. This avoids
+                // promoting tensors that quantize well enough at the base level.
                 let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if (use_mq4g256 || use_mq4_mq6exp || use_mq3g256 || use_mq2g256
+                let skip_promote = adaptive && k_dim % 256 == 0 && {
+                    let probe_q = quantize_hfq4g256(&f32_data);
+                    let probe_d = dequant_hfq4g256(&probe_q, n_elements);
+                    let cs = cosine_similarity(&f32_data, &probe_d);
+                    adaptive_total += 1;
+                    if cs >= cosim_threshold {
+                        true // cosim OK — skip promotion
+                    } else {
+                        adaptive_promoted += 1;
+                        eprintln!("  PROMOTE: {} (cosim={:.6} < {:.4})", name, cs, cosim_threshold);
+                        false // cosim bad — promote
+                    }
+                };
+                if skip_promote {
+                    // Fall through to base-level quantization
+                    let is_mq = use_mq4g256 || use_mq4_mq6exp || use_mq3g256 || use_mq2g256
+                        || use_mq2g256_lloyd || use_mq3g256_lloyd || use_mq6g256;
+                    if is_mq && k_dim % 256 == 0 {
+                        let signs1 = gen_fwht_signs(42, 256);
+                        let signs2 = gen_fwht_signs(1042, 256);
+                        let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                        (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                    } else if k_dim % 256 == 0 {
+                        let q = quantize_hfq4g256(&f32_data);
+                        (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                    } else {
+                        let q = quantize_hfq4g128(&f32_data);
+                        (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                    }
+                } else if (use_mq4g256 || use_mq4_mq6exp || use_mq3g256 || use_mq2g256
                     || use_mq2g256_lloyd || use_mq3g256_lloyd) && k_dim % 256 == 0
                 {
                     let signs1 = gen_fwht_signs(42, 256);
@@ -3078,17 +3215,14 @@ fn main() {
                     let q = quantize_hfq6g256(&f32_data);
                     (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
                 } else if use_mq6g256 && k_dim % 256 == 0 {
-                    // Already 6-bit MQ — no-op promotion
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
                     let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
                     (q, QuantType::MQ6G256, 256u32, "MQ6G256")
                 } else if use_hfq6 && k_dim % 256 == 0 {
-                    // Already 6-bit HFQ — no-op promotion
                     let q = quantize_hfq6g256(&f32_data);
                     (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
                 } else {
-                    // Non-256-aligned fallback: Q8
                     let q = quantize_q8f16(&f32_data);
                     (q, QuantType::Q8F16, 32u32, "Q8_F16")
                 }

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1424,6 +1424,14 @@ struct AdaptiveResult {
 ///
 /// `base_format` is one of: "mq2", "mq3", "mq4", "hfq2", "hfq3", "hfq4".
 /// Only call this for tensors with k_dim % 256 == 0 (G256 formats).
+///
+/// **Cosim probe strategy:** For MQ formats (FWHT-rotated), cosim is measured
+/// using the equivalent HFQ (non-rotated) quant/dequant at each bit level.
+/// FWHT normalizes quantization error so uniformly that post-rotation cosim
+/// has zero per-tensor variance (~0.99967 for every tensor). By probing on
+/// raw weights without rotation, we see the actual per-tensor difficulty —
+/// tensors with outliers or heavy-tailed distributions get low raw cosim and
+/// are promoted, even though FWHT would mask the problem at runtime.
 fn try_adaptive_promote(
     f32_data: &[f32],
     base_format: &str,
@@ -1433,146 +1441,149 @@ fn try_adaptive_promote(
     signs2: &[f32],
 ) -> AdaptiveResult {
     let n = f32_data.len();
+    let is_mq = base_format.starts_with("mq");
 
     // Define the promotion ladder per base format.
-    // Each entry: (quantize_fn, dequant_fn, QuantType, group_size, label)
-    let ladder: Vec<(
-        Box<dyn Fn(&[f32]) -> Vec<u8>>,
-        Box<dyn Fn(&[u8], usize) -> Vec<f32>>,
-        QuantType,
-        u32,
-        &'static str,
-    )> = match base_format {
+    // Each entry: (quantize_fn, QuantType, group_size, label, probe_bits)
+    // probe_bits: the HFQ bit-equivalent used for cosim probing.
+    struct Rung {
+        quantize: Box<dyn Fn(&[f32]) -> Vec<u8>>,
+        qt: QuantType,
+        gs: u32,
+        label: &'static str,
+        probe_bits: u8, // 2, 3, 4, 6, or 8 (8 = terminal, skip cosim)
+    }
+
+    let ladder: Vec<Rung> = match base_format {
         "mq2" => {
             let s1a = signs1.to_vec(); let s2a = signs2.to_vec();
             let s1b = signs1.to_vec(); let s2b = signs2.to_vec();
             let s1c = signs1.to_vec(); let s2c = signs2.to_vec();
             let s1d = signs1.to_vec(); let s2d = signs2.to_vec();
-            let s1e = signs1.to_vec(); let s2e = signs2.to_vec();
-            let s1f = signs1.to_vec(); let s2f = signs2.to_vec();
             vec![
-                (Box::new(move |d: &[f32]| quantize_mq2g256(d, &s1a, &s2a)),
-                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]), // no dequant for mq2 yet — will fail cosim
-                 QuantType::MQ2G256, 256, "MQ2G256"),
-                (Box::new(move |d: &[f32]| quantize_mq3g256(d, &s1b, &s2b)),
-                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-                 QuantType::MQ3G256, 256, "MQ3G256"),
-                (Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1c, &s2c)),
-                 Box::new(move |d: &[u8], n: usize| dequant_mq4g256(d, n, &s1d, &s2d)),
-                 QuantType::MQ4G256, 256, "MQ4G256"),
-                (Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1e, &s2e)),
-                 Box::new(move |d: &[u8], n: usize| dequant_mq6g256(d, n, &s1f, &s2f)),
-                 QuantType::MQ6G256, 256, "MQ6G256"),
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq2g256(d, &s1a, &s2a)),
+                       qt: QuantType::MQ2G256, gs: 256, label: "MQ2G256", probe_bits: 2 },
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq3g256(d, &s1b, &s2b)),
+                       qt: QuantType::MQ3G256, gs: 256, label: "MQ3G256", probe_bits: 3 },
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1c, &s2c)),
+                       qt: QuantType::MQ4G256, gs: 256, label: "MQ4G256", probe_bits: 4 },
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1d, &s2d)),
+                       qt: QuantType::MQ6G256, gs: 256, label: "MQ6G256", probe_bits: 6 },
             ]
         }
         "mq3" => {
             let s1a = signs1.to_vec(); let s2a = signs2.to_vec();
             let s1b = signs1.to_vec(); let s2b = signs2.to_vec();
             let s1c = signs1.to_vec(); let s2c = signs2.to_vec();
-            let s1d = signs1.to_vec(); let s2d = signs2.to_vec();
             vec![
-                (Box::new(move |d: &[f32]| quantize_mq3g256(d, &s1a, &s2a)),
-                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-                 QuantType::MQ3G256, 256, "MQ3G256"),
-                (Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1b, &s2b)),
-                 Box::new(move |d: &[u8], n: usize| dequant_mq4g256(d, n, &s1c, &s2c)),
-                 QuantType::MQ4G256, 256, "MQ4G256"),
-                (Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1d, &s2d)),
-                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-                 QuantType::MQ6G256, 256, "MQ6G256"),
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq3g256(d, &s1a, &s2a)),
+                       qt: QuantType::MQ3G256, gs: 256, label: "MQ3G256", probe_bits: 3 },
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1b, &s2b)),
+                       qt: QuantType::MQ4G256, gs: 256, label: "MQ4G256", probe_bits: 4 },
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1c, &s2c)),
+                       qt: QuantType::MQ6G256, gs: 256, label: "MQ6G256", probe_bits: 6 },
             ]
         }
         "mq4" => {
             let s1a = signs1.to_vec(); let s2a = signs2.to_vec();
             let s1b = signs1.to_vec(); let s2b = signs2.to_vec();
-            let s1c = signs1.to_vec(); let s2c = signs2.to_vec();
-            let s1d = signs1.to_vec(); let s2d = signs2.to_vec();
             vec![
-                (Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1a, &s2a)),
-                 Box::new(move |d: &[u8], n: usize| dequant_mq4g256(d, n, &s1b, &s2b)),
-                 QuantType::MQ4G256, 256, "MQ4G256"),
-                (Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1c, &s2c)),
-                 Box::new(move |d: &[u8], n: usize| dequant_mq6g256(d, n, &s1d, &s2d)),
-                 QuantType::MQ6G256, 256, "MQ6G256"),
-                (Box::new(|d: &[f32]| quantize_q8f16(d)),
-                 Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]), // Q8 is terminal — no dequant needed
-                 QuantType::Q8F16, 32, "Q8_F16"),
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq4g256(d, &s1a, &s2a)),
+                       qt: QuantType::MQ4G256, gs: 256, label: "MQ4G256", probe_bits: 4 },
+                Rung { quantize: Box::new(move |d: &[f32]| quantize_mq6g256(d, &s1b, &s2b)),
+                       qt: QuantType::MQ6G256, gs: 256, label: "MQ6G256", probe_bits: 6 },
+                Rung { quantize: Box::new(|d: &[f32]| quantize_q8f16(d)),
+                       qt: QuantType::Q8F16, gs: 32, label: "Q8_F16", probe_bits: 8 },
             ]
         }
         "hfq2" => vec![
-            (Box::new(|d: &[f32]| quantize_hfq2g256(d)),
-             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-             QuantType::HFQ2G256, 256, "HFQ2G256"),
-            (Box::new(|d: &[f32]| quantize_hfq3g256(d)),
-             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-             QuantType::HFQ3G256, 256, "HFQ3G256"),
-            (Box::new(|d: &[f32]| quantize_hfq4g256(d)),
-             Box::new(|d: &[u8], n: usize| dequant_hfq4g256(d, n)),
-             QuantType::HFQ4G256, 256, "HFQ4G256"),
-            (Box::new(|d: &[f32]| quantize_hfq6g256(d)),
-             Box::new(|d: &[u8], n: usize| dequant_hfq6g256(d, n)),
-             QuantType::HFQ6G256, 256, "HFQ6G256"),
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq2g256(d)),
+                   qt: QuantType::HFQ2G256, gs: 256, label: "HFQ2G256", probe_bits: 2 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq3g256(d)),
+                   qt: QuantType::HFQ3G256, gs: 256, label: "HFQ3G256", probe_bits: 3 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq4g256(d)),
+                   qt: QuantType::HFQ4G256, gs: 256, label: "HFQ4G256", probe_bits: 4 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq6g256(d)),
+                   qt: QuantType::HFQ6G256, gs: 256, label: "HFQ6G256", probe_bits: 6 },
         ],
         "hfq3" => vec![
-            (Box::new(|d: &[f32]| quantize_hfq3g256(d)),
-             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-             QuantType::HFQ3G256, 256, "HFQ3G256"),
-            (Box::new(|d: &[f32]| quantize_hfq4g256(d)),
-             Box::new(|d: &[u8], n: usize| dequant_hfq4g256(d, n)),
-             QuantType::HFQ4G256, 256, "HFQ4G256"),
-            (Box::new(|d: &[f32]| quantize_hfq6g256(d)),
-             Box::new(|d: &[u8], n: usize| dequant_hfq6g256(d, n)),
-             QuantType::HFQ6G256, 256, "HFQ6G256"),
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq3g256(d)),
+                   qt: QuantType::HFQ3G256, gs: 256, label: "HFQ3G256", probe_bits: 3 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq4g256(d)),
+                   qt: QuantType::HFQ4G256, gs: 256, label: "HFQ4G256", probe_bits: 4 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq6g256(d)),
+                   qt: QuantType::HFQ6G256, gs: 256, label: "HFQ6G256", probe_bits: 6 },
         ],
         "hfq4" => vec![
-            (Box::new(|d: &[f32]| quantize_hfq4g256(d)),
-             Box::new(|d: &[u8], n: usize| dequant_hfq4g256(d, n)),
-             QuantType::HFQ4G256, 256, "HFQ4G256"),
-            (Box::new(|d: &[f32]| quantize_hfq6g256(d)),
-             Box::new(|d: &[u8], n: usize| dequant_hfq6g256(d, n)),
-             QuantType::HFQ6G256, 256, "HFQ6G256"),
-            (Box::new(|d: &[f32]| quantize_q8f16(d)),
-             Box::new(|_d: &[u8], _n: usize| vec![0.0f32; 0]),
-             QuantType::Q8F16, 32, "Q8_F16"),
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq4g256(d)),
+                   qt: QuantType::HFQ4G256, gs: 256, label: "HFQ4G256", probe_bits: 4 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_hfq6g256(d)),
+                   qt: QuantType::HFQ6G256, gs: 256, label: "HFQ6G256", probe_bits: 6 },
+            Rung { quantize: Box::new(|d: &[f32]| quantize_q8f16(d)),
+                   qt: QuantType::Q8F16, gs: 32, label: "Q8_F16", probe_bits: 8 },
         ],
         _ => panic!("unsupported base format for adaptive: {base_format}"),
     };
 
     let mut best_data = Vec::new();
-    let mut best_qt = ladder[0].2;
-    let mut best_gs = ladder[0].3;
-    let mut best_label = ladder[0].4;
+    let mut best_qt = ladder[0].qt;
+    let mut best_gs = ladder[0].gs;
+    let mut best_label = ladder[0].label;
     let mut best_cosim = 0.0f64;
     let mut promotions = 0usize;
 
-    // Walk the ladder: base level + up to max_promotions steps
-    let max_idx = (1 + max_promotions).min(ladder.len());
-    for (i, (quantize_fn, dequant_fn, qt, gs, label)) in ladder.iter().enumerate() {
-        if i >= max_idx { break; }
-        let quantized = quantize_fn(f32_data);
-        best_data = quantized;
-        best_qt = *qt;
-        best_gs = *gs;
-        best_label = label;
-        promotions = i;
+    // Probe cosim at the BASE level only (rung 0), using raw (non-rotated)
+    // HFQ quant/dequant. If cosim >= threshold, keep base level. Otherwise,
+    // promote up to max_promotions steps without re-probing — the raw probe
+    // measures weight-distribution difficulty, not per-format quality, so
+    // re-checking at MQ6 would give misleading results.
+    let base_rung = &ladder[0];
+    let base_cosim = if is_mq {
+        match base_rung.probe_bits {
+            4 => {
+                let q = quantize_hfq4g256(f32_data);
+                let d = dequant_hfq4g256(&q, n);
+                cosine_similarity(f32_data, &d)
+            }
+            6 => {
+                let q = quantize_hfq6g256(f32_data);
+                let d = dequant_hfq6g256(&q, n);
+                cosine_similarity(f32_data, &d)
+            }
+            _ => 0.0, // sub-4-bit: promote unconditionally
+        }
+    } else {
+        // HFQ formats: quantize and dequant directly
+        let q = (base_rung.quantize)(f32_data);
+        match base_rung.probe_bits {
+            4 => {
+                let d = dequant_hfq4g256(&q, n);
+                cosine_similarity(f32_data, &d)
+            }
+            6 => {
+                let d = dequant_hfq6g256(&q, n);
+                cosine_similarity(f32_data, &d)
+            }
+            _ => 0.0,
+        }
+    };
 
-        // Terminal level (Q8) — no dequant needed, accept unconditionally
-        if *qt == QuantType::Q8F16 {
-            best_cosim = 1.0;
-            break;
-        }
-
-        let reconstructed = dequant_fn(&best_data, n);
-        if reconstructed.is_empty() {
-            // No dequant available for this level — promote unconditionally
-            continue;
-        }
-        let cs = cosine_similarity(f32_data, &reconstructed);
-        best_cosim = cs;
-        if cs >= threshold {
-            break;
-        }
-    }
+    let need_promote = base_cosim < threshold;
+    // Pick the target rung: base (0) if cosim passes, else promote by 1 step.
+    // max_promotions caps how far up we go (default 2, but practically 1 is
+    // the sweet spot since the probe only measures base-level difficulty).
+    let target_idx = if need_promote {
+        (1usize).min(max_promotions).min(ladder.len() - 1)
+    } else {
+        0
+    };
+    let rung = &ladder[target_idx];
+    best_data = (rung.quantize)(f32_data);
+    best_qt = rung.qt;
+    best_gs = rung.gs;
+    best_label = rung.label;
+    best_cosim = base_cosim;
+    promotions = target_idx;
 
     AdaptiveResult {
         data: best_data,
@@ -2565,7 +2576,7 @@ fn main() {
     let cosim_threshold: f64 = args.iter().position(|a| a == "--cosim-threshold")
         .and_then(|i| args.get(i + 1))
         .and_then(|v| v.parse().ok())
-        .unwrap_or(0.9995);
+        .unwrap_or(0.995);
     let max_promotions: usize = args.iter().position(|a| a == "--max-promotions")
         .and_then(|i| args.get(i + 1))
         .and_then(|v| v.parse().ok())
@@ -2901,29 +2912,60 @@ fn main() {
                 else if use_hfq3g256 { "hfq3" }
                 else if use_hfq2g256 { "hfq2" }
                 else { "" };
-            let expert_promote_count = std::sync::atomic::AtomicU64::new(0);
+            // Adaptive expert strategy: probe ALL experts with raw cosim,
+            // if ANY fail the threshold, promote the ENTIRE group to MQ6.
+            // Mixed quant types within an expert group are not supported by
+            // the runtime (all slices share one QuantType in the HFQ index).
+            let is_mq_expert = expert_base_fmt.starts_with("mq");
+            let expert_promote_group = if expert_adaptive && !expert_base_fmt.is_empty() {
+                use rayon::prelude::*;
+                let fail_count = std::sync::atomic::AtomicU64::new(0);
+                (0..n_experts).into_par_iter().for_each(|x| {
+                    let slice_off = x * inner_bytes;
+                    let slice = &raw_data[slice_off..slice_off + inner_bytes];
+                    let f32_slice = to_f32(slice, &dtype);
+                    // Probe with HFQ4 (no rotation) to see raw weight difficulty
+                    let cs = if is_mq_expert {
+                        let q = quantize_hfq4g256(&f32_slice);
+                        let d = dequant_hfq4g256(&q, f32_slice.len());
+                        cosine_similarity(&f32_slice, &d)
+                    } else {
+                        let q = quantize_hfq4g256(&f32_slice);
+                        let d = dequant_hfq4g256(&q, f32_slice.len());
+                        cosine_similarity(&f32_slice, &d)
+                    };
+                    if cs < cosim_threshold {
+                        fail_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                });
+                let n_fail = fail_count.load(std::sync::atomic::Ordering::Relaxed);
+                if n_fail > 0 {
+                    eprintln!("  PROMOTE: {parent_owned}{{..}}.{base_owned}.weight: {n_fail}/{n_experts} experts below cosim threshold — promoting entire group");
+                    adaptive_promoted += 1; // count as 1 group promotion
+                }
+                adaptive_total += 1; // 1 group
+                n_fail > 0
+            } else {
+                false
+            };
             let mut new_tensors: Vec<HfqTensor> = (0..n_experts).into_par_iter().map(|x| {
                 let slice_off = x * inner_bytes;
                 let slice = &raw_data[slice_off..slice_off + inner_bytes];
                 let f32_slice = to_f32(slice, &dtype);
-                let (quantized, qt, gs) = if expert_mq6 {
-                    let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32)
+                let (quantized, qt, gs) = if expert_mq6 || expert_promote_group {
+                    if is_mq_expert || expert_mq6 {
+                        let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
+                        (q, QuantType::MQ6G256, 256u32)
+                    } else {
+                        let q = quantize_hfq6g256(&f32_slice);
+                        (q, QuantType::HFQ6G256, 256u32)
+                    }
                 } else if expert_hfq6 {
                     let q = quantize_hfq6g256(&f32_slice);
                     (q, QuantType::HFQ6G256, 256u32)
                 } else if expert_hfq4 {
                     let q = quantize_hfq4g256(&f32_slice);
                     (q, QuantType::HFQ4G256, 256u32)
-                } else if expert_adaptive && !expert_base_fmt.is_empty() {
-                    let ar = try_adaptive_promote(
-                        &f32_slice, expert_base_fmt, cosim_threshold, max_promotions,
-                        &signs1, &signs2,
-                    );
-                    if ar.promotions > 0 {
-                        expert_promote_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    }
-                    (ar.data, ar.quant_type, ar.group_size)
                 } else if supports_g256 {
                     let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
                     (q, QuantType::MQ4G256, 256u32)
@@ -2940,14 +2982,6 @@ fn main() {
                     spilled_len: 0,
                 }
             }).collect();
-            let n_expert_promoted = expert_promote_count.load(std::sync::atomic::Ordering::Relaxed);
-            if expert_adaptive && n_expert_promoted > 0 {
-                eprintln!("  PROMOTE: {parent_owned}{{..}}.{base_owned}.weight: {n_expert_promoted}/{n_experts} experts promoted");
-                adaptive_promoted += n_expert_promoted;
-            }
-            if expert_adaptive {
-                adaptive_total += n_experts as u64;
-            }
             quantized_params += inner_n as u64 * n_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
             let label = if expert_mq6 { "MQ6G256" } else if expert_hfq6 { "HFQ6G256" } else if expert_hfq4 { "HFQ4G256" } else if supports_g256 { "MQ4G256" } else { "HFQ4G128" };
@@ -3732,16 +3766,16 @@ mod tests {
     fn adaptive_promotes_when_threshold_above_base_cosim() {
         let signs1 = gen_fwht_signs(42, 256);
         let signs2 = gen_fwht_signs(1042, 256);
-        // Generate data, quantize at MQ4, measure its actual cosim, then set
-        // threshold just above that to force promotion.
+        // Probe uses HFQ4 (no rotation) cosim. Measure that directly,
+        // then set threshold just above to force promotion.
         let data: Vec<f32> = (0..256).map(|i| (i as f32 * 0.1) - 12.8).collect();
-        let q = quantize_mq4g256(&data, &signs1, &signs2);
-        let recon = dequant_mq4g256(&q, 256, &signs1, &signs2);
-        let base_cosim = cosine_similarity(&data, &recon);
-        // Set threshold above base cosim to guarantee promotion
-        let threshold = base_cosim + 0.0001;
+        let q = quantize_hfq4g256(&data);
+        let recon = dequant_hfq4g256(&q, 256);
+        let probe_cosim = cosine_similarity(&data, &recon);
+        // Set threshold above probe cosim to guarantee promotion
+        let threshold = probe_cosim + 0.0001;
         let ar = try_adaptive_promote(&data, "mq4", threshold, 2, &signs1, &signs2);
-        assert!(ar.promotions > 0, "expected promotion: base cosim={base_cosim}, threshold={threshold}");
+        assert!(ar.promotions > 0, "expected promotion: probe cosim={probe_cosim}, threshold={threshold}");
         // Should promote to MQ6
         assert_eq!(ar.quant_type, QuantType::MQ6G256);
     }


### PR DESCRIPTION
## Summary

Implements issue #196 step 2: adaptive per-tensor cosine similarity override for the quantizer, plus two new K-map promotion strategies discovered during benchmarking.

### New flags

- `--adaptive` — measure per-tensor reconstruction quality and auto-promote tensors below threshold
- `--cosim-threshold <f64>` — minimum cosine similarity (default: 0.995)
- `--max-promotions <N>` — max promotion steps per tensor (default: 2)
- `--kmap-mode alternating` — llama.cpp-style positional promotion (edge + every 3rd layer)
- `--kmap-mode typed` — promote ffn_down + attn_v in all layers
- `--adaptive` now works WITH K-map (gates Promote6 decisions by cosim)

### Key findings (MoE 3.6-35B-A3B, asym4 KV, wikitext-2-test)

| Config | Size | PPL 2K | PPL 8K |
|---|---:|---:|---:|
| Uniform MQ4 | 19.6 GB | 13.95 | 25.00 |
| **K-map alternating** | **22.9 GB (+17%)** | **13.55** | **19.96** |
| K-map default | 27.7 GB (+41%) | 13.58 | 20.07 |
| K-map typed | 27.7 GB (+41%) | 13.13 | 20.23 |

**K-map alternating is the best size/quality tradeoff**: same PPL as full K-map at 17% less model size. Promotes expert FFNs in edge layers + every 3rd middle layer instead of all layers.

### What we learned

1. **FWHT eliminates per-tensor cosim variance.** Post-rotation, every MQ4 tensor reconstructs at ~0.99967 cosim regardless of weight distribution. The adaptive probe must measure raw (pre-rotation) HFQ4 cosim to see real differences.

2. **Partial promotion is catastrophic at long context.** Promoting a random subset of tensors based on cosim threshold creates inconsistent precision boundaries. At 8K context, PPL degrades 2x worse than uniform MQ4. Structural coherence (all experts in a group, all layers of a type) matters more than individual tensor quality.

3. **llama.cpp's alternating pattern is validated.** Positional promotion (every Nth layer) is a budget-allocation strategy, not a quality signal. Per-tensor cosim variance within a type is too narrow (~0.001) to discriminate which layers need promotion.

4. **Type-level cosim is the right granularity.** Routers have the worst raw cosim (0.968-0.990), followed by edge layers (0.972-0.994), then expert FFNs (~0.992). This matches K-map's existing priority order.

### Implementation

- 4 dequant functions (MQ4G256, MQ6G256, HFQ4G256, HFQ6G256) with inverse FWHT
- `cosine_similarity()` in f64 precision
- `try_adaptive_promote()` with raw HFQ probe for MQ formats
- Group-level expert promotion (all-or-nothing per expert group)
- `is_positional_promote()` for alternating layer selection
- `kmap_resolve_mode()` supporting default/alternating/typed strategies
- 27 unit tests (all pass)

## Test plan

- [x] `cargo test -p hipfire-quantize` — 27/27 pass
- [x] PPL sweep on MoE 3.6-35B-A3B at ctx=2048 and ctx=8192
- [x] Verified alternating mode matches full K-map PPL at reduced size
- [x] Verified partial adaptive promotion causes PPL regression (documented)
- [ ] Dense model validation (0.8B, 4B, 9B, 27B) — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)