### PR TITLE
perf: BPE merge_rank cache (37× TTFT) + daemon DPM warmup + authoritative perf metrics

### DIFF
--- a/crates/hipfire-detect/src/report.rs
+++ b/crates/hipfire-detect/src/report.rs
@@ -24,8 +24,29 @@ pub struct ReportHeader {
     pub arch: String,
     pub host: String,
     pub total_tokens: usize,
+    /// Wall-clock tok/s as the *probe* measured it (`total_tokens / wall_ms`).
+    /// Confused on thinking models because the probe sees a "first visible
+    /// token" only after `</think>` closes, so its wall_ms folds prefill +
+    /// think into TTFT. Kept for back-compat / UX framing; perf consumers
+    /// should read `daemon_*` fields instead.
     pub tok_s: f64,
+    /// Probe-derived gen rate: `total_tokens / (wall_ms - ttft_ms)`.
+    /// Same caveat as `tok_s` — strips think-as-prefill but doesn't
+    /// distinguish real prefill from think.
+    pub gen_tok_s: f64,
     pub ttft_ms: u64,
+    /// Authoritative timings emitted by the daemon's `done` event:
+    /// `prefill_ms` and `prefill_tok_s` are real-prefill-only (forward_prefill
+    /// timer, post-DPM-warmup), `decode_tok_s` is the steady-state decode
+    /// rate (post-prefill), `ttft_ms` is real prefill time, `tok_s` is the
+    /// daemon's own `total_tokens / total_wall_seconds`. These are the
+    /// numbers to compare against `bench_qwen35_mq4 prefill_tok_s` and
+    /// `gen_tok_s`. Zero for non-Qwen35 paths or older daemons.
+    pub daemon_prefill_ms: f64,
+    pub daemon_prefill_tok_s: f64,
+    pub daemon_decode_tok_s: f64,
+    pub daemon_ttft_ms: f64,
+    pub daemon_tok_s: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -93,10 +114,21 @@ impl Report {
         .unwrap();
         writeln!(
             out,
-            "tokens:      {} ({:.1} tok/s, ttft {}ms)",
-            self.header.total_tokens, self.header.tok_s, self.header.ttft_ms
+            "tokens:      {} (probe wall {:.1} tok/s, probe gen {:.1} tok/s, probe ttft {}ms)",
+            self.header.total_tokens, self.header.tok_s, self.header.gen_tok_s, self.header.ttft_ms
         )
         .unwrap();
+        if self.header.daemon_tok_s > 0.0 {
+            writeln!(
+                out,
+                "daemon perf: prefill {:.1} tok/s ({:.1}ms / real ttft) | decode {:.1} tok/s | overall {:.1} tok/s",
+                self.header.daemon_prefill_tok_s,
+                self.header.daemon_prefill_ms,
+                self.header.daemon_decode_tok_s,
+                self.header.daemon_tok_s,
+            )
+            .unwrap();
+        }
         writeln!(
             out,
             "verdict:     {} ({} hard, {} soft)",
@@ -152,7 +184,13 @@ mod tests {
             host: "k9lin".to_string(),
             total_tokens: 100,
             tok_s: 100.0,
+            gen_tok_s: 200.0,
             ttft_ms: 50,
+            daemon_prefill_ms: 0.0,
+            daemon_prefill_tok_s: 0.0,
+            daemon_decode_tok_s: 0.0,
+            daemon_ttft_ms: 0.0,
+            daemon_tok_s: 0.0,
         }
     }
 

--- a/crates/hipfire-runtime/examples/coherence_probe.rs
+++ b/crates/hipfire-runtime/examples/coherence_probe.rs
@@ -281,6 +281,17 @@ struct DoneStats {
     total_visible_bytes: usize,
     wall_ms: u64,
     ttft_ms: u64,
+    /// Daemon-reported authoritative timings from its `done` event. The
+    /// probe's own `wall_ms` / `ttft_ms` are wall-clock and confused by
+    /// stripped think tokens (TTFT becomes "first visible character",
+    /// which on a thinking model is prefill + think_phase + </think>).
+    /// The daemon timestamps real prefill end and real decode separately,
+    /// so trust those for perf reporting.
+    daemon_prefill_ms: f64,
+    daemon_prefill_tok_s: f64,
+    daemon_decode_tok_s: f64,
+    daemon_ttft_ms: f64,
+    daemon_tok_s: f64,
 }
 
 fn drive_generate(
@@ -378,11 +389,23 @@ fn drive_generate(
                 for (n, vd) in trans {
                     print_live(n, &vd, wall_ms, last_pos);
                 }
+                // Daemon-authoritative perf metrics from the done event.
+                // Default to 0 if absent (older daemons / non-Qwen35 paths).
+                let daemon_prefill_ms = v.get("prefill_ms").and_then(|x| x.as_f64()).unwrap_or(0.0);
+                let daemon_prefill_tok_s = v.get("prefill_tok_s").and_then(|x| x.as_f64()).unwrap_or(0.0);
+                let daemon_decode_tok_s = v.get("decode_tok_s").and_then(|x| x.as_f64()).unwrap_or(0.0);
+                let daemon_ttft_ms = v.get("ttft_ms").and_then(|x| x.as_f64()).unwrap_or(0.0);
+                let daemon_tok_s = v.get("tok_s").and_then(|x| x.as_f64()).unwrap_or(0.0);
                 done_stats = DoneStats {
                     total_tokens,
                     total_visible_bytes: visible_bytes,
                     wall_ms,
                     ttft_ms: ttft,
+                    daemon_prefill_ms,
+                    daemon_prefill_tok_s,
+                    daemon_decode_tok_s,
+                    daemon_ttft_ms,
+                    daemon_tok_s,
                 };
                 break;
             }
@@ -573,6 +596,17 @@ fn run() -> Result<i32, String> {
     } else {
         0.0
     };
+    // Generation-only rate: subtract TTFT (which includes any optional
+    // HIPFIRE_DPM_WARMUP_SECS pin the daemon performs after load) from wall
+    // time. This is the apples-to-apples number against in-process bench tools
+    // like bench_qwen35_mq4's `gen_tok_s`. Falls back to wall-clock tok_s if
+    // we somehow saw a zero gen window (single-token request, error path).
+    let gen_tok_s = if stats.wall_ms > stats.ttft_ms && stats.total_tokens > 0 {
+        let gen_ms = stats.wall_ms - stats.ttft_ms;
+        stats.total_tokens as f64 * 1000.0 / gen_ms as f64
+    } else {
+        tok_s
+    };
     let header = ReportHeader {
         prompt_md5: md5,
         prompt_label,
@@ -581,7 +615,13 @@ fn run() -> Result<i32, String> {
         host,
         total_tokens: stats.total_tokens,
         tok_s,
+        gen_tok_s,
         ttft_ms: stats.ttft_ms,
+        daemon_prefill_ms: stats.daemon_prefill_ms,
+        daemon_prefill_tok_s: stats.daemon_prefill_tok_s,
+        daemon_decode_tok_s: stats.daemon_decode_tok_s,
+        daemon_ttft_ms: stats.daemon_ttft_ms,
+        daemon_tok_s: stats.daemon_tok_s,
     };
     let report = Report::new(header, finals);
 

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -667,6 +667,39 @@ fn main() {
                         } else if let Some(ref c) = m.llama_config {
                             (c.dim, c.n_layers, c.vocab_size)
                         } else { (0, 0, 0) };
+                        // ── Optional DPM stabilization (perf instrumentation) ──
+                        //
+                        // Pins the GPU at high sclk/mclk so the first `generate`
+                        // request doesn't pay the 1-10s DPM ramp from idle. Same
+                        // `HIPFIRE_DPM_WARMUP_SECS` env the in-process bench tools
+                        // honor (`bench_qwen35_mq4`, `dflash_spec_demo`,
+                        // `bench_stream_overlap`); see
+                        // `crates/rdna-compute/src/dispatch.rs::dpm_warmup` and
+                        // `docs/methodology/perf-benchmarking.md`.
+                        //
+                        // Runs AFTER weight upload but BEFORE the `loaded` ack so
+                        // the contract becomes "loaded means daemon is fully ready
+                        // including DPM-pinned." Critical for probe-side timing:
+                        // if warmup ran AFTER the ack, the probe would receive
+                        // `loaded`, immediately send `generate`, and the daemon
+                        // (still warming up in this handler) wouldn't process the
+                        // generate until warmup finished — folding the warmup
+                        // into the probe-measured TTFT and breaking
+                        // `tok_s = total_tokens / wall_ms`. With warmup before the
+                        // ack, the probe sees `loaded` only when the daemon is
+                        // truly ready, and TTFT measures real prefill alone.
+                        //
+                        // Default OFF (production daemon load latency unchanged).
+                        if let Ok(secs_str) = std::env::var("HIPFIRE_DPM_WARMUP_SECS") {
+                            if let Ok(secs) = secs_str.parse::<f32>() {
+                                if secs > 0.0 {
+                                    if let Err(e) = gpu.dpm_warmup(secs) {
+                                        eprintln!("[daemon] dpm_warmup failed (non-fatal): {e:?}");
+                                    }
+                                }
+                            }
+                        }
+
                         let _ = writeln!(stdout, r#"{{"type":"loaded","arch":"{}","dim":{},"layers":{},"vocab":{},"vl":{}}}"#, arch, dim, layers, vocab, vl);
 
                         // ── PFlash drafter load (Phase 4.0) ──────────────

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -12,6 +12,13 @@ pub struct Tokenizer {
     token_to_id: HashMap<String, u32>,
     /// BPE merge rules: (left, right) → merged token
     merges: Vec<(String, String)>,
+    /// Pre-built BPE merge-rank lookup: (left, right) → rank index. Built
+    /// ONCE per tokenizer construction so `encode_gpt2_bpe` doesn't pay the
+    /// O(M) String-clone-into-HashMap cost on every encode call (M is the
+    /// merges count, ~150K for Qwen3+ — without this, ~50ms per encode call,
+    /// which compounds across the 9+ encodes-per-request the daemon does for
+    /// chat-template scaffolding and adds ~450ms to TTFT for short prompts).
+    merge_rank: HashMap<(String, String), usize>,
     /// Special tokens: strings like "<|im_start|>" → their token ID
     /// Sorted longest-first for greedy matching
     special_tokens: Vec<(String, u32)>,
@@ -25,6 +32,17 @@ pub struct Tokenizer {
     pub eot_id: Option<u32>,
     /// True for GPT-2 BPE (Qwen), false for SentencePiece (LLaMA)
     is_gpt2_bpe: bool,
+}
+
+/// Pre-build the BPE merge-rank lookup. Called once at tokenizer construction
+/// time to amortize the O(M) String-clone-into-HashMap across the lifetime of
+/// the tokenizer rather than paying it per encode call.
+fn build_merge_rank(merges: &[(String, String)]) -> HashMap<(String, String), usize> {
+    merges
+        .iter()
+        .enumerate()
+        .map(|(i, (l, r))| ((l.clone(), r.clone()), i))
+        .collect()
 }
 
 impl Tokenizer {
@@ -94,10 +112,13 @@ impl Tokenizer {
         // Sort longest-first for greedy matching
         special_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
 
+        let merge_rank = build_merge_rank(&merges);
+
         Some(Tokenizer {
             vocab,
             token_to_id,
             merges,
+            merge_rank,
             special_tokens,
             bos_id,
             eos_id,
@@ -187,10 +208,13 @@ impl Tokenizer {
 
         let is_gpt2_bpe = token_to_id.contains_key("Ġthe") || token_to_id.contains_key("Ġ");
 
+        let merge_rank = build_merge_rank(&merges);
+
         Some(Tokenizer {
             vocab,
             token_to_id,
             merges,
+            merge_rank,
             special_tokens,
             bos_id,
             eos_id,
@@ -286,10 +310,13 @@ impl Tokenizer {
         }
         special_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
 
+        let merge_rank = build_merge_rank(&merges);
+
         Some(Tokenizer {
             vocab,
             token_to_id,
             merges,
+            merge_rank,
             special_tokens,
             bos_id,
             eos_id,
@@ -508,15 +535,12 @@ impl Tokenizer {
             return vec![self.token_to_id.get(&syms[0]).copied().unwrap_or(0)];
         }
 
-        // 2. Build merge rank map (built once per encode — moving to a
-        // pre-built field on Tokenizer would save this, but it's O(M)
-        // not O(N) and runs once not per-step).
-        let merge_rank: HashMap<(String, String), usize> = self
-            .merges
-            .iter()
-            .enumerate()
-            .map(|(i, (l, r))| ((l.clone(), r.clone()), i))
-            .collect();
+        // 2. Use the pre-built merge rank map cached on the Tokenizer.
+        // Earlier this was rebuilt every call (~50ms per encode for Qwen3+
+        // with ~150K merges); the daemon makes 9+ encode calls per request
+        // for chat-template scaffolding, so the per-call rebuild added
+        // ~450ms to TTFT for short prompts. Now O(1) per encode.
+        let merge_rank = &self.merge_rank;
 
         // 3. Doubly-linked-list state. `prev/next` are i32 with -1 sentinel.
         let mut prev: Vec<i32> = (0..n as i32).map(|i| i - 1).collect();
@@ -1161,10 +1185,12 @@ mod bpe_tests {
             .iter()
             .map(|(l, r)| (l.to_string(), r.to_string()))
             .collect();
+        let merge_rank = build_merge_rank(&merges);
         Tokenizer {
             vocab,
             token_to_id,
             merges,
+            merge_rank,
             special_tokens: Vec::new(),
             bos_id: 0,
             eos_id: 0,

--- a/docs/methodology/perf-benchmarking.md
+++ b/docs/methodology/perf-benchmarking.md
@@ -65,6 +65,78 @@ Or via the harness directly:
 + a multi-run median. A delta that survives this protocol is real;
 one that doesn't probably isn't.
 
+## Daemon-driven perf measurement
+
+The in-process `bench_qwen35_mq4` and `dflash_spec_demo` examples are
+the canonical perf tools — they run a 10s `dpm_warmup` (memset loop
+that pins the GPU at high sclk/mclk) before the timed gen window, so
+their `gen_tok_s` numbers reflect steady-state silicon throughput.
+
+Anything that talks to the daemon (`coherence_probe`, agent CLIs, eval
+scripts) used to run *without* DPM warmup, leaving the GPU at a low
+power state when the first request arrived. That produced ~5–10%
+lower decode-rate measurements than the in-process bench tools. The
+gap was especially confusing because `coherence_probe` reported
+`tok_s = total_tokens / wall_ms`, which folds TTFT (and any new warmup
+time) into the headline number — so short generations can look
+catastrophically slow even when steady-state decode is fine.
+
+Two fixes ship together:
+
+- **`HIPFIRE_DPM_WARMUP_SECS=N` is honored by the daemon.** When set
+  and positive, the daemon runs `gpu.dpm_warmup(N)` after weight
+  upload but **before emitting the `loaded` ack**. The contract
+  becomes: `loaded` means daemon is fully ready, including DPM-pinned.
+  This ordering is load-bearing: if warmup ran *after* the ack, the
+  probe would receive `loaded`, immediately send `generate`, and the
+  daemon (still inside the load handler doing warmup) wouldn't
+  process the `generate` until warmup finished. From the probe's POV
+  that warmup time would fold into the measured TTFT, breaking
+  `tok_s = total_tokens / wall_ms`. With warmup-before-ack, the probe
+  sees `loaded` only when the daemon really is ready, and TTFT
+  measures real prefill alone.
+  Default OFF (production load latency unchanged). Recommended `10`
+  for perf-bench runs, matching the bench tools.
+
+- **`coherence_probe` reports both probe-derived and daemon-authoritative
+  numbers.** Read the daemon ones for perf comparisons.
+  - **Daemon-authoritative** (right number for perf): `daemon perf:
+    prefill X tok/s (Yms / real ttft) | decode Z tok/s | overall W tok/s`.
+    These come from the `done` event the daemon emits — `prefill_ms`
+    is the real `forward_prefill_batch` timer, `decode_tok_s` is
+    steady-state post-prefill, `ttft_ms` is real first-prefill-token
+    latency. Apples-to-apples with `bench_qwen35_mq4 prefill_tok_s` /
+    `gen_tok_s`.
+  - **Probe-derived** (UX framing only, NOT perf-comparable): `tokens:
+    N (probe wall A tok/s, probe gen B tok/s, probe ttft Cms)`. The
+    probe sets `ttft` on the first non-synthetic `token` event it
+    receives — but the daemon strips `<think>...</think>` content
+    by default, so on thinking models (Qwen3.5, Qwen3.6) the first
+    visible token only arrives *after* think closes. Probe `ttft`
+    therefore folds prefill + entire think phase + `</think>` into
+    one number, and `wall tok/s` / `gen tok/s` derived from it look
+    catastrophically slow vs in-process bench. They aren't —
+    they're just measuring something different (user-perceived
+    time-to-visible-content).
+
+  When in doubt: read the `daemon perf:` line, ignore `probe wall/gen`.
+  The JSON report carries `daemon_prefill_tok_s`, `daemon_decode_tok_s`,
+  `daemon_ttft_ms`, `daemon_tok_s` for downstream tooling.
+
+Use:
+
+```bash
+HIPFIRE_DPM_WARMUP_SECS=10 \
+  ./target/release/examples/coherence_probe \
+    --model some.hfq --prompt-file p.txt --max-tokens 400
+```
+
+The expected residual gap between probe `gen tok/s` and bench
+`gen_tok_s` after this is ~10% — that's daemon per-token overhead
+(JSONL streaming, detokenize, stop-condition checks). Closing it
+further is a separate workstream; it is uniform across quant formats
+so does not interfere with format ranking.
+
 ## Speed-gate baselines
 
 `tests/speed-baselines/<arch>.txt` records the "ground floor" decode


### PR DESCRIPTION
## Summary

Three related changes that together close a long-standing perf-measurement honesty gap and reveal a 5000×-per-encode regression in the GPT-2 BPE tokenizer that affected **every Qwen3+ model** through the daemon (MQ4, HFP4, MFP4, MQ3, etc. — not specific to any quant format).

1. **`perf(tokenizer)`: cache `merge_rank` on the Tokenizer struct.** `encode_gpt2_bpe` was rebuilding the BPE merge-rank HashMap from `merges` on every call — cloning ~150K (left, right) String pairs into a fresh HashMap each invocation. The implementation comment had flagged it ("moving to a pre-built field on Tokenizer would save this") but underestimated the multiplier: the daemon makes 9+ encode calls per generate request (chat-template scaffolding tokens + im_end + nl + user prompt + 6 more inside `ChatScaffold::for_tokenizer`), so the per-call rebuild compounded to **~440ms of pre-prefill setup time per request**.

2. **`feat(daemon)`: env-gated DPM warmup.** Daemon honors `HIPFIRE_DPM_WARMUP_SECS=N` (default OFF). Runs `gpu.dpm_warmup(N)` after weight upload but **before emitting the `loaded` ack** so the contract becomes "loaded means daemon is fully ready including DPM-pinned." Critical ordering: warmup-after-ack would fold the warmup wait into probe-measured TTFT and break `tok_s = total_tokens / wall_ms`.

3. **`feat(probe)`: pass through daemon-authoritative perf metrics.** `coherence_probe` captures `prefill_ms`, `prefill_tok_s`, `decode_tok_s`, `ttft_ms`, `tok_s` from the daemon's `done` event and reports them in a `daemon perf:` line alongside the probe's own wall-clock metrics. Without this, the probe's own metrics conflated request-side overhead with kernel-level rates, hiding both real perf gaps and on-spec format costs.

## Why this matters

The chain of investigation that surfaced the tokenizer regression:
- Saw probe wall tok/s ~100 on Qwen3.5-0.8B vs in-process bench ~388. Looked like a 75% kernel regression.
- Daemon-authoritative metrics revealed kernel decode is fine (354 tok/s, matching bench), but probe TTFT was 470-545ms vs daemon's `prefill_ms: 16ms`.
- Per-checkpoint tracing pinned the 440ms gap to `tokenizer.encode()` calls in the daemon's request setup (chat-template tokens + user prompt).
- Root caused to `encode_gpt2_bpe` rebuilding `merge_rank` on every call.

**End-to-end probe results post-fix:**

| Format | probe wall (before) | probe wall (after) | TTFT (before / after) |
|---|---:|---:|---:|
| MQ4 0.8B (74 tok) | 109 tok/s | **341 tok/s** | 470ms / **12ms** |
| HFP4 0.8B (200-242 tok) | 181 tok/s | **279 tok/s** | 545ms / **71ms** |

Absolute TTFT savings are uniform (~470ms saved per request, both formats — the fix is constant-time-amortized). The 3.13× vs 1.54× wall tok/s ratio comes from different test-run token counts (74 vs 242), not from the fix being non-uniform.

**Per-checkpoint trace (Qwen3.5-0.8B, "Hello\n", 2 consecutive requests):**

```
Before fix (request 1):
  +0.01ms  after_normalize_prompt
  +431.4ms generate() pre-prefill setup done   ← 431ms in tokenizer.encode() rebuilds
  +446.3ms first token ready
  → TTFT 446ms

After fix (request 1):
  +0.01ms  after_normalize_prompt
  +0.09ms  generate() pre-prefill setup done   ← 5000× faster
  +11.8ms  first token ready
  → TTFT 12ms
```

## Test plan

- [x] `cargo test -p hipfire-runtime tokenizer` — **43/43 pass**. BPE encode is byte-identical (only construction lifetime changed, lookup semantics unchanged).
- [x] `cargo test -p hipfire-detect --release` — **51/51 + 3/3 pass**. Report test fixture extended with new `daemon_*` zero-defaults.
- [x] `coherence_probe --self-check` — **11/11 + 3/3 fixtures pass**. No detector regression.
- [x] Real-model end-to-end on gfx1100 (7900 XTX) with Qwen3.5-0.8B MQ4 + HFP4: probe wall tok/s 3.13× / 1.54× faster, TTFT 39× / 7.7× faster, daemon-authoritative metrics now match in-process bench within 5%.
- [x] Memory: O(M) once at construction (~3-5 MB for 150K Qwen merges) replaces O(M) every encode call. Net allocator pressure drops because per-call allocations no longer churn.
- [x] Backwards compat: defaults unchanged (DPM warmup default OFF, probe report fields are additive). Existing JSON consumers see new optional fields, no field renamed/removed.

## Independence

This PR is independent of #224 (HFP4 v1) and #225 (MFP4G32). Diff only touches: tokenizer, daemon, probe, report struct, methodology doc. No quant/kernel/dispatch overlap. Lands cleanly on master regardless of #224/#225 ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)