### PR TITLE
perf(tokenizer): hot-path hardening — cache merge_rank, allocator-free SP scan

### DIFF
--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -18,7 +18,13 @@ pub struct Tokenizer {
     /// merges count, ~150K for Qwen3+ — without this, ~50ms per encode call,
     /// which compounds across the 9+ encodes-per-request the daemon does for
     /// chat-template scaffolding and adds ~450ms to TTFT for short prompts).
-    merge_rank: HashMap<(String, String), usize>,
+    ///
+    /// Named `merge_pair_rank` (not `merge_rank`) to disambiguate from the
+    /// public `merge_rank(&self, id: u32) -> Option<usize>` diagnostic
+    /// method (token-id → rank, O(merges) linear scan — different lookup,
+    /// different shape). The two compiled fine sharing a name but invited
+    /// subtle field-vs-method confusion at call sites.
+    merge_pair_rank: HashMap<(String, String), usize>,
     /// Special tokens: strings like "<|im_start|>" → their token ID
     /// Sorted longest-first for greedy matching
     special_tokens: Vec<(String, u32)>,
@@ -37,7 +43,7 @@ pub struct Tokenizer {
 /// Pre-build the BPE merge-rank lookup. Called once at tokenizer construction
 /// time to amortize the O(M) String-clone-into-HashMap across the lifetime of
 /// the tokenizer rather than paying it per encode call.
-fn build_merge_rank(merges: &[(String, String)]) -> HashMap<(String, String), usize> {
+fn build_merge_pair_rank(merges: &[(String, String)]) -> HashMap<(String, String), usize> {
     merges
         .iter()
         .enumerate()
@@ -112,13 +118,13 @@ impl Tokenizer {
         // Sort longest-first for greedy matching
         special_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
 
-        let merge_rank = build_merge_rank(&merges);
+        let merge_pair_rank = build_merge_pair_rank(&merges);
 
         Some(Tokenizer {
             vocab,
             token_to_id,
             merges,
-            merge_rank,
+            merge_pair_rank,
             special_tokens,
             bos_id,
             eos_id,
@@ -208,13 +214,13 @@ impl Tokenizer {
 
         let is_gpt2_bpe = token_to_id.contains_key("Ġthe") || token_to_id.contains_key("Ġ");
 
-        let merge_rank = build_merge_rank(&merges);
+        let merge_pair_rank = build_merge_pair_rank(&merges);
 
         Some(Tokenizer {
             vocab,
             token_to_id,
             merges,
-            merge_rank,
+            merge_pair_rank,
             special_tokens,
             bos_id,
             eos_id,
@@ -310,13 +316,13 @@ impl Tokenizer {
         }
         special_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
 
-        let merge_rank = build_merge_rank(&merges);
+        let merge_pair_rank = build_merge_pair_rank(&merges);
 
         Some(Tokenizer {
             vocab,
             token_to_id,
             merges,
-            merge_rank,
+            merge_pair_rank,
             special_tokens,
             bos_id,
             eos_id,
@@ -453,23 +459,58 @@ impl Tokenizer {
     }
 
     /// SentencePiece greedy encoding: prepend ▁ for spaces, longest-match lookup.
+    ///
+    /// Each suffix trial is a `&str` slice of `sp_text` keyed against
+    /// `token_to_id` (HashMap's `Borrow<str>` impl matches `String` keys
+    /// against `&str` lookups by hash). The previous impl built a
+    /// `Vec<char>` and reallocated a `String` per trial — same iteration
+    /// shape, but allocator-heavy on long prompts.
+    ///
+    /// Algorithmic shape (unchanged from the pre-rewrite code): for each
+    /// position `pos` we scan `end` from `n_chars` down to `pos+1`,
+    /// stopping at the first vocab match (greedy longest). The loop has
+    /// no `max_token_len` cap — typical inputs `break` early once a
+    /// match is found, but worst-case unmatchable suffixes are O(N²)
+    /// HashMap lookups. Capping by a precomputed `max_token_chars`
+    /// would fix this and is tracked as a follow-up; this PR is scoped
+    /// to allocator pressure only.
+    ///
+    /// Note: the single-char fallback silently *drops* missing chars
+    /// (cf. #203) — different failure mode from `encode_gpt2_bpe`'s
+    /// `unwrap_or(0)`. Fix is a separate concern from this PR.
     fn encode_sentencepiece(&self, text: &str) -> Vec<u32> {
         let mut tokens = Vec::new();
-        // SentencePiece convention: spaces become ▁, start of text gets ▁
-        let sp_text = text.replace(' ', "\u{2581}");
-        let sp_text = format!("\u{2581}{}", sp_text);
+        // SentencePiece convention: spaces become ▁, start of text gets ▁.
+        // Single-pass build: the prior `text.replace(...)` + `format!(...)`
+        // allocated twice; iterating chars and pushing into a pre-sized
+        // String allocates once. ▁ is 3 bytes UTF-8, so the worst case
+        // (all-space input) needs `text.len() * 3 + 3` bytes; typical
+        // inputs fit in the lower-bound hint and the String grows only
+        // if needed.
+        let mut sp_text = String::with_capacity(text.len() + 3);
+        sp_text.push('\u{2581}');
+        for ch in text.chars() {
+            sp_text.push(if ch == ' ' { '\u{2581}' } else { ch });
+        }
 
-        let chars: Vec<char> = sp_text.chars().collect();
-        let mut pos = 0;
+        // Char-boundary byte offsets. `boundaries[i]` is the byte index of
+        // char `i`; the trailing entry is `sp_text.len()` so `boundaries[end]`
+        // is always a valid slice endpoint, including `end == n_chars`.
+        let mut boundaries: Vec<usize> = Vec::with_capacity(sp_text.len() + 1);
+        for (i, _) in sp_text.char_indices() {
+            boundaries.push(i);
+        }
+        boundaries.push(sp_text.len());
+        let n_chars = boundaries.len() - 1;
 
-        while pos < chars.len() {
-            // Greedy longest match from vocabulary
+        let mut pos = 0usize;
+        while pos < n_chars {
+            // Greedy longest match from vocabulary (high-`end` first).
             let mut best_len = 0;
             let mut best_id = 0u32;
-
-            for end in (pos + 1..=chars.len()).rev() {
-                let candidate: String = chars[pos..end].iter().collect();
-                if let Some(&id) = self.token_to_id.get(&candidate) {
+            for end in (pos + 1..=n_chars).rev() {
+                let candidate = &sp_text[boundaries[pos]..boundaries[end]];
+                if let Some(&id) = self.token_to_id.get(candidate) {
                     best_len = end - pos;
                     best_id = id;
                     break;
@@ -477,9 +518,10 @@ impl Tokenizer {
             }
 
             if best_len == 0 {
-                // Single character fallback — look up the byte
-                let ch = chars[pos];
-                if let Some(&id) = self.token_to_id.get(&ch.to_string()) {
+                // Single-character fallback — look up the byte slice for
+                // the one char at `pos`. Silently skips unknown chars.
+                let ch_slice = &sp_text[boundaries[pos]..boundaries[pos + 1]];
+                if let Some(&id) = self.token_to_id.get(ch_slice) {
                     tokens.push(id);
                 }
                 pos += 1;
@@ -540,7 +582,7 @@ impl Tokenizer {
         // with ~150K merges); the daemon makes 9+ encode calls per request
         // for chat-template scaffolding, so the per-call rebuild added
         // ~450ms to TTFT for short prompts. Now O(1) per encode.
-        let merge_rank = &self.merge_rank;
+        let merge_rank = &self.merge_pair_rank;
 
         // 3. Doubly-linked-list state. `prev/next` are i32 with -1 sentinel.
         let mut prev: Vec<i32> = (0..n as i32).map(|i| i - 1).collect();
@@ -1185,12 +1227,12 @@ mod bpe_tests {
             .iter()
             .map(|(l, r)| (l.to_string(), r.to_string()))
             .collect();
-        let merge_rank = build_merge_rank(&merges);
+        let merge_pair_rank = build_merge_pair_rank(&merges);
         Tokenizer {
             vocab,
             token_to_id,
             merges,
-            merge_rank,
+            merge_pair_rank,
             special_tokens: Vec::new(),
             bos_id: 0,
             eos_id: 0,
@@ -1279,6 +1321,82 @@ mod bpe_tests {
         // pointing at vocab id 2 ("aaaa").
         assert_eq!(out.len(), 256);
         assert!(out.iter().all(|&id| id == 2));
+    }
+}
+
+#[cfg(test)]
+mod sp_tests {
+    //! Tests for `encode_sentencepiece`. Added alongside the
+    //! `Vec<char>` + per-trial `String::collect()` → `Vec<usize>`
+    //! boundary-offset + `&str` slice rewrite. The four cases below
+    //! cover the boundary-vec correctness contract (off-by-one between
+    //! char index and byte offset, multi-byte UTF-8, and the
+    //! `best_len == 0` fallback branch).
+
+    use super::*;
+
+    /// Build a synthetic SentencePiece Tokenizer from a vocab list.
+    /// `is_gpt2_bpe = false` selects the SentencePiece encode path.
+    /// No merges (SP doesn't use them).
+    fn synth_sp(vocab: &[&str]) -> Tokenizer {
+        let vocab: Vec<String> = vocab.iter().map(|s| s.to_string()).collect();
+        let token_to_id: HashMap<String, u32> = vocab
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.clone(), i as u32))
+            .collect();
+        let merges: Vec<(String, String)> = Vec::new();
+        let merge_pair_rank = build_merge_pair_rank(&merges);
+        Tokenizer {
+            vocab,
+            token_to_id,
+            merges,
+            merge_pair_rank,
+            special_tokens: Vec::new(),
+            bos_id: 0,
+            eos_id: 0,
+            eot_id: None,
+            is_gpt2_bpe: false,
+        }
+    }
+
+    #[test]
+    fn sp_encode_longest_match_ascii() {
+        // Vocab has the full "▁hello" plus shorter prefixes. sp_text is
+        // "▁hello"; greedy starts at end=6 (full string) and matches
+        // immediately → single token.
+        let tok = synth_sp(&["\u{2581}hello", "\u{2581}", "h", "e", "l", "o"]);
+        assert_eq!(tok.encode_sentencepiece("hello"), vec![0]);
+    }
+
+    #[test]
+    fn sp_encode_multibyte_char() {
+        // 4-byte UTF-8 emoji 🦀 (U+1F980). sp_text = "▁🦀" (3 + 4 = 7
+        // bytes, 2 chars). boundaries = [0, 3, 7]. Vocab has "▁" and
+        // "🦀" individually but not the pair. Expected: [0, 1].
+        // Guards `boundaries[pos]..boundaries[end]` against off-by-one
+        // when char span ≠ byte span.
+        let tok = synth_sp(&["\u{2581}", "\u{1F980}"]);
+        assert_eq!(tok.encode_sentencepiece("\u{1F980}"), vec![0, 1]);
+    }
+
+    #[test]
+    fn sp_encode_unmatched_fallback() {
+        // sp_text = "▁ab"; vocab has "▁" and "a" but not "b". The "b"
+        // position drives `best_len == 0`; the fallback slice
+        // `boundaries[pos]..boundaries[pos+1]` looks up "b", which is
+        // also absent, and the position is silently skipped.
+        let tok = synth_sp(&["\u{2581}", "a"]);
+        assert_eq!(tok.encode_sentencepiece("ab"), vec![0, 1]);
+    }
+
+    #[test]
+    fn sp_encode_space_substitution() {
+        // Spaces become ▁. "hello world" → "▁hello▁world" → matches
+        // "▁hello" (id 0) then "▁world" (id 1). Verifies the single-pass
+        // `sp_text` build correctly substitutes spaces.
+        let tok = synth_sp(&["\u{2581}hello", "\u{2581}world"]);
+        assert_eq!(tok.encode_sentencepiece("hello world"), vec![0, 1]);
     }
 }
 


### PR DESCRIPTION
Closes #202.

**Rebased onto upstream master** to drop the `merge_rank`-cache half (now redundant with #226, already merged). What remains is the SentencePiece-side allocator-pressure work and the F1 readability rename that #226 left on the table.

## Summary

1. **`encode_sentencepiece` allocator-free scan.** A `Vec<usize>` of char-boundary byte offsets replaces the old `Vec<char>`; trials are `&str` slices into `sp_text`, looked up via `HashMap<String, u32>::get(&str)` (`Borrow<str>` impl). `sp_text` itself is now built in a single pass (was: `text.replace(' ', "▁")` + `format!(...)` → two allocations).
2. **Field `merge_rank` renamed → `merge_pair_rank`.** The existing public `merge_rank(&self, id: u32) -> Option<usize>` diagnostic method (token-id → rank, O(merges) linear scan — different lookup) shared the name with #226's new field. Compiled fine, but field-vs-method call syntax is a single paren apart. Helper renamed correspondingly: `build_merge_rank` → `build_merge_pair_rank`.
3. **New `sp_tests` module.** ASCII longest-match, 4-byte UTF-8 (🦀) boundary safety, unmatched-fallback, space substitution. The pre-rebase SP path had zero direct test coverage.
4. **Doc comment rewrite.** Honestly describes the algorithm: no `max_token_len` cap, worst-case O(N²) on unmatchable tails (pre-existing — preserved here, not introduced). #203's silent-skip in the SP fallback is called out explicitly.

## Diff size

143 insertions / 25 deletions on `crates/hipfire-runtime/src/tokenizer.rs`. Single commit.

## Deferred (per `docs/plans/tokenizer-interned-symbols-202-203.md`)

- `syms` as `Vec<u32>` + `(u32,u32)` keys for `merge_pair_rank` (eliminates ~64K residual `push_pair` String clones per encode call)
- `max_token_chars` cap on the SentencePiece greedy scan (bounds worst-case unmatchable-suffix lookups)
- Loud OOV handling at construction time (#203 — `Result<Self, TokenizerError>` constructors with vocab/merges consistency check)

These three plus #203 share an architectural change (interned symbols) and are bundled into one follow-up PR.

## Test plan

- [x] `cargo test -p hipfire-runtime --lib tokenizer::` — 47 pass (43 prior + 4 new SP tests)
- [x] `cargo build -p hipfire-runtime` — clean (only pre-existing unrelated warnings)
- [ ] Multi-segment prefill bench against #134's reported workload — deferred to a separate verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)