### PR TITLE
MFP4G32 v2 #3-5: hipGraph default-on for gfx11+gfx12 decode (+0.7-2.6%)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -3808,6 +3808,16 @@ fn is_batchable_la(dt: DType, arch: &str) -> bool {
             | "gfx1200" | "gfx1201"
         );
 
+    // HFP4G32 / MFP4G32 (v2 #2 batched WMMA prefill): same arch gate as
+    // MQ3. The 4 fused kernels (gemm_qkv/qkvza/gate_up/residual_hfp4g32_wmma)
+    // ship in pairs for gfx11 + gfx12; identical eligibility to llama.rs
+    // (see hipfire_runtime::llama::is_batchable_la).
+    let fp4_with_wmma = matches!(dt, DType::HFP4G32 | DType::MFP4G32)
+        && matches!(arch,
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
+            | "gfx1200" | "gfx1201"
+        );
+
     // Lloyd-MQ3 (MQ3G256Lloyd) on gfx11: Phase 5 of issue #116 ships the
     // gemm_*_mq3g256_lloyd_wmma family alongside the existing HFQ3 WMMA
     // path; group stride differs (112 B Lloyd vs 104 B HFQ3) so dispatch
@@ -3833,7 +3843,7 @@ fn is_batchable_la(dt: DType, arch: &str) -> bool {
         && matches!(arch, "gfx1200" | "gfx1201")
         && std::env::var("HIPFIRE_LLOYD_GFX12").ok().as_deref() == Some("1");
 
-    mq3_uniform_with_wmma || lloyd_mq3_with_gfx11_wmma || lloyd_mq3_with_gfx12_wmma
+    mq3_uniform_with_wmma || lloyd_mq3_with_gfx11_wmma || lloyd_mq3_with_gfx12_wmma || fp4_with_wmma
 }
 
 /// Process one chunk of up to `pbs.max_batch` tokens through the batched
@@ -4222,10 +4232,11 @@ fn forward_prefill_chunk(
                 // together (the all-together corruption-prevention rule from
                 // docs/plans/mq-lloyd-batched-prefill-followup.md). MQ4-Lloyd
                 // is wired in a separate PR (issue #182).
-                let is_mq = matches!(layer.wqkv.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let is_mq = matches!(layer.wqkv.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let is_6bit = matches!(layer.wqkv.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let is_mq3 = matches!(layer.wqkv.gpu_dtype, DType::MQ3G256);
                 let is_mq3_lloyd = matches!(layer.wqkv.gpu_dtype, DType::MQ3G256Lloyd);
+                let is_fp4 = matches!(layer.wqkv.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
 
                 // Batched rmsnorm (+ FWHT for MQ) for the LA preamble.
                 // x_batch / x_rot_batch are [N × dim] contiguous. For HFQ
@@ -4264,6 +4275,18 @@ fn forward_prefill_chunk(
                     // 104 B/group HFQ3-stride; X is already FWHT-rotated by
                     // fused_rmsnorm_rotate_mq_batched above.
                     gpu.gemm_qkvza_hfq3g256_wmma(
+                        &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.dn_qkv_batch, &pbs.dn_z_batch, &pbs.dn_beta_batch, &pbs.dn_alpha_batch,
+                        layer.wqkv.m, layer.wz.m, layer.w_beta.m, layer.w_alpha.m,
+                        layer.wqkv.k, n,
+                    )?;
+                } else if is_fp4 {
+                    // HFP4G32: 17-B blocks (vs HFQ4's 136-B groups), per-row 16-B header.
+                    // MFP4G32: same storage as HFP4 + offline-FWHT weights; X is already
+                    // rotated above when is_mq, so this branch handles both unrotated
+                    // (HFP4) and post-rotation (MFP4) activations identically.
+                    gpu.gemm_qkvza_hfp4g32(
                         &layer.wqkv.buf, &layer.wz.buf, &layer.w_beta.buf, &layer.w_alpha.buf,
                         &pbs.x_rot_batch,
                         &pbs.dn_qkv_batch, &pbs.dn_z_batch, &pbs.dn_beta_batch, &pbs.dn_alpha_batch,
@@ -4404,10 +4427,11 @@ fn forward_prefill_chunk(
                 // at quant time; math requires dot(rot(W), rot(x)) = dot(W,x)).
                 // For HFQ weights no rotation is needed — the activation
                 // feeds gemm_hfq{4,6}g256_residual directly.
-                let wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let wo_is_6bit = matches!(layer.wo.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let wo_is_mq3 = matches!(layer.wo.gpu_dtype, DType::MQ3G256);
                 let wo_is_mq3_lloyd = matches!(layer.wo.gpu_dtype, DType::MQ3G256Lloyd);
+                let wo_is_fp4 = matches!(layer.wo.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
                 let wo_input = if wo_is_mq {
                     gpu.rotate_x_mq_batched(
                         &pbs.dn_normed_batch, &pbs.dn_normed_rot_batch, layer.wo.k, n,
@@ -4431,6 +4455,11 @@ fn forward_prefill_chunk(
                         &layer.wo.buf, wo_input, &pbs.x_batch,
                         layer.wo.m, layer.wo.k, n,
                     )?;
+                } else if wo_is_fp4 {
+                    gpu.gemm_hfp4g32_residual(
+                        &layer.wo.buf, wo_input, &pbs.x_batch,
+                        layer.wo.m, layer.wo.k, n,
+                    )?;
                 } else {
                     gpu.gemm_hfq4g256_residual(
                         &layer.wo.buf, wo_input, &pbs.x_batch,
@@ -4439,10 +4468,11 @@ fn forward_prefill_chunk(
                 }
 
                 // FFN: rmsnorm (+ rotate for MQ).
-                let ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let ffn_is_6bit = matches!(layer.w_gate.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let ffn_is_mq3 = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256);
                 let ffn_is_mq3_lloyd = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256Lloyd);
+                let ffn_is_fp4 = matches!(layer.w_gate.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
                 if ffn_is_mq {
                     gpu.fused_rmsnorm_rotate_mq_batched(
                         &pbs.x_batch, &layer.ffn_norm, &pbs.x_rot_batch, dim, config.norm_eps, n,
@@ -4479,6 +4509,14 @@ fn forward_prefill_chunk(
                         layer.w_gate.m, layer.w_up.m,
                         layer.w_gate.k, n,
                     )?;
+                } else if ffn_is_fp4 {
+                    gpu.gemm_gate_up_hfp4g32(
+                        &layer.w_gate.buf, &layer.w_up.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.gate_ffn_batch, &pbs.up_batch,
+                        layer.w_gate.m, layer.w_up.m,
+                        layer.w_gate.k, n,
+                    )?;
                 } else {
                     gpu.gemm_gate_up_hfq4g256(
                         &layer.w_gate.buf, &layer.w_up.buf,
@@ -4495,10 +4533,11 @@ fn forward_prefill_chunk(
                 // is purely element-wise and uses numel() as its length,
                 // so a [N × hidden_dim] tensor processes all rows in one
                 // launch with no batch offset needed.
-                let w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let w_down_is_6bit = matches!(layer.w_down.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let w_down_is_mq3 = matches!(layer.w_down.gpu_dtype, DType::MQ3G256);
                 let w_down_is_mq3_lloyd = matches!(layer.w_down.gpu_dtype, DType::MQ3G256Lloyd);
+                let w_down_is_fp4 = matches!(layer.w_down.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
                 if w_down_is_mq {
                     gpu.fused_silu_mul_rotate_mq_batched(
                         &pbs.gate_ffn_batch, &pbs.up_batch, &pbs.ffn_hidden_batch,
@@ -4526,6 +4565,11 @@ fn forward_prefill_chunk(
                         &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
                         layer.w_down.m, layer.w_down.k, n,
                     )?;
+                } else if w_down_is_fp4 {
+                    gpu.gemm_hfp4g32_residual(
+                        &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
+                        layer.w_down.m, layer.w_down.k, n,
+                    )?;
                 } else {
                     gpu.gemm_hfq4g256_residual(
                         &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
@@ -4550,10 +4594,11 @@ fn forward_prefill_chunk(
                 // launch covers all N tokens at once.
                 let kv_dim = config.n_kv_heads * config.head_dim;
                 let q_dim = config.n_heads * config.head_dim;
-                let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let qkv_is_6bit = matches!(layer.wq.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let qkv_is_mq3 = matches!(layer.wq.gpu_dtype, DType::MQ3G256);
                 let qkv_is_mq3_lloyd = matches!(layer.wq.gpu_dtype, DType::MQ3G256Lloyd);
+                let qkv_is_fp4 = matches!(layer.wq.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
 
                 // 1. rmsnorm (+ rotate for MQ) for the attn preamble.
                 if qkv_is_mq {
@@ -4588,6 +4633,17 @@ fn forward_prefill_chunk(
                     // X is already FWHT-rotated by fused_rmsnorm_rotate_mq_batched
                     // above; call the bare HFQ3 WMMA (no second rotation).
                     gpu.gemm_qkv_hfq3g256_wmma(
+                        &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.fa_q_full_batch, &pbs.fa_k_batch, &pbs.fa_v_batch,
+                        layer.wq.m, layer.wk.m, layer.wv.m,
+                        layer.wq.k, n,
+                    )?;
+                } else if qkv_is_fp4 {
+                    // HFP4G32 / MFP4G32 FP4 batched WMMA. X is already
+                    // rotated above for MFP4 (is_mq path) — same kernel
+                    // covers both unrotated HFP4 and rotated MFP4 inputs.
+                    gpu.gemm_qkv_hfp4g32(
                         &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
                         &pbs.x_rot_batch,
                         &pbs.fa_q_full_batch, &pbs.fa_k_batch, &pbs.fa_v_batch,
@@ -4824,10 +4880,11 @@ fn forward_prefill_chunk(
 
                 // 9. wo residual: x_batch += wo · (optional rotate)(fa_attn_out_batch).
                 // Same MQ rotation requirement as the LA wo path.
-                let fa_wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let fa_wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let fa_wo_is_6bit = matches!(layer.wo.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let fa_wo_is_mq3 = matches!(layer.wo.gpu_dtype, DType::MQ3G256);
                 let fa_wo_is_mq3_lloyd = matches!(layer.wo.gpu_dtype, DType::MQ3G256Lloyd);
+                let fa_wo_is_fp4 = matches!(layer.wo.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
                 let fa_wo_input = if fa_wo_is_mq {
                     gpu.rotate_x_mq_batched(
                         &pbs.fa_attn_out_batch, &pbs.fa_attn_out_rot_batch, layer.wo.k, n,
@@ -4851,6 +4908,11 @@ fn forward_prefill_chunk(
                         &layer.wo.buf, fa_wo_input, &pbs.x_batch,
                         layer.wo.m, layer.wo.k, n,
                     )?;
+                } else if fa_wo_is_fp4 {
+                    gpu.gemm_hfp4g32_residual(
+                        &layer.wo.buf, fa_wo_input, &pbs.x_batch,
+                        layer.wo.m, layer.wo.k, n,
+                    )?;
                 } else {
                     gpu.gemm_hfq4g256_residual(
                         &layer.wo.buf, fa_wo_input, &pbs.x_batch,
@@ -4860,10 +4922,11 @@ fn forward_prefill_chunk(
 
                 // 10. FFN: rmsnorm (+ rotate for MQ), gate+up, silu_mul
                 // (+ rotate for MQ), w_down residual.
-                let fa_ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let fa_ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let fa_ffn_is_6bit = matches!(layer.w_gate.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let fa_ffn_is_mq3 = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256);
                 let fa_ffn_is_mq3_lloyd = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256Lloyd);
+                let fa_ffn_is_fp4 = matches!(layer.w_gate.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
                 if fa_ffn_is_mq {
                     gpu.fused_rmsnorm_rotate_mq_batched(
                         &pbs.x_batch, &layer.ffn_norm, &pbs.x_rot_batch, dim, config.norm_eps, n,
@@ -4898,6 +4961,14 @@ fn forward_prefill_chunk(
                         layer.w_gate.m, layer.w_up.m,
                         layer.w_gate.k, n,
                     )?;
+                } else if fa_ffn_is_fp4 {
+                    gpu.gemm_gate_up_hfp4g32(
+                        &layer.w_gate.buf, &layer.w_up.buf,
+                        &pbs.x_rot_batch,
+                        &pbs.gate_ffn_batch, &pbs.up_batch,
+                        layer.w_gate.m, layer.w_up.m,
+                        layer.w_gate.k, n,
+                    )?;
                 } else {
                     gpu.gemm_gate_up_hfq4g256(
                         &layer.w_gate.buf, &layer.w_up.buf,
@@ -4907,10 +4978,11 @@ fn forward_prefill_chunk(
                         layer.w_gate.k, n,
                     )?;
                 }
-                let fa_w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd);
+                let fa_w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MQ3G256Lloyd | DType::MFP4G32);
                 let fa_w_down_is_6bit = matches!(layer.w_down.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let fa_w_down_is_mq3 = matches!(layer.w_down.gpu_dtype, DType::MQ3G256);
                 let fa_w_down_is_mq3_lloyd = matches!(layer.w_down.gpu_dtype, DType::MQ3G256Lloyd);
+                let fa_w_down_is_fp4 = matches!(layer.w_down.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
                 if fa_w_down_is_mq {
                     gpu.fused_silu_mul_rotate_mq_batched(
                         &pbs.gate_ffn_batch, &pbs.up_batch, &pbs.ffn_hidden_batch,
@@ -4933,6 +5005,11 @@ fn forward_prefill_chunk(
                     )?;
                 } else if fa_w_down_is_mq3 {
                     gpu.gemm_hfq3g256_residual_wmma(
+                        &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
+                        layer.w_down.m, layer.w_down.k, n,
+                    )?;
+                } else if fa_w_down_is_fp4 {
+                    gpu.gemm_hfp4g32_residual(
                         &layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch,
                         layer.w_down.m, layer.w_down.k, n,
                     )?;

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -2945,8 +2945,26 @@ pub fn forward_scratch(
     //   HIPFIRE_SMOKE_PROMPT="Count from one to twenty in English." \
     //   ./target/release/examples/a3b_smoke_forward <a3b.mq4>
     let allow_moe = std::env::var("HIPFIRE_GRAPH_MOE").ok().as_deref() == Some("1");
-    let use_graph = std::env::var("HIPFIRE_GRAPH").ok().as_deref() == Some("1")
-        && (config.num_experts == 0 || allow_moe);
+    // hipGraph per-forward-pass capture/replay default policy:
+    //   - gfx12 (RDNA4): default-ON. Empirically +2.4% decode on 9B
+    //     Qwen 3.5 MFP4G32 (5-run mean, all positive, tight variance,
+    //     measured 2026-05-11). Launch overhead amortization survives
+    //     ROCm 7.2 burst-mode pipelining — different from the per-gemv
+    //     graph cache experiment which lost (PR3 LOSS, 2026-05-07).
+    //   - other archs: default-OFF (opt-in via HIPFIRE_GRAPH=1) since
+    //     not yet A/B'd on those.
+    //   - MoE configs: always direct unless HIPFIRE_GRAPH_MOE=1; the
+    //     graph path numerically drifts after ~30-50 tokens on MoE
+    //     (see surrounding comment block for repro).
+    // Explicit HIPFIRE_GRAPH=0 always wins (kill switch).
+    let graph_env = std::env::var("HIPFIRE_GRAPH").ok();
+    let graph_arch_default = gpu.arch.starts_with("gfx12");
+    let graph_enabled = match graph_env.as_deref() {
+        Some("0") => false,
+        Some("1") => true,
+        _ => graph_arch_default,
+    };
+    let use_graph = graph_enabled && (config.num_experts == 0 || allow_moe);
 
     // Embedding lookup into scratch.x (always direct, changes per token)
     match weights.embd_format {

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -2946,19 +2946,22 @@ pub fn forward_scratch(
     //   ./target/release/examples/a3b_smoke_forward <a3b.mq4>
     let allow_moe = std::env::var("HIPFIRE_GRAPH_MOE").ok().as_deref() == Some("1");
     // hipGraph per-forward-pass capture/replay default policy:
-    //   - gfx12 (RDNA4): default-ON. Empirically +2.4% decode on 9B
-    //     Qwen 3.5 MFP4G32 (5-run mean, all positive, tight variance,
-    //     measured 2026-05-11). Launch overhead amortization survives
-    //     ROCm 7.2 burst-mode pipelining — different from the per-gemv
-    //     graph cache experiment which lost (PR3 LOSS, 2026-05-07).
-    //   - other archs: default-OFF (opt-in via HIPFIRE_GRAPH=1) since
-    //     not yet A/B'd on those.
+    //   - gfx12 (RDNA4): default-ON. +2.4-2.7% decode on 9B Qwen 3.5
+    //     MFP4G32 (5-run mean, all positive, tight variance, 2026-05-11).
+    //   - gfx11 (RDNA3 / 3.5): default-ON. +0.6-0.7% decode on 9B and
+    //     0.8B HFP4G32 on 7900 XTX (5-run mean per model, all positive,
+    //     variance 1.001-1.010×, 2026-05-11). Smaller win than gfx12 —
+    //     gfx11 has less per-launch overhead to amortize — but real
+    //     and consistent across model sizes.
+    //   - other archs (RDNA1/2, CDNA): default-OFF (opt-in via
+    //     HIPFIRE_GRAPH=1) since not yet A/B'd on those.
     //   - MoE configs: always direct unless HIPFIRE_GRAPH_MOE=1; the
     //     graph path numerically drifts after ~30-50 tokens on MoE
     //     (see surrounding comment block for repro).
     // Explicit HIPFIRE_GRAPH=0 always wins (kill switch).
     let graph_env = std::env::var("HIPFIRE_GRAPH").ok();
-    let graph_arch_default = gpu.arch.starts_with("gfx12");
+    let graph_arch_default =
+        gpu.arch.starts_with("gfx12") || gpu.arch.starts_with("gfx11");
     let graph_enabled = match graph_env.as_deref() {
         Some("0") => false,
         Some("1") => true,

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -1186,12 +1186,15 @@ pub fn is_batchable_la(dt: DType, arch: &str) -> bool {
     if always_ok {
         return true;
     }
-    let mq3_with_wmma = matches!(dt, DType::MQ3G256)
+    // HFP4G32 / MFP4G32 + MQ3G256 require WMMA. Same arch gate as MQ3.
+    let wmma_only = matches!(dt,
+        DType::MQ3G256 | DType::HFP4G32 | DType::MFP4G32
+    )
         && matches!(arch,
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
             | "gfx1200" | "gfx1201"
         );
-    mq3_with_wmma
+    wmma_only
 }
 
 /// Per-call scratch for `forward_prefill_batch`. Holds [N × ...] working
@@ -1518,11 +1521,13 @@ fn forward_prefill_chunk(
     // 2. Per-layer loop.
     for layer_idx in 0..config.n_layers {
         let layer = &weights.layers[layer_idx];
-        let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
+        let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MFP4G32);
         let qkv_is_6bit = matches!(layer.wq.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
         let qkv_is_mq3 = matches!(layer.wq.gpu_dtype, DType::MQ3G256);
+        let qkv_is_fp4 = matches!(layer.wq.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
 
-        // attn_norm (+ FWHT for MQ).
+        // attn_norm (+ FWHT for MQ — includes MFP4G32 since rotation is the
+        // same FWHT pattern as MQ4).
         if qkv_is_mq {
             gpu.fused_rmsnorm_rotate_mq_batched(
                 &pbs.x_batch, &layer.attn_norm, &pbs.x_rot_batch, dim, config.norm_eps, n,
@@ -1545,6 +1550,14 @@ fn forward_prefill_chunk(
             )?;
         } else if qkv_is_mq3 {
             gpu.gemm_qkv_hfq3g256_wmma(
+                &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
+                &pbs.x_rot_batch,
+                &pbs.fa_q_batch, &pbs.fa_k_batch, &pbs.fa_v_batch,
+                layer.wq.m, layer.wk.m, layer.wv.m,
+                layer.wq.k, n,
+            )?;
+        } else if qkv_is_fp4 {
+            gpu.gemm_qkv_hfp4g32(
                 &layer.wq.buf, &layer.wk.buf, &layer.wv.buf,
                 &pbs.x_rot_batch,
                 &pbs.fa_q_batch, &pbs.fa_k_batch, &pbs.fa_v_batch,
@@ -1690,9 +1703,10 @@ fn forward_prefill_chunk(
         }
 
         // wo + residual.
-        let wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
+        let wo_is_mq = matches!(layer.wo.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MFP4G32);
         let wo_is_6bit = matches!(layer.wo.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
         let wo_is_mq3 = matches!(layer.wo.gpu_dtype, DType::MQ3G256);
+        let wo_is_fp4 = matches!(layer.wo.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
         let wo_input = if wo_is_mq {
             gpu.rotate_x_mq_batched(
                 &pbs.fa_attn_out_batch, &pbs.fa_attn_out_rot_batch, layer.wo.k, n,
@@ -1705,14 +1719,18 @@ fn forward_prefill_chunk(
             gpu.gemm_hfq6g256_residual(&layer.wo.buf, wo_input, &pbs.x_batch, layer.wo.m, layer.wo.k, n)?;
         } else if wo_is_mq3 {
             gpu.gemm_hfq3g256_residual_wmma(&layer.wo.buf, wo_input, &pbs.x_batch, layer.wo.m, layer.wo.k, n)?;
+        } else if wo_is_fp4 {
+            gpu.gemm_hfp4g32_residual(&layer.wo.buf, wo_input, &pbs.x_batch, layer.wo.m, layer.wo.k, n)?;
         } else {
             gpu.gemm_hfq4g256_residual(&layer.wo.buf, wo_input, &pbs.x_batch, layer.wo.m, layer.wo.k, n)?;
         }
 
-        // FFN: rmsnorm (+ FWHT for MQ), gate+up, silu_mul, w_down + residual.
-        let ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
+        // FFN: rmsnorm (+ FWHT for MQ — includes MFP4G32), gate+up, silu_mul,
+        // w_down + residual.
+        let ffn_is_mq = matches!(layer.w_gate.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MFP4G32);
         let ffn_is_6bit = matches!(layer.w_gate.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
         let ffn_is_mq3 = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256);
+        let ffn_is_fp4 = matches!(layer.w_gate.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
         if ffn_is_mq {
             gpu.fused_rmsnorm_rotate_mq_batched(
                 &pbs.x_batch, &layer.ffn_norm, &pbs.x_rot_batch, dim, config.norm_eps, n,
@@ -1737,6 +1755,13 @@ fn forward_prefill_chunk(
                 &pbs.gate_ffn_batch, &pbs.up_batch,
                 layer.w_gate.m, layer.w_up.m, layer.w_gate.k, n,
             )?;
+        } else if ffn_is_fp4 {
+            gpu.gemm_gate_up_hfp4g32(
+                &layer.w_gate.buf, &layer.w_up.buf,
+                &pbs.x_rot_batch,
+                &pbs.gate_ffn_batch, &pbs.up_batch,
+                layer.w_gate.m, layer.w_up.m, layer.w_gate.k, n,
+            )?;
         } else {
             gpu.gemm_gate_up_hfq4g256(
                 &layer.w_gate.buf, &layer.w_up.buf,
@@ -1745,9 +1770,10 @@ fn forward_prefill_chunk(
                 layer.w_gate.m, layer.w_up.m, layer.w_gate.k, n,
             )?;
         }
-        let w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256);
+        let w_down_is_mq = matches!(layer.w_down.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256 | DType::MFP4G32);
         let w_down_is_6bit = matches!(layer.w_down.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
         let w_down_is_mq3 = matches!(layer.w_down.gpu_dtype, DType::MQ3G256);
+        let w_down_is_fp4 = matches!(layer.w_down.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
         if w_down_is_mq {
             gpu.fused_silu_mul_rotate_mq_batched(
                 &pbs.gate_ffn_batch, &pbs.up_batch, &pbs.ffn_hidden_batch,
@@ -1760,6 +1786,8 @@ fn forward_prefill_chunk(
             gpu.gemm_hfq6g256_residual(&layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch, layer.w_down.m, layer.w_down.k, n)?;
         } else if w_down_is_mq3 {
             gpu.gemm_hfq3g256_residual_wmma(&layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch, layer.w_down.m, layer.w_down.k, n)?;
+        } else if w_down_is_fp4 {
+            gpu.gemm_hfp4g32_residual(&layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch, layer.w_down.m, layer.w_down.k, n)?;
         } else {
             gpu.gemm_hfq4g256_residual(&layer.w_down.buf, &pbs.ffn_hidden_batch, &pbs.x_batch, layer.w_down.m, layer.w_down.k, n)?;
         }
@@ -4030,6 +4058,19 @@ mod tests {
         }
         for arch in ["gfx900", "gfx906", "gfx1010", "gfx1030", "gfx942"] {
             assert!(!is_batchable_la(DType::MQ3G256, arch), "MQ3 must fall back on {arch}");
+        }
+    }
+
+    #[test]
+    fn is_batchable_la_fp4_wmma_only() {
+        // HFP4G32 / MFP4G32 require WMMA — same arch gate as MQ3.
+        for arch in ["gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"] {
+            assert!(is_batchable_la(DType::HFP4G32, arch), "HFP4G32 should batch on {arch}");
+            assert!(is_batchable_la(DType::MFP4G32, arch), "MFP4G32 should batch on {arch}");
+        }
+        for arch in ["gfx900", "gfx906", "gfx1010", "gfx1030", "gfx942"] {
+            assert!(!is_batchable_la(DType::HFP4G32, arch), "HFP4G32 must fall back on {arch}");
+            assert!(!is_batchable_la(DType::MFP4G32, arch), "MFP4G32 must fall back on {arch}");
         }
     }
 

--- a/crates/rdna-compute/examples/bench_gemv_hfp4g32_bw.rs
+++ b/crates/rdna-compute/examples/bench_gemv_hfp4g32_bw.rs
@@ -1,0 +1,135 @@
+//! Effective-bandwidth probe for `gemv_hfp4g32` at production decode shapes
+//! on gfx1201 (R9700). Determines whether decode is BW-bound (FP8 dot4
+//! won't help) or ALU-bound (FP8 dot4 could deliver a real win).
+//!
+//! For each (M, K) shape, runs many iterations and reports:
+//!   - kernel µs per call
+//!   - effective BW = weight_bytes / time (weight matrix is the dominant read;
+//!     x vector is L2-cached after the first call within the same dispatch)
+//!   - % of theoretical peak BW (R9700 spec ~800 GB/s)
+//!
+//! Decision rule:
+//!   > 75% peak  → BW-bound, FP8 dot4 won't help
+//!   < 50% peak  → ALU-bound, FP8 dot4 has real headroom
+//!   50-75%      → mixed, profile first before kernel work
+
+use rdna_compute::{DType, Gpu};
+use std::time::Instant;
+
+const PEAK_GBPS: f64 = 800.0; // R9700 GDDR6 ~800 GB/s spec; adjust if wrong
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    eprintln!("=== gemv_hfp4g32 BW probe ===");
+    eprintln!("  arch={arch}  peak_bw_gbps={PEAK_GBPS}");
+
+    // Production decode shapes from Qwen 3.5 9B and 27B:
+    //  9B:  q_proj  m=2048 k=2048    (per-layer hidden→qkv)
+    //       kv_proj m=512  k=2048    (smaller GQA outputs)
+    //       wo      m=2048 k=2048
+    //       gate_up m=11008 k=2048   (FFN gate or up)
+    //       down    m=2048  k=11008  (FFN down)
+    //  Lm head: 152064 x hidden_dim
+    let shapes: Vec<(usize, usize, &str)> = vec![
+        (2048,  2048,  "9B qkv-q   M=2048 K=2048"),
+        (512,   2048,  "9B qkv-kv  M=512  K=2048"),
+        (11008, 2048,  "9B gate_up M=11008 K=2048"),
+        (2048,  11008, "9B w_down  M=2048  K=11008"),
+        (4096,  2048,  "9B med     M=4096 K=2048"),
+        (1024,  2048,  "9B small   M=1024 K=2048"),
+    ];
+
+    let trials = 200;
+    let warmup = 20;
+
+    for (m, k, label) in &shapes {
+        let (m, k) = (*m, *k);
+        let row_bytes = 16 + (k / 32) * 17;
+        let total_w_bytes = m * row_bytes;
+
+        let w = gpu.upload_raw(&synth(m, k, 0xAA00 | (m as u64) ^ (k as u64)), &[total_w_bytes]).unwrap();
+        let x = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+        let y = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+
+        let x_host = make_x(k, 0x1111);
+        gpu.hip.memcpy_htod(&x.buf, bytes_of(&x_host)).unwrap();
+
+        // Warmup
+        for _ in 0..warmup {
+            gpu.gemv_hfp4g32(&w, &x, &y, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+
+        // Timed
+        let t = Instant::now();
+        for _ in 0..trials {
+            gpu.gemv_hfp4g32(&w, &x, &y, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let us_per_call = t.elapsed().as_secs_f64() * 1e6 / trials as f64;
+
+        let bw_gbps = (total_w_bytes as f64) / (us_per_call * 1e-6) / 1e9;
+        let pct_peak = bw_gbps / PEAK_GBPS * 100.0;
+        let bound = if pct_peak >= 75.0 {
+            "BW-BOUND"
+        } else if pct_peak >= 50.0 {
+            "mixed"
+        } else {
+            "ALU-BOUND"
+        };
+
+        eprintln!(
+            "  {label:42}  {us_per_call:7.2} µs/call   {bw_gbps:6.1} GB/s   ({pct_peak:4.1}% peak)  [{bound}]"
+        );
+    }
+}
+
+fn make_x(n: usize, seed: i64) -> Vec<f32> {
+    (0..n).map(|i| ((i as i64).wrapping_mul(seed.wrapping_add(0x91c2_a73d)).wrapping_add(seed) & 0xFFFFFF) as f32 * 1e-7 - 0.5).collect()
+}
+
+fn synth(m: usize, k: usize, seed: u64) -> Vec<u8> {
+    let blocks_per_row = k / 32;
+    let row_bytes = 16 + blocks_per_row * 17;
+    let mut out = vec![0u8; m * row_bytes];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        let row_off = row * row_bytes;
+        let rs_f32 = 0.02f32 + ((next() & 0xFF) as f32) * 1e-4;
+        let rs_f16 = f32_to_f16_bits(rs_f32);
+        out[row_off..row_off + 2].copy_from_slice(&rs_f16.to_le_bytes());
+        let bc = blocks_per_row as u16;
+        out[row_off + 4..row_off + 6].copy_from_slice(&bc.to_le_bytes());
+        for b in 0..blocks_per_row {
+            let bp = row_off + 16 + b * 17;
+            let e = 120 + (next() & 0x7) as u8;
+            out[bp] = e;
+            for i in 0..16 {
+                out[bp + 1 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn f32_to_f16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = bits & 0x7F_FFFF;
+    if exp == 0 { return sign; }
+    if exp >= 143 { return sign | 0x7C00; }
+    if exp <= 112 { return sign; }
+    let new_exp = (exp - 127 + 15) as u16;
+    let new_mant = (mant >> 13) as u16;
+    sign | (new_exp << 10) | new_mant
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/bench_gemv_mfp4g32_rotate.rs
+++ b/crates/rdna-compute/examples/bench_gemv_mfp4g32_rotate.rs
@@ -1,0 +1,109 @@
+//! Production-realistic bench for the MFP4G32 decode GEMV path
+//! (`gemv_mfp4g32_with_rotate`). Compares env=0 fallback (rotate +
+//! gemv_hfp4g32 fallback) vs env=1 A3 (fused rotate+pack + FP8 GEMV).
+
+use rdna_compute::{DType, Gpu};
+use std::time::Instant;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    if !arch.starts_with("gfx12") {
+        eprintln!("=== SKIP === FP8 dot4 path is gfx12-only (arch={arch})");
+        return;
+    }
+    eprintln!("=== gemv_mfp4g32_with_rotate (production path) ===");
+    eprintln!("  arch={arch}");
+
+    let shapes: Vec<(usize, usize, &str)> = vec![
+        (2048,  2048,  "qkv-q     M=2048 K=2048"),
+        (512,   2048,  "qkv-kv    M=512  K=2048"),
+        (11008, 2048,  "gate_up   M=11008 K=2048"),
+        (2048,  11008, "w_down    M=2048  K=11008"),
+        (4096,  2048,  "med       M=4096 K=2048"),
+        (1024,  2048,  "small     M=1024 K=2048"),
+    ];
+
+    let trials = 200;
+    let warmup = 20;
+
+    for (m, k, label) in &shapes {
+        let (m, k) = (*m, *k);
+        let row_bytes = 16 + (k / 32) * 17;
+        let total_w_bytes = m * row_bytes;
+
+        let w = gpu.upload_raw(&synth(m, k, 0xAA00 | (m as u64) ^ (k as u64)), &[total_w_bytes]).unwrap();
+        let x = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+        let y = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+        let x_rot = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+
+        let x_host = make_x(k, 0x1111);
+        gpu.hip.memcpy_htod(&x.buf, bytes_of(&x_host)).unwrap();
+
+        // Force a different `x` per call by overwriting from host between
+        // each launch — mimics the production case where each gemv has
+        // freshly-written x (which is what blocks the v1 src_ptr cache).
+        for _ in 0..warmup {
+            gpu.gemv_mfp4g32_with_rotate(&w, &x, &y, &x_rot, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+
+        let t = Instant::now();
+        for _ in 0..trials {
+            gpu.gemv_mfp4g32_with_rotate(&w, &x, &y, &x_rot, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let us = t.elapsed().as_secs_f64() * 1e6 / trials as f64;
+
+        eprintln!("  {label:30}  {us:6.2} µs/call");
+    }
+}
+
+fn make_x(n: usize, seed: i64) -> Vec<f32> {
+    (0..n).map(|i| ((i as i64).wrapping_mul(seed.wrapping_add(0x91c2_a73d)).wrapping_add(seed) & 0xFFFFFF) as f32 * 1e-7 - 0.5).collect()
+}
+
+fn synth(m: usize, k: usize, seed: u64) -> Vec<u8> {
+    let blocks_per_row = k / 32;
+    let row_bytes = 16 + blocks_per_row * 17;
+    let mut out = vec![0u8; m * row_bytes];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        let row_off = row * row_bytes;
+        let rs_f32 = 0.02f32 + ((next() & 0xFF) as f32) * 1e-4;
+        let rs_f16 = f32_to_f16_bits(rs_f32);
+        out[row_off..row_off + 2].copy_from_slice(&rs_f16.to_le_bytes());
+        let bc = blocks_per_row as u16;
+        out[row_off + 4..row_off + 6].copy_from_slice(&bc.to_le_bytes());
+        for b in 0..blocks_per_row {
+            let bp = row_off + 16 + b * 17;
+            let e = 120 + (next() & 0x7) as u8;
+            out[bp] = e;
+            for i in 0..16 {
+                out[bp + 1 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn f32_to_f16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = bits & 0x7F_FFFF;
+    if exp == 0 { return sign; }
+    if exp >= 143 { return sign | 0x7C00; }
+    if exp <= 112 { return sign; }
+    let new_exp = (exp - 127 + 15) as u16;
+    let new_mant = (mant >> 13) as u16;
+    sign | (new_exp << 10) | new_mant
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/test_gemm_hfp4g32.rs
+++ b/crates/rdna-compute/examples/test_gemm_hfp4g32.rs
@@ -1,0 +1,327 @@
+//! Unified correctness + perf test for the three batched HFP4-G32
+//! GEMM kernels:
+//!   * gemm_qkv_hfp4g32           (QKV preamble, 3-way fused)
+//!   * gemm_gate_up_hfp4g32       (FFN preamble, 2-way fused)
+//!   * gemm_hfp4g32_residual      (wo / w_down with += semantics)
+//!
+//! Reference for each: gemv_hfp4g32 × N (one call per batch row).
+//! Tolerance: 1e-3 relative against max|y_ref|, plus 1e-4 abs floor.
+//! WMMA accumulates in FP16, scalar GEMV in FP32 — exact byte match
+//! is not expected.
+
+use rdna_compute::{DType, Gpu, GpuTensor};
+use std::time::Instant;
+
+fn main() {
+    // n_list runs in DESCENDING order: each test reuses one x_gemm tensor
+    // across all N values, but `ensure_fp16_x` caches by src_ptr — so smaller
+    // N after larger N reads already-converted data, while smaller N before
+    // larger N would skip reconversion of the larger range. Doing max N first
+    // guarantees full coverage of the fp16 scratch on the first call.
+    let n_list: Vec<usize> = vec![64, 16, 4, 1];
+    let k: usize = 1024;
+
+    let mut gpu = Gpu::init().expect("gpu init");
+
+    let mut all_pass = true;
+    all_pass &= test_qkv(&mut gpu, &n_list, k);
+    all_pass &= test_gate_up(&mut gpu, &n_list, k);
+    all_pass &= test_residual(&mut gpu, &n_list, k);
+
+    if !all_pass {
+        eprintln!("\n=== FAIL ===");
+        std::process::exit(1);
+    }
+    eprintln!("\n=== ALL PASS ===");
+}
+
+fn row_bytes_for(k: usize) -> usize {
+    16 + (k / 32) * 17
+}
+
+fn test_qkv(gpu: &mut Gpu, n_list: &[usize], k: usize) -> bool {
+    let q_m: usize = 2048;
+    let k_m: usize = 512;
+    let v_m: usize = 512;
+    let row_bytes = row_bytes_for(k);
+
+    eprintln!("=== gemm_qkv_hfp4g32 ===");
+    eprintln!("  q_m={q_m} k_m={k_m} v_m={v_m} K={k}");
+
+    let w_q = gpu.upload_raw(&synth(q_m, k, 0xAA), &[q_m * row_bytes]).unwrap();
+    let w_k = gpu.upload_raw(&synth(k_m, k, 0xBB), &[k_m * row_bytes]).unwrap();
+    let w_v = gpu.upload_raw(&synth(v_m, k, 0xCC), &[v_m * row_bytes]).unwrap();
+
+    let max_n = *n_list.iter().max().unwrap();
+    let x_host: Vec<f32> = make_x(max_n * k, 0x1111);
+
+    let x_gemv = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+    let y_q_1 = gpu.alloc_tensor(&[q_m], DType::F32).unwrap();
+    let y_k_1 = gpu.alloc_tensor(&[k_m], DType::F32).unwrap();
+    let y_v_1 = gpu.alloc_tensor(&[v_m], DType::F32).unwrap();
+    let y_q_col = gpu.alloc_tensor(&[max_n * q_m], DType::F32).unwrap();
+    let y_k_col = gpu.alloc_tensor(&[max_n * k_m], DType::F32).unwrap();
+    let y_v_col = gpu.alloc_tensor(&[max_n * v_m], DType::F32).unwrap();
+
+    let x_gemm = gpu.alloc_tensor(&[max_n * k], DType::F32).unwrap();
+    let y_q_gemm = gpu.alloc_tensor(&[max_n * q_m], DType::F32).unwrap();
+    let y_k_gemm = gpu.alloc_tensor(&[max_n * k_m], DType::F32).unwrap();
+    let y_v_gemm = gpu.alloc_tensor(&[max_n * v_m], DType::F32).unwrap();
+
+    gpu.hip.memcpy_htod(&x_gemm.buf, bytes_of(&x_host)).unwrap();
+
+    let mut all_pass = true;
+    for &n in n_list {
+        let mut gemv_us = 0.0;
+        for i in 0..n {
+            gpu.hip.memcpy_htod(&x_gemv.buf, bytes_of(&x_host[i * k..(i + 1) * k])).unwrap();
+            gpu.hip.device_synchronize().unwrap();
+            let t = Instant::now();
+            gpu.gemv_hfp4g32(&w_q, &x_gemv, &y_q_1, q_m, k).unwrap();
+            gpu.gemv_hfp4g32(&w_k, &x_gemv, &y_k_1, k_m, k).unwrap();
+            gpu.gemv_hfp4g32(&w_v, &x_gemv, &y_v_1, v_m, k).unwrap();
+            gpu.hip.device_synchronize().unwrap();
+            gemv_us += t.elapsed().as_secs_f64() * 1e6;
+            gpu.hip.memcpy_dtod_at(&y_q_col.buf, i * q_m * 4, &y_q_1.buf, 0, q_m * 4).unwrap();
+            gpu.hip.memcpy_dtod_at(&y_k_col.buf, i * k_m * 4, &y_k_1.buf, 0, k_m * 4).unwrap();
+            gpu.hip.memcpy_dtod_at(&y_v_col.buf, i * v_m * 4, &y_v_1.buf, 0, v_m * 4).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let t = Instant::now();
+        gpu.gemm_qkv_hfp4g32(
+            &w_q, &w_k, &w_v, &x_gemm,
+            &y_q_gemm, &y_k_gemm, &y_v_gemm,
+            q_m, k_m, v_m, k, n,
+        ).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let gemm_us = t.elapsed().as_secs_f64() * 1e6;
+
+        let ok_q = cmp_tol(gpu, &y_q_col, &y_q_gemm, n, q_m, "q");
+        let ok_k = cmp_tol(gpu, &y_k_col, &y_k_gemm, n, k_m, "k");
+        let ok_v = cmp_tol(gpu, &y_v_col, &y_v_gemm, n, v_m, "v");
+        let ok = ok_q && ok_k && ok_v;
+        eprintln!(
+            "  N={n:3}  gemv×N: {:8.1} µs   gemm×1: {:8.1} µs   speedup: {:5.2}x   [{}]",
+            gemv_us, gemm_us, gemv_us / gemm_us,
+            if ok { "PASS" } else { "FAIL" }
+        );
+        all_pass &= ok;
+    }
+    all_pass
+}
+
+fn test_gate_up(gpu: &mut Gpu, n_list: &[usize], k: usize) -> bool {
+    let gate_m: usize = 4096;
+    let up_m: usize = 4096;
+    let row_bytes = row_bytes_for(k);
+
+    eprintln!("\n=== gemm_gate_up_hfp4g32 ===");
+    eprintln!("  gate_m={gate_m} up_m={up_m} K={k}");
+
+    let w_g = gpu.upload_raw(&synth(gate_m, k, 0xDD), &[gate_m * row_bytes]).unwrap();
+    let w_u = gpu.upload_raw(&synth(up_m, k, 0xEE), &[up_m * row_bytes]).unwrap();
+
+    let max_n = *n_list.iter().max().unwrap();
+    let x_host: Vec<f32> = make_x(max_n * k, 0x2222);
+
+    let x_gemv = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+    let y_g_1 = gpu.alloc_tensor(&[gate_m], DType::F32).unwrap();
+    let y_u_1 = gpu.alloc_tensor(&[up_m], DType::F32).unwrap();
+    let y_g_col = gpu.alloc_tensor(&[max_n * gate_m], DType::F32).unwrap();
+    let y_u_col = gpu.alloc_tensor(&[max_n * up_m], DType::F32).unwrap();
+
+    let x_gemm = gpu.alloc_tensor(&[max_n * k], DType::F32).unwrap();
+    let y_g_gemm = gpu.alloc_tensor(&[max_n * gate_m], DType::F32).unwrap();
+    let y_u_gemm = gpu.alloc_tensor(&[max_n * up_m], DType::F32).unwrap();
+
+    gpu.hip.memcpy_htod(&x_gemm.buf, bytes_of(&x_host)).unwrap();
+
+    let mut all_pass = true;
+    for &n in n_list {
+        let mut gemv_us = 0.0;
+        for i in 0..n {
+            gpu.hip.memcpy_htod(&x_gemv.buf, bytes_of(&x_host[i * k..(i + 1) * k])).unwrap();
+            gpu.hip.device_synchronize().unwrap();
+            let t = Instant::now();
+            gpu.gemv_hfp4g32(&w_g, &x_gemv, &y_g_1, gate_m, k).unwrap();
+            gpu.gemv_hfp4g32(&w_u, &x_gemv, &y_u_1, up_m, k).unwrap();
+            gpu.hip.device_synchronize().unwrap();
+            gemv_us += t.elapsed().as_secs_f64() * 1e6;
+            gpu.hip.memcpy_dtod_at(&y_g_col.buf, i * gate_m * 4, &y_g_1.buf, 0, gate_m * 4).unwrap();
+            gpu.hip.memcpy_dtod_at(&y_u_col.buf, i * up_m * 4, &y_u_1.buf, 0, up_m * 4).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let t = Instant::now();
+        gpu.gemm_gate_up_hfp4g32(
+            &w_g, &w_u, &x_gemm,
+            &y_g_gemm, &y_u_gemm,
+            gate_m, up_m, k, n,
+        ).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let gemm_us = t.elapsed().as_secs_f64() * 1e6;
+
+        let ok_g = cmp_tol(gpu, &y_g_col, &y_g_gemm, n, gate_m, "gate");
+        let ok_u = cmp_tol(gpu, &y_u_col, &y_u_gemm, n, up_m, "up");
+        let ok = ok_g && ok_u;
+        eprintln!(
+            "  N={n:3}  gemv×N: {:8.1} µs   gemm×1: {:8.1} µs   speedup: {:5.2}x   [{}]",
+            gemv_us, gemm_us, gemv_us / gemm_us,
+            if ok { "PASS" } else { "FAIL" }
+        );
+        all_pass &= ok;
+    }
+    all_pass
+}
+
+fn test_residual(gpu: &mut Gpu, n_list: &[usize], k: usize) -> bool {
+    let m: usize = 2048;
+    let row_bytes = row_bytes_for(k);
+
+    eprintln!("\n=== gemm_hfp4g32_residual (+= semantics) ===");
+    eprintln!("  M={m} K={k}");
+
+    let w = gpu.upload_raw(&synth(m, k, 0xFF), &[m * row_bytes]).unwrap();
+
+    let max_n = *n_list.iter().max().unwrap();
+    let x_host: Vec<f32> = make_x(max_n * k, 0x3333);
+    // Residual seed: small constant so += semantics is testable.
+    let res_seed: Vec<f32> = (0..max_n * m)
+        .map(|i| ((i as i32) % 7 - 3) as f32 * 1e-3)
+        .collect();
+
+    let x_gemv = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+    let y_1 = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+    let y_col = gpu.alloc_tensor(&[max_n * m], DType::F32).unwrap();
+
+    let x_gemm = gpu.alloc_tensor(&[max_n * k], DType::F32).unwrap();
+    let y_gemm = gpu.alloc_tensor(&[max_n * m], DType::F32).unwrap();
+
+    gpu.hip.memcpy_htod(&x_gemm.buf, bytes_of(&x_host)).unwrap();
+
+    let mut all_pass = true;
+    for &n in n_list {
+        let mut gemv_us = 0.0;
+        // Build the host-side reference: ref[b][r] = seed[b][r] + gemv(w, x[b])[r].
+        let mut ref_host: Vec<f32> = vec![0.0; n * m];
+        for i in 0..n {
+            gpu.hip.memcpy_htod(&x_gemv.buf, bytes_of(&x_host[i * k..(i + 1) * k])).unwrap();
+            gpu.hip.device_synchronize().unwrap();
+            let t = Instant::now();
+            gpu.gemv_hfp4g32(&w, &x_gemv, &y_1, m, k).unwrap();
+            gpu.hip.device_synchronize().unwrap();
+            gemv_us += t.elapsed().as_secs_f64() * 1e6;
+            let y_1_host = gpu.download_f32(&y_1).unwrap();
+            for r in 0..m {
+                ref_host[i * m + r] = res_seed[i * m + r] + y_1_host[r];
+            }
+        }
+        gpu.hip.memcpy_htod(&y_col.buf, bytes_of(&ref_host)).unwrap();
+        // Seed y_gemm with res_seed; the residual GEMM accumulates into it.
+        gpu.hip.memcpy_htod(&y_gemm.buf, bytes_of(&res_seed[..n * m])).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let t = Instant::now();
+        gpu.gemm_hfp4g32_residual(&w, &x_gemm, &y_gemm, m, k, n).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let gemm_us = t.elapsed().as_secs_f64() * 1e6;
+
+        let ok = cmp_tol(gpu, &y_col, &y_gemm, n, m, "res");
+        eprintln!(
+            "  N={n:3}  gemv×N: {:8.1} µs   gemm×1: {:8.1} µs   speedup: {:5.2}x   [{}]",
+            gemv_us, gemm_us, gemv_us / gemm_us,
+            if ok { "PASS" } else { "FAIL" }
+        );
+        all_pass &= ok;
+    }
+    all_pass
+}
+
+fn cmp_tol(gpu: &mut Gpu, y_ref: &GpuTensor, y_kernel: &GpuTensor, n: usize, m: usize, label: &str) -> bool {
+    let r = gpu.download_f32(y_ref).unwrap();
+    let k = gpu.download_f32(y_kernel).unwrap();
+
+    let mut max_abs: f64 = 0.0;
+    let mut max_abs_ref: f64 = 0.0;
+    let mut bad = 0usize;
+
+    for b in 0..n {
+        for row in 0..m {
+            let r_v = r[b * m + row] as f64;
+            let k_v = k[b * m + row] as f64;
+            let abs = (r_v - k_v).abs();
+            if abs > max_abs { max_abs = abs; }
+            if r_v.abs() > max_abs_ref { max_abs_ref = r_v.abs(); }
+        }
+    }
+    let tol_abs = 1e-3 * max_abs_ref.max(1e-4);
+    for b in 0..n {
+        for row in 0..m {
+            let r_v = r[b * m + row] as f64;
+            let k_v = k[b * m + row] as f64;
+            if (r_v - k_v).abs() > tol_abs { bad += 1; }
+        }
+    }
+
+    if bad > 0 {
+        eprintln!(
+            "  {label}: FAIL  {bad} elements outside tol  max_abs={:.3e}  tol={:.3e}  max_|y_ref|={:.3e}",
+            max_abs, tol_abs, max_abs_ref
+        );
+        return false;
+    }
+    eprintln!(
+        "  {label}: PASS  max_abs={:.3e}  max_|y_ref|={:.3e}",
+        max_abs, max_abs_ref
+    );
+    true
+}
+
+fn make_x(n: usize, seed: i64) -> Vec<f32> {
+    (0..n)
+        .map(|i| ((i as i64).wrapping_mul(seed.wrapping_add(0x91c2_a73d)).wrapping_add(seed) & 0xFFFFFF) as f32 * 1e-7 - 0.5)
+        .collect()
+}
+
+fn synth(m: usize, k: usize, seed: u64) -> Vec<u8> {
+    let blocks_per_row = k / 32;
+    let row_bytes = 16 + blocks_per_row * 17;
+    let mut out = vec![0u8; m * row_bytes];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        let row_off = row * row_bytes;
+        let rs_f32 = 0.02f32 + ((next() & 0xFF) as f32) * 1e-4;
+        let rs_f16 = f32_to_f16_bits(rs_f32);
+        out[row_off..row_off + 2].copy_from_slice(&rs_f16.to_le_bytes());
+        let bc = blocks_per_row as u16;
+        out[row_off + 4..row_off + 6].copy_from_slice(&bc.to_le_bytes());
+        for b in 0..blocks_per_row {
+            let bp = row_off + 16 + b * 17;
+            let e = 120 + (next() & 0x7) as u8;
+            out[bp] = e;
+            for i in 0..16 {
+                out[bp + 1 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn f32_to_f16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = bits & 0x7F_FFFF;
+    if exp == 0 { return sign; }
+    if exp >= 143 { return sign | 0x7C00; }
+    if exp <= 112 { return sign; }
+    let new_exp = (exp - 127 + 15) as u16;
+    let new_mant = (mant >> 13) as u16;
+    sign | (new_exp << 10) | new_mant
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/test_gemm_hfp4g32_fp8.rs
+++ b/crates/rdna-compute/examples/test_gemm_hfp4g32_fp8.rs
@@ -1,0 +1,193 @@
+//! Correctness + perf test for the gfx12 FP8-WMMA QKV HFP4G32 kernel.
+//!
+//! Compares `gemm_qkv_hfp4g32_wmma_fp8_gfx12` against the FP16-WMMA
+//! sibling `gemm_qkv_hfp4g32_wmma_gfx12` (already validated against the
+//! gemv scalar reference by `test_gemm_hfp4g32`). FP8 path uses E4M3
+//! for both operands so per-element precision is ~12.5%; over K=1024
+//! accumulation the relative error should be sub-1%, but we allow 5%
+//! to cover worst-case rows.
+//!
+//! Skips silently with PASS on non-gfx12 archs.
+
+use rdna_compute::{DType, Gpu, GpuTensor};
+use std::time::Instant;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    if !arch.starts_with("gfx12") {
+        eprintln!("=== SKIP === FP8 WMMA is gfx12-only (arch={arch})");
+        return;
+    }
+    eprintln!("=== gemm_qkv_hfp4g32_wmma_fp8_gfx12 ===");
+    eprintln!("  arch={arch}");
+
+    // Sweep both small N (decode-batch-like) and realistic prefill N
+    // (256-2048) at production K=2048 to see whether the constant
+    // per-warp dequant overhead amortizes against the 1.87x raw WMMA
+    // throughput advantage when M tile count grows.
+    let n_list: Vec<usize> = vec![2048, 512, 256, 64, 16, 4, 1];
+    let k: usize = 2048;
+    let q_m: usize = 2048;
+    let k_m: usize = 512;
+    let v_m: usize = 512;
+    let row_bytes = 16 + (k / 32) * 17;
+
+    let w_q = gpu.upload_raw(&synth(q_m, k, 0xAA), &[q_m * row_bytes]).unwrap();
+    let w_k = gpu.upload_raw(&synth(k_m, k, 0xBB), &[k_m * row_bytes]).unwrap();
+    let w_v = gpu.upload_raw(&synth(v_m, k, 0xCC), &[v_m * row_bytes]).unwrap();
+
+    let max_n = *n_list.iter().max().unwrap();
+    let x_host: Vec<f32> = make_x(max_n * k, 0x1111);
+
+    let x_gemm = gpu.alloc_tensor(&[max_n * k], DType::F32).unwrap();
+    let y_q_ref = gpu.alloc_tensor(&[max_n * q_m], DType::F32).unwrap();
+    let y_k_ref = gpu.alloc_tensor(&[max_n * k_m], DType::F32).unwrap();
+    let y_v_ref = gpu.alloc_tensor(&[max_n * v_m], DType::F32).unwrap();
+    let y_q_fp8 = gpu.alloc_tensor(&[max_n * q_m], DType::F32).unwrap();
+    let y_k_fp8 = gpu.alloc_tensor(&[max_n * k_m], DType::F32).unwrap();
+    let y_v_fp8 = gpu.alloc_tensor(&[max_n * v_m], DType::F32).unwrap();
+
+    gpu.hip.memcpy_htod(&x_gemm.buf, bytes_of(&x_host)).unwrap();
+
+    // n_list descending order: ensure_fp16_x is keyed by src_ptr — the
+    // first call at max_n fills the scratch; later smaller N reuses it.
+    let mut all_pass = true;
+    for &n in &n_list {
+        // FP16 reference (direct entry point — bypasses HIPFIRE_FP8_WMMA gate).
+        gpu.hip.device_synchronize().unwrap();
+        let t = Instant::now();
+        gpu.gemm_qkv_hfp4g32_wmma_gfx12(
+            &w_q, &w_k, &w_v, &x_gemm,
+            &y_q_ref, &y_k_ref, &y_v_ref,
+            q_m, k_m, v_m, k, n,
+        ).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let f16_us = t.elapsed().as_secs_f64() * 1e6;
+
+        // FP8 candidate.
+        gpu.hip.device_synchronize().unwrap();
+        let t = Instant::now();
+        gpu.gemm_qkv_hfp4g32_wmma_fp8_gfx12(
+            &w_q, &w_k, &w_v, &x_gemm,
+            &y_q_fp8, &y_k_fp8, &y_v_fp8,
+            q_m, k_m, v_m, k, n,
+        ).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let fp8_us = t.elapsed().as_secs_f64() * 1e6;
+
+        let ok_q = cmp_tol(&mut gpu, &y_q_ref, &y_q_fp8, n, q_m, "q");
+        let ok_k = cmp_tol(&mut gpu, &y_k_ref, &y_k_fp8, n, k_m, "k");
+        let ok_v = cmp_tol(&mut gpu, &y_v_ref, &y_v_fp8, n, v_m, "v");
+        let ok = ok_q && ok_k && ok_v;
+        eprintln!(
+            "  N={n:3}  fp16: {:8.1} µs   fp8: {:8.1} µs   speedup: {:5.2}x   [{}]",
+            f16_us, fp8_us, f16_us / fp8_us,
+            if ok { "PASS" } else { "FAIL" }
+        );
+        all_pass &= ok;
+    }
+
+    if !all_pass {
+        eprintln!("\n=== FAIL ===");
+        std::process::exit(1);
+    }
+    eprintln!("\n=== ALL PASS ===");
+}
+
+fn cmp_tol(gpu: &mut Gpu, y_ref: &GpuTensor, y_kernel: &GpuTensor, n: usize, m: usize, label: &str) -> bool {
+    let r = gpu.download_f32(y_ref).unwrap();
+    let k = gpu.download_f32(y_kernel).unwrap();
+
+    let mut max_abs: f64 = 0.0;
+    let mut max_abs_ref: f64 = 0.0;
+    let mut sum_sq_err: f64 = 0.0;
+    let mut sum_sq_ref: f64 = 0.0;
+
+    for b in 0..n {
+        for row in 0..m {
+            let r_v = r[b * m + row] as f64;
+            let k_v = k[b * m + row] as f64;
+            let abs = (r_v - k_v).abs();
+            if abs > max_abs { max_abs = abs; }
+            if r_v.abs() > max_abs_ref { max_abs_ref = r_v.abs(); }
+            sum_sq_err += (r_v - k_v) * (r_v - k_v);
+            sum_sq_ref += r_v * r_v;
+        }
+    }
+    let nrmse = (sum_sq_err / sum_sq_ref.max(1e-30)).sqrt();
+    // 5% relative tol on element max, plus 1e-3 abs floor. NRMSE shown for context.
+    let tol_abs = 0.05 * max_abs_ref.max(1e-3);
+    let mut bad = 0usize;
+    for b in 0..n {
+        for row in 0..m {
+            let r_v = r[b * m + row] as f64;
+            let k_v = k[b * m + row] as f64;
+            if (r_v - k_v).abs() > tol_abs { bad += 1; }
+        }
+    }
+
+    if bad > 0 {
+        eprintln!(
+            "  {label}: FAIL  {bad} elements outside tol  max_abs={:.3e}  tol={:.3e}  max_|y_ref|={:.3e}  NRMSE={:.3e}",
+            max_abs, tol_abs, max_abs_ref, nrmse
+        );
+        return false;
+    }
+    eprintln!(
+        "  {label}: PASS  max_abs={:.3e}  max_|y_ref|={:.3e}  NRMSE={:.3e}",
+        max_abs, max_abs_ref, nrmse
+    );
+    true
+}
+
+fn make_x(n: usize, seed: i64) -> Vec<f32> {
+    (0..n)
+        .map(|i| ((i as i64).wrapping_mul(seed.wrapping_add(0x91c2_a73d)).wrapping_add(seed) & 0xFFFFFF) as f32 * 1e-7 - 0.5)
+        .collect()
+}
+
+fn synth(m: usize, k: usize, seed: u64) -> Vec<u8> {
+    let blocks_per_row = k / 32;
+    let row_bytes = 16 + blocks_per_row * 17;
+    let mut out = vec![0u8; m * row_bytes];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        let row_off = row * row_bytes;
+        let rs_f32 = 0.02f32 + ((next() & 0xFF) as f32) * 1e-4;
+        let rs_f16 = f32_to_f16_bits(rs_f32);
+        out[row_off..row_off + 2].copy_from_slice(&rs_f16.to_le_bytes());
+        let bc = blocks_per_row as u16;
+        out[row_off + 4..row_off + 6].copy_from_slice(&bc.to_le_bytes());
+        for b in 0..blocks_per_row {
+            let bp = row_off + 16 + b * 17;
+            let e = 120 + (next() & 0x7) as u8;
+            out[bp] = e;
+            for i in 0..16 {
+                out[bp + 1 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn f32_to_f16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = bits & 0x7F_FFFF;
+    if exp == 0 { return sign; }
+    if exp >= 143 { return sign | 0x7C00; }
+    if exp <= 112 { return sign; }
+    let new_exp = (exp - 127 + 15) as u16;
+    let new_mant = (mant >> 13) as u16;
+    sign | (new_exp << 10) | new_mant
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/test_gemv_hfp4g32_dot2.rs
+++ b/crates/rdna-compute/examples/test_gemv_hfp4g32_dot2.rs
@@ -1,0 +1,172 @@
+//! Correctness + perf test for the gfx11 v_dot2_f32_f16 HFP4G32 decode GEMV.
+//! Compares `gemv_hfp4g32_dot2_gfx11` (FP16 + fdot2) against the F32 fallback
+//! (`gemv_hfp4g32_fallback`) across production Qwen 9B decode shapes.
+//! Skips silently on archs without dot2 support.
+
+use rdna_compute::{DType, Gpu, GpuTensor};
+use std::time::Instant;
+
+const PEAK_GBPS_GFX1100: f64 = 960.0; // 7900 XTX GDDR6 384-bit @ 20 Gbps
+const PEAK_GBPS_GFX12: f64 = 800.0;   // R9700 spec
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    if !arch.starts_with("gfx11") && !arch.starts_with("gfx12") {
+        eprintln!("=== SKIP === dot2 path needs gfx11+ (arch={arch})");
+        return;
+    }
+    let peak_gbps = if arch.starts_with("gfx12") { PEAK_GBPS_GFX12 } else { PEAK_GBPS_GFX1100 };
+    eprintln!("=== gemv_hfp4g32_dot2_gfx11 vs fallback ===");
+    eprintln!("  arch={arch}  peak_bw_gbps={peak_gbps}");
+
+    let shapes: Vec<(usize, usize, &str)> = vec![
+        (2048,  2048,  "qkv-q     M=2048 K=2048"),
+        (512,   2048,  "qkv-kv    M=512  K=2048"),
+        (11008, 2048,  "gate_up   M=11008 K=2048"),
+        (2048,  11008, "w_down    M=2048  K=11008"),
+        (4096,  2048,  "med       M=4096 K=2048"),
+        (1024,  2048,  "small     M=1024 K=2048"),
+    ];
+
+    let trials = 200;
+    let warmup = 20;
+
+    let mut all_pass = true;
+    for (m, k, label) in &shapes {
+        let (m, k) = (*m, *k);
+        let row_bytes = 16 + (k / 32) * 17;
+        let total_w_bytes = m * row_bytes;
+
+        let w = gpu.upload_raw(&synth(m, k, 0xAA00 | (m as u64) ^ (k as u64)), &[total_w_bytes]).unwrap();
+        let x = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+        let y_ref = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+        let y_dot2 = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+
+        let x_host = make_x(k, 0x1111);
+        gpu.hip.memcpy_htod(&x.buf, bytes_of(&x_host)).unwrap();
+
+        // Warmup both kernels
+        for _ in 0..warmup {
+            gpu.gemv_hfp4g32_fallback(&w, &x, &y_ref, m, k).unwrap();
+            gpu.gemv_hfp4g32_dot2_gfx11(&w, &x, &y_dot2, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+
+        // Time fallback
+        let t = Instant::now();
+        for _ in 0..trials {
+            gpu.gemv_hfp4g32_fallback(&w, &x, &y_ref, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let ref_us = t.elapsed().as_secs_f64() * 1e6 / trials as f64;
+
+        // Time dot2
+        let t = Instant::now();
+        for _ in 0..trials {
+            gpu.gemv_hfp4g32_dot2_gfx11(&w, &x, &y_dot2, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let dot2_us = t.elapsed().as_secs_f64() * 1e6 / trials as f64;
+
+        let ref_bw = (total_w_bytes as f64) / (ref_us * 1e-6) / 1e9;
+        let dot2_bw = (total_w_bytes as f64) / (dot2_us * 1e-6) / 1e9;
+
+        let ok = cmp_tol(&mut gpu, &y_ref, &y_dot2, m, label);
+        all_pass &= ok;
+
+        let speedup = ref_us / dot2_us;
+        eprintln!(
+            "  {label:30}  ref: {ref_us:6.2}µs ({ref_bw:5.1} GB/s = {:4.1}%)  dot2: {dot2_us:6.2}µs ({dot2_bw:5.1} GB/s = {:4.1}%)  speedup: {speedup:4.2}×",
+            ref_bw / peak_gbps * 100.0,
+            dot2_bw / peak_gbps * 100.0,
+        );
+    }
+
+    if !all_pass {
+        eprintln!("\n=== FAIL ===");
+        std::process::exit(1);
+    }
+    eprintln!("\n=== ALL PASS ===");
+}
+
+fn cmp_tol(gpu: &mut Gpu, y_ref: &GpuTensor, y_dot2: &GpuTensor, m: usize, label: &str) -> bool {
+    let r = gpu.download_f32(y_ref).unwrap();
+    let k = gpu.download_f32(y_dot2).unwrap();
+    let mut max_abs: f64 = 0.0;
+    let mut max_abs_ref: f64 = 0.0;
+    let mut sum_sq_err: f64 = 0.0;
+    let mut sum_sq_ref: f64 = 0.0;
+    for i in 0..m {
+        let r_v = r[i] as f64;
+        let k_v = k[i] as f64;
+        let abs = (r_v - k_v).abs();
+        if abs > max_abs { max_abs = abs; }
+        if r_v.abs() > max_abs_ref { max_abs_ref = r_v.abs(); }
+        sum_sq_err += (r_v - k_v) * (r_v - k_v);
+        sum_sq_ref += r_v * r_v;
+    }
+    let nrmse = (sum_sq_err / sum_sq_ref.max(1e-30)).sqrt();
+    // 3% relative tol on element max (dot2 uses FP16 multiply intermediate,
+    // a touch less precise than F32 mul). Plus 1e-3 abs floor.
+    let tol_abs = 0.03 * max_abs_ref.max(1e-3);
+    let bad: usize = (0..m).filter(|&i| ((r[i] as f64) - (k[i] as f64)).abs() > tol_abs).count();
+    if bad > 0 {
+        eprintln!(
+            "  {label}: FAIL  {bad}/{m}  max_abs={:.3e}  tol={:.3e}  max_|y|={:.3e}  NRMSE={:.3e}",
+            max_abs, tol_abs, max_abs_ref, nrmse
+        );
+        return false;
+    }
+    eprintln!("  {label}: OK  NRMSE={:.3e}", nrmse);
+    true
+}
+
+fn make_x(n: usize, seed: i64) -> Vec<f32> {
+    (0..n).map(|i| ((i as i64).wrapping_mul(seed.wrapping_add(0x91c2_a73d)).wrapping_add(seed) & 0xFFFFFF) as f32 * 1e-7 - 0.5).collect()
+}
+
+fn synth(m: usize, k: usize, seed: u64) -> Vec<u8> {
+    let blocks_per_row = k / 32;
+    let row_bytes = 16 + blocks_per_row * 17;
+    let mut out = vec![0u8; m * row_bytes];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        let row_off = row * row_bytes;
+        let rs_f32 = 0.02f32 + ((next() & 0xFF) as f32) * 1e-4;
+        let rs_f16 = f32_to_f16_bits(rs_f32);
+        out[row_off..row_off + 2].copy_from_slice(&rs_f16.to_le_bytes());
+        let bc = blocks_per_row as u16;
+        out[row_off + 4..row_off + 6].copy_from_slice(&bc.to_le_bytes());
+        for b in 0..blocks_per_row {
+            let bp = row_off + 16 + b * 17;
+            let e = 120 + (next() & 0x7) as u8;
+            out[bp] = e;
+            for i in 0..16 {
+                out[bp + 1 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn f32_to_f16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = bits & 0x7F_FFFF;
+    if exp == 0 { return sign; }
+    if exp >= 143 { return sign | 0x7C00; }
+    if exp <= 112 { return sign; }
+    let new_exp = (exp - 127 + 15) as u16;
+    let new_mant = (mant >> 13) as u16;
+    sign | (new_exp << 10) | new_mant
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/examples/test_gemv_hfp4g32_fp8.rs
+++ b/crates/rdna-compute/examples/test_gemv_hfp4g32_fp8.rs
@@ -1,0 +1,174 @@
+//! Correctness + perf test for the gfx12 FP8-dot4 HFP4G32 decode GEMV.
+//!
+//! Compares `gemv_hfp4g32_fp8_gfx12` against the fallback `gemv_hfp4g32`
+//! across production Qwen 9B decode shapes. Reports speedup, NRMSE, and
+//! % of theoretical peak BW.
+//!
+//! Skips silently on non-gfx12 archs.
+
+use rdna_compute::{DType, Gpu, GpuTensor};
+use std::time::Instant;
+
+const PEAK_GBPS: f64 = 800.0;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let arch = gpu.arch.clone();
+    if !arch.starts_with("gfx12") {
+        eprintln!("=== SKIP === FP8 dot4 GEMV is gfx12-only (arch={arch})");
+        return;
+    }
+    eprintln!("=== gemv_hfp4g32_fp8_gfx12 vs fallback gemv_hfp4g32 ===");
+    eprintln!("  arch={arch}  peak_bw_gbps={PEAK_GBPS}");
+
+    // 9B Qwen3.5 decode-path GEMV shapes:
+    let shapes: Vec<(usize, usize, &str)> = vec![
+        (2048,  2048,  "qkv-q     M=2048 K=2048"),
+        (512,   2048,  "qkv-kv    M=512  K=2048"),
+        (11008, 2048,  "gate_up   M=11008 K=2048"),
+        (2048,  11008, "w_down    M=2048  K=11008"),
+        (4096,  2048,  "med       M=4096 K=2048"),
+        (1024,  2048,  "small     M=1024 K=2048"),
+    ];
+
+    let trials = 200;
+    let warmup = 20;
+
+    let mut all_pass = true;
+    for (m, k, label) in &shapes {
+        let (m, k) = (*m, *k);
+        let row_bytes = 16 + (k / 32) * 17;
+        let total_w_bytes = m * row_bytes;
+
+        let w = gpu.upload_raw(&synth(m, k, 0xAA00 | (m as u64) ^ (k as u64)), &[total_w_bytes]).unwrap();
+        let x = gpu.alloc_tensor(&[k], DType::F32).unwrap();
+        let y_ref = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+        let y_fp8 = gpu.alloc_tensor(&[m], DType::F32).unwrap();
+
+        let x_host = make_x(k, 0x1111);
+        gpu.hip.memcpy_htod(&x.buf, bytes_of(&x_host)).unwrap();
+
+        // Warmup both kernels
+        for _ in 0..warmup {
+            gpu.gemv_hfp4g32(&w, &x, &y_ref, m, k).unwrap();
+            gpu.gemv_hfp4g32_fp8_gfx12(&w, &x, &y_fp8, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+
+        // Time fallback
+        let t = Instant::now();
+        for _ in 0..trials {
+            gpu.gemv_hfp4g32(&w, &x, &y_ref, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let ref_us = t.elapsed().as_secs_f64() * 1e6 / trials as f64;
+
+        // Time FP8 dot4
+        let t = Instant::now();
+        for _ in 0..trials {
+            gpu.gemv_hfp4g32_fp8_gfx12(&w, &x, &y_fp8, m, k).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let fp8_us = t.elapsed().as_secs_f64() * 1e6 / trials as f64;
+
+        let ref_bw = (total_w_bytes as f64) / (ref_us * 1e-6) / 1e9;
+        let fp8_bw = (total_w_bytes as f64) / (fp8_us * 1e-6) / 1e9;
+
+        // Correctness check
+        let ok = cmp_tol(&mut gpu, &y_ref, &y_fp8, m, label);
+        all_pass &= ok;
+
+        let speedup = ref_us / fp8_us;
+        eprintln!(
+            "  {label:30}  ref: {ref_us:6.2}µs ({ref_bw:5.1} GB/s = {:4.1}%)  fp8: {fp8_us:6.2}µs ({fp8_bw:5.1} GB/s = {:4.1}%)  speedup: {speedup:4.2}×",
+            ref_bw / PEAK_GBPS * 100.0,
+            fp8_bw / PEAK_GBPS * 100.0,
+        );
+    }
+
+    if !all_pass {
+        eprintln!("\n=== FAIL ===");
+        std::process::exit(1);
+    }
+    eprintln!("\n=== ALL PASS ===");
+}
+
+fn cmp_tol(gpu: &mut Gpu, y_ref: &GpuTensor, y_fp8: &GpuTensor, m: usize, label: &str) -> bool {
+    let r = gpu.download_f32(y_ref).unwrap();
+    let k = gpu.download_f32(y_fp8).unwrap();
+
+    let mut max_abs: f64 = 0.0;
+    let mut max_abs_ref: f64 = 0.0;
+    let mut sum_sq_err: f64 = 0.0;
+    let mut sum_sq_ref: f64 = 0.0;
+    for i in 0..m {
+        let r_v = r[i] as f64;
+        let k_v = k[i] as f64;
+        let abs = (r_v - k_v).abs();
+        if abs > max_abs { max_abs = abs; }
+        if r_v.abs() > max_abs_ref { max_abs_ref = r_v.abs(); }
+        sum_sq_err += (r_v - k_v) * (r_v - k_v);
+        sum_sq_ref += r_v * r_v;
+    }
+    let nrmse = (sum_sq_err / sum_sq_ref.max(1e-30)).sqrt();
+    let tol_abs = 0.05 * max_abs_ref.max(1e-3);
+    let bad: usize = (0..m).filter(|&i| ((r[i] as f64) - (k[i] as f64)).abs() > tol_abs).count();
+    if bad > 0 {
+        eprintln!(
+            "  {label}: FAIL  {bad}/{m}  max_abs={:.3e}  tol={:.3e}  max_|y|={:.3e}  NRMSE={:.3e}",
+            max_abs, tol_abs, max_abs_ref, nrmse
+        );
+        return false;
+    }
+    eprintln!("  {label}: OK  NRMSE={:.3e}", nrmse);
+    true
+}
+
+fn make_x(n: usize, seed: i64) -> Vec<f32> {
+    (0..n).map(|i| ((i as i64).wrapping_mul(seed.wrapping_add(0x91c2_a73d)).wrapping_add(seed) & 0xFFFFFF) as f32 * 1e-7 - 0.5).collect()
+}
+
+fn synth(m: usize, k: usize, seed: u64) -> Vec<u8> {
+    let blocks_per_row = k / 32;
+    let row_bytes = 16 + blocks_per_row * 17;
+    let mut out = vec![0u8; m * row_bytes];
+    let mut state = seed;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    for row in 0..m {
+        let row_off = row * row_bytes;
+        let rs_f32 = 0.02f32 + ((next() & 0xFF) as f32) * 1e-4;
+        let rs_f16 = f32_to_f16_bits(rs_f32);
+        out[row_off..row_off + 2].copy_from_slice(&rs_f16.to_le_bytes());
+        let bc = blocks_per_row as u16;
+        out[row_off + 4..row_off + 6].copy_from_slice(&bc.to_le_bytes());
+        for b in 0..blocks_per_row {
+            let bp = row_off + 16 + b * 17;
+            let e = 120 + (next() & 0x7) as u8;
+            out[bp] = e;
+            for i in 0..16 {
+                out[bp + 1 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}
+
+fn f32_to_f16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xFF) as i32;
+    let mant = bits & 0x7F_FFFF;
+    if exp == 0 { return sign; }
+    if exp >= 143 { return sign | 0x7C00; }
+    if exp <= 112 { return sign; }
+    let new_exp = (exp - 127 + 15) as u16;
+    let new_mant = (mant >> 13) as u16;
+    sign | (new_exp << 10) | new_mant
+}
+
+fn bytes_of(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -164,6 +164,44 @@ fn has_wmma_f16_gfx12(arch: &str) -> bool {
     arch.starts_with("gfx12")
 }
 
+/// gfx12 (RDNA4) WMMA fp8. Same gating as fp16 (both are gfx12-only
+/// builtins); separate helper to allow finer-grained future gating
+/// (e.g. if a future RDNA arch lands fp16 WMMA without fp8). The
+/// fp8 prefill kernels are opt-in via HIPFIRE_FP8_WMMA=1 until they
+/// are perf-validated and made default on gfx12.
+fn has_wmma_fp8_gfx12(arch: &str) -> bool {
+    arch.starts_with("gfx12")
+}
+
+/// Opt-in gate for the fp8 prefill WMMA and decode dot4 kernels.
+/// Cached in a OnceLock — reading HIPFIRE_FP8_WMMA via `std::env::var`
+/// on every dispatch costs a syscall + String alloc which was visible
+/// as ~4 µs/call overhead in tight bench loops, swamping the FP8 win.
+fn is_fp8_wmma_enabled() -> bool {
+    use std::sync::OnceLock;
+    static GATE: OnceLock<bool> = OnceLock::new();
+    *GATE.get_or_init(|| {
+        std::env::var("HIPFIRE_FP8_WMMA").map_or(false, |v| v == "1")
+    })
+}
+
+/// Minimum batch size at which the FP8 WMMA prefill path is enabled.
+/// Below this, the FP16 WMMA path wins on gfx1201 (measured 0.71-0.94×
+/// at N ≤ 512, 0.82-1.26× only at N ≥ 2048 with high DPM variance —
+/// see project_fp8_wmma_hfp4g32_2026_05_10.md). Decode (batch_size=1)
+/// must never hit FP8 WMMA. Threshold tuned conservatively; A/B against
+/// FP16 WMMA on the production prefill bench can lower it later.
+const FP8_WMMA_MIN_BATCH: usize = 1024;
+
+/// Minimum output dimension M at which the FP8-dot4 decode GEMV path
+/// is enabled. Below this, the fallback wins or ties on gfx1201
+/// (measured 0.92-1.03× on wo M=2048 K=2048 vs 1.17-1.21× on FFN
+/// shapes M ≥ 4096 — see mq_rotate_x_dual_fp8 bench, 2026-05-11).
+/// This is the empirical embodiment of "Option α" mixed-precision
+/// routing — choose the kernel that wins for the actual shape rather
+/// than uniformly applying FP8 everywhere.
+const FP8_GEMV_MIN_M: usize = 4096;
+
 /// Gates the wave64 FP16 hybrid prefill path. gfx906 (Vega 20, MI50) is the
 /// only arch with measured data: +90% prefill on Qwen 3.5 9B (74 → 141 tk/s).
 /// gfx908 (CDNA1, MI100) shares __hfma2 + wave64 and would code-correctly
@@ -372,6 +410,18 @@ pub struct Gpu {
     /// Pointer to the last FP32 source that was converted to fp16_x_scratch.
     /// If the next GEMM uses the same X, skip the conversion.
     pub fp16_x_source_ptr: *mut c_void,
+    /// FP8 (E4M3) scratch buffer for the gfx12 FP8-WMMA prefill path.
+    /// Sized to max(batch_size × K) × 1 byte. Cached by src_ptr like
+    /// `fp16_x_scratch`.
+    fp8_x_scratch: Option<hip_bridge::DeviceBuffer>,
+    fp8_x_scratch_bytes: usize,
+    fp8_x_source_ptr: *mut c_void,
+    /// FP8 (E4M3) sibling of `mq_x_rot`. Filled by
+    /// `mq_rotate_x_dual_fp8` so the FP8 decode GEMV can read FP8
+    /// activations without a separate pack launch. Lifetime is tied
+    /// to mq_x_rot; reallocated together.
+    pub mq_x_rot_fp8: Option<hip_bridge::DeviceBuffer>,
+    pub mq_x_rot_fp8_bytes: usize,
     /// Q8_1/MMQ scratch for prefill activations. Layout matches llama.cpp's
     /// `block_q8_1_mmq`, ordered by [K/128 block, batch column].
     q8_1_mmq_x_scratch: Option<hip_bridge::DeviceBuffer>,
@@ -647,6 +697,11 @@ impl Gpu {
             fp16_x_scratch: None,
             fp16_x_scratch_bytes: 0,
             fp16_x_source_ptr: std::ptr::null_mut(),
+            fp8_x_scratch: None,
+            fp8_x_scratch_bytes: 0,
+            fp8_x_source_ptr: std::ptr::null_mut(),
+            mq_x_rot_fp8: None,
+            mq_x_rot_fp8_bytes: 0,
             q8_1_mmq_x_scratch: None,
             q8_1_mmq_x_scratch_bytes: 0,
             mmq_screen_cache: HashMap::new(),
@@ -1227,6 +1282,51 @@ impl Gpu {
         }
 
         Ok(self.fp16_x_scratch.as_ref().unwrap().as_ptr())
+    }
+
+    /// Ensure the FP8 (E4M3) X scratch contains the conversion of `x`
+    /// (an F32 GpuTensor). Returns the FP8 device pointer. gfx12 only —
+    /// uses cvt_pk_fp8_f32. Caches by `x.buf.as_ptr()` like its FP16
+    /// sibling so back-to-back same-X GEMM dispatches skip reconversion.
+    fn ensure_fp8_x(&mut self, x: &GpuTensor, n_elems: usize) -> HipResult<*mut c_void> {
+        self.ensure_kernel("pack_f32_to_fp8_gfx12", kernels::PACK_F32_TO_FP8_GFX12_SRC, "pack_f32_to_fp8_gfx12")?;
+
+        let src_ptr = x.buf.as_ptr();
+        let needed = n_elems; // 1 byte per element
+
+        if self.fp8_x_scratch_bytes < needed {
+            self.fp8_x_scratch = Some(self.hip.malloc(needed)?);
+            self.fp8_x_scratch_bytes = needed;
+            self.fp8_x_source_ptr = std::ptr::null_mut();
+        }
+
+        let must_convert = self.capture_mode || self.fp8_x_source_ptr != src_ptr;
+        if must_convert {
+            let in_ptr = src_ptr;
+            let out_ptr = self.fp8_x_scratch.as_ref().unwrap().as_ptr();
+            let n_val = n_elems as i32;
+            let mut in_ptr_m = in_ptr;
+            let mut out_ptr_m = out_ptr;
+            let mut n_val_m = n_val;
+            let mut conv_params: Vec<*mut c_void> = vec![
+                &mut in_ptr_m as *mut _ as *mut c_void,
+                &mut out_ptr_m as *mut _ as *mut c_void,
+                &mut n_val_m as *mut _ as *mut c_void,
+            ];
+            // 16 elements per thread, 256 threads per block = 4096 elements/block.
+            let grid = ((n_elems + 4095) / 4096) as u32;
+            self.launch_maybe_blob(
+                "pack_f32_to_fp8_gfx12", [grid, 1, 1], [256, 1, 1], 0, &mut conv_params,
+                || {
+                    let mut b = hip_bridge::KernargBlob::new();
+                    b.push_ptr(in_ptr); b.push_ptr(out_ptr); b.push_i32(n_val);
+                    b
+                },
+            )?;
+            self.fp8_x_source_ptr = src_ptr;
+        }
+
+        Ok(self.fp8_x_scratch.as_ref().unwrap().as_ptr())
     }
 
     /// Ensure prefill activations are quantized into a llama.cpp-style
@@ -2714,6 +2814,12 @@ impl Gpu {
     ) -> HipResult<()> {
         assert!(k % 256 == 0, "gemv_hfp4g32 requires K%256==0 in v1, got K={}", k);
         self.bind_thread()?;
+        // Shape-gated: FP8 dot4 only when M is large enough that it
+        // actually wins (FFN shapes). At M < 4096 the fallback wins or
+        // ties; uniform-FP8 was net-negative in 9B Qwen 3.5 decode.
+        if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && m >= FP8_GEMV_MIN_M {
+            return self.gemv_hfp4g32_fp8_gfx12(a_raw, x, y, m, k);
+        }
         let (src, module) = kernels::gemv_hfp4g32_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfp4g32")?;
         let func = &self.functions["gemv_hfp4g32"];
@@ -2731,6 +2837,33 @@ impl Gpu {
         ];
         // LDS: 16-entry FP16 LUT = 32 bytes.
         unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 32, self.stream_ref(), &mut params) }
+    }
+
+    /// gfx12 FP8-dot4 decode-path GEMV for HFP4G32. Uses
+    /// `dot4_f32_fp8_fp8` to cut inner-loop ALU vs the dequant/FMA
+    /// fallback. Activation X is consumed as FP8 (E4M3); when called
+    /// via `gemv_hfp4g32` (env-gated routing for HFP4G32 weights, no
+    /// rotation), this function calls `ensure_fp8_x` to pack F32 → FP8
+    /// scratch. The MFP4G32 rotation path uses
+    /// `rotate_x_mq_dual_fp8` + `gemv_hfp4g32_fp8_gfx12_with_fp8_ptr`
+    /// instead so the FP8 pack is fused into the rotation kernel.
+    pub fn gemv_hfp4g32_fp8_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        assert!(k % 256 == 0, "gemv_hfp4g32_fp8 requires K%256==0, got K={}", k);
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemv_hfp4g32_fp8_gfx12",
+            kernels::GEMV_HFP4G32_FP8_GFX12_SRC,
+            "gemv_hfp4g32_fp8_gfx12",
+        )?;
+        let x_fp8_ptr = self.ensure_fp8_x(x, k)?;
+        self.gemv_hfp4g32_fp8_gfx12_with_fp8_ptr(a_raw, x_fp8_ptr, y, m, k)
     }
 
     /// Fused RMSNorm + MagnumQuant FWHT rotation. Replaces the
@@ -2802,6 +2935,7 @@ impl Gpu {
         if let Some(t) = timer {
             t.finish(&self.hip);
         }
+        self.invalidate_x_caches_for(xrp);
         result
     }
 
@@ -2864,6 +2998,7 @@ impl Gpu {
             },
         );
         if let Some(t) = timer { t.finish(&self.hip); }
+        self.invalidate_x_caches_for(xrp);
         result
     }
 
@@ -2916,6 +3051,7 @@ impl Gpu {
             },
         );
         if let Some(t) = timer { t.finish(&self.hip); }
+        self.invalidate_x_caches_for(xrp);
         result
     }
 
@@ -2970,7 +3106,27 @@ impl Gpu {
             },
         );
         if let Some(t) = timer { t.finish(&self.hip); }
+        self.invalidate_x_caches_for(xrp);
         result
+    }
+
+    /// Invalidate any `ensure_*_x` caches whose source pointer matches
+    /// `dst_ptr`. Must be called by any kernel that overwrites data at
+    /// `dst_ptr` since the caches key on raw pointer equality and have
+    /// no way to detect data changes otherwise. The `mq_x_rot` scratch
+    /// buffer used by the MagnumQuant rotation wrappers is the canonical
+    /// case — its pointer is stable across all gemv calls but its data
+    /// changes per rotation; without this invalidation, the FP8/FP16
+    /// activation scratch returns stale data on every call after the
+    /// first within a forward pass (silent correctness bug — coherence
+    /// detectors miss it because output stays vaguely on-topic).
+    fn invalidate_x_caches_for(&mut self, dst_ptr: *mut c_void) {
+        if self.fp16_x_source_ptr == dst_ptr {
+            self.fp16_x_source_ptr = std::ptr::null_mut();
+        }
+        if self.fp8_x_source_ptr == dst_ptr {
+            self.fp8_x_source_ptr = std::ptr::null_mut();
+        }
     }
 
     /// Standalone FWHT rotation for MagnumQuant (MQ4). Writes K floats into x_rot.
@@ -3008,6 +3164,7 @@ impl Gpu {
             },
         );
         if let Some(t) = timer { t.finish(&self.hip); }
+        self.invalidate_x_caches_for(xrp);
         result
     }
 
@@ -3055,6 +3212,7 @@ impl Gpu {
             },
         );
         if let Some(t) = timer { t.finish(&self.hip); }
+        self.invalidate_x_caches_for(xrp);
         result
     }
 
@@ -3090,6 +3248,14 @@ impl Gpu {
         x_rot: &GpuTensor, m: usize, k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // Shape-gated FP8 routing (Option α empirical embodiment): only
+        // when M ≥ FP8_GEMV_MIN_M does FP8 dot4 win measurably on this
+        // path. Below threshold (e.g. wo M=2048), the FP8 fused-rotation
+        // costs more than the dot4 ALU savings — keep the F32 fallback.
+        if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && m >= FP8_GEMV_MIN_M {
+            let x_fp8_ptr = self.rotate_x_mq_dual_fp8(x, x_rot, k)?;
+            return self.gemv_hfp4g32_fp8_gfx12_with_fp8_ptr(a_raw, x_fp8_ptr, y, m, k);
+        }
         self.rotate_x_mq(x, x_rot, k)?;
         self.gemv_hfp4g32(a_raw, x_rot, y, m, k)
     }
@@ -3101,6 +3267,94 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         self.gemv_hfp4g32(a_raw, x_rot, y, m, k)
+    }
+
+    /// Fused FWHT rotation + FP8 pack for the decode FP8 path.
+    /// Writes both F32 (into `x_rot`) and FP8 (into `mq_x_rot_fp8`
+    /// sibling scratch) in one kernel launch. Returns the FP8 buffer's
+    /// device pointer for the caller to feed directly to the FP8 GEMV.
+    /// gfx12-only — uses cvt_pk_fp8_f32.
+    fn rotate_x_mq_dual_fp8(
+        &mut self, x: &GpuTensor, x_rot: &GpuTensor, k: usize,
+    ) -> HipResult<*mut c_void> {
+        self.ensure_mq_signs()?;
+        self.ensure_kernel(
+            "mq_rotate_x_dual_fp8_gfx12",
+            kernels::MQ_ROTATE_X_DUAL_FP8_GFX12_SRC,
+            "mq_rotate_x_dual_fp8_gfx12",
+        )?;
+        // Lazily allocate the FP8 sibling scratch sized to match k bytes.
+        if self.mq_x_rot_fp8_bytes < k {
+            self.mq_x_rot_fp8 = Some(self.hip.malloc(k)?);
+            self.mq_x_rot_fp8_bytes = k;
+        }
+        let s1_ptr = self.mq_signs1.as_ref().unwrap().buf.as_ptr();
+        let s2_ptr = self.mq_signs2.as_ref().unwrap().buf.as_ptr();
+        let xp = x.buf.as_ptr();
+        let xrp = x_rot.buf.as_ptr();
+        let xfp = self.mq_x_rot_fp8.as_ref().unwrap().as_ptr();
+        let n_groups = (k / 256) as u32;
+        let kv = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &xp as *const _ as *mut c_void,
+            &xrp as *const _ as *mut c_void,
+            &xfp as *const _ as *mut c_void,
+            &s1_ptr as *const _ as *mut c_void,
+            &s2_ptr as *const _ as *mut c_void,
+            &kv as *const _ as *mut c_void,
+        ];
+        let bytes = crate::profile::mq_rotate_bytes(k) + k; // +1 byte/elem fp8 write
+        let timer = crate::profile::begin_timer(&self.hip, "fwht", "mq_rotate_x_dual_fp8", bytes);
+        let result = self.launch_maybe_blob(
+            "mq_rotate_x_dual_fp8_gfx12",
+            [n_groups, 1, 1], [32, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(xp); b.push_ptr(xrp); b.push_ptr(xfp);
+                b.push_ptr(s1_ptr); b.push_ptr(s2_ptr);
+                b.push_i32(kv);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        // Same x_rot dst as the standalone rotation path → invalidate
+        // any ensure_*_x caches that were keyed by this pointer.
+        self.invalidate_x_caches_for(xrp);
+        result?;
+        Ok(xfp)
+    }
+
+    /// FP8-dot4 GEMV variant that takes an FP8 device pointer directly
+    /// (bypassing `ensure_fp8_x`). Used by `gemv_mfp4g32_with_rotate`
+    /// after the fused rotation+pack kernel produces the FP8 buffer
+    /// in-place.
+    fn gemv_hfp4g32_fp8_gfx12_with_fp8_ptr(
+        &mut self,
+        a_raw: &GpuTensor,
+        x_fp8_ptr: *mut c_void,
+        y: &GpuTensor,
+        m: usize, k: usize,
+    ) -> HipResult<()> {
+        assert!(k % 256 == 0, "gemv_hfp4g32_fp8 requires K%256==0, got K={}", k);
+        self.ensure_kernel(
+            "gemv_hfp4g32_fp8_gfx12",
+            kernels::GEMV_HFP4G32_FP8_GFX12_SRC,
+            "gemv_hfp4g32_fp8_gfx12",
+        )?;
+        let func = &self.functions["gemv_hfp4g32_fp8_gfx12"];
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_fp8_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+        ];
+        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 32, self.stream_ref(), &mut params) }
     }
 
     /// MagnumQuant MQ3: rotate x once, then HFQ3-G256 GEMV against rotated x.
@@ -6003,6 +6257,17 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // FP8 WMMA gate: only at batch sizes where the prefill bench
+        // measured ≥1× vs FP16 WMMA. At small batches (decode FA QKV
+        // calls this with batch_size=1) the FP8 path measures
+        // 0.71-0.84×, so we keep the FP16 path there. Threshold is
+        // conservative — see project_fp8_wmma_hfp4g32_2026_05_10.md
+        // for the full N sweep. The decode-path FP8 win is on the
+        // GEMV side (gemv_hfp4g32_fp8_gfx12), not WMMA.
+        if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && batch_size >= FP8_WMMA_MIN_BATCH {
+            return self.gemm_qkv_hfp4g32_wmma_fp8_gfx12(
+                a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+        }
         if has_wmma_f16_gfx12(&self.arch) {
             return self.gemm_qkv_hfp4g32_wmma_gfx12(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
@@ -6147,6 +6412,88 @@ impl Gpu {
         let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfp4g32_wmma_gfx12", bytes);
         let result = self.launch_maybe_blob(
             "gemm_qkv_hfp4g32_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// gfx12 FP8-WMMA variant of `gemm_qkv_hfp4g32_wmma_gfx12`. Same
+    /// 16x16x16 tile shape, same C-mapping; weight LUT pre-converts
+    /// E2M1->E4M3 bytes (no scale) and per-output-row row_scale * UE8M0
+    /// is applied to the F32 accumulator after each WMMA pair via
+    /// lane-shuffle. Activation is converted FP16->FP8 inline by
+    /// cvt_pk_fp8_f32 (unscaled — post-RMSNorm magnitudes are bounded
+    /// well below E4M3 saturation). Opt-in via HIPFIRE_FP8_WMMA=1.
+    pub fn gemm_qkv_hfp4g32_wmma_fp8_gfx12(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkv_hfp4g32_wmma_fp8_gfx12",
+            kernels::GEMM_QKV_HFP4G32_WMMA_FP8_GFX12_SRC,
+            "gemm_qkv_hfp4g32_wmma_fp8_gfx12",
+        )?;
+        let x_fp8_ptr = self.ensure_fp8_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_fp8_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_val = q_m as i32;
+        let mut k_m_val = k_m as i32;
+        let mut v_m_val = v_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_val as *mut _ as *mut c_void,
+            &mut k_m_val as *mut _ as *mut c_void,
+            &mut v_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(q_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(k_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(v_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfp4g32_wmma_fp8_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfp4g32_wmma_fp8_gfx12",
             [row_tiles as u32, batch_tiles as u32, 1],
             [32, 1, 1],
             0,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -202,6 +202,23 @@ const FP8_WMMA_MIN_BATCH: usize = 1024;
 /// than uniformly applying FP8 everywhere.
 const FP8_GEMV_MIN_M: usize = 4096;
 
+/// Opt-in (default-OFF) gate for the gfx11 v_dot2_f32_f16 GEMV
+/// trickle-down. Synthetic bench measures 1.13-2.08× wins on FFN
+/// shapes on 7900 XTX, but production decode on 9B HFP4G32 lost 0.90×
+/// across two kernel variants (single-carry chain + 4 independent
+/// partials), same trap as the gfx12 FP8 paths — kernel-level ALU
+/// wins don't survive cross-kernel context costs in real decode.
+/// Kept opt-in via HIPFIRE_DOT2_GEMV=1 as research scaffold (the
+/// bench tools are still useful for future kernels). Default-off
+/// preserves the fallback that wins production.
+fn is_dot2_gemv_enabled() -> bool {
+    use std::sync::OnceLock;
+    static GATE: OnceLock<bool> = OnceLock::new();
+    *GATE.get_or_init(|| {
+        std::env::var("HIPFIRE_DOT2_GEMV").map_or(false, |v| v == "1")
+    })
+}
+
 /// Gates the wave64 FP16 hybrid prefill path. gfx906 (Vega 20, MI50) is the
 /// only arch with measured data: +90% prefill on Qwen 3.5 9B (74 → 141 tk/s).
 /// gfx908 (CDNA1, MI100) shares __hfma2 + wave64 and would code-correctly
@@ -2820,6 +2837,28 @@ impl Gpu {
         if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && m >= FP8_GEMV_MIN_M {
             return self.gemv_hfp4g32_fp8_gfx12(a_raw, x, y, m, k);
         }
+        // gfx11 (RDNA3) v_dot2_f32_f16 trickle-down: replaces the
+        // fallback's F32 mul+fma chain with one fdot2 per 2 elements.
+        // No new scratch (reuses ensure_fp16_x), no cross-kernel
+        // context cost like the FP8 path had. Default-on for gfx11.
+        // Kill switch HIPFIRE_DOT2_GEMV=0 for A/B benching.
+        if has_wmma_f16(&self.arch) && is_dot2_gemv_enabled() {
+            return self.gemv_hfp4g32_dot2_gfx11(a_raw, x, y, m, k);
+        }
+        self.gemv_hfp4g32_fallback(a_raw, x, y, m, k)
+    }
+
+    /// Direct fallback entry point (F32 mul+fma chain). Useful for
+    /// A/B benchmarking against the dot2/fp8 variants.
+    pub fn gemv_hfp4g32_fallback(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
         let (src, module) = kernels::gemv_hfp4g32_for_arch(&self.arch);
         self.ensure_kernel(module, src, "gemv_hfp4g32")?;
         let func = &self.functions["gemv_hfp4g32"];
@@ -3322,6 +3361,45 @@ impl Gpu {
         self.invalidate_x_caches_for(xrp);
         result?;
         Ok(xfp)
+    }
+
+    /// gfx11 (RDNA3) v_dot2_f32_f16 decode-path GEMV for HFP4G32.
+    /// Takes F32 x and converts to FP16 INLINE in the inner loop;
+    /// `__builtin_amdgcn_fdot2` (v_dot2_f32_f16) does 2 FP16 muls +
+    /// 1 FP32 add per VALU. Reduces inner-loop multiply count ~4×
+    /// vs the fallback F32 mul+fma chain on ALU-bound shapes.
+    /// Routed automatically from `gemv_hfp4g32` when on gfx11+ archs
+    /// (gfx1100/1101/1102/1150/1151). NO ensure_fp16_x pre-pass —
+    /// that's the v1 trap (eats the dot2 savings in production).
+    pub fn gemv_hfp4g32_dot2_gfx11(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        assert!(k % 256 == 0, "gemv_hfp4g32_dot2 requires K%256==0, got K={}", k);
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemv_hfp4g32_dot2_gfx11",
+            kernels::GEMV_HFP4G32_DOT2_GFX11_SRC,
+            "gemv_hfp4g32_dot2_gfx11",
+        )?;
+        let func = &self.functions["gemv_hfp4g32_dot2_gfx11"];
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x.buf.as_ptr();
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+        ];
+        unsafe { self.hip.launch_kernel(func, [m as u32, 1, 1], [32, 1, 1], 32, self.stream_ref(), &mut params) }
     }
 
     /// FP8-dot4 GEMV variant that takes an FP8 device pointer directly

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -5271,6 +5271,195 @@ impl Gpu {
         result
     }
 
+    /// HFP4-G32 batched 4-way fused GEMM (qkv + z + beta + alpha) for
+    /// the Qwen3.5 DeltaNet LA preamble. Routes gfx11 / gfx12. Used for
+    /// HFP4G32 (raw X) and MFP4G32 (FWHT-rotated X handled upstream).
+    pub fn gemm_qkvza_hfp4g32(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_qkvza_hfp4g32_wmma_gfx12(
+                a_qkv, a_z, a_beta, a_alpha, x,
+                y_qkv, y_z, y_beta, y_alpha,
+                qkv_m, z_m, beta_m, alpha_m, k, batch_size);
+        }
+        self.gemm_qkvza_hfp4g32_wmma(
+            a_qkv, a_z, a_beta, a_alpha, x,
+            y_qkv, y_z, y_beta, y_alpha,
+            qkv_m, z_m, beta_m, alpha_m, k, batch_size)
+    }
+
+    pub fn gemm_qkvza_hfp4g32_wmma(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkvza_hfp4g32_wmma",
+            kernels::GEMM_QKVZA_HFP4G32_WMMA_SRC,
+            "gemm_qkvza_hfp4g32_wmma",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_qkv.buf.as_ptr();
+        let mut az = a_z.buf.as_ptr();
+        let mut ab = a_beta.buf.as_ptr();
+        let mut aa = a_alpha.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_qkv.buf.as_ptr();
+        let mut yz = y_z.buf.as_ptr();
+        let mut yb = y_beta.buf.as_ptr();
+        let mut ya = y_alpha.buf.as_ptr();
+        let mut q_m = qkv_m as i32;
+        let mut z_m_val = z_m as i32;
+        let mut b_m = beta_m as i32;
+        let mut a_m = alpha_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut az as *mut _ as *mut c_void,
+            &mut ab as *mut _ as *mut c_void,
+            &mut aa as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yz as *mut _ as *mut c_void,
+            &mut yb as *mut _ as *mut c_void,
+            &mut ya as *mut _ as *mut c_void,
+            &mut q_m as *mut _ as *mut c_void,
+            &mut z_m_val as *mut _ as *mut c_void,
+            &mut b_m as *mut _ as *mut c_void,
+            &mut a_m as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(qkv_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(z_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(beta_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(alpha_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_hfp4g32_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_hfp4g32_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(q_m); b.push_i32(z_m_val); b.push_i32(b_m); b.push_i32(a_m);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_qkvza_hfp4g32_wmma_gfx12(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkvza_hfp4g32_wmma_gfx12",
+            kernels::GEMM_QKVZA_HFP4G32_WMMA_GFX12_SRC,
+            "gemm_qkvza_hfp4g32_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_qkv.buf.as_ptr();
+        let mut az = a_z.buf.as_ptr();
+        let mut ab = a_beta.buf.as_ptr();
+        let mut aa = a_alpha.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_qkv.buf.as_ptr();
+        let mut yz = y_z.buf.as_ptr();
+        let mut yb = y_beta.buf.as_ptr();
+        let mut ya = y_alpha.buf.as_ptr();
+        let mut q_m = qkv_m as i32;
+        let mut z_m_val = z_m as i32;
+        let mut b_m = beta_m as i32;
+        let mut a_m = alpha_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut az as *mut _ as *mut c_void,
+            &mut ab as *mut _ as *mut c_void,
+            &mut aa as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yz as *mut _ as *mut c_void,
+            &mut yb as *mut _ as *mut c_void,
+            &mut ya as *mut _ as *mut c_void,
+            &mut q_m as *mut _ as *mut c_void,
+            &mut z_m_val as *mut _ as *mut c_void,
+            &mut b_m as *mut _ as *mut c_void,
+            &mut a_m as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(qkv_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(z_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(beta_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(alpha_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_hfp4g32_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_hfp4g32_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(q_m); b.push_i32(z_m_val); b.push_i32(b_m); b.push_i32(a_m);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ3-G256 sister of `gemm_qkvza_hfq4g256_wmma`. Same WMMA shape +
     /// lane decomposition; only the inner K-tile unpack differs (3-bit
     /// cross-byte vs 4-bit nibble) and the per-group byte stride is 104
@@ -5787,6 +5976,464 @@ impl Gpu {
                 b.push_ptr(xp);
                 b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
                 b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// WMMA-accelerated batched 3-way fused HFP4-G32 GEMM (Q + K + V).
+    /// Sister of `gemm_qkv_hfq4g256_wmma` for the FP4 (E2M1 + UE8M0 g32 +
+    /// FP16 row scale) family. Routes to the gfx11 or gfx12 variant by
+    /// arch. Asserts a WMMA-capable arch — callers must gate via
+    /// `is_batchable_la` (which restricts HFP4G32 to gfx11+/gfx12 archs).
+    ///
+    /// Used for both HFP4G32 (raw, X is the rmsnormed activation) and
+    /// MFP4G32 (X is the FWHT-rotated activation; rotation happens
+    /// upstream via `mq_rotate_x` so the kernel is identical).
+    pub fn gemm_qkv_hfp4g32(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_qkv_hfp4g32_wmma_gfx12(
+                a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
+        }
+        self.gemm_qkv_hfp4g32_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size)
+    }
+
+    /// gfx11 (RDNA3) variant of `gemm_qkv_hfp4g32`. Direct entry point
+    /// for tests; production callers should use `gemm_qkv_hfp4g32` to
+    /// pick up the gfx12 sister automatically.
+    pub fn gemm_qkv_hfp4g32_wmma(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkv_hfp4g32_wmma",
+            kernels::GEMM_QKV_HFP4G32_WMMA_SRC,
+            "gemm_qkv_hfp4g32_wmma",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_val = q_m as i32;
+        let mut k_m_val = k_m as i32;
+        let mut v_m_val = v_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_val as *mut _ as *mut c_void,
+            &mut k_m_val as *mut _ as *mut c_void,
+            &mut v_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(q_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(k_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(v_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfp4g32_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfp4g32_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// gfx12 (RDNA4) variant of `gemm_qkv_hfp4g32`. half8_t lane-split +
+    /// K4 unroll. Same C-output mapping as `gemm_qkv_hfq4g256_wmma_gfx12`.
+    pub fn gemm_qkv_hfp4g32_wmma_gfx12(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkv_hfp4g32_wmma_gfx12",
+            kernels::GEMM_QKV_HFP4G32_WMMA_GFX12_SRC,
+            "gemm_qkv_hfp4g32_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_val = q_m as i32;
+        let mut k_m_val = k_m as i32;
+        let mut v_m_val = v_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_val as *mut _ as *mut c_void,
+            &mut k_m_val as *mut _ as *mut c_void,
+            &mut v_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(q_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(k_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(v_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_hfp4g32_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfp4g32_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// HFP4-G32 batched residual GEMM with fused += semantics.
+    /// Sister of `gemm_hfq4g256_residual_wmma_k2`. Used for wo + w_down
+    /// projections in the batched prefill path. Routes to gfx11/gfx12.
+    /// Caller must initialize Y to the residual stream before this call.
+    pub fn gemm_hfp4g32_residual(
+        &mut self,
+        a: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize, k: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_hfp4g32_residual_wmma_gfx12(a, x, y, m, k, batch_size);
+        }
+        self.gemm_hfp4g32_residual_wmma(a, x, y, m, k, batch_size)
+    }
+
+    pub fn gemm_hfp4g32_residual_wmma(
+        &mut self,
+        a: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize, k: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfp4g32_residual_wmma",
+            kernels::GEMM_HFP4G32_RESIDUAL_WMMA_SRC,
+            "gemm_hfp4g32_residual_wmma",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ap = a.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yp = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ap as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yp as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(m, k)
+                  + batch_size * k * 2
+                  + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfp4g32_residual_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfp4g32_residual_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ap); b.push_ptr(xp); b.push_ptr(yp);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_hfp4g32_residual_wmma_gfx12(
+        &mut self,
+        a: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize, k: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfp4g32_residual_wmma_gfx12",
+            kernels::GEMM_HFP4G32_RESIDUAL_WMMA_GFX12_SRC,
+            "gemm_hfp4g32_residual_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ap = a.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yp = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ap as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yp as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(m, k)
+                  + batch_size * k * 2
+                  + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfp4g32_residual_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfp4g32_residual_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ap); b.push_ptr(xp); b.push_ptr(yp);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// HFP4-G32 batched 2-way fused GEMM (gate + up). Routes gfx11/gfx12.
+    pub fn gemm_gate_up_hfp4g32(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        if has_wmma_f16_gfx12(&self.arch) {
+            return self.gemm_gate_up_hfp4g32_wmma_gfx12(
+                a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
+        }
+        self.gemm_gate_up_hfp4g32_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size)
+    }
+
+    pub fn gemm_gate_up_hfp4g32_wmma(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_gate_up_hfp4g32_wmma",
+            kernels::GEMM_GATE_UP_HFP4G32_WMMA_SRC,
+            "gemm_gate_up_hfp4g32_wmma",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ag = a_gate.buf.as_ptr();
+        let mut au = a_up.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yg = y_gate.buf.as_ptr();
+        let mut yu = y_up.buf.as_ptr();
+        let mut gm_val = gate_m as i32;
+        let mut um_val = up_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ag as *mut _ as *mut c_void,
+            &mut au as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yg as *mut _ as *mut c_void,
+            &mut yu as *mut _ as *mut c_void,
+            &mut gm_val as *mut _ as *mut c_void,
+            &mut um_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(gate_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(up_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_hfp4g32_wmma", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_hfp4g32_wmma",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ag); b.push_ptr(au); b.push_ptr(xp);
+                b.push_ptr(yg); b.push_ptr(yu);
+                b.push_i32(gm_val); b.push_i32(um_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_gate_up_hfp4g32_wmma_gfx12(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_gate_up_hfp4g32_wmma_gfx12",
+            kernels::GEMM_GATE_UP_HFP4G32_WMMA_GFX12_SRC,
+            "gemm_gate_up_hfp4g32_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut ag = a_gate.buf.as_ptr();
+        let mut au = a_up.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yg = y_gate.buf.as_ptr();
+        let mut yu = y_up.buf.as_ptr();
+        let mut gm_val = gate_m as i32;
+        let mut um_val = up_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ag as *mut _ as *mut c_void,
+            &mut au as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yg as *mut _ as *mut c_void,
+            &mut yu as *mut _ as *mut c_void,
+            &mut gm_val as *mut _ as *mut c_void,
+            &mut um_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfp4g32_bytes(gate_m, k)
+                  + crate::profile::gemv_hfp4g32_bytes(up_m, k)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_hfp4g32_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_hfp4g32_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ag); b.push_ptr(au); b.push_ptr(xp);
+                b.push_ptr(yg); b.push_ptr(yu);
+                b.push_i32(gm_val); b.push_i32(um_val);
                 b.push_i32(k_val); b.push_i32(n_val);
                 b
             },

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -275,6 +275,13 @@ pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/sr
 /// then (K/32) blocks × 17 B (UE8M0:u8 + 16 B nibbles).
 pub const GEMV_HFP4G32_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32.hip");
 pub const GEMV_HFP4G32_GFX1100_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32.gfx1100.hip");
+// gfx11 (RDNA3) v_dot2_f32_f16-accelerated decode-path variant.
+// Inner loop uses 4 fdot2 ops per K-block (8 K-elts), replacing the
+// fallback's 8 F32 mul + 8 F32 fma chain. Activation X consumed as
+// FP16 via ensure_fp16_x. Wins biggest on ALU-bound shapes (FFN
+// M=11008 measured 40% peak BW on 7900 XTX with fallback — headroom
+// to ~2×). Reaches gfx11/RDNA3.5 archs (gfx1100/1101/1102/1150/1151).
+pub const GEMV_HFP4G32_DOT2_GFX11_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32_dot2.gfx11.hip");
 // gfx12 (RDNA4) FP8-dot4 decode-path variant. dot4_f32_fp8_fp8 cuts inner-loop
 // ALU ~2-2.4× vs the fallback dequant/FMA chain; biggest win on ALU-bound
 // small-M attention shapes (k_proj/v_proj at ~16-20% peak BW on R9700).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -275,6 +275,11 @@ pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/sr
 /// then (K/32) blocks × 17 B (UE8M0:u8 + 16 B nibbles).
 pub const GEMV_HFP4G32_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32.hip");
 pub const GEMV_HFP4G32_GFX1100_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32.gfx1100.hip");
+// gfx12 (RDNA4) FP8-dot4 decode-path variant. dot4_f32_fp8_fp8 cuts inner-loop
+// ALU ~2-2.4× vs the fallback dequant/FMA chain; biggest win on ALU-bound
+// small-M attention shapes (k_proj/v_proj at ~16-20% peak BW on R9700).
+// Activation X consumed as FP8 (E4M3), pre-packed by `ensure_fp8_x`.
+pub const GEMV_HFP4G32_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/gemv_hfp4g32_fp8.gfx12.hip");
 
 
 
@@ -504,6 +509,24 @@ pub const GEMM_QKV_HFP4G32_WMMA_SRC: &str = include_str!("../../../kernels/src/g
 // + K4 unroll (each iter consumes 2 HFP4 blocks). Same C-output mapping
 // as gemm_qkv_hfq4g256_wmma.gfx12 (validated on R9700).
 pub const GEMM_QKV_HFP4G32_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfp4g32_wmma.gfx12.hip");
+// gfx12 FP8-WMMA variant of GEMM_QKV_HFP4G32_WMMA_GFX12_SRC. Uses
+// wmma_f32_16x16x16_fp8_fp8 (~1.87x raw issue throughput vs fp16 WMMA
+// on gfx1201, microbenched). Weight LUT pre-converts E2M1->E4M3 bytes
+// (no scale baked); per-output-row row_scale * UE8M0_block is applied
+// to the F32 accumulator after each WMMA-pair via lane-shuffle.
+// Activation X is consumed in pre-packed FP8 (E4M3) layout, produced
+// by PACK_F32_TO_FP8_GFX12_SRC + ensure_fp8_x.
+pub const GEMM_QKV_HFP4G32_WMMA_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfp4g32_wmma_fp8.gfx12.hip");
+// Activation pre-pass for FP8 WMMA kernels: F32 -> E4M3 elementwise,
+// no scaling. Memory-BW-bound; lifts the FP8 GEMM kernels above FP16
+// parity by moving the cvt out of the WMMA inner loop.
+pub const PACK_F32_TO_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/pack_f32_to_fp8.gfx12.hip");
+// Fused MagnumQuant FWHT rotation + FP8 (E4M3) pack — gfx12 only.
+// Writes both F32 (for legacy consumers) and FP8 outputs in one launch.
+// Replaces the standalone mq_rotate_x + pack_f32_to_fp8 sequence on the
+// FP8 decode path so the pack launch is no longer on the critical path
+// of every weight_gemv(MFP4G32) call.
+pub const MQ_ROTATE_X_DUAL_FP8_GFX12_SRC: &str = include_str!("../../../kernels/src/mq_rotate_x_dual.gfx12.hip");
 
 // HFP4-G32 residual GEMM (used for wo + w_down). Mirrors the K2 HFQ4
 // variant — canonical wave32 WMMA C-output mapping `acc[j] = C[2*j +

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -493,6 +493,34 @@ pub const GEMM_QKV_HFQ4G256_WMMA_SRC: &str = include_str!("../../../kernels/src/
 // validated on R9700 in PR #56's channel-tests.
 pub const GEMM_QKV_HFQ4G256_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq4g256_wmma.gfx12.hip");
 
+// Batched 3-way fused HFP4-G32 GEMM (FA preamble: Q + K + V). Sister of
+// GEMM_QKV_HFQ4G256_WMMA_SRC for the FP4 (E2M1 + UE8M0 g32 + FP16 row
+// scale) family. Same WMMA shape (16x16x16 f16) and lane decomposition;
+// only the per-row layout (16-B header + 17-B blocks) and per-tile
+// dequant arithmetic (row_scale * 2^(block_e-127) * E2M1_LUT[nibble])
+// differ from the HFQ4G256 anchor.
+pub const GEMM_QKV_HFP4G32_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfp4g32_wmma.hip");
+// gfx12 (RDNA4) sister of GEMM_QKV_HFP4G32_WMMA_SRC. half8_t lane-split
+// + K4 unroll (each iter consumes 2 HFP4 blocks). Same C-output mapping
+// as gemm_qkv_hfq4g256_wmma.gfx12 (validated on R9700).
+pub const GEMM_QKV_HFP4G32_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfp4g32_wmma.gfx12.hip");
+
+// HFP4-G32 residual GEMM (used for wo + w_down). Mirrors the K2 HFQ4
+// variant — canonical wave32 WMMA C-output mapping `acc[j] = C[2*j +
+// (tid>>4)][tid & 15]`.
+pub const GEMM_HFP4G32_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_hfp4g32_residual_wmma.hip");
+pub const GEMM_HFP4G32_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfp4g32_residual_wmma.gfx12.hip");
+
+// HFP4-G32 batched 2-way fused GEMM (gate + up). Sister of
+// GEMM_QKV_HFP4G32_WMMA_SRC for the FFN preamble.
+pub const GEMM_GATE_UP_HFP4G32_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfp4g32_wmma.hip");
+pub const GEMM_GATE_UP_HFP4G32_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfp4g32_wmma.gfx12.hip");
+
+// HFP4-G32 batched 4-way fused GEMM (qkv + z + beta + alpha) for the
+// Qwen3.5 DeltaNet LA preamble.
+pub const GEMM_QKVZA_HFP4G32_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfp4g32_wmma.hip");
+pub const GEMM_QKVZA_HFP4G32_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfp4g32_wmma.gfx12.hip");
+
 // Batched 4-way fused HFQ4-G256 GEMM (LA preamble: wqkv + wz + w_beta + w_alpha).
 // Batched counterpart of fused_qkvza_hfq4g256 — byte-exact vs running that kernel
 // N times on the same x[b]. Used for batched prefill of the LA layer projection.

--- a/crates/rdna-compute/src/profile.rs
+++ b/crates/rdna-compute/src/profile.rs
@@ -159,6 +159,17 @@ pub fn gemm_hfq4g256_bytes(m: usize, k: usize, batch: usize) -> usize {
     hfq4g256_weight_bytes(m, k) + batch * (k + m) * 4
 }
 
+/// HFP4-G32 weight footprint: 16-B row header + (K/32)*17-B blocks per row.
+pub fn hfp4g32_weight_bytes(m: usize, k: usize) -> usize {
+    let blocks = k / 32;
+    m * (16 + blocks * 17)
+}
+
+/// Single-row HFP4-G32 GEMV bytes: weight + x (FP32) + y (FP32).
+pub fn gemv_hfp4g32_bytes(m: usize, k: usize) -> usize {
+    hfp4g32_weight_bytes(m, k) + k * 4 + m * 4
+}
+
 /// FWHT rotation kernel: read x, read two sign tables, write x_rot.
 pub fn mq_rotate_bytes(k: usize) -> usize {
     k * 4 + 256 * 4 * 2 + k * 4

--- a/kernels/src/gemm_gate_up_hfp4g32_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_hfp4g32_wmma.gfx12.hip
@@ -1,0 +1,139 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) sister of gemm_gate_up_hfp4g32_wmma. half8_t lane-split
+// + K4 unroll. C-output mapping `acc[j] = C[8*(tid>>4) + j][tid & 15]`.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_hfp4g32_wmma_gfx12(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate;  local_row = safe_row;
+    } else {
+        A = A_up;    local_row = safe_row - gate_m;
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int blk_a = kt >> 1;
+            const int blk_c = blk_a + 1;
+            const char* bpa = group_base + blk_a * 17;
+            const char* bpc = group_base + blk_c * 17;
+
+            const unsigned int e_a = *(const unsigned char*)bpa;
+            const unsigned int e_c = *(const unsigned char*)bpc;
+            const float sc_block_a_f = __builtin_bit_cast(float, e_a << 23);
+            const float sc_block_c_f = __builtin_bit_cast(float, e_c << 23);
+            const _Float16 sc_h_ab = row_scale_h * (_Float16)sc_block_a_f;
+            const _Float16 sc_h_cd = row_scale_h * (_Float16)sc_block_c_f;
+
+            unsigned int pka = *(const unsigned int*)(bpa + 1 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(bpa + 9 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(bpc + 1 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(bpc + 9 + k_grp * 4);
+
+            const int k_off_a = (kt + 0) * 16 + k_grp * 8;
+            const int k_off_b = (kt + 1) * 16 + k_grp * 8;
+            const int k_off_c = (kt + 2) * 16 + k_grp * 8;
+            const int k_off_d = (kt + 3) * 16 + k_grp * 8;
+
+            half8_t b_a = *(const half8_t*)(x_base + k_off_a);
+            half8_t b_b = *(const half8_t*)(x_base + k_off_b);
+            half8_t b_c = *(const half8_t*)(x_base + k_off_c);
+            half8_t b_d = *(const half8_t*)(x_base + k_off_d);
+
+            half8_t a_reg;
+            #define DQ8(pk, sc) \
+                a_reg[0] = (sc) * lut[((pk) >>  0) & 0xFu]; \
+                a_reg[1] = (sc) * lut[((pk) >>  4) & 0xFu]; \
+                a_reg[2] = (sc) * lut[((pk) >>  8) & 0xFu]; \
+                a_reg[3] = (sc) * lut[((pk) >> 12) & 0xFu]; \
+                a_reg[4] = (sc) * lut[((pk) >> 16) & 0xFu]; \
+                a_reg[5] = (sc) * lut[((pk) >> 20) & 0xFu]; \
+                a_reg[6] = (sc) * lut[((pk) >> 24) & 0xFu]; \
+                a_reg[7] = (sc) * lut[((pk) >> 28) & 0xFu]
+
+            DQ8(pka, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            DQ8(pkb, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+
+            #undef DQ8
+        }
+    }
+
+    const int out_col = batch_start + m_lane;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < gate_m) {
+                    Y = Y_gate;  proj_row = out_row;              out_stride = gate_m;
+                } else {
+                    Y = Y_up;    proj_row = out_row - gate_m;     out_stride = up_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_gate_up_hfp4g32_wmma.hip
+++ b/kernels/src/gemm_gate_up_hfp4g32_wmma.hip
@@ -1,0 +1,129 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 2-way fused HFP4-G32 GEMM (gate + up).
+// gfx1100+ only (RDNA3 wave32 WMMA). Sister of gemm_qkv_hfp4g32_wmma
+// for the FFN preamble.
+//
+// Same dequant + K-tile structure as gemm_qkv_hfp4g32_wmma; only the
+// per-thread output routing differs (2-way gate/up split instead of
+// 3-way Q/K/V). Output overwrite (y = acc, not +=).
+//
+// Grid: [ceil((gate_m + up_m)/16), ceil(N/16)]. Block: [32]. LDS: 32B.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_hfp4g32_wmma(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    const int my_row = row_start + (tid & 15);
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate;  local_row = safe_row;
+    } else {
+        A = A_up;    local_row = safe_row - gate_m;
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const int safe_batch = (batch_start + (tid & 15) < N)
+                           ? (batch_start + (tid & 15)) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const int block_idx = kt >> 1;
+            const char* bp = group_base + block_idx * 17;
+
+            const unsigned int e_byte = *(const unsigned char*)bp;
+            const float sc_block_f = __builtin_bit_cast(float, e_byte << 23);
+            const _Float16 sc_h = row_scale_h * (_Float16)sc_block_f;
+
+            unsigned int pk0a = *(const unsigned int*)(bp + 1);
+            unsigned int pk1a = *(const unsigned int*)(bp + 5);
+            unsigned int pk0b = *(const unsigned int*)(bp + 9);
+            unsigned int pk1b = *(const unsigned int*)(bp + 13);
+
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+            half16_t b_a = *(const half16_t*)(x_base + k_off_a);
+            half16_t b_b = *(const half16_t*)(x_base + k_off_b);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = sc_h * lut[((pk) >> (sh)) & 0xFu]
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    const int out_col = batch_start + (tid & 15);
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < gate_m) {
+                    Y = Y_gate;  proj_row = out_row;              out_stride = gate_m;
+                } else {
+                    Y = Y_up;    proj_row = out_row - gate_m;     out_stride = up_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_hfp4g32_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_hfp4g32_residual_wmma.gfx12.hip
@@ -1,0 +1,121 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) sister of gemm_hfp4g32_residual_wmma. half8_t lane-split
+// + K4 unroll. Same dequant + Y semantics; only WMMA shape differs.
+//
+// gfx12 wave32 WMMA C-mapping (rows contiguous):
+//   acc[j] = C[8*(tid>>4) + j][tid & 15]
+// Lane group 0 → output rows 0..7, group 1 → rows 8..15.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfp4g32_residual_wmma_gfx12(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int safe_row   = (row_start   + m_lane < M)          ? (row_start   + m_lane) : (M - 1);
+    const int safe_batch = (batch_start + m_lane < batch_size) ? (batch_start + m_lane) : 0;
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)safe_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* xg = x_base + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int blk_a = kt >> 1;
+            const int blk_c = blk_a + 1;
+            const char* bpa = group_base + blk_a * 17;
+            const char* bpc = group_base + blk_c * 17;
+
+            const unsigned int e_a = *(const unsigned char*)bpa;
+            const unsigned int e_c = *(const unsigned char*)bpc;
+            const float sc_block_a_f = __builtin_bit_cast(float, e_a << 23);
+            const float sc_block_c_f = __builtin_bit_cast(float, e_c << 23);
+            const _Float16 sc_h_ab = row_scale_h * (_Float16)sc_block_a_f;
+            const _Float16 sc_h_cd = row_scale_h * (_Float16)sc_block_c_f;
+
+            unsigned int pka = *(const unsigned int*)(bpa + 1 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(bpa + 9 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(bpc + 1 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(bpc + 9 + k_grp * 4);
+
+            const int k_off_a = (kt + 0) * 16 + k_grp * 8;
+            const int k_off_b = (kt + 1) * 16 + k_grp * 8;
+            const int k_off_c = (kt + 2) * 16 + k_grp * 8;
+            const int k_off_d = (kt + 3) * 16 + k_grp * 8;
+
+            half8_t b_a = *(const half8_t*)(xg + k_off_a);
+            half8_t b_b = *(const half8_t*)(xg + k_off_b);
+            half8_t b_c = *(const half8_t*)(xg + k_off_c);
+            half8_t b_d = *(const half8_t*)(xg + k_off_d);
+
+            half8_t a_reg;
+            #define DQ8(pk, sc) \
+                a_reg[0] = (sc) * lut[((pk) >>  0) & 0xFu]; \
+                a_reg[1] = (sc) * lut[((pk) >>  4) & 0xFu]; \
+                a_reg[2] = (sc) * lut[((pk) >>  8) & 0xFu]; \
+                a_reg[3] = (sc) * lut[((pk) >> 12) & 0xFu]; \
+                a_reg[4] = (sc) * lut[((pk) >> 16) & 0xFu]; \
+                a_reg[5] = (sc) * lut[((pk) >> 20) & 0xFu]; \
+                a_reg[6] = (sc) * lut[((pk) >> 24) & 0xFu]; \
+                a_reg[7] = (sc) * lut[((pk) >> 28) & 0xFu]
+
+            DQ8(pka, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            DQ8(pkb, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+
+            #undef DQ8
+        }
+    }
+
+    const int out_col = batch_start + m_lane;  // batch index (N)
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;  // M index
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] += acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_hfp4g32_residual_wmma.hip
+++ b/kernels/src/gemm_hfp4g32_residual_wmma.hip
@@ -1,0 +1,120 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched HFP4-G32 GEMM with fused residual add.
+// gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// Sister of gemm_hfq4g256_residual_wmma_k2 for the FP4 (E2M1 + UE8M0
+// g32 + FP16 row scale) family. Used for both wo (after attention) and
+// w_down (after FFN) projections in the batched prefill path.
+//
+// HFP4G32 layout differences from HFQ4G256 (same as gemm_qkv_hfp4g32_wmma):
+//   - Per row: 16-B header + (K/32) blocks * 17 B (1B UE8M0 + 16B nibbles)
+//   - Outer iter on 256-K-element groups (= 8 blocks = 136 B)
+//   - Inner 2-tile-per-iter shares one block's UE8M0 + nibbles
+//   - Dequant: row_scale_h * 2^(block_e - 127) * E2M1_LUT[nibble]
+//
+// Output mapping: canonical RDNA3 wave32 WMMA — `acc[j] = C[2*j + (tid>>4)]
+// [tid & 15]`. Mirrors the K2 residual variant; the base `_wmma` and `_wmma2`
+// HFQ4 residual variants carry known mapping bugs and must NOT be mirrored.
+//
+// Y semantics: += (residual). Caller must initialize Y to the residual
+// stream (e.g. embedding output) before this kernel.
+//
+// Grid: [ceil(M/16), ceil(N/16)]. Block: [32]. LDS: 32B (E2M1 LUT).
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfp4g32_residual_wmma(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    const int safe_row = (row_start + (tid & 15) < M) ? (row_start + (tid & 15)) : (M - 1);
+    const int safe_batch = (batch_start + (tid & 15) < batch_size) ? (batch_start + (tid & 15)) : 0;
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)safe_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* xg = x_base + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const int block_idx = kt >> 1;
+            const char* bp = group_base + block_idx * 17;
+
+            const unsigned int e_byte = *(const unsigned char*)bp;
+            const float sc_block_f = __builtin_bit_cast(float, e_byte << 23);
+            const _Float16 sc_h = row_scale_h * (_Float16)sc_block_f;
+
+            unsigned int pk0a = *(const unsigned int*)(bp + 1);
+            unsigned int pk1a = *(const unsigned int*)(bp + 5);
+            unsigned int pk0b = *(const unsigned int*)(bp + 9);
+            unsigned int pk1b = *(const unsigned int*)(bp + 13);
+
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+            half16_t b_a = *(const half16_t*)(xg + k_off_a);
+            half16_t b_b = *(const half16_t*)(xg + k_off_b);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = sc_h * lut[((pk) >> (sh)) & 0xFu]
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    // Canonical gfx11 wave32 WMMA mapping: acc[j] = C[2*j + (tid>>4)][tid & 15].
+    // A = weight rows (M), B = batch X cols (N). Y[batch][m] = Y[batch * M + m].
+    const int out_col = batch_start + (tid & 15);  // batch index (N)
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);  // M index
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] += acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_hfp4g32_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_hfp4g32_wmma.gfx12.hip
@@ -1,0 +1,194 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 3-way fused HFP4-G32 GEMM for the FP4
+// FullAttention preamble (Q + K + V projections).
+//
+// **gfx12 (RDNA4) variant** — sister of gemm_qkv_hfp4g32_wmma.hip
+// (gfx11 / RDNA3). Compile this file with
+//   hipcc --offload-arch=gfx1200  (or gfx1201).
+//
+// SCAFFOLD STATUS:
+//   The C-output mapping below is the SAME hypothesis used by the
+//   gemm_qkv_hfq4g256_wmma.gfx12 sibling (`acc[j] = C[8*(tid>>4) + j]
+//   [tid & 15]`). That mapping was hardware-validated for HFQ4 in
+//   commit b7ac66a era and verified on gfx1201 (R9700) by the test
+//   harness; HFP4G32 inherits identical lane decomposition + WMMA
+//   shape so the same mapping holds.
+//
+// Differences from the gfx11 HFP4 kernel:
+//   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
+//   2. A and B operands: half8_t per lane (8 fp16) instead of half16_t.
+//      Each lane carries half the K-tile; lane-group split:
+//        lane (tid >> 4) = 0  -> K = [0..7]  of the 16-K tile
+//        lane (tid >> 4) = 1  -> K = [8..15] of the 16-K tile
+//   3. K4 unroll: 4 K-tiles per inner iter (= 2 HFP4 blocks). The
+//      gfx12 K4 pattern measured 2× on gate_up_hfq4 at 9B pp=128.
+//   4. C-output mapping uses kCM0PerLane=1 / kCM1PerLane=8 swap
+//      (lane group 0 holds rows 0..7, lane group 1 holds rows 8..15).
+//
+// HFP4 dequant is identical to the gfx11 variant — only the K-tile
+// shape and WMMA builtin change.
+//
+// Grid: [ceil((q_m + k_m + v_m)/16), ceil(N/16)].
+// Block: [32]. LDS: 32B (E2M1 LUT).
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_hfp4g32_wmma_gfx12(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,      // [N x K], FP16
+    float*         __restrict__ Y_q,     // [N x q_m]
+    float*         __restrict__ Y_k,     // [N x k_m]
+    float*         __restrict__ Y_v,     // [N x v_m]
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    // 16-entry signed E2M1 LUT in LDS (32B).
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    // Lane decomposition (gfx12 wave32 WMMA):
+    //   m_lane = tid & 15   (0..15)  -> row index within the 16-row tile
+    //   k_grp  = tid >> 4   (0 or 1) -> which K half-tile this lane carries
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    // Route to the correct weight matrix for this thread's row.
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+
+        // K4 unroll: 4 K-tiles per inner iter = 2 HFP4 blocks. The two
+        // pairs share scales: tiles {0,1} use block kt/2, tiles {2,3}
+        // use block kt/2+1.
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int blk_a = kt >> 1;             // 0,2,4,6  → blocks 0,2,4,6
+            const int blk_c = blk_a + 1;           // 1,3,5,7  → blocks 1,3,5,7
+            const char* bpa = group_base + blk_a * 17;
+            const char* bpc = group_base + blk_c * 17;
+
+            const unsigned int e_a = *(const unsigned char*)bpa;
+            const unsigned int e_c = *(const unsigned char*)bpc;
+            const float sc_block_a_f = __builtin_bit_cast(float, e_a << 23);
+            const float sc_block_c_f = __builtin_bit_cast(float, e_c << 23);
+            const _Float16 sc_h_ab = row_scale_h * (_Float16)sc_block_a_f;
+            const _Float16 sc_h_cd = row_scale_h * (_Float16)sc_block_c_f;
+
+            // Each K-tile = 16 K-elements = 16 nibbles = 8 bytes = 2 uint.
+            // gfx12 lane-group split: lane group k_grp carries K[8*k_grp .. 8*k_grp+7],
+            // so it reads the corresponding 4-byte half of the tile's nibble payload.
+            // Tile A = block_a low half  (bp + 1 .. bp + 8)
+            // Tile B = block_a high half (bp + 9 .. bp + 16)
+            // Tile C = block_c low half
+            // Tile D = block_c high half
+            unsigned int pka = *(const unsigned int*)(bpa + 1 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(bpa + 9 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(bpc + 1 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(bpc + 9 + k_grp * 4);
+
+            const int k_off_a = (kt + 0) * 16 + k_grp * 8;
+            const int k_off_b = (kt + 1) * 16 + k_grp * 8;
+            const int k_off_c = (kt + 2) * 16 + k_grp * 8;
+            const int k_off_d = (kt + 3) * 16 + k_grp * 8;
+
+            half8_t b_a = *(const half8_t*)(x_base + k_off_a);
+            half8_t b_b = *(const half8_t*)(x_base + k_off_b);
+            half8_t b_c = *(const half8_t*)(x_base + k_off_c);
+            half8_t b_d = *(const half8_t*)(x_base + k_off_d);
+
+            half8_t a_reg;
+
+            #define DQ8(pk, sc) \
+                a_reg[0] = (sc) * lut[((pk) >>  0) & 0xFu]; \
+                a_reg[1] = (sc) * lut[((pk) >>  4) & 0xFu]; \
+                a_reg[2] = (sc) * lut[((pk) >>  8) & 0xFu]; \
+                a_reg[3] = (sc) * lut[((pk) >> 12) & 0xFu]; \
+                a_reg[4] = (sc) * lut[((pk) >> 16) & 0xFu]; \
+                a_reg[5] = (sc) * lut[((pk) >> 20) & 0xFu]; \
+                a_reg[6] = (sc) * lut[((pk) >> 24) & 0xFu]; \
+                a_reg[7] = (sc) * lut[((pk) >> 28) & 0xFu]
+
+            DQ8(pka, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            DQ8(pkb, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+
+            #undef DQ8
+        }
+    }
+
+    // gfx12 wave32 WMMA C-mapping (matches gemm_qkv_hfq4g256_wmma.gfx12):
+    //   kCMLane=2, kCM0PerLane=1, kCM1PerLane=8
+    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
+    // Lane group 0 holds output rows 0..7, lane group 1 rows 8..15.
+    const int out_col = batch_start + m_lane;  // batch index
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < q_m) {
+                    Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                } else if (out_row < q_m + k_m) {
+                    Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                } else {
+                    Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_hfp4g32_wmma.hip
+++ b/kernels/src/gemm_qkv_hfp4g32_wmma.hip
@@ -1,0 +1,179 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 3-way fused HFP4-G32 GEMM for the FP4
+// FullAttention preamble (Q + K + V projections).
+// gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// Sister of gemm_qkv_hfq4g256_wmma. Same WMMA shape (16x16x16 f16),
+// same lane decomposition, same C-output mapping. Differences:
+//
+//   1. Per-row layout — HFP4G32 has a 16-B row header (FP16 row_scale_a
+//      first 2 bytes) followed by (K/32) * 17-byte blocks (1B UE8M0 +
+//      16B nibbles). HFQ4-G256 has 136-byte groups (4B fp32 sc + 4B fp32
+//      zp + 128B nibbles, one group per 256 K-elements).
+//
+//   2. Dequant arithmetic —
+//        HFQ4: value = sc * (float)nibble + zp
+//        HFP4: value = row_scale_a * 2^(block_e - 127) * E2M1_LUT[nibble]
+//      The row_scale_a multiply hoists ONCE per row before the K loop.
+//      The UE8M0 block scale is pure FP32 bit construction:
+//      `__builtin_bit_cast(float, e_byte << 23)` materializes 2^(e-127)
+//      directly (mirrors gemv_hfp4g32.hip:106).
+//
+//   3. K-tile loop — HFP4G32's 32-element block aligns with a pair of
+//      WMMA 16-K tiles. Iterating 2 tiles per loop body keeps one block
+//      load (block_e + 16B nibbles) shared across both tiles, saving
+//      half the UE8M0 reads vs a per-tile fetch.
+//
+// Grid: [ceil((q_m + k_m + v_m)/16), ceil(N/16)].
+// Block: [32].  LDS: 32B (E2M1 LUT).
+//
+// Each 16-row tile may straddle projection boundaries.  Per-thread output
+// routing resolves which Y pointer each row writes to.
+// Overwrite semantics (y = acc, not +=).
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_hfp4g32_wmma(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,      // [N x K], FP16
+    float*         __restrict__ Y_q,     // [N x q_m]
+    float*         __restrict__ Y_k,     // [N x k_m]
+    float*         __restrict__ Y_v,     // [N x v_m]
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    // 16-entry signed E2M1 magnitude LUT in LDS (32B). Lanes 0..15 init.
+    // OCP E2M1: {0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}. Locked to spec.
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    // Each thread owns one row in the 16-row tile (tid & 15).
+    const int my_row = row_start + (tid & 15);
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    // Route to the correct weight matrix for this thread's row.
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    // Per row: 16-B header + (K/32) * 17-B blocks.
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;     // first block
+
+    // Hoist FP16 row_scale_a — first 2 bytes of header.
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const int safe_batch = (batch_start + (tid & 15) < N)
+                           ? (batch_start + (tid & 15)) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    // Outer loop: each "group" covers 256 K-elements = 8 HFP4 blocks = 136 B.
+    // This matches HFQ4G256's outer iteration shape and lets the inner
+    // 2-tile-per-iter unroll consume one block per pair.
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+
+        // 16 K-tiles per group, processed 2 at a time.
+        // Each pair shares one HFP4 block (block_idx = kt >> 1):
+        //   tile A = nibbles[0..8]   (low 16 K-elements of the block)
+        //   tile B = nibbles[8..16]  (high 16 K-elements of the block)
+        for (int kt = 0; kt < 16; kt += 2) {
+            const int block_idx = kt >> 1;             // 0..7
+            const char* bp = group_base + block_idx * 17;
+
+            // UE8M0 block scale → FP32 bit-construct → FP16. One mul with
+            // row_scale_h gives the per-tile dequant scale.
+            const unsigned int e_byte = *(const unsigned char*)bp;
+            const float sc_block_f = __builtin_bit_cast(float, e_byte << 23);
+            const _Float16 sc_h = row_scale_h * (_Float16)sc_block_f;
+
+            // 16 packed nibbles per tile (= 8 bytes = 2 uints).
+            unsigned int pk0a = *(const unsigned int*)(bp + 1);
+            unsigned int pk1a = *(const unsigned int*)(bp + 5);
+            unsigned int pk0b = *(const unsigned int*)(bp + 9);
+            unsigned int pk1b = *(const unsigned int*)(bp + 13);
+
+            // Load both X tiles early — consecutive addresses, prefetcher-friendly.
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+            half16_t b_a = *(const half16_t*)(x_base + k_off_a);
+            half16_t b_b = *(const half16_t*)(x_base + k_off_b);
+
+            // Dequant tile A.
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = sc_h * lut[((pk) >> (sh)) & 0xFu]
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            // Dequant tile B (same sc_h — same block).
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    // RDNA3 wave32 WMMA output: acc[j] = C[2*j + (tid>>4)][tid & 15].
+    // A operand = weight rows (m-dim), B operand = batch X cols (n-dim).
+    const int out_col = batch_start + (tid & 15);  // batch index
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < q_m) {
+                    Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                } else if (out_row < q_m + k_m) {
+                    Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                } else {
+                    Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_hfp4g32_wmma_fp8.gfx12.hip
+++ b/kernels/src/gemm_qkv_hfp4g32_wmma_fp8.gfx12.hip
@@ -1,0 +1,232 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// FP8-WMMA-accelerated batched 3-way fused HFP4-G32 GEMM for the FP4
+// FullAttention preamble (Q + K + V projections) — gfx12 (RDNA4) only.
+//
+// STATUS: opt-in research kernel, default-off (gate via HIPFIRE_FP8_WMMA=1
+// in `gemm_qkv_hfp4g32` dispatch). Correctness PASS at NRMSE ~2.7% vs
+// the FP16-WMMA sibling. Perf at K=2048, gfx1201:
+//   N=1..64    FP8 is ~0.73-0.93x FP16 (consistently slower)
+//   N=256-512  FP8 is ~0.86-0.94x FP16
+//   N=2048     FP8 is ~0.82-1.26x FP16 (high variance from DPM noise,
+//              mean ~1.05x — at-parity to marginal win)
+//
+// Architectural ceiling: the raw FP8 WMMA throughput on gfx1201 is
+// 1.87x FP16-WMMA (microbenched). But HFP4G32's per-32-block UE8M0
+// scale forces post-WMMA `acc[j] += partial[j] * scale[j]` chains on
+// the F32 accumulator (FP16 path bakes scale into the half operand
+// pre-WMMA so no post-mul is needed). The FMA chain + cross-lane
+// shuffle to gather per-output-row scales costs roughly what the
+// WMMA-throughput advantage delivers, netting close to parity.
+//
+// Lifting this would require either (a) baking row_scale * UE8M0 into
+// the FP8 weight at dequant time (risks E4M3 saturation if UE8M0 is
+// large) or (b) a new quant format with row-scale-only (no per-block
+// UE8M0). Both are out of scope for the HFP4G32-storage-preserving v2
+// effort that prompted this kernel.
+//
+// Sister kernel of gemm_qkv_hfp4g32_wmma.gfx12.hip. Same C-mapping,
+// same lane-decomposition, same K4 unroll over 256-element groups.
+// Differences from the FP16 sibling:
+//   1. WMMA: __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12.
+//   2. Weight LUT holds E2M1 values pre-converted to E4M3 bytes (no
+//      scale baked).
+//   3. Activation X is pre-packed by `pack_f32_to_fp8_gfx12` (F32 ->
+//      E4M3 via cvt_pk_fp8_f32, unscaled — post-RMSNorm activations
+//      are bounded well below E4M3 saturation). The in-kernel cvt
+//      variant measured 0.7-0.86x FP16; moving cvt to the pre-pass
+//      kernel recovered ~10pp. Both result + Y_q/k/v stay F32.
+//   4. row_scale * UE8M0_block scale is applied AFTER each pair of
+//      WMMAs sharing a UE8M0 block. Per-output-row scales gathered via
+//      lane-shuffle (8 shfl per pair) since each lane's A-row is not
+//      its output rows under WMMA C-mapping.
+//
+// Grid: [ceil((q_m + k_m + v_m)/16), ceil(N/16)].
+// Block: [32]. LDS: 16B (E4M3 LUT).
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef int      __attribute__((ext_vector_type(2))) v2i_t;
+typedef float    __attribute__((ext_vector_type(8))) v8f_t;
+
+// E2M1 (FP4) value lookup as E4M3 (FP8) bytes.
+// E4M3 byte layout: sign(1) | exp(4, bias 7) | mant(3).
+// E2M1 values: +0, +0.5, +1.0, +1.5, +2.0, +3.0, +4.0, +6.0 and signed negatives.
+__device__ static constexpr unsigned char E2M1_AS_E4M3[16] = {
+    0x00, 0x30, 0x38, 0x3C, 0x40, 0x44, 0x48, 0x4C,
+    0x80, 0xB0, 0xB8, 0xBC, 0xC0, 0xC4, 0xC8, 0xCC,
+};
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_hfp4g32_wmma_fp8_gfx12(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const unsigned char* __restrict__ X_fp8,  // [N x K], FP8 (E4M3) packed
+    float*         __restrict__ Y_q,     // [N x q_m]
+    float*         __restrict__ Y_k,     // [N x k_m]
+    float*         __restrict__ Y_v,     // [N x v_m]
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    // 16-byte E4M3 LUT in LDS.
+    __shared__ unsigned char lut[16];
+    if (tid < 16) lut[tid] = E2M1_AS_E4M3[tid];
+    __syncthreads();
+
+    // Lane decomposition (gfx12 wave32 WMMA, identical to FP16 sibling).
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    // Route to the correct weight matrix for this thread's A-row.
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) { A = A_q;  local_row = safe_row; }
+    else if (safe_row < q_m + k_m) { A = A_k;  local_row = safe_row - q_m; }
+    else { A = A_v;  local_row = safe_row - q_m - k_m; }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+    const float row_scale_self = (float)row_scale_h;
+
+    // Gather the 8 per-output-row `row_scale` values for this lane's
+    // output mapping (rows 8*k_grp .. 8*k_grp+7 under gfx12 C-mapping).
+    // Source lane: m_lane = (8*k_grp + j) lives at lane index (8*k_grp + j)
+    // in lane group 0 (lanes 0..15). Both lane groups read from lane group 0.
+    float out_row_scales[8];
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        int src_lane = 8 * k_grp + j;
+        out_row_scales[j] = __shfl(row_scale_self, src_lane);
+    }
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    v8f_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const unsigned char* x_base = X_fp8 + (long long)safe_batch * K + g * 256;
+
+        #pragma unroll
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int blk_a = kt >> 1;
+            const int blk_c = blk_a + 1;
+            const char* bpa = group_base + blk_a * 17;
+            const char* bpc = group_base + blk_c * 17;
+
+            // Per-lane UE8M0 byte (= its own A-row's UE8M0 for current block).
+            const unsigned int e_a_self = *(const unsigned char*)bpa;
+            const unsigned int e_c_self = *(const unsigned char*)bpc;
+            const float ue8m0_a_self = __builtin_bit_cast(float, e_a_self << 23);
+            const float ue8m0_c_self = __builtin_bit_cast(float, e_c_self << 23);
+
+            // Combined per-output-row scale gathered via shuffle.
+            float scale_a[8], scale_c[8];
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int src_lane = 8 * k_grp + j;
+                scale_a[j] = out_row_scales[j] * __shfl(ue8m0_a_self, src_lane);
+                scale_c[j] = out_row_scales[j] * __shfl(ue8m0_c_self, src_lane);
+            }
+
+            // Each tile = 16 K-elements = 16 nibbles = 8 bytes; lane group
+            // k_grp carries K[8*k_grp .. 8*k_grp+7] = 4 bytes worth.
+            unsigned int pka = *(const unsigned int*)(bpa + 1 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(bpa + 9 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(bpc + 1 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(bpc + 9 + k_grp * 4);
+
+            const int k_off_a = (kt + 0) * 16 + k_grp * 8;
+            const int k_off_b = (kt + 1) * 16 + k_grp * 8;
+            const int k_off_c = (kt + 2) * 16 + k_grp * 8;
+            const int k_off_d = (kt + 3) * 16 + k_grp * 8;
+
+            // FP8 activation: 8 bytes per tile per lane (K[8*k_grp..8*k_grp+7]).
+            // Pre-packed by `pack_fp16_to_fp8` so the inner loop has zero
+            // conversion ALU. Loaded as v2i_t (2 uint32) directly.
+            v2i_t x_a = *(const v2i_t*)(x_base + k_off_a);
+            v2i_t x_b = *(const v2i_t*)(x_base + k_off_b);
+            v2i_t x_c = *(const v2i_t*)(x_base + k_off_c);
+            v2i_t x_d = *(const v2i_t*)(x_base + k_off_d);
+
+            // Build FP8 weight v2i_t from nibble pack via LUT lookup.
+            // pk holds 8 nibbles in 32 bits; each nibble -> 1 byte E4M3.
+            #define BUILD_W_FP8(pk, out)                                                  \
+                {                                                                          \
+                    unsigned int lo = 0u, hi = 0u;                                         \
+                    lo |= (unsigned int)lut[((pk) >>  0) & 0xFu] <<  0;                    \
+                    lo |= (unsigned int)lut[((pk) >>  4) & 0xFu] <<  8;                    \
+                    lo |= (unsigned int)lut[((pk) >>  8) & 0xFu] << 16;                    \
+                    lo |= (unsigned int)lut[((pk) >> 12) & 0xFu] << 24;                    \
+                    hi |= (unsigned int)lut[((pk) >> 16) & 0xFu] <<  0;                    \
+                    hi |= (unsigned int)lut[((pk) >> 20) & 0xFu] <<  8;                    \
+                    hi |= (unsigned int)lut[((pk) >> 24) & 0xFu] << 16;                    \
+                    hi |= (unsigned int)lut[((pk) >> 28) & 0xFu] << 24;                    \
+                    (out)[0] = (int)lo; (out)[1] = (int)hi;                                \
+                }
+
+            v2i_t a_a, a_b, a_c, a_d;
+            BUILD_W_FP8(pka, a_a);
+            BUILD_W_FP8(pkb, a_b);
+            BUILD_W_FP8(pkc, a_c);
+            BUILD_W_FP8(pkd, a_d);
+
+            #undef BUILD_W_FP8
+
+            // WMMA pair for block_a (tiles 0,1 share UE8M0 block_a).
+            v8f_t part_ab = {0,0,0,0,0,0,0,0};
+            part_ab = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a_a, x_a, part_ab);
+            part_ab = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a_b, x_b, part_ab);
+            #pragma unroll
+            for (int j = 0; j < 8; j++) acc[j] += part_ab[j] * scale_a[j];
+
+            // WMMA pair for block_c.
+            v8f_t part_cd = {0,0,0,0,0,0,0,0};
+            part_cd = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a_c, x_c, part_cd);
+            part_cd = __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(a_d, x_d, part_cd);
+            #pragma unroll
+            for (int j = 0; j < 8; j++) acc[j] += part_cd[j] * scale_c[j];
+        }
+    }
+
+    // gfx12 wave32 WMMA C-mapping (identical to FP16 sibling):
+    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
+    const int out_col = batch_start + m_lane;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < q_m) {
+                    Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                } else if (out_row < q_m + k_m) {
+                    Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                } else {
+                    Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_hfp4g32_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_hfp4g32_wmma.gfx12.hip
@@ -1,0 +1,151 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 (RDNA4) sister of gemm_qkvza_hfp4g32_wmma. half8_t lane-split
+// + K4 unroll. Same C-output mapping as gemm_qkvza_hfq4g256_wmma.gfx12.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_hfp4g32_wmma_gfx12(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const int safe_batch = (batch_start + m_lane < N) ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int blk_a = kt >> 1;
+            const int blk_c = blk_a + 1;
+            const char* bpa = group_base + blk_a * 17;
+            const char* bpc = group_base + blk_c * 17;
+
+            const unsigned int e_a = *(const unsigned char*)bpa;
+            const unsigned int e_c = *(const unsigned char*)bpc;
+            const float sc_block_a_f = __builtin_bit_cast(float, e_a << 23);
+            const float sc_block_c_f = __builtin_bit_cast(float, e_c << 23);
+            const _Float16 sc_h_ab = row_scale_h * (_Float16)sc_block_a_f;
+            const _Float16 sc_h_cd = row_scale_h * (_Float16)sc_block_c_f;
+
+            unsigned int pka = *(const unsigned int*)(bpa + 1 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(bpa + 9 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(bpc + 1 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(bpc + 9 + k_grp * 4);
+
+            const int k_off_a = (kt + 0) * 16 + k_grp * 8;
+            const int k_off_b = (kt + 1) * 16 + k_grp * 8;
+            const int k_off_c = (kt + 2) * 16 + k_grp * 8;
+            const int k_off_d = (kt + 3) * 16 + k_grp * 8;
+
+            half8_t b_a = *(const half8_t*)(x_base + k_off_a);
+            half8_t b_b = *(const half8_t*)(x_base + k_off_b);
+            half8_t b_c = *(const half8_t*)(x_base + k_off_c);
+            half8_t b_d = *(const half8_t*)(x_base + k_off_d);
+
+            half8_t a_reg;
+            #define DQ8(pk, sc) \
+                a_reg[0] = (sc) * lut[((pk) >>  0) & 0xFu]; \
+                a_reg[1] = (sc) * lut[((pk) >>  4) & 0xFu]; \
+                a_reg[2] = (sc) * lut[((pk) >>  8) & 0xFu]; \
+                a_reg[3] = (sc) * lut[((pk) >> 12) & 0xFu]; \
+                a_reg[4] = (sc) * lut[((pk) >> 16) & 0xFu]; \
+                a_reg[5] = (sc) * lut[((pk) >> 20) & 0xFu]; \
+                a_reg[6] = (sc) * lut[((pk) >> 24) & 0xFu]; \
+                a_reg[7] = (sc) * lut[((pk) >> 28) & 0xFu]
+
+            DQ8(pka, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            DQ8(pkb, sc_h_ab);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd, sc_h_cd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+
+            #undef DQ8
+        }
+    }
+
+    const int out_col = batch_start + m_lane;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < qkv_m) {
+                    Y = Y_qkv;   proj_row = out_row;                            out_stride = qkv_m;
+                } else if (out_row < qkv_m + z_m) {
+                    Y = Y_z;     proj_row = out_row - qkv_m;                    out_stride = z_m;
+                } else if (out_row < qkv_m + z_m + beta_m) {
+                    Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);            out_stride = beta_m;
+                } else {
+                    Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m);   out_stride = alpha_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_hfp4g32_wmma.hip
+++ b/kernels/src/gemm_qkvza_hfp4g32_wmma.hip
@@ -1,0 +1,143 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 4-way fused HFP4-G32 GEMM for the Qwen3.5
+// DeltaNet LA preamble (qkv + z + beta + alpha projections).
+// gfx1100+ only (RDNA3 wave32 WMMA).
+//
+// Sister of gemm_qkvza_hfq4g256_wmma for the FP4 family. Same WMMA shape
+// + lane decomposition; only the per-row layout (16-B header + 17-B
+// blocks) and per-tile dequant arithmetic differ — see
+// gemm_qkv_hfp4g32_wmma.hip for the full structural notes.
+//
+// Grid: [ceil((qkv_m + z_m + beta_m + alpha_m)/16), ceil(N/16)].
+// Block: [32].  LDS: 32B (E2M1 LUT).
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_hfp4g32_wmma(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    const int my_row = row_start + (tid & 15);
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)local_row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+
+    const int safe_batch = (batch_start + (tid & 15) < N)
+                           ? (batch_start + (tid & 15)) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const int groups_per_row = K / 256;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* group_base = row_ptr + (long long)g * 136;
+        const _Float16* x_base = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const int block_idx = kt >> 1;
+            const char* bp = group_base + block_idx * 17;
+
+            const unsigned int e_byte = *(const unsigned char*)bp;
+            const float sc_block_f = __builtin_bit_cast(float, e_byte << 23);
+            const _Float16 sc_h = row_scale_h * (_Float16)sc_block_f;
+
+            unsigned int pk0a = *(const unsigned int*)(bp + 1);
+            unsigned int pk1a = *(const unsigned int*)(bp + 5);
+            unsigned int pk0b = *(const unsigned int*)(bp + 9);
+            unsigned int pk1b = *(const unsigned int*)(bp + 13);
+
+            const int k_off_a = kt * 16;
+            const int k_off_b = (kt + 1) * 16;
+            half16_t b_a = *(const half16_t*)(x_base + k_off_a);
+            half16_t b_b = *(const half16_t*)(x_base + k_off_b);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = sc_h * lut[((pk) >> (sh)) & 0xFu]
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+        }
+    }
+
+    const int out_col = batch_start + (tid & 15);
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < qkv_m) {
+                    Y = Y_qkv;   proj_row = out_row;                            out_stride = qkv_m;
+                } else if (out_row < qkv_m + z_m) {
+                    Y = Y_z;     proj_row = out_row - qkv_m;                    out_stride = z_m;
+                } else if (out_row < qkv_m + z_m + beta_m) {
+                    Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);            out_stride = beta_m;
+                } else {
+                    Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m);   out_stride = alpha_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemv_hfp4g32_dot2.gfx11.hip
+++ b/kernels/src/gemv_hfp4g32_dot2.gfx11.hip
@@ -1,0 +1,142 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// HFP4G32 decode-path GEMV using gfx11 (RDNA3) v_dot2_f32_f16 instruction
+// via __builtin_amdgcn_fdot2. One warp per output row M; each thread
+// accumulates a slice of K, warp-reduces at the end.
+//
+// MOTIVATION: gfx1100 decode GEMV on HFP4G32 was severely ALU-bound —
+// measured 8-40% peak BW across decode shapes on 7900 XTX (vs ~78% on
+// gfx1201 for FFN). The fallback `gemv_hfp4g32.hip` reads x as F32,
+// dequants weight to F16, then multiplies F32×F32 — ~8 single-VALU
+// ops per 4 K-elements. Replacing the multiply chain with
+// `__builtin_amdgcn_fdot2` (one v_dot2_f32_f16 = 2 FP16 muls + 1
+// FP32 add per VALU) cuts the inner-loop multiply count ~4×.
+//
+// Activation x is consumed as F32 and converted to FP16 INLINE per
+// K-block. The pre-pass `ensure_fp16_x` approach (v1) added a kernel
+// launch per gemv call that exceeded the dot2 savings in production
+// decode (0.89× on 0.8B HFP4G32, 2026-05-11) — same trap as the
+// gfx12 FP8 v1 ensure_fp8_x pre-pass. F32→FP16 cvt is one VALU per
+// element (essentially free), unlike FP8 cvt_pk_fp8_f32 which carried
+// real per-call cost.
+//
+// LAYOUT MATCH WITH FALLBACK: same per-row 16B header + 8 × 17B blocks
+// per 256-K group. Same thread-to-block mapping (block_in_iter = tid >> 2,
+// nibble byte-offset = (tid & 3) * 4). NOT byte-exact with the
+// fallback's add ordering — fdot2 uses F32 accumulator + per-block
+// scale FMA, different reduction structure; tolerance ~2-3% relative
+// against F32 reference.
+//
+// SCALE APPLICATION: per-block UE8M0 × row_scale (F32) is applied to
+// the F32 partial AFTER each block's 4 fdot2 calls covering 8
+// K-elements. No cross-lane work — each thread owns its block's scale
+// natively under the HFP4G32 layout.
+//
+// Grid: [M, 1, 1]. Block: [32]. LDS: 32B (16-entry E2M1 FP16 LUT).
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfp4g32_dot2_gfx11(
+    const char*  __restrict__ A,    // [M] rows of HFP4G32
+    const float* __restrict__ x,    // [K] F32, converted to FP16 inline
+    float*       __restrict__ y,    // [M]
+    int M, int K
+) {
+    typedef _Float16 __attribute__((ext_vector_type(2))) half2_t;
+
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    // 16-entry signed E2M1 FP16 LUT in LDS.
+    __shared__ _Float16 lut[16];
+    if (tid < 16) {
+        const float E2M1[16] = {
+            +0.0f, +0.5f, +1.0f, +1.5f, +2.0f, +3.0f, +4.0f, +6.0f,
+            -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+        };
+        lut[tid] = (_Float16)E2M1[tid];
+    }
+    __syncthreads();
+
+    // Same row addressing as the fallback kernel.
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+    const float row_scale_f = (float)row_scale_h;
+
+    // Thread layout within an 8-block group (256 K-elements):
+    //   block_in_iter = tid >> 2  (0..7)
+    //   sub           = tid & 3   (0..3)
+    // Each thread covers 8 K-elements per group at base = group*256 + tid*8.
+    const int block_in_iter = tid >> 2;
+    const int sub           = tid & 3;
+    const int nib_off       = sub * 4;
+    const int thread_block_off = block_in_iter * 17;
+
+    const int groups_per_row = K / 256;
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+
+        // UE8M0 -> F32 via direct exponent bit construction.
+        const unsigned int e = *(const unsigned char*)gp;
+        const float sc = row_scale_f * __builtin_bit_cast(float, e << 23);
+
+        // 8 nibbles for this thread's 8 K-elements, packed in 32 bits.
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + nib_off);
+
+        // Load 8 F32 activation values for this thread's K-range and
+        // convert to FP16 inline. F32→FP16 is one VALU per element
+        // (truncate mantissa). Inlining the cvt avoids the pre-pass
+        // kernel launch that ensure_fp16_x would add (~3-5 µs per
+        // call) — that overhead exceeded the dot2 savings in
+        // production decode (measured 0.89× on 0.8B HFP4G32 on
+        // gfx1100 with ensure_fp16_x pre-pass, 2026-05-11).
+        const int x_base = g * 256 + tid * 8;
+        const float* xp = x + x_base;
+        const half2_t x01 = {(_Float16)xp[0], (_Float16)xp[1]};
+        const half2_t x23 = {(_Float16)xp[2], (_Float16)xp[3]};
+        const half2_t x45 = {(_Float16)xp[4], (_Float16)xp[5]};
+        const half2_t x67 = {(_Float16)xp[6], (_Float16)xp[7]};
+
+        // Dequant nibbles → 8 FP16 weight values (unscaled), packed
+        // into half2 pairs. Per-block scale `sc` is applied to the F32
+        // partial after fdot2 accumulation.
+        const half2_t w01 = {lut[(pk      ) & 0xFu], lut[(pk >>  4) & 0xFu]};
+        const half2_t w23 = {lut[(pk >>  8) & 0xFu], lut[(pk >> 12) & 0xFu]};
+        const half2_t w45 = {lut[(pk >> 16) & 0xFu], lut[(pk >> 20) & 0xFu]};
+        const half2_t w67 = {lut[(pk >> 24) & 0xFu], lut[(pk >> 28) & 0xFu]};
+
+        // 4 fdot2 with INDEPENDENT partial accumulators — each
+        // `fdot2(a, b, 0.0)` has no carry dependency on the others, so
+        // the compiler can dual-issue them. The single-carry version
+        // (partial = fdot2(..., partial) ×4) emits clean disassembly
+        // but its 4-deep dependency chain (fdot2 has ~4-cycle latency)
+        // measured 0.90× in production decode despite 2.4× fewer
+        // total instructions vs fallback — ILP, not instruction count,
+        // is the binding constraint here.
+        float p0 = __builtin_amdgcn_fdot2(w01, x01, 0.0f, false);
+        float p1 = __builtin_amdgcn_fdot2(w23, x23, 0.0f, false);
+        float p2 = __builtin_amdgcn_fdot2(w45, x45, 0.0f, false);
+        float p3 = __builtin_amdgcn_fdot2(w67, x67, 0.0f, false);
+
+        // Apply per-block scale (row_scale × UE8M0) and accumulate.
+        // Reduce 4 partials in a balanced tree to preserve numerical
+        // determinism across re-runs and keep the dep chain shallow.
+        const float partial = (p0 + p1) + (p2 + p3);
+        acc = __builtin_fmaf(partial, sc, acc);
+    }
+
+    // Warp reduce + write.
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        acc += __shfl_down(acc, offset);
+    }
+    if (tid == 0) y[row] = acc;
+}

--- a/kernels/src/gemv_hfp4g32_fp8.gfx12.hip
+++ b/kernels/src/gemv_hfp4g32_fp8.gfx12.hip
@@ -1,0 +1,144 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// HFP4G32 decode-path GEMV using gfx12 (RDNA4) FP8 dot4 instruction
+// (__builtin_amdgcn_dot4_f32_fp8_fp8). One warp per output row M; each
+// thread accumulates a slice of K, warp-reduces at the end.
+//
+// MOTIVATION: decode GEMV on gfx1201 for small-M attention shapes (e.g.
+// k_proj, v_proj at M=512 K=2048) is heavily ALU-bound — measured 16-30%
+// peak BW for M ≤ 2048 K=2048 on R9700 (~150-240 GB/s effective vs
+// 800 GB/s peak). The fallback `gemv_hfp4g32.hip` does ~6-7 F32 ops per
+// K-element in the dequant + multiply-accumulate chain; replacing those
+// with one `dot4_f32_fp8_fp8` per 4 elements cuts inner-loop ALU by
+// ~2-2.4× and lifts decode tok/s on the ALU-bound shapes. BW-bound FFN
+// shapes (gate_up, w_down at ~78% peak) see only ~10% lift.
+//
+// LAYOUT MATCH WITH FALLBACK: same per-row 16B header + 8 × 17B blocks
+// per 256-K group. Same thread-to-block mapping (block_in_iter = tid >>
+// 2, nibble byte-offset = (tid & 3) * 4). NOT byte-exact with the
+// fallback's add ordering — FP8 path uses a different accumulator
+// structure and a different intermediate precision; tolerance ~5%
+// relative against FP32 reference.
+//
+// ACTIVATION FORMAT (v3 / A3): x is consumed as FP8 (E4M3) bytes,
+// produced by the FUSED `mq_rotate_x_dual_fp8` kernel that writes
+// both F32 and FP8 outputs in one launch (gfx12 only). Earlier
+// attempts:
+//   v1 (pre-pass + ensure_fp8_x cache by src_ptr): correct in
+//     isolation but lost 0.93× on 9B Qwen 3.5 MFP4G32 in production
+//     — `mq_x_rot` scratch has stable pointer + per-call data
+//     turnover, forcing cache invalidation per weight_gemv call and
+//     putting pack launch on critical path.
+//   v2 / A2 (inline F32→FP8 cvt per K-block): 0.79-0.97× synthetic
+//     bench — 4× activation memory pressure from per-warp F32 reads
+//     overwhelmed any ALU savings.
+//   v3 / A3 (this — fused FP8 pack at rotation time): rotation
+//     already reads K F32 + writes K F32; adding K FP8 byte writes
+//     is ~25% more output BW (8KB → 10KB for K=2048, negligible) +
+//     4 cvt VALU ops per K-block per thread. The FP8 GEMV then
+//     reads FP8 directly with no separate pack launch.
+//
+// SCALE APPLICATION: per-block UE8M0 × row_scale is applied to the F32
+// dot4 partial AFTER the 2 dot4 calls covering that block (one per 4
+// K-elements; 8 K-elements per thread per block). No cross-lane work —
+// each thread owns its block's scale natively under the HFP4G32 layout.
+//
+// Grid: [M, 1, 1]. Block: [32]. LDS: 32B (16-entry E2M1->E4M3 byte LUT).
+
+// E2M1 (FP4) values pre-converted to E4M3 (FP8) bytes; same table as
+// the prefill FP8 kernel. E2M1 max=6 fits cleanly in E4M3 max=448 with
+// no scale baked, so the LUT is a fixed 16-byte lookup.
+__device__ static constexpr unsigned char E2M1_AS_E4M3[16] = {
+    0x00, 0x30, 0x38, 0x3C, 0x40, 0x44, 0x48, 0x4C,
+    0x80, 0xB0, 0xB8, 0xBC, 0xC0, 0xC4, 0xC8, 0xCC,
+};
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfp4g32_fp8_gfx12(
+    const char*          __restrict__ A,        // [M] rows of HFP4G32
+    const unsigned char* __restrict__ X_fp8,    // [K] E4M3 FP8, produced by mq_rotate_x_dual_fp8 (or pack_f32_to_fp8)
+    float*               __restrict__ y,        // [M]
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int tid = threadIdx.x;
+
+    __shared__ unsigned char lut[16];
+    if (tid < 16) lut[tid] = E2M1_AS_E4M3[tid];
+    __syncthreads();
+
+    // Same row addressing as the fallback kernel.
+    const int blocks_per_row = K / 32;
+    const long long row_stride = 16 + (long long)blocks_per_row * 17;
+    const char* hdr = A + (long long)row * row_stride;
+    const char* row_ptr = hdr + 16;
+
+    const unsigned short rs_bits = *(const unsigned short*)hdr;
+    const _Float16 row_scale_h = __builtin_bit_cast(_Float16, rs_bits);
+    const float row_scale_f = (float)row_scale_h;
+
+    // Thread layout within an 8-block group (256 K-elements):
+    //   block_in_iter = tid >> 2   (0..7)   — which of the 8 blocks
+    //   sub          = tid & 3     (0..3)   — which 8-element slice of the block
+    // So each thread covers 8 K-elements per group at base = group*256 + tid*8.
+    const int block_in_iter = tid >> 2;
+    const int sub           = tid & 3;
+    const int nib_off       = sub * 4;
+    const int thread_block_off = block_in_iter * 17;
+
+    const int groups_per_row = K / 256;
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136 + thread_block_off;
+
+        // UE8M0 -> F32 via direct exponent bit construction.
+        const unsigned int e = *(const unsigned char*)gp;
+        const float sc = row_scale_f * __builtin_bit_cast(float, e << 23);
+
+        // 8 nibbles for this thread's 8 K-elements, packed in 32 bits.
+        const unsigned int pk = *(const unsigned int*)(gp + 1 + nib_off);
+
+        // Build weight FP8 bytes (8 bytes = 2 uint32) from nibble pack.
+        // Each nibble -> 1 byte E4M3 via LDS LUT. Lane-local lookups.
+        unsigned int w_lo, w_hi;
+        w_lo  = (unsigned int)lut[(pk      ) & 0xFu];
+        w_lo |= (unsigned int)lut[(pk >>  4) & 0xFu] << 8;
+        w_lo |= (unsigned int)lut[(pk >>  8) & 0xFu] << 16;
+        w_lo |= (unsigned int)lut[(pk >> 12) & 0xFu] << 24;
+        w_hi  = (unsigned int)lut[(pk >> 16) & 0xFu];
+        w_hi |= (unsigned int)lut[(pk >> 20) & 0xFu] << 8;
+        w_hi |= (unsigned int)lut[(pk >> 24) & 0xFu] << 16;
+        w_hi |= (unsigned int)lut[(pk >> 28) & 0xFu] << 24;
+
+        // Read 8 FP8 activation bytes for this thread's K-range. The
+        // FP8 stream was produced upstream by either:
+        //   (a) mq_rotate_x_dual_fp8 — fused rotation + FP8 pack
+        //       (preferred — eliminates the per-call pack launch)
+        //   (b) pack_f32_to_fp8_gfx12 — standalone pre-pass (used when
+        //       caller doesn't go through the MFP4G32 rotation path,
+        //       e.g. test paths or HFP4G32 direct callers).
+        const int x_base = g * 256 + tid * 8;
+        const unsigned int x_lo = *(const unsigned int*)(X_fp8 + x_base);
+        const unsigned int x_hi = *(const unsigned int*)(X_fp8 + x_base + 4);
+
+        // Two dot4 calls cover 8 elements. F32 partial accumulator
+        // chained between them (single dep chain, fine because the per-
+        // block scale FMA at the end resets the dependency).
+        float partial = 0.0f;
+        partial = __builtin_amdgcn_dot4_f32_fp8_fp8(w_lo, x_lo, partial);
+        partial = __builtin_amdgcn_dot4_f32_fp8_fp8(w_hi, x_hi, partial);
+
+        // Apply per-block scale (row_scale × UE8M0) and accumulate.
+        acc = __builtin_fmaf(partial, sc, acc);
+    }
+
+    // Warp reduce + write.
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        acc += __shfl_down(acc, offset);
+    }
+    if (tid == 0) y[row] = acc;
+}

--- a/kernels/src/mq_rotate_x_dual.gfx12.hip
+++ b/kernels/src/mq_rotate_x_dual.gfx12.hip
@@ -1,0 +1,121 @@
+#include <hip/hip_runtime.h>
+
+// Dual-output MagnumQuant FWHT rotation: produces BOTH F32 and FP8 (E4M3)
+// outputs in one launch. gfx12 (RDNA4) only — uses cvt_pk_fp8_f32.
+//
+// MOTIVATION: the FP8-dot4 decode GEMV (`gemv_hfp4g32_fp8_gfx12`)
+// expects FP8-packed activations. With the standalone `mq_rotate_x` +
+// `pack_f32_to_fp8` pre-pass approach, every weight_gemv(MFP4G32) call
+// in production decode had to invalidate the FP8 cache (mq_x_rot's
+// pointer is stable but data turns over per rotation) and re-pack —
+// putting the pack launch on the critical path (~5-10 µs) and
+// exceeding the dot4 savings (~3-5 µs) → 0.93× net regression on
+// 9B Qwen 3.5 measured 2026-05-10.
+//
+// FUSING the FP8 pack into the rotation kernel itself adds only ~K bytes
+// of extra global writes (1 byte per K-element) and 4 cvt_pk_fp8_f32
+// VALU ops per thread per K-group — negligible compared to a saved
+// kernel launch. The fallback F32 output is preserved so non-FP8
+// consumers (gemv_hfp4g32 fallback path, any FP16-path that reads
+// mq_x_rot directly) keep working unchanged.
+//
+// LAYOUT: same as mq_rotate_x except an additional `x_out_fp8`
+// (1 byte per K-element). x_out and x_out_fp8 hold the same numerical
+// values; FP8 is E4M3-rounded F32.
+//
+// Grid: [groups_total, batch, 1]. Block: [32]. LDS: 0.
+
+extern "C" __launch_bounds__(32, 16)
+__global__ void mq_rotate_x_dual_fp8_gfx12(
+    const float* __restrict__ x_in,
+    float* __restrict__ x_out,
+    unsigned char* __restrict__ x_out_fp8,
+    const float* __restrict__ signs1,
+    const float* __restrict__ signs2,
+    int K
+) {
+    const int group = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int groups_total = K / 256;
+    if (group >= groups_total) return;
+
+    const long long batch_off = (long long)blockIdx.y * K;
+    const float* x_in_b  = x_in  + batch_off;
+          float* x_out_b = x_out + batch_off;
+          unsigned char* x_out_fp8_b = x_out_fp8 + batch_off;
+
+    int d0 = tid * 8;
+    int base = group * 256 + d0;
+
+    float v0 = x_in_b[base]     * signs1[d0];
+    float v1 = x_in_b[base + 1] * signs1[d0 + 1];
+    float v2 = x_in_b[base + 2] * signs1[d0 + 2];
+    float v3 = x_in_b[base + 3] * signs1[d0 + 3];
+    float v4 = x_in_b[base + 4] * signs1[d0 + 4];
+    float v5 = x_in_b[base + 5] * signs1[d0 + 5];
+    float v6 = x_in_b[base + 6] * signs1[d0 + 6];
+    float v7 = x_in_b[base + 7] * signs1[d0 + 7];
+
+    float t;
+    t = v0; v0 = v0 + v1; v1 = t - v1;
+    t = v2; v2 = v2 + v3; v3 = t - v3;
+    t = v4; v4 = v4 + v5; v5 = t - v5;
+    t = v6; v6 = v6 + v7; v7 = t - v7;
+
+    t = v0; v0 = v0 + v2; v2 = t - v2;
+    t = v1; v1 = v1 + v3; v3 = t - v3;
+    t = v4; v4 = v4 + v6; v6 = t - v6;
+    t = v5; v5 = v5 + v7; v7 = t - v7;
+
+    t = v0; v0 = v0 + v4; v4 = t - v4;
+    t = v1; v1 = v1 + v5; v5 = t - v5;
+    t = v2; v2 = v2 + v6; v6 = t - v6;
+    t = v3; v3 = v3 + v7; v7 = t - v7;
+
+    #define HBFLY(v, pat, str) do { \
+        float _p = __int_as_float(__builtin_amdgcn_ds_swizzle(__float_as_int(v), (pat))); \
+        if (tid & (str)) { (v) = _p - (v); } else { (v) = (v) + _p; } \
+    } while(0)
+
+    #define HBFLY8(pat, str) \
+        HBFLY(v0,pat,str); HBFLY(v1,pat,str); HBFLY(v2,pat,str); HBFLY(v3,pat,str); \
+        HBFLY(v4,pat,str); HBFLY(v5,pat,str); HBFLY(v6,pat,str); HBFLY(v7,pat,str)
+
+    HBFLY8(0x041F, 1);
+    HBFLY8(0x081F, 2);
+    HBFLY8(0x101F, 4);
+    HBFLY8(0x201F, 8);
+    HBFLY8(0x401F, 16);
+    #undef HBFLY8
+    #undef HBFLY
+
+    const float s = 0.0625f;
+    // Final scale + sign — produce F32 values first, then write both
+    // F32 and FP8 from the same registers.
+    v0 *= s * signs2[d0];
+    v1 *= s * signs2[d0 + 1];
+    v2 *= s * signs2[d0 + 2];
+    v3 *= s * signs2[d0 + 3];
+    v4 *= s * signs2[d0 + 4];
+    v5 *= s * signs2[d0 + 5];
+    v6 *= s * signs2[d0 + 6];
+    v7 *= s * signs2[d0 + 7];
+
+    x_out_b[base    ] = v0;
+    x_out_b[base + 1] = v1;
+    x_out_b[base + 2] = v2;
+    x_out_b[base + 3] = v3;
+    x_out_b[base + 4] = v4;
+    x_out_b[base + 5] = v5;
+    x_out_b[base + 6] = v6;
+    x_out_b[base + 7] = v7;
+
+    // FP8: 8 floats → 2 uint32 (8 packed E4M3 bytes) via 4 cvt_pk_fp8_f32.
+    unsigned int lo = 0u, hi = 0u;
+    lo = __builtin_amdgcn_cvt_pk_fp8_f32(v0, v1, lo, false);
+    lo = __builtin_amdgcn_cvt_pk_fp8_f32(v2, v3, lo, true);
+    hi = __builtin_amdgcn_cvt_pk_fp8_f32(v4, v5, hi, false);
+    hi = __builtin_amdgcn_cvt_pk_fp8_f32(v6, v7, hi, true);
+    *(unsigned int*)(x_out_fp8_b + base    ) = lo;
+    *(unsigned int*)(x_out_fp8_b + base + 4) = hi;
+}

--- a/kernels/src/pack_f32_to_fp8.gfx12.hip
+++ b/kernels/src/pack_f32_to_fp8.gfx12.hip
@@ -1,0 +1,59 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Activation pre-pass for FP8-WMMA GEMM kernels on gfx12 (RDNA4).
+// Converts F32 elements to E4M3 FP8 bytes one-to-one with no scaling.
+//
+// Rationale: doing the FP16->FP8 conversion inside the GEMM inner loop
+// was the dominant ALU bottleneck for the FP8 WMMA path (measured
+// 0.7-0.86x FP16 with in-kernel cvt vs 1.05-1.35x FP16 with cvt stubbed
+// out at K=2048 on gfx1201). Moving it to a separate, memory-bandwidth-
+// bound pre-pass kernel that runs once per layer input (cached by
+// src_ptr, same lifetime as ensure_fp16_x's scratch) recovers the FP8
+// WMMA throughput advantage.
+//
+// Saturation: E4M3 max is ±448. Post-RMSNorm transformer activations
+// are bounded well below this in practice (typically [-5, 5]); occasional
+// outliers in deep residual streams may approach ±20, still safe. We
+// rely on cvt_pk_fp8_f32's hardware saturation for the rare outlier.
+//
+// Layout: each thread converts 16 F32 -> 16 FP8 bytes (16 floats = 64 B
+// in, 16 B = 1 dword4 out). Block = 256 threads = 4096 elements per
+// block. Grid scaled to (len + 4095) / 4096.
+
+typedef int   __attribute__((ext_vector_type(2))) v2i_t;
+typedef float __attribute__((ext_vector_type(4))) v4f_t;
+
+extern "C" __global__ void pack_f32_to_fp8_gfx12(
+    const float* __restrict__ in,     // [len], F32
+    unsigned char* __restrict__ out,  // [len], E4M3 FP8 (1 byte each)
+    int len
+) {
+    const int base = (blockIdx.x * blockDim.x + threadIdx.x) * 16;
+    if (base >= len) return;
+
+    if (base + 16 <= len) {
+        // 4x v4f_t load = 16 F32 elements coalesced
+        const v4f_t* in_v = (const v4f_t*)(in + base);
+        v4f_t a = in_v[0], b = in_v[1], c = in_v[2], d = in_v[3];
+        v2i_t out_pack = {0, 0};
+        out_pack[0] = __builtin_amdgcn_cvt_pk_fp8_f32(a[0], a[1], out_pack[0], false);
+        out_pack[0] = __builtin_amdgcn_cvt_pk_fp8_f32(a[2], a[3], out_pack[0], true);
+        out_pack[1] = __builtin_amdgcn_cvt_pk_fp8_f32(b[0], b[1], out_pack[1], false);
+        out_pack[1] = __builtin_amdgcn_cvt_pk_fp8_f32(b[2], b[3], out_pack[1], true);
+        *(v2i_t*)(out + base) = out_pack;
+        v2i_t out_pack2 = {0, 0};
+        out_pack2[0] = __builtin_amdgcn_cvt_pk_fp8_f32(c[0], c[1], out_pack2[0], false);
+        out_pack2[0] = __builtin_amdgcn_cvt_pk_fp8_f32(c[2], c[3], out_pack2[0], true);
+        out_pack2[1] = __builtin_amdgcn_cvt_pk_fp8_f32(d[0], d[1], out_pack2[1], false);
+        out_pack2[1] = __builtin_amdgcn_cvt_pk_fp8_f32(d[2], d[3], out_pack2[1], true);
+        *(v2i_t*)(out + base + 8) = out_pack2;
+    } else {
+        // Tail elements: one-by-one.
+        for (int k = base; k < len; k++) {
+            unsigned int tmp = 0;
+            tmp = __builtin_amdgcn_cvt_pk_fp8_f32(in[k], 0.0f, tmp, false);
+            out[k] = (unsigned char)(tmp & 0xFFu);
+        }
+    }
+}


### PR DESCRIPTION
## TL;DR

Three production wins shipped default-on, three negative-result research artifacts shipped opt-in default-off, and two silent-correctness/perf-infra bug fixes. All on the same `feat/MFP4G32-v2-batched-wmma` branch as the v2 #2 batched-WMMA prefill work (`ada4eddf` + `9145f06a`).

| What | Where | Result |
|---|---|---|
| **HIPFIRE_GRAPH default-on for gfx12** | `7fca62df` | **+2.4-2.7%** decode on 9B Qwen 3.5 MFP4G32 (R9700) |
| **HIPFIRE_GRAPH default-on for gfx11** | `9582ac39` | **+0.7-1.55%** decode on 9B + 0.8B HFP4G32 (7900 XTX) |
| **`invalidate_x_caches_for` rotation cache fix** | `7fca62df` | **silent correctness bug fixed** — `ensure_*_x` was returning stale data on every `weight_gemv(MFP4G32)` call after the first within a forward pass |
| OnceLock env-gate cache (`is_fp8_wmma_enabled`) | `7fca62df` | ~4 µs/call overhead removed; was masking perf-bench signal |
| FP8 prefill WMMA + decode dot4 GEMV infra | `7fca62df` | opt-in research, default-off (production decode 0.93-0.97×) |
| gfx11 fdot2 GEMV (v_dot2_f32_f16) | `2a71f91f` | opt-in research, default-off (synthetic 2.08×, production 0.90×) |

## What ships default-on

### β: per-forward hipGraph capture/replay on gfx11+gfx12

Capturing each decode token's forward pass as a hipGraph and replaying it amortizes per-launch overhead across all the kernels in the forward chain. Measured on production decode workloads:

| Arch | Model | Mean speedup | Variance |
|---|---|---|---|
| gfx1201 (R9700)        | 9B Qwen 3.5 MFP4G32 | **+2.6%**  | 1.023-1.029× (5 runs) |
| gfx1100 (7900 XTX)     | 9B Qwen 3.5 HFP4G32 | **+1.55%** | 1.007-1.019× (5 runs) |
| gfx1100 (7900 XTX)     | 0.8B HFP4G32        | **+0.6%**  | 1.001-1.009× (5 runs) |

Default policy in `qwen35.rs` forward():
- **gfx12 + gfx11**: default-ON
- **other archs (RDNA1/2, CDNA)**: default-OFF (opt-in via `HIPFIRE_GRAPH=1`)
- **MoE configs**: always direct unless `HIPFIRE_GRAPH_MOE=1` (known numerical drift)
- `HIPFIRE_GRAPH=0` always wins as kill switch

### Silent correctness fix: `invalidate_x_caches_for` on rotations

`ensure_fp16_x` / `ensure_fp8_x` cache the FP16/FP8 conversion result by source pointer (`fp16_x_source_ptr` / `fp8_x_source_ptr`). On the MFP4G32 path, `gemv_mfp4g32_with_rotate` writes rotated activations into the persistent `mq_x_rot` scratch buffer — **the pointer is stable across calls but the data turns over per rotation**. The cache silently returned stale FP16/FP8 from the previous gemv on every subsequent weight_gemv call within a forward pass.

Coherence detectors missed it because the output stayed vaguely on-topic, but the activations being passed to gemv kernels were silently wrong post-call-1 in every MFP4G32 forward. Fix adds `invalidate_x_caches_for(dst_ptr)` to all rotation entry points: `rotate_x_mq` / `_batched`, `fused_rmsnorm_rotate_mq` / `_batched`, `fused_silu_mul_rotate_mq` / `_batched`, and the new `mq_rotate_x_dual_fp8`. Memory checkpoint `ada4eddf` had flagged this caveat as "latent in HFQ4 test too" — now fixed for both fp8 and fp16 caches.

### OnceLock env-gate

`is_fp8_wmma_enabled()` (and now `is_dot2_gemv_enabled()`) cache the env var lookup in `std::sync::OnceLock`. Reading via `std::env::var` on every dispatch was a ~4 µs/call overhead in tight bench loops (syscall + String alloc), which was masking the synthetic FP8 win and distorting all our A/B perf measurements. Cleanup that always applies.

## What ships opt-in default-off (research scaffold)

Three independent hypotheses tested and falsified in production. Code is correct, well-instrumented, and saved for future researchers — the bench tools especially are reusable.

### Hypothesis: FP8 WMMA prefill on gfx12

`gemm_qkv_hfp4g32_wmma_fp8.gfx12.hip` — uses `wmma_f32_16x16x16_fp8_fp8_w32_gfx12`. Microbench measured **1.87× raw WMMA throughput** vs FP16. End-to-end QKV prefill measured **0.71-1.10×** (loss at small N, ~at-parity at N=2048).

Root cause: HFP4G32's per-32-block UE8M0 scale forces post-WMMA `acc[j] += partial[j] * row_scale[j] * UE8M0[j]` chains on F32 accumulator. The FP16 sibling sidesteps this by baking scale into the half operand pre-WMMA. The required cross-lane shuffle + FMA chain costs roughly what the WMMA-throughput advantage delivers.

Gated by `HIPFIRE_FP8_WMMA=1` + `FP8_WMMA_MIN_BATCH=1024` so it never triggers at decode (N=1 measures 0.71×).

### Hypothesis: FP8 dot4 decode GEMV on gfx12

`gemv_hfp4g32_fp8.gfx12.hip` — uses `dot4_f32_fp8_fp8`. Synthetic bench measured **1.04-1.42× wins** on FFN shapes (gate_up M=11008 hits 99% peak BW vs 78% fallback). Tried 4 variants:

| Variant | Production decode |
|---|---|
| v1 (ensure_fp8_x pre-pass) | -7% |
| v2 (inline F32→FP8 cvt) | -7% |
| v3 / A3 (fused mq_rotate_x_dual_fp8) | -6% |
| v3 + FP8_GEMV_MIN_M shape-gate | -6% |

rocprof attribution: per-call FP8 GEMV is ~3 µs slower than fallback in production despite winning by ~4 µs in synthetic isolation. The ~30 µs gap between synthetic and production per call is cross-kernel context cost (L2 thrashing from interleaved attention/conv1d/norm ops between gemvs, scheduler interference). FP8 path pays MORE of this than fallback.

### Hypothesis: gfx11 v_dot2_f32_f16 trickle-down

`gemv_hfp4g32_dot2.gfx11.hip` — uses `__builtin_amdgcn_fdot2` (one v_dot2_f32_f16 = 2 FP16 muls + 1 FP32 add). Synthetic bench measured **1.13-2.08× wins** on 7900 XTX (gate_up hit 84% peak BW vs 40% fallback). Tested two kernel variants (single-carry chain + 4 parallel partial accumulators).

Production decode on 9B HFP4G32: **0.90× consistently across both variants and 5 paired runs each**. Same trap as gfx12 FP8 — synthetic wins evaporate in production workload context.

NRMSE 2e-4 (FP16 multiply intermediate; much more precise than FP8's 2.7%). Correctness intact, perf empirically falsified.

## What this branch empirically established

Across three independent hypothesis lines on two arches:

| Lever class | Verdict on this codebase + ROCm 7.2 |
|---|---|
| **Launch-reduction (β / hipGraph capture)** | **alive, shipped default-on for gfx11+gfx12** |
| Per-kernel ALU optimization (FP8 dot4, FP8 WMMA, fdot2) | dead in production despite synthetic wins |
| Activation pre-pass kernels with src_ptr caching | trap unless paired with rotation invalidation (now fixed) |
| Speculative-decode cross-stream pipelining | already tested in PR5 D0-D3b: -1.7% / -7% |

**The single positive lever** that crosses zero in production on this codebase is launch-overhead amortization. Three independent kernel-level ALU experiments all lost in production despite synthetic wins — that's not bad luck, it's a structural property of this codebase + ROCm 7.2 + decode workload pattern (cross-kernel L2/scheduler context costs dominate per-call kernel time).

## Files touched

**Kernels added (opt-in research):**
- `kernels/src/gemm_qkv_hfp4g32_wmma_fp8.gfx12.hip` — prefill FP8 WMMA QKV
- `kernels/src/pack_f32_to_fp8.gfx12.hip` — F32→E4M3 pre-pass
- `kernels/src/gemv_hfp4g32_fp8.gfx12.hip` — decode FP8 dot4 GEMV
- `kernels/src/mq_rotate_x_dual.gfx12.hip` — fused FWHT + FP8 pack
- `kernels/src/gemv_hfp4g32_dot2.gfx11.hip` — gfx11 fdot2 GEMV

**Rust wiring:**
- `crates/rdna-compute/src/kernels.rs` — 5 new source-include consts
- `crates/rdna-compute/src/dispatch.rs` — ensure_fp8_x, rotate_x_mq_dual_fp8, FP8 + dot2 dispatch wrappers, FP8_WMMA_MIN_BATCH + FP8_GEMV_MIN_M empirical thresholds, OnceLock env-gates, invalidate_x_caches_for and its call sites in all rotation entry points
- `crates/hipfire-arch-qwen35/src/qwen35.rs` — HIPFIRE_GRAPH default-on policy for gfx11+gfx12

**Bench + test tooling:**
- `crates/rdna-compute/examples/test_gemm_hfp4g32_fp8.rs`
- `crates/rdna-compute/examples/test_gemv_hfp4g32_fp8.rs`
- `crates/rdna-compute/examples/test_gemv_hfp4g32_dot2.rs`
- `crates/rdna-compute/examples/bench_gemv_hfp4g32_bw.rs`
- `crates/rdna-compute/examples/bench_gemv_mfp4g32_rotate.rs`

## Memory references (where the detailed empirical data lives)

- `memory/project_hypothesis_beta_graph_wins_2026_05_11.md` — full β data tables, rocprof breakdown, FP8 + β conflict analysis
- `memory/project_gfx11_dot2_trickle_down_falsified_2026_05_11.md` — fdot2 synthetic vs production analysis
- `memory/project_fp8_wmma_hfp4g32_2026_05_10.md` — earlier FP8 WMMA prefill analysis

## Test plan

- [x] **Correctness**: all opt-in research kernels pass `cmp_tol` correctness tests against F32 reference (NRMSE 2.7% for FP8 paths, 2e-4 for dot2 path)
- [x] **β + cleanup fixes**: 9B Qwen 3.5 MFP4G32 on hiptrx gfx1201, 5-run paired (FP8=0/GRAPH=0 vs FP8=0/GRAPH=1) — all coherence detectors PASS, decode +2.4-2.7%
- [x] **β default-on gfx12**: 9B Qwen 3.5 MFP4G32, 5-run paired (HIPFIRE_GRAPH=0 vs no-env) — all PASS, decode +2.4-2.7%
- [x] **β default-on gfx11**: 9B + 0.8B HFP4G32 on local 7900 XTX, 5-run paired each — all PASS, decode +0.6-1.55%
- [x] **rocprof attribution**: gfx12 FP8 ON vs OFF, kernel-level stats CSV produced, gap localized to per-FP8-call context cost (+3 µs vs fallback in production)
- [x] **Opt-in FP8 + dot2 paths default to OFF**: verified via dispatch routing in `gemv_hfp4g32` / `gemm_qkv_hfp4g32` / `gemv_mfp4g32_with_rotate`
- [ ] **Multi-arch sweep**: gfx1010 / gfx1030 / gfx906 still default-off for β; need bench before flipping their defaults. **Not in this PR.**
- [ ] **MoE archs (Qwen 35B-A3B)**: β remains default-off for MoE; the known DeltaNet state-drift bug is unfixed. **Not in this PR.**

## Why this round didn't ship a bigger win

The branch's original v2 #2 scope (batched WMMA prefill) shipped at `ada4eddf` + `9145f06a`. This PR is the v2 #3-5 follow-on after extensive empirical exploration. The honest summary: synthetic bench wins are not predictive of production decode wins on this codebase + ROCm 7.2. The +2.4-2.7% gfx12 / +0.7-1.55% gfx11 β win is what the empirical method actually validated.

Three other levers (FP8 prefill, FP8 decode dot4, gfx11 fdot2 trickle-down) showed clean synthetic wins of 1.04-2.08× but lost in production. Those are kept as research scaffold so the next researcher has the bench + rocprof methodology in place; rebuilding it would take a full day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)