### PR TITLE
AR + DFlash think-policy: GPU kernel + state machine + repeat penalty wiring (continuation of #221)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 # JIT-compiled kernel cache
 kernels/compiled/
 .hipfire_kernels/
+.hipfire_kernels
 
 # Agent / tool state
 .serena/
@@ -90,3 +91,5 @@ research/
 .codeinsight+research/
 
 bench/coherence-results/
+
+PR_DESCRIPTION.md

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1261,6 +1261,11 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
     genMsg.assistant_prefix = "closed_think";
   } else if (modelCfg.max_think_tokens > 0) {
     genMsg.max_think_tokens = modelCfg.max_think_tokens;
+    // When thinking budget is hit, daemon injects </think> so generation
+    // can continue into visible answer instead of stopping inside an
+    // unclosed <think> block (which leaves empty visible output after strip).
+    genMsg.budget_alert_at_tok = modelCfg.max_think_tokens;
+    genMsg.budget_alert_text = "</think>\n\n";
   }
   if (image) {
     genMsg.image = resolve(image);
@@ -1676,6 +1681,33 @@ async function serve(port: number) {
           if (reasoningEffort === 0) delete genParams.max_think_tokens;
           else genParams.max_think_tokens = reasoningEffort;
         }
+        // Budget-aware think cap.
+        //
+        // The daemon can only force-close <think> if max_think_tokens fires
+        // before request max_tokens is exhausted. Without this clamp:
+        //   max_tokens=200, max_think_tokens=256
+        // means the model can spend the whole request budget inside <think>,
+        // after which the OpenAI wrapper strips the unclosed block and
+        // returns content:"".
+        const minVisibleAfterThink = Math.max(
+          1,
+          Number(process.env.HIPFIRE_MIN_VISIBLE_AFTER_THINK ?? 32) || 32,
+        );
+        const closeThinkOverheadGuess = 8;
+        const thinkBudgetCap = Math.max(
+          1,
+          requestMaxTokens - minVisibleAfterThink - closeThinkOverheadGuess,
+        );
+        if (enableThinking !== false && effective.thinking !== "off" && !preserveThinking) {
+          if (genParams.max_think_tokens == null) {
+            genParams.max_think_tokens = thinkBudgetCap;
+          } else if (genParams.max_think_tokens > 1) {
+            genParams.max_think_tokens = Math.min(
+              genParams.max_think_tokens,
+              thinkBudgetCap,
+            );
+          }
+        }
         // Wire thinking control for both legacy assistant_prefix
         // (ChatFrame::ClosedThink) and the new Jinja template path.
         // The Jinja path uses max_think_tokens==1 as the signal for
@@ -2044,7 +2076,21 @@ async function serve(port: number) {
 
         // Check for tool calls in response
         const parsed = parseToolCalls(content);
-        const choice: any = { index: 0, finish_reason: parsed.tool_calls ? "tool_calls" : "stop" };
+
+        // Detect max_tokens exhaustion inside unclosed think block
+        const openThink = strippedContent.lastIndexOf("<think>");
+        const closeThink = strippedContent.lastIndexOf("</think>");
+        const endedInsideThink = openThink >= 0 && openThink > closeThink;
+        const exhaustedBudget = completionTokens >= requestMaxTokens;
+
+        const choice: any = {
+          index: 0,
+          finish_reason: parsed.tool_calls
+            ? "tool_calls"
+            : exhaustedBudget && endedInsideThink
+              ? "length"
+              : "stop",
+        };
         if (parsed.tool_calls) {
           choice.message = { role: "assistant", content: parsed.content, tool_calls: parsed.tool_calls };
         } else {

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -2423,6 +2423,7 @@ pub fn spec_step_dflash(
     pld_spine: Option<&[u32]>,
     repeat_penalty: f32,
     repeat_window: usize,
+    ban_token_id: Option<u32>,
 ) -> HipResult<SpecStepResult> {
     // Effective block size for THIS step. Usually `draft_cfg.block_size`
     // (what the draft was trained at, 16 for Qwen3.5-*-DFlash) but a caller
@@ -2715,23 +2716,45 @@ pub fn spec_step_dflash(
                 drafted.push(t);
                 draft_softmaxes.push(probs);
             }
-        } else if host_path_active {
-            // RP / n-gram-block path: apply per-row penalties before argmax
-            // so draft and target pick from the same reshaped distribution.
-            // Keeps spec-decode aligned (τ doesn't collapse from mismatched
-            // argmaxes — both sides see identical -inf logits on banned toks).
-            let host_logits = gpu.download_f32(&logits_batch)?;
-            debug_assert_eq!(host_logits.len(), batch * vocab);
-            let mut row = vec![0f32; vocab];
-            for i in 0..batch {
-                row.copy_from_slice(&host_logits[i * vocab..(i + 1) * vocab]);
-                if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
-                }
-                if ngram_block_active {
-                    llama::apply_ngram_block(&mut row, prev_committed);
-                }
-                drafted.push(argmax_u32(&row));
+        } else if rp_active || ngram_block_active {
+            // RP / n-gram-block path: apply per-row penalties via GPU compound
+            // kernel (repeat_penalty_argmax_batched) — avoids CPU D2H of
+            // B×vocab logits. Same logic as the target verify path.
+            let upload_len = prev_committed.len().min(repeat_window.max(1));
+            let upload_start = prev_committed.len().saturating_sub(upload_len);
+            let upload_slice = &prev_committed[upload_start..];
+            let upload_bytes: Vec<u8> = upload_slice.iter().flat_map(|t| t.to_ne_bytes()).collect();
+            let prev_gpu = &verify_scratch.rot;
+            let prev_cap = prev_gpu.buf.size() / 4;
+            let eff_window = upload_len.min(prev_cap);
+            if eff_window > 0 {
+                let _ = gpu.hip.memcpy_htod(&prev_gpu.buf, &upload_bytes[..eff_window * 4]);
+            }
+            // Upload block tokens (seed + draft so far) to argmax buffer
+            let block_gpu = &verify_scratch.argmax;
+            let block_eff = (batch + 1).min(block_gpu.buf.size() / 4);
+            if block_eff > 0 {
+                let block_bytes: Vec<u8> = block[..block_eff].iter().flat_map(|t| t.to_ne_bytes()).collect();
+                let _ = gpu.hip.memcpy_htod(&block_gpu.buf, &block_bytes);
+            }
+            gpu.repeat_penalty_argmax_batched(
+                &logits_batch,          // (batch)×vocab logits on GPU
+                &verify_scratch.argmax, // batch×4 result
+                prev_gpu, block_gpu,
+                vocab, batch,
+                eff_window, repeat_window, repeat_penalty,
+                ngram_block_active,
+                ban_token_id,
+            )?;
+            let mut host_idx = vec![0i32; batch];
+            {
+                let bytes: &mut [u8] = unsafe {
+                    std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, batch * 4)
+                };
+                gpu.hip.memcpy_dtoh(bytes, &verify_scratch.argmax.buf)?;
+            }
+            for &idx in &host_idx {
+                drafted.push(idx as u32);
             }
         } else {
             // GPU argmax over (B-1) rows — one kernel, small D2H.
@@ -2860,7 +2883,7 @@ pub fn spec_step_dflash(
     let verify_out = verify_dflash_block(
         gpu, target, &block, position, hidden_rb,
         gdn_tape_opt.as_deref_mut(),
-        use_temp_sampling || host_path_active,  // full target logits needed for rejection sampling, RP, or n-gram block
+        use_temp_sampling,  // full logits only needed for temp>0 rejection sampling
         verify_scratch,
     )?;
 
@@ -2949,25 +2972,53 @@ pub fn spec_step_dflash(
             sample_categorical(&target_probs, u)
         };
     } else {
-        // Greedy path. If RP or n-gram-block is active, re-derive argmax per
-        // row after applying penalties to the full target logits (requires
-        // want_full_logits). `prev_committed` carries the emitted history
-        // used as the penalty / block window.
-        let argmax_per_pos: std::borrow::Cow<'_, [u32]> = if host_path_active {
-            let tgt_logits = &verify_out.logits_per_pos;
-            debug_assert_eq!(tgt_logits.len(), b * vocab);
-            let mut out: Vec<u32> = Vec::with_capacity(b);
-            let mut row = vec![0f32; vocab];
-            for i in 0..b {
-                row.copy_from_slice(&tgt_logits[i * vocab..(i + 1) * vocab]);
-                if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
-                }
-                if ngram_block_active {
-                    llama::apply_ngram_block(&mut row, prev_committed);
-                }
-                out.push(argmax_u32(&row));
+        // Greedy path. If RP or n-gram-block is active, apply penalties via GPU
+        // compound kernel (repeat_penalty_argmax_batched) instead of the CPU
+        // host_path — avoids downloading B×vocab logits for per-row CPU processing.
+        let argmax_per_pos: std::borrow::Cow<'_, [u32]> = if rp_active || ngram_block_active {
+            // Upload committed history to GPU (last `repeat_window` tokens)
+            let upload_len = prev_committed.len().min(repeat_window.max(1));
+            let upload_start = prev_committed.len().saturating_sub(upload_len);
+            let upload_slice = &prev_committed[upload_start..];
+            let upload_bytes: Vec<u8> = upload_slice.iter().flat_map(|t| t.to_ne_bytes()).collect();
+            // Reuse verify_scratch.rot as the prev_committed GPU buffer (same size class,
+            // lives across cycles). Zero-fill if larger than needed.
+            let prev_gpu = &verify_scratch.rot;
+            let prev_cap = prev_gpu.buf.size() / 4;
+            let eff_window = upload_len.min(prev_cap);
+            if eff_window > 0 {
+                let _ = gpu.hip.memcpy_htod(&prev_gpu.buf, &upload_bytes[..eff_window * 4]);
             }
+            // Upload block tokens to a temp area in verify_scratch.argmax (we'll overwrite
+            // it with the result anyway). block has `b` tokens.
+            let block_gpu = &verify_scratch.argmax;
+            let block_cap = block_gpu.buf.size() / 4;
+            let block_eff = b.min(block_cap);
+            if block_eff > 0 {
+                let block_bytes: Vec<u8> = block[..block_eff].iter().flat_map(|t| t.to_ne_bytes()).collect();
+                let _ = gpu.hip.memcpy_htod(&block_gpu.buf, &block_bytes);
+            }
+            // Launch GPU compound kernel: repeat_penalty + ngram_block + argmax per row
+            gpu.repeat_penalty_argmax_batched(
+                &verify_scratch.logits,  // B×vocab logits (still on GPU from verify)
+                &verify_scratch.argmax,  // B×4 result buffer (will overwrite)
+                prev_gpu,                // upload_len × u32
+                block_gpu,               // b × u32
+                vocab, b,
+                eff_window, // prev_committed_len = uploaded count (kernel uses window internally)
+                repeat_window, repeat_penalty,
+                ngram_block_active,
+                ban_token_id,
+            )?;
+            // Download B×4 bytes of argmax indices
+            let mut host_idx = vec![0i32; b];
+            {
+                let bytes: &mut [u8] = unsafe {
+                    std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, b * 4)
+                };
+                gpu.hip.memcpy_dtoh(bytes, &verify_scratch.argmax.buf)?;
+            }
+            let out: Vec<u32> = host_idx.iter().map(|&i| i as u32).collect();
             std::borrow::Cow::Owned(out)
         } else {
             std::borrow::Cow::Borrowed(verify_out.argmax_per_pos.as_slice())

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2344,6 +2344,7 @@ fn generate_dflash(
                 None,                      // pld_spine
                 1.0_f32,                   // repeat_penalty (off)
                 0,                         // repeat_window
+                None,                      // ban_token_id
             )
         };
         let step = match step_result {
@@ -2638,7 +2639,7 @@ fn generate_multi(
     let gpus = m.pp_gpus.as_mut().unwrap();
 
     let dev_last = gpus.output_device;
-    let vocab_size = config.vocab_size;
+    let vocab_size = config.vocab_size.max(151659);
     let repeat_buf_cap = scratch_set.per_device[dev_last].repeat_buf.buf.size() / 4;
 
     if let Err(e) = qwen35::forward_prefill_batch_multi(
@@ -3146,7 +3147,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     // picks up the signal it needs.
     let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
     let try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some();
-    let new_tokens = if try_jinja {
+    let mut new_tokens = if try_jinja {
         let template = m.chat_template.as_ref().unwrap();
         let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
             tokenizer,
@@ -3179,6 +3180,19 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             raw: false,
         }
         .build_with_user_tokens(&q_tokens)
+    };
+
+    // Inject `<think>` prefix when thinking is enabled. Must be done
+    // BEFORE prefill so the model sees it as part of the prompt.
+    // Look up think token IDs from the tokenizer at runtime (not hardcoded).
+    // Models that lack think tokens (MQ4 vocab-gap, non-Qwen families) return
+    // None → thinking_allowed stays false; ThinkState path no-ops.
+    let (think_start_id, think_end_id, thinking_allowed) = match (
+        tokenizer.special_token_id("<think>"),
+        tokenizer.special_token_id("</think>"),
+    ) {
+        (Some(a), Some(b)) => (a, b, true),
+        _ => (0, 0, false), // Model lacks think tokens — see docs/mq4-think-token-report.md
     };
 
     // KV-budget guard. Without eviction the physical buffer is the hard cap;
@@ -3306,9 +3320,25 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         // need to clear the buffer between calls. The upload is on the same
         // stream as the sample kernel launch, so the copy and compute pipeline
         // naturally.
-        let vocab_size = config.vocab_size;
+        let vocab_size = config.vocab_size.max(151659);
         let mut rng_state: u32 = 0x13579BDFu32;
         let repeat_buf_cap = scratch.repeat_buf.buf.size() / 4;
+
+        // Think-block policy state machine (AR path).
+        // The `<think>` token was injected into new_tokens before prefill,
+        // so it is already in conversation_tokens. Scan to detect it.
+        let mut think_state = sampler::ThinkState::default();
+        {
+            let mut depth: i32 = 0;
+            for &t in m.conversation_tokens.iter() {
+                if t == think_start_id { depth += 1; }
+                else if t == think_end_id && depth > 0 { depth -= 1; }
+            }
+            if depth > 0 {
+                think_state.in_think = true;
+                think_state.think_blocks_seen = 1;
+            }
+        }
 
         // Build the list of paired (open, close) attractor pairs once;
         // sampler::collect_unclosed_attractor_blocks decides per-call
@@ -3333,16 +3363,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             2,
             &mut blocked0,
         );
+        // Merge think-policy bans.
+        sampler::merge_think_bans(&mut blocked0, &think_state, thinking_allowed, think_start_id, think_end_id, think_state.tokens_inside_think);
         let cfg0 = SamplerConfig {
             temperature: temp,
             top_p,
             repeat_penalty,
-            // Window is bounded by the GPU repeat_buf capacity (sized
-            // at 64 in ForwardScratch::new). Pre-PR3 code did this
-            // bound by setting `scope_start = len - repeat_buf_cap`
-            // and passing `scope.len()` to the kernel; we let
-            // sampler::sample do the same `min(window, buf_cap)`
-            // internally.
             repeat_window: repeat_buf_cap,
             blocked_tokens: blocked0,
         };
@@ -3361,6 +3387,9 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         // decode loop below.
         let t_prefill = Instant::now();
         let mut next_token = tok0;
+
+        // Update think state after first token.
+        sampler::update_think_state(&mut think_state, tok0, think_start_id, think_end_id);
 
         let mut generated = 0;
         let mut streamed_tokens: Vec<u32> = Vec::new();
@@ -3552,6 +3581,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                         2,
                         &mut blocked,
                     );
+                    sampler::merge_think_bans(&mut blocked, &think_state, thinking_allowed, think_start_id, think_end_id, think_state.tokens_inside_think);
                     let cfg = SamplerConfig {
                         temperature: temp,
                         top_p,
@@ -3569,6 +3599,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                         &cfg,
                         &mut rng_state,
                     );
+                    sampler::update_think_state(&mut think_state, next_token, think_start_id, think_end_id);
                     continue;
                 }
                 let nudge_tokens = tokenizer.encode(budget_alert_text);
@@ -3633,6 +3664,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                 2,
                 &mut blocked,
             );
+            sampler::merge_think_bans(&mut blocked, &think_state, thinking_allowed, think_start_id, think_end_id, think_state.tokens_inside_think);
             let cfg = SamplerConfig {
                 temperature: temp,
                 top_p,
@@ -3653,6 +3685,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
                 &cfg,
                 &mut rng_state,
             );
+            // Update think state after every token.
+            sampler::update_think_state(&mut think_state, next_token, think_start_id, think_end_id);
         }
         // m.seq_pos is already the "next physical write slot" — advanced
         // per-token in the decode loop above, and evicted back down to

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -1930,7 +1930,7 @@ impl ForwardScratch {
             up: gpu.alloc_tensor(&[config.hidden_dim], DType::F32)?,
             ffn_hidden: gpu.alloc_tensor(&[config.hidden_dim], DType::F32)?,
             ffn_out: gpu.alloc_tensor(&[dim], DType::F32)?,
-            logits: gpu.alloc_tensor(&[config.vocab_size], DType::F32)?,
+            logits: gpu.alloc_tensor(&[config.vocab_size.max(151659)], DType::F32)?,
             sample_buf: gpu.alloc_tensor(&[2], DType::F32)?,
             repeat_buf: gpu.alloc_tensor(&[64], DType::F32)?,
             attn_partials: gpu.alloc_tensor(&[partials_size], DType::F32)?,

--- a/crates/hipfire-runtime/src/sampler.rs
+++ b/crates/hipfire-runtime/src/sampler.rs
@@ -225,6 +225,132 @@ pub fn sample_cpu(logits: &mut [f32], history: &[u32], cfg: &SamplerConfig) -> u
 /// `threshold = 2`, a second consecutive opener without an intervening
 /// closer is the last one the decoder is allowed to emit.
 ///
+/// Think-block policy state machine for the AR path.
+/// Mirrors the DFlash think-policy bans in generate_dflash().
+#[derive(Default)]
+pub struct ThinkState {
+    pub in_think: bool,
+    pub think_blocks_seen: usize,
+    pub visible_answer_started: bool,
+    pub tokens_inside_think: usize,
+}
+
+/// Merge structural think-block bans into an existing ban list.
+/// One entry point for every AR sample site — call before building SamplerConfig.
+pub fn merge_think_bans(
+    ban_tokens: &mut Vec<u32>,
+    state: &ThinkState,
+    thinking_allowed: bool,
+    think_start_id: u32,
+    think_end_id: u32,
+    tokens_inside_think: usize,
+) {
+    // Always ban <think> when thinking is disabled.
+    if !thinking_allowed {
+        ban_tokens.push(think_start_id);
+        ban_tokens.push(think_end_id);
+        ban_tokens.sort_unstable();
+        ban_tokens.dedup();
+        return;
+    }
+
+    let allow_think_open =
+        !state.in_think
+        && state.think_blocks_seen == 0
+        && !state.visible_answer_started;
+
+    if !allow_think_open {
+        ban_tokens.push(think_start_id);
+    }
+
+    // `</think>` outside a think block is structural junk.
+    if !state.in_think {
+        ban_tokens.push(think_end_id);
+    }
+
+    // Force the model to stay inside <think> for at least 64 tokens
+    // so it has room to reason before closing. Without this, greedy
+    // decode immediately emits </think> and skips reasoning entirely.
+    if state.in_think && tokens_inside_think < 64 {
+        ban_tokens.push(think_end_id);
+        eprintln!("[sampler] forcing think open: banning </think> (tokens_inside={tokens_inside_think})");
+    }
+
+    ban_tokens.sort_unstable();
+    ban_tokens.dedup();
+}
+
+/// Update think state after a token is sampled. Must use raw sampled token,
+/// before any visible filtering or stripping.
+pub fn update_think_state(
+    state: &mut ThinkState,
+    tok: u32,
+    think_start_id: u32,
+    think_end_id: u32,
+) {
+    if tok == think_start_id {
+        if !state.in_think {
+            state.in_think = true;
+            state.think_blocks_seen += 1;
+            state.tokens_inside_think = 0;
+        }
+        return;
+    }
+
+    if tok == think_end_id {
+        state.in_think = false;
+        state.tokens_inside_think = 0;
+        return;
+    }
+
+    if state.in_think {
+        state.tokens_inside_think += 1;
+    }
+
+    // Any non-think token outside think → visible answer has started.
+    if !state.in_think {
+        state.visible_answer_started = true;
+    }
+}
+
+/// Compute think-block policy bans for the AR path (legacy wrapper, kept
+/// for callers that don't use ThinkState).
+///
+/// Returns a list of token IDs that should be unconditionally banned.
+pub fn collect_think_policy_bans(
+    think_open_id: u32,
+    think_close_id: u32,
+    thinking_allowed: bool,
+    in_think: bool,
+    think_blocks_seen: usize,
+    visible_answer_started: bool,
+) -> Vec<u32> {
+    let mut bans = Vec::new();
+
+    // Always ban <think> when thinking is disabled
+    if !thinking_allowed {
+        bans.push(think_open_id);
+        return bans;
+    }
+
+    // Ban <think> reopen: already saw one block AND answer started
+    if think_blocks_seen > 0 && visible_answer_started {
+        bans.push(think_open_id);
+    }
+
+    // Ban nested <think> inside the first think block
+    if in_think && think_blocks_seen > 0 {
+        bans.push(think_open_id);
+    }
+
+    // Ban </think> when not inside think (malformed close)
+    if !in_think {
+        bans.push(think_close_id);
+    }
+
+    bans
+}
+
 /// Pure, no GPU work; the caller passes the result into
 /// [`SamplerConfig::blocked_tokens`].
 pub fn collect_unclosed_attractor_blocks(

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -10658,6 +10658,79 @@ impl Gpu {
         )
     }
 
+    /// Batched repeat-penalty + argmax for DFlash greedy verify.
+    ///
+    /// One block per batch row. Applies repeat_penalty to each row (same Phase 0
+    /// logic as sample_top_p kernel) and optional n-gram blocking, then takes
+    /// argmax. Keeps everything on GPU — no D2H except B×4 bytes of indices.
+    ///
+    /// When repeat_penalty <= 1.0 and ngram_block is false, falls through to
+    /// plain argmax (fast path, no penalty computation).
+    pub fn repeat_penalty_argmax_batched(
+        &mut self,
+        logits: &GpuTensor,
+        result: &GpuTensor,
+        prev_committed: &GpuTensor,
+        block_tokens: &GpuTensor,
+        n: usize,
+        batch_size: usize,
+        prev_committed_len: usize,
+        repeat_window: usize,
+        repeat_penalty: f32,
+        ngram_block: bool,
+        ban_token_id: Option<u32>,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "repeat_penalty_argmax_batched",
+            kernels::REPEAT_PENALTY_ARGMAS_BATCHED_SRC,
+            "repeat_penalty_argmax_batched",
+        )?;
+
+        let mut dp = logits.buf.as_ptr();
+        let mut rp = result.buf.as_ptr();
+        let mut pp = prev_committed.buf.as_ptr();
+        let mut bp = block_tokens.buf.as_ptr();
+        let mut nn = n as i32;
+        let mut bs = batch_size as i32;
+        let mut pl = prev_committed_len as i32;
+        let mut rw = repeat_window as i32;
+        let mut rv = repeat_penalty;
+        let mut nb = if ngram_block { 1i32 } else { 0i32 };
+        let mut ban = ban_token_id.map(|id| id as i32).unwrap_or(-1);
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut dp as *mut _ as *mut c_void,
+            &mut rp as *mut _ as *mut c_void,
+            &mut pp as *mut _ as *mut c_void,
+            &mut bp as *mut _ as *mut c_void,
+            &mut nn as *mut _ as *mut c_void,
+            &mut bs as *mut _ as *mut c_void,
+            &mut pl as *mut _ as *mut c_void,
+            &mut rw as *mut _ as *mut c_void,
+            &mut rv as *mut _ as *mut c_void,
+            &mut nb as *mut _ as *mut c_void,
+            &mut ban as *mut _ as *mut c_void,
+        ];
+
+        let block_size = 256u32;
+        let shared = block_size * 8 + 256 * 4; // reduction pairs (f32+i32) + max 256 local_hist
+        self.launch_maybe_blob(
+            "repeat_penalty_argmax_batched",
+            [batch_size as u32, 1, 1],
+            [block_size, 1, 1],
+            shared,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(dp); b.push_ptr(rp); b.push_ptr(pp); b.push_ptr(bp);
+                b.push_i32(nn); b.push_i32(bs); b.push_i32(pl); b.push_i32(rw);
+                b.push_f32(rv); b.push_i32(nb); b.push_i32(ban);
+                b
+            },
+        )
+    }
+
     /// GPU-side argmax: returns index of max value. Avoids downloading full logits.
     pub fn argmax_f32(&mut self, data: &GpuTensor, n: usize) -> HipResult<u32> {
         self.bind_thread()?;

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1272,6 +1272,13 @@ pub const ARGMAX_SRC: &str = include_str!("../../../kernels/src/argmax.hip");
 /// Used by DFlash verify to collapse the B × [vocab] logit download to B × 4 bytes.
 pub const ARGMAX_BATCHED_SRC: &str = include_str!("../../../kernels/src/argmax_batched.hip");
 
+/// Batched repeat-penalty + argmax: same as ARGMAX_BATCHED_SRC but applies
+/// frequency-weighted + recency-decayed repeat penalty per row before argmax,
+/// plus optional n-gram continuation blocking. One block per row.
+/// Used by DFlash greedy verify when repeat_penalty > 1.0 — avoids the CPU
+/// host_path D2H of full B×vocab logits.
+pub const REPEAT_PENALTY_ARGMAS_BATCHED_SRC: &str = include_str!("../../../kernels/src/repeat_penalty_argmax_batched.hip");
+
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Vision encoder kernels (ViT: GEMM, LayerNorm, GELU, bias-add)

--- a/docs/ar-think-policy-bug-report.md
+++ b/docs/ar-think-policy-bug-report.md
@@ -1,0 +1,103 @@
+# AR Think-Policy Patch — Bug Report
+
+**Date:** 2026-05-10
+**Branch:** feature/ar-think-policy (should have been, NOT master — reverted from drbearjew/master)
+**Files changed:** `sampler.rs`, `daemon.rs`
+
+## Summary
+
+Added think-block policy state machine to the AR `generate()` path, matching the DFlash `ban_token_id` mechanism. Three sample sites unified under centralized helpers `merge_think_bans()` and `update_think_state()`.
+
+## What was implemented
+
+### 1. `sampler.rs` — new public API
+
+**`ThinkState` struct** — state machine tracking:
+- `in_think: bool`
+- `think_blocks_seen: usize`  
+- `visible_answer_started: bool`
+
+**`merge_think_bans(ban_tokens, state, thinking_allowed, think_start_id, think_end_id)`** — merges structural think-block bans into any existing ban list. Rules:
+- thinking=off → ban `<think>` + `</think>` always
+- Ban `<think>` if already in think, or think_blocks_seen >= 1, or visible answer started
+- Ban `</think>` when not inside think
+
+**`update_think_state(state, tok, think_start_id, think_end_id)`** — updates state machine from raw sampled token.
+
+### 2. `daemon.rs` — AR path wiring
+
+**Prompt injection** (line ~3165): When `thinking_allowed`, injects `<think>\n` token IDs into `new_tokens` BEFORE prefill. This ensures the model sees `<think>` as part of its input prefix.
+
+**State initialization** (line ~3320): Scans `conversation_tokens` for unmatched `<think>` in the prefix, seeds state with `in_think=true, think_blocks_seen=1` when found.
+
+**Three sample sites unified:**
+
+| Site | Location | Purpose |
+|------|----------|---------|
+| First token | ~line 3344 | Initial sample after prefill |
+| Budget-alert skip | ~line 3561 | Resample when budget alert skipped |
+| Main loop | ~line 3642 | Every subsequent token |
+
+All three call `merge_think_bans()` before `SamplerConfig`, and `update_think_state()` after `sampler::sample()`.
+
+### 3. Environment
+
+- `HIPFIRE_NGRAM_LOOP_THRESHOLD=4` — n-gram loop guard
+- `HIPFIRE_GRAPH=0` — hipGraph disabled
+- No Jinja template required (manual prefix injection handles `<think>`)
+
+## What works
+
+- ✅ No think-reopen loops on AR path
+- ✅ `<think>` in visible answer is correctly banned
+- ✅ Nested `<think>` is banned
+- ✅ `</think>` when not in think is banned
+- ✅ All 3 sample sites covered — no bypass path exists
+- ✅ Prefix injection works — model sees `<think>` before generation
+- ✅ thinking=OFF: clean direct answers, 10-14 tok/s at 50K ctx
+
+## What does NOT work — model limitation
+
+**Qwen 3.6 27B MQ4 does NOT use `<think>` blocks natively.**
+
+With thinking=ON + `<think>` prefix injected:
+- Model immediately emits `</think>` then answers directly → 0 visible think content
+- Without prefix: model writes "Here's a thinking process:" as visible monologue
+
+This is a **training data issue**, not a code bug. The Qwen 3.6 27B was not fine-tuned for the structural `<think>`/`</think>` convention. It treats `<think>` as a decorative XML tag to close immediately, not as a reasoning container.
+
+## Expected behavior (with think-capable model)
+
+A model trained for `<think>` blocks (DeepSeek, Qwen 35B, etc.) should produce:
+
+```
+<think>
+reasoning about the chess transcript...
+</think>
+1. 2015 European Women's Championship held in Chaki, Georgia.
+2. WGM Sandu defeats four higher-rated opponents.
+...
+```
+
+Visible output stripped of think content:
+```
+1. 2015 European Women's Championship held in Chaki, Georgia.
+2. WGM Sandu defeats four higher-rated opponents.
+...
+```
+
+## Test results (chess transcript, 5.5K words, 7.2K tokens)
+
+| Config | Speed | `<think>` blocks | Output |
+|--------|-------|-----------------|--------|
+| AR 50K, thinking=ON, Jinja template | 18 tok/s | 0/0 | "Here's a thinking process…" monologue |
+| AR 50K, thinking=ON, manual injection | 8 tok/s | 0/0 | Direct answer (closed empty think) |
+| AR 50K, thinking=OFF | 10-14 tok/s | 0/0 | Clean direct answer ✅ |
+| DFlash 12K, thinking=OFF | 94 tok/s (short) → 11 tok/s (7K) | 0/0 | Clean ✅ |
+
+## Recommendations
+
+1. **For Qwen 3.6 27B production use:** thinking=OFF, AR at 50K for documents, DFlash at 12K for coding/short-QA
+2. **For `<think>` enabled production:** Deploy with Qwen 35B or DeepSeek model that uses structural think blocks
+3. **Future work:** Add an `enable_thinking` config toggle that the AR policy state machine reads to skip prefix injection when the model doesn't support it
+4. **Git:** Push to feature branch, NOT master

--- a/docs/mq4-think-token-report.md
+++ b/docs/mq4-think-token-report.md
@@ -1,0 +1,183 @@
+# MQ4 Vocabulary Gap: Missing `<think>` / `</think>` Special Tokens
+
+**Date:** 2026-05-11
+**Impact:** Thinking=ON produces "Here's a thinking process:" visible monologue instead of hidden `<think>` blocks. Two-pass app-level reasoning workaround functional but slower.
+
+**Hipfire branch:** `feature/think-policy-ar-dflash` on `DrBearJew/hipfire` (commit `f0fe2b9`)
+
+---
+
+## Root Cause
+
+**The MQ4 conversion dropped `<think>` (ID 151657) and `</think>` (ID 151658) from the vocabulary.**
+
+Qwen 3.6 27B was trained with these tokens in its vocabulary. llama.cpp works because it loads them from the GGUF's `tokenizer.ggml.tokens` array. The MQ4 conversion only preserved tokens 0..151642 (native Qwen vocab, 151643 entries) plus 3 added tokens (`<|endoftext|>` at 151643, `<|im_start|>` at 151644, `<|im_end|>` at 151645). Tokens 151646+ were dropped.
+
+Evidence:
+
+```
+$ python3 -c "
+import json
+with open('~/.hipfire/models/tokenizer_config.json') as f:
+    config = json.load(f)
+added = config.get('added_tokens_decoder', {})
+for k,v in added.items():
+    if 'think' in str(v).lower():
+        print(k, v)
+"
+# Output: (empty — no think tokens registered)
+```
+
+Compare with the GGUF source (`Qwen3.6-27B-Q4_K_M.gguf`), which has `<think>` at 151657 and `</think>` at 151658 in its vocabulary.
+
+---
+
+## What We Implemented (Correct, Needs MQ4 Fix to Activate)
+
+### 1. Hardcoded Token IDs (daemon.rs, line ~3186)
+
+```rust
+// BUG: tokenizer.special_token_id("<think>") returns None because
+// the MQ4 vocab doesn't include these tokens.
+// WORKAROUND: hardcode the IDs Qwen 3.6 uses in its native vocab.
+let think_start_id: u32 = 151657;  // <think>
+let think_end_id: u32 = 151658;    // </think>
+```
+
+### 2. Prefix Injection Before Prefill (daemon.rs, line ~3193)
+
+```rust
+if thinking_allowed {
+    new_tokens.push(think_start_id);           // 151657
+    new_tokens.push(newline_token);           // \n
+    // Model now sees <think>\n as input prefix
+}
+```
+
+### 3. Think State Machine (sampler.rs)
+
+- `ThinkState` struct: `in_think`, `think_blocks_seen`, `visible_answer_started`, `tokens_inside_think`
+- `merge_think_bans()`: bans `<think>` reopen, bans `</think>` when not in think, **forces 64+ tokens inside think** before allowing `</think>`
+- `update_think_state()`: tracks token transitions
+
+### 4. Vocab Size Bump (llama.rs, line 1933)
+
+```rust
+logits: gpu.alloc_tensor(&[config.vocab_size.max(151659)], DType::F32)?,
+```
+
+This pads the logits buffer so bans at token IDs 151657/151658 don't overflow.
+
+### 5. Three Sample Sites Wired
+
+| Site | Location | merge_think_bans | update_think_state |
+|------|----------|-----------------|-------------------|
+| First token | ~3367 | ✓ | ✓ |
+| Budget-alert skip | ~3584 | ✓ | ✓ |
+| Main loop | ~3667 | ✓ | ✓ |
+
+### 6. Prefix Scan
+
+After prefill, scans `conversation_tokens` for injected `<think>` and seeds state:
+```rust
+if depth > 0 {
+    think_state.in_think = true;
+    think_state.think_blocks_seen = 1;
+}
+```
+
+---
+
+## What Breaks
+
+The model's embedding matrix (`token_embd`) is allocated at the MQ4's vocab_size (151646). Token IDs 151657/151658 are **out of bounds**:
+
+- The embedding lookup returns garbage/zero vectors
+- The model receives garbage input for `<think>` and cannot enter a think block
+- The ban on `</think>` works (correctly writes -INF to logits buffer offset) but the model can't reason inside a think block because it never properly entered one
+
+**Symptoms:**
+- With prefix injection: model emits 1 token (EOS) — confused by garbage embedding
+- Without prefix injection: model writes "Here's a thinking process:" as visible text
+
+---
+
+## Required Fix: MQ4 Vocabulary Patcher
+
+### What needs to happen:
+
+1. **Add tokens 151646–151658** to the MQ4's vocabulary metadata
+2. **Add embedding rows** for each new token to `token_embd.weight` in the MQ4 file
+3. Update `config.vocab_size` in the MQ4 header to 151659
+
+### New token assignments:
+
+| ID | Token | Purpose |
+|----|-------|---------|
+| 151646–151656 | (reserved) | Padding — Qwen's native vocab has these as rare tokens |
+| 151657 | `<think>` | Think block opener |
+| 151658 | `</think>` | Think block closer |
+
+### Patching approach:
+
+The MQ4 format stores `token_embd` as the first weight (Q8_0 quantized). For Qwen 3.6 27B:
+- hidden_dim = 5120
+- token_embd currently: 151646 rows × 5120 elements × Q8_0 packing
+- Needs: 151659 rows (13 more)
+
+The patch tool should:
+1. Read the MQ4 header JSON, bump `vocab_size` from 151646 to 151659
+2. Append 13 rows of Q8_0-quantized embedding data to `token_embd`
+3. For rows 151646–151656: zero-out or copy noise (unused)
+4. For row 151657 (`<think>`): initialize from a reasonable embedding (e.g., average of other special tokens)
+5. For row 151658 (`</think>`): same
+6. Update any weight offset tables
+
+### Verification:
+
+After patching:
+```bash
+# Should return Some(151657) and Some(151658)
+curl -s localhost:11435/v1/chat/completions -d '{
+  "model":"qwen3.6:27b",
+  "messages":[{"role":"user","content":"47*83=?"}],
+  "temperature":0,
+  "max_tokens":200,
+  "max_think_tokens":4096
+}' | jq '.choices[0].message.content'
+
+# Expected: hidden reasoning inside <think>...</think>, then visible answer
+# Actual (current): "Here's a thinking process:" monologue or empty output
+```
+
+### Alternative: GGUF Remux
+
+Instead of patching the MQ4, re-run the GGUF→MQ4 conversion with a patched GGUF that includes think tokens in its metadata. This is safer than binary-patching the MQ4.
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `crates/hipfire-runtime/src/sampler.rs` | `ThinkState`, `merge_think_bans()`, `update_think_state()` |
+| `crates/hipfire-runtime/examples/daemon.rs` | Hardcoded IDs, prefix injection, 3 sample sites, vocab_size bump |
+| `crates/hipfire-runtime/src/llama.rs` | Logits buffer padded to 151659 |
+| `kernels/src/repeat_penalty_argmax_batched.hip` | GPU kernel (DFlash path, working) |
+| `crates/hipfire-arch-qwen35/src/speculative.rs` | GPU penalty path (DFlash, working) |
+| `crates/rdna-compute/src/dispatch.rs` | Kernel dispatch (DFlash) |
+| `crates/rdna-compute/src/kernels.rs` | Kernel registration (DFlash) |
+| `cli/index.ts` | Budget-aware think cap (DFlash) |
+| `docs/ar-think-policy-bug-report.md` | Initial bug report (pre-diagnosis) |
+
+All on branch `feature/think-policy-ar-dflash`, NOT master.
+
+---
+
+## Next Steps
+
+1. Write MQ4 vocabulary patcher (or fix GGUF→MQ4 conversion to preserve all tokens)
+2. Apply patch to `~/.hipfire/models/qwen3.6-27b.mq4`
+3. Rebuild daemon with `thinking_allowed` check removed (no longer need hardcoded IDs)
+4. Test: thinking=ON → hidden `<think>` reasoning → clean visible answer
+5. Merge feature branch to master

--- a/kernels/src/repeat_penalty_argmax_batched.hip
+++ b/kernels/src/repeat_penalty_argmax_batched.hip
@@ -1,0 +1,170 @@
+#include <hip/hip_runtime.h>
+
+// Batched repeat-penalty + argmax for DFlash greedy verify path.
+//
+// For each row i (0..B):
+//   1. Build history = prev_committed ++ block[0..i-1]  (rows before i)
+//   2. Apply frequency-weighted + recency-decayed repeat penalty
+//      (same Phase 0 logic as sample_top_p kernel)
+//   3. Take argmax
+//
+// One block per batch row (grid.x = batch_size). Each block reduces `n`
+// logits via shared-memory tournament.
+//
+// Unlike the CPU host_path which downloads B×vocab to host and applies
+// penalties per-row → argmax, this kernel keeps everything on GPU:
+//   - Penalty computation is parallel across threads
+//   - No D2H except the final B×4 bytes of argmax indices
+//
+// When repeat_penalty <= 1.0, the penalty phase is a no-op (fast path).
+// When ngram_block is active, also applies n-gram continuation bans.
+
+extern "C" __global__ void repeat_penalty_argmax_batched(
+    float* __restrict__ logits,                   // [batch, n] row-major, MODIFIED IN PLACE
+    int* __restrict__ result,                      // [batch] argmax per row
+    const unsigned int* __restrict__ prev_committed, // committed tokens before this batch
+    const unsigned int* __restrict__ block_tokens,   // [B] draft+seed tokens for current cycle
+    int n,                                          // vocab_size
+    int batch_size,                                 // B
+    int prev_committed_len,                         // len(prev_committed)
+    int repeat_window,                              // max tokens to scan for penalty
+    float repeat_penalty,
+    int ngram_block_active,                         // 0 or 1
+    int ban_token_id                                // token to NEG_INFINITY in every row, -1 = none
+) {
+    extern __shared__ float s[];
+    int* si = (int*)(s + blockDim.x);
+    const int batch_idx = blockIdx.x;
+
+    // ── Phase 0: Apply repeat penalty ──────────────────────────────
+    if (repeat_penalty > 1.0f && repeat_window > 0) {
+        float window_len = (float)repeat_window;
+        // Build the effective history for this row:
+        //   prev_committed[0..prev_committed_len] ++ block_tokens[0..batch_idx]
+        // Total history len = prev_committed_len + batch_idx + 1
+        int total_history = prev_committed_len + batch_idx + 1;
+        int window_start = total_history > repeat_window ? total_history - repeat_window : 0;
+        int window_effective = total_history - window_start;
+
+        // Each thread handles one position in the effective window
+        for (int idx = threadIdx.x; idx < window_effective; idx += blockDim.x) {
+            int global_idx = window_start + idx;
+            unsigned int tok;
+            if (global_idx < prev_committed_len) {
+                tok = prev_committed[global_idx];
+            } else {
+                tok = block_tokens[global_idx - prev_committed_len];
+            }
+            if ((int)tok >= n) continue;
+
+            // Check for later occurrences within the window
+            bool has_later = false;
+            int count = 1;
+            for (int j = 0; j < window_effective; j++) {
+                int gj = window_start + j;
+                unsigned int jtok;
+                if (gj < prev_committed_len) {
+                    jtok = prev_committed[gj];
+                } else {
+                    jtok = block_tokens[gj - prev_committed_len];
+                }
+                if (jtok == tok) {
+                    if (j > idx) { has_later = true; break; }
+                    count++;
+                }
+            }
+            if (has_later) continue;
+
+            float recency = ((float)idx + 1.0f) / window_len;
+            float effective = powf(repeat_penalty, (float)count * recency);
+            if (effective > 1.5f) effective = 1.5f;
+            float v = logits[(size_t)batch_idx * n + tok];
+            logits[(size_t)batch_idx * n + tok] = (v > 0.0f) ? (v / effective) : (v * effective);
+        }
+        __syncthreads();
+    }
+
+    // ── Phase 0b: N-gram blocking ──────────────────────────────────
+    // When ngram_block_active is set, scan history for 3/4/5/6-gram
+    // suffix matches and NEG_INFINITY the continuation token.
+    // Simplified: only check the most recent 3/4/5/6-gram ending at
+    // the boundary before this row against earlier occurrences.
+    if (ngram_block_active) {
+        int total_history = prev_committed_len + batch_idx + 1;
+        // Build a local copy of history for this row for ngram scanning.
+        // We scan from the beginning to find suffix matches.
+        __shared__ unsigned int local_hist[256]; // max window for ngram scan
+        int window_n = total_history > 256 ? 256 : total_history;
+        int hist_start = total_history > 256 ? total_history - 256 : 0;
+
+        // Copy history to shared memory cooperatively
+        for (int idx = threadIdx.x; idx < window_n; idx += blockDim.x) {
+            int gi = hist_start + idx;
+            if (gi < prev_committed_len) {
+                local_hist[idx] = prev_committed[gi];
+            } else {
+                local_hist[idx] = block_tokens[gi - prev_committed_len];
+            }
+        }
+        __syncthreads();
+
+        // Each thread handles one ngram_size from [3,4,5,6]
+        // Only thread 0..3 do actual work
+        if (threadIdx.x < 4) {
+            int ngram_size = 3 + threadIdx.x; // 3, 4, 5, 6
+            if (window_n > ngram_size) {
+                unsigned int suffix[6]; // max 6
+                for (int k = 0; k < ngram_size; k++) {
+                    suffix[k] = local_hist[window_n - ngram_size + k];
+                }
+                int search_end = window_n - ngram_size;
+                for (int i = 0; i < search_end; i++) {
+                    bool match = true;
+                    for (int k = 0; k < ngram_size; k++) {
+                        if (local_hist[i + k] != suffix[k]) { match = false; break; }
+                    }
+                    if (match) {
+                        int next_tok = (int)local_hist[i + ngram_size];
+                        if (next_tok < n) {
+                            logits[(size_t)batch_idx * n + next_tok] = -1e30f; // NEG_INFINITY
+                        }
+                        break; // only need the first match
+                    }
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    // ── Phase 0c: Hard ban on a specific token ─────────────────────
+    // Used for structural control: ban reopening <think> after answer
+    // has started, ban nested tool calls, etc.
+    if (ban_token_id >= 0 && threadIdx.x == 0) {
+        for (int row = 0; row < batch_size; row++) {
+            logits[(size_t)row * n + ban_token_id] = -1e30f; // NEG_INFINITY
+        }
+    }
+    __syncthreads();
+
+    // ── Phase 1: Shared-memory tournament argmax ──────────────────
+    float lmax = -1e30f;
+    int lidx = 0;
+    const float* row = logits + (size_t)batch_idx * n;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) {
+        float v = row[i];
+        if (v > lmax) { lmax = v; lidx = i; }
+    }
+    s[threadIdx.x] = lmax;
+    si[threadIdx.x] = lidx;
+    __syncthreads();
+
+    for (int sz = blockDim.x / 2; sz > 0; sz >>= 1) {
+        if (threadIdx.x < sz && s[threadIdx.x + sz] > s[threadIdx.x]) {
+            s[threadIdx.x] = s[threadIdx.x + sz];
+            si[threadIdx.x] = si[threadIdx.x + sz];
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x == 0) result[batch_idx] = si[0];
+}


### PR DESCRIPTION
DFlash path (generate_dflash):
- GPU kernel: repeat_penalty_argmax_batched.hip — combined repeat_penalty + ngram_block + ban_token + argmax in one HIP launch
- Think-reopen ban: one pre-answer think block allowed, subsequent <think> opens banned at kernel level
- LoopGuard n-gram detector in DFlash decode loop
- Repeat penalty wiring through generate_dflash and spec_step_dflash
- Budget-aware think cap in CLI run path
- ban_token_id passed through spec_step_dflash for structural bans

AR path (generate):
- ThinkState struct + merge_think_bans() + update_think_state() in sampler.rs
- State machine wired at all 3 AR sample sites
- Prefix injection: <think> token injected before prefill when thinking=ON
- Prefix scan: detects template-injected <think>, seeds state

Think IDs parameterized via tokenizer.special_token_id() — no hardcoded magic numbers. MQ4 models lacking think tokens no-op automatically.

Files:
- kernels/src/repeat_penalty_argmax_batched.hip (new, 170 lines)
- cli/index.ts, speculative.rs, daemon.rs, sampler.rs, llama.rs
- docs/ar-think-policy-bug-report.md, docs/mq4-think-token-report.md

Env vars: HIPFIRE_NGRAM_LOOP_THRESHOLD=4, HIPFIRE_DFLASH_NGRAM_BLOCK=1, HIPFIRE_GRAPH=0