### PR TITLE
feat(kernel): tiled online-softmax for attention_dflash_f32 (LDS-overflow fix at L≥16128)

### DIFF
--- a/crates/rdna-compute/examples/test_attention_dflash.rs
+++ b/crates/rdna-compute/examples/test_attention_dflash.rs
@@ -1,0 +1,178 @@
+//! Parity test for `attention_dflash_f32` against a CPU naive softmax reference.
+//!
+//! Sweeps L × head_dim per the reviewer matrix on PR #222:
+//!   L        ∈ {1, 127, 128, 13951, 13952, 13953, 16384}
+//!   head_dim ∈ {64, 128, 256, 512}
+//!
+//! The boundary cases at L = 13951..13953 cover the single-tile/multi-tile
+//! transition: tile_size for head_dim=128 is 13952, so n_tiles=1 at L=13952
+//! and n_tiles=2 at L=13953. head_dim=512 forces nthreads(=256) < head_dim,
+//! exercising the strided V-accumulation in Phase C.
+//!
+//! Tolerance is max-abs-diff < 1e-3. Inputs are bounded in [-0.1, 0.1) via a
+//! deterministic LCG so accumulated FP error stays well below tolerance even
+//! at L=16384.
+
+use rdna_compute::{DType, Gpu};
+
+fn lcg_data(seed: u32, n: usize) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s = s.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+            let u = (s >> 16) & 0x7fff;
+            (u as f32 / 32_768.0 - 0.5) * 0.2
+        })
+        .collect()
+}
+
+fn cpu_attention_ref(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    b: usize,
+    l: usize,
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+) -> Vec<f32> {
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    let rep = n_heads / n_kv_heads;
+    let q_stride = n_heads * head_dim;
+    let kv_stride = n_kv_heads * head_dim;
+    let mut out = vec![0.0f32; b * n_heads * head_dim];
+    let mut scores = vec![0.0f32; l];
+
+    for qi in 0..b {
+        for h in 0..n_heads {
+            let kv_h = h / rep;
+            let q_off = qi * q_stride + h * head_dim;
+
+            let mut max_score = f32::NEG_INFINITY;
+            for j in 0..l {
+                let k_off = j * kv_stride + kv_h * head_dim;
+                let mut dot = 0.0f32;
+                for d in 0..head_dim {
+                    dot += q[q_off + d] * k[k_off + d];
+                }
+                let s = dot * scale;
+                scores[j] = s;
+                if s > max_score {
+                    max_score = s;
+                }
+            }
+
+            let mut sum_exp = 0.0f32;
+            for j in 0..l {
+                scores[j] = (scores[j] - max_score).exp();
+                sum_exp += scores[j];
+            }
+            let inv_sum = 1.0f32 / sum_exp;
+
+            let out_off = qi * q_stride + h * head_dim;
+            for d in 0..head_dim {
+                let mut acc = 0.0f32;
+                for j in 0..l {
+                    let v_off = j * kv_stride + kv_h * head_dim;
+                    acc += scores[j] * v[v_off + d];
+                }
+                out[out_off + d] = acc * inv_sum;
+            }
+        }
+    }
+    out
+}
+
+fn compute_n_tiles(l: usize, head_dim: usize) -> usize {
+    let block_size = std::cmp::min(256, std::cmp::max(l, head_dim));
+    let block_size = (block_size as u32).next_power_of_two() as usize;
+    const LDS_BUDGET_F32: usize = 14_336;
+    let fixed = block_size + head_dim;
+    let max_tile_room = LDS_BUDGET_F32.saturating_sub(fixed).max(1);
+    let tile_size = std::cmp::min(l.max(1), max_tile_room);
+    (l + tile_size - 1) / tile_size.max(1)
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    println!("GPU initialized: {}", gpu.arch);
+
+    let b = 1usize;
+    let n_heads = 2usize;
+    let n_kv_heads = 1usize;
+
+    let l_values = [1usize, 127, 128, 13_951, 13_952, 13_953, 16_384];
+    let hd_values = [64usize, 128, 256, 512];
+    let tol = 1.0e-3f32;
+
+    let mut total = 0;
+    let mut failed = 0;
+    let mut max_err_seen = 0.0f32;
+
+    println!(
+        "matrix: B={b} n_heads={n_heads} n_kv_heads={n_kv_heads} (rep={})",
+        n_heads / n_kv_heads
+    );
+    println!("tolerance: max-abs-diff < {tol:.0e}\n");
+    println!("{:>5}  {:>3}  {:>7}  {:>11}  {:>4}", "L", "hd", "n_tiles", "max_diff", "stat");
+    println!("{}", "-".repeat(40));
+
+    for &l in &l_values {
+        for &hd in &hd_values {
+            total += 1;
+            let n_tiles = compute_n_tiles(l, hd);
+
+            let q = lcg_data(0xa5a5_a5a5 ^ ((l as u32).wrapping_mul(31)), b * n_heads * hd);
+            let k = lcg_data(0xc3c3_c3c3 ^ ((l as u32).wrapping_mul(17)), l * n_kv_heads * hd);
+            let v = lcg_data(0x9696_9696 ^ ((l as u32).wrapping_mul(13)), l * n_kv_heads * hd);
+
+            let out_ref = cpu_attention_ref(&q, &k, &v, b, l, n_heads, n_kv_heads, hd);
+
+            let d_q = gpu.upload_f32(&q, &[b * n_heads * hd]).unwrap();
+            let d_k = gpu.upload_f32(&k, &[l * n_kv_heads * hd]).unwrap();
+            let d_v = gpu.upload_f32(&v, &[l * n_kv_heads * hd]).unwrap();
+            let d_out = gpu.zeros(&[b * n_heads * hd], DType::F32).unwrap();
+
+            gpu.attention_dflash_f32(&d_q, &d_k, &d_v, &d_out, b, l, n_heads, n_kv_heads, hd)
+                .unwrap();
+
+            let out_gpu = gpu.download_f32(&d_out).unwrap();
+
+            let mut max_abs_diff = 0.0f32;
+            for i in 0..out_ref.len() {
+                let diff = (out_gpu[i] - out_ref[i]).abs();
+                if diff > max_abs_diff {
+                    max_abs_diff = diff;
+                }
+            }
+            max_err_seen = max_err_seen.max(max_abs_diff);
+            let pass = max_abs_diff < tol;
+            if !pass {
+                failed += 1;
+            }
+            println!(
+                "{:>5}  {:>3}  {:>7}  {:>11.3e}  {}",
+                l,
+                hd,
+                n_tiles,
+                max_abs_diff,
+                if pass { "PASS" } else { "FAIL" }
+            );
+
+            gpu.free_tensor(d_q).unwrap();
+            gpu.free_tensor(d_k).unwrap();
+            gpu.free_tensor(d_v).unwrap();
+            gpu.free_tensor(d_out).unwrap();
+        }
+    }
+
+    println!();
+    println!("=== Summary ===");
+    println!(
+        "{} cases, {} failed, max-abs-diff seen: {:.3e} (tolerance {:.0e})",
+        total, failed, max_err_seen, tol
+    );
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -15220,6 +15220,21 @@ impl Gpu {
         self.ensure_kernel("attention_dflash_f32", kernels::ATTENTION_DFLASH_SRC, "attention_dflash_f32")?;
         let func = &self.functions["attention_dflash_f32"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
+        // Tiled online-softmax (FlashAttention-style). LDS layout:
+        //   tile_scores[tile_size] + ws[block_size] + out_run[head_dim]
+        //
+        // tile_size is chosen to keep LDS ≤ 56 KB (8 KB margin under gfx1100's
+        // 64 KB hard limit for kernel launch overhead). Single-tile case
+        // (l ≤ tile_size) is mathematically equivalent to the prior
+        // single-pass softmax up to FP order; multi-tile carries (max, sum,
+        // out) running state across tiles. Replaces the prior `scores[L]`
+        // allocation that overflowed LDS at l > ~16128.
+        let block_size = std::cmp::min(256, std::cmp::max(l, head_dim)) as u32;
+        let block_size = block_size.next_power_of_two();
+        const LDS_BUDGET_F32: usize = 14_336; // 56 KB / 4 bytes
+        let fixed = block_size as usize + head_dim;
+        let max_tile_room = LDS_BUDGET_F32.saturating_sub(fixed);
+        let tile_size = std::cmp::min(l.max(1), max_tile_room.max(1));
         let mut qp = q.buf.as_ptr();
         let mut kp = k.buf.as_ptr();
         let mut vp = v.buf.as_ptr();
@@ -15230,6 +15245,7 @@ impl Gpu {
         let mut nkv = n_kv_heads as i32;
         let mut hd = head_dim as i32;
         let mut sc = scale;
+        let mut ts = tile_size as i32;
         let mut params: Vec<*mut c_void> = vec![
             &mut qp as *mut _ as *mut c_void,
             &mut kp as *mut _ as *mut c_void,
@@ -15241,11 +15257,9 @@ impl Gpu {
             &mut nkv as *mut _ as *mut c_void,
             &mut hd as *mut _ as *mut c_void,
             &mut sc as *mut _ as *mut c_void,
+            &mut ts as *mut _ as *mut c_void,
         ];
-        let block_size = std::cmp::min(256, std::cmp::max(l, head_dim)) as u32;
-        let block_size = block_size.next_power_of_two();
-        // Shared: scores[L] + workspace[block_size]
-        let shared_mem = ((l + block_size as usize) * 4) as u32;
+        let shared_mem = ((tile_size + block_size as usize + head_dim) * 4) as u32;
         unsafe {
             self.hip.launch_kernel(
                 func,

--- a/kernels/src/attention_dflash.hip
+++ b/kernels/src/attention_dflash.hip
@@ -3,8 +3,7 @@
 // Each query position attends to ALL key/value positions (non-causal,
 // bidirectional). Supports GQA where n_heads > n_kv_heads. Q/K/V are
 // separate buffers — K can be longer than Q. Grid: [n_heads, B, 1],
-// one block per (head, query-position). Block size is chosen to cover
-// max(L, head_dim). Shared mem: L scores + block_size workspace.
+// one block per (head, query-position).
 //
 // Layout (row-major, flat):
 //   q    : [B  * n_heads    * head_dim]
@@ -13,6 +12,16 @@
 //   out  : [B  * n_heads    * head_dim]
 //
 // rep = n_heads / n_kv_heads (must divide evenly).
+//
+// PR3 step 2 follow-up: this is a tiled online-softmax (FlashAttention-style)
+// implementation. Replaces the prior single-pass `scores[L]` allocation that
+// overflowed gfx1100/RDNA3's 64 KB LDS budget at L > ~16128. With tiling,
+// LDS = (tile_size + block_size + head_dim) * 4 bytes — independent of L.
+// Single-tile case (tile_size = L when L ≤ tile_size) is mathematically
+// equivalent to the prior kernel up to FP non-associativity in the same
+// reduce trees. Multi-tile case carries a running (max, sum, output)
+// triplet across tiles, mathematically identical to single-pass softmax
+// modulo FP order.
 
 #include <hip/hip_runtime.h>
 
@@ -22,7 +31,8 @@ extern "C" __global__ void attention_dflash_f32(
     const float* __restrict__ v,
     float* __restrict__ out,
     int B, int L, int n_heads, int n_kv_heads, int head_dim,
-    float scale
+    float scale,
+    int tile_size
 ) {
     extern __shared__ float sdata[];
     int head = blockIdx.x;
@@ -36,68 +46,103 @@ extern "C" __global__ void attention_dflash_f32(
     int q_stride = n_heads * head_dim;
     int kv_stride = n_kv_heads * head_dim;
 
-    float* scores = sdata;               // [L]
-    float* ws = sdata + L;               // [blockDim.x]
+    // LDS layout: [tile_scores[tile_size]] [ws[nthreads]] [out_run[head_dim]]
+    float* tile_scores = sdata;                                // [tile_size]
+    float* ws          = sdata + tile_size;                    // [nthreads]
+    float* out_run     = sdata + tile_size + nthreads;         // [head_dim]
 
     const float* q_ptr = q + qi * q_stride + head * head_dim;
 
-    // Phase 1: scores[j] = dot(Q[qi,head], K[j,kv_head]) * scale, tracking max.
-    float local_max = -1e30f;
-    for (int j = tid; j < L; j += nthreads) {
-        const float* k_ptr = k + j * kv_stride + kv_head * head_dim;
-        float dot = 0.0f;
-        for (int d = 0; d < head_dim; ++d) {
-            dot += q_ptr[d] * k_ptr[d];
-        }
-        float s = dot * scale;
-        scores[j] = s;
-        if (s > local_max) local_max = s;
-    }
-
-    // Block-wide max reduce.
-    ws[tid] = local_max;
-    __syncthreads();
-    for (int s = nthreads / 2; s > 0; s >>= 1) {
-        if (tid < s) {
-            float a = ws[tid];
-            float b = ws[tid + s];
-            ws[tid] = a > b ? a : b;
-        }
-        __syncthreads();
-    }
-    float max_val = ws[0];
-    __syncthreads();
-
-    // Phase 2: exp(score - max), tracking sum.
-    float local_sum = 0.0f;
-    for (int j = tid; j < L; j += nthreads) {
-        float e = expf(scores[j] - max_val);
-        scores[j] = e;
-        local_sum += e;
-    }
-    ws[tid] = local_sum;
-    __syncthreads();
-    for (int s = nthreads / 2; s > 0; s >>= 1) {
-        if (tid < s) ws[tid] += ws[tid + s];
-        __syncthreads();
-    }
-    float sum_val = ws[0];
-    __syncthreads();
-
-    // Normalize.
-    float inv_sum = 1.0f / sum_val;
-    for (int j = tid; j < L; j += nthreads) {
-        scores[j] *= inv_sum;
-    }
-    __syncthreads();
-
-    // Phase 3: out[qi, head, :] = sum_j scores[j] * V[j, kv_head, :]
-    float* out_ptr = out + qi * q_stride + head * head_dim;
+    // Initialize running output to 0.
     for (int d = tid; d < head_dim; d += nthreads) {
-        float val = 0.0f;
-        for (int j = 0; j < L; ++j) {
-            val += scores[j] * v[j * kv_stride + kv_head * head_dim + d];
+        out_run[d] = 0.0f;
+    }
+    __syncthreads();
+
+    // Online-softmax running state.
+    float m_run = -1e30f;  // running max of all scores seen so far
+    float l_run = 0.0f;    // running sum of exp(scores - m_run)
+
+    int n_tiles = (L + tile_size - 1) / tile_size;
+    for (int t = 0; t < n_tiles; ++t) {
+        int tile_start = t * tile_size;
+        int tile_len = L - tile_start;
+        if (tile_len > tile_size) tile_len = tile_size;
+
+        // Phase A: compute scores for this tile, track tile-local max.
+        float local_max = -1e30f;
+        for (int j = tid; j < tile_len; j += nthreads) {
+            int abs_j = tile_start + j;
+            const float* k_ptr = k + abs_j * kv_stride + kv_head * head_dim;
+            float dot = 0.0f;
+            for (int d = 0; d < head_dim; ++d) {
+                dot += q_ptr[d] * k_ptr[d];
+            }
+            float s = dot * scale;
+            tile_scores[j] = s;
+            if (s > local_max) local_max = s;
         }
-        out_ptr[d] = val;
+        ws[tid] = local_max;
+        __syncthreads();
+        for (int s = nthreads / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                float a = ws[tid];
+                float b = ws[tid + s];
+                ws[tid] = a > b ? a : b;
+            }
+            __syncthreads();
+        }
+        float tile_max = ws[0];
+        __syncthreads();
+
+        // Phase B: rescale running state to the new global max.
+        //   m_new   = max(m_run, tile_max)
+        //   alpha   = exp(m_run - m_new)             (= 1 if m_run won, < 1 otherwise)
+        //   l_new   = alpha * l_run + sum_j exp(score_j - m_new)
+        //   out_new = alpha * out_run + sum_j exp(score_j - m_new) * V[j]
+        // First tile (m_run = -inf): alpha = exp(-inf - finite) = 0, so the
+        // running state correctly reduces to fresh-tile contribution.
+        float m_new = m_run > tile_max ? m_run : tile_max;
+        float alpha = expf(m_run - m_new);
+
+        // Convert tile_scores in place to exp(score - m_new), summing.
+        float local_sum = 0.0f;
+        for (int j = tid; j < tile_len; j += nthreads) {
+            float e = expf(tile_scores[j] - m_new);
+            tile_scores[j] = e;
+            local_sum += e;
+        }
+        ws[tid] = local_sum;
+        __syncthreads();
+        for (int s = nthreads / 2; s > 0; s >>= 1) {
+            if (tid < s) ws[tid] += ws[tid + s];
+            __syncthreads();
+        }
+        float tile_sum = ws[0];
+        __syncthreads();
+
+        // Update running denominator.
+        l_run = alpha * l_run + tile_sum;
+
+        // Update running output: each thread updates the head_dim slots it owns.
+        for (int d = tid; d < head_dim; d += nthreads) {
+            float scaled_old = alpha * out_run[d];
+            float contrib = 0.0f;
+            for (int j = 0; j < tile_len; ++j) {
+                int abs_j = tile_start + j;
+                contrib += tile_scores[j] * v[abs_j * kv_stride + kv_head * head_dim + d];
+            }
+            out_run[d] = scaled_old + contrib;
+        }
+        __syncthreads();
+
+        m_run = m_new;
+    }
+
+    // Finalize: out = out_run / l_run.
+    float* out_ptr = out + qi * q_stride + head * head_dim;
+    float inv_l = 1.0f / l_run;
+    for (int d = tid; d < head_dim; d += nthreads) {
+        out_ptr[d] = out_run[d] * inv_l;
     }
 }

--- a/kernels/src/attention_dflash.hip
+++ b/kernels/src/attention_dflash.hip
@@ -59,9 +59,11 @@ extern "C" __global__ void attention_dflash_f32(
     }
     __syncthreads();
 
-    // Online-softmax running state.
-    float m_run = -1e30f;  // running max of all scores seen so far
-    float l_run = 0.0f;    // running sum of exp(scores - m_run)
+    // Online-softmax running state. m_run starts at -INFINITY so the
+    // first-tile bootstrap is exact: alpha = exp(-inf - finite) = 0
+    // by IEEE-754, no reliance on FP underflow of (-1e30 - finite).
+    float m_run = -INFINITY;  // running max of all scores seen so far
+    float l_run = 0.0f;       // running sum of exp(scores - m_run)
 
     int n_tiles = (L + tile_size - 1) / tile_size;
     for (int t = 0; t < n_tiles; ++t) {
@@ -70,7 +72,7 @@ extern "C" __global__ void attention_dflash_f32(
         if (tile_len > tile_size) tile_len = tile_size;
 
         // Phase A: compute scores for this tile, track tile-local max.
-        float local_max = -1e30f;
+        float local_max = -INFINITY;
         for (int j = tid; j < tile_len; j += nthreads) {
             int abs_j = tile_start + j;
             const float* k_ptr = k + abs_j * kv_stride + kv_head * head_dim;


### PR DESCRIPTION
# Tiled online-softmax for `attention_dflash_f32` — correctness fix at L ≥ 16128

The DFlash drafter's cross-attention kernel previously allocated `(L + block_size) * 4` bytes of LDS (`scores[L]` plus a small reduce workspace). On gfx1100/RDNA3 the per-workgroup LDS budget is 64 KB, so any forward at `L ≥ 16128` returned `hipModuleLaunchKernel: invalid argument` (block_size=256, L=16139 → 65580 bytes, 44 over the limit).

Single-card paths can't reach this regime — the drafter scratch buffer OOMs the GPU first. Hetero PFlash+DFlash (PR3 step 2 in the original tree) distributes drafter scratch onto a second card and exposes the bug at the canonical 16K bench.

## Fix: tiled online-softmax (FlashAttention-style)

Replace the single-pass `scores[L]` softmax with a per-tile online softmax:

```
for tile in [0, T), [T, 2T), …:
    compute tile scores
    m_new   = max(m_run, max(tile_scores))
    alpha   = exp(m_run - m_new)
    l_run   = alpha * l_run + sum_j exp(score_j - m_new)
    out_run = alpha * out_run + sum_j exp(score_j - m_new) * V[j]
    m_run   = m_new
out = out_run / l_run
```

LDS layout becomes `tile_scores[T] + ws[block_size] + out_run[head_dim]` — independent of L. Tile size is chosen at dispatch to keep LDS ≤ 56 KB (8 KB margin under the 64 KB hard limit). For typical Qwen3.5-DFlash shapes (head_dim=128, block_size up to 256) max tile ≈ 13950.

## Sentinel fix (commit `5bf3c0c`)

Running-max sentinel switched from `-1e30f` to `-INFINITY` per reviewer feedback. With `-INFINITY` the first-tile bootstrap is exact by IEEE-754: `alpha = exp(-inf - finite) = 0` unconditionally, no reliance on FP underflow of `(-1e30 - finite)`.

## Numerical equivalence (not bit-equality)

Single-tile case (L ≤ tile) is **mathematically equivalent** to the prior single-pass kernel — same softmax, same exp/normalize math — but **not bit-identical**: the deferred `out_run / l_run` divide and the reduction tree produce different FP rounding even at n_tiles=1. Multi-tile carries (m, l, out) running state across tiles, identical to single-pass softmax modulo FP order.

## Validation

Parity test (`crates/rdna-compute/examples/test_attention_dflash.rs`, commit `2908df1`) sweeps the reviewer matrix L ∈ {1, 127, 128, 13951, 13952, 13953, 16384} × head_dim ∈ {64, 128, 256, 512} against a CPU naive single-pass softmax reference on gfx1100 (RX 7900 XTX, ROCm 6.4):

```
28 cases, 0 failed, max-abs-diff seen: 1.211e-8 (tolerance 1e-3)
```

Five orders of magnitude under the tolerance — confirms numerical equivalence (not bit-equality). Boundary cases at L=13951..13953 span the single-tile/multi-tile transition (n_tiles 1→2); head_dim=512 exercises the strided V-accumulation path with nthreads(=256) < head_dim.

End-to-end:
- Single-card 1K prompt, 16 tokens decode: τ=1.14, decode_tok_s=36.2 — emitted token sequence matches the prior kernel exactly under `--temp 0` (argmax-stable through FP rounding).
- Hetero canonical 16K prompt (16139 BPE), 128 tokens decode: τ=1.78 cycles=46 decode_tok_s=11.4. Previously τ=0 with a 15,872 ctx cap workaround in `spec_step_dflash`; the cap is now removed.
- Hetero 4K word prompt: τ=10.0 cycles=2 — non-regression confirmed.
- `coherence-gate.sh`: 7/7 models emit tokens without panic/timeout; outputs coherent (Paris answer, Python one-liner, sheep=9, tool-call JSON, etc).

## Commit layout

```
2908df1 test(kernel): parity sweep for attention_dflash_f32 vs CPU naive softmax
5bf3c0c fix(kernel): use -INFINITY sentinel in attention_dflash_f32
35c815a feat(kernel): tiled online-softmax for attention_dflash_f32
```

## What's not here

An earlier revision of this PR included a Phase C full-workgroup V-accumulation commit (j-partitioning) that claimed +33 % decode tok/s on a hetero 16K bench. That commit has been dropped because:

- The original measurement was within-session × 3, not fresh-process; CLAUDE.md `## Perf benchmarking` requires fresh-process probe (`scripts/probe_commits.sh`) for any kernel-level tok/s claim.
- Independent fresh-process A/B on gfx1100 single-card single-tile L=10888 shows Δ = −0.2 % vs the pre-Phase-C kernel (τ bit-identical at 1.300, three runs each, stddev < 0.1 tok/s) — well within noise.
- gfx1151 reviewer measurement showed −15 % regression on single-tile due to LDS-overhead vs FMA-savings imbalance on APU.

The workgroup-utilization win is plausibly real for multi-tile/hetero regimes (where FMA savings amortize across tiles), but cannot be honestly probed in fresh-process mode without PR #204's hetero plumbing — which is no longer in tree. That work is punted to a separate PR with proper hetero infrastructure and a `n_tiles == 1 → original path` guard to avoid the gfx1151 regression. This PR ships only the LDS-overflow correctness fix.