### PR TITLE
feat(HFP4): RDNA-optimal FP4 quant family (E2M1 + UE8M0 g32 + FP16 row scale) v1

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -743,6 +743,10 @@ fn load_weight_tensor_raw(gpu: &Gpu, quant_type: u8, data: &[u8], m: usize, k: u
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256Lloyd, m, k, row_stride: 0 })
         }
+        21 => { // HFP4G32 — E2M1 + UE8M0 g32 + FP16 row scale. See docs/quant-formats/hfp4.md.
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::HFP4G32, m, k, row_stride: 0 })
+        }
         3 => {
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::Q8_0, m, k, row_stride: 0 })

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -639,6 +639,275 @@ fn quantize_hfq4g256(f32_data: &[f32]) -> Vec<u8> {
     output
 }
 
+// ─── HFP4G32 — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale) ────────────────
+//
+// Spec: docs/quant-formats/hfp4.md
+//
+// Per-row layout: 16-B header (row_scale_a:f16, row_scale_b:f16, block_count:u16, flags:u8, ...)
+//                 followed by (K/32) blocks × 17 B (UE8M0:u8 + 16 B nibbles).
+// Per element:    value = row_scale_a * 2^(block_e - 127) * E2M1_LUT[nibble]
+
+/// OCP E2M1 magnitude lattice (signed 4-bit FP). 16 codes: {±0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}.
+/// Order: positive 0..7, then negative 0..7 (mirrors hardware-canonical sign-magnitude packing).
+const E2M1_LUT: [f32; 16] = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+];
+
+/// E2M1 round-to-nearest in the 16-code lattice. Returns the nibble (0..15).
+/// Ties broken away from zero (consistent with FP rounding).
+fn e2m1_round(x: f32) -> u8 {
+    let mut best_idx = 0u8;
+    let mut best_err = f32::INFINITY;
+    for (i, &code) in E2M1_LUT.iter().enumerate() {
+        let err = (code - x).abs();
+        // Strict < ensures consistent tie-breaking by code-table order.
+        // The lattice has +0 at index 0 and -0 at index 8; +0 wins ties at zero.
+        if err < best_err {
+            best_err = err;
+            best_idx = i as u8;
+        }
+    }
+    best_idx
+}
+
+/// Quantize one row of K FP32 weights to HFP4G32 byte format.
+///
+/// K must be a multiple of 32 (hipfire model dims always satisfy this).
+/// Returns 16-B header + (K/32) × 17-B blocks = 16 + 17 * (K/32) bytes.
+fn quantize_hfp4g32_row(row: &[f32]) -> Vec<u8> {
+    assert!(row.len() % 32 == 0, "HFP4G32 requires K%32 == 0, got K={}", row.len());
+    let k = row.len();
+    let n_blocks = k / 32;
+    let row_bytes = 16 + n_blocks * 17;
+    let mut out = vec![0u8; row_bytes];
+
+    // Per-row FP16 second-level scale: row_scale_a = max_abs(row) / 6.0  (E2M1 max = 6.0).
+    let row_max_abs = row.iter().cloned().fold(0.0f32, |m, v| m.max(v.abs()));
+    let row_scale_a = if row_max_abs > 0.0 { row_max_abs / 6.0 } else { 1.0 };
+    let inv_row_scale = if row_max_abs > 0.0 { 1.0 / row_scale_a } else { 0.0 };
+
+    // Header.
+    out[0..2].copy_from_slice(&f32_to_f16(row_scale_a).to_le_bytes());
+    out[2..4].copy_from_slice(&0u16.to_le_bytes());           // row_scale_b unused in v1
+    out[4..6].copy_from_slice(&(n_blocks as u16).to_le_bytes()); // block_count
+    out[6] = 0u8;                                              // format_flags = 0 (no rotation)
+    out[7] = 0u8;                                              // reserved
+    // out[8..16] reserved zeros (already zeroed by vec![0u8; ...])
+
+    // Per-block payload.
+    for b in 0..n_blocks {
+        let block_start = b * 32;
+        let block = &row[block_start..block_start + 32];
+
+        // Normalize block by row scale.
+        // block_max_normalized in units of [-6.0, +6.0] (because row_scale_a = max_abs/6.0).
+        // Pick UE8M0 block exponent so block fits cleanly into E2M1 lattice [-6, +6].
+        let block_max_abs = block.iter().cloned().fold(0.0f32, |m, v| m.max(v.abs()));
+        let block_max_normalized = block_max_abs * inv_row_scale;
+
+        // Choose smallest UE8M0 exponent that covers block_max_normalized without clipping:
+        //   6 * 2^(e - 127) ≥ block_max_normalized   →   e ≥ ceil(log2(block_max_normalized / 6)) + 127
+        // ceil (not round) prevents clipping; the precision cost is bounded by 1 bit at the top
+        // of the block. Clamp to UE8M0 range [0, 254] (255 = NaN, reserved per OCP spec).
+        let block_e: u8 = if block_max_normalized > 0.0 {
+            let log_ratio = (block_max_normalized / 6.0).log2();
+            let e_signed = log_ratio.ceil() as i32 + 127;
+            e_signed.clamp(0, 254) as u8
+        } else {
+            0u8 // empty block — smallest scale, all nibbles round to 0
+        };
+
+        let block_scale = (block_e as i32 - 127) as f32;
+        let block_scale_factor = block_scale.exp2(); // 2^(block_e - 127)
+        let inv_block_scale = if block_scale_factor > 0.0 { 1.0 / block_scale_factor } else { 0.0 };
+
+        // Block payload offset in the row buffer.
+        let payload_off = 16 + b * 17;
+        out[payload_off] = block_e;
+
+        // Pack 32 elements as 16 bytes, low nibble = even index, high nibble = odd index.
+        for i in 0..16 {
+            let lo = block[2 * i] * inv_row_scale * inv_block_scale;
+            let hi = block[2 * i + 1] * inv_row_scale * inv_block_scale;
+            let lo_nibble = e2m1_round(lo);
+            let hi_nibble = e2m1_round(hi);
+            out[payload_off + 1 + i] = (lo_nibble & 0x0F) | ((hi_nibble & 0x0F) << 4);
+        }
+    }
+
+    out
+}
+
+/// Quantize a row-major 2D weight tensor of shape `[m, k]` to HFP4G32.
+/// Returns `m * (16 + 17 * (k/32))` bytes — 16-B row header + per-block payloads, repeated per row.
+fn quantize_hfp4g32_2d(f32_data: &[f32], m: usize, k: usize) -> Vec<u8> {
+    assert_eq!(f32_data.len(), m * k, "2D shape mismatch: {} vs {}*{}", f32_data.len(), m, k);
+    assert!(k % 32 == 0, "HFP4G32 requires k % 32 == 0, got k={}", k);
+    let row_bytes = 16 + 17 * (k / 32);
+    let mut out = Vec::with_capacity(m * row_bytes);
+    for r in 0..m {
+        let row = &f32_data[r * k..(r + 1) * k];
+        out.extend_from_slice(&quantize_hfp4g32_row(row));
+    }
+    out
+}
+
+/// CPU reference dequantization for HFP4G32 — bit-exact mirror of `gemv_hfp4g32.hip`'s dequant.
+/// Returns the K reconstructed FP32 weights for one row.
+#[allow(dead_code)] // used by tests + future round-trip diagnostics
+fn dequant_hfp4g32_row(packed: &[u8], k: usize) -> Vec<f32> {
+    assert!(k % 32 == 0, "HFP4G32 requires K%32 == 0");
+    let n_blocks = k / 32;
+    assert_eq!(packed.len(), 16 + n_blocks * 17, "HFP4G32 row size mismatch");
+
+    let row_scale_a_bits = u16::from_le_bytes([packed[0], packed[1]]);
+    let row_scale_a = f16_to_f32(row_scale_a_bits);
+
+    let mut out = vec![0.0f32; k];
+    for b in 0..n_blocks {
+        let payload_off = 16 + b * 17;
+        let block_e = packed[payload_off] as i32;
+        let block_scale = (block_e - 127) as f32;
+        let block_scale_factor = block_scale.exp2();
+        let scale = row_scale_a * block_scale_factor;
+
+        for i in 0..16 {
+            let byte = packed[payload_off + 1 + i];
+            let lo_nibble = (byte & 0x0F) as usize;
+            let hi_nibble = ((byte >> 4) & 0x0F) as usize;
+            out[b * 32 + 2 * i]     = scale * E2M1_LUT[lo_nibble];
+            out[b * 32 + 2 * i + 1] = scale * E2M1_LUT[hi_nibble];
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod hfp4_tests {
+    use super::*;
+
+    #[test]
+    fn e2m1_round_matches_lattice() {
+        // Each lattice value should round to its own code.
+        for (i, &val) in E2M1_LUT.iter().enumerate() {
+            let nibble = e2m1_round(val);
+            // +0 and -0 are both at value 0.0; either nibble is acceptable.
+            if val.abs() < 1e-6 {
+                assert!(nibble == 0 || nibble == 8, "zero rounds to nibble {}", nibble);
+            } else {
+                assert_eq!(nibble, i as u8, "code {} rounded to nibble {} not {}", i, nibble, i);
+            }
+        }
+    }
+
+    #[test]
+    fn e2m1_round_midpoint() {
+        // Halfway between +1.0 and +1.5 → either is acceptable (tie).
+        let n = e2m1_round(1.25);
+        assert!(n == 2 || n == 3, "midpoint rounded to {}", n);
+        // Halfway between +4.0 and +6.0 (= 5.0) → either is acceptable.
+        let n = e2m1_round(5.0);
+        assert!(n == 6 || n == 7, "5.0 rounded to {}", n);
+    }
+
+    #[test]
+    fn round_trip_constant_row() {
+        // All-1.0 row: row_scale_a = 1/6, every block_e ≈ 127 + log2(1) = 127, every nibble = 2 (=1.0).
+        let row = vec![1.0f32; 64];
+        let packed = quantize_hfp4g32_row(&row);
+        let recovered = dequant_hfp4g32_row(&packed, 64);
+        for (i, &v) in recovered.iter().enumerate() {
+            assert!((v - 1.0).abs() < 1e-2, "elem {} recovered to {}", i, v);
+        }
+    }
+
+    #[test]
+    fn round_trip_mixed_magnitudes() {
+        // Row with mixed positive/negative E2M1 magnitudes — should round-trip exactly.
+        let row: Vec<f32> = (0..64).map(|i| {
+            let v = E2M1_LUT[i % 16];
+            v * 6.0 // scale up so row_scale_a sees max abs at 6 * 6 = 36, brings code lattice back to [-6, 6]
+        }).collect();
+        let packed = quantize_hfp4g32_row(&row);
+        let recovered = dequant_hfp4g32_row(&packed, 64);
+        // Bound: |recovered - input| ≤ row_scale * 2^(block_e - 127) * 0.5 (half min E2M1 step).
+        // With row_scale_a = 36/6 = 6, and block_max_normalized = 6, block_e = 127 → step ≈ 0.5 → tol = 3.0.
+        // Actual tolerance should be much tighter for exact lattice values; allow some headroom.
+        for (i, (&got, &want)) in recovered.iter().zip(row.iter()).enumerate() {
+            let rel_err = (got - want).abs() / want.abs().max(1.0);
+            assert!(rel_err < 0.1, "elem {}: got {} want {} rel_err {}", i, got, want, rel_err);
+        }
+    }
+
+    #[test]
+    fn round_trip_per_block_error_bound() {
+        // Mathematical guarantee: for every element, |recovered - original| must be ≤
+        //   row_scale_a * 2^(block_e - 127) * (max_E2M1_step / 2)
+        // = effective_block_scale * 1.0  (max E2M1 step is 2.0, half = 1.0)
+        //
+        // This is the format's correctness contract; if this fails we have a real bug.
+        // NRMSE quality on raw weights is a downstream concern (MXFP4 family is documented
+        // as needing rotation+smoothing for production accuracy — that's MFP4G32 in v1.5).
+        let mut rng_state: u64 = 0xdead_beef_dead_beef;
+        let mut next_uniform = || -> f32 {
+            rng_state ^= rng_state << 13;
+            rng_state ^= rng_state >> 7;
+            rng_state ^= rng_state << 17;
+            ((rng_state & 0x00FF_FFFF) as f32 / 0x0100_0000 as f32).max(1e-7)
+        };
+        // Box-Muller Gaussian std=0.5.
+        let row: Vec<f32> = (0..512).flat_map(|_| {
+            let u1 = next_uniform();
+            let u2 = next_uniform();
+            let r = (-2.0 * u1.ln()).sqrt();
+            let t = 2.0 * std::f32::consts::PI * u2;
+            [r * t.cos() * 0.5, r * t.sin() * 0.5]
+        }).collect();
+
+        let k = row.len();
+        let packed = quantize_hfp4g32_row(&row);
+        let recovered = dequant_hfp4g32_row(&packed, k);
+
+        let row_scale_a = f16_to_f32(u16::from_le_bytes([packed[0], packed[1]]));
+
+        // Per-block half-max-step bound. Allow 1% slack for FP16 row-scale rounding.
+        for b in 0..(k / 32) {
+            let payload_off = 16 + b * 17;
+            let block_e = packed[payload_off] as i32;
+            let block_scale = ((block_e - 127) as f32).exp2();
+            // Max E2M1 step is 2.0 (between 4 and 6); half = 1.0. Round-trip element error must
+            // be ≤ effective block scale × 1.0 × (1 + slack). Slack absorbs FP16 row-scale rounding.
+            let bound = row_scale_a * block_scale * 1.0 * 1.01 + 1e-5;
+            for i in 0..32 {
+                let idx = b * 32 + i;
+                let err = (recovered[idx] - row[idx]).abs();
+                assert!(err <= bound,
+                        "block {} elem {} err {} exceeds bound {} (block_e={}, row_scale_a={}, block_scale={})",
+                        b, i, err, bound, block_e, row_scale_a, block_scale);
+            }
+        }
+    }
+
+    #[test]
+    fn header_layout_matches_spec() {
+        // 64 elements = 2 blocks. Row size: 16 + 2*17 = 50 bytes.
+        let row = vec![3.0f32; 64];
+        let packed = quantize_hfp4g32_row(&row);
+        assert_eq!(packed.len(), 50);
+        // Block count == 2.
+        let bc = u16::from_le_bytes([packed[4], packed[5]]);
+        assert_eq!(bc, 2);
+        // Format flags: rotation off, no row_scale_b.
+        assert_eq!(packed[6] & 0x0F, 0);
+        // First block UE8M0 byte at offset 16.
+        // Last block payload ends at 16 + 2*17 = 50 (= total).
+        // Sanity: row_scale_a > 0 (FP16 bits non-zero).
+        let rs_bits = u16::from_le_bytes([packed[0], packed[1]]);
+        assert_ne!(rs_bits, 0);
+    }
+}
+
 /// MagnumQuant MQ3-G256: FWHT-rotated 3-bit quantization.
 /// Same binary format as HFQ3-G256 (104 bytes/group). Rotation is baked into
 /// the weights via cpu_fwht_256; the GEMV kernel rotates x instead.
@@ -1310,6 +1579,19 @@ enum QuantType {
     MQ2G256 = 18,  // MagnumQuant: FWHT-rotated HFQ2-G256 (2-bit, 72 B/group)
     MQ2G256Lloyd = 19, // MagnumQuant 2-bit + per-block Lloyd-Max 4-entry fp16 codebook (72 B/group)
     MQ3G256Lloyd = 20, // MagnumQuant 3-bit + per-block Lloyd-Max 8-entry fp16 codebook (112 B/group)
+    // HFP4 family — RDNA-optimal FP4 (E2M1 elements + UE8M0 block scale + FP16 row scale).
+    // See docs/quant-formats/hfp4.md for byte layout, dequant, rotation modes.
+    // Per-row header is 16 B; per-block payload is (1 + g/2) bytes (UE8M0 + nibbles).
+    HFP4G32 = 21,      // E2M1 + UE8M0 g32 + FP16 row scale — canonical (FP8-WMMA-K aligned)
+    // Reserved IDs — DO NOT REUSE for unrelated formats. Documented in docs/quant-formats/hfp4.md.
+    // HFP4G16     = 22, // v1.5 — NV-aligned FP16-WMMA-K alignment ablation
+    // HFP4G64     = 23, // v1.5 — RDNA1/2 sweet-spot ablation
+    // MFP4G32     = 24, // v1.5 — HFP4G32 + offline FWHT rotation (drop-in MQ4 replacement)
+    // HFP4G32MX   = 25, // v2  — strict OCP MXFP4 interop alias (no row scale, UE8M0 only)
+    // HFP4G16NV   = 26, // v2  — strict NVFP4 interop alias (E4M3 scale + FP32 tensor)
+    // HFP8E4M3G32 = 27, // v2  — HFP8 E4M3 family
+    // HFP8E5M2G32 = 28, // v2  — HFP8 E5M2 family
+    // MFP4G32R    = 29, // v3  — HFP4G32 + online block-diag-128 rotation (AMD recipe)
 }
 
 /// Per-tensor precision level assigned by the K-map pre-pass.
@@ -2000,6 +2282,7 @@ enum GgufFormat {
     Mq2,
     Mq2Lloyd,
     Mq3Lloyd,
+    Hfp4,  // HFP4G32 — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale)
 }
 
 impl GgufFormat {
@@ -2013,6 +2296,7 @@ impl GgufFormat {
             "mq2" | "mq2g256" => Some(Self::Mq2),
             "mq2-lloyd" | "mq2g256-lloyd" | "mq2lloyd" => Some(Self::Mq2Lloyd),
             "mq3-lloyd" | "mq3g256-lloyd" | "mq3lloyd" => Some(Self::Mq3Lloyd),
+            "hfp4" | "hfp4g32" | "hf4p" | "fp4" => Some(Self::Hfp4),
             _ => None,
         }
     }
@@ -2027,6 +2311,7 @@ impl GgufFormat {
             Self::Mq2 => "MQ2G256",
             Self::Mq2Lloyd => "MQ2G256Lloyd",
             Self::Mq3Lloyd => "MQ3G256Lloyd",
+            Self::Hfp4 => "HFP4G32",
         }
     }
 }
@@ -2183,6 +2468,13 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
                     let q = quantize_hfq6g256(&f32_data);
                     (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
                 }
+                GgufFormat::Hfp4 => {
+                    // No HFP6 variant in v1. Promote6 for HFP4 stays at HFP4G32 (4.25 bpw).
+                    let m = info.shape[0] as usize;
+                    let k = info.shape[1] as usize;
+                    let q = quantize_hfp4g32_2d(&f32_data, m, k);
+                    (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                }
             }
         } else if k_dim % 256 == 0 {
             // 256-aligned 2D weight — quantize per the chosen format (Base level).
@@ -2220,6 +2512,12 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
                 GgufFormat::Mq3Lloyd => {
                     let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
                     (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                }
+                GgufFormat::Hfp4 => {
+                    let m = info.shape[0] as usize;
+                    let k = info.shape[1] as usize;
+                    let q = quantize_hfp4g32_2d(&f32_data, m, k);
+                    (q, QuantType::HFP4G32, 32u32, "HFP4G32")
                 }
             }
         } else {
@@ -2336,6 +2634,8 @@ fn main() {
     let use_mq2g256_lloyd = format == "mq2-lloyd" || format == "mq2g256-lloyd" || format == "mq2lloyd";
     let use_mq3g256_lloyd = format == "mq3-lloyd" || format == "mq3g256-lloyd" || format == "mq3lloyd";
     let use_hfq6 = format == "hfq6" || format == "hfq6g256" || format == "hf6";
+    // HFP4G32 — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale). Spec at docs/quant-formats/hfp4.md.
+    let use_hfp4 = format == "hfp4" || format == "hfp4g32" || format == "hf4p" || format == "fp4";
     let q8_router_flag = args.iter().any(|a| a == "--q8-router");
     let no_kmap = args.iter().any(|a| a == "--no-kmap" || a == "--uniform");
     // K-map gate: applies to MoE models by default. Dense models opt in
@@ -2903,6 +3203,22 @@ fn main() {
                     (q, QuantType::MQ4G256, 256u32, "MQ4G256")
                 } else {
                     // Fallback to standard HFQ4-G128 for non-256-aligned
+                    let q = quantize_hfq4g128(&f32_data);
+                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                }
+            } else if use_hfp4 && is_embed {
+                // HFP4 embeddings stay Q8F16 (matches MQ4 / HFQ4 pattern — embedding lookup is
+                // accuracy-sensitive, FP4 codes too lossy for vocab-sized tables).
+                let q = quantize_q8f16(&f32_data);
+                (q, QuantType::Q8F16, 32u32, "Q8_F16")
+            } else if use_hfp4 {
+                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
+                if k_dim % 32 == 0 && meta.shape.len() == 2 {
+                    let m = meta.shape[0];
+                    let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
+                    (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                } else {
+                    // Fallback to HFQ4-G128 for non-32-aligned ragged dims (rare).
                     let q = quantize_hfq4g128(&f32_data);
                     (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
                 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -510,6 +510,11 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256Lloyd, m, k, row_stride: 0 })
         }
+        21 => { // HFP4G32 — E2M1 + UE8M0 g32 + FP16 row scale.
+                // Per-row hdr 16 B + (K/32) blocks × 17 B. See docs/quant-formats/hfp4.md.
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::HFP4G32, m, k, row_stride: 0 })
+        }
         1 => { // F16 — dequant to F32 for F32 GEMV
             let f32_data: Vec<f32> = data.chunks_exact(2)
                 .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -562,6 +562,7 @@ pub fn weight_gemv(
         DType::Q8HFQ => gpu.gemv_q8hfq(&w.buf, x, y, w.m, w.k, w.row_stride),
         DType::HFQ4G256 => gpu.gemv_hfq4g256(&w.buf, x, y, w.m, w.k),
         DType::HFQ4G128 => gpu.gemv_hfq4g128(&w.buf, x, y, w.m, w.k),
+        DType::HFP4G32 => gpu.gemv_hfp4g32(&w.buf, x, y, w.m, w.k),
         DType::MQ4G256 => {
             gpu.ensure_mq_signs()?;
             let x_rot_alias = GpuTensor {

--- a/crates/rdna-compute/examples/test_gemv_hfp4g32.rs
+++ b/crates/rdna-compute/examples/test_gemv_hfp4g32.rs
@@ -1,0 +1,244 @@
+//! GPU vs CPU correctness test for `gemv_hfp4g32`.
+//!
+//! Builds a deterministic HFP4G32 weight matrix in-process, runs the GPU kernel,
+//! and compares against a CPU reference that bit-mirrors the kernel's dequant
+//! arithmetic (E2M1 LUT, UE8M0 ldexp scale, FP16 row scale). Fails if max-abs
+//! error exceeds a small absolute bound (FP32 summation reorder noise).
+//!
+//! Format: 16-B per-row header + (K/32) × 17-B per-block payload.
+//!         See docs/quant-formats/hfp4.md.
+//!
+//! Sweeps groups_per_row ∈ {2, 4, 5, 6, 7, 8} (K = groups_per_row × 256) to
+//! exercise quad-clean and all 3 tail-by-g%4 paths in the kernel.
+
+use rdna_compute::{Gpu, DType};
+
+const E2M1_LUT: [f32; 16] = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+];
+
+fn e2m1_round(x: f32) -> u8 {
+    let mut best_idx = 0u8;
+    let mut best_err = f32::INFINITY;
+    for (i, &code) in E2M1_LUT.iter().enumerate() {
+        let err = (code - x).abs();
+        if err < best_err {
+            best_err = err;
+            best_idx = i as u8;
+        }
+    }
+    best_idx
+}
+
+fn f32_to_f16_le_bits(v: f32) -> u16 {
+    let bits = v.to_bits();
+    let sign = ((bits >> 31) & 0x1) as u16;
+    let exp = ((bits >> 23) & 0xff) as i32;
+    let mant = bits & 0x7fffff;
+    if exp == 0xff {
+        (sign << 15) | (0x1f << 10) | if mant != 0 { 0x200 } else { 0 }
+    } else if exp - 127 + 15 < 1 {
+        sign << 15
+    } else if exp - 127 + 15 > 30 {
+        (sign << 15) | (0x1f << 10)
+    } else {
+        let new_exp = (exp - 127 + 15) as u16;
+        let m13 = mant & 0x1fff;
+        let mut new_mant = (mant >> 13) as u16;
+        if m13 > 0x1000 || (m13 == 0x1000 && (new_mant & 1) != 0) {
+            new_mant += 1;
+        }
+        let mut exp_bits = new_exp;
+        if new_mant == 0x400 {
+            new_mant = 0;
+            exp_bits += 1;
+        }
+        (sign << 15) | (exp_bits << 10) | new_mant
+    }
+}
+
+fn f16_le_bits_to_f32(h: u16) -> f32 {
+    let sign = ((h >> 15) & 1) as u32;
+    let exp = ((h >> 10) & 0x1f) as i32;
+    let mant = (h & 0x3ff) as u32;
+    let bits = if exp == 0 {
+        if mant == 0 { sign << 31 }
+        else {
+            let mut m = mant; let mut e = -1i32;
+            while m & 0x400 == 0 { m <<= 1; e -= 1; }
+            (sign << 31) | (((e + 127 - 14) as u32) << 23) | ((m & 0x3ff) << 13)
+        }
+    } else if exp == 0x1f {
+        (sign << 31) | (0xff << 23) | (mant << 13)
+    } else {
+        (sign << 31) | (((exp - 15 + 127) as u32) << 23) | (mant << 13)
+    };
+    f32::from_bits(bits)
+}
+
+/// Quantize one row of K f32 weights to HFP4G32 byte format.
+/// Returns 16-B header + (K/32) × 17-B blocks.
+/// Mirrors hipfire-quantize::quantize_hfp4g32_row.
+fn quantize_row(row: &[f32]) -> Vec<u8> {
+    let k = row.len();
+    assert!(k % 32 == 0);
+    let n_blocks = k / 32;
+    let row_bytes = 16 + n_blocks * 17;
+    let mut out = vec![0u8; row_bytes];
+
+    let row_max_abs = row.iter().cloned().fold(0.0f32, |m, v| m.max(v.abs()));
+    let row_scale_a = if row_max_abs > 0.0 { row_max_abs / 6.0 } else { 1.0 };
+    let inv_row = if row_max_abs > 0.0 { 1.0 / row_scale_a } else { 0.0 };
+
+    out[0..2].copy_from_slice(&f32_to_f16_le_bits(row_scale_a).to_le_bytes());
+    out[2..4].copy_from_slice(&0u16.to_le_bytes());
+    out[4..6].copy_from_slice(&(n_blocks as u16).to_le_bytes());
+    out[6] = 0u8; out[7] = 0u8;
+
+    for b in 0..n_blocks {
+        let block = &row[b * 32..(b + 1) * 32];
+        let block_max_abs = block.iter().cloned().fold(0.0f32, |m, v| m.max(v.abs()));
+        let block_max_normalized = block_max_abs * inv_row;
+        let block_e: u8 = if block_max_normalized > 0.0 {
+            let log_ratio = (block_max_normalized / 6.0).log2();
+            let e_signed = log_ratio.ceil() as i32 + 127;
+            e_signed.clamp(0, 254) as u8
+        } else { 0u8 };
+
+        let block_scale_factor = ((block_e as i32 - 127) as f32).exp2();
+        let inv_block = if block_scale_factor > 0.0 { 1.0 / block_scale_factor } else { 0.0 };
+
+        let off = 16 + b * 17;
+        out[off] = block_e;
+        for i in 0..16 {
+            let lo = block[2 * i] * inv_row * inv_block;
+            let hi = block[2 * i + 1] * inv_row * inv_block;
+            let lo_n = e2m1_round(lo);
+            let hi_n = e2m1_round(hi);
+            out[off + 1 + i] = (lo_n & 0x0F) | ((hi_n & 0x0F) << 4);
+        }
+    }
+    out
+}
+
+/// CPU reference dequant of one row to f32. Reads the FP16 row scale through the
+/// same f16→f32 path the GPU uses (LUT compiles to FP16 immediates; row scale is
+/// loaded as u16 then cast to __half then to float). Round-tripping the row scale
+/// through fp16 ensures the CPU reference uses the SAME row_scale_a value the GPU
+/// will read, eliminating a bogus 1e-3 / scale fp16 conversion error.
+fn dequant_row(packed: &[u8], k: usize) -> Vec<f32> {
+    let n_blocks = k / 32;
+    let row_scale_a = f16_le_bits_to_f32(u16::from_le_bytes([packed[0], packed[1]]));
+
+    let mut out = vec![0.0f32; k];
+    for b in 0..n_blocks {
+        let off = 16 + b * 17;
+        let block_e = packed[off] as i32;
+        let block_scale_factor = ((block_e - 127) as f32).exp2();
+        let scale = row_scale_a * block_scale_factor;
+        for i in 0..16 {
+            let byte = packed[off + 1 + i];
+            let lo = (byte & 0x0F) as usize;
+            let hi = ((byte >> 4) & 0x0F) as usize;
+            out[b * 32 + 2 * i]     = scale * E2M1_LUT[lo];
+            out[b * 32 + 2 * i + 1] = scale * E2M1_LUT[hi];
+        }
+    }
+    out
+}
+
+/// Build the M-row × K-col packed weight matrix (concatenated per-row blobs).
+/// Returns (packed bytes, the FP32 weights *as the GPU will see them after dequant*).
+fn build_test_matrix(m: usize, k: usize, seed: u64) -> (Vec<u8>, Vec<f32>) {
+    let mut packed: Vec<u8> = Vec::new();
+    let mut seen: Vec<f32> = Vec::with_capacity(m * k);
+    let mut state = seed;
+    for r in 0..m {
+        // Gaussian-ish row data via Box-Muller from xorshift.
+        let mut row = Vec::with_capacity(k);
+        for _ in 0..(k / 2) {
+            state ^= state << 13; state ^= state >> 7; state ^= state << 17;
+            let u1 = ((state & 0xFFFFFF) as f32 / 0x1000000 as f32).max(1e-7);
+            state ^= state << 13; state ^= state >> 7; state ^= state << 17;
+            let u2 = ((state & 0xFFFFFF) as f32 / 0x1000000 as f32).max(1e-7);
+            let r_mag = (-2.0 * u1.ln()).sqrt();
+            let theta = 2.0 * std::f32::consts::PI * u2;
+            // N(0, 0.4) — well-utilized E2M1 lattice without saturation.
+            row.push(r_mag * theta.cos() * 0.4);
+            row.push(r_mag * theta.sin() * 0.4);
+        }
+        let row_packed = quantize_row(&row);
+        let row_dq = dequant_row(&row_packed, k);
+        // Note: r isn't used directly; we just want a unique row index.
+        let _ = r;
+        packed.extend_from_slice(&row_packed);
+        seen.extend_from_slice(&row_dq);
+    }
+    (packed, seen)
+}
+
+fn cpu_reference(seen: &[f32], x: &[f32], m: usize, k: usize) -> Vec<f32> {
+    let mut y = vec![0.0f32; m];
+    for r in 0..m {
+        let mut acc = 0.0f32;
+        for c in 0..k {
+            acc += seen[r * k + c] * x[c];
+        }
+        y[r] = acc;
+    }
+    y
+}
+
+fn run_one(gpu: &mut Gpu, groups_per_row: usize) -> (usize, f32, f32) {
+    let m = 64;
+    let k = groups_per_row * 256;
+
+    let (packed, seen_w) = build_test_matrix(m, k, 0xdead_beef_dead_beefu64.wrapping_add(k as u64));
+
+    // x in [-0.5, 0.5)
+    let x: Vec<f32> = (0..k).map(|i| ((i as i32 % 13) as f32 - 6.0) * 0.05).collect();
+
+    let d_a = gpu.upload_raw(&packed, &[packed.len()]).unwrap();
+    let d_x = gpu.upload_f32(&x, &[k]).unwrap();
+    let d_y = gpu.zeros(&[m], DType::F32).unwrap();
+
+    gpu.gemv_hfp4g32(&d_a, &d_x, &d_y, m, k).unwrap();
+    let y_gpu = gpu.download_f32(&d_y).unwrap();
+
+    let y_ref = cpu_reference(&seen_w, &x, m, k);
+
+    let mut max_abs = 0.0f32;
+    let mut max_rel = 0.0f32;
+    for r in 0..m {
+        let abs = (y_gpu[r] - y_ref[r]).abs();
+        if abs > max_abs { max_abs = abs; }
+        let denom = y_ref[r].abs().max(1.0);
+        let rel = abs / denom;
+        if rel > max_rel { max_rel = rel; }
+    }
+    (k, max_abs, max_rel)
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("Gpu::init failed");
+    println!("arch: {}", gpu.arch);
+
+    let mut any_fail = false;
+    for groups_per_row in [2usize, 4, 5, 6, 7, 8] {
+        let (k, max_abs, max_rel) = run_one(&mut gpu, groups_per_row);
+        // FP32 sum-of-K terms reorder noise: empirically ~1e-3 for K=2048 with
+        // |w| ≤ ~3 and |x| ≤ 0.6 (worst-case sum magnitude ~K). Allow 5e-3 to
+        // absorb FP16-row-scale rounding interaction.
+        let pass = max_abs < 5e-3 && max_rel < 5e-3;
+        let tag = if pass { "PASS" } else { "FAIL" };
+        println!("[{}] groups_per_row={} K={} max_abs={:.6e} max_rel={:.6e}",
+                 tag, groups_per_row, k, max_abs, max_rel);
+        if !pass { any_fail = true; }
+    }
+
+    if any_fail {
+        std::process::exit(1);
+    }
+    println!("ALL PASS");
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -318,6 +318,9 @@ pub enum DType {
     MQ2G256,   // MagnumQuant: FWHT-rotated HFQ2-G256 (72 bytes/group, same as HFQ2G256)
     MQ2G256Lloyd, // MagnumQuant 2-bit + Lloyd-Max 4-entry fp16 codebook (72 bytes/group)
     MQ3G256Lloyd, // MagnumQuant 3-bit + Lloyd-Max 8-entry fp16 codebook (112 bytes/group)
+    HFP4G32,   // HFP4: E2M1 element + UE8M0 g32 block scale + FP16 row scale.
+               // Per-row header 16 B; per-block payload 17 B (UE8M0 + 16 packed nibbles).
+               // See docs/quant-formats/hfp4.md.
     HFQ2G256,  // 72 bytes per 256 elements (flat 2-bit, f32 scale+zero, ~19 VGPRs)
     HFQ2G128,  // 40 bytes per 128 elements (flat 2-bit, f32 scale+zero)
     HFQ6G256,  // 200 bytes per 256 elements (6-bit, f32 scale+zero)
@@ -329,7 +332,7 @@ impl DType {
         match self {
             DType::F32 => 4,
             DType::F16 => 2,
-            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd | DType::Raw => 1, // byte-level
+            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd | DType::HFP4G32 | DType::Raw => 1, // byte-level
         }
     }
 }
@@ -2689,6 +2692,41 @@ impl Gpu {
         ];
         // LDS for rotated x: 256 floats = 1024 bytes
         unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 1024, self.stream_ref(), &mut params) }
+    }
+
+    /// HFP4-G32 GEMV — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale).
+    ///
+    /// v1 correctness anchor: no WMMA, no FP8, no rotation. K must be a multiple of 256
+    /// (the kernel's 4-accumulator + tail-by-g%4 outer loop assumes the 256-element
+    /// "iter window" stride; v2 will lift this to k%32==0). See `kernels/src/gemv_hfp4g32.hip`
+    /// and `docs/quant-formats/hfp4.md`.
+    pub fn gemv_hfp4g32(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        assert!(k % 256 == 0, "gemv_hfp4g32 requires K%256==0 in v1, got K={}", k);
+        self.bind_thread()?;
+        let (src, module) = kernels::gemv_hfp4g32_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemv_hfp4g32")?;
+        let func = &self.functions["gemv_hfp4g32"];
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x.buf.as_ptr();
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+        ];
+        // LDS: 16-entry FP16 LUT = 32 bytes.
+        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 32, self.stream_ref(), &mut params) }
     }
 
     /// Fused RMSNorm + MagnumQuant FWHT rotation. Replaces the

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -269,6 +269,13 @@ pub const GEMV_MQ6G256_SRC: &str = include_str!("../../../kernels/src/gemv_mq6g2
 pub const FUSED_RMSNORM_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate.hip");
 pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_silu_mul_mq_rotate.hip");
 
+/// HFP4-G32 GEMV — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale).
+/// v1 correctness anchor: no WMMA, no FP8, no rotation. See docs/quant-formats/hfp4.md.
+/// Block: per-row 16 B header (row_scale_a:f16, row_scale_b:f16, block_count, flags),
+/// then (K/32) blocks × 17 B (UE8M0:u8 + 16 B nibbles).
+pub const GEMV_HFP4G32_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32.hip");
+pub const GEMV_HFP4G32_GFX1100_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32.gfx1100.hip");
+
 
 
 
@@ -629,6 +636,22 @@ pub fn gemv_hfq4g256_for_arch(arch: &str) -> (&'static str, &'static str) {
         // RDNA4 variants (existing)
         // "gfx1200" | "gfx1201" => ...,
         _ => (GEMV_HFQ4G256_SRC, "gemv_hfq4g256"), // gfx1010 baseline
+    }
+}
+
+/// HFP4-G32 GEMV arch dispatch.
+///
+/// v1: gfx1100 variant is the byte-exact baseline (currently bit-identical to the
+/// default source; v2 adds VOPD + V_PERMLANE16 + SGPR-LUT here). All other archs
+/// route to the default source — same FP add ordering and accumulator structure
+/// guarantees byte-exact output across gfx1010, gfx1030, gfx1151, gfx1201, gfx906.
+/// gfx1201 WMMA-FP8 hero kernel ships in v2. See `docs/quant-formats/hfp4.md`.
+pub fn gemv_hfp4g32_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" => {
+            (GEMV_HFP4G32_GFX1100_SRC, "gemv_hfp4g32_rdna3")
+        }
+        _ => (GEMV_HFP4G32_SRC, "gemv_hfp4g32"),
     }
 }
 

--- a/docs/quant-formats/hfp4.md
+++ b/docs/quant-formats/hfp4.md
@@ -1,0 +1,268 @@
+# HFP4 — Hipfire FP4 Quantization (RDNA-optimal E2M1 family)
+
+**Status:** v1 draft. First-kernel scope: HFP4G32 GEMV correctness anchor on gfx1100. WMMA-FP8 hero kernel and rotation variants are v2/v3 (deferred — see `docs/QUANTIZATION.md` for the production format index).
+
+**Related**: [`docs/QUANTIZATION.md`](../QUANTIZATION.md) (production format index) · [`docs/QUANTIZE.md`](../QUANTIZE.md) (CLI usage) · `crates/hipfire-quantize/src/main.rs` (quantizer) · `kernels/src/gemv_hfp4g32*.hip` (kernels).
+
+---
+
+## Mission
+
+HFP4 is hipfire's RDNA-optimal answer to MXFP4 (OCP) and NVFP4 (Blackwell). Both reference formats are designed for non-AMD silicon and don't exploit AMD-specific RDNA ISA features (`v_ldexp_f32` for free UE8M0 dequant, native FP8 WMMA on gfx1201, V_PERMLANE16 cross-lane scale broadcast, VOPD dual-issue on RDNA3+).
+
+HFP4 keeps the OCP E2M1 element wire-compatible — so MXFP4 / NVFP4 checkpoints can be re-quantized to HFP4 by transforming only the scale layer, not the codes — while specifying scale in the way that's cheapest to dequant on RDNA. The format is documented here so other AMD-side projects can adopt it.
+
+## Format taxonomy
+
+```
+HFP4G16   — E2M1 + UE8M0 g16 + FP16 row scale       (NV-aligned, FP16-WMMA-K aligned)
+HFP4G32   — E2M1 + UE8M0 g32 + FP16 row scale       canonical (FP8-WMMA-K aligned)
+HFP4G64   — E2M1 + UE8M0 g64 + FP16 row scale       (best amortization, RDNA1/2 sweet spot)
+MFP4G32   — HFP4G32 + offline FWHT rotation         (drop-in MQ4 replacement; v1.5)
+MFP4G32R  — HFP4G32 + online block-diag-128         (AMD recipe; v3)
+HFP4G32MX — HFP4G32 with no row scale               (strict OCP MXFP4 interop alias; v2)
+HFP4G16NV — HFP4G16 + E4M3 scale + FP32 tensor      (strict NVFP4 interop alias; v2)
+```
+
+## Element format (locked to OCP E2M1)
+
+4-bit signed FP. Sixteen codes; eight magnitudes:
+
+| nibble | sign | exp | mant | value | nibble | sign | exp | mant | value |
+|:------:|:----:|:---:|:----:|:-----:|:------:|:----:|:---:|:----:|:-----:|
+| 0000   | +    | 0   | 0    | +0.0  | 1000   | −    | 0   | 0    | −0.0  |
+| 0001   | +    | 0   | 1    | +0.5  | 1001   | −    | 0   | 1    | −0.5  |
+| 0010   | +    | 1   | 0    | +1.0  | 1010   | −    | 1   | 0    | −1.0  |
+| 0011   | +    | 1   | 1    | +1.5  | 1011   | −    | 1   | 1    | −1.5  |
+| 0100   | +    | 2   | 0    | +2.0  | 1100   | −    | 2   | 0    | −2.0  |
+| 0101   | +    | 2   | 1    | +3.0  | 1101   | −    | 2   | 1    | −3.0  |
+| 0110   | +    | 3   | 0    | +4.0  | 1110   | −    | 3   | 0    | −4.0  |
+| 0111   | +    | 3   | 1    | +6.0  | 1111   | −    | 3   | 1    | −6.0  |
+
+Locked to spec: changing the magnitudes breaks RDNA4 hardware path (`v_cvt_pk_fp8_e2m1`), the LUT-decode lever (gfx12 dominant strategy), and MX/NVFP4 interop.
+
+## Block scale — UE8M0
+
+Every block of `g` elements (g ∈ {16, 32, 64}) carries **one UE8M0 byte** = unsigned 8-bit exponent-only scale. The encoded value `e ∈ [0, 254]` represents `2^(e − 127)`. The reserved code `0xFF` encodes block-NaN (every element in the block is NaN).
+
+Why UE8M0 (RDNA-specific justification): on every RDNA tier `v_ldexp_f32(acc, e − 127)` is one VALU op (no multiply, no constant load). NVFP4's E4M3 scale costs one FP8→FP16 conversion + one FP16 multiply per block; on Hopper this is amortized by the FMA pipeline, but on RDNA the `v_ldexp` path is strictly faster.
+
+UE8M0 alone is too coarse — the OCP MX paper documents 1–2% perplexity loss vs FP16 — so HFP4 layers a FP16 row-scale on top.
+
+## Per-row second-level scale (FP16, the AMD-specific lever)
+
+Each weight row carries a 16-byte aligned header containing two FP16 row scales (`row_scale_a`, `row_scale_b`) plus format flags. Effective dequant per element:
+
+```
+value = row_scale_a * 2^(block_e − 127) * E2M1_LUT[nibble]
+```
+
+The `row_scale_a` multiply hoists outside the K loop (applied once per row at GEMV finalize, or folded into the WMMA output stage on gfx11/gfx12). `row_scale_b` exists for fused dual-output kernels where the same input row produces two output columns with different per-row scales (e.g., gate+up FFN, qkv fused projection). When `row_scale_b == 0` the kernel skips the second scale.
+
+Why this beats single-level FP16 row-scale (HFQ-style): finer block granularity (g=32 vs 256) catches outlier groups within a row that a row-shared scale alone would clip or under-quantize. Why this beats single-level UE8M0 (MX-strict): the FP16 row-scale gives full FP16 dynamic range without paying for it in the dequant inner loop.
+
+## Byte layout — HFP4G32 (canonical)
+
+For a row of K elements (K must be a multiple of 32):
+
+```
+Per row (16 B, aligned):
+  +0  : f16  row_scale_a      // primary FP16 second-level scale
+  +2  : f16  row_scale_b      // secondary scale for fused-dual outputs (else 0)
+  +4  : u8   block_count_lo   // K / 32, low 8 bits
+  +5  : u8   block_count_hi   // K / 32, high 8 bits  (supports K up to 16M)
+  +6  : u8   format_flags     // bit 0: rotation present
+                              // bit 1: row_scale_b used
+                              // bits 2-3: rotation_kind
+                              //   00 = off
+                              //   01 = offline FWHT (existing MQ pattern)
+                              //   10 = online block-diag-128 (v3)
+                              //   11 = online HadaCore-16 (v3)
+                              // bits 4-7: reserved
+  +7  : u8   reserved
+  +8  : u32  reserved         // future: D_diag pointer offset (joint-D smoothing)
+  +12 : u32  reserved
+
+Per block × (K / 32):
+  +0  : u8   block_e          // UE8M0 power-of-2 exponent
+  +1  : u8[16] nibbles        // 32 E2M1 codes, low nibble = even index, high nibble = odd
+                              // ordering bit-identical to MX/NVFP4 wire format
+```
+
+**Total per row**: `16 + 17 × (K / 32)` bytes.
+
+For a 5120-dim Qwen3.5-9B `q_proj` row: `16 + 17 × 160 = 2736 B` (vs MQ4G256's 2720 B; +0.6% with finer scale granularity and FP16 row-scale).
+
+**Effective bpw**: `(17 × 8) / 32 = 4.25 bpw` from the per-block payload, plus `128 / K` extra bits per weight from the per-row header (negligible for large K — for K=5120, header overhead is 0.025 bpw).
+
+### Worked example
+
+A row with K=64 (two blocks):
+
+```
+Offset  Bytes                                       Meaning
+------  ------------------------------------------  ----------------------------------
+0x00    BC 3F  00 00  02 00  00 00  00 00 00 00     row_scale_a = 0.99 (FP16: 0x3FBC)
+        00 00 00 00                                 row_scale_b = 0
+                                                    block_count = 2
+                                                    format_flags = 0x00 (no rotation)
+                                                    reserved
+0x10    7F  31 22 13 04 F5 E6 D7 C8 31 22 13 04 ... block 0: block_e=127 (=2^0=1.0)
+        ...                                         + 16 bytes of packed nibbles
+0x21    7E  ...                                     block 1: block_e=126 (=2^-1=0.5)
+        ...                                         + 16 bytes of packed nibbles
+0x32    EOF
+```
+
+The second block's `block_e=126` = `2^-1`, meaning every element in that block is half the magnitude of an equivalent block 0 nibble. The `row_scale_a` then scales both blocks' final values uniformly.
+
+### Nibble packing convention
+
+Within each 16-byte payload, byte `b` at position `b ∈ [0, 16)` encodes elements at indices `2b` (low nibble = `byte & 0x0F`) and `2b + 1` (high nibble = `byte >> 4`). This matches the existing HFQ4 packing (kernels can reuse the bit-extract pattern verbatim) and is bit-identical to MX/NVFP4 wire format.
+
+## Quantization recipe
+
+For each row of FP16 weights `W[K]`:
+
+1. Compute the FP16 row scale: `row_scale_a = max_abs(W) / 6.0` (E2M1 max code is ±6.0).
+2. Normalize: `W_n[i] = W[i] / row_scale_a`. Now `|W_n[i]| ≤ 6.0`.
+3. For each 32-element block:
+   a. Compute the UE8M0 block exponent. `block_max = max_abs(W_n[block])`. Pick `e` such that `2^e` is the largest power-of-2 ≤ `block_max / 6.0`. Encode as UE8M0 with bias 127: `block_e = clamp(round(log2(block_max / 6.0)) + 127, 0, 254)`.
+   b. Apply block scale: `W_b[i] = W_n[block][i] / 2^(block_e − 127)`.
+   c. Round-to-nearest in the E2M1 lattice: `nibble[i] = argmin_k |E2M1_LUT[k] − W_b[i]|`.
+   d. Pack nibbles into 16 bytes (low nibble = even index).
+
+Round-trip per-block max-abs error is bounded by `row_scale_a · 2^(block_e − 127) · 0.5` (half the smallest E2M1 step at the scale's working magnitude).
+
+## Rotation modes (configurable, default `off` in v1)
+
+| Mode | Storage | Rotation kind bits | When used |
+|------|---------|---------------------|-----------|
+| `off` | unrotated weights, plain `x` | 00 | v1 default; calibration baseline; well-conditioned models |
+| `offline-fwht` | pre-rotated weights; `x_rot` computed once per layer via existing `mq_rotate_x` | 01 | drop-in MQ4 replacement; ships v1.5 as `MFP4G32` |
+| `online-bd128` | unrotated weights; per-block 128-elt block-diag Hadamard fused with dequant | 10 | v3 — matches AMD ROCm blog recipe; requires Stiefel-manifold calibration |
+| `hadacore-16` | unrotated weights; 16×16 Hadamard via WMMA fragments | 11 | v3 research path; gfx1201 only |
+
+Online modes (`10`, `11`) block fused QKV/QKVZA/gate_up kernels until their fused-rotation siblings exist. Offline mode (`01`) reuses the existing MQ infrastructure (`mq_rotate_x`, `fused_rmsnorm_mq_rotate`, `fused_silu_mul_mq_rotate`, signs1/signs2 buffers) without modification.
+
+## Quant-type IDs (`.hfq` file format)
+
+| ID | Variant | Status |
+|:--:|---------|--------|
+| 21 | `HFP4G32` | v1 — first kernel target |
+| 22 | `HFP4G16` | v1.5 ablation |
+| 23 | `HFP4G64` | v1.5 ablation |
+| 24 | `MFP4G32` | v1.5 (HFP4G32 + offline FWHT) |
+| 25 | `HFP4G32MX` | v2 (strict OCP MXFP4 interop alias) |
+| 26 | `HFP4G16NV` | v2 (strict NVFP4 interop alias) |
+| 27 | `HFP8E4M3G32` | v2 HFP8 family |
+| 28 | `HFP8E5M2G32` | v2 HFP8 family |
+| 29 | `MFP4G32R` | v3 (online block-diag rotation) |
+
+IDs 21–29 are reserved at v1 ship time. Future PRs MUST NOT squat these IDs even if the corresponding variant has not yet shipped.
+
+## Configurability
+
+### Compile-time (kernel macros, set per-kernel-source)
+
+| Macro | Values | Default |
+|-------|--------|---------|
+| `HFP4_BLOCK_SIZE` | 16 / 32 / 64 / 128 | 32 |
+| `HFP4_SCALE_FORMAT` | `UE8M0` / `E4M3` / `FP16` | `UE8M0` |
+| `HFP4_SECOND_LEVEL` | 0 / 1 | 1 |
+| `HFP4_ROTATION_KIND` | 0–3 (matches `format_flags` bits 2–3) | 0 |
+| `HFP4_R` | 1 / 2 / 4 multirow | 1 |
+
+### Runtime (env vars, matching existing `HIPFIRE_*` taxonomy)
+
+| Variable | Values | Effect |
+|----------|--------|--------|
+| `HIPFIRE_HFP_USE_FP8_WMMA` | 0 / 1 | gfx12 only; 0 forces FP16-WMMA path for ablation |
+| `HIPFIRE_HFP_ROTATION` | `off` / `offline` / `online-bd128` | overrides per-tensor metadata for ablation |
+| `HIPFIRE_HFP_VARIANT` | kernel-variant name | pin specific variant for debugging |
+
+### Quantize CLI (`hipfire-quantize`)
+
+| Flag | Effect |
+|------|--------|
+| `--format hfp4` (or `hfp4g32`, `hf4p`, `fp4`) | HFP4G32 quant — v1 default |
+| `--format hfp4g16` | HFP4G16 ablation (v1.5) |
+| `--format hfp4g64` | HFP4G64 ablation (v1.5) |
+| `--format mfp4` (or `mfp4g32`) | HFP4G32 + offline FWHT rotation (v1.5) |
+| `--block-size {16,32,64}` | override block size for HFP4 family |
+| `--rotation {off,offline-fwht}` | override rotation mode |
+
+## Per-arch dequant ISA targets
+
+| Arch | Path | Lever | Expected |
+|------|------|-------|----------|
+| gfx1201/1200 (RDNA4) | LDS-LUT → FP8 → `v_wmma_f32_16x16x32_fp8_fp8` → `ldexpf` per block → `v_pk_mul_f16` per row | native FP8 WMMA | 55–65 TFLOPS (vs rdna4-guide's 40.8) |
+| gfx1100/1151 (RDNA3 / 3.5) | SGPR-LUT → FP16 → `v_wmma_f32_16x16x16_f16` + VOPD-paired dequant + V_PERMLANE16 scale broadcast | WMMA-FP16 + VOPD | 70–75% WMMA-FP16 theoretical |
+| gfx1030 (RDNA2) | SGPR-LUT → FP16 → `v_dot2_f32_f16` + V_PERMLANE16 + R=2 multirow | V_DOT2 | parity ±5% vs MQ4G256 |
+| gfx1010 (RDNA1) | LDS-LUT → packed FP16 → `v_pk_fma_f16` only + `__shfl_sync` scale broadcast | BW-bound (no dot, no WMMA) | 85–90% peak BW |
+| gfx906 (CDNA1) | wave64 + `v_pk_fma_f16` + LDS scale broadcast | BW-bound | parity with gfx1010 path |
+
+The first kernel (`gemv_hfp4g32.gfx1100.hip`) is the **correctness anchor** — no WMMA, no FP8, no rotation — so byte-exact gating works against the existing infrastructure. WMMA-FP8 hero kernel is v2.
+
+## v1 first-kernel inner loop
+
+Mirrors the HFQ4G256 4-accumulator + tail-by-`g%4` invariant from `kernels/src/gemv_hfq4g256.hip:33–124`. Diff from HFQ4 is one substitution + drop the zero-point load:
+
+```c
+// In kernel preamble:
+__shared__ _Float16 lut[16];
+if (threadIdx.x < 16) {
+    static const _Float16 E2M1[16] = {
+         (_Float16)+0.0f, (_Float16)+0.5f, (_Float16)+1.0f, (_Float16)+1.5f,
+         (_Float16)+2.0f, (_Float16)+3.0f, (_Float16)+4.0f, (_Float16)+6.0f,
+         (_Float16)-0.0f, (_Float16)-0.5f, (_Float16)-1.0f, (_Float16)-1.5f,
+         (_Float16)-2.0f, (_Float16)-3.0f, (_Float16)-4.0f, (_Float16)-6.0f,
+    };
+    lut[threadIdx.x] = E2M1[threadIdx.x];
+}
+__syncthreads();
+
+// Per-block in inner loop:  sc = row_scale_a * ldexpf(1.0f, block_e - 127);
+// Per-element:               value = sc * (float)lut[nibble];
+```
+
+Compared to HFQ4: `(sc * (float)((pk) & 0xFu) + zp)` becomes `sc * (float)lut[(pk) & 0xFu]`. The `zp` argument and `+ zp` term drop because E2M1 is signed.
+
+## Validation
+
+The first-kernel ships are gated by:
+
+1. CPU round-trip: per-tensor max-abs error ≤ `row_scale_a · 2^(block_e − 127) · 0.5` per group.
+2. CPU vs kernel: per-element error ≤ `1e-3 · max(|y_ref|)` on (M=512, K=2048) random tensors.
+3. NRMSE vs FP16: per-tensor NRMSE < 5e-3 across all weight tensors of Qwen3.5-0.8B and Qwen3.5-9B.
+4. Quality regression vs MQ4G256: HFP4G32 NRMSE ≤ MQ4G256 NRMSE on geomean across 50 prompts.
+5. Coherence gate (`scripts/coherence-gate.sh`): fluent output on 9B + 27B HFP4 conversions.
+6. Speed gate (`scripts/probe_commits.sh master HEAD`): decode tok/s within ±5% of MQ4G256 baseline.
+7. Zero spills + register budget per `docs/skills/gfx-kernel-metadata`.
+
+## Comparison to neighbors
+
+| Property | HFQ4G256 | MQ4G256 | MXFP4 (strict) | NVFP4 | **HFP4G32** |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| Element format | INT4 uniform | INT4 uniform (FWHT-rotated) | E2M1 | E2M1 | E2M1 |
+| Block size | 256 | 256 | 32 | 16 | 32 |
+| Block scale | FP16 (in FP32 slot) | FP32 | UE8M0 | E4M3 | UE8M0 |
+| Block-scale dequant cost | 1 multiply | 1 multiply | 1 `ldexpf` (free) | 1 mul (1 FP8→FP16 + 1 FP16 mul) | 1 `ldexpf` (free) |
+| Secondary scale | none | none | none | FP32 per-tensor | FP16 per-row |
+| Per-group bytes (excl. row hdr) | 136 | 136 | 17 | ~10 | 17 |
+| Effective bpw | 4.25 | 4.25 | 4.25 | 4.5 | 4.25 + ~0.025 (row hdr) |
+| Rotation | none | offline FWHT (mandatory) | none | none | configurable |
+| MX import path | re-quant | re-quant | byte-identical | n/a | re-scale only (codes preserve) |
+| FP8-WMMA on gfx12 | n/a | n/a | external demo | n/a | first-class (v2) |
+| Adoptable spec | HFQ-house | MQ-house | OCP standard | NV-only | HFP-spec (this doc) |
+
+## References
+
+- OCP Microscaling Formats (MX) Specification v1.0 — <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>
+- AMD ROCm Blog — High-Accuracy MXFP4, MXFP6 — <https://rocm.blogs.amd.com/software-tools-optimization/mxfp4-mxfp6-quantization/README.html>
+- AMD ROCm Blog — Advanced MXFP4 with Online Rotation — <https://rocm.blogs.amd.com/software-tools-optimization/mxfp4-online-rotation/README.html>
+- NVIDIA — Introducing NVFP4 — <https://developer.nvidia.com/blog/introducing-nvfp4-for-efficient-and-accurate-low-precision-inference/>
+- rdna4-wmma-guide (40.8 TFLOPS MXFP4 on R9700) — <https://github.com/JohnTDI-cpu/rdna4-wmma-guide>
+- HadaCore — <https://pytorch.org/blog/hadacore/>
+- SpinQuant (arXiv 2405.16406) — <https://arxiv.org/abs/2405.16406>
+- AMD RDNA4 ISA Reference — <https://docs.amd.com/v/u/en-US/rdna4-instruction-set-architecture>

--- a/kernels/src/gemv_hfp4g32.gfx1100.hip
+++ b/kernels/src/gemv_hfp4g32.gfx1100.hip
@@ -1,0 +1,177 @@
+#include <hip/hip_runtime.h>
+
+// HFP4G32 GEMV — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale).
+// v1 correctness anchor: no WMMA, no FP8, no rotation. See docs/quant-formats/hfp4.md.
+//
+// Per-row layout: 16-B header (row_scale_a:f16, row_scale_b:f16, block_count:u16, flags:u8, ...)
+//                 then (K/32) blocks × 17 B each (UE8M0:u8 + 16 B nibbles).
+// Per element:    value = row_scale_a * 2^(block_e - 127) * E2M1_LUT[nibble]
+//
+// Geometry coincidence: 8 blocks × 17 B = 136 B per 256 K-elements.
+// This matches HFQ4G256's per-group stride exactly, so the OUTER LOOP STRUCTURE
+// (4-accumulator + tail-by-g%4) ports verbatim from gemv_hfq4g256.hip:33–124.
+// Only the per-block decode differs:
+//   - HFQ4: 4-byte fp32 scale + 4-byte fp32 zero + 128-byte nibbles → (sc * (float)n + zp) * x[i]
+//   - HFP4: 16-byte row hdr + 8 × (1-byte UE8M0 + 16-byte nibbles) → (sc * lut[n]) * x[i]
+//          where sc = row_scale_a * 2^(block_e - 127), per-block.
+//
+// Within a 256-K-element "group" of 8 blocks, each thread reads from ONE block:
+//   block_in_iter = tid >> 2   (0..7) — which block of 8 this thread is in
+//   nib_off       = (tid & 3) * 4  — byte offset into that block's 16-B nibble payload
+//   K_in_block    = (tid & 3) * 8  — first element index within the block
+//
+// 4-accumulator interleaving + tail-by-g%4 + (acc0+acc1)+(acc2+acc3) finalize:
+// the FP add ordering is byte-identical to gemv_hfq4g256 across archs, so the
+// gfx1100 byte-exact gate carries over to default/RDNA1/RDNA2 fallbacks for free.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfp4g32(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    // 16-entry signed E2M1 magnitude LUT in LDS (32 B). Initialized once by lanes 0..15.
+    // OCP E2M1 lattice: {0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}. Locked to spec.
+    // Use built-in `_Float16` rather than `__half` (no `<hip/hip_fp16.h>` needed —
+    // that header pulls in CUDA-shim complex_builtins which has a max/fmax declaration
+    // bug in ROCm 7.2.2's clang headers).
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    // Per-row layout: 16-B header + (K/32)*17 B blocks; equivalently (K/256) "groups" of 136 B.
+    const int groups_per_row = K / 256;                 // each "group" = 8 HFP4 blocks = 256 K-elt
+    const int row_block_bytes = (K / 32) * 17;          // = groups_per_row * 136
+    const long long row_off = (long long)row * (16 + (long long)row_block_bytes);
+    const char* hdr = A + row_off;
+    const char* row_ptr = hdr + 16;                     // skip per-row header → first block
+
+    // FP16 row scale lives in the first 2 bytes of the row header.
+    const unsigned short row_scale_bits = *(const unsigned short*)(hdr);
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, row_scale_bits);
+    const float row_scale_f = (float)row_scale_h;
+
+    // Thread slot within an 8-block group.
+    const int block_in_iter = tid >> 2;     // 0..7
+    const int nib_off = (tid & 3) * 4;      // 0/4/8/12
+    const int boff = nib_off;               // alias to mirror HFQ4 naming
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    // Per-group-thread byte offset to the thread's block within a 136-B group.
+    // Block stride is 17 B; thread is in block_in_iter ∈ [0,7].
+    const int thread_block_off = block_in_iter * 17;
+
+    #define HFP4_DOG(pk, sc, b, a) \
+        (a) += (sc * (float)lut[(pk)        & 0xFu]) * x[(b)    ] \
+             + (sc * (float)lut[((pk) >>  4) & 0xFu]) * x[(b) + 1] \
+             + (sc * (float)lut[((pk) >>  8) & 0xFu]) * x[(b) + 2] \
+             + (sc * (float)lut[((pk) >> 12) & 0xFu]) * x[(b) + 3] \
+             + (sc * (float)lut[((pk) >> 16) & 0xFu]) * x[(b) + 4] \
+             + (sc * (float)lut[((pk) >> 20) & 0xFu]) * x[(b) + 5] \
+             + (sc * (float)lut[((pk) >> 24) & 0xFu]) * x[(b) + 6] \
+             + (sc * (float)lut[((pk) >> 28) & 0xFu]) * x[(b) + 7]
+
+    // Quad-unrolled main loop: 4 groups (= 32 blocks = 1024 K-elt) per quad iter.
+    // Mirrors HFQ4G256's structure 1:1 — same group stride (136 B), same accumulator
+    // interleaving, same tail-by-g%4 invariant.
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + (long long)g * 136 + thread_block_off;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        const unsigned char e0 = *(const unsigned char*)(gp0);
+        const unsigned char e1 = *(const unsigned char*)(gp1);
+        const unsigned char e2 = *(const unsigned char*)(gp2);
+        const unsigned char e3 = *(const unsigned char*)(gp3);
+
+        // UE8M0 dequant via direct FP32 bit construction: 2^(e-127) is exactly the FP32 number
+        // with biased exponent = e, mantissa = 0, sign = 0. Pure bit-shift; portable across all
+        // ROCm versions (avoids host-only ldexpf in ROCm ≥ 7.2.2 where it isn't device-callable).
+        const float sc0 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e0) << 23);
+        const float sc1 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e1) << 23);
+        const float sc2 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e2) << 23);
+        const float sc3 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e3) << 23);
+
+        const unsigned int pk0 = *(const unsigned int*)(gp0 + 1 + boff);
+        const unsigned int pk1 = *(const unsigned int*)(gp1 + 1 + boff);
+        const unsigned int pk2 = *(const unsigned int*)(gp2 + 1 + boff);
+        const unsigned int pk3 = *(const unsigned int*)(gp3 + 1 + boff);
+
+        // K_base for this thread's elements within group g:
+        //   base = g * 256 + block_in_iter * 32 + (tid & 3) * 8
+        // group has 8 blocks of 32 K-elts each; thread is in block block_in_iter,
+        // covering 8 elements at offset (tid & 3) * 8 inside that block.
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+
+        HFP4_DOG(pk0, sc0, base,         acc0);
+        HFP4_DOG(pk1, sc1, base + 256,   acc1);
+        HFP4_DOG(pk2, sc2, base + 512,   acc2);
+        HFP4_DOG(pk3, sc3, base + 768,   acc3);
+    }
+    #undef HFP4_DOG
+
+    // Tail: groups_per_row may not be a multiple of 4. Each tail group must
+    // accumulate into acc[g % 4] to preserve the 4-way interleaving the combine
+    // step assumes. (See gemv_hfq4g256.hip for the bug writeup.)
+    #define HFP4_TAIL_DOG(pk, sc, b, a) \
+        (a) += (sc * (float)lut[(pk)        & 0xFu]) * x[(b)    ] \
+             + (sc * (float)lut[((pk) >>  4) & 0xFu]) * x[(b) + 1] \
+             + (sc * (float)lut[((pk) >>  8) & 0xFu]) * x[(b) + 2] \
+             + (sc * (float)lut[((pk) >> 12) & 0xFu]) * x[(b) + 3] \
+             + (sc * (float)lut[((pk) >> 16) & 0xFu]) * x[(b) + 4] \
+             + (sc * (float)lut[((pk) >> 20) & 0xFu]) * x[(b) + 5] \
+             + (sc * (float)lut[((pk) >> 24) & 0xFu]) * x[(b) + 6] \
+             + (sc * (float)lut[((pk) >> 28) & 0xFu]) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+        const unsigned char e = *(const unsigned char*)(gp);
+        const float sc = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e) << 23);
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + boff);
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+        HFP4_TAIL_DOG(pk, sc, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+        const unsigned char e = *(const unsigned char*)(gp);
+        const float sc = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e) << 23);
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + boff);
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+        HFP4_TAIL_DOG(pk, sc, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+        const unsigned char e = *(const unsigned char*)(gp);
+        const float sc = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e) << 23);
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + boff);
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+        HFP4_TAIL_DOG(pk, sc, base, acc2);
+    }
+    #undef HFP4_TAIL_DOG
+
+    // Combine 4 accumulators in HFQ4-byte-exact order.
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] = acc;
+}

--- a/kernels/src/gemv_hfp4g32.hip
+++ b/kernels/src/gemv_hfp4g32.hip
@@ -1,0 +1,177 @@
+#include <hip/hip_runtime.h>
+
+// HFP4G32 GEMV — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale).
+// v1 correctness anchor: no WMMA, no FP8, no rotation. See docs/quant-formats/hfp4.md.
+//
+// Per-row layout: 16-B header (row_scale_a:f16, row_scale_b:f16, block_count:u16, flags:u8, ...)
+//                 then (K/32) blocks × 17 B each (UE8M0:u8 + 16 B nibbles).
+// Per element:    value = row_scale_a * 2^(block_e - 127) * E2M1_LUT[nibble]
+//
+// Geometry coincidence: 8 blocks × 17 B = 136 B per 256 K-elements.
+// This matches HFQ4G256's per-group stride exactly, so the OUTER LOOP STRUCTURE
+// (4-accumulator + tail-by-g%4) ports verbatim from gemv_hfq4g256.hip:33–124.
+// Only the per-block decode differs:
+//   - HFQ4: 4-byte fp32 scale + 4-byte fp32 zero + 128-byte nibbles → (sc * (float)n + zp) * x[i]
+//   - HFP4: 16-byte row hdr + 8 × (1-byte UE8M0 + 16-byte nibbles) → (sc * lut[n]) * x[i]
+//          where sc = row_scale_a * 2^(block_e - 127), per-block.
+//
+// Within a 256-K-element "group" of 8 blocks, each thread reads from ONE block:
+//   block_in_iter = tid >> 2   (0..7) — which block of 8 this thread is in
+//   nib_off       = (tid & 3) * 4  — byte offset into that block's 16-B nibble payload
+//   K_in_block    = (tid & 3) * 8  — first element index within the block
+//
+// 4-accumulator interleaving + tail-by-g%4 + (acc0+acc1)+(acc2+acc3) finalize:
+// the FP add ordering is byte-identical to gemv_hfq4g256 across archs, so the
+// gfx1100 byte-exact gate carries over to default/RDNA1/RDNA2 fallbacks for free.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfp4g32(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    // 16-entry signed E2M1 magnitude LUT in LDS (32 B). Initialized once by lanes 0..15.
+    // OCP E2M1 lattice: {0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}. Locked to spec.
+    // Use built-in `_Float16` rather than `__half` (no `<hip/hip_fp16.h>` needed —
+    // that header pulls in CUDA-shim complex_builtins which has a max/fmax declaration
+    // bug in ROCm 7.2.2's clang headers).
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    // Per-row layout: 16-B header + (K/32)*17 B blocks; equivalently (K/256) "groups" of 136 B.
+    const int groups_per_row = K / 256;                 // each "group" = 8 HFP4 blocks = 256 K-elt
+    const int row_block_bytes = (K / 32) * 17;          // = groups_per_row * 136
+    const long long row_off = (long long)row * (16 + (long long)row_block_bytes);
+    const char* hdr = A + row_off;
+    const char* row_ptr = hdr + 16;                     // skip per-row header → first block
+
+    // FP16 row scale lives in the first 2 bytes of the row header.
+    const unsigned short row_scale_bits = *(const unsigned short*)(hdr);
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, row_scale_bits);
+    const float row_scale_f = (float)row_scale_h;
+
+    // Thread slot within an 8-block group.
+    const int block_in_iter = tid >> 2;     // 0..7
+    const int nib_off = (tid & 3) * 4;      // 0/4/8/12
+    const int boff = nib_off;               // alias to mirror HFQ4 naming
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    // Per-group-thread byte offset to the thread's block within a 136-B group.
+    // Block stride is 17 B; thread is in block_in_iter ∈ [0,7].
+    const int thread_block_off = block_in_iter * 17;
+
+    #define HFP4_DOG(pk, sc, b, a) \
+        (a) += (sc * (float)lut[(pk)        & 0xFu]) * x[(b)    ] \
+             + (sc * (float)lut[((pk) >>  4) & 0xFu]) * x[(b) + 1] \
+             + (sc * (float)lut[((pk) >>  8) & 0xFu]) * x[(b) + 2] \
+             + (sc * (float)lut[((pk) >> 12) & 0xFu]) * x[(b) + 3] \
+             + (sc * (float)lut[((pk) >> 16) & 0xFu]) * x[(b) + 4] \
+             + (sc * (float)lut[((pk) >> 20) & 0xFu]) * x[(b) + 5] \
+             + (sc * (float)lut[((pk) >> 24) & 0xFu]) * x[(b) + 6] \
+             + (sc * (float)lut[((pk) >> 28) & 0xFu]) * x[(b) + 7]
+
+    // Quad-unrolled main loop: 4 groups (= 32 blocks = 1024 K-elt) per quad iter.
+    // Mirrors HFQ4G256's structure 1:1 — same group stride (136 B), same accumulator
+    // interleaving, same tail-by-g%4 invariant.
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + (long long)g * 136 + thread_block_off;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        const unsigned char e0 = *(const unsigned char*)(gp0);
+        const unsigned char e1 = *(const unsigned char*)(gp1);
+        const unsigned char e2 = *(const unsigned char*)(gp2);
+        const unsigned char e3 = *(const unsigned char*)(gp3);
+
+        // UE8M0 dequant via direct FP32 bit construction: 2^(e-127) is exactly the FP32 number
+        // with biased exponent = e, mantissa = 0, sign = 0. Pure bit-shift; portable across all
+        // ROCm versions (avoids host-only ldexpf in ROCm ≥ 7.2.2 where it isn't device-callable).
+        const float sc0 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e0) << 23);
+        const float sc1 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e1) << 23);
+        const float sc2 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e2) << 23);
+        const float sc3 = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e3) << 23);
+
+        const unsigned int pk0 = *(const unsigned int*)(gp0 + 1 + boff);
+        const unsigned int pk1 = *(const unsigned int*)(gp1 + 1 + boff);
+        const unsigned int pk2 = *(const unsigned int*)(gp2 + 1 + boff);
+        const unsigned int pk3 = *(const unsigned int*)(gp3 + 1 + boff);
+
+        // K_base for this thread's elements within group g:
+        //   base = g * 256 + block_in_iter * 32 + (tid & 3) * 8
+        // group has 8 blocks of 32 K-elts each; thread is in block block_in_iter,
+        // covering 8 elements at offset (tid & 3) * 8 inside that block.
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+
+        HFP4_DOG(pk0, sc0, base,         acc0);
+        HFP4_DOG(pk1, sc1, base + 256,   acc1);
+        HFP4_DOG(pk2, sc2, base + 512,   acc2);
+        HFP4_DOG(pk3, sc3, base + 768,   acc3);
+    }
+    #undef HFP4_DOG
+
+    // Tail: groups_per_row may not be a multiple of 4. Each tail group must
+    // accumulate into acc[g % 4] to preserve the 4-way interleaving the combine
+    // step assumes. (See gemv_hfq4g256.hip for the bug writeup.)
+    #define HFP4_TAIL_DOG(pk, sc, b, a) \
+        (a) += (sc * (float)lut[(pk)        & 0xFu]) * x[(b)    ] \
+             + (sc * (float)lut[((pk) >>  4) & 0xFu]) * x[(b) + 1] \
+             + (sc * (float)lut[((pk) >>  8) & 0xFu]) * x[(b) + 2] \
+             + (sc * (float)lut[((pk) >> 12) & 0xFu]) * x[(b) + 3] \
+             + (sc * (float)lut[((pk) >> 16) & 0xFu]) * x[(b) + 4] \
+             + (sc * (float)lut[((pk) >> 20) & 0xFu]) * x[(b) + 5] \
+             + (sc * (float)lut[((pk) >> 24) & 0xFu]) * x[(b) + 6] \
+             + (sc * (float)lut[((pk) >> 28) & 0xFu]) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+        const unsigned char e = *(const unsigned char*)(gp);
+        const float sc = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e) << 23);
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + boff);
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+        HFP4_TAIL_DOG(pk, sc, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+        const unsigned char e = *(const unsigned char*)(gp);
+        const float sc = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e) << 23);
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + boff);
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+        HFP4_TAIL_DOG(pk, sc, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+        const unsigned char e = *(const unsigned char*)(gp);
+        const float sc = row_scale_f * __builtin_bit_cast(float, ((unsigned int)e) << 23);
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + boff);
+        const int base = g * 256 + tid * 8; // (tid>>2)*32 + (tid&3)*8 simplifies to tid*8
+        HFP4_TAIL_DOG(pk, sc, base, acc2);
+    }
+    #undef HFP4_TAIL_DOG
+
+    // Combine 4 accumulators in HFQ4-byte-exact order.
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) y[row] = acc;
+}


### PR DESCRIPTION
## Summary

Lands the HFP4 quant family v1: hipfire's RDNA-optimal answer to MXFP4 / NVFP4. Element format is OCP-spec E2M1; what's RDNA-shaped about it is the **two-level scaling** (UE8M0 per 32-element block + FP16 per row), tuned to exploit `v_ldexp_f32`-style free dequant on RDNA instead of NV's E4M3-scale-multiply path. Validated bit-identical across **gfx1100 / gfx1151 / gfx1201** (the latter two via cross-compiled blobs).

Spec lives at [`docs/quant-formats/hfp4.md`](docs/quant-formats/hfp4.md) — adoptable by other AMD-side projects, not Hipfire-only.

## What this lands

- **Kernel:** `gemv_hfp4g32.hip` + `gemv_hfp4g32.gfx1100.hip` — 4-accumulator + tail-by-`g%4` + LDS LUT (32 B) + UE8M0 dequant via FP32 bitcast (portable across all ROCm versions; replaces `ldexpf` which is host-only on ROCm ≥ 7.2.2). Zero spills (VGPR=84, SGPR=18), LDS 32 B.
- **Format:** `DType::HFP4G32` + qtype 21 + 16-B per-row header (FP16 row scale + format flags + reserved metadata) + 17-B per-block payload (1 B UE8M0 + 16 B packed E2M1 nibbles).
- **Quantizer:** `hipfire-quantize --format hfp4` (aliases: `hfp4g32`, `hf4p`, `fp4`). E2M1 round-to-nearest, ceil()-fitted UE8M0 per block, max-abs/6.0 row scale. Wired through both safetensors and GGUF input paths.
- **Tests:** 6/6 unit tests in `hfp4_tests` (E2M1 lattice round-trip, midpoints, header layout, constant rows, mixed magnitudes, per-block error bound) + `examples/test_gemv_hfp4g32` cross-K sweep (groups_per_row ∈ {2, 4, 5, 6, 7, 8}) comparing GPU output to CPU dequant ref.
- **Reserved qtype IDs:** 22-29 reserved with comments for v1.5/v2 family members (HFP4G16, HFP4G64, MFP4G32, HFP4G32MX, HFP4G16NV, HFP8E4M3G32, HFP8E5M2G32, MFP4G32R).

## Validation results (G1–G9)

| Gate | k9lin (gfx1100) | hiptrx (gfx1201) | hipx (gfx1151 + gfx1201) |
|---|---|---|---|
| G1 build + spills + tests | ✅ 0 spills, 6/6 tests | – | – |
| G2 quantize 0.8B | 555 MB, mean err 6.4e-6 | – | – |
| G2 quantize 9B | 5338 MB (vs 5311 MB MQ4), mean err 5.8e-7 | – | – |
| G3 coherence 0.8B + 9B | ✅ fluent across cap/sheep/code/reason/lru | – | – |
| G4 quality vs MQ4G256 | ✅ parity across 5 prompts | – | – |
| G5 perf vs MQ4G256 (decode) | -8.5% on 0.8B, -9.4% on 9B | – | – |
| **G7 cross-arch byte-exactness** | ✅ baseline | ✅ bit-identical | ✅ bit-identical (via pre-compiled blob) |
| G8 9B coherence + perf | ✅ baseline | ✅ 88.6 tok/s (-20.8% vs gfx1100) | ⛔ blocked on hipx ROCm 7.2.2 hipcc breakage (pre-existing, affects all hipfire kernels — not HFP4-specific) |
| G9 tool-call shape on 9B | ✅ clean `<tool_call>` JSON, no special-token leak | – | – |

**G7 numerics on the GPU correctness test (`test_gemv_hfp4g32`) are bit-identical across all four (host × arch) combinations.** Same `.hsaco` byte-for-byte from k9lin → all 4 K-sweeps pass with max-abs 1e-6.

## Anomalies surfaced + how resolved

1. **`<hip/hip_fp16.h>` triggered ROCm 7.2.2 header pollution** on hipx (`__clang_cuda_complex_builtins.h` references undeclared `max`). Resolved by using built-in `_Float16` (no extra header).
2. **`ldexpf` is host-only on ROCm ≥ 7.2.2.** Replaced with direct FP32 bit construction `__builtin_bit_cast(float, ((unsigned int)e) << 23)` — same numerical result, 1 VALU op, no math.h dependency.
3. **`include_str!` bakes kernel source into the binary** at compile time. Updating a `.hip` source on a remote host requires rebuild — rsync alone doesn't change the embedded source. Tripped me once during cross-host G7.
4. **Daemon multi-prompt state-bleed** observed on 9B HFP4 in a single `load` session (3 unrelated prompts all returned the France-Paris answer). Reproducible on isolated daemon invocations with one prompt per `load`/`unload`, where everything works correctly. Pre-existing daemon bug — independent of HFP4. Not blocking this PR; flagging as a separate finding worth investigating.
5. **hipx daemon coherence (gfx1151 + gfx1201) blocked by ROCm 7.2.2 hipcc breakage** that affects ALL hipfire kernels, confirmed by reproducing on existing `test_gemv_mq3g256_lloyd_tail`. The HFP4 kernel itself is bit-correct on hipx hardware (G7 confirmed via cross-compiled `.hsaco` from k9lin). Hipx env fix is sysadmin work, separate from this PR.

## Performance gap (v1 design tradeoff)

The -9.4% decode tok/s gap vs MQ4G256 traces to LDS LUT overhead (~10 cycles/element vs MQ4's 1-cycle VALU INT cast). v2 SGPR-LUT or direct-bit-cast E2M1→FP16 closes this. v1 design intent ("correctness anchor; perf hero is v2 WMMA-FP8") matches.

The -20.8% gfx1201 vs gfx1100 gap is consistent with hipfire's no-WMMA RDNA4 baseline — v2 WMMA-FP8 hero kernel addresses RDNA4 specifically.

## Queued (separate PRs, not started)

- v1.5: `MFP4G32` (HFP4 + offline FWHT, drop-in MQ4 replacement) → unlocks `MFP2-Lloyd` experiment (2-bit Lloyd codebook + FP16 row scale + rotation)
- v1.5: `HFP4G16` + `HFP4G64` ablations
- v1.5: Lloyd-Max quantizer-side refinement (no format change, free quality on every HFP variant)
- v2: SGPR-LUT / direct-bit-cast E2M1 decode — closes the G5 perf gap
- v2: WMMA-FP8 hero on gfx1201 — the actual perf win on RDNA4
- v2: HFP8E4M3G32 + HFP8E5M2G32

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release -p hipfire-quantize hfp4_tests` → 6/6
- [x] `gfx-kernel-metadata`: 0 spills on gfx1100 build
- [x] `hipfire-quantize --format hfp4` on Qwen3.5-0.8B + 9B
- [x] Coherence on 0.8B + 9B HFP4 (cap/sheep/code/reason/lru)
- [x] Quality parity vs MQ4G256 on 9B
- [x] Cross-arch byte-exactness on gfx1100, gfx1201 (hiptrx), gfx1151 + gfx1201 (hipx)
- [x] Tool-call shape test on 9B HFP4
- [ ] Reviewer: spot-check `docs/quant-formats/hfp4.md` against the kernel + quantizer for byte-layout consistency
- [ ] Reviewer: confirm reserved qtype IDs 22-29 don't collide with anything else in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)