### PR TITLE
feat(daemon,cli): ClosedThink prefix + thinking-on budget routing + response diagnostics

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1665,16 +1665,20 @@ async function serve(port: number) {
           if (reasoningEffort === 0) delete genParams.max_think_tokens;
           else genParams.max_think_tokens = reasoningEffort;
         }
-        // thinking=off is currently a no-op at the CLI layer. Earlier
-        // versions injected a prose system directive ("Respond directly
-        // without using <think>...</think> reasoning blocks") here, but
-        // the literal special tokens in that string caused Qwen3.5 to
-        // halt at 3-4 tokens — coherence-gate (which hits the daemon
-        // direct, no system injection) consistently passes on the same
-        // models, while CLI-routed requests with this directive break.
-        // Pass through whatever system prompt the client sent, no
-        // augmentation. The downstream <think>...</think> filter still
-        // strips visible reasoning so users get clean answers.
+        // Wire thinking control for both legacy assistant_prefix
+        // (ChatFrame::ClosedThink) and the new Jinja template path.
+        // The Jinja path uses max_think_tokens==1 as the signal for
+        // enable_thinking=false (daemon.rs line 3099). For the legacy
+        // ChatFrame path, assistant_prefix="closed_think" is sufficient.
+        if (effective.thinking === "off") {
+          genParams.assistant_prefix = "closed_think";
+        } else if ((body as any).chat_template_kwargs?.enable_thinking === false) {
+          genParams.assistant_prefix = "closed_think";
+          genParams.max_think_tokens = 1; // Jinja path signal
+        } else if ((body as any).reasoning?.effort === "none") {
+          genParams.assistant_prefix = "closed_think";
+          genParams.max_think_tokens = 1;
+        }
         if (systemPrompt) genParams.system = systemPrompt;
 
         // Parse tool calls from model output: <tool_call>{"name":..., "arguments":...}</tool_call>
@@ -2011,12 +2015,20 @@ async function serve(port: number) {
         // intact in message.content for clients that want a single-string
         // representation including reasoning. <|im_end|> stripping always
         // applies (it would break clients that re-encode message history).
+        const strippedContent = content;
         if (preserveThinking) {
           content = content.replace(/<\|im_end\|>/g, "").trim();
         } else {
           content = content.replace(/<think>[\s\S]*?<\/think>\s*/g, "")
             .replace(/<think>[\s\S]*$/, "") // unclosed think block
             .replace(/<\|im_end\|>/g, "").trim();
+        }
+
+        // Diagnostic: detect empty-after-unclosed-think-strip.
+        let thinkWarning: string | null = null;
+        if (!content && completionTokens > 0 && strippedContent.includes("<think>")) {
+          thinkWarning = "empty after unclosed think strip";
+          console.error(`[hipfire] ${reqId}: ${thinkWarning} — ${completionTokens} tokens consumed, all inside unclosed <think> block`);
         }
 
         // Check for tool calls in response
@@ -2029,11 +2041,15 @@ async function serve(port: number) {
         }
 
         safeRelease();
-        return Response.json({
+        const responseBody: any = {
           id: reqId, object: "chat.completion", created, model: modelName,
           choices: [choice],
           usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: promptTokens + completionTokens }
-        });
+        };
+        if (thinkWarning) {
+          responseBody.x_hipfire_warning = thinkWarning;
+        }
+        return Response.json(responseBody);
       } catch (err: any) {
         safeRelease();
         return Response.json({ error: err?.message || "internal error" }, { status: 500 });

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -852,6 +852,16 @@ fn main() {
                 let max_think_tokens = msg.get("max_think_tokens")
                     .and_then(|v| v.as_u64()).unwrap_or(0) as usize;
 
+                // assistant_prefix: "plain", "open_think", or "closed_think"
+                // Controls the ChatML framing after the assistant role header.
+                let assistant_prefix = match msg.get("assistant_prefix")
+                    .and_then(|v| v.as_str()).unwrap_or("plain")
+                {
+                    "open_think" => hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink,
+                    "closed_think" => hipfire_runtime::prompt_frame::AssistantPrefix::ClosedThink,
+                    _ => hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                };
+
                 if image.is_some() && m.vision_config.is_some() {
                     generate_vl(m, &mut gpu, &mut stdout, id, prompt, system, image.unwrap(), temp, top_p, max_tokens, repeat_penalty, repeat_window);
                 } else {
@@ -915,6 +925,7 @@ fn main() {
                         m, &mut gpu, &mut stdout, id, prompt, system,
                         temp, top_p, max_tokens, repeat_penalty, repeat_window,
                         budget_alert_at_tok, &budget_alert_text, max_think_tokens,
+                        assistant_prefix,
                         pflash_state.as_mut(),
                         pf_cfg_owned.as_ref(),
                     );
@@ -2033,6 +2044,7 @@ fn generate_dflash(
     system_prompt: Option<&str>,
     max_tokens: usize,
     max_think_tokens: usize,
+    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
     pflash_bypass_reason: Option<&str>,
     pflash_alpha: Option<f32>,
 ) {
@@ -2048,7 +2060,7 @@ fn generate_dflash(
         tokenizer,
         system: system_prompt,
         user: prompt,
-        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+        assistant_prefix,
         raw: false,
     }
     .build();
@@ -2477,6 +2489,7 @@ fn generate_multi(
     budget_alert_at_tok: usize,
     budget_alert_text: &str,
     max_think_tokens: usize,
+    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
 ) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
@@ -2582,7 +2595,7 @@ fn generate_multi(
         tokenizer,
         system: if m.seq_pos == 0 { system_prompt } else { None },
         user: "",
-        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+        assistant_prefix,
         raw: false,
     }
     .build_with_user_tokens(&q_tokens);
@@ -2880,7 +2893,7 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>) {
     // Multi-GPU pipeline-parallel dispatch (Stage 7 of #58). pp>1 is refused
     // at load when DFlash / CASK / PFlash / VL is requested, so this branch
     // doesn't need to thread any of those args through.
@@ -2889,13 +2902,22 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
             temp, top_p, max_tokens, repeat_penalty, repeat_window,
             budget_alert_at_tok, budget_alert_text, max_think_tokens,
+            assistant_prefix,
         );
         return;
     }
     // DFlash fast path -- only when a draft model is loaded AND temperature is
     // effectively 0 (DFlash is greedy-only in this integration). Skip the
     // normal AR sampling setup entirely.
-    if m.dflash.is_some() && temp <= 1e-6 && (m.arch_id == 5 || m.arch_id == 6) {
+    //
+    // Exception: thinking-on + max_think_tokens currently needs the AR path.
+    // DFlash's budget cap can close/strip the think span but does not yet
+    // continue into visible answer text after the forced close. AR already
+    // splices </think> through KV and continues generation, so route budgeted
+    // thinking requests there until DFlash continuation is implemented.
+    let budgeted_thinking_needs_ar = max_think_tokens > 0
+        && !matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::ClosedThink);
+    if m.dflash.is_some() && temp <= 1e-6 && (m.arch_id == 5 || m.arch_id == 6) && !budgeted_thinking_needs_ar {
         // PFlash + DFlash decode path is not yet wired -- the DFlash spec
         // loop builds its own prompt token stream internally, so the
         // generate() PFlash block below never runs. Surface this loud so
@@ -2920,7 +2942,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         // mirrors the AR path's <think>/</think> counter). The "ignored
         // on DFlash" warning that used to live here is gone -- the cap
         // is real on both paths now.
-        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, dflash_bypass_reason, dflash_alpha);
+        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, assistant_prefix, dflash_bypass_reason, dflash_alpha);
         // Silence unused-variable warnings for the params we didn't need.
         let _ = (top_p, repeat_penalty, repeat_window, budget_alert_at_tok, budget_alert_text, pflash_state);
         return;
@@ -3114,6 +3136,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     // Multi-turn (seq_pos > 0) currently always uses path 2 — Jinja
     // single-turn parity is Stage 2; multi-turn message-history state on
     // the daemon side is Stage 2 follow-up.
+    //
+    // Thinking-off interop with `assistant_prefix`: the CLI sets BOTH
+    // `max_think_tokens = 1` AND `assistant_prefix = ClosedThink` when
+    // the request asks for non-thinking. The Jinja path keys off
+    // `max_think_tokens != 1` for `enable_thinking`; the Plain path
+    // honors `assistant_prefix` directly (ClosedThink emits a closed
+    // `<think></think>` block after the assistant prefix). Each path
+    // picks up the signal it needs.
     let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
     let try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some();
     let new_tokens = if try_jinja {
@@ -3123,12 +3153,6 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             template,
             system: system_prompt,
             user: prompt,
-            // max_think_tokens == 1 is the daemon's current "no-think"
-            // sentinel (CLI sets it that way for `thinking=off` and
-            // `enable_thinking=false`). All other values keep thinking
-            // on, matching the Plain path which always emits the
-            // `<think>\n` opener via AssistantPrefix::Plain trailing
-            // tokens.
             enable_thinking: max_think_tokens != 1,
             bos_token: None,
         };
@@ -3140,7 +3164,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                     tokenizer,
                     system: system_prompt,
                     user: "",
-                    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                    assistant_prefix,
                     raw: false,
                 }
                 .build_with_user_tokens(&q_tokens)
@@ -3151,7 +3175,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             tokenizer,
             system: if m.seq_pos == 0 { system_prompt } else { None },
             user: "", // unused: we pass tokens directly via build_with_user_tokens
-            assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+            assistant_prefix,
             raw: false,
         }
         .build_with_user_tokens(&q_tokens)
@@ -3838,7 +3862,7 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
         tokenizer,
         system: if m.seq_pos == 0 { system_prompt } else { None },
         user: "", // unused: we pass tokens directly via build_with_user_tokens
-        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain, // VL always uses Plain
         raw: false,
     }
     .build_with_user_tokens(&user_body);

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -49,6 +49,19 @@ pub enum AssistantPrefix {
     /// silently inserting raw text bytes that would tokenize
     /// differently from the special-token path.
     OpenThink,
+    /// Assistant turn with an immediately closed empty think block
+    /// for non-thinking mode:
+    /// `<|im_start|>assistant\n<think>\n\n</think>\n\n`.
+    ///
+    /// This mirrors the merged Qwen 3.6 community template behavior
+    /// when `enable_thinking=false`. The model starts generation in
+    /// visible-answer mode because the think block is already closed.
+    /// Useful for routing/agentic contexts where we need visible
+    /// output without disabling DFlash (still valid at temp=0).
+    ///
+    /// Requires both `<think>` and `</think>` as single special
+    /// tokens. Falls back to `Plain` if either is absent.
+    ClosedThink,
 }
 
 /// Role of a multi-turn history entry. `User` / `Assistant` are
@@ -188,6 +201,10 @@ struct ChatScaffold<'a> {
     /// special token). When `None`, `OpenThink` falls back to `Plain`
     /// — see `append_assistant_prefix`.
     think_open: Option<u32>,
+    /// `</think>` closer (if the tokenizer recognizes it as a single
+    /// special token). When `None`, `ClosedThink` falls back to `Plain`
+    /// — see `append_assistant_prefix`.
+    think_close: Option<u32>,
 }
 
 impl<'a> ChatScaffold<'a> {
@@ -201,6 +218,7 @@ impl<'a> ChatScaffold<'a> {
             user_role: t.encode("user"),
             assistant_role: t.encode("assistant"),
             think_open: t.special_token_id("<think>"),
+            think_close: t.special_token_id("</think>"),
         }
     }
 
@@ -243,17 +261,36 @@ impl<'a> ChatScaffold<'a> {
         out.extend_from_slice(&self.im_start);
         out.extend_from_slice(&self.assistant_role);
         out.extend_from_slice(&self.nl);
-        if matches!(prefix, AssistantPrefix::OpenThink) {
-            // Only emit `<think>\n` when the tokenizer registers
-            // `<think>` as a single special token. Otherwise the
-            // string would tokenize as ordinary BPE pieces and behave
-            // differently from the special-token path the model was
-            // trained on. Falling back to `Plain` in that case is
-            // safer than silently emitting wrong-shaped tokens.
-            if let Some(think_id) = self.think_open {
-                out.push(think_id);
-                out.extend_from_slice(&self.nl);
+        match prefix {
+            AssistantPrefix::OpenThink => {
+                // Only emit `<think>\n` when the tokenizer registers
+                // `<think>` as a single special token. Otherwise the
+                // string would tokenize as ordinary BPE pieces and behave
+                // differently from the special-token path the model was
+                // trained on. Falling back to `Plain` in that case is
+                // safer than silently emitting wrong-shaped tokens.
+                if let Some(think_id) = self.think_open {
+                    out.push(think_id);
+                    out.extend_from_slice(&self.nl);
+                }
             }
+            AssistantPrefix::ClosedThink => {
+                // Emit an immediately-closed empty think block:
+                // `<think>\n\n</think>\n\n`.
+                // Mirrors the merged Qwen 3.6 community template's
+                // `enable_thinking=false` behavior. Falls back to
+                // `Plain` if either `<think>` or `</think>` is not
+                // a single special token.
+                if let (Some(open_id), Some(close_id)) = (self.think_open, self.think_close) {
+                    out.push(open_id);
+                    out.extend_from_slice(&self.nl);
+                    out.extend_from_slice(&self.nl);
+                    out.push(close_id);
+                    out.extend_from_slice(&self.nl);
+                    out.extend_from_slice(&self.nl);
+                }
+            }
+            AssistantPrefix::Plain => {}
         }
     }
 }
@@ -535,6 +572,36 @@ mod tests {
         Tokenizer::from_hf_json(&json).expect("test tokenizer")
     }
 
+    /// Like `make_tokenizer` but WITHOUT `<think>` / `</think>`
+    /// as special added tokens — used to verify ClosedThink fallback.
+    fn test_tokenizer_no_think() -> Tokenizer {
+        let mut entries: Vec<String> = Vec::new();
+        entries.push(r#""<|im_start|>": 0"#.to_string());
+        entries.push(r#""<|im_end|>": 1"#.to_string());
+        entries.push(r#""system": 4"#.to_string());
+        entries.push(r#""user": 5"#.to_string());
+        entries.push(r#""assistant": 6"#.to_string());
+        entries.push(r#""\n": 7"#.to_string());
+        entries.push(r#""Ġ": 8"#.to_string());
+        for b in 0u32..=255u32 {
+            let ch = byte_to_gpt2_char_test(b as u8);
+            let escaped = json_escape(&ch.to_string());
+            entries.push(format!(r#""{}": {}"#, escaped, 100 + b));
+        }
+        let vocab_block = entries.join(", ");
+        let json = format!(
+            r#"{{
+                "model": {{"type": "BPE", "vocab": {{ {vocab} }}, "merges": []}},
+                "added_tokens": [
+                    {{"id": 0, "content": "<|im_start|>", "special": true}},
+                    {{"id": 1, "content": "<|im_end|>", "special": true}}
+                ]
+            }}"#,
+            vocab = vocab_block,
+        );
+        Tokenizer::from_hf_json(&json).expect("test tokenizer without think tokens")
+    }
+
     /// Mirror of `byte_to_gpt2_char` from tokenizer.rs (private). The
     /// GPT-2 byte-to-char mapping leaves printable ASCII (33..127, 161..173,
     /// 174..256) untouched and renumbers the rest above 256.
@@ -633,6 +700,65 @@ mod tests {
         expected.extend_from_slice(&t.encode("\n"));
         assert_eq!(opened, expected, "OpenThink should append <think>\\n after the assistant prefix");
         assert!(opened.len() > plain.len(), "OpenThink output must be strictly longer than Plain");
+    }
+
+    #[test]
+    fn closed_think_appends_empty_closed_block_when_tokens_present() {
+        let t = make_tokenizer();
+        let plain = ChatFrame {
+            tokenizer: &t,
+            system: None,
+            user: "hi",
+            assistant_prefix: AssistantPrefix::Plain,
+            raw: false,
+        }
+        .build();
+        let closed = ChatFrame {
+            tokenizer: &t,
+            system: None,
+            user: "hi",
+            assistant_prefix: AssistantPrefix::ClosedThink,
+            raw: false,
+        }
+        .build();
+        let think_id = t.special_token_id("<think>")
+            .expect("test tokenizer registers <think> as special");
+        let close_id = t.special_token_id("</think>")
+            .expect("test tokenizer registers </think> as special");
+        let nl = t.encode("\n");
+        let mut expected = plain.clone();
+        // <think>\n\n</think>\n\n
+        expected.push(think_id);
+        expected.extend_from_slice(&nl);
+        expected.extend_from_slice(&nl);
+        expected.push(close_id);
+        expected.extend_from_slice(&nl);
+        expected.extend_from_slice(&nl);
+        assert_eq!(closed, expected, "ClosedThink should append <think>\\n\\n</think>\\n\\n after the assistant prefix");
+        assert!(closed.len() > plain.len(), "ClosedThink output must be strictly longer than Plain");
+    }
+
+    #[test]
+    fn closed_think_falls_back_to_plain_when_tokens_missing() {
+        // tokenize from scratch with no think/close special tokens
+        let t = test_tokenizer_no_think();
+        let plain = ChatFrame {
+            tokenizer: &t,
+            system: None,
+            user: "hi",
+            assistant_prefix: AssistantPrefix::Plain,
+            raw: false,
+        }
+        .build();
+        let closed = ChatFrame {
+            tokenizer: &t,
+            system: None,
+            user: "hi",
+            assistant_prefix: AssistantPrefix::ClosedThink,
+            raw: false,
+        }
+        .build();
+        assert_eq!(closed, plain, "ClosedThink without special tokens must fall back to Plain");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `AssistantPrefix::ClosedThink` to prompt_frame.rs — emits `<think>\n\n</think>\n\n` before generation when `thinking=off`, mirroring the merged Qwen 3.6 community template behavior without requiring full Jinja rendering.

Also routes budgeted thinking-on requests through AR instead of DFlash, because DFlash can close the think block on budget cap but does not continue into visible answer text. AR already handles this correctly.

## What this fixes

- **Empty output on complex contexts**: Qwen 3.6 models can terminate inside `<think>` without closing it, producing empty `message.content`. The `ClosedThink` prefix eliminates this by closing the think block before generation starts.
- **Silent empty success**: Adds `x_hipfire_warning` field when content is empty after think-strip but completion tokens were consumed inside an unclosed `<think>` block.
- **Thinking-on + budget**: Routes budgeted thinking requests through AR (working) instead of DFlash (broken) until DFlash continuation is implemented.

## Changes

| File | Change |
|---|---|
| `crates/hipfire-runtime/src/prompt_frame.rs` | Add `ClosedThink` enum variant, `think_close` scaffold field, impl + 2 unit tests |
| `crates/hipfire-runtime/examples/daemon.rs` | Thread `assistant_prefix` through all 4 generate paths; route budgeted thinking-on to AR |
| `cli/index.ts` | Map `thinking=off` / `chat_template_kwargs.enable_thinking=false` / `reasoning.effort=none` to `closed_think`; add `x_hipfire_warning` diagnostic |

## Tests

- 8/8 `prompt_frame` unit tests pass, including 2 new `ClosedThink` tests
- Template matrix: 10/10 visible output across 5 context scenarios (was 6/10 before)
- Tested on gfx1100 (7900 XTX), ROCm 7.13, Qwen 3.6 27B MQ4

## Relationship to PR #219

This is a stopgap fix. PR #219 (Jinja template rendering) will eventually handle this at the template level. But this patch works today with zero new dependencies and no breaking changes. The `assistant_prefix` field is additive and the Jinja path can coexist with it (see `max_think_tokens=1` signal in cli/index.ts).