### PR TITLE
feat(runtime): Jinja chat-template rendering — Stages 0–4 (opt-in, parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,8 @@ dependencies = [
  "hipfire-detect",
  "libc",
  "memmap2",
+ "minijinja",
+ "minijinja-contrib",
  "rayon",
  "rdna-compute",
  "serde",
@@ -265,6 +267,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45092d80391870622fcf3bd82f5d2af18f99533ea60debb4bc9db0c76f0e809a"
+dependencies = [
+ "minijinja",
+ "serde",
 ]
 
 [[package]]

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -55,6 +55,16 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 libc = "0.2"
 rayon = "1"
+# Renders the upstream HF chat_template (Jinja) when present in
+# .hfq metadata, so prompt framing matches what the model was
+# trained on. Falls back to the hand-rolled `prompt_frame::ChatFrame`
+# scaffolding when the template is absent or fails to render.
+minijinja = { version = "2", features = ["loop_controls"] }
+# `pycompat` ships an unknown-method callback that makes Python
+# str/list/dict methods (e.g. `.startswith`, `.split`, `.rstrip`)
+# work on plain Jinja values — required by the Qwen3 family
+# template which uses these throughout.
+minijinja-contrib = { version = "2", features = ["pycompat"] }
 
 # Examples in this crate (daemon, infer_qwen35, infer_qwen3, infer_vl, etc.)
 # consume the arch crates. These are dev-dependencies — cargo refuses

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -59,7 +59,11 @@ rayon = "1"
 # .hfq metadata, so prompt framing matches what the model was
 # trained on. Falls back to the hand-rolled `prompt_frame::ChatFrame`
 # scaffolding when the template is absent or fails to render.
-minijinja = { version = "2", features = ["loop_controls"] }
+# `json` enables the `tojson` filter — Qwen3.5/3.6 + Gemma 4 tool-rendering
+# branches use `{{ tool | tojson }}` to emit OpenAI-shape function specs
+# inside the system block; without it, tool-using turns die at render time
+# (caught by jinja_smoke scenario C, 2026-05-09).
+minijinja = { version = "2", features = ["loop_controls", "json"] }
 # `pycompat` ships an unknown-method callback that makes Python
 # str/list/dict methods (e.g. `.startswith`, `.split`, `.rstrip`)
 # work on plain Jinja values — required by the Qwen3 family

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1161,6 +1161,76 @@ fn main() {
     }
 }
 
+/// Resolve the chat_template to use for a loaded model, walking the
+/// override-precedence chain:
+///
+///   1. `HIPFIRE_CHAT_TEMPLATE_FILE` env var → if set and file readable,
+///      that template wins. Operator escape hatch / debugging knob.
+///   2. Per-model file at `~/.hipfire/templates/<sanitized-tag>.j2`
+///      where the tag is derived from the model file basename
+///      (`qwen3.5-9b.mq4` → `qwen3.5-9b.mq4.j2`). User-controllable
+///      override for a specific model without env-var globalness.
+///   3. HFQ-embedded `tokenizer_config.chat_template`. Default — what
+///      the model was trained with.
+///   4. None of the above → `None`. The render path falls back to the
+///      hand-rolled `ChatFrame::Plain` scaffold (current default
+///      behavior under Stage 2's `HIPFIRE_JINJA_CHAT=1` gate). Stage 5+
+///      will tighten this to a hard error once Plain is removed.
+///
+/// Per-request inline override (`chat_template_kwargs.chat_template`,
+/// vLLM-style) is the responsibility of the per-request render call,
+/// not load-time resolution. It belongs in Stage 5 alongside the CLI
+/// passthrough refactor; this resolver only handles the load-time
+/// sources.
+fn resolve_chat_template(
+    hfq: &hipfire_runtime::hfq::HfqFile,
+    model_path: &str,
+) -> Option<String> {
+    // 1. Env-var override.
+    if let Ok(env_path) = std::env::var("HIPFIRE_CHAT_TEMPLATE_FILE") {
+        if !env_path.is_empty() {
+            match std::fs::read_to_string(&env_path) {
+                Ok(s) => {
+                    eprintln!("[chat_template] using HIPFIRE_CHAT_TEMPLATE_FILE={}", env_path);
+                    return Some(s);
+                }
+                Err(e) => eprintln!(
+                    "[chat_template] HIPFIRE_CHAT_TEMPLATE_FILE={env_path} failed to read ({e}); falling through"
+                ),
+            }
+        }
+    }
+
+    // 2. Per-model file at ~/.hipfire/templates/<basename>.j2.
+    if let Some(home) = std::env::var_os("HOME") {
+        let basename = std::path::Path::new(model_path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        if !basename.is_empty() {
+            let per_model = std::path::Path::new(&home)
+                .join(".hipfire")
+                .join("templates")
+                .join(format!("{basename}.j2"));
+            if per_model.is_file() {
+                match std::fs::read_to_string(&per_model) {
+                    Ok(s) => {
+                        eprintln!("[chat_template] using per-model override {}", per_model.display());
+                        return Some(s);
+                    }
+                    Err(e) => eprintln!(
+                        "[chat_template] per-model file {} failed to read ({e}); falling through",
+                        per_model.display()
+                    ),
+                }
+            }
+        }
+    }
+
+    // 3. HFQ-embedded.
+    hfq.chat_template()
+}
+
 fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_override: Option<&str>, cask: &CaskConfig, pp: usize, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
     if pp > 1 {
         // Refusal contracts (DFlash, CASK sidecar) are enforced upstream in
@@ -1461,7 +1531,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             }
         } else { None };
 
-        let chat_template = hfq.chat_template();
+        let chat_template = resolve_chat_template(&hfq, path);
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
             pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
@@ -1490,7 +1560,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         eprintln!("  KV cache: Q8");
         let kv = llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?;
         let scratch = <Llama as Architecture>::new_state(gpu, &config)?;
-        let chat_template = hfq.chat_template();
+        let chat_template = resolve_chat_template(&hfq, path);
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
             pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
@@ -1632,7 +1702,7 @@ fn load_model_pp(
         conversation_tokens: Vec::new(),
         model_path: path.to_string(),
         dflash: None,
-        chat_template: hfq.chat_template(),
+        chat_template: resolve_chat_template(&hfq, path),
     })
 }
 

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -355,6 +355,15 @@ struct LoadedModel {
     model_path: String,
     // DFlash speculative decoding state (populated when load supplied a draft).
     dflash: Option<DflashState>,
+    // Upstream HF Jinja chat_template, extracted from the HFQ
+    // `tokenizer_config.chat_template` at load time. `None` when the source
+    // model didn't ship one (rare for instruct models). Only consumed when
+    // `HIPFIRE_JINJA_CHAT=1` is set; otherwise the daemon's hand-rolled
+    // `prompt_frame::ChatFrame::Plain` scaffolding is used as today.
+    //
+    // Stage 2 partial: AR generate() path only. DFlash, multi-GPU PP>1, and
+    // VL paths still hit the Plain scaffold.
+    chat_template: Option<String>,
 }
 
 /// Print a friendly, user-actionable message when Gpu::init fails. Matches
@@ -1452,6 +1461,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             }
         } else { None };
 
+        let chat_template = hfq.chat_template();
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
             pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
@@ -1464,6 +1474,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             conversation_tokens: Vec::new(),
             model_path: path.to_string(),
             dflash,
+            chat_template,
         })
     } else {
         // Qwen3 / LLaMA — no eviction supported on this path (TriAttention needs
@@ -1479,6 +1490,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         eprintln!("  KV cache: Q8");
         let kv = llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?;
         let scratch = <Llama as Architecture>::new_state(gpu, &config)?;
+        let chat_template = hfq.chat_template();
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
             pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
@@ -1491,6 +1503,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             conversation_tokens: Vec::new(),
             model_path: path.to_string(),
             dflash: None,
+            chat_template,
         })
     }
 }
@@ -1619,6 +1632,7 @@ fn load_model_pp(
         conversation_tokens: Vec::new(),
         model_path: path.to_string(),
         dflash: None,
+        chat_template: hfq.chat_template(),
     })
 }
 
@@ -3012,19 +3026,66 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         raw_q_tokens
     };
 
-    // ChatML framing via the canonical hipfire_runtime::prompt_frame module.
-    // System prompt is prepended only on the first turn (seq_pos == 0)
-    // — subsequent turns continue the conversation in-place. The user
-    // body comes in pre-tokenized as `q_tokens` because PFlash may
-    // have compressed it upstream.
-    let new_tokens = hipfire_runtime::prompt_frame::ChatFrame {
-        tokenizer,
-        system: if m.seq_pos == 0 { system_prompt } else { None },
-        user: "", // unused: we pass tokens directly via build_with_user_tokens
-        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
-        raw: false,
-    }
-    .build_with_user_tokens(&q_tokens);
+    // ChatML framing — two paths:
+    //
+    //   1) `HIPFIRE_JINJA_CHAT=1` AND model carries an embedded chat_template
+    //      AND first turn (seq_pos == 0): render through `JinjaChatFrame`
+    //      against the upstream HF Jinja template, producing the byte
+    //      sequence the model was actually trained on (fixes the "hand-roll
+    //      drifted from upstream template" class — XML tool calls on
+    //      Qwen3.5/3.6 instead of JSON, `<|im_start|>user` for tool
+    //      responses instead of `<|im_start|>tool`, etc.). PFlash
+    //      compression is bypassed under Jinja for now (q_tokens not
+    //      reusable when the template renders to a String).
+    //
+    //   2) Default: hand-rolled `prompt_frame::ChatFrame::Plain`
+    //      scaffold, byte-identical to today's behavior.
+    //
+    // Multi-turn (seq_pos > 0) currently always uses path 2 — Jinja
+    // single-turn parity is Stage 2; multi-turn message-history state on
+    // the daemon side is Stage 2 follow-up.
+    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
+    let try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some();
+    let new_tokens = if try_jinja {
+        let template = m.chat_template.as_ref().unwrap();
+        let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+            tokenizer,
+            template,
+            system: system_prompt,
+            user: prompt,
+            // max_think_tokens == 1 is the daemon's current "no-think"
+            // sentinel (CLI sets it that way for `thinking=off` and
+            // `enable_thinking=false`). All other values keep thinking
+            // on, matching the Plain path which always emits the
+            // `<think>\n` opener via AssistantPrefix::Plain trailing
+            // tokens.
+            enable_thinking: max_think_tokens != 1,
+            bos_token: None,
+        };
+        match frame.render() {
+            Ok(rendered) => tokenizer.encode(&rendered),
+            Err(e) => {
+                eprintln!("[daemon] jinja render failed ({e}) — falling back to Plain");
+                hipfire_runtime::prompt_frame::ChatFrame {
+                    tokenizer,
+                    system: system_prompt,
+                    user: "",
+                    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                    raw: false,
+                }
+                .build_with_user_tokens(&q_tokens)
+            }
+        }
+    } else {
+        hipfire_runtime::prompt_frame::ChatFrame {
+            tokenizer,
+            system: if m.seq_pos == 0 { system_prompt } else { None },
+            user: "", // unused: we pass tokens directly via build_with_user_tokens
+            assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+            raw: false,
+        }
+        .build_with_user_tokens(&q_tokens)
+    };
 
     // KV-budget guard. Without eviction the physical buffer is the hard cap;
     // we must fit prefill + generation + trailer in one allocation. With

--- a/crates/hipfire-runtime/examples/jinja_smoke.rs
+++ b/crates/hipfire-runtime/examples/jinja_smoke.rs
@@ -289,10 +289,25 @@ fn main() {
 
     let t_decode = Instant::now();
     let mut generated: Vec<u32> = Vec::new();
-    let mut next_token = llama::sample_top_p(&logits, temp, sc.top_p);
+    let mut token_history: Vec<u32> = prompt_tokens.clone();
+
+    // Apply CPU-side repeat-penalty pre-pass (matches the daemon's
+    // sampler::sample path). Without this, top-p sampling at temp 0.3
+    // collapses to a greedy attractor on hard prompts and produces
+    // visible loops in the last 256 tokens. text_thinking() defaults
+    // to penalty=1.15, window=128.
+    let sample_one = |logits: &mut [f32], history: &[u32]| -> u32 {
+        if sc.repeat_penalty != 1.0 && sc.repeat_window > 0 {
+            llama::apply_repeat_penalty(logits, history, sc.repeat_window, sc.repeat_penalty);
+        }
+        llama::sample_top_p(logits, temp, sc.top_p)
+    };
+
+    let mut next_token = sample_one(&mut logits, &token_history);
 
     for _ in 0..max_gen {
         generated.push(next_token);
+        token_history.push(next_token);
         if Some(next_token) == im_end_token { break; }
         if Some(next_token) == endoftext_token { break; }
         if next_token == config.eos_token { break; }
@@ -301,7 +316,7 @@ fn main() {
         qwen35::forward_scratch(&mut gpu, &weights, &config, next_token, pos, &mut kv_cache, &mut dn_state, &scratch)
             .expect("decode forward");
         logits = gpu.download_f32(&scratch.logits).expect("download logits");
-        next_token = llama::sample_top_p(&logits, temp, sc.top_p);
+        next_token = sample_one(&mut logits, &token_history);
     }
     let decode_ms = t_decode.elapsed().as_millis();
     let decode_tok_s = (generated.len() as f64) * 1000.0 / (decode_ms as f64).max(1.0);

--- a/crates/hipfire-runtime/examples/jinja_smoke.rs
+++ b/crates/hipfire-runtime/examples/jinja_smoke.rs
@@ -1,0 +1,354 @@
+//! Stage 0/2-partial smoke harness — render via JinjaChatFrame and
+//! run end-to-end inference on Qwen3.5/3.6 (dense or A3B). Validates
+//! that the multi-turn JinjaChatFrame produces prompts that lead to
+//! coherent generation across the full thinking-on / thinking-off /
+//! tool-using axes.
+//!
+//! Usage:
+//!   jinja_smoke --model PATH --scenario A|B|C --output JSONL [--max-gen N]
+//!
+//! Scenarios:
+//!   A — Deliberately confusing prompt, thinking ENABLED
+//!   B — Deliberately difficult prompt, thinking DISABLED
+//!   C — Multi-turn (5 messages) with tool calls, thinking ENABLED
+//!
+//! Output: one JSONL record per run with rendered_prompt summary,
+//! generation summary, token counts, prefill_ms, decode tok/s, and
+//! coherence flags (max_freq + unique_ratio in first 256 / last 256).
+//!
+//! GPU device is selected via ROCR_VISIBLE_DEVICES on the parent
+//! process — this binary itself doesn't manage device selection.
+
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::{self, KvCache};
+use hipfire_runtime::prompt_frame::{JinjaChatFrame, Message, Role, ToolCall};
+use hipfire_runtime::tokenizer::Tokenizer;
+use hipfire_arch_qwen35::qwen35::{self, DeltaNetState, Qwen35Scratch};
+use serde_json::json;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug)]
+enum Scenario {
+    A, // confusing prompt, thinking ON
+    B, // difficult prompt, thinking OFF
+    C, // multi-turn 5-msg with tool calls, thinking ON
+}
+
+fn parse_scenario(s: &str) -> Option<Scenario> {
+    match s.to_ascii_uppercase().as_str() {
+        "A" => Some(Scenario::A),
+        "B" => Some(Scenario::B),
+        "C" => Some(Scenario::C),
+        _ => None,
+    }
+}
+
+fn build_messages(scenario: Scenario) -> (Vec<Message>, Vec<serde_json::Value>) {
+    match scenario {
+        Scenario::A => (
+            vec![
+                Message {
+                    role: Role::System,
+                    content: "You are a careful reasoner. If the user's question is contradictory, ambiguous, or self-referential, identify the contradiction explicitly before answering.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::User,
+                    content: "I am lying. The previous statement is true. Which of the two is the lie? Explain by listing the assumptions you have to make to answer, then commit to one.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+            ],
+            vec![],
+        ),
+        Scenario::B => (
+            vec![
+                Message {
+                    role: Role::System,
+                    content: "You are a senior systems engineer. Answer concisely with concrete code where applicable.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::User,
+                    content: "Write a Rust async function that fans out 1000 concurrent HTTPS GETs against an arbitrary URL list, caps in-flight at 32, retries on 5xx with exponential backoff capped at 30s, and aggregates response sizes. No external crates beyond `tokio`, `reqwest`, `futures`. Provide complete code that compiles.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+            ],
+            vec![],
+        ),
+        Scenario::C => {
+            let tools = vec![
+                json!({
+                    "type": "function",
+                    "function": {
+                        "name": "list_landmarks",
+                        "description": "List notable landmarks in the given city",
+                        "parameters": {
+                            "type": "object",
+                            "properties": { "city": { "type": "string" } },
+                            "required": ["city"]
+                        }
+                    }
+                }),
+                json!({
+                    "type": "function",
+                    "function": {
+                        "name": "get_population",
+                        "description": "Return current population estimate for a city in millions",
+                        "parameters": {
+                            "type": "object",
+                            "properties": { "city": { "type": "string" } },
+                            "required": ["city"]
+                        }
+                    }
+                }),
+            ];
+            let messages = vec![
+                Message {
+                    role: Role::System,
+                    content: "You are a travel concierge. Use the available tools to answer user questions about cities.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::User,
+                    content: "What's the capital of France?".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: "The capital of France is Paris.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::User,
+                    content: "List 3 famous landmarks there using the list_landmarks tool, and also fetch its population.".into(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::Assistant,
+                    content: "I'll fetch both.".into(),
+                    tool_calls: vec![
+                        ToolCall {
+                            name: "list_landmarks".into(),
+                            arguments: json!({ "city": "Paris" }),
+                        },
+                    ],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::Tool,
+                    content: "Eiffel Tower\nLouvre Museum\nNotre-Dame Cathedral".into(),
+                    tool_call_id: Some("call_landmarks_paris".into()),
+                    tool_calls: vec![],
+                },
+            ];
+            (messages, tools)
+        }
+    }
+}
+
+fn enable_thinking_for(s: Scenario) -> bool {
+    match s {
+        Scenario::A | Scenario::C => true,
+        Scenario::B => false,
+    }
+}
+
+/// Window stats for coherence scoring.
+fn window_stats(toks: &[u32], window: usize) -> (f32, f32) {
+    let slice: &[u32] = if toks.len() <= window { toks } else { &toks[toks.len() - window..] };
+    if slice.is_empty() { return (0.0, 0.0); }
+    let mut counts: HashMap<u32, u32> = HashMap::new();
+    for &t in slice { *counts.entry(t).or_insert(0) += 1; }
+    let max_freq = (*counts.values().max().unwrap_or(&0) as f32) / (slice.len() as f32);
+    let unique_ratio = (counts.len() as f32) / (slice.len() as f32);
+    (max_freq, unique_ratio)
+}
+
+fn parse_args() -> (String, Scenario, String, usize) {
+    let args: Vec<String> = std::env::args().collect();
+    let mut model: Option<String> = None;
+    let mut scenario: Option<Scenario> = None;
+    let mut output: Option<String> = None;
+    let mut max_gen: usize = 4096;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--model" => { model = args.get(i+1).cloned(); i += 2; }
+            "--scenario" => { scenario = args.get(i+1).and_then(|s| parse_scenario(s)); i += 2; }
+            "--output" => { output = args.get(i+1).cloned(); i += 2; }
+            "--max-gen" => { max_gen = args.get(i+1).and_then(|s| s.parse().ok()).unwrap_or(4096); i += 2; }
+            _ => { i += 1; }
+        }
+    }
+    let model = model.expect("--model PATH required");
+    let scenario = scenario.expect("--scenario A|B|C required");
+    let output = output.expect("--output JSONL required");
+    (model, scenario, output, max_gen)
+}
+
+fn main() {
+    let (model_path, scenario, output_path, max_gen) = parse_args();
+
+    eprintln!("=== jinja_smoke ===");
+    eprintln!("model: {}", model_path);
+    eprintln!("scenario: {:?}", scenario);
+    eprintln!("max_gen: {}", max_gen);
+
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let template = hfq.chat_template().expect("model lacks chat_template");
+    let tokenizer = Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .expect("tokenizer not in HFQ metadata");
+
+    let (messages, tools) = build_messages(scenario);
+    let enable_thinking = enable_thinking_for(scenario);
+
+    let frame = JinjaChatFrame {
+        tokenizer: &tokenizer,
+        template: &template,
+        system: None,
+        user: "",
+        enable_thinking,
+        bos_token: None,
+    };
+
+    let t_render = Instant::now();
+    let rendered = match frame.render_messages(
+        &messages,
+        if tools.is_empty() { None } else { Some(&tools) },
+        None,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("RENDER FAILED: {e}");
+            let rec = json!({
+                "model": model_path, "scenario": format!("{:?}", scenario),
+                "ok": false, "stage": "render", "error": e,
+            });
+            fs::write(&output_path, format!("{}\n", rec)).expect("write output");
+            std::process::exit(1);
+        }
+    };
+    let render_ms = t_render.elapsed().as_millis();
+    eprintln!("render_ms: {} | rendered_len: {} bytes", render_ms, rendered.len());
+
+    let prompt_tokens = tokenizer.encode(&rendered);
+    eprintln!("prompt_tokens: {}", prompt_tokens.len());
+
+    // Load model + run inference. Reuses arch-qwen35 primitives the
+    // daemon's AR path uses; the smoke is bit-equivalent to a daemon
+    // chat-completion call where the prompt is pre-rendered.
+    let config = qwen35::config_from_hfq(&hfq).expect("read config");
+    let mut gpu = rdna_compute::Gpu::init().expect("GPU init");
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
+
+    // KV cache sized for prompt + max_gen + headroom. Use asym3 (KV
+    // 5.5x compressed) for the bigger models to keep each smoke under
+    // a single 32 GB R9700 budget. asym3 is the daemon default for 27B
+    // and A3B per the existing config.
+    let kv_seq = (prompt_tokens.len() + max_gen + 64).max(2048);
+    let mut kv_cache = KvCache::new_gpu_asym3(
+        &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_seq,
+    ).expect("kv cache");
+    let mut dn_state = DeltaNetState::new(&mut gpu, &config).expect("dn state");
+    let scratch = Qwen35Scratch::new(&mut gpu, &config, 128).expect("scratch");
+
+    // Sequential prefill, AR loop (greedy from the deterministic CPU
+    // sampler — matches daemon temp=0.0 path for reproducibility).
+    let t_prefill = Instant::now();
+    let mut logits = vec![0.0f32; config.vocab_size];
+    for (pos, &tok) in prompt_tokens.iter().enumerate() {
+        qwen35::forward_scratch(&mut gpu, &weights, &config, tok, pos, &mut kv_cache, &mut dn_state, &scratch)
+            .expect("prefill forward");
+        if pos == prompt_tokens.len() - 1 {
+            logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        }
+    }
+    let prefill_ms = t_prefill.elapsed().as_millis();
+    eprintln!("prefill: {}ms ({:.0} tok/s)", prefill_ms,
+        prompt_tokens.len() as f64 * 1000.0 / (prefill_ms as f64).max(1.0));
+
+    let im_end = tokenizer.encode("<|im_end|>");
+    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    let endoftext = tokenizer.encode("<|endoftext|>");
+    let endoftext_token = if endoftext.len() == 1 { Some(endoftext[0]) } else { None };
+
+    let sc = llama::SamplingConfig::text_thinking();
+    let temp = if enable_thinking { sc.think_temp } else { sc.answer_temp };
+
+    let t_decode = Instant::now();
+    let mut generated: Vec<u32> = Vec::new();
+    let mut next_token = llama::sample_top_p(&logits, temp, sc.top_p);
+
+    for _ in 0..max_gen {
+        generated.push(next_token);
+        if Some(next_token) == im_end_token { break; }
+        if Some(next_token) == endoftext_token { break; }
+        if next_token == config.eos_token { break; }
+
+        let pos = prompt_tokens.len() + generated.len() - 1;
+        qwen35::forward_scratch(&mut gpu, &weights, &config, next_token, pos, &mut kv_cache, &mut dn_state, &scratch)
+            .expect("decode forward");
+        logits = gpu.download_f32(&scratch.logits).expect("download logits");
+        next_token = llama::sample_top_p(&logits, temp, sc.top_p);
+    }
+    let decode_ms = t_decode.elapsed().as_millis();
+    let decode_tok_s = (generated.len() as f64) * 1000.0 / (decode_ms as f64).max(1.0);
+
+    let gen_text = tokenizer.decode(&generated);
+    let (max_freq_first, unique_first) = window_stats(&generated[..generated.len().min(256)], 256);
+    let (max_freq_last, unique_last) = window_stats(&generated, 256);
+
+    let rendered_first = &rendered[..rendered.len().min(400)];
+    let rendered_last_start = rendered.len().saturating_sub(200);
+    let rendered_last = &rendered[rendered_last_start..];
+
+    let gen_first = &gen_text.as_str()[..gen_text.len().min(500)];
+    let gen_last_start = gen_text.len().saturating_sub(300);
+    let gen_last = &gen_text.as_str()[gen_last_start..];
+
+    let rec = json!({
+        "model": model_path,
+        "scenario": format!("{:?}", scenario),
+        "ok": true,
+        "enable_thinking": enable_thinking,
+        "render_ms": render_ms,
+        "rendered_len_bytes": rendered.len(),
+        "rendered_first_400": rendered_first,
+        "rendered_last_200": rendered_last,
+        "prompt_tokens": prompt_tokens.len(),
+        "max_gen": max_gen,
+        "generated_tokens": generated.len(),
+        "prefill_ms": prefill_ms,
+        "decode_ms": decode_ms,
+        "decode_tok_s": decode_tok_s,
+        "gen_first_500": gen_first,
+        "gen_last_300": gen_last,
+        "max_freq_first_256": max_freq_first,
+        "unique_ratio_first_256": unique_first,
+        "max_freq_last_256": max_freq_last,
+        "unique_ratio_last_256": unique_last,
+        "stopped_im_end": Some(generated.last().copied()) == im_end_token.map(Some),
+        "stopped_endoftext": Some(generated.last().copied()) == endoftext_token.map(Some),
+    });
+
+    let mut out = fs::File::create(&output_path).expect("create output");
+    writeln!(out, "{}", rec).expect("write output");
+
+    eprintln!("=== summary ===");
+    eprintln!("generated: {} tokens, {:.0} tok/s", generated.len(), decode_tok_s);
+    eprintln!("max_freq first/last: {:.3} / {:.3}", max_freq_first, max_freq_last);
+    eprintln!("unique_ratio first/last: {:.3} / {:.3}", unique_first, unique_last);
+    eprintln!("output: {}", output_path);
+}

--- a/crates/hipfire-runtime/examples/render_bench.rs
+++ b/crates/hipfire-runtime/examples/render_bench.rs
@@ -1,0 +1,188 @@
+//! Render-time microbench, with three timing paths to expose the cost
+//! split between Environment setup, per-render template execution, and
+//! the existing hand-rolled `ChatFrame::Plain` build path.
+//!
+//! Usage:
+//!   render_bench <model.mq4> [iterations]
+//!
+//! Default 1000 iterations. Reports mean / p50 / p99 / min / max in
+//! microseconds for each path.
+//!
+//! What this answers: "does Jinja rendering hurt perf vs ChatFrame::Plain
+//! in production?" Production daemons would build the minijinja Environment
+//! once at model load and reuse it per request — Path J2 measures that. The
+//! current `JinjaChatFrame::render` impl rebuilds Env+parse each call
+//! (Path J1), which is correct for Stage 0 dead-code but a real cost we
+//! must cache before wiring into the daemon (tracked: Stage 2 follow-up).
+
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::prompt_frame::{
+    AssistantPrefix, ChatFrame, JinjaChatFrame,
+};
+use hipfire_runtime::tokenizer::Tokenizer;
+use minijinja::{context, Environment, Error, ErrorKind, Value};
+use minijinja_contrib::pycompat::unknown_method_callback;
+use serde_json::json;
+use std::path::Path;
+use std::time::Instant;
+
+fn percentile(sorted_us: &[u64], pct: f64) -> u64 {
+    if sorted_us.is_empty() { return 0; }
+    let i = ((sorted_us.len() as f64) * pct).floor() as usize;
+    sorted_us[i.min(sorted_us.len() - 1)]
+}
+
+fn report(label: &str, samples_us: &mut Vec<u64>) {
+    samples_us.sort();
+    let n = samples_us.len();
+    let mean = samples_us.iter().sum::<u64>() / (n as u64);
+    println!(
+        "  {:<48} n={} mean={}us p50={}us p99={}us min={}us max={}us",
+        label, n, mean,
+        percentile(samples_us, 0.50),
+        percentile(samples_us, 0.99),
+        samples_us.first().copied().unwrap_or(0),
+        samples_us.last().copied().unwrap_or(0),
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let model_path = args.get(1).expect("usage: render_bench <model.mq4> [iters]");
+    let iters: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
+
+    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let template = hfq.chat_template().expect("model lacks chat_template");
+    let tokenizer = Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .expect("tokenizer not in HFQ metadata");
+
+    let system = "You are a careful coding assistant. Respond concisely with concrete code where applicable.";
+    let user = "Write a Rust async function that fans out 1000 concurrent HTTPS GETs against an arbitrary URL list, caps in-flight at 32, retries on 5xx with exponential backoff capped at 30s, and aggregates response sizes.";
+
+    println!("=== render_bench ({} iterations) ===", iters);
+    println!("model:    {}", model_path);
+    println!("template: {} bytes", template.len());
+    println!();
+
+    // ── Path J0: Environment setup + template parse, ONCE.
+    //
+    // Measure how long the one-time setup takes. In production the
+    // daemon would do this at load_model time and store the Env in
+    // LoadedModel; per-request render reuses it.
+    let t = Instant::now();
+    let mut env_cached = Environment::new();
+    env_cached.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+    env_cached.set_unknown_method_callback(unknown_method_callback);
+    env_cached.add_function("raise_exception", |msg: String| -> Result<Value, Error> {
+        Err(Error::new(ErrorKind::InvalidOperation, msg))
+    });
+    env_cached.add_template("chat", &template).expect("template parse");
+    let env_setup_us = t.elapsed().as_micros() as u64;
+    println!("Path J0 (one-time Env setup + template parse): {} us", env_setup_us);
+    println!();
+
+    // Build the bos_token + messages once; identical across all paths.
+    let bos_token: String = String::from_utf8_lossy(
+        &tokenizer.decode_bytes(&[tokenizer.bos_id])
+    ).to_string();
+    let empty_list: Vec<serde_json::Value> = Vec::new();
+    let empty_map = serde_json::Map::<String, serde_json::Value>::new();
+    let messages_single = vec![
+        json!({ "role": "system", "content": system, "tool_calls": [] }),
+        json!({ "role": "user", "content": user, "tool_calls": [] }),
+    ];
+
+    // ── Path J1: full JinjaChatFrame::render — rebuilds Env each call.
+    // This is the CURRENT cost of `JinjaChatFrame::render` as committed.
+    let frame_jinja = JinjaChatFrame {
+        tokenizer: &tokenizer,
+        template: &template,
+        system: Some(system),
+        user,
+        enable_thinking: true,
+        bos_token: None,
+    };
+    let mut j1: Vec<u64> = Vec::with_capacity(iters);
+    let mut last_render_len = 0;
+    for _ in 0..iters {
+        let t = Instant::now();
+        let s = frame_jinja.render().expect("J1 render");
+        j1.push(t.elapsed().as_micros() as u64);
+        last_render_len = s.len();
+    }
+
+    // ── Path J2: cached Env + template render only — the production cost.
+    // Equivalent to what the daemon should do with a cached renderer.
+    let tmpl_cached = env_cached.get_template("chat").expect("template lookup");
+    let mut j2: Vec<u64> = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t = Instant::now();
+        let ctx = context! {
+            messages => Value::from_serialize(&messages_single),
+            add_generation_prompt => true,
+            enable_thinking => true,
+            bos_token => bos_token.clone(),
+            tools => Value::from_serialize(&empty_list),
+            documents => Value::from_serialize(&empty_list),
+            tool_call_kwargs => Value::from_serialize(&empty_map),
+        };
+        let _s = tmpl_cached.render(ctx).expect("J2 render");
+        j2.push(t.elapsed().as_micros() as u64);
+    }
+
+    // ── Path P: hand-rolled ChatFrame::Plain — the legacy baseline.
+    let frame_plain = ChatFrame {
+        tokenizer: &tokenizer,
+        system: Some(system),
+        user,
+        assistant_prefix: AssistantPrefix::OpenThink,
+        raw: false,
+    };
+    let mut p: Vec<u64> = Vec::with_capacity(iters);
+    let mut last_plain_len = 0;
+    for _ in 0..iters {
+        let t = Instant::now();
+        let toks = frame_plain.build();
+        p.push(t.elapsed().as_micros() as u64);
+        last_plain_len = toks.len();
+    }
+
+    // ── Path T: tokenize the J1/J2 rendered string. Both J paths
+    // need this on top, since they produce a String the daemon must
+    // encode; Path P already returns tokens directly.
+    let representative = frame_jinja.render().expect("render for tokenize");
+    let mut t_us: Vec<u64> = Vec::with_capacity(iters);
+    let mut last_tok_n = 0;
+    for _ in 0..iters {
+        let t = Instant::now();
+        let toks = tokenizer.encode(&representative);
+        t_us.push(t.elapsed().as_micros() as u64);
+        last_tok_n = toks.len();
+    }
+
+    println!("Output sizes:");
+    println!("  Jinja rendered string:   {} bytes  ({} tokens after encode)", last_render_len, last_tok_n);
+    println!("  Plain build tokens:      {} tokens", last_plain_len);
+    println!();
+    println!("Per-call timings (microseconds):");
+    report("J1 — full JinjaChatFrame::render (no cache)", &mut j1);
+    report("J2 — cached Env + tmpl.render (production)", &mut j2);
+    report("P  — ChatFrame::Plain build", &mut p);
+    report("T  — tokenizer.encode (rendered string)", &mut t_us);
+    println!();
+
+    // Effective end-to-end "ready-for-forward" cost: bytes -> tokens.
+    let mean_j2 = j2.iter().sum::<u64>() / (j2.len() as u64);
+    let mean_t = t_us.iter().sum::<u64>() / (t_us.len() as u64);
+    let mean_p = p.iter().sum::<u64>() / (p.len() as u64);
+    let mean_j1 = j1.iter().sum::<u64>() / (j1.len() as u64);
+
+    println!("Apples-to-apples (bytes -> ready tokens):");
+    println!("  Jinja prod path:    {} us = {} (J2) + {} (T)", mean_j2 + mean_t, mean_j2, mean_t);
+    println!("  Plain baseline:     {} us (P, returns tokens directly)", mean_p);
+    println!("  Delta:              {} us per request", (mean_j2 + mean_t).saturating_sub(mean_p));
+    println!();
+    println!("If JinjaChatFrame::render were called as-is (J1, no caching):");
+    println!("  Jinja no-cache path: {} us = {} (J1) + {} (T)", mean_j1 + mean_t, mean_j1, mean_t);
+    println!("  Delta vs Plain:      {} us per request", (mean_j1 + mean_t).saturating_sub(mean_p));
+}

--- a/crates/hipfire-runtime/examples/render_chat_template.rs
+++ b/crates/hipfire-runtime/examples/render_chat_template.rs
@@ -1,0 +1,68 @@
+//! Render a model's upstream HF chat_template via JinjaChatFrame and
+//! print the result to stdout. Diagnostic for issue #171 — verifies
+//! minijinja can parse the Qwen3 family template and that the rendered
+//! string matches the transformers/jinja2 reference output byte-for-byte.
+//!
+//! Usage:
+//!   cargo run --release -p hipfire-runtime --example render_chat_template -- \
+//!     <model.mq4> <prompt.txt>
+//!
+//! Prints rendered length + first/last bytes. Compare against the
+//! Python jinja2 reference render to confirm parity.
+
+use std::fs;
+use std::path::Path;
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::tokenizer::Tokenizer;
+use hipfire_runtime::prompt_frame::JinjaChatFrame;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: render_chat_template <model.mq4> <prompt.txt>");
+        std::process::exit(2);
+    }
+    let model_path = &args[1];
+    let prompt_path = &args[2];
+
+    let hfq = HfqFile::open(Path::new(model_path)).expect("open model");
+    let template = hfq.chat_template().expect("model has no chat_template");
+    let tokenizer = Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .expect("tokenizer not found");
+    let prompt = fs::read_to_string(prompt_path).expect("read prompt");
+
+    let frame = JinjaChatFrame {
+        tokenizer: &tokenizer,
+        template: &template,
+        system: None,
+        user: &prompt,
+        enable_thinking: true,
+        bos_token: None,
+    };
+
+    eprintln!("=== template lines around 45 ===");
+    for (i, line) in template.split("\n").enumerate() {
+        if i >= 40 && i <= 55 { eprintln!("{:3}  {}", i+1, line); }
+    }
+    match frame.render() {
+        Ok(rendered) => {
+            println!("=== rendered length: {}", rendered.len());
+            println!("=== first 500 chars ===");
+            println!("{:?}", &rendered[..rendered.len().min(500)]);
+            println!("=== last 200 chars ===");
+            let n = rendered.len();
+            let start = n.saturating_sub(200);
+            println!("{:?}", &rendered[start..]);
+
+            // Also tokenize and report token count for a sanity check.
+            let tokens = tokenizer.encode(&rendered);
+            println!("=== token count: {}", tokens.len());
+            println!("=== first 8 tokens: {:?}", &tokens[..tokens.len().min(8)]);
+            println!("=== last 8 tokens: {:?}", &tokens[tokens.len().saturating_sub(8)..]);
+        }
+        Err(e) => {
+            eprintln!("render failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -200,6 +200,20 @@ impl HfqFile {
         &self.path
     }
 
+    /// The upstream HuggingFace Jinja `chat_template` baked into this
+    /// .hfq's `tokenizer_config` metadata. `None` when the source model
+    /// did not ship a chat_template (rare for instruct models, common
+    /// for base models). The runtime renders this when present so prompt
+    /// framing matches the model's training-time expectation; absent or
+    /// failing renders fall back to the hand-rolled `prompt_frame` path.
+    pub fn chat_template(&self) -> Option<String> {
+        let meta: serde_json::Value = serde_json::from_str(&self.metadata_json).ok()?;
+        meta.get("tokenizer_config")?
+            .get("chat_template")?
+            .as_str()
+            .map(|s| s.to_string())
+    }
+
     /// Look up a tensor's metadata (name, quant_type, shape, byte offset/size)
     /// without copying its data. The weight pager calls this at load time to
     /// register byte ranges without forcing eager VRAM allocation.

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -31,3 +31,4 @@ pub mod weight_pager;
 pub mod tokenizer;
 pub mod eos_filter;
 pub mod prompt_frame;
+pub mod tool_call;

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -51,11 +51,22 @@ pub enum AssistantPrefix {
     OpenThink,
 }
 
-/// Direction of a multi-turn history entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Role of a multi-turn history entry. `User` / `Assistant` are
+/// canonical for `ChatFrame::Plain` (the hand-rolled ChatML path).
+/// `System` / `Tool` are accepted by `JinjaChatFrame::render_messages`
+/// (the upstream-template path) but rejected by `ChatFrame::Plain`,
+/// which has no scaffold for them — that route panics loudly to
+/// signal "migrate this caller to JinjaChatFrame".
+///
+/// Lowercase serialization matches what the Qwen3.5/3.6 + Gemma 4
+/// templates compare against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Role {
+    System,
     User,
     Assistant,
+    Tool,
 }
 
 /// ChatML frame builder. Holds borrowed references to the tokenizer
@@ -149,6 +160,10 @@ impl<'a> ChatFrame<'a> {
             match role {
                 Role::User => scaffold.append_user_turn(&mut out, content),
                 Role::Assistant => scaffold.append_assistant_turn(&mut out, content),
+                Role::System | Role::Tool => panic!(
+                    "ChatFrame::Plain does not support {role:?} role in history. \
+                     Use JinjaChatFrame::render_messages for system/tool turns."
+                ),
             }
         }
         scaffold.append_user_turn(&mut out, self.user);
@@ -272,8 +287,10 @@ pub struct JinjaChatFrame<'a> {
     /// `tokenizer_config.json:chat_template` field.
     pub template: &'a str,
     /// Optional system message for this turn. `None` = no system block.
+    /// Ignored by `render_messages` (the multi-turn entry point); use
+    /// only when going through the single-turn `render()` convenience.
     pub system: Option<&'a str>,
-    /// User content for the new turn.
+    /// User content for the new turn. Ignored by `render_messages`.
     pub user: &'a str,
     /// Maps to the upstream `enable_thinking` template kwarg. For
     /// Qwen3.5/3.6 thinking-mode models, `true` (the upstream default)
@@ -294,6 +311,40 @@ pub struct JinjaChatFrame<'a> {
     pub bos_token: Option<&'a str>,
 }
 
+/// Multi-turn message representation for `JinjaChatFrame::render_messages`.
+///
+/// The fields are intentionally serialize-friendly so the entire `&[Message]`
+/// slice can be passed straight into the Jinja `messages` context var via
+/// `Value::from_serialize(...)`. Templates probe `message['role']`,
+/// `message['content']`, `message['tool_calls']`, and (less commonly)
+/// `message['tool_call_id']` under strict-undefined mode; all four fields
+/// are always present (defaults: empty content, empty tool_calls vec, no
+/// tool_call_id) so probes never raise.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: String,
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCall>,
+    /// Set on Tool-role messages to identify which assistant tool_call
+    /// this is responding to. Qwen3.5/3.6 templates currently ignore
+    /// this field; OpenAI-spec clients and some other templates require
+    /// it. Skipped from the serialized JSON when None so templates that
+    /// `is defined` against it don't see a misleading null.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+/// One assistant-emitted tool call, attached to an assistant `Message`.
+/// `arguments` is a free-form JSON value (typically an object). Templates
+/// that render in XML format (Qwen3.5/3.6's `<function=NAME><parameter=ARG>`
+/// shape) walk this with `arguments | items` under pycompat.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ToolCall {
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
 impl<'a> JinjaChatFrame<'a> {
     /// Render the template and tokenize the result. Returns `Err` on
     /// any template-side failure so the caller can fall back to
@@ -303,10 +354,51 @@ impl<'a> JinjaChatFrame<'a> {
         Ok(self.tokenizer.encode(&rendered))
     }
 
-    /// Render the template to a string without tokenizing. Exposed
-    /// separately so a diagnostic example can dump the rendered prompt
-    /// for byte-level comparison against transformers' output.
+    /// Render the template to a string without tokenizing. Single-turn
+    /// convenience wrapper around `render_messages` that synthesizes a
+    /// `[system?, user]` message slice from the struct's `system` /
+    /// `user` fields. Exposed separately so a diagnostic example can
+    /// dump the rendered prompt for byte-level comparison against
+    /// transformers' output.
     pub fn render(&self) -> Result<String, String> {
+        let mut messages: Vec<Message> = Vec::new();
+        if let Some(sys) = self.system {
+            messages.push(Message {
+                role: Role::System,
+                content: sys.to_string(),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            });
+        }
+        messages.push(Message {
+            role: Role::User,
+            content: self.user.to_string(),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+        });
+        self.render_messages(&messages, None, None)
+    }
+
+    /// Render the template against a full multi-turn message history.
+    /// This is the canonical entry point — `render()` above is just a
+    /// single-turn convenience.
+    ///
+    /// `tools` is the OpenAI tool definitions list (each entry an object
+    /// with `type` + `function`); pass `None` for plain (no-tools)
+    /// turns and the template's `if tools` predicate evaluates false.
+    /// `tool_call_kwargs` is a free-form map propagated to the template
+    /// context for templates that opt into per-call rendering switches;
+    /// pass `None` for the default empty map.
+    ///
+    /// Strict-undefined empty defaults still apply when args are `None`,
+    /// so templates that probe `tools` / `documents` / `tool_call_kwargs`
+    /// don't raise.
+    pub fn render_messages(
+        &self,
+        messages: &[Message],
+        tools: Option<&[serde_json::Value]>,
+        tool_call_kwargs: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<String, String> {
         use minijinja::{Environment, Error, ErrorKind, Value};
         use minijinja_contrib::pycompat::unknown_method_callback;
 
@@ -336,31 +428,6 @@ impl<'a> JinjaChatFrame<'a> {
         let tmpl = env.get_template("chat")
             .map_err(|e| format!("template lookup: {e}"))?;
 
-        // Build the messages list the way transformers does: optional
-        // system first, then a single user turn. Multi-turn history is
-        // not yet plumbed through — the daemon's request shape is
-        // single-turn, and the template's `<think>` stripping for
-        // prior assistant turns only matters once that lands.
-        let mut messages: Vec<serde_json::Value> = Vec::new();
-        // Each message gets `tool_calls: []` so chat templates can use
-        // bracket-access (`message['tool_calls']`) without tripping
-        // strict-undefined. Gemma 4's template hits this on every loop
-        // iteration; without the empty default the render fails and we
-        // silently fall back to a raw bos+token shape that breaks the
-        // model's instruct framing.
-        if let Some(sys) = self.system {
-            messages.push(serde_json::json!({
-                "role": "system",
-                "content": sys,
-                "tool_calls": [],
-            }));
-        }
-        messages.push(serde_json::json!({
-            "role": "user",
-            "content": self.user,
-            "tool_calls": [],
-        }));
-
         // Pass bos_token to the template context. Caller may override via
         // `self.bos_token` (Gemma 4 needs explicit `<bos>` because its
         // tokenizer returns LLaMA-cosmetic `<s>` for decode_bytes(bos_id)
@@ -374,20 +441,27 @@ impl<'a> JinjaChatFrame<'a> {
                 String::from_utf8_lossy(&bytes).to_string()
             }
         };
-        // Strict-undefined needs every var the template might reference to be
-        // defined (else the render Errs and we fall back to Plain). Common
-        // chat templates probe `tools`, `documents`, and `tool_call_kwargs`
-        // even on plain user-only turns; pass empty defaults so the
-        // template predicates evaluate to false rather than raise.
+        // Strict-undefined empty defaults so templates that probe
+        // `tools` / `documents` / `tool_call_kwargs` on plain turns
+        // don't raise. Caller-provided values override the empties.
         let empty_list: Vec<serde_json::Value> = Vec::new();
+        let empty_map = serde_json::Map::new();
+        let tools_val = match tools {
+            Some(t) => Value::from_serialize(t),
+            None => Value::from_serialize(&empty_list),
+        };
+        let kwargs_val = match tool_call_kwargs {
+            Some(k) => Value::from_serialize(k),
+            None => Value::from_serialize(&empty_map),
+        };
         let ctx = minijinja::context! {
-            messages => Value::from_serialize(&messages),
+            messages => Value::from_serialize(messages),
             add_generation_prompt => true,
             enable_thinking => self.enable_thinking,
             bos_token => bos_token,
-            tools => Value::from_serialize(&empty_list),
+            tools => tools_val,
             documents => Value::from_serialize(&empty_list),
-            tool_call_kwargs => Value::from_serialize(&serde_json::json!({})),
+            tool_call_kwargs => kwargs_val,
         };
         tmpl.render(ctx).map_err(|e| format!("template render: {e}"))
     }

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -243,6 +243,156 @@ impl<'a> ChatScaffold<'a> {
     }
 }
 
+// ─── Jinja path — render upstream HF chat_template ──────────────────────────
+//
+// `ChatFrame` above is a hand-rolled approximation of ChatML scaffolding.
+// `JinjaChatFrame` renders the actual `chat_template` shipped with the
+// model (via the .hfq metadata blob). When the template is present this
+// is strictly more correct: the model sees the exact prefix shape it
+// was trained on, including default system prompts, `<think>\n` openers
+// gated by `enable_thinking`, tool-call scaffolding, and any other
+// per-arch quirks the upstream tokenizer_config encodes.
+//
+// Failure modes (template parse error, missing context var, explicit
+// `raise_exception`) bubble up as `Err(String)` so the caller can fall
+// back to `ChatFrame::Plain` rather than panicking.
+//
+// The render output is a plain UTF-8 string. Tokenization goes through
+// `Tokenizer::encode` which recognizes registered special tokens
+// (`<|im_start|>`, `<|im_end|>`, `<think>`, etc.) and emits their
+// single-token IDs — so the rendered string round-trips to the same
+// token sequence the model would see under transformers' apply_chat_template.
+
+/// Renders the upstream HF Jinja `chat_template` to produce a prompt
+/// token sequence. Use when the .hfq carries a chat_template; fall back
+/// to `ChatFrame::Plain` when it doesn't or when render fails.
+pub struct JinjaChatFrame<'a> {
+    pub tokenizer: &'a Tokenizer,
+    /// The Jinja template source string from the model's
+    /// `tokenizer_config.json:chat_template` field.
+    pub template: &'a str,
+    /// Optional system message for this turn. `None` = no system block.
+    pub system: Option<&'a str>,
+    /// User content for the new turn.
+    pub user: &'a str,
+    /// Maps to the upstream `enable_thinking` template kwarg. For
+    /// Qwen3.5/3.6 thinking-mode models, `true` (the upstream default)
+    /// emits `<|im_start|>assistant\n<think>\n` at the end; `false`
+    /// emits the empty-think pattern `<think>\n\n</think>\n\n` which
+    /// is known to cause loop pathologies (see
+    /// `feedback_no_think_directive_loops.prd`). Default callers
+    /// should pass `true`.
+    pub enable_thinking: bool,
+    /// Optional explicit bos_token string for the template's
+    /// `{{ bos_token }}` expression. Required when the tokenizer's
+    /// `decode_bytes(bos_id)` does NOT match the canonical BOS string
+    /// the template expects. Example: Gemma 4's tokenizer reports
+    /// bos_id=203 (and id=2 decodes to LLaMA-cosmetic `<s>`), but the
+    /// Gemma 4 template needs the literal `<bos>` which re-tokenizes to
+    /// single special token id=2 (the actual BOS the model trained on).
+    /// When None, falls back to decoding bos_id (works for Qwen3.5/3.6).
+    pub bos_token: Option<&'a str>,
+}
+
+impl<'a> JinjaChatFrame<'a> {
+    /// Render the template and tokenize the result. Returns `Err` on
+    /// any template-side failure so the caller can fall back to
+    /// `ChatFrame::Plain` framing.
+    pub fn render_and_encode(&self) -> Result<Vec<u32>, String> {
+        let rendered = self.render()?;
+        Ok(self.tokenizer.encode(&rendered))
+    }
+
+    /// Render the template to a string without tokenizing. Exposed
+    /// separately so a diagnostic example can dump the rendered prompt
+    /// for byte-level comparison against transformers' output.
+    pub fn render(&self) -> Result<String, String> {
+        use minijinja::{Environment, Error, ErrorKind, Value};
+        use minijinja_contrib::pycompat::unknown_method_callback;
+
+        let mut env = Environment::new();
+        // Strict-undefined: a missing context variable raises Err instead of
+        // silently rendering empty/partial output. Without this, malformed
+        // prompts could propagate to the model unnoticed (Codex review on
+        // PR #175 flagged this; we apply it here in the same port).
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+        // Make Python-style str/list/dict methods (`.startswith`,
+        // `.split`, `.rstrip`, `.lstrip`, `|items`, etc.) work on
+        // ordinary Jinja values. Required by the Qwen3 family
+        // template — it calls these throughout the assistant-turn
+        // and tool branches.
+        env.set_unknown_method_callback(unknown_method_callback);
+        // The Qwen3 template uses `raise_exception('...')` to fail
+        // fast on malformed inputs (e.g. system message in the
+        // middle of the conversation). minijinja has no builtin
+        // for this, so we register it as a global function that
+        // surfaces the message as a render error.
+        env.add_function("raise_exception", |msg: String| -> Result<Value, Error> {
+            Err(Error::new(ErrorKind::InvalidOperation, msg))
+        });
+
+        env.add_template("chat", self.template)
+            .map_err(|e| format!("template parse: {e}"))?;
+        let tmpl = env.get_template("chat")
+            .map_err(|e| format!("template lookup: {e}"))?;
+
+        // Build the messages list the way transformers does: optional
+        // system first, then a single user turn. Multi-turn history is
+        // not yet plumbed through — the daemon's request shape is
+        // single-turn, and the template's `<think>` stripping for
+        // prior assistant turns only matters once that lands.
+        let mut messages: Vec<serde_json::Value> = Vec::new();
+        // Each message gets `tool_calls: []` so chat templates can use
+        // bracket-access (`message['tool_calls']`) without tripping
+        // strict-undefined. Gemma 4's template hits this on every loop
+        // iteration; without the empty default the render fails and we
+        // silently fall back to a raw bos+token shape that breaks the
+        // model's instruct framing.
+        if let Some(sys) = self.system {
+            messages.push(serde_json::json!({
+                "role": "system",
+                "content": sys,
+                "tool_calls": [],
+            }));
+        }
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": self.user,
+            "tool_calls": [],
+        }));
+
+        // Pass bos_token to the template context. Caller may override via
+        // `self.bos_token` (Gemma 4 needs explicit `<bos>` because its
+        // tokenizer returns LLaMA-cosmetic `<s>` for decode_bytes(bos_id)
+        // and that re-tokenizes to a 3-token BPE fragment instead of
+        // single id=2 the template expects). Default: decode bos_id back
+        // to text (works for Qwen / LLaMA).
+        let bos_token: String = match self.bos_token {
+            Some(s) => s.to_string(),
+            None => {
+                let bytes = self.tokenizer.decode_bytes(&[self.tokenizer.bos_id]);
+                String::from_utf8_lossy(&bytes).to_string()
+            }
+        };
+        // Strict-undefined needs every var the template might reference to be
+        // defined (else the render Errs and we fall back to Plain). Common
+        // chat templates probe `tools`, `documents`, and `tool_call_kwargs`
+        // even on plain user-only turns; pass empty defaults so the
+        // template predicates evaluate to false rather than raise.
+        let empty_list: Vec<serde_json::Value> = Vec::new();
+        let ctx = minijinja::context! {
+            messages => Value::from_serialize(&messages),
+            add_generation_prompt => true,
+            enable_thinking => self.enable_thinking,
+            bos_token => bos_token,
+            tools => Value::from_serialize(&empty_list),
+            documents => Value::from_serialize(&empty_list),
+            tool_call_kwargs => Value::from_serialize(&serde_json::json!({})),
+        };
+        tmpl.render(ctx).map_err(|e| format!("template render: {e}"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hipfire-runtime/src/tool_call.rs
+++ b/crates/hipfire-runtime/src/tool_call.rs
@@ -1,0 +1,581 @@
+//! Per-arch tool-call output parsers.
+//!
+//! Stage 3 of the Jinja transition: move tool-call parsing out of
+//! `cli/index.ts:parseToolCalls` (TypeScript, single-format JSON) into
+//! the Rust runtime so the daemon can parse per-arch and emit structured
+//! `tool_calls` events on the SSE stream. Once Stage 5 lands, the CLI
+//! becomes a passthrough and `cli/parse_tool_calls.test.ts` is archived.
+//!
+//! Three implementations cover the formats observed in production:
+//!
+//! - [`Qwen35XmlParser`] — Qwen3.5/3.6 (dense + MoE/A3B + VL) emit
+//!   `<tool_call><function=NAME><parameter=ARG>\nVALUE\n</parameter>...</function></tool_call>`
+//!   per their upstream chat_template's tools-block instructions.
+//!   This is the format scenario C of `jinja_smoke` validated all
+//!   four target models emit cleanly.
+//!
+//! - [`Gemma4NativeParser`] — Gemma 4 emits its own
+//!   `<|tool_call|>{...json...}<|/tool_call|>` shape using literal
+//!   special tokens. (Wired in via Stage 3; arch-gemma4 crate pulled
+//!   in alongside Stage 7 — Gemma 4 itself is not present on master
+//!   yet.)
+//!
+//! - [`HermesJsonParser`] — bare `<tool_call>{...JSON...}</tool_call>`
+//!   shape. Port of `cli/index.ts:parseToolCalls` + `parseOneToolCall`.
+//!   Includes the MQ4 #111 stopgap repairs (stacked-opener strip,
+//!   flat-object coercion, XML-tag head fallback). This is the
+//!   default `Architecture::tool_call_parser` because most current
+//!   model paths still go through the daemon's hand-rolled Hermes
+//!   prompt — Stage 5 flips that.
+
+use serde::{Deserialize, Serialize};
+
+/// One assistant-emitted tool call recovered from the model's output
+/// stream. `arguments` is a free-form JSON value (typically an object).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ParsedToolCall {
+    pub name: String,
+    pub arguments: serde_json::Value,
+    /// `true` when the parser had to coerce off-spec input (flat object
+    /// with sibling args, XML-tag `<plain></param>` shape, stacked
+    /// `<tool_call>` openers from the MQ4 #111 attractor, etc.). The
+    /// daemon emits a stderr trace when this is set so operators can
+    /// see when the legacy repair path saved a request.
+    pub repaired: bool,
+}
+
+/// Result of parsing an assistant-emitted output buffer for tool calls.
+///
+/// `prose` is everything before the first `<tool_call>` opener, trimmed
+/// — the visible "natural language" content the user sees. `tool_calls`
+/// is the list of recovered structured calls.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ToolCallParseResult {
+    pub prose: Option<String>,
+    pub tool_calls: Vec<ParsedToolCall>,
+}
+
+/// Parser surface. Each arch's preferred format gets its own
+/// implementation; `Architecture::tool_call_parser` selects the
+/// right one at load time.
+pub trait ToolCallParser: Send + Sync {
+    /// Parse the full assistant output (after EOS / generation stop).
+    /// Streaming partial-output parsing is a follow-up; for now the
+    /// daemon buffers complete responses and parses once.
+    fn parse(&self, text: &str) -> ToolCallParseResult;
+
+    /// Diagnostic name for logs.
+    fn name(&self) -> &'static str;
+}
+
+// ── Hermes JSON parser ──────────────────────────────────────────────
+
+/// Hermes-style: `<tool_call>{"name": ..., "arguments": {...}}</tool_call>`.
+/// Port of `cli/index.ts:parseToolCalls` + `parseOneToolCall` with the
+/// MQ4 #111 stopgap repairs (stacked-opener strip, flat-object
+/// coercion, XML-tag fallback).
+pub struct HermesJsonParser;
+
+impl HermesJsonParser {
+    pub fn new() -> Self { Self }
+}
+
+impl Default for HermesJsonParser {
+    fn default() -> Self { Self::new() }
+}
+
+impl ToolCallParser for HermesJsonParser {
+    fn name(&self) -> &'static str { "hermes_json" }
+
+    fn parse(&self, text: &str) -> ToolCallParseResult {
+        if !text.contains("<tool_call>") {
+            return ToolCallParseResult {
+                prose: trim_to_option(text),
+                tool_calls: Vec::new(),
+            };
+        }
+        let mut tool_calls = Vec::new();
+        let mut cursor = 0usize;
+        while let Some(open_off) = text[cursor..].find("<tool_call>") {
+            let open_abs = cursor + open_off;
+            let body_start = open_abs + "<tool_call>".len();
+            let close_off = text[body_start..].find("</tool_call>");
+            let body_end = close_off
+                .map(|o| body_start + o)
+                .unwrap_or(text.len());
+            let raw = text[body_start..body_end].trim();
+            cursor = match close_off {
+                Some(_) => body_end + "</tool_call>".len(),
+                None => text.len(),
+            };
+            // Strip MQ4-#111 stacked openers — sometimes the model
+            // emits 1-2 nested `<tool_call>` before the JSON body.
+            let mut working = raw.to_string();
+            let mut stripped = 0;
+            while working.starts_with("<tool_call>") {
+                working = working["<tool_call>".len()..].trim_start().to_string();
+                stripped += 1;
+            }
+            if working.is_empty() { continue; }
+            if let Some(parsed) = parse_one_hermes(&working, stripped > 0) {
+                tool_calls.push(parsed);
+            }
+            if close_off.is_none() { break; }
+        }
+        // Prose is the text before the FIRST `<tool_call>` opener.
+        let prose = match text.find("<tool_call>") {
+            Some(idx) => trim_to_option(&text[..idx]),
+            None => trim_to_option(text),
+        };
+        ToolCallParseResult { prose, tool_calls }
+    }
+}
+
+fn parse_one_hermes(raw: &str, already_repaired: bool) -> Option<ParsedToolCall> {
+    // Form 1: spec-compliant `{"name": ..., "arguments": {...}}`.
+    if let Ok(tc) = serde_json::from_str::<serde_json::Value>(raw) {
+        if let serde_json::Value::Object(map) = &tc {
+            if let Some(name) = map.get("name").and_then(|v| v.as_str()) {
+                if let Some(args) = map.get("arguments") {
+                    return Some(ParsedToolCall {
+                        name: name.to_string(),
+                        arguments: args.clone(),
+                        repaired: already_repaired,
+                    });
+                }
+                // Form 2: flat object — sibling args without an
+                // `arguments` wrapper. Promote everything except a few
+                // known metadata keys.
+                let drop: &[&str] = &["name", "type", "id", "function"];
+                let mut args = serde_json::Map::new();
+                let mut coerced = false;
+                for (k, v) in map.iter() {
+                    if drop.contains(&k.as_str()) { continue; }
+                    args.insert(k.clone(), v.clone());
+                    coerced = true;
+                }
+                if coerced {
+                    return Some(ParsedToolCall {
+                        name: name.to_string(),
+                        arguments: serde_json::Value::Object(args),
+                        repaired: true,
+                    });
+                }
+                // Bare `{"name": "X"}` is legal for zero-arg tools.
+                return Some(ParsedToolCall {
+                    name: name.to_string(),
+                    arguments: serde_json::json!({}),
+                    repaired: already_repaired,
+                });
+            }
+        }
+    }
+
+    // Form 3: XML-tag head + balanced JSON. Patterns observed in MQ4
+    // attractor output:
+    //   <plain>NAME</param> {...}
+    //   <function=NAME> {...}
+    //   <tool name="NAME"> {...}
+    let candidates: &[(&str, &str)] = &[
+        ("<plain>", "</param>"),
+        ("<function=", ">"),
+        ("<tool name=\"", "\">"),
+    ];
+    for (open, close) in candidates {
+        if let Some(rest) = raw.strip_prefix(open) {
+            if let Some(close_idx) = rest.find(close) {
+                let name = rest[..close_idx].trim().trim_matches('"');
+                if !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.') {
+                    let after = rest[close_idx + close.len()..].trim();
+                    let args = extract_first_json_object(after).unwrap_or(serde_json::json!({}));
+                    return Some(ParsedToolCall {
+                        name: name.to_string(),
+                        arguments: args,
+                        repaired: true,
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract the first balanced top-level JSON object from `s`. Returns
+/// the parsed `Value` or `None` if no balanced object found.
+fn extract_first_json_object(s: &str) -> Option<serde_json::Value> {
+    let start = s.find('{')?;
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut escape = false;
+    for i in start..bytes.len() {
+        let ch = bytes[i] as char;
+        if in_str {
+            if escape { escape = false; continue; }
+            if ch == '\\' { escape = true; continue; }
+            if ch == '"' { in_str = false; }
+            continue;
+        }
+        match ch {
+            '"' => in_str = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let candidate = &s[start..=i];
+                    return serde_json::from_str(candidate).ok();
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn trim_to_option(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+}
+
+// ── Qwen3.5/3.6 XML parser ──────────────────────────────────────────
+
+/// Qwen3.5/3.6 native XML format:
+///
+/// ```text
+/// <tool_call>
+/// <function=NAME>
+/// <parameter=ARG1>
+/// VALUE1
+/// </parameter>
+/// <parameter=ARG2>
+/// VALUE2
+/// </parameter>
+/// </function>
+/// </tool_call>
+/// ```
+///
+/// VALUE may contain literal `<` characters inside string-like values;
+/// the scanner uses `</parameter>` as the close marker (not just `<`)
+/// and is escape-aware on parameter contents.
+pub struct Qwen35XmlParser;
+
+impl Qwen35XmlParser {
+    pub fn new() -> Self { Self }
+}
+
+impl Default for Qwen35XmlParser {
+    fn default() -> Self { Self::new() }
+}
+
+impl ToolCallParser for Qwen35XmlParser {
+    fn name(&self) -> &'static str { "qwen35_xml" }
+
+    fn parse(&self, text: &str) -> ToolCallParseResult {
+        if !text.contains("<tool_call>") {
+            return ToolCallParseResult {
+                prose: trim_to_option(text),
+                tool_calls: Vec::new(),
+            };
+        }
+        let mut tool_calls = Vec::new();
+        let mut cursor = 0usize;
+        while let Some(open_off) = text[cursor..].find("<tool_call>") {
+            let open_abs = cursor + open_off;
+            let body_start = open_abs + "<tool_call>".len();
+            let close_off = text[body_start..].find("</tool_call>");
+            let body_end = close_off.map(|o| body_start + o).unwrap_or(text.len());
+            let body = text[body_start..body_end].trim();
+            cursor = match close_off {
+                Some(_) => body_end + "</tool_call>".len(),
+                None => text.len(),
+            };
+            if let Some(parsed) = parse_one_qwen35_xml(body) {
+                tool_calls.push(parsed);
+            } else {
+                // XML parse failed — try Hermes JSON fallback for this
+                // block (MQ4 attractor sometimes flips a Qwen XML model
+                // into JSON shape). Lets `Qwen35XmlParser` recover
+                // without a separate format hint.
+                if let Some(parsed) = parse_one_hermes(body, false) {
+                    tool_calls.push(ParsedToolCall { repaired: true, ..parsed });
+                }
+            }
+            if close_off.is_none() { break; }
+        }
+        let prose = match text.find("<tool_call>") {
+            Some(idx) => trim_to_option(&text[..idx]),
+            None => trim_to_option(text),
+        };
+        ToolCallParseResult { prose, tool_calls }
+    }
+}
+
+fn parse_one_qwen35_xml(body: &str) -> Option<ParsedToolCall> {
+    // Find <function=NAME> opener.
+    let fn_open = "<function=";
+    let fn_idx = body.find(fn_open)?;
+    let after_fn_open = &body[fn_idx + fn_open.len()..];
+    let name_end = after_fn_open.find('>')?;
+    let name = after_fn_open[..name_end].trim();
+    if name.is_empty() { return None; }
+    // Walk parameters between <function=NAME> and </function>.
+    let after_name_open = &after_fn_open[name_end + 1..];
+    let fn_close = after_name_open.find("</function>").unwrap_or(after_name_open.len());
+    let params_region = &after_name_open[..fn_close];
+    let mut args = serde_json::Map::new();
+    let mut walker = params_region;
+    while let Some(p_open) = walker.find("<parameter=") {
+        let after_p_open = &walker[p_open + "<parameter=".len()..];
+        let arg_end = match after_p_open.find('>') {
+            Some(i) => i,
+            None => break,
+        };
+        let arg_name = after_p_open[..arg_end].trim();
+        let after_arg_open = &after_p_open[arg_end + 1..];
+        let p_close = match after_arg_open.find("</parameter>") {
+            Some(i) => i,
+            None => after_arg_open.len(),
+        };
+        // Value may have a leading + trailing newline (template
+        // emits `<parameter=ARG>\nVALUE\n</parameter>`); strip them.
+        let value_str = after_arg_open[..p_close].trim_matches('\n').trim().to_string();
+        // If the value parses as a JSON value (e.g., model emitted
+        // `{"key": "..."}` because the parameter is structured), use
+        // that. Otherwise treat as a raw string.
+        let value_json: serde_json::Value = serde_json::from_str(&value_str)
+            .unwrap_or_else(|_| serde_json::Value::String(value_str));
+        if !arg_name.is_empty() {
+            args.insert(arg_name.to_string(), value_json);
+        }
+        walker = match after_arg_open[p_close..].find("</parameter>") {
+            Some(i) => &after_arg_open[p_close + i + "</parameter>".len()..],
+            None => "",
+        };
+    }
+    Some(ParsedToolCall {
+        name: name.to_string(),
+        arguments: serde_json::Value::Object(args),
+        repaired: false,
+    })
+}
+
+// ── Gemma 4 native parser ───────────────────────────────────────────
+
+/// Gemma 4's native shape: `<|tool_call|>{...JSON...}<|/tool_call|>`.
+/// Same JSON body shape as Hermes but wrapped in literal special-token
+/// markers. Accepts `name`+`args` (Gemma's spec) or `name`+`arguments`
+/// (Hermes-spec compatibility).
+pub struct Gemma4NativeParser;
+
+impl Gemma4NativeParser {
+    pub fn new() -> Self { Self }
+}
+
+impl Default for Gemma4NativeParser {
+    fn default() -> Self { Self::new() }
+}
+
+impl ToolCallParser for Gemma4NativeParser {
+    fn name(&self) -> &'static str { "gemma4_native" }
+
+    fn parse(&self, text: &str) -> ToolCallParseResult {
+        const OPEN: &str = "<|tool_call|>";
+        const CLOSE: &str = "<|/tool_call|>";
+        if !text.contains(OPEN) {
+            return ToolCallParseResult {
+                prose: trim_to_option(text),
+                tool_calls: Vec::new(),
+            };
+        }
+        let mut tool_calls = Vec::new();
+        let mut cursor = 0usize;
+        while let Some(open_off) = text[cursor..].find(OPEN) {
+            let open_abs = cursor + open_off;
+            let body_start = open_abs + OPEN.len();
+            let close_off = text[body_start..].find(CLOSE);
+            let body_end = close_off.map(|o| body_start + o).unwrap_or(text.len());
+            let body = text[body_start..body_end].trim();
+            cursor = match close_off {
+                Some(_) => body_end + CLOSE.len(),
+                None => text.len(),
+            };
+            if let Ok(tc) = serde_json::from_str::<serde_json::Value>(body) {
+                if let serde_json::Value::Object(map) = &tc {
+                    if let Some(name) = map.get("name").and_then(|v| v.as_str()) {
+                        // Gemma uses `args`; accept `arguments` as a
+                        // Hermes-shape alias.
+                        let args = map.get("args")
+                            .or_else(|| map.get("arguments"))
+                            .cloned()
+                            .unwrap_or(serde_json::json!({}));
+                        tool_calls.push(ParsedToolCall {
+                            name: name.to_string(),
+                            arguments: args,
+                            repaired: false,
+                        });
+                    }
+                }
+            }
+            if close_off.is_none() { break; }
+        }
+        let prose = match text.find(OPEN) {
+            Some(idx) => trim_to_option(&text[..idx]),
+            None => trim_to_option(text),
+        };
+        ToolCallParseResult { prose, tool_calls }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_eq(a: &serde_json::Value, b: serde_json::Value) -> bool { *a == b }
+
+    // ── Hermes JSON parser ────────────────────────────────────────
+
+    #[test]
+    fn hermes_clean() {
+        let p = HermesJsonParser::new();
+        let text = "Sure, calling read.\n<tool_call>\n{\"name\":\"read\",\"arguments\":{\"path\":\"/etc/hosts\"}}\n</tool_call><|im_end|>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert_eq!(r.tool_calls[0].name, "read");
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({"path":"/etc/hosts"})));
+        assert!(!r.tool_calls[0].repaired);
+        assert_eq!(r.prose.as_deref(), Some("Sure, calling read."));
+    }
+
+    #[test]
+    fn hermes_no_tool_call_returns_prose() {
+        let p = HermesJsonParser::new();
+        let r = p.parse("Hi there.");
+        assert!(r.tool_calls.is_empty());
+        assert_eq!(r.prose.as_deref(), Some("Hi there."));
+    }
+
+    #[test]
+    fn hermes_flat_form_coerced() {
+        let p = HermesJsonParser::new();
+        let text = "<tool_call>{\"name\":\"write\",\"path\":\"/tmp/x\",\"contents\":\"hi\"}</tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert!(r.tool_calls[0].repaired);
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({"path":"/tmp/x","contents":"hi"})));
+    }
+
+    #[test]
+    fn hermes_stacked_opener_repair() {
+        let p = HermesJsonParser::new();
+        let text = "<tool_call><tool_call>{\"name\":\"read\",\"arguments\":{\"p\":1}}</tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert!(r.tool_calls[0].repaired);
+    }
+
+    #[test]
+    fn hermes_xml_function_head() {
+        let p = HermesJsonParser::new();
+        let text = "<tool_call><function=cat>{\"path\":\"/x\"}</tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert_eq!(r.tool_calls[0].name, "cat");
+        assert!(r.tool_calls[0].repaired);
+    }
+
+    #[test]
+    fn hermes_zero_arg_call() {
+        let p = HermesJsonParser::new();
+        let text = "<tool_call>{\"name\":\"ping\"}</tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert_eq!(r.tool_calls[0].name, "ping");
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({})));
+    }
+
+    #[test]
+    fn hermes_multiple_calls() {
+        let p = HermesJsonParser::new();
+        let text = "<tool_call>{\"name\":\"a\",\"arguments\":{}}</tool_call>\n<tool_call>{\"name\":\"b\",\"arguments\":{\"x\":1}}</tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 2);
+        assert_eq!(r.tool_calls[0].name, "a");
+        assert_eq!(r.tool_calls[1].name, "b");
+    }
+
+    // ── Qwen3.5/3.6 XML parser ────────────────────────────────────
+
+    #[test]
+    fn qwen35_xml_clean() {
+        let p = Qwen35XmlParser::new();
+        let text = "<tool_call>\n<function=read_file>\n<parameter=path>\n/etc/hosts\n</parameter>\n</function>\n</tool_call><|im_end|>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert_eq!(r.tool_calls[0].name, "read_file");
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({"path":"/etc/hosts"})));
+        assert!(!r.tool_calls[0].repaired);
+    }
+
+    #[test]
+    fn qwen35_xml_multi_param() {
+        let p = Qwen35XmlParser::new();
+        let text = "<tool_call><function=write><parameter=path>\n/tmp/x\n</parameter><parameter=contents>\nhello world\n</parameter></function></tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({
+            "path":"/tmp/x", "contents":"hello world"
+        })));
+    }
+
+    #[test]
+    fn qwen35_xml_value_with_lt_char() {
+        let p = Qwen35XmlParser::new();
+        // VALUE contains < but parameter close is full `</parameter>`,
+        // so the scanner should not be fooled.
+        let text = "<tool_call><function=set><parameter=expr>\nx<5\n</parameter></function></tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({"expr":"x<5"})));
+    }
+
+    #[test]
+    fn qwen35_xml_falls_back_to_hermes_on_json_body() {
+        // MQ4 attractor: model trained on XML emits Hermes JSON.
+        // Qwen35XmlParser recovers via internal Hermes fallback.
+        let p = Qwen35XmlParser::new();
+        let text = "<tool_call>{\"name\":\"read\",\"arguments\":{\"p\":\"/x\"}}</tool_call>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert_eq!(r.tool_calls[0].name, "read");
+        assert!(r.tool_calls[0].repaired);
+    }
+
+    // ── Gemma 4 native parser ─────────────────────────────────────
+
+    #[test]
+    fn gemma4_native_clean() {
+        let p = Gemma4NativeParser::new();
+        let text = "<|tool_call|>{\"name\":\"read\",\"args\":{\"path\":\"/x\"}}<|/tool_call|>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert_eq!(r.tool_calls[0].name, "read");
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({"path":"/x"})));
+    }
+
+    #[test]
+    fn gemma4_native_accepts_arguments_alias() {
+        let p = Gemma4NativeParser::new();
+        let text = "<|tool_call|>{\"name\":\"read\",\"arguments\":{\"path\":\"/x\"}}<|/tool_call|>";
+        let r = p.parse(text);
+        assert_eq!(r.tool_calls.len(), 1);
+        assert!(args_eq(&r.tool_calls[0].arguments, serde_json::json!({"path":"/x"})));
+    }
+
+    #[test]
+    fn gemma4_native_no_match() {
+        let p = Gemma4NativeParser::new();
+        let r = p.parse("<tool_call>{\"name\":\"read\"}</tool_call>");
+        assert!(r.tool_calls.is_empty());
+        assert!(r.prose.is_some());
+    }
+}

--- a/crates/hipfire-runtime/templates/gemma-4-it.jinja
+++ b/crates/hipfire-runtime/templates/gemma-4-it.jinja
@@ -1,0 +1,354 @@
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not has_content) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking | default(false) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endif -%}


### PR DESCRIPTION
# Jinja chat-template rendering — Stages 0–4 (opt-in, parity)

## Why

`cli/index.ts:1442-1540` hand-rolls a Hermes-style ChatML scaffold for every chat-completions request: `<|im_start|>{role}\n…<|im_end|>` framing, JSON-format `<tool_call>` body. This was correct for older Qwen / Hermes-tuned models but has drifted from what current models actually expect. Concrete drift cases caught in this work:

- **Qwen3.5/3.6 native tool-call format** is XML, not JSON — `<tool_call><function=NAME><parameter=ARG>VAL</parameter></function></tool_call>` per the model's embedded `tokenizer_config.chat_template`. The hand-roll's JSON shape produces tool-call attractor failures + looping in agentic flows (the `lutet` field report that started this work).
- **`tool` role wrapping**: Qwen3.5/3.6 wrap tool responses inside a `user` turn with `<tool_response>…</tool_response>`. The hand-roll emits a `<|im_start|>tool` role the model was never trained on.
- **Missing `<IMPORTANT>` block + `<think>\n` opener** that the upstream template emits and the hand-roll skips.

llama.cpp doesn't have these bugs because it renders the model's own Jinja template via `apply_chat_template`. This PR brings the same approach to hipfire — render the upstream HF template via `minijinja`, with the model's `tokenizer_config.chat_template` as the source of truth, no per-arch hand-roll to maintain.

Plan doc: `~/.claude/plans/do-171-but-it-humming-moth.md`. Picks up from PR #171 / PR #175 on `feat/jinja-land` with strict-undefined empty-defaults review fixes already integrated.

## What's in (Stages 0–4)

| Stage | Commit | Surface |
|---|---|---|
| **0** Cherry-pick Jinja core | `7d797aa` | `minijinja v2 + minijinja-contrib v2 (pycompat, json)` deps; `JinjaChatFrame` struct + `render()` (strict-undefined, raise_exception, empty defaults for tools/documents/tool_call_kwargs); `HfqFile::chat_template()` accessor; `examples/render_chat_template.rs` diagnostic; transitional `templates/gemma-4-it.jinja` fallback. |
| **2 partial** Multi-turn renderer | `fdf70a9` | `Role` extended with `System`/`Tool`; `Message` + `ToolCall` serialize-friendly types; `render_messages(&[Message], tools, kwargs)` canonical entry; `examples/jinja_smoke.rs` end-to-end harness (4 models × 3 scenarios). |
| **2 fix** json filter + sampler | `577a9de` | `minijinja "json"` feature for `tojson` filter (caught by smoke scenario C — without this, every tool-using turn dies at render); smoke binary uses `apply_repeat_penalty` to match daemon production sampling. |
| **2 daemon AR** | `06e8fe3` | `LoadedModel.chat_template`; `HIPFIRE_JINJA_CHAT=1` gate; AR `generate()` prompt-build site routes through `JinjaChatFrame::render()` on first turn when env+template both present, falls back to `ChatFrame::Plain` otherwise. PFlash compression bypassed under Jinja (q_tokens not directly composable with a string-rendered template). |
| **3** Per-arch tool-call parsers | `a9ca67d` | `crates/hipfire-runtime/src/tool_call.rs` (~430 LoC) — `ToolCallParser` trait + `HermesJsonParser` (port of cli/index.ts:1700, includes #111 stopgap repairs), `Qwen35XmlParser` (escape-aware on parameter values), `Gemma4NativeParser`. 14 unit tests. Not yet wired into daemon emit-site (Stage 5 work). |
| **4** Override precedence | `0107591f` | `resolve_chat_template(hfq, model_path)` — env (`HIPFIRE_CHAT_TEMPLATE_FILE`) > per-model file (`~/.hipfire/templates/<basename>.j2`) > HFQ-embedded > `None` (caller falls back to Plain under current opt-in gate). Diagnostic stderr per source. |

**Net:** +1963 / −21 lines, 11 files. Nothing on the default path changes — `HIPFIRE_JINJA_CHAT=1` is opt-in.

## What's not in (Stage 5+)

- **Stage 5**: delete `cli/index.ts:1442-1540` ChatML construction, route raw `messages` to daemon. Requires daemon-side message-history state which is a bigger surface change.
- **Stage 6**: delete `ChatFrame::Plain` + `ChatScaffold`, migrate examples to `JinjaChatFrame`.
- **Stage 7**: extend `agentic-gate.sh` Jinja axis + 6-arch coverage (Gemma 4, Qwen3.5-VL).
- **DFlash, generate_multi (PP>1), generate_vl** prompt-build sites still use `ChatFrame::Plain`. Stage 2 covered the AR path only.

**Adjacent work**: post-fix MoE quant (PR #214, K-map alternating mode by @fivetide) interacts with this transition only at the agentic-gate parity test — the gate's `qwen3.6-35b-a3b` cell exposes stale-MoE artifacts before #214's smaller alternating-promote default. We tested with #214 staged locally; this PR doesn't depend on it.

## Validation

### Smoke (`crates/hipfire-runtime/examples/jinja_smoke.rs`)

12 cells = 4 models × 3 scenarios end-to-end on RX 7900 XTX (gfx1100):

| Model | Scenario A (confusing+thinking-on) | Scenario B (difficult+thinking-off) | Scenario C (5-turn+tools+thinking-on) |
|---|---|---|---|
| qwen3.5-4b   | ✅ 4096 tok @ 137 t/s | ⚠ HARD 4096 @ 137 t/s (model capacity) | ✅ 108 tok → clean XML tool call + im_end |
| qwen3.5-9b   | ✅ 4096 tok @ 95 t/s  | ✅ 4096 tok @ 95 t/s   | ✅ 73 tok → clean XML tool call + im_end |
| qwen3.5-27b  | ⚠ soft 4096 @ 34 t/s | ✅ 748 tok @ 34 t/s → im_end | ⚠ soft 4096 @ 34 t/s (model second-guesses tool) |
| qwen3.5-35b-a3b | ✅ 4096 tok @ 53 t/s | ⚠ soft 4096 @ 53 t/s (model capacity) | ✅ 140 tok → clean XML tool call + im_end |

**Scenario C is the validation gold** — every model emits the canonical Qwen3.5/3.6 XML shape on the synthesized 5-message agentic flow, picks the un-used `get_population` tool after `list_landmarks` already returned, stops cleanly at `<|im_end|>`. The flagged cells are sampling/capacity interactions on hard prompts, not template/render bugs.

### Agentic-gate (canonical)

```
HIPFIRE_JINJA_CHAT=1 ./scripts/agentic-gate.sh --fast    # qwen3.6-35b-a3b, Hermes prompt 3132 bytes
PASS, 0 hard fails, 0 soft warns
{"name":"read","arguments":{"path":"/tmp/fibonacci.c"}}
```

Identical result to the same gate without `HIPFIRE_JINJA_CHAT=1` (master baseline).

### Render microbench (`examples/render_bench.rs`)

```
=== RX 7900 XTX, Qwen3.5-9B template (7.7 KB), 200 iters ===

Path J0  one-time Env+parse setup:           229 μs   (pay once at model load)

Per-call timings (microseconds):
  J1  full JinjaChatFrame::render (no cache)   mean=152  p50=146  p99=217
  J2  cached Env + tmpl.render (production)    mean= 13  p50= 13  p99= 20
  P   ChatFrame::Plain build                   mean=416_932 (= 417 ms)
  T   tokenizer.encode (rendered string)       mean=250_167 (= 250 ms)

Apples-to-apples (bytes → ready tokens):
  Jinja prod path:   250 ms (J2 + T)
  Plain baseline:    417 ms (P, returns tokens directly)
  Jinja is 167 ms FASTER per request.
```

`ChatFrame::Plain::build` calls `tokenizer.encode()` ~15 times per build (once each for `<|im_start|>` / role / `\n` / `<|im_end|>` per turn), each ~25–40 ms (BPE init dominates over short strings). Jinja produces a single string and encodes once, amortizing better. **JinjaChatFrame is faster than Plain by ~40% on a typical request.**

### Speed-gate parity (canonical flags, `asym3 KV`, `HIPFIRE_DPM_WARMUP_SECS=3`, `HIPFIRE_GRAPH=1`, `--gen 50`)

| Cell | master `0dcfd49c` wallclock | this branch wallclock | Δ |
|---|---:|---:|---:|
| 27b pp32 (run 1, hot cache) | 14.03 s | 13.76 s | −0.3 s |
| 27b pp32 (run 2)            | 13.79 s | — | within ±0.3 s noise |
| 27b pp32 (run 3)            | 13.75 s | — | within ±0.3 s noise |

Per-phase 27b pp32 on this branch: load 6.24 s, prefill 79 ms, gen 1090 ms (50 tok @ 45.8 t/s), warmup 138 ms; the residual 6.20 s is `dpm_warmup(3)` × 2 (canonical, present on master too).

13/13 speed-gate metrics pass on the branch with `HIPFIRE_JINJA_CHAT=1` set:
- 27b decode 45.9 t/s (baseline 46.5, **−1.3% within tolerance**)
- 9b decode 128.5 t/s (baseline 114.8, **+11.9% faster than baseline**)
- 27b-3.5 LRU DFlash 203.6 t/s τ=10.64 (memory anchor 199 t/s τ=10.36, **+2.3% / +2.7% within ±2-5% deterministic envelope**)
- 27b-3.5 merge_sort DFlash 253.6 t/s τ=13.27 (baseline 250.0, **+1.4%**)

### Decode tok/s parity (smoke 7900 XTX vs your "45ish AR" memory anchor)

| Model | this branch (Jinja) | memory anchor |
|---|---:|---:|
| 27b AR | 43–46 t/s | "45ish" |
| 27b DFlash LRU | 203.6 t/s τ=10.64 | "199 t/s τ=10.36" |
| 27b DFlash merge_sort | 253.6 t/s τ=13.27 | n/a (new metric in canon) |

## Risk + rollback

- **Default behavior unchanged.** `HIPFIRE_JINJA_CHAT` is opt-in. With it unset (the default), every code path is byte-identical to master.
- **Per-render cost** is 152 μs no-cache (current daemon impl rebuilds Env per request), or 13 μs once we add `LoadedModel`-side Env caching (Stage 5 follow-up). Even no-cache is sub-millisecond per-request, **zero per-token impact**, and *faster* end-to-end than `ChatFrame::Plain::build`.
- **Render failures fall through** to Plain with a stderr diagnostic — operator sees the failure, generation continues with the legacy scaffold.
- **Multi-turn under Jinja** restricted to first turn (`seq_pos == 0`); subsequent turns always Plain. Daemon-side message-history (true multi-turn Jinja) is the second half of Stage 2 — known scope, deferred.
- **Stage 3 parsers are dormant** — unit-tested but not wired into the daemon emit-site. Stage 5 wires them.

Rollback if a regression slips: `git revert <Stage 2 daemon commit>` restores byte-identical Plain behavior; Stages 0/3/4 stay merged as additive infrastructure.

## Migration notes

- **Per-model template override**: drop a `.j2` file at `~/.hipfire/templates/<model-basename>.j2` (e.g. `~/.hipfire/templates/qwen3.5-27b.mq4.j2`).
- **Env override (debugging)**: `HIPFIRE_CHAT_TEMPLATE_FILE=/path/to/template.j2`.
- **Quantizer should preserve `chat_template`** in HFQ metadata going forward — Stage 1 (deferred) tightens this so existing on-disk Gemma 4 HFQs without embedded templates can be patched.

## Test plan

- [x] `cargo test -p hipfire-runtime --lib` — **149/149 pass** (135 baseline + 14 new in `tool_call`).
- [x] `cargo build --release --example daemon --features deltanet` — clean.
- [x] `agentic-gate.sh --fast` with and without `HIPFIRE_JINJA_CHAT=1` — both PASS.
- [x] `agentic-gate.sh --fast` on hiptrx (R9700 32 GB) with re-quantized A3B (PR #214 alternating mode, staged locally) — PASS.
- [x] `speed-gate.sh` — 13/13 metrics within tolerance, 27B AR decode at master parity.
- [x] `jinja_smoke` 4 models × 3 scenarios — 12/12 cells render+decode end-to-end.
- [x] `render_bench` 200-iter — Jinja faster than Plain by 167 ms/request.
- [ ] (Stage 5) Daemon-side message-history state for true multi-turn Jinja.
- [ ] (Stage 5/6) Wire Stage 3 parsers into daemon emit-site, delete `cli/index.ts:1442-1540`.
- [ ] (Stage 7) `agentic-gate.sh` Jinja axis + Gemma 4 / Qwen3.5-VL coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
