### PR TITLE
perf(mq3): _mb4 batch-tile fanout — +77% gfx1151 / +17-27% gfx1100

### DIFF
--- a/benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md
+++ b/benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md
@@ -199,7 +199,8 @@ through `forward_scratch` + GEMV, untouched.
 - ✅ gfx12 explicitly excluded from `_mb4` selectors
 - ✅ 9B: MQ3 +76.6 %, MQ3-Lloyd +67.6 %
 - ✅ 4B: MQ3-Lloyd +60.6 % (4B uniform-MQ3 model not on this host)
-- ⏳ gfx1100 cross-arch confirmation — bench help-wanted (no local hardware)
+- ✅ gfx1100 cross-arch confirmation: 9B-MQ3 +16.7 %, 9B-MQ3-Lloyd +27.1 %,
+  4B-MQ3-Lloyd +16.9 % (see "gfx1100 cross-arch confirmation" section below)
 
 ## Bench config (reproducer)
 
@@ -231,3 +232,120 @@ gpu_release
 | Model md5 (4B-MQ3-Lloyd) | `865a2ab1e7d97ae02b02be95e08cc852` |
 | Branch HEAD | `feat/mq3-batch-fanout` (off `upstream/master a4e42c5`) |
 | Prompt | N/A — synthetic deterministic token sequence (token ids `0..prefill_len`) |
+
+---
+
+## gfx1100 cross-arch confirmation (2026-05-10)
+
+**Hardware:** AMD Radeon RX 7900 XT (gfx1100 RDNA3, 21.5 GB GDDR6 ~800 GB/s).
+**ROCm:** HIP 7.2.53211 (vs maintainer's 7.12 on gfx1151).
+**Bench binary md5:** `a09ce9fd129825563cf73ab09e067dae` (differs from gfx1151
+binary because of arch-specific compile; built from same `a268d3d1` source).
+**Model md5s:** identical to maintainer's three values above (verified).
+**Local-vs-maintainer offset:** this gfx1100 is the RX 7900 XT, ~10 % slower
+than the maintainer's perf-optimized gfx1100 reference; multiply local absolute
+tok/s by 1.10 for cross-machine comparison. The Δ % (the load-bearing number
+for cross-arch confirmation) is unaffected.
+
+### HFQ3 _mb4 == _wmma parity (gfx1100)
+
+```
+GPU: gfx1100
+Verifying HFQ3 _mb4 == _wmma at all shapes (TOL=1e-4).
+[all 13 shapes: max_abs=0.000e0  max_rel=0.000e0  rms=0.000e0  PASS]
+ALL PASS — HFQ3 _mb4 produces output bit-equivalent to _wmma
+```
+
+`max_abs = 0.000e0` across all 13 shapes (5 residual + 3 qkvza + 3 qkv + 2
+gate_up). **Bit-exact on gfx1100 RDNA3 just as on gfx1151 RDNA3.5** —
+confirms the WMMA accumulation order is identical between the two archs.
+mb4 multiplexes 4 sub-tiles in time, each acc independent, so no
+fp32-reorder envelope opens up regardless of arch.
+
+### Cross-process A/B (3 runs × 2 modes, prefill=256, asym3, GRAPH=1)
+
+#### qwen3.5-9b.mq3 (uniform / HFQ3)
+
+| Mode | run 1 | run 2 | run 3 | mean prefill | mean gen |
+|---|---|---|---|---|---|
+| `MB4=0` | 1720.2 | 1715.5 | 1712.5 | **1716.1 tok/s** | 119.4 |
+| `MB4=1` | 2006.2 | 2001.6 | 1999.9 | **2002.6 tok/s** | 118.7 |
+| Δ      |        |        |        | **+286.5 (+16.7 %)** | -0.5 % |
+
+#### qwen3.5-9b.mq3-lloyd
+
+| Mode | run 1 | run 2 | run 3 | mean prefill | mean gen |
+|---|---|---|---|---|---|
+| `MB4=0` | 1458.5 | 1459.8 | 1472.1 | **1463.5 tok/s** | 112.3 |
+| `MB4=1` | 1857.7 | 1862.1 | 1859.4 | **1859.7 tok/s** | 112.2 |
+| Δ      |        |        |        | **+396.2 (+27.1 %)** | -0.1 % |
+
+#### qwen3.5-4b.mq3-lloyd
+
+| Mode | run 1 | run 2 | run 3 | mean prefill | mean gen |
+|---|---|---|---|---|---|
+| `MB4=0` | 2641.7 | 2648.3 | 2633.9 | **2641.3 tok/s** | 149.7 |
+| `MB4=1` | 3100.2 | 3073.7 | 3092.3 | **3088.7 tok/s** | 151.0 |
+| Δ      |        |        |        | **+447.4 (+16.9 %)** | +0.8 % |
+
+Stddev across the 3 runs is <0.5 % per cell — every Δ is many sigma outside noise.
+
+### Decode regression — none (matches gfx1151)
+
+`gen_tok_s` invariant across MB4 modes for all three models:
+- 9B-MQ3 (uniform): 119.4 vs 118.7 — within ±0.5 %
+- 9B-MQ3-Lloyd: 112.3 vs 112.2 — within ±0.1 %
+- 4B-MQ3-Lloyd: 149.7 vs 151.0 — within ±0.8 %
+
+`bw_gib_s` (decode bandwidth) likewise invariant (±1 GiB/s on 9B's ~478 GiB/s
+plateau; ±1 GiB/s on 4B's ~315 GiB/s). Same conclusion as gfx1151: mb4 only
+touches the prefill batched path.
+
+### gfx1151 vs gfx1100 — Δ comparison
+
+| Model | gfx1151 Δ | gfx1100 Δ |
+|---|---|---|
+| qwen3.5-9b.mq3 (uniform) | +76.6 % | **+16.7 %** |
+| qwen3.5-9b.mq3-lloyd | +67.6 % | **+27.1 %** |
+| qwen3.5-4b.mq3-lloyd | +60.6 % | **+16.9 %** |
+
+The gfx1100 wins are smaller in % terms but absolute throughput is far
+higher: 9B-MQ3 baseline jumps from gfx1151's 518 tok/s to gfx1100's 1716
+tok/s (3.3×) — consistent with GDDR6 vs LPDDR5x bandwidth ratio.
+Pre-mb4 the kernels were not as bandwidth-starved on gfx1100 as on
+gfx1151 (per-kernel GiB/s on gfx1151 was 9-14, vs the GDDR6 ceiling
+~800 — gfx1100 had more headroom to begin with), so mb4's contribution
+is smaller in proportional terms but still real and well outside noise.
+
+### Lloyd / uniform-MQ3 ratio at 9B — mb4 helps Lloyd MORE on gfx1100
+
+| Phase | gfx1151 ratio | gfx1100 ratio |
+|---|---|---|
+| Pre-mb4  | 97.1 % | **85.3 %** |
+| Post-mb4 | 92.1 % | **92.9 %** |
+
+Notable: pre-mb4 Lloyd was hit *harder* by the 16×16 wall on gfx1100
+(85 %) than on gfx1151 (97 %) — the extra cooperative codebook +
+syncthread overhead matters more when the SIMDs are otherwise faster.
+mb4 closes that gap entirely: post-mb4 the gfx1100 Lloyd / uniform
+ratio (92.9 %) lands essentially on top of gfx1151's (92.1 %). The
+fanout fix is doing exactly what it should on the bigger GPU.
+
+### Format ranking on gfx1100 (post-mb4 prefill)
+
+| Model | Prefill tok/s on gfx1100 |
+|---|---|
+| qwen3.5-9b.mq3 (uniform) | 2002.6 |
+| qwen3.5-9b.mq3-lloyd     | 1859.7 |
+
+Unlike gfx1151 (where Lloyd post-mb4 at 843 narrowly beat uniform-MQ4
+at 801), on gfx1100 uniform-MQ3 stays ahead of Lloyd-MQ3 by ~7 %.
+Different bandwidth profile, different ranking.
+
+### What's locked in for gfx1100
+
+- ✅ Bit-exact HFQ3 `_mb4` == `_wmma` parity across all 13 shapes
+- ✅ +16.7 % / +27.1 % / +16.9 % prefill on 9B-MQ3 / 9B-Lloyd / 4B-Lloyd
+- ✅ Decode untouched (<1 % drift across all three models)
+- ✅ Tight stddev (<0.5 %) across 3 fresh-process runs per cell
+- ✅ `bw_gib_s` invariant — mb4 confined to prefill path as designed

--- a/benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md
+++ b/benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md
@@ -63,17 +63,44 @@ arch ∈ {gfx1100,1101,1102,1150,1151}`. Env override
 
 ## Parity (gfx1151)
 
-`test_gemm_mq3g256_lloyd_residual_wmma` with `HIPFIRE_MQ3_MB4=1` (force-on):
-bit-exact across all 8 shapes (max_abs/max_rel/rms identical to last
-digit between `_wmma` and `_mb4`).
+**MQ3-Lloyd `_mb4` vs `_wmma`** (both run with synthetic shapes,
+compared against fp64 CPU reference):
+- `test_gemm_mq3g256_lloyd_residual_wmma` with `HIPFIRE_MQ3_MB4=1`:
+  bit-exact across all 8 residual shapes (max_abs/max_rel/rms identical
+  to last digit between `_wmma` and `_mb4`).
+- `test_gemm_fused_mq3g256_lloyd_wmma` with `HIPFIRE_MQ3_MB4=1`: bit-exact
+  across all 8 fused shapes (qkvza, qkv, gate_up).
 
-`test_gemm_fused_mq3g256_lloyd_wmma` with `HIPFIRE_MQ3_MB4=1`: bit-exact
-across all 8 fused shapes (qkvza, qkv, gate_up).
+**HFQ3 `_mb4` vs `_wmma`** (`test_gemm_hfq3g256_wmma`, GPU-vs-GPU
+comparison — both kernels run on identical inputs, output diff
+measured directly):
 
-HFQ3 has no dedicated parity test; correctness verified end-to-end by
-the integrated 9B bench (gen tok/s and weight-bytes-per-second both
-invariant across MB4 modes — a logits corruption would break the gen
-phase or shift the bandwidth column).
+```
+GPU: gfx1151
+Verifying HFQ3 _mb4 == _wmma at all shapes (TOL=1e-04).
+--- residual M=64    K=1024  N=16   max_abs=0.000e0  PASS
+--- residual M=64    K=1024  N=64   max_abs=0.000e0  PASS
+--- residual M=256   K=4096  N=256  max_abs=0.000e0  PASS
+--- residual M=1024  K=4096  N=64   max_abs=0.000e0  PASS
+--- residual M=1024  K=12288 N=64   max_abs=0.000e0  PASS
+--- qkvza M=(64+16+8+8)     K=1024 N=16   PASS  all=0.000e0
+--- qkvza M=(256+32+16+16)  K=4096 N=64   PASS  all=0.000e0
+--- qkvza M=(512+64+32+32)  K=4096 N=32   PASS  all=0.000e0
+--- qkv   M=(64+64+64)      K=1024 N=16   PASS  all=0.000e0
+--- qkv   M=(256+32+32)     K=4096 N=64   PASS  all=0.000e0
+--- qkv   M=(512+64+64)     K=4096 N=32   PASS  all=0.000e0
+--- gate_up M=(256+256)     K=1024 N=16   PASS  all=0.000e0
+--- gate_up M=(1024+1024)   K=4096 N=64   PASS  all=0.000e0
+ALL PASS — HFQ3 _mb4 produces output bit-equivalent to _wmma
+```
+
+**Bit-exact, zero diff** across all 13 shapes. HFQ3 `_mb4` produces
+output literally identical to `_wmma` for the same inputs — no
+fp32-reorder envelope opens up, since both kernels use the same
+WMMA accumulation order per output (one acc per 16×16 sub-tile;
+mb4 multiplexes 4 sub-tiles in time but each acc is independent).
+Strongest possible correctness signal — `_mb4` inherits `_wmma`'s
+production-validated correctness mechanically.
 
 ## Cross-process A/B (gfx1151, 9B prefill=256, asym3, GRAPH=1)
 
@@ -95,6 +122,22 @@ phase or shift the bandwidth column).
 | `MB4=0` | 503.7 | 501.8 | 503.1 | **502.9 tok/s** | 49.0 |
 | `MB4=1` | 823.4 | 852.8 | 852.1 | **842.8 tok/s** | 48.8 |
 | Δ      |       |       |       | **+339.9 (+67.6 %)** | -0.2 |
+
+### qwen3.5-4b.mq3-lloyd
+
+(No 4B uniform-MQ3 model on this host; just the Lloyd self-A/B.)
+
+| Mode | run 1 | run 2 | run 3 | mean prefill | mean gen |
+|---|---|---|---|---|---|
+| `MB4=0` | 980.8  | 997.0  | 985.6  | **987.8 tok/s**  | 70.4 |
+| `MB4=1` | 1596.8 | 1596.2 | 1566.3 | **1586.4 tok/s** | 69.9 |
+| Δ      |        |        |        | **+598.6 (+60.6 %)** | -0.5 |
+
+Notable: 4B-MQ3-Lloyd post-mb4 (1586 tok/s) is essentially equal to
+4B-MQ4-Lloyd post-Phase-D (1607 tok/s) on the same hardware. At 4B
+both formats are in the same compute-bound regime; the LPDDR5x
+bandwidth ceiling that punishes MQ4-Lloyd's larger format at 9B
+isn't fully exposed at 4B.
 
 ### Lloyd / uniform-MQ3 ratio
 
@@ -149,12 +192,13 @@ through `forward_scratch` + GEMV, untouched.
 
 ## What's locked in
 
-- ✅ Bit-exact parity on residual + 3 fused MQ3-Lloyd kernels (16 shapes)
-- ✅ HFQ3 mb4 correctness via integrated bench gen/bandwidth invariance
+- ✅ Bit-exact parity on residual + 3 fused MQ3-Lloyd kernels (16 shapes vs CPU reference)
+- ✅ HFQ3 _mb4 == _wmma bit-exact across 13 shapes (`test_gemm_hfq3g256_wmma`, GPU-vs-GPU)
 - ✅ Size-gated default routing — production-safe at all prefill sizes
 - ✅ Env override `HIPFIRE_MQ3_MB4={0,1}` for A/B benching
 - ✅ gfx12 explicitly excluded from `_mb4` selectors
-- ✅ Both 9B-MQ3 (+76.6%) and 9B-MQ3-Lloyd (+67.6%) clear large gains
+- ✅ 9B: MQ3 +76.6 %, MQ3-Lloyd +67.6 %
+- ✅ 4B: MQ3-Lloyd +60.6 % (4B uniform-MQ3 model not on this host)
 - ⏳ gfx1100 cross-arch confirmation — bench help-wanted (no local hardware)
 
 ## Bench config (reproducer)
@@ -184,5 +228,6 @@ gpu_release
 | Bench binary md5 | `5230b8391b4c00659b86b27112947352` |
 | Model md5 (9B-MQ3) | `e4412f6dd785e82de2ece629f33ecc14` |
 | Model md5 (9B-MQ3-Lloyd) | `ba99df5e20f44a49fe45f2fa3ce05f59` |
+| Model md5 (4B-MQ3-Lloyd) | `865a2ab1e7d97ae02b02be95e08cc852` |
 | Branch HEAD | `feat/mq3-batch-fanout` (off `upstream/master a4e42c5`) |
 | Prompt | N/A — synthetic deterministic token sequence (token ids `0..prefill_len`) |

--- a/benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md
+++ b/benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md
@@ -1,0 +1,188 @@
+# Dev log 2026-05-10 — MQ3 batch-tile fanout (`_mb4`), gfx1151
+
+**Branch:** `feat/mq3-batch-fanout` (off `upstream/master` `a4e42c5`).
+**Hardware:** gfx1151 (Radeon 8060S, AMD Ryzen AI Max+ 395 / Strix Halo APU,
+LPDDR5x ~250 GB/s), ROCm 7.12.
+**Sibling work:** MQ4 Phase D — `feat/issue-182-mq4-lloyd` branch landed
+the same multi-batch-tile pattern for the MQ4-Lloyd family; this branch
+ports the pattern to **HFQ3 (uniform-MQ3) AND MQ3-Lloyd** jointly.
+
+## Motivation
+
+Initial baseline bench (gfx1151, 9B prefill=256, ROCm 7.12):
+
+| Model | prefill tok/s | Lloyd / uniform |
+|---|---|---|
+| qwen3.5-9b.mq3 (uniform) | 503.7 | — |
+| qwen3.5-9b.mq3-lloyd | 494.1 | 98.1 % |
+
+The Lloyd / uniform ratio was already healthy at 98 % — but **both
+absolute numbers are roughly half of uniform-MQ4's 1123 tok/s** on the
+same hardware. Profile confirmed why: uniform-MQ3 (HFQ3) has no `_mmq`
+sibling (unlike HFQ4 which routes batch ≥ 128 to a 128×128 LDS-staged
+tile), so HFQ3 stays on the 16×16 WMMA path at all batch sizes —
+the same wall MQ4-Lloyd hit pre-Phase-D.
+
+Per-kernel GiB/s on the 9B baseline profile:
+
+| Kernel | HFQ3 GiB/s | MQ3-Lloyd GiB/s |
+|---|---|---|
+| `gemm_gate_up_*_wmma` | 12.3 | 9.0 |
+| `gemm_*_residual_wmma` | 12.8 | 13.4 |
+| `gemm_qkvza_*_wmma` | 13.4 | 10.1 |
+| `gemm_qkv_*_wmma` | 14.3 | 10.3 |
+
+Both families at 9-14 GiB/s — exactly the regime mb4 fixed for MQ4-Lloyd.
+
+## Approach
+
+8 new kernels following the Phase D `_mb4` template (16×64 output tile
+per WG, 4 batch sub-tiles share `a_reg` decode, 4 distinct named B-vars
+to defeat the compiler register-recycling trap):
+
+**MQ3-Lloyd `_mb4`** (codebook-based, 256 B LDS):
+- `kernels/src/gemm_mq3g256_lloyd_residual_wmma_mb4.hip`
+- `kernels/src/gemm_qkvza_mq3g256_lloyd_wmma_mb4.hip`
+- `kernels/src/gemm_qkv_mq3g256_lloyd_wmma_mb4.hip`
+- `kernels/src/gemm_gate_up_mq3g256_lloyd_wmma_mb4.hip`
+
+**HFQ3 (uniform) `_mb4`** (affine sc/zp, no LDS, no syncs):
+- `kernels/src/gemm_hfq3g256_residual_wmma_mb4.hip`
+- `kernels/src/gemm_qkvza_hfq3g256_wmma_mb4.hip`
+- `kernels/src/gemm_qkv_hfq3g256_wmma_mb4.hip`
+- `kernels/src/gemm_gate_up_hfq3g256_wmma_mb4.hip`
+
+HFQ3 mb4 is structurally simpler than the Lloyd siblings — no
+cooperative codebook load, no `__syncthreads()`, no LDS. The 4× batch
+fanout is the only structural change vs the Phase A WMMA kernel.
+
+Wired through size-gated dispatch on each existing `_wmma` method:
+default routes to `_mb4` when `batch ≥ 128 AND total_m ≥ 4096 AND
+arch ∈ {gfx1100,1101,1102,1150,1151}`. Env override
+`HIPFIRE_MQ3_MB4={0|1}` for A/B benching.
+
+## Parity (gfx1151)
+
+`test_gemm_mq3g256_lloyd_residual_wmma` with `HIPFIRE_MQ3_MB4=1` (force-on):
+bit-exact across all 8 shapes (max_abs/max_rel/rms identical to last
+digit between `_wmma` and `_mb4`).
+
+`test_gemm_fused_mq3g256_lloyd_wmma` with `HIPFIRE_MQ3_MB4=1`: bit-exact
+across all 8 fused shapes (qkvza, qkv, gate_up).
+
+HFQ3 has no dedicated parity test; correctness verified end-to-end by
+the integrated 9B bench (gen tok/s and weight-bytes-per-second both
+invariant across MB4 modes — a logits corruption would break the gen
+phase or shift the bandwidth column).
+
+## Cross-process A/B (gfx1151, 9B prefill=256, asym3, GRAPH=1)
+
+3 fresh process invocations × 2 modes, `--prefill 256 --prefill-runs 3
+--gen 30 --warmup 5`.
+
+### qwen3.5-9b.mq3 (uniform / HFQ3)
+
+| Mode | run 1 | run 2 | run 3 | mean prefill | mean gen |
+|---|---|---|---|---|---|
+| `MB4=0` | 521.4 | 516.6 | 516.3 | **518.1 tok/s** | 53.97 |
+| `MB4=1` | 907.9 | 920.2 | 916.7 | **914.9 tok/s** | 53.63 |
+| Δ      |       |       |       | **+396.8 (+76.6 %)** | -0.3 |
+
+### qwen3.5-9b.mq3-lloyd
+
+| Mode | run 1 | run 2 | run 3 | mean prefill | mean gen |
+|---|---|---|---|---|---|
+| `MB4=0` | 503.7 | 501.8 | 503.1 | **502.9 tok/s** | 49.0 |
+| `MB4=1` | 823.4 | 852.8 | 852.1 | **842.8 tok/s** | 48.8 |
+| Δ      |       |       |       | **+339.9 (+67.6 %)** | -0.2 |
+
+### Lloyd / uniform-MQ3 ratio
+
+| Phase | HFQ3 prefill | Lloyd prefill | Ratio |
+|---|---|---|---|
+| Pre-mb4 | 518.1 | 502.9 | 97.1 % |
+| Post-mb4 | 914.9 | 842.8 | 92.1 % |
+
+The ratio narrowed slightly (97.1 → 92.1 %) because uniform-MQ3 gained
+more than Lloyd (76.6 % vs 67.6 %). Both are still far above the
+format-tax floor of ~85 % (Lloyd's 7.7 % weight footprint penalty,
+112 B/group vs 104 B/group).
+
+### Comparison with MQ4 (post-Phase-D)
+
+| Model | Prefill tok/s on gfx1151 (post-mb4) |
+|---|---|
+| qwen3.5-9b.mq4 (uniform) | 1122.9 |
+| qwen3.5-9b.mq4-lloyd     |  800.8 |
+| qwen3.5-9b.mq3 (uniform) |  914.9 |
+| qwen3.5-9b.mq3-lloyd     |  842.8 |
+
+**MQ3-Lloyd post-mb4 (843 tok/s) is now FASTER than MQ4-Lloyd
+post-Phase-D (801 tok/s)** on the same hardware — consistent with MQ3's
+30 % smaller weight format on bandwidth-bound APUs. MQ3 uniform sits
+between MQ3-Lloyd and MQ4 uniform; the latter still has a faster path
+because HFQ4 routes through `_mmq` (128×128 LDS-staged tile) at large
+batch.
+
+## Size gate validation
+
+Force `MB4=1` at prefill=16 on 9B-MQ3 (uniform) regresses:
+
+| Mode | prefill tok/s |
+|---|---|
+| `MB4=0` (baseline)             | 479.9 |
+| `MB4=1` (force, gate bypassed) | 361.4 (**-24.7 %**) |
+
+Default mode (no env var) at prefill=16 falls through to `_wmma` (batch
+< 128) and matches the 479.9 baseline. The 4× WG reduction at small
+batch starves the SIMDs — same effect as MQ4 Phase D-C documented.
+
+## Decode regression — none
+
+`gen_tok_s` invariant for both models across MB4 modes:
+- 9B-MQ3 (uniform): 53.97 (MB4=0) vs 53.63 (MB4=1) — within ±0.6%
+- 9B-MQ3-Lloyd: 49.0 (MB4=0) vs 48.8 (MB4=1) — within ±0.4%
+
+`bw_gib_s` (decode bandwidth) also matches to ±0.5 GiB/s. Confirms
+mb4 only affects the prefill batched-LA path; per-token decode goes
+through `forward_scratch` + GEMV, untouched.
+
+## What's locked in
+
+- ✅ Bit-exact parity on residual + 3 fused MQ3-Lloyd kernels (16 shapes)
+- ✅ HFQ3 mb4 correctness via integrated bench gen/bandwidth invariance
+- ✅ Size-gated default routing — production-safe at all prefill sizes
+- ✅ Env override `HIPFIRE_MQ3_MB4={0,1}` for A/B benching
+- ✅ gfx12 explicitly excluded from `_mb4` selectors
+- ✅ Both 9B-MQ3 (+76.6%) and 9B-MQ3-Lloyd (+67.6%) clear large gains
+- ⏳ gfx1100 cross-arch confirmation — bench help-wanted (no local hardware)
+
+## Bench config (reproducer)
+
+```bash
+export PATH="/opt/rocm-7.12/bin:$PATH"
+export LD_LIBRARY_PATH="/opt/rocm-7.12/lib:${LD_LIBRARY_PATH:-}"
+
+source scripts/gpu-lock.sh && gpu_acquire "mq3-mb4-bench"
+
+for model in qwen3.5-9b.mq3 qwen3.5-9b.mq3-lloyd; do
+  for mb4 in 0 1; do
+    for run in 1 2 3; do
+      HIPFIRE_MQ3_MB4=$mb4 HIPFIRE_KV_MODE=asym3 HIPFIRE_GRAPH=1 \
+        ./target/release/examples/bench_qwen35_mq4 \
+        ~/.hipfire/models/$model \
+        --prefill 256 --prefill-runs 3 --warmup 5 --gen 30
+    done
+  done
+done
+
+gpu_release
+```
+
+| Field | Value |
+|---|---|
+| Bench binary md5 | `5230b8391b4c00659b86b27112947352` |
+| Model md5 (9B-MQ3) | `e4412f6dd785e82de2ece629f33ecc14` |
+| Model md5 (9B-MQ3-Lloyd) | `ba99df5e20f44a49fe45f2fa3ce05f59` |
+| Branch HEAD | `feat/mq3-batch-fanout` (off `upstream/master a4e42c5`) |
+| Prompt | N/A — synthetic deterministic token sequence (token ids `0..prefill_len`) |

--- a/crates/rdna-compute/examples/test_gemm_hfq3g256_wmma.rs
+++ b/crates/rdna-compute/examples/test_gemm_hfq3g256_wmma.rs
@@ -1,0 +1,323 @@
+//! Parity test for the HFQ3 (uniform-MQ3) WMMA family — covers all 4
+//! kernels (residual + qkvza + qkv + gate_up) with both `_wmma` and `_mb4`
+//! variants. Verifies `_mb4` output is bit-exact against `_wmma` for the
+//! same inputs at production shapes.
+//!
+//! Strategy: don't bother with a CPU reference; the existing `_wmma`
+//! kernels are the production baseline (well-trodden in master / 5b/5c
+//! reviews). Run both kernels on identical inputs and check max-abs of
+//! the GPU-vs-GPU diff. If `_wmma` and `_mb4` produce identical-in-fp32
+//! output — modulo the well-defined WMMA reorder envelope — mb4 inherits
+//! the same numerical correctness as the production `_wmma`.
+//!
+//! Routing between `_wmma` and `_mb4` is controlled in-process via the
+//! `HIPFIRE_MQ3_MB4` env var (set/unset around each call).
+
+use rdna_compute::{Gpu, DType};
+
+// HFQ3 group: 8 B header (sc:f32 + zp:f32) + 96 B 3-bit indices = 104 B.
+// Same packing as MQ3-Lloyd test (see test_gemm_fused_mq3g256_lloyd_wmma.rs):
+// 32 chunks × 3 B per group; K-tile reads 6 B = 2 adjacent chunks.
+fn pack_3bit_group(qs: &[u8; 256]) -> [u8; 96] {
+    let mut out = [0u8; 96];
+    for tid in 0..32 {
+        let mut pk: u32 = 0;
+        for i in 0..8 { pk |= (qs[tid * 8 + i] as u32 & 7) << (3 * i); }
+        out[tid * 3]     = (pk        & 0xff) as u8;
+        out[tid * 3 + 1] = ((pk >>  8) & 0xff) as u8;
+        out[tid * 3 + 2] = ((pk >> 16) & 0xff) as u8;
+    }
+    out
+}
+
+/// Build a synthetic HFQ3 matrix [m × k] with per-projection-distinct sc/zp.
+/// proj_id seeds sc/zp variation so a swapped weight pointer in dispatch
+/// yields a detectable Y delta — though the real correctness signal here
+/// is `_wmma == _mb4` regardless of proj_id.
+fn build_hfq3_matrix(m: usize, k: usize, proj_id: usize) -> Vec<u8> {
+    let groups_per_row = k / 256;
+    let mut all_bytes = Vec::with_capacity(m * groups_per_row * 104);
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let proj_off = proj_id as f32 * 0.05;
+            let sc_raw = ((row * 7 + g * 11 + proj_id * 31) % 19) as f32 * 0.001 + 0.01 + proj_off * 0.005;
+            let zp_raw = ((row * 13 + g * 17 + proj_id * 29) % 23) as f32 * 0.002 - 0.02 + proj_off;
+            all_bytes.extend_from_slice(&sc_raw.to_le_bytes());
+            all_bytes.extend_from_slice(&zp_raw.to_le_bytes());
+            let mut q = [0u8; 256];
+            for i in 0..256 {
+                q[i] = ((row.wrapping_mul(31) ^ g.wrapping_mul(53) ^ i.wrapping_mul(7)
+                       ^ proj_id.wrapping_mul(101)) & 7) as u8;
+            }
+            all_bytes.extend_from_slice(&pack_3bit_group(&q));
+        }
+    }
+    assert_eq!(all_bytes.len(), m * groups_per_row * 104);
+    all_bytes
+}
+
+fn make_x(n: usize, k: usize) -> Vec<f32> {
+    (0..(n * k)).map(|i| ((i as i32 % 13) as f32 - 6.0) * 0.05).collect()
+}
+
+fn diff_metrics(a: &[f32], b: &[f32]) -> (f32, f32, f32) {
+    let mut max_abs = 0f32;
+    let mut max_rel = 0f32;
+    let mut sum_sq = 0.0f64;
+    for i in 0..a.len() {
+        let d = (a[i] - b[i]).abs();
+        let denom = b[i].abs().max(1e-3);
+        max_abs = max_abs.max(d);
+        max_rel = max_rel.max(d / denom);
+        sum_sq += (d as f64) * (d as f64);
+    }
+    let rms = (sum_sq / a.len() as f64).sqrt() as f32;
+    (max_abs, max_rel, rms)
+}
+
+/// Helper: run kernel `f` with HIPFIRE_MQ3_MB4 set to `mode`, return Y.
+fn run_with_mode<F: FnOnce(&mut Gpu)>(gpu: &mut Gpu, mode: &str, f: F) {
+    std::env::set_var("HIPFIRE_MQ3_MB4", mode);
+    f(gpu);
+    std::env::remove_var("HIPFIRE_MQ3_MB4");
+}
+
+// `_wmma` vs `_mb4` accumulation order is identical for both (one acc per
+// 16×N tile, K-tile loop is the same). Expected max-abs delta = 0.0 for
+// shapes where mb4 fully covers (n divisible by 64 and m divisible by 16).
+// For boundary shapes, mb4's safe_batch=0 fallback may differ from wmma's
+// safe_batch=0 in the OOB-output rows that get masked anyway — set a
+// tight envelope that catches real bugs but tolerates fp32-reorder noise.
+const TOL: f32 = 1e-4;
+
+fn test_residual(gpu: &mut Gpu, m: usize, k: usize, n: usize) -> bool {
+    println!("--- residual M={} K={} N={} ---", m, k, n);
+
+    let a_b = build_hfq3_matrix(m, k, 0);
+    let x = make_x(n, k);
+    let y_init: Vec<f32> = (0..(n * m)).map(|i| ((i as i32 % 11) as f32 - 5.0) * 0.001).collect();
+
+    let d_a = gpu.upload_raw(&a_b, &[a_b.len()]).unwrap();
+    let d_x = gpu.upload_f32(&x, &[n, k]).unwrap();
+
+    // _wmma path
+    let d_y_wmma = gpu.upload_f32(&y_init, &[n, m]).unwrap();
+    run_with_mode(gpu, "0", |g| {
+        g.gemm_hfq3g256_residual_wmma(&d_a, &d_x, &d_y_wmma, m, k, n).unwrap();
+    });
+    let y_wmma = gpu.download_f32(&d_y_wmma).unwrap();
+
+    // _mb4 path (force-on regardless of size gate)
+    let d_y_mb4 = gpu.upload_f32(&y_init, &[n, m]).unwrap();
+    run_with_mode(gpu, "1", |g| {
+        g.gemm_hfq3g256_residual_wmma(&d_a, &d_x, &d_y_mb4, m, k, n).unwrap();
+    });
+    let y_mb4 = gpu.download_f32(&d_y_mb4).unwrap();
+
+    let (ma, mr, rms) = diff_metrics(&y_mb4, &y_wmma);
+    let pass = ma < TOL;
+    println!("  max_abs={:.3e}  max_rel={:.3e}  rms={:.3e}  {}",
+             ma, mr, rms, if pass { "PASS" } else { "FAIL" });
+
+    for d in [d_a, d_x, d_y_wmma, d_y_mb4] { gpu.free_tensor(d).unwrap(); }
+    pass
+}
+
+fn test_qkvza(gpu: &mut Gpu, qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize, k: usize, n: usize) -> bool {
+    println!("--- qkvza M=({}+{}+{}+{}) K={} N={} ---", qkv_m, z_m, beta_m, alpha_m, k, n);
+
+    let a_qkv_b = build_hfq3_matrix(qkv_m, k, 0);
+    let a_z_b = build_hfq3_matrix(z_m, k, 1);
+    let a_beta_b = build_hfq3_matrix(beta_m, k, 2);
+    let a_alpha_b = build_hfq3_matrix(alpha_m, k, 3);
+    let x = make_x(n, k);
+
+    let d_a_qkv = gpu.upload_raw(&a_qkv_b, &[a_qkv_b.len()]).unwrap();
+    let d_a_z = gpu.upload_raw(&a_z_b, &[a_z_b.len()]).unwrap();
+    let d_a_beta = gpu.upload_raw(&a_beta_b, &[a_beta_b.len()]).unwrap();
+    let d_a_alpha = gpu.upload_raw(&a_alpha_b, &[a_alpha_b.len()]).unwrap();
+    let d_x = gpu.upload_f32(&x, &[n, k]).unwrap();
+
+    let alloc = |gpu: &mut Gpu| {
+        (
+            gpu.zeros(&[n, qkv_m], DType::F32).unwrap(),
+            gpu.zeros(&[n, z_m], DType::F32).unwrap(),
+            gpu.zeros(&[n, beta_m], DType::F32).unwrap(),
+            gpu.zeros(&[n, alpha_m], DType::F32).unwrap(),
+        )
+    };
+
+    let (d_yq_w, d_yz_w, d_yb_w, d_ya_w) = alloc(gpu);
+    run_with_mode(gpu, "0", |g| {
+        g.gemm_qkvza_hfq3g256_wmma(
+            &d_a_qkv, &d_a_z, &d_a_beta, &d_a_alpha, &d_x,
+            &d_yq_w, &d_yz_w, &d_yb_w, &d_ya_w,
+            qkv_m, z_m, beta_m, alpha_m, k, n,
+        ).unwrap();
+    });
+    let yq_w = gpu.download_f32(&d_yq_w).unwrap();
+    let yz_w = gpu.download_f32(&d_yz_w).unwrap();
+    let yb_w = gpu.download_f32(&d_yb_w).unwrap();
+    let ya_w = gpu.download_f32(&d_ya_w).unwrap();
+
+    let (d_yq_m, d_yz_m, d_yb_m, d_ya_m) = alloc(gpu);
+    run_with_mode(gpu, "1", |g| {
+        g.gemm_qkvza_hfq3g256_wmma(
+            &d_a_qkv, &d_a_z, &d_a_beta, &d_a_alpha, &d_x,
+            &d_yq_m, &d_yz_m, &d_yb_m, &d_ya_m,
+            qkv_m, z_m, beta_m, alpha_m, k, n,
+        ).unwrap();
+    });
+    let yq_m = gpu.download_f32(&d_yq_m).unwrap();
+    let yz_m = gpu.download_f32(&d_yz_m).unwrap();
+    let yb_m = gpu.download_f32(&d_yb_m).unwrap();
+    let ya_m = gpu.download_f32(&d_ya_m).unwrap();
+
+    let (ma_q, _, _) = diff_metrics(&yq_m, &yq_w);
+    let (ma_z, _, _) = diff_metrics(&yz_m, &yz_w);
+    let (ma_b, _, _) = diff_metrics(&yb_m, &yb_w);
+    let (ma_a, _, _) = diff_metrics(&ya_m, &ya_w);
+    let max_abs = ma_q.max(ma_z).max(ma_b).max(ma_a);
+    let pass = max_abs < TOL;
+    println!("  qkv max_abs={:.3e}  z={:.3e}  beta={:.3e}  alpha={:.3e}  {}",
+             ma_q, ma_z, ma_b, ma_a, if pass { "PASS" } else { "FAIL" });
+
+    for d in [d_a_qkv, d_a_z, d_a_beta, d_a_alpha, d_x,
+              d_yq_w, d_yz_w, d_yb_w, d_ya_w,
+              d_yq_m, d_yz_m, d_yb_m, d_ya_m] {
+        gpu.free_tensor(d).unwrap();
+    }
+    pass
+}
+
+fn test_qkv(gpu: &mut Gpu, q_m: usize, k_m: usize, v_m: usize, k: usize, n: usize) -> bool {
+    println!("--- qkv M=({}+{}+{}) K={} N={} ---", q_m, k_m, v_m, k, n);
+
+    let a_q_b = build_hfq3_matrix(q_m, k, 0);
+    let a_k_b = build_hfq3_matrix(k_m, k, 1);
+    let a_v_b = build_hfq3_matrix(v_m, k, 2);
+    let x = make_x(n, k);
+
+    let d_a_q = gpu.upload_raw(&a_q_b, &[a_q_b.len()]).unwrap();
+    let d_a_k = gpu.upload_raw(&a_k_b, &[a_k_b.len()]).unwrap();
+    let d_a_v = gpu.upload_raw(&a_v_b, &[a_v_b.len()]).unwrap();
+    let d_x = gpu.upload_f32(&x, &[n, k]).unwrap();
+
+    let alloc = |gpu: &mut Gpu| (
+        gpu.zeros(&[n, q_m], DType::F32).unwrap(),
+        gpu.zeros(&[n, k_m], DType::F32).unwrap(),
+        gpu.zeros(&[n, v_m], DType::F32).unwrap(),
+    );
+
+    let (d_yq_w, d_yk_w, d_yv_w) = alloc(gpu);
+    run_with_mode(gpu, "0", |g| {
+        g.gemm_qkv_hfq3g256_wmma(&d_a_q, &d_a_k, &d_a_v, &d_x,
+            &d_yq_w, &d_yk_w, &d_yv_w, q_m, k_m, v_m, k, n).unwrap();
+    });
+    let yq_w = gpu.download_f32(&d_yq_w).unwrap();
+    let yk_w = gpu.download_f32(&d_yk_w).unwrap();
+    let yv_w = gpu.download_f32(&d_yv_w).unwrap();
+
+    let (d_yq_m, d_yk_m, d_yv_m) = alloc(gpu);
+    run_with_mode(gpu, "1", |g| {
+        g.gemm_qkv_hfq3g256_wmma(&d_a_q, &d_a_k, &d_a_v, &d_x,
+            &d_yq_m, &d_yk_m, &d_yv_m, q_m, k_m, v_m, k, n).unwrap();
+    });
+    let yq_m = gpu.download_f32(&d_yq_m).unwrap();
+    let yk_m = gpu.download_f32(&d_yk_m).unwrap();
+    let yv_m = gpu.download_f32(&d_yv_m).unwrap();
+
+    let (ma_q, _, _) = diff_metrics(&yq_m, &yq_w);
+    let (ma_k, _, _) = diff_metrics(&yk_m, &yk_w);
+    let (ma_v, _, _) = diff_metrics(&yv_m, &yv_w);
+    let max_abs = ma_q.max(ma_k).max(ma_v);
+    let pass = max_abs < TOL;
+    println!("  q max_abs={:.3e}  k={:.3e}  v={:.3e}  {}",
+             ma_q, ma_k, ma_v, if pass { "PASS" } else { "FAIL" });
+
+    for d in [d_a_q, d_a_k, d_a_v, d_x, d_yq_w, d_yk_w, d_yv_w, d_yq_m, d_yk_m, d_yv_m] {
+        gpu.free_tensor(d).unwrap();
+    }
+    pass
+}
+
+fn test_gate_up(gpu: &mut Gpu, gate_m: usize, up_m: usize, k: usize, n: usize) -> bool {
+    println!("--- gate_up M=({}+{}) K={} N={} ---", gate_m, up_m, k, n);
+
+    let a_g_b = build_hfq3_matrix(gate_m, k, 0);
+    let a_u_b = build_hfq3_matrix(up_m, k, 1);
+    let x = make_x(n, k);
+
+    let d_a_g = gpu.upload_raw(&a_g_b, &[a_g_b.len()]).unwrap();
+    let d_a_u = gpu.upload_raw(&a_u_b, &[a_u_b.len()]).unwrap();
+    let d_x = gpu.upload_f32(&x, &[n, k]).unwrap();
+
+    let alloc = |gpu: &mut Gpu| (
+        gpu.zeros(&[n, gate_m], DType::F32).unwrap(),
+        gpu.zeros(&[n, up_m], DType::F32).unwrap(),
+    );
+
+    let (d_yg_w, d_yu_w) = alloc(gpu);
+    run_with_mode(gpu, "0", |g| {
+        g.gemm_gate_up_hfq3g256_wmma(&d_a_g, &d_a_u, &d_x, &d_yg_w, &d_yu_w,
+            gate_m, up_m, k, n).unwrap();
+    });
+    let yg_w = gpu.download_f32(&d_yg_w).unwrap();
+    let yu_w = gpu.download_f32(&d_yu_w).unwrap();
+
+    let (d_yg_m, d_yu_m) = alloc(gpu);
+    run_with_mode(gpu, "1", |g| {
+        g.gemm_gate_up_hfq3g256_wmma(&d_a_g, &d_a_u, &d_x, &d_yg_m, &d_yu_m,
+            gate_m, up_m, k, n).unwrap();
+    });
+    let yg_m = gpu.download_f32(&d_yg_m).unwrap();
+    let yu_m = gpu.download_f32(&d_yu_m).unwrap();
+
+    let (ma_g, _, _) = diff_metrics(&yg_m, &yg_w);
+    let (ma_u, _, _) = diff_metrics(&yu_m, &yu_w);
+    let max_abs = ma_g.max(ma_u);
+    let pass = max_abs < TOL;
+    println!("  gate max_abs={:.3e}  up={:.3e}  {}",
+             ma_g, ma_u, if pass { "PASS" } else { "FAIL" });
+
+    for d in [d_a_g, d_a_u, d_x, d_yg_w, d_yu_w, d_yg_m, d_yu_m] {
+        gpu.free_tensor(d).unwrap();
+    }
+    pass
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    eprintln!("GPU: {}", gpu.arch);
+    eprintln!("Verifying HFQ3 _mb4 == _wmma at all shapes (TOL={:.0e}).", TOL);
+
+    let mut all_pass = true;
+
+    // residual — covers boundary cases (n=16 padded to 64; n=64 partial-mb4).
+    all_pass &= test_residual(&mut gpu, 64,   1024,  16);
+    all_pass &= test_residual(&mut gpu, 64,   1024,  64);
+    all_pass &= test_residual(&mut gpu, 256,  4096, 256);
+    all_pass &= test_residual(&mut gpu, 1024, 4096,  64);
+    all_pass &= test_residual(&mut gpu, 1024, 12288, 64);
+
+    // qkvza — straddles projection boundaries (4-way fan-out).
+    all_pass &= test_qkvza(&mut gpu, 64, 16, 8, 8, 1024, 16);
+    all_pass &= test_qkvza(&mut gpu, 256, 32, 16, 16, 4096, 64);
+    all_pass &= test_qkvza(&mut gpu, 512, 64, 32, 32, 4096, 32);
+
+    // qkv — 3-way fan-out, balanced + asymmetric.
+    all_pass &= test_qkv(&mut gpu, 64, 64, 64, 1024, 16);
+    all_pass &= test_qkv(&mut gpu, 256, 32, 32, 4096, 64);
+    all_pass &= test_qkv(&mut gpu, 512, 64, 64, 4096, 32);
+
+    // gate_up — 2-way fan-out.
+    all_pass &= test_gate_up(&mut gpu, 256, 256, 1024, 16);
+    all_pass &= test_gate_up(&mut gpu, 1024, 1024, 4096, 64);
+
+    println!();
+    if !all_pass {
+        eprintln!("FAIL: one or more HFQ3 _wmma vs _mb4 parity tests failed");
+        std::process::exit(1);
+    }
+    println!("ALL PASS — HFQ3 _mb4 produces output bit-equivalent to _wmma");
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -2206,6 +2206,17 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        // mb4 path selector — same gate as MQ4-Lloyd's mb4 family.
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_mq3g256_lloyd_residual_wmma_mb4(a_raw, x, y, m, k, batch_size);
+        }
         self.bind_thread()?;
         let (src, module) = kernels::gemm_mq3g256_lloyd_residual_wmma_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemm_mq3g256_lloyd_residual_wmma")?;
@@ -2252,6 +2263,64 @@ impl Gpu {
         result
     }
 
+    /// MQ3-Lloyd WMMA residual mb4: 16×64 output tile per WG. Sibling of
+    /// `gemm_mq4g256_lloyd_residual_wmma_mb4` ported to the MQ3 codebook
+    /// (8 entries) + 3-bit cross-byte K-tile decode.
+    pub fn gemm_mq3g256_lloyd_residual_wmma_mb4(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let (src, module) = kernels::gemm_mq3g256_lloyd_residual_wmma_mb4_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemm_mq3g256_lloyd_residual_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 63) / 64;
+
+        let weight_bytes = m * (k / 256) * LLOYD_MQ3_GROUP_BYTES;
+        let bytes = weight_bytes + batch_size * k * 2 + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_mq3g256_lloyd_residual_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_mq3g256_lloyd_residual_wmma_mb4",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// MQ3-Lloyd WMMA fused QKVZA GEMM (LA preamble: qkv + z + beta + alpha).
     /// 4-way fused — one launch covers all four projections of the LA layer.
     /// Caller pre-rotates X (FWHT) for MQ3-Lloyd dtype.
@@ -2263,6 +2332,21 @@ impl Gpu {
         qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
         k: usize, n: usize,
     ) -> HipResult<()> {
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_qkvza_mq3g256_lloyd_wmma_mb4(
+                a_qkv, a_z, a_beta, a_alpha, x,
+                y_qkv, y_z, y_beta, y_alpha,
+                qkv_m, z_m, beta_m, alpha_m, k, n,
+            );
+        }
         self.bind_thread()?;
         let (src, module) = kernels::gemm_qkvza_mq3g256_lloyd_wmma_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemm_qkvza_mq3g256_lloyd_wmma")?;
@@ -2331,6 +2415,82 @@ impl Gpu {
     }
 
     /// MQ3-Lloyd WMMA fused QKV GEMM (FA preamble: q + k + v).
+    /// MQ3-Lloyd qkvza mb4 dispatch.
+    pub fn gemm_qkvza_mq3g256_lloyd_wmma_mb4(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize, n: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let (src, module) = kernels::gemm_qkvza_mq3g256_lloyd_wmma_mb4_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemm_qkvza_mq3g256_lloyd_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, n * k)?;
+
+        let mut a_qkv_p = a_qkv.buf.as_ptr();
+        let mut a_z_p = a_z.buf.as_ptr();
+        let mut a_beta_p = a_beta.buf.as_ptr();
+        let mut a_alpha_p = a_alpha.buf.as_ptr();
+        let mut x_p = x_f16_ptr;
+        let mut y_qkv_p = y_qkv.buf.as_ptr();
+        let mut y_z_p = y_z.buf.as_ptr();
+        let mut y_beta_p = y_beta.buf.as_ptr();
+        let mut y_alpha_p = y_alpha.buf.as_ptr();
+        let mut qkv_m_v = qkv_m as i32;
+        let mut z_m_v = z_m as i32;
+        let mut beta_m_v = beta_m as i32;
+        let mut alpha_m_v = alpha_m as i32;
+        let mut k_v = k as i32;
+        let mut n_v = n as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_qkv_p as *mut _ as *mut c_void,
+            &mut a_z_p as *mut _ as *mut c_void,
+            &mut a_beta_p as *mut _ as *mut c_void,
+            &mut a_alpha_p as *mut _ as *mut c_void,
+            &mut x_p as *mut _ as *mut c_void,
+            &mut y_qkv_p as *mut _ as *mut c_void,
+            &mut y_z_p as *mut _ as *mut c_void,
+            &mut y_beta_p as *mut _ as *mut c_void,
+            &mut y_alpha_p as *mut _ as *mut c_void,
+            &mut qkv_m_v as *mut _ as *mut c_void,
+            &mut z_m_v as *mut _ as *mut c_void,
+            &mut beta_m_v as *mut _ as *mut c_void,
+            &mut alpha_m_v as *mut _ as *mut c_void,
+            &mut k_v as *mut _ as *mut c_void,
+            &mut n_v as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (n + 63) / 64;
+        let weight_bytes = total_m * (k / 256) * LLOYD_MQ3_GROUP_BYTES;
+        let bytes = weight_bytes + n * k * 2 + n * total_m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_qkvza_mq3g256_lloyd_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_mq3g256_lloyd_wmma_mb4",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_qkv_p); b.push_ptr(a_z_p); b.push_ptr(a_beta_p); b.push_ptr(a_alpha_p);
+                b.push_ptr(x_p);
+                b.push_ptr(y_qkv_p); b.push_ptr(y_z_p); b.push_ptr(y_beta_p); b.push_ptr(y_alpha_p);
+                b.push_i32(qkv_m_v); b.push_i32(z_m_v); b.push_i32(beta_m_v); b.push_i32(alpha_m_v);
+                b.push_i32(k_v); b.push_i32(n_v);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     pub fn gemm_qkv_mq3g256_lloyd_wmma(
         &mut self,
         a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
@@ -2339,6 +2499,20 @@ impl Gpu {
         q_m: usize, k_m: usize, v_m: usize,
         k: usize, n: usize,
     ) -> HipResult<()> {
+        let total_m = q_m + k_m + v_m;
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_qkv_mq3g256_lloyd_wmma_mb4(
+                a_q, a_k, a_v, x, y_q, y_k, y_v,
+                q_m, k_m, v_m, k, n,
+            );
+        }
         self.bind_thread()?;
         let (src, module) = kernels::gemm_qkv_mq3g256_lloyd_wmma_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemm_qkv_mq3g256_lloyd_wmma")?;
@@ -2401,6 +2575,76 @@ impl Gpu {
     }
 
     /// MQ3-Lloyd WMMA fused gate+up GEMM (FFN preamble).
+    /// MQ3-Lloyd qkv mb4 dispatch.
+    pub fn gemm_qkv_mq3g256_lloyd_wmma_mb4(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize, n: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let (src, module) = kernels::gemm_qkv_mq3g256_lloyd_wmma_mb4_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemm_qkv_mq3g256_lloyd_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, n * k)?;
+
+        let mut a_q_p = a_q.buf.as_ptr();
+        let mut a_k_p = a_k.buf.as_ptr();
+        let mut a_v_p = a_v.buf.as_ptr();
+        let mut x_p = x_f16_ptr;
+        let mut y_q_p = y_q.buf.as_ptr();
+        let mut y_k_p = y_k.buf.as_ptr();
+        let mut y_v_p = y_v.buf.as_ptr();
+        let mut q_m_v = q_m as i32;
+        let mut k_m_v = k_m as i32;
+        let mut v_m_v = v_m as i32;
+        let mut k_v = k as i32;
+        let mut n_v = n as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_q_p as *mut _ as *mut c_void,
+            &mut a_k_p as *mut _ as *mut c_void,
+            &mut a_v_p as *mut _ as *mut c_void,
+            &mut x_p as *mut _ as *mut c_void,
+            &mut y_q_p as *mut _ as *mut c_void,
+            &mut y_k_p as *mut _ as *mut c_void,
+            &mut y_v_p as *mut _ as *mut c_void,
+            &mut q_m_v as *mut _ as *mut c_void,
+            &mut k_m_v as *mut _ as *mut c_void,
+            &mut v_m_v as *mut _ as *mut c_void,
+            &mut k_v as *mut _ as *mut c_void,
+            &mut n_v as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (n + 63) / 64;
+        let weight_bytes = total_m * (k / 256) * LLOYD_MQ3_GROUP_BYTES;
+        let bytes = weight_bytes + n * k * 2 + n * total_m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_qkv_mq3g256_lloyd_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_mq3g256_lloyd_wmma_mb4",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_q_p); b.push_ptr(a_k_p); b.push_ptr(a_v_p);
+                b.push_ptr(x_p);
+                b.push_ptr(y_q_p); b.push_ptr(y_k_p); b.push_ptr(y_v_p);
+                b.push_i32(q_m_v); b.push_i32(k_m_v); b.push_i32(v_m_v);
+                b.push_i32(k_v); b.push_i32(n_v);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     pub fn gemm_gate_up_mq3g256_lloyd_wmma(
         &mut self,
         a_gate: &GpuTensor, a_up: &GpuTensor,
@@ -2409,6 +2653,19 @@ impl Gpu {
         gate_m: usize, up_m: usize,
         k: usize, n: usize,
     ) -> HipResult<()> {
+        let total_m = gate_m + up_m;
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_gate_up_mq3g256_lloyd_wmma_mb4(
+                a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, n,
+            );
+        }
         self.bind_thread()?;
         let (src, module) = kernels::gemm_gate_up_mq3g256_lloyd_wmma_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemm_gate_up_mq3g256_lloyd_wmma")?;
@@ -2446,6 +2703,70 @@ impl Gpu {
         );
         let result = self.launch_maybe_blob(
             "gemm_gate_up_mq3g256_lloyd_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_gate_p); b.push_ptr(a_up_p);
+                b.push_ptr(x_p);
+                b.push_ptr(y_gate_p); b.push_ptr(y_up_p);
+                b.push_i32(gate_m_v); b.push_i32(up_m_v);
+                b.push_i32(k_v); b.push_i32(n_v);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// MQ3-Lloyd gate_up mb4 dispatch.
+    pub fn gemm_gate_up_mq3g256_lloyd_wmma_mb4(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize, n: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let (src, module) = kernels::gemm_gate_up_mq3g256_lloyd_wmma_mb4_for_arch(&self.arch);
+        self.ensure_kernel(module, src, "gemm_gate_up_mq3g256_lloyd_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, n * k)?;
+
+        let mut a_gate_p = a_gate.buf.as_ptr();
+        let mut a_up_p = a_up.buf.as_ptr();
+        let mut x_p = x_f16_ptr;
+        let mut y_gate_p = y_gate.buf.as_ptr();
+        let mut y_up_p = y_up.buf.as_ptr();
+        let mut gate_m_v = gate_m as i32;
+        let mut up_m_v = up_m as i32;
+        let mut k_v = k as i32;
+        let mut n_v = n as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_gate_p as *mut _ as *mut c_void,
+            &mut a_up_p as *mut _ as *mut c_void,
+            &mut x_p as *mut _ as *mut c_void,
+            &mut y_gate_p as *mut _ as *mut c_void,
+            &mut y_up_p as *mut _ as *mut c_void,
+            &mut gate_m_v as *mut _ as *mut c_void,
+            &mut up_m_v as *mut _ as *mut c_void,
+            &mut k_v as *mut _ as *mut c_void,
+            &mut n_v as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (n + 63) / 64;
+        let weight_bytes = total_m * (k / 256) * LLOYD_MQ3_GROUP_BYTES;
+        let bytes = weight_bytes + n * k * 2 + n * total_m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_gate_up_mq3g256_lloyd_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_mq3g256_lloyd_wmma_mb4",
             [row_tiles as u32, batch_tiles as u32, 1],
             [32, 1, 1],
             0,
@@ -5222,6 +5543,22 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        // HFQ3 mb4 path selector. Only triggers on gfx11; gfx12 keeps its
+        // existing fast path (line below) since mb4 sibling not ported.
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_qkvza_hfq3g256_wmma_mb4(
+                a_qkv, a_z, a_beta, a_alpha, x,
+                y_qkv, y_z, y_beta, y_alpha,
+                qkv_m, z_m, beta_m, alpha_m, k, batch_size);
+        }
         self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_qkvza_hfq3g256_wmma_gfx12(
@@ -5289,6 +5626,81 @@ impl Gpu {
                 b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
                 b.push_i32(q_m); b.push_i32(z_m_val); b.push_i32(b_m); b.push_i32(a_m);
                 b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// HFQ3 qkvza mb4 dispatch: 16×64 output tile per WG.
+    pub fn gemm_qkvza_hfq3g256_wmma_mb4(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel("gemm_qkvza_hfq3g256_wmma_mb4", kernels::GEMM_QKVZA_HFQ3G256_WMMA_MB4_SRC, "gemm_qkvza_hfq3g256_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_qkv.buf.as_ptr();
+        let mut az = a_z.buf.as_ptr();
+        let mut ab = a_beta.buf.as_ptr();
+        let mut aa = a_alpha.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_qkv.buf.as_ptr();
+        let mut yz = y_z.buf.as_ptr();
+        let mut yb = y_beta.buf.as_ptr();
+        let mut ya = y_alpha.buf.as_ptr();
+        let mut q_m_v = qkv_m as i32;
+        let mut z_m_v = z_m as i32;
+        let mut b_m_v = beta_m as i32;
+        let mut a_m_v = alpha_m as i32;
+        let mut k_v = k as i32;
+        let mut n_v = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut az as *mut _ as *mut c_void,
+            &mut ab as *mut _ as *mut c_void,
+            &mut aa as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yz as *mut _ as *mut c_void,
+            &mut yb as *mut _ as *mut c_void,
+            &mut ya as *mut _ as *mut c_void,
+            &mut q_m_v as *mut _ as *mut c_void,
+            &mut z_m_v as *mut _ as *mut c_void,
+            &mut b_m_v as *mut _ as *mut c_void,
+            &mut a_m_v as *mut _ as *mut c_void,
+            &mut k_v as *mut _ as *mut c_void,
+            &mut n_v as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 63) / 64;
+        let bytes = total_m * (k / 256) * 104 + batch_size * k * 2 + batch_size * total_m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_qkvza_hfq3g256_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_hfq3g256_wmma_mb4",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(q_m_v); b.push_i32(z_m_v); b.push_i32(b_m_v); b.push_i32(a_m_v);
+                b.push_i32(k_v); b.push_i32(n_v);
                 b
             },
         );
@@ -5587,6 +5999,18 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        let total_m = q_m + k_m + v_m;
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_qkv_hfq3g256_wmma_mb4(
+                a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+        }
         self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_qkv_hfq3g256_wmma_gfx12(
@@ -5643,6 +6067,75 @@ impl Gpu {
                 b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
                 b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
                 b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// HFQ3 qkv mb4 dispatch: 16×64 output tile per WG.
+    pub fn gemm_qkv_hfq3g256_wmma_mb4(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel("gemm_qkv_hfq3g256_wmma_mb4", kernels::GEMM_QKV_HFQ3G256_WMMA_MB4_SRC, "gemm_qkv_hfq3g256_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_v = q_m as i32;
+        let mut k_m_v = k_m as i32;
+        let mut v_m_v = v_m as i32;
+        let mut k_v = k as i32;
+        let mut n_v = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_v as *mut _ as *mut c_void,
+            &mut k_m_v as *mut _ as *mut c_void,
+            &mut v_m_v as *mut _ as *mut c_void,
+            &mut k_v as *mut _ as *mut c_void,
+            &mut n_v as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 63) / 64;
+        let bytes = total_m * (k / 256) * 104 + batch_size * k * 2 + batch_size * total_m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_qkv_hfq3g256_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfq3g256_wmma_mb4",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_v); b.push_i32(k_m_v); b.push_i32(v_m_v);
+                b.push_i32(k_v); b.push_i32(n_v);
                 b
             },
         );
@@ -5892,6 +6385,18 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        let total_m = gate_m + up_m;
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_gate_up_hfq3g256_wmma_mb4(
+                a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
+        }
         self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_gate_up_hfq3g256_wmma_gfx12(
@@ -5941,6 +6446,69 @@ impl Gpu {
                 b.push_ptr(xp);
                 b.push_ptr(yg); b.push_ptr(yu);
                 b.push_i32(g_m); b.push_i32(u_m); b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// HFQ3 gate_up mb4 dispatch: 16×64 output tile per WG.
+    pub fn gemm_gate_up_hfq3g256_wmma_mb4(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel("gemm_gate_up_hfq3g256_wmma_mb4", kernels::GEMM_GATE_UP_HFQ3G256_WMMA_MB4_SRC, "gemm_gate_up_hfq3g256_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ag = a_gate.buf.as_ptr();
+        let mut au = a_up.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yg = y_gate.buf.as_ptr();
+        let mut yu = y_up.buf.as_ptr();
+        let mut g_m_v = gate_m as i32;
+        let mut u_m_v = up_m as i32;
+        let mut k_v = k as i32;
+        let mut n_v = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ag as *mut _ as *mut c_void,
+            &mut au as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yg as *mut _ as *mut c_void,
+            &mut yu as *mut _ as *mut c_void,
+            &mut g_m_v as *mut _ as *mut c_void,
+            &mut u_m_v as *mut _ as *mut c_void,
+            &mut k_v as *mut _ as *mut c_void,
+            &mut n_v as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 63) / 64;
+        let bytes = total_m * (k / 256) * 104 + batch_size * k * 2 + batch_size * total_m * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_gate_up_hfq3g256_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_hfq3g256_wmma_mb4",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ag); b.push_ptr(au);
+                b.push_ptr(xp);
+                b.push_ptr(yg); b.push_ptr(yu);
+                b.push_i32(g_m_v); b.push_i32(u_m_v);
+                b.push_i32(k_v); b.push_i32(n_v);
                 b
             },
         );
@@ -7980,6 +8548,16 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        let arch_supports_mb4 = matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
+        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
+            Some("0") => false,
+            Some("1") => arch_supports_mb4,
+            _ => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
+        };
+        if use_mb4 {
+            return self.gemm_hfq3g256_residual_wmma_mb4(a_raw, x, y, m, k, batch_size);
+        }
         self.bind_thread()?;
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_hfq3g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
@@ -8011,6 +8589,59 @@ impl Gpu {
         let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq3g256_residual_wmma", bytes);
         let result = self.launch_maybe_blob(
             "gemm_hfq3g256_residual_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// HFQ3 residual mb4 dispatch: 16×64 output tile per WG.
+    pub fn gemm_hfq3g256_residual_wmma_mb4(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel("gemm_hfq3g256_residual_wmma_mb4", kernels::GEMM_HFQ3G256_RESIDUAL_WMMA_MB4_SRC, "gemm_hfq3g256_residual_wmma_mb4")?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 63) / 64;
+        let bytes = m * (k / 256) * 104 + batch_size * k * 2 + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_hfq3g256_residual_wmma_mb4", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_hfq3g256_residual_wmma_mb4",
             [row_tiles as u32, batch_tiles as u32, 1],
             [32, 1, 1],
             0,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -53,15 +53,23 @@ pub const GEMV_MQ3G256_LLOYD_RESIDUAL_GFX1100_SRC: &str = include_str!("../../..
 pub const GEMM_MQ3G256_LLOYD_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_mq3g256_lloyd_residual_wmma.hip");
 /// gfx12 (RDNA4) sibling — code-complete but runtime-unvalidated locally per Phase B1 plan.
 pub const GEMM_MQ3G256_LLOYD_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_mq3g256_lloyd_residual_wmma.gfx12.hip");
+/// MQ3-Lloyd batch-fanout (mb4) family — 16×64 output tile per WG, 4 batch
+/// sub-tiles share A_reg decode. Same multi-batch-tile pattern as the
+/// MQ4-Lloyd mb4 family. gfx11 only (gfx12 sibling deferred).
+pub const GEMM_MQ3G256_LLOYD_RESIDUAL_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_mq3g256_lloyd_residual_wmma_mb4.hip");
+
 /// MQ3G256Lloyd WMMA fused QKVZA (LA preamble: qkv + z + beta + alpha, 4-way).
 pub const GEMM_QKVZA_MQ3G256_LLOYD_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq3g256_lloyd_wmma.hip");
 pub const GEMM_QKVZA_MQ3G256_LLOYD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq3g256_lloyd_wmma.gfx12.hip");
+pub const GEMM_QKVZA_MQ3G256_LLOYD_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq3g256_lloyd_wmma_mb4.hip");
 /// MQ3G256Lloyd WMMA fused QKV (FA preamble: q + k + v, 3-way).
 pub const GEMM_QKV_MQ3G256_LLOYD_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq3g256_lloyd_wmma.hip");
 pub const GEMM_QKV_MQ3G256_LLOYD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq3g256_lloyd_wmma.gfx12.hip");
+pub const GEMM_QKV_MQ3G256_LLOYD_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq3g256_lloyd_wmma_mb4.hip");
 /// MQ3G256Lloyd WMMA fused gate+up (FFN, 2-way).
 pub const GEMM_GATE_UP_MQ3G256_LLOYD_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq3g256_lloyd_wmma.hip");
 pub const GEMM_GATE_UP_MQ3G256_LLOYD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq3g256_lloyd_wmma.gfx12.hip");
+pub const GEMM_GATE_UP_MQ3G256_LLOYD_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq3g256_lloyd_wmma_mb4.hip");
 
 /// Returns the MQ3G256Lloyd WMMA residual GEMM kernel source AND module name for
 /// the given arch. Mirrors `gemm_hfq3g256_residual_wmma_for_arch`'s arch matrix.
@@ -74,6 +82,15 @@ pub fn gemm_mq3g256_lloyd_residual_wmma_for_arch(arch: &str) -> (&'static str, &
         _ => (GEMM_MQ3G256_LLOYD_RESIDUAL_WMMA_SRC, "gemm_mq3g256_lloyd_residual_wmma"),
     }
 }
+/// MQ3-Lloyd mb4 residual selector. gfx11 only — gfx12 sibling deferred.
+pub fn gemm_mq3g256_lloyd_residual_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" =>
+            (GEMM_MQ3G256_LLOYD_RESIDUAL_WMMA_MB4_SRC, "gemm_mq3g256_lloyd_residual_wmma_mb4_rdna3"),
+        _ => panic!("MQ3-Lloyd WMMA mb4 residual: unsupported arch {arch}. gfx11-only."),
+    }
+}
+
 pub fn gemm_qkvza_mq3g256_lloyd_wmma_for_arch(arch: &str) -> (&'static str, &'static str) {
     match arch {
         "gfx1200" | "gfx1201" =>
@@ -99,6 +116,29 @@ pub fn gemm_gate_up_mq3g256_lloyd_wmma_for_arch(arch: &str) -> (&'static str, &'
         "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" =>
             (GEMM_GATE_UP_MQ3G256_LLOYD_WMMA_SRC, "gemm_gate_up_mq3g256_lloyd_wmma_rdna3"),
         _ => (GEMM_GATE_UP_MQ3G256_LLOYD_WMMA_SRC, "gemm_gate_up_mq3g256_lloyd_wmma"),
+    }
+}
+
+/// MQ3-Lloyd fused mb4 selectors (gfx11 only).
+pub fn gemm_qkvza_mq3g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" =>
+            (GEMM_QKVZA_MQ3G256_LLOYD_WMMA_MB4_SRC, "gemm_qkvza_mq3g256_lloyd_wmma_mb4_rdna3"),
+        _ => panic!("MQ3-Lloyd WMMA mb4 qkvza: unsupported arch {arch}. gfx11-only."),
+    }
+}
+pub fn gemm_qkv_mq3g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" =>
+            (GEMM_QKV_MQ3G256_LLOYD_WMMA_MB4_SRC, "gemm_qkv_mq3g256_lloyd_wmma_mb4_rdna3"),
+        _ => panic!("MQ3-Lloyd WMMA mb4 qkv: unsupported arch {arch}. gfx11-only."),
+    }
+}
+pub fn gemm_gate_up_mq3g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
+    match arch {
+        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" =>
+            (GEMM_GATE_UP_MQ3G256_LLOYD_WMMA_MB4_SRC, "gemm_gate_up_mq3g256_lloyd_wmma_mb4_rdna3"),
+        _ => panic!("MQ3-Lloyd WMMA mb4 gate_up: unsupported arch {arch}. gfx11-only."),
     }
 }
 /// MQ3G256Lloyd fused gate+up GEMV: two GEMVs in one launch (saves 1 launch
@@ -473,6 +513,12 @@ pub const GEMM_QKVZA_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/sr
 pub const GEMM_GATE_UP_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma.hip");
 pub const GEMM_HFQ3G256_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_hfq3g256_residual_wmma.hip");
 pub const GEMM_QKV_HFQ3G256_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq3g256_wmma.hip");
+/// HFQ3 mb4 sources: 16×64 output tile per WG, 4 batch sub-tiles share
+/// A_reg decode. gfx11 only. No LDS, no syncs (HFQ3 has no codebook).
+pub const GEMM_HFQ3G256_RESIDUAL_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_hfq3g256_residual_wmma_mb4.hip");
+pub const GEMM_QKVZA_HFQ3G256_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq3g256_wmma_mb4.hip");
+pub const GEMM_QKV_HFQ3G256_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq3g256_wmma_mb4.hip");
+pub const GEMM_GATE_UP_HFQ3G256_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma_mb4.hip");
 pub const GEMM_QKVZA_HFQ3G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq3g256_wmma.gfx12.hip");
 pub const GEMM_QKV_HFQ3G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq3g256_wmma.gfx12.hip");
 pub const GEMM_GATE_UP_HFQ3G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq3g256_wmma.gfx12.hip");

--- a/kernels/src/gemm_gate_up_hfq3g256_wmma_mb4.hip
+++ b/kernels/src/gemm_gate_up_hfq3g256_wmma_mb4.hip
@@ -1,0 +1,169 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// HFQ3 (uniform-MQ3) WMMA fused gate+up GEMM, 4× batch-tile fanout.
+// Sibling of gemm_hfq3g256_residual_wmma_mb4.hip; 2-way fan-out.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_hfq3g256_wmma_mb4(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate; local_row = safe_row;
+    } else {
+        A = A_up;   local_row = safe_row - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)local_row * groups_per_row * 104;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < gate_m) {
+                        Y = Y_gate; proj_row = out_row;            out_stride = gate_m;
+                    } else {
+                        Y = Y_up;   proj_row = out_row - gate_m;   out_stride = up_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_gate_up_mq3g256_lloyd_wmma_mb4.hip
+++ b/kernels/src/gemm_gate_up_mq3g256_lloyd_wmma_mb4.hip
@@ -1,0 +1,192 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ3-Lloyd WMMA fused gate+up GEMM, 4× batch-tile fanout.
+// Sibling of gemm_mq4g256_lloyd_..._mb4.hip family.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_mq3g256_lloyd_wmma_mb4(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate; local_row = safe_row;
+    } else {
+        A = A_up;   local_row = safe_row - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 112;
+    const char* row_base = A + local_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 4;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < gate_m) {
+        load_A = A_gate; load_local_row = load_safe_row;
+    } else {
+        load_A = A_up;   load_local_row = load_safe_row - gate_m;
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 8];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 112);
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            cb_lds[load_tile_row * 8 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 112;
+        const unsigned char* dp = (const unsigned char*)(gp + 16);
+        const int cb_base = my_tile_row * 8;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = cb_lds[cb_base + (q)]
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < gate_m) {
+                        Y = Y_gate; proj_row = out_row;            out_stride = gate_m;
+                    } else {
+                        Y = Y_up;   proj_row = out_row - gate_m;   out_stride = up_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_hfq3g256_residual_wmma_mb4.hip
+++ b/kernels/src/gemm_hfq3g256_residual_wmma_mb4.hip
@@ -1,0 +1,159 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// HFQ3 (uniform-MQ3) WMMA residual GEMM with 4× batch-tile fanout per WG.
+// Sibling of gemm_mq{3,4}g256_lloyd_..._mb4.hip family. Same multi-batch-
+// tile pattern (16×64 output, 4 distinct named B-vars to defeat compiler
+// register-recycling) — but no cooperative codebook load (HFQ3 has no
+// codebook; sc/zp affine reconstruction is per-group).
+//
+// HFQ3 has no LDS staging and no __syncthreads() — simpler than the Lloyd
+// variants. The 4× batch fanout is the only structural change vs the
+// Phase A WMMA kernel.
+//
+// Group layout: 104 B = 8 B header (sc:f32 + zp:f32) + 96 B 3-bit indices.
+// 6 B per K-tile (16 weights × 3 bits / 8 = 6 B) with cross-byte boundaries.
+//
+// Grid: [ceil(M/16), ceil(batch/64)]. Block: [32]. LDS: 0 B.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq3g256_residual_wmma_mb4(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int my_tile_row = tid & 15;
+    const int safe_row = (row_start + my_tile_row < M) ? (row_start + my_tile_row) : (M - 1);
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 104;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < batch_size) ? (long long)b_idx : 0LL;
+    }
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < batch_size) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                const int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < M) {
+                    Y[(long long)out_col * M + out_row] += acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_mq3g256_lloyd_residual_wmma_mb4.hip
+++ b/kernels/src/gemm_mq3g256_lloyd_residual_wmma_mb4.hip
@@ -1,0 +1,175 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ3-Lloyd WMMA residual GEMM with 4× batch-tile fanout per workgroup.
+// Sibling of gemm_mq4g256_lloyd_residual_wmma_mb4.hip — same multi-batch-
+// tile pattern (16×64 output tile, 4 distinct named B-vars to defeat
+// compiler register-recycling) ported to MQ3-Lloyd's 3-bit cross-byte
+// indices + 8-entry codebook.
+//
+// Group layout (112 B): 16 B fp16 codebook (8 entries) + 96 B 3-bit
+// indices. 6 B per K-tile (16 weights × 3 bits / 8 = 6 B). Decode does
+// per-byte bit extraction with cross-byte boundary at q2/q5/q10/q13.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_mq3g256_lloyd_residual_wmma_mb4(
+    const char*    __restrict__ A,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;  // 4 sub-tiles
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int my_tile_row = tid & 15;
+    const int safe_row = (row_start + my_tile_row < M) ? (row_start + my_tile_row) : (M - 1);
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 112;
+    const char* row_base = A + safe_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < batch_size) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 4;  // MQ3 codebook is 8 entries → 4 fp16 per thread
+    const int safe_load_row = (row_start + load_tile_row < M) ? (row_start + load_tile_row) : (M - 1);
+    const char* load_row_base = A + (long long)safe_load_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 8];  // 256 B (vs MQ4's 512 B — half the codebook)
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        // Cooperative codebook load (32 threads × 4 fp16 = 128 entries = 16 rows × 8).
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 112);
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            cb_lds[load_tile_row * 8 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 112;
+        const unsigned char* dp = (const unsigned char*)(gp + 16);  // skip 16 B codebook header
+        const int cb_base = my_tile_row * 8;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            // === Tile A decode (3-bit cross-byte, 6 bytes → 16 weights) ===
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = cb_lds[cb_base + (q)]
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            // 4 distinct B-vars + 4 WMMAs sharing A_reg.
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            // === Tile B decode (kt+1) ===
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+
+        __syncthreads();
+    }
+
+    // Output write: 4 sub-tiles × 8 outputs/lane.
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < batch_size) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                const int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < M) {
+                    Y[(long long)out_col * M + out_row] += acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_hfq3g256_wmma_mb4.hip
+++ b/kernels/src/gemm_qkv_hfq3g256_wmma_mb4.hip
@@ -1,0 +1,175 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// HFQ3 (uniform-MQ3) WMMA fused QKV GEMM, 4× batch-tile fanout.
+// Sibling of gemm_hfq3g256_residual_wmma_mb4.hip; 3-way fan-out.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_hfq3g256_wmma_mb4(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_q,
+    float*         __restrict__ Y_k,
+    float*         __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)local_row * groups_per_row * 104;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < q_m) {
+                        Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                    } else if (out_row < q_m + k_m) {
+                        Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                    } else {
+                        Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_mq3g256_lloyd_wmma_mb4.hip
+++ b/kernels/src/gemm_qkv_mq3g256_lloyd_wmma_mb4.hip
@@ -1,0 +1,200 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ3-Lloyd WMMA fused QKV GEMM (FA preamble: q + k + v),
+// 4× batch-tile fanout. Sibling of gemm_mq4g256_lloyd_..._mb4.hip family.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_mq3g256_lloyd_wmma_mb4(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_q,
+    float*         __restrict__ Y_k,
+    float*         __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 112;
+    const char* row_base = A + local_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 4;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < q_m) {
+        load_A = A_q;  load_local_row = load_safe_row;
+    } else if (load_safe_row < q_m + k_m) {
+        load_A = A_k;  load_local_row = load_safe_row - q_m;
+    } else {
+        load_A = A_v;  load_local_row = load_safe_row - q_m - k_m;
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 8];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 112);
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            cb_lds[load_tile_row * 8 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 112;
+        const unsigned char* dp = (const unsigned char*)(gp + 16);
+        const int cb_base = my_tile_row * 8;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = cb_lds[cb_base + (q)]
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < q_m) {
+                        Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                    } else if (out_row < q_m + k_m) {
+                        Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                    } else {
+                        Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_hfq3g256_wmma_mb4.hip
+++ b/kernels/src/gemm_qkvza_hfq3g256_wmma_mb4.hip
@@ -1,0 +1,184 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// HFQ3 (uniform-MQ3) WMMA fused QKVZA GEMM, 4× batch-tile fanout.
+// Sibling of gemm_hfq3g256_residual_wmma_mb4.hip; same affine
+// reconstruction (sc, zp per group), same 3-bit cross-byte decode,
+// 4-way fan-out at output write.
+// Group: 104 B. No LDS, no __syncthreads().
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_hfq3g256_wmma_mb4(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)local_row * groups_per_row * 104;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 104;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const unsigned char* dp = (const unsigned char*)(gp + 8);
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = sc_h * (_Float16)(float)(q) + zp_h
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < qkv_m) {
+                        Y = Y_qkv;   proj_row = out_row;                          out_stride = qkv_m;
+                    } else if (out_row < qkv_m + z_m) {
+                        Y = Y_z;     proj_row = out_row - qkv_m;                  out_stride = z_m;
+                    } else if (out_row < qkv_m + z_m + beta_m) {
+                        Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);          out_stride = beta_m;
+                    } else {
+                        Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m); out_stride = alpha_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_mq3g256_lloyd_wmma_mb4.hip
+++ b/kernels/src/gemm_qkvza_mq3g256_lloyd_wmma_mb4.hip
@@ -1,0 +1,211 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ3-Lloyd WMMA fused QKVZA GEMM (LA preamble: qkv + z + beta + alpha),
+// 4× batch-tile fanout. Sibling of gemm_mq4g256_lloyd_..._mb4.hip family.
+// Same multi-batch-tile pattern; MQ3 codebook (8 entries, 256 B LDS) +
+// 3-bit cross-byte K-tile decode.
+// Grid: [ceil(total_m/16), ceil(N/64)]. Block: [32]. LDS: 256 B.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_mq3g256_lloyd_wmma_mb4(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 112;
+    const char* row_base = A + local_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 4;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < qkv_m) {
+        load_A = A_qkv;   load_local_row = load_safe_row;
+    } else if (load_safe_row < qkv_m + z_m) {
+        load_A = A_z;     load_local_row = load_safe_row - qkv_m;
+    } else if (load_safe_row < qkv_m + z_m + beta_m) {
+        load_A = A_beta;  load_local_row = load_safe_row - (qkv_m + z_m);
+    } else {
+        load_A = A_alpha; load_local_row = load_safe_row - (qkv_m + z_m + beta_m);
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 8];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 112);
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            cb_lds[load_tile_row * 8 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 112;
+        const unsigned char* dp = (const unsigned char*)(gp + 16);
+        const int cb_base = my_tile_row * 8;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const unsigned char* dpa = dp + kt * 6;
+            const unsigned char* dpb = dp + (kt + 1) * 6;
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+
+            unsigned int a0 = dpa[0], a1 = dpa[1], a2 = dpa[2];
+            unsigned int a3 = dpa[3], a4 = dpa[4], a5 = dpa[5];
+
+            unsigned int q0  = a0 & 7u;
+            unsigned int q1  = (a0 >> 3) & 7u;
+            unsigned int q2  = ((a0 >> 6) | (a1 << 2)) & 7u;
+            unsigned int q3  = (a1 >> 1) & 7u;
+            unsigned int q4  = (a1 >> 4) & 7u;
+            unsigned int q5  = ((a1 >> 7) | (a2 << 1)) & 7u;
+            unsigned int q6  = (a2 >> 2) & 7u;
+            unsigned int q7  = (a2 >> 5) & 7u;
+            unsigned int q8  = a3 & 7u;
+            unsigned int q9  = (a3 >> 3) & 7u;
+            unsigned int q10 = ((a3 >> 6) | (a4 << 2)) & 7u;
+            unsigned int q11 = (a4 >> 1) & 7u;
+            unsigned int q12 = (a4 >> 4) & 7u;
+            unsigned int q13 = ((a4 >> 7) | (a5 << 1)) & 7u;
+            unsigned int q14 = (a5 >> 2) & 7u;
+            unsigned int q15 = (a5 >> 5) & 7u;
+
+            half16_t a_reg;
+            #define DQ(i, q) a_reg[i] = cb_lds[cb_base + (q)]
+            DQ(0,  q0);  DQ(1,  q1);  DQ(2,  q2);  DQ(3,  q3);
+            DQ(4,  q4);  DQ(5,  q5);  DQ(6,  q6);  DQ(7,  q7);
+            DQ(8,  q8);  DQ(9,  q9);  DQ(10, q10); DQ(11, q11);
+            DQ(12, q12); DQ(13, q13); DQ(14, q14); DQ(15, q15);
+
+            half16_t b0a = *(const half16_t*)(xg_s[0] + k_off_a);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + k_off_a);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + k_off_a);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + k_off_a);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            unsigned int B0 = dpb[0], B1 = dpb[1], B2 = dpb[2];
+            unsigned int B3 = dpb[3], B4 = dpb[4], B5 = dpb[5];
+
+            unsigned int Q0  = B0 & 7u;
+            unsigned int Q1  = (B0 >> 3) & 7u;
+            unsigned int Q2  = ((B0 >> 6) | (B1 << 2)) & 7u;
+            unsigned int Q3  = (B1 >> 1) & 7u;
+            unsigned int Q4  = (B1 >> 4) & 7u;
+            unsigned int Q5  = ((B1 >> 7) | (B2 << 1)) & 7u;
+            unsigned int Q6  = (B2 >> 2) & 7u;
+            unsigned int Q7  = (B2 >> 5) & 7u;
+            unsigned int Q8  = B3 & 7u;
+            unsigned int Q9  = (B3 >> 3) & 7u;
+            unsigned int Q10 = ((B3 >> 6) | (B4 << 2)) & 7u;
+            unsigned int Q11 = (B4 >> 1) & 7u;
+            unsigned int Q12 = (B4 >> 4) & 7u;
+            unsigned int Q13 = ((B4 >> 7) | (B5 << 1)) & 7u;
+            unsigned int Q14 = (B5 >> 2) & 7u;
+            unsigned int Q15 = (B5 >> 5) & 7u;
+
+            DQ(0,  Q0);  DQ(1,  Q1);  DQ(2,  Q2);  DQ(3,  Q3);
+            DQ(4,  Q4);  DQ(5,  Q5);  DQ(6,  Q6);  DQ(7,  Q7);
+            DQ(8,  Q8);  DQ(9,  Q9);  DQ(10, Q10); DQ(11, Q11);
+            DQ(12, Q12); DQ(13, Q13); DQ(14, Q14); DQ(15, Q15);
+            #undef DQ
+
+            half16_t b0b = *(const half16_t*)(xg_s[0] + k_off_b);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + k_off_b);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + k_off_b);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + k_off_b);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < qkv_m) {
+                        Y = Y_qkv;   proj_row = out_row;                          out_stride = qkv_m;
+                    } else if (out_row < qkv_m + z_m) {
+                        Y = Y_z;     proj_row = out_row - qkv_m;                  out_stride = z_m;
+                    } else if (out_row < qkv_m + z_m + beta_m) {
+                        Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);          out_stride = beta_m;
+                    } else {
+                        Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m); out_stride = alpha_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the multi-batch-tile (`_mb4`) pattern from MQ4-Lloyd Phase D
to **HFQ3 (uniform-MQ3) AND MQ3-Lloyd** jointly. 8 new kernels,
size-gated dispatch, env-overridable for A/B benching. Two existing
commits from `feat/mq3-batch-fanout`:

- `659afc74` — feat(mq3): _mb4 batch-tile fanout for HFQ3 + MQ3-Lloyd
- `a268d3d1` — test+bench(mq3): HFQ3 _wmma vs _mb4 bit-exact parity + 4B-Lloyd row

Plus the gfx1100 cross-arch confirmation requested by the maintainer:

- `0c76d31c` — docs(mq3): gfx1100 cross-arch confirmation for _mb4

Plus a clean merge of upstream/master to integrate concurrent #224/#225
HFP4 work (`8ff7c73b`).

Devlog with full bench config, model md5s, raw numbers, and gfx1100
section: [\`benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md\`](benchmarks/results/devlog_20260510_mq3_batch_fanout_gfx1151.md)

---

## What changed

**8 new kernels** following the Phase-D `_mb4` template (16×64 output
tile per WG, 4 batch sub-tiles share `a_reg` decode, 4 distinct named
B-vars to defeat compiler register-recycling):

| HFQ3 (uniform, no LDS, no syncs) | MQ3-Lloyd (256 B codebook in LDS) |
|---|---|
| \`gemm_hfq3g256_residual_wmma_mb4.hip\` | \`gemm_mq3g256_lloyd_residual_wmma_mb4.hip\` |
| \`gemm_qkvza_hfq3g256_wmma_mb4.hip\` | \`gemm_qkvza_mq3g256_lloyd_wmma_mb4.hip\` |
| \`gemm_qkv_hfq3g256_wmma_mb4.hip\` | \`gemm_qkv_mq3g256_lloyd_wmma_mb4.hip\` |
| \`gemm_gate_up_hfq3g256_wmma_mb4.hip\` | \`gemm_gate_up_mq3g256_lloyd_wmma_mb4.hip\` |

**Size-gated dispatch** on each existing `_wmma` method: routes to
`_mb4` when `batch ≥ 128 AND total_m ≥ 4096 AND arch ∈
{gfx1100,1101,1102,1150,1151}`. gfx12 deliberately excluded.
Env override `HIPFIRE_MQ3_MB4={0|1}` for A/B benching (single var
covers both HFQ3 and MQ3-Lloyd dispatch).

---

## Uplifts

### gfx1151 (Radeon 8060S, Strix Halo APU, LPDDR5x ~250 GB/s, ROCm 7.12)

3 fresh-process runs × 2 modes, prefill=256, asym3, GRAPH=1, --prefill-runs 3 --gen 30 --warmup 5:

| Model | MB4=0 | MB4=1 | Δ | gen Δ |
|---|---|---|---|---|
| qwen3.5-9b.mq3 (uniform) | 518.1 tok/s | 914.9 tok/s | **+76.6 %** | -0.6 % |
| qwen3.5-9b.mq3-lloyd | 502.9 tok/s | 842.8 tok/s | **+67.6 %** | -0.4 % |
| qwen3.5-4b.mq3-lloyd | 987.8 tok/s | 1586.4 tok/s | **+60.6 %** | -0.7 % |

### gfx1100 cross-arch confirmation (RX 7900 XT, GDDR6 ~800 GB/s, ROCm 7.2)

| Model | MB4=0 | MB4=1 | Δ | gen Δ |
|---|---|---|---|---|
| qwen3.5-9b.mq3 (uniform) | 1716.1 tok/s | 2002.6 tok/s | **+16.7 %** | -0.5 % |
| qwen3.5-9b.mq3-lloyd | 1463.5 tok/s | 1859.7 tok/s | **+27.1 %** | -0.1 % |
| qwen3.5-4b.mq3-lloyd | 2641.3 tok/s | 3088.7 tok/s | **+16.9 %** | +0.8 % |

Stddev across the 3 runs is <0.5 % per cell — every Δ is many sigma
outside noise. gfx1100 absolute baseline is 3.3× higher than gfx1151
(consistent with GDDR6 vs LPDDR5x bandwidth ratio), so the kernels
were already closer to compute saturation pre-mb4 — Δ % is smaller
on gfx1100 but still solidly positive.

**Local-vs-maintainer offset disclosure:** the gfx1100 absolute numbers
above are from an RX 7900 XT, ~10 % slower than the maintainer's
perf-optimized 7900 XTX reference. Multiply by 1.10 for the
maintainer-machine equivalent. The Δ % is unaffected and is the
load-bearing number for cross-arch confirmation.

### Notable: Lloyd / uniform-MQ3 ratio at 9B

| Phase | gfx1151 ratio | gfx1100 ratio |
|---|---|---|
| Pre-mb4  | 97.1 % | **85.3 %** |
| Post-mb4 | 92.1 % | **92.9 %** |

Pre-mb4 Lloyd was hit *harder* by the 16×16 wall on gfx1100 (the
extra cooperative codebook + syncthread overhead matters more when the
SIMDs are otherwise faster). mb4 closes the gap entirely — post-mb4
the gfx1100 ratio (92.9 %) lands on top of gfx1151's (92.1 %).

---

## Correctness checks

### Bit-exact parity (gfx1151 + gfx1100, run on both)

**MQ3-Lloyd `_mb4` vs CPU fp64 reference** via existing
`test_gemm_mq3g256_lloyd_residual_wmma` and
`test_gemm_fused_mq3g256_lloyd_wmma` with `HIPFIRE_MQ3_MB4=1`:
bit-exact across all 8 residual + 8 fused (qkvza/qkv/gate_up) shapes.

**HFQ3 `_mb4` vs `_wmma`** (new test in this PR,
`test_gemm_hfq3g256_wmma`, GPU-vs-GPU on identical inputs):

```
GPU: gfx1100   (and gfx1151 — both confirmed)
ALL PASS — HFQ3 _mb4 produces output bit-equivalent to _wmma
```

`max_abs = max_rel = rms = 0.000e0` across all 13 production-relevant
shapes (5 residual + 3 qkvza + 3 qkv + 2 gate_up) on both archs.
No fp32-reorder envelope opens because `_mb4` just multiplexes 4
sub-tiles in time — each WMMA accumulator is independent and inherits
`_wmma`'s production-validated correctness mechanically.

### Decode regression — none (both archs)

`gen_tok_s` invariant across MB4 modes for all three benchmarked
models, on both gfx1151 and gfx1100 — within ±1 % everywhere.
`bw_gib_s` (decode bandwidth) likewise invariant. mb4 only touches
the prefill batched-LA path; per-token decode goes through
`forward_scratch` + GEMV, untouched.

### Size-gate validation (gfx1151)

Force `MB4=1` at prefill=16 on 9B-MQ3 (uniform) regresses 25 % (479 →
361) — confirms the gate's necessity at small batch where 4× WG
reduction starves the SIMDs. Default mode (no env var) at prefill=16
correctly falls through to `_wmma` and matches the baseline.

---

## Test plan

- [ ] `cargo build --release --example bench_qwen35_mq4 --example test_gemm_hfq3g256_wmma`
- [ ] Parity: `./target/release/examples/test_gemm_hfq3g256_wmma` → expect `ALL PASS — HFQ3 _mb4 produces output bit-equivalent to _wmma`
- [ ] Parity (existing): `HIPFIRE_MQ3_MB4=1 ./target/release/examples/test_gemm_mq3g256_lloyd_residual_wmma` and `HIPFIRE_MQ3_MB4=1 ./target/release/examples/test_gemm_fused_mq3g256_lloyd_wmma` → bit-exact across 16 shapes
- [ ] A/B prefill: `HIPFIRE_MQ3_MB4={0,1} HIPFIRE_KV_MODE=asym3 HIPFIRE_GRAPH=1 ./target/release/examples/bench_qwen35_mq4 ~/.hipfire/models/qwen3.5-9b.mq3 --prefill 256 --prefill-runs 3 --warmup 5 --gen 30` → expect MB4=1 ≥ 1.6× MB4=0 prefill on gfx1151, ≥ 1.15× on gfx1100
- [ ] Same for `qwen3.5-9b.mq3-lloyd` and `qwen3.5-4b.mq3-lloyd`
- [ ] Verify decode `gen_tok_s` invariant (within ±1 %) across MB4 modes for all three models
- [ ] Size-gate sanity: force `HIPFIRE_MQ3_MB4=1 ... --prefill 16` regresses; default mode at `--prefill 16` matches baseline

---

## Open / follow-ups

- HFQ3 `_mb4` parity test landed in this PR; previously only had
  end-to-end coverage via integrated bench (a268d3d1 addresses that gap)
- Coverage for additional MQ3-Lloyd-in-MoE paths is unchanged from
  master — mb4 follows the same dispatch hooks as the existing `_wmma`
  routing, no MoE-specific changes needed
- gfx12 deliberately excluded from `_mb4` selectors; sibling work for
  gfx12 deferred per maintainer note in the original commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)