### PR TITLE
quality-eval: act on claude + glm-5 review (followup to #233)

### DIFF
--- a/benchmarks/quality-baselines/harness/kld_diff.py
+++ b/benchmarks/quality-baselines/harness/kld_diff.py
@@ -107,15 +107,35 @@ def main() -> None:
     gate_ci = ci_overlaps
     gates = [gate_abs, gate_rel, gate_rho, gate_p99, gate_ci]
     all_pass = all(gates)
-    # Ranking-preservation heuristic: per-seq sign of (A - B) is mostly one
-    # direction → systematic bias; mostly equal → noise. We don't have other
-    # variants here, but flag if more than 90% of per-seq deltas are
-    # one-signed (suggests systematic bias even if mean delta passes).
+    # Sign-test for systematic bias: under H0 of no bias, per-seq sign of
+    # (A - B) is Bernoulli(0.5). Reject H0 (call it "one-sided / systematic
+    # bias") when a binomial two-tailed p-value < 0.001 — i.e. the observed
+    # one-sided count is wildly inconsistent with chance. Prior rev used a
+    # naive 90%-threshold heuristic which missed the canonical V1 gfx1100
+    # MQ4 result (n=1175, ~80–88% one-signed, definitively systematic but
+    # below the 90% bar).
     if n > 0:
-        pos_frac = float((delta > 0).sum()) / n
-        neg_frac = float((delta < 0).sum()) / n
-        one_sided = max(pos_frac, neg_frac) > 0.90
+        pos = int((delta > 0).sum())
+        neg = int((delta < 0).sum())
+        pos_frac = pos / n
+        neg_frac = neg / n
+        ones = max(pos, neg)
+        # Binomial CDF: P(X >= ones | n, 0.5). Two-tailed via *2.
+        from math import comb
+        # tail_p = 2 * Σ_{k=ones..n} C(n,k) * 0.5^n
+        # For large n this underflows; switch to log-domain for n>200.
+        if n <= 200:
+            tail = sum(comb(n, k) for k in range(ones, n + 1)) * (0.5 ** n)
+            p_value = min(1.0, 2.0 * tail)
+        else:
+            # Normal approx: under H0, count ~ N(n/2, sqrt(n)/2). Standardise.
+            from math import erfc, sqrt
+            z = (ones - n / 2) / (sqrt(n) / 2)
+            p_value = float(erfc(z / sqrt(2.0)))
+        one_sided = p_value < 0.001
     else:
+        pos_frac = neg_frac = 0.0
+        p_value = 1.0
         one_sided = False
 
     # --- report ---
@@ -130,7 +150,7 @@ def main() -> None:
     if one_sided:
         print(
             f"  WARN: {max(pos_frac, neg_frac):.0%} of per-seq deltas are "
-            f"one-signed — systematic bias suspected even if mean passes"
+            f"one-signed (sign-test p={p_value:.2e}) — systematic bias"
         )
     print()
     print("# Gates")
@@ -153,7 +173,12 @@ def main() -> None:
         print("VERDICT: PASS — prefill ≡ per-token within tolerance for this variant.")
         sys.exit(0)
     elif one_sided:
-        print("VERDICT: HARD FAIL — systematic bias suspected; root-cause via V0 microtests before flipping default.")
+        print(
+            "VERDICT: HARD FAIL — systematic bias detected (sign-test "
+            f"p={p_value:.2e}). For prefill-vs-per-token comparisons this "
+            "is the expected kernel-path effect documented in PRD §5.3. "
+            "Investigate via V0 microtests if you see this on a same-mode A/B."
+        )
         sys.exit(2)
     else:
         print("VERDICT: SOFT FAIL — some gates failed but no systematic bias detected. See plan §M5 escalation tree.")

--- a/benchmarks/quality-baselines/harness/kld_reduce.py
+++ b/benchmarks/quality-baselines/harness/kld_reduce.py
@@ -110,10 +110,38 @@ def reduce_one(path: Path) -> Row:
 
 
 def render_markdown_table(rows: list[Row]) -> str:
+    """Render rows grouped by scoring_mode so historical per-token rows are
+    visually separated from canonical prefill rows. Mixed-mode tables emit a
+    prominent warning at the top — see PRD §5.3 ("modes are separate
+    measurement classes; do not cross-compare").
+    """
     out = []
+
+    # Detect mode-collision: same (variant, arch) with multiple scoring modes.
+    by_key: dict[tuple[str, str], set[str]] = {}
+    for r in rows:
+        by_key.setdefault((r.variant, r.arch), set()).add(r.scoring_mode)
+    mixed = {k: v for k, v in by_key.items() if len(v) > 1}
+
+    if mixed:
+        out.append(
+            "> ⚠️  **Mixed-mode rows detected.** The following (variant, arch) "
+            "pairs have rows in more than one scoring mode. KLDs from "
+            "different modes are NOT directly comparable (kernel-path "
+            "numerical effect, ~7% mean shift on hipfire MQ; see PRD §5.3)."
+        )
+        out.append(">")
+        for (v, a), modes in sorted(mixed.items()):
+            out.append(f">  - `{v}` @ `{a}` → {sorted(modes)}")
+        out.append("")
+
     out.append("| Variant | Arch | Mode | n_chunks | Mean KLD ± 95% CI | p99 KLD | PPL | Notes |")
     out.append("|---|---|---|---:|---|---:|---:|---|")
-    for r in sorted(rows, key=lambda r: (r.variant, r.arch, r.scoring_mode)):
+
+    # Group by mode: prefill (canonical) first, then per-token (historical),
+    # then gguf (anchors). Within each group, sort by (variant, arch).
+    mode_order = {"prefill": 0, "per-token": 1, "gguf": 2}
+    for r in sorted(rows, key=lambda r: (mode_order.get(r.scoring_mode, 99), r.variant, r.arch)):
         ci = f"{r.mean_kld:.4f} (CI {r.mean_kld_ci_lo:.4f}–{r.mean_kld_ci_hi:.4f})"
         ppl = f"{r.ppl:.3f}" if r.ppl is not None else "—"
         out.append(f"| {r.variant} | {r.arch} | {r.scoring_mode} | {r.n_chunks} | {ci} | {r.p99_kld:.3f} | {ppl} | {r.notes} |")

--- a/crates/hipfire-runtime/examples/build_kld_ref.rs
+++ b/crates/hipfire-runtime/examples/build_kld_ref.rs
@@ -86,8 +86,10 @@ fn main() {
     let args = parse_args();
 
     // 0. Sanity checks (H1 + M4): pinned llama.cpp commit + slice md5.
-    verify_llama_commit(&args.llama_perplexity_bin);
-    verify_slice_md5(&args.slice);
+    hipfire_runtime::eval_common::verify_llama_commit(
+        &args.llama_perplexity_bin, PINNED_LLAMACPP_COMMIT, "build_kld_ref",
+    );
+    hipfire_runtime::eval_common::verify_slice_md5(&args.slice, "build_kld_ref");
 
     // 1. mkfifo
     let fifo_path = PathBuf::from(format!("/tmp/hipfire-kldref-{}.fifo", std::process::id()));
@@ -289,104 +291,6 @@ fn main() {
     );
 }
 
-/// Verify that the resolved llama-perplexity binary was built from the
-/// pinned commit. The binary's `--version` output looks like:
-///
-///   ```
-///   version: 9076 (9dcf83552)
-///   ```
-///
-/// We require the parenthesized short hash to be a prefix of
-/// `PINNED_LLAMACPP_COMMIT`. Format drift (different headers, different
-/// uint16 packing) silently corrupts the reduction, so a hard-fail here
-/// is cheap insurance.
-fn verify_llama_commit(bin: &str) {
-    let out = match Command::new(bin).arg("--version").output() {
-        Ok(o) => o,
-        Err(e) => {
-            eprintln!("ERROR: failed to invoke `{bin} --version`: {e}");
-            std::process::exit(2);
-        }
-    };
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
-    );
-    let needle = "version: ";
-    let after_version = match combined.find(needle) {
-        Some(i) => &combined[i + needle.len()..],
-        None => {
-            eprintln!("ERROR: could not find 'version: ' in `{bin} --version` output");
-            eprintln!("--- captured output ---\n{combined}\n---");
-            std::process::exit(2);
-        }
-    };
-    let open = match after_version.find('(') {
-        Some(i) => i,
-        None => {
-            eprintln!("ERROR: malformed `--version` output: no '(' after version number");
-            std::process::exit(2);
-        }
-    };
-    let after_paren = &after_version[open + 1..];
-    let close = match after_paren.find(')') {
-        Some(i) => i,
-        None => {
-            eprintln!("ERROR: malformed `--version` output: no ')' after commit hash");
-            std::process::exit(2);
-        }
-    };
-    let hash = &after_paren[..close];
-    if !PINNED_LLAMACPP_COMMIT.starts_with(hash) {
-        eprintln!("ERROR: llama-perplexity commit mismatch");
-        eprintln!("  binary:           {bin}");
-        eprintln!("  expected (pinned): {PINNED_LLAMACPP_COMMIT}");
-        eprintln!("  actual (--version): {hash}");
-        eprintln!("  Either rebuild llama.cpp at the pinned commit, or update");
-        eprintln!("  PINNED_LLAMACPP_COMMIT in this binary AND in the plan.");
-        std::process::exit(2);
-    }
-    eprintln!("build_kld_ref: verified llama.cpp commit prefix {hash}");
-}
-
-/// Verify the slice file's md5 against the sibling `slice.md5` (one-line
-/// `<md5>` or `md5sum` output). Aborts on mismatch; warns and continues
-/// if no sibling md5 file is present (developer regen).
-fn verify_slice_md5(slice_path: &std::path::Path) {
-    let md5_path = match slice_path.parent() {
-        Some(p) => p.join("slice.md5"),
-        None => {
-            eprintln!("warning: cannot resolve slice.md5 sibling; skipping check");
-            return;
-        }
-    };
-    if !md5_path.exists() {
-        eprintln!(
-            "warning: {} not found; skipping slice md5 check",
-            md5_path.display()
-        );
-        return;
-    }
-    let expected = fs::read_to_string(&md5_path)
-        .expect("read slice.md5")
-        .split_whitespace()
-        .next()
-        .map(String::from)
-        .expect("empty slice.md5");
-    let out = Command::new("md5sum").arg(slice_path).output()
-        .expect("invoke md5sum");
-    let actual = String::from_utf8_lossy(&out.stdout)
-        .split_whitespace()
-        .next()
-        .map(String::from)
-        .expect("empty md5sum output");
-    if actual != expected {
-        eprintln!("ERROR: slice md5 mismatch");
-        eprintln!("  slice:    {}", slice_path.display());
-        eprintln!("  expected: {expected}");
-        eprintln!("  actual:   {actual}");
-        std::process::exit(2);
-    }
-    eprintln!("build_kld_ref: verified slice md5 = {actual}");
-}
+// verify_llama_commit and verify_slice_md5 now live in
+// hipfire_runtime::eval_common (crates/hipfire-runtime/src/eval_common.rs)
+// so the same fix applies across eval_hipfire / eval_gguf / build_kld_ref.

--- a/crates/hipfire-runtime/examples/eval_gguf.rs
+++ b/crates/hipfire-runtime/examples/eval_gguf.rs
@@ -91,9 +91,11 @@ fn main() {
     let args = parse_args();
 
     // ---------- Sanity (H1 + M1 + M4) ----------
-    verify_llama_commit(&args.llama_perplexity_bin);
-    verify_slice_md5(&args.slice);
-    verify_ref_sha256(&args.ref_path);
+    hipfire_runtime::eval_common::verify_llama_commit(
+        &args.llama_perplexity_bin, PINNED_LLAMACPP_COMMIT, "eval_gguf",
+    );
+    hipfire_runtime::eval_common::verify_slice_md5(&args.slice, "eval_gguf");
+    hipfire_runtime::eval_common::verify_ref_sha256(&args.ref_path, "eval_gguf");
 
     // ---------- Open ref file, read header + tokens ----------
     let ref_file = File::open(&args.ref_path).expect("open ref");
@@ -328,7 +330,12 @@ fn main() {
                 kld_token += sum_p_residual_ref
                     * (sum_p_residual_ref.ln() - sum_p_residual_cand.ln());
             }
-            if kld_token < 0.0 && kld_token > -1e-6 { kld_token = 0.0; }
+            // KLD ≥ 0 by Gibbs' inequality. Same rationale as eval_hipfire.rs.
+            debug_assert!(
+                kld_token >= -1e-9,
+                "negative KLD beyond fp roundoff: {kld_token}"
+            );
+            let kld_token = kld_token.max(0.0);
 
             // NLL: -log P_cand(actual_next_token). actual next token at
             // chunk c, logit-pos (scoring_start + j) is tokens[c*n_ctx + scoring_start + j + 1].
@@ -427,110 +434,5 @@ fn main() {
     eprintln!("eval_gguf: wrote {}", args.output.display());
 }
 
-/// See build_kld_ref.rs::verify_llama_commit — same logic.
-fn verify_llama_commit(bin: &str) {
-    let out = match Command::new(bin).arg("--version").output() {
-        Ok(o) => o,
-        Err(e) => {
-            eprintln!("ERROR: failed to invoke `{bin} --version`: {e}");
-            std::process::exit(2);
-        }
-    };
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
-    );
-    let needle = "version: ";
-    let after_version = match combined.find(needle) {
-        Some(i) => &combined[i + needle.len()..],
-        None => {
-            eprintln!("ERROR: could not find 'version: ' in `{bin} --version` output");
-            std::process::exit(2);
-        }
-    };
-    let open = after_version.find('(').expect("malformed --version output");
-    let after_paren = &after_version[open + 1..];
-    let close = after_paren.find(')').expect("malformed --version output");
-    let hash = &after_paren[..close];
-    if !PINNED_LLAMACPP_COMMIT.starts_with(hash) {
-        eprintln!("ERROR: llama-perplexity commit mismatch");
-        eprintln!("  expected (pinned): {PINNED_LLAMACPP_COMMIT}");
-        eprintln!("  actual (--version): {hash}");
-        std::process::exit(2);
-    }
-    eprintln!("eval_gguf: verified llama.cpp commit prefix {hash}");
-}
-
-fn verify_slice_md5(slice_path: &std::path::Path) {
-    let md5_path = match slice_path.parent() {
-        Some(p) => p.join("slice.md5"),
-        None => return,
-    };
-    if !md5_path.exists() {
-        eprintln!("warning: {} not found; skipping slice md5 check", md5_path.display());
-        return;
-    }
-    let expected = fs::read_to_string(&md5_path)
-        .expect("read slice.md5")
-        .split_whitespace()
-        .next()
-        .map(String::from)
-        .expect("empty slice.md5");
-    let out = Command::new("md5sum").arg(slice_path).output()
-        .expect("invoke md5sum");
-    let actual = String::from_utf8_lossy(&out.stdout)
-        .split_whitespace()
-        .next()
-        .map(String::from)
-        .expect("empty md5sum output");
-    if actual != expected {
-        eprintln!("ERROR: slice md5 mismatch (expected {expected}, got {actual})");
-        std::process::exit(2);
-    }
-    eprintln!("eval_gguf: verified slice md5 = {actual}");
-}
-
-fn verify_ref_sha256(ref_path: &std::path::Path) {
-    let manifest_path = match ref_path.parent().and_then(|p| p.parent()) {
-        Some(p) => p.join("harness").join("manifest.json"),
-        None => {
-            eprintln!("warning: cannot locate harness/manifest.json; skipping ref sha256 check");
-            return;
-        }
-    };
-    if !manifest_path.exists() {
-        eprintln!("warning: {} missing; skipping ref sha256 check", manifest_path.display());
-        return;
-    }
-    let manifest_file = File::open(&manifest_path).expect("open manifest.json");
-    let manifest: serde_json::Value = serde_json::from_reader(manifest_file)
-        .expect("parse manifest.json");
-    let ref_name = ref_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    let expected = manifest
-        .get("references")
-        .and_then(|r| r.get(ref_name))
-        .and_then(|r| r.get("sha256"))
-        .and_then(|s| s.as_str())
-        .map(String::from);
-    let expected = match expected {
-        Some(s) => s,
-        None => {
-            eprintln!("warning: no manifest entry / sha256 for {ref_name}; skipping check");
-            return;
-        }
-    };
-    eprintln!("eval_gguf: computing sha256 of {} ...", ref_path.display());
-    let out = Command::new("sha256sum").arg(ref_path).output()
-        .expect("invoke sha256sum");
-    let actual = String::from_utf8_lossy(&out.stdout)
-        .split_whitespace()
-        .next()
-        .map(String::from)
-        .expect("empty sha256sum output");
-    if actual != expected {
-        eprintln!("ERROR: ref sha256 mismatch (expected {expected}, got {actual})");
-        std::process::exit(2);
-    }
-    eprintln!("eval_gguf: verified ref sha256 = {actual}");
-}
+// (verify_llama_commit / verify_slice_md5 / verify_ref_sha256 now live in
+// hipfire_runtime::eval_common — see crates/hipfire-runtime/src/eval_common.rs)

--- a/crates/hipfire-runtime/examples/eval_hipfire.rs
+++ b/crates/hipfire-runtime/examples/eval_hipfire.rs
@@ -15,7 +15,7 @@
 //!                [--kv-mode <mode>=asym3] \
 //!                [--scoring-mode <per-token|prefill>=per-token]
 //!
-//! Scoring modes (per docs/plans/eval_hipfire_speedup.md):
+//! Scoring modes (per `docs/plans/issue-113-quant-quality-eval.md` §5):
 //!   prefill:   (default, canonical since 2026-05-11) forward_prefill_batch
 //!              (transformer stack batched, lm_head fan-out per scored
 //!              position). ~7× wall-clock vs per-token on gfx1100/gfx1151
@@ -146,7 +146,7 @@ fn main() {
     );
 
     // -------- ref sha256 sanity (M1) --------
-    verify_ref_sha256(&args.ref_path);
+    hipfire_runtime::eval_common::verify_ref_sha256(&args.ref_path, "eval_hipfire");
 
     // -------- load model --------
     let mut hfq = HfqFile::open(&args.model).expect("open model");
@@ -243,9 +243,9 @@ fn main() {
     // with per_token_hidden_out=Some(buf) writes one row per scored token
     // (post-output-norm hidden state); we then loop weight_gemv per row to
     // recover logits — the "option C / per-token GPU lm_head fan-out"
-    // resolution from the rev-2 plan (§"lm_head fan-out options").
+    // resolution from PRD §5 lm_head fan-out options.
     // Shape: [scored_per_chunk, dim]; ~16 MB at scored_per_chunk=1023, dim=4096.
-    let scored_per_chunk = n_ctx - 1 - n_ctx / 2;
+    // `scored_per_chunk` already bound above at line ~188.
     let hidden_buf = if args.scoring_mode == "prefill" {
         Some(
             gpu.alloc_tensor(&[scored_per_chunk, config.dim], DType::F32)
@@ -321,7 +321,14 @@ fn main() {
             kld_token += sum_p_residual_ref
                 * (sum_p_residual_ref.ln() - sum_p_residual_cand.ln());
         }
-        if kld_token < 0.0 && kld_token > -1e-6 { kld_token = 0.0; }
+        // KLD ≥ 0 by Gibbs' inequality. Tiny negatives are fp64 roundoff on
+        // ~257-term sums; >1e-9 magnitudes indicate a math bug. debug_assert
+        // surfaces the latter in dev builds; release runs clamp at 0.
+        debug_assert!(
+            kld_token >= -1e-9,
+            "negative KLD beyond fp roundoff: {kld_token}"
+        );
+        let kld_token = kld_token.max(0.0);
 
         let nll = if actual_next < cand_logits.len() {
             Some(-((cand_logits[actual_next] as f64) - log_z))
@@ -369,7 +376,7 @@ fn main() {
                     let rate = total_scored_done as f64 / elapsed.max(1e-9);
                     eprint!(
                         "\r  chunk {:4}/{}  scored {:8}/{:8}  ({:5.1}%, {:.0} tok/s)   ",
-                        c + 1, n_chunk, total_scored_done, total_scored, pct, rate
+                        c + 1, effective_n_chunk, total_scored_done, total_scored, pct, rate
                     );
                 }
             }
@@ -426,7 +433,7 @@ fn main() {
                     let rate = total_scored_done as f64 / elapsed.max(1e-9);
                     eprint!(
                         "\r  chunk {:4}/{}  scored {:8}/{:8}  ({:5.1}%, {:.0} tok/s)   ",
-                        c + 1, n_chunk, total_scored_done, total_scored, pct, rate
+                        c + 1, effective_n_chunk, total_scored_done, total_scored, pct, rate
                     );
                 }
             }
@@ -495,61 +502,5 @@ fn main() {
     eprintln!("eval_hipfire: wrote {}", args.output.display());
 }
 
-/// Verify the reference file's sha256 against
-/// `<repo>/benchmarks/quality-baselines/harness/manifest.json`.
-///
-/// Layout assumption: ref lives at `.../refs/<name>.kldref.bin`,
-/// manifest at `.../harness/manifest.json` (sibling to refs/).
-///
-/// If the manifest entry is absent, warn and continue (developer
-/// pre-upload state). If sha256 disagrees, abort.
-#[cfg(feature = "deltanet")]
-fn verify_ref_sha256(ref_path: &std::path::Path) {
-    use std::process::Command;
-    let manifest_path = match ref_path.parent().and_then(|p| p.parent()) {
-        Some(p) => p.join("harness").join("manifest.json"),
-        None => {
-            eprintln!("warning: cannot locate harness/manifest.json; skipping ref sha256 check");
-            return;
-        }
-    };
-    if !manifest_path.exists() {
-        eprintln!("warning: {} missing; skipping ref sha256 check", manifest_path.display());
-        return;
-    }
-    let manifest_file = std::fs::File::open(&manifest_path)
-        .expect("open manifest.json");
-    let manifest: serde_json::Value = serde_json::from_reader(manifest_file)
-        .expect("parse manifest.json");
-    let ref_name = ref_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    let expected = manifest
-        .get("references")
-        .and_then(|r| r.get(ref_name))
-        .and_then(|r| r.get("sha256"))
-        .and_then(|s| s.as_str())
-        .map(String::from);
-    let expected = match expected {
-        Some(s) => s,
-        None => {
-            eprintln!("warning: no manifest entry / sha256 for {ref_name}; skipping check");
-            return;
-        }
-    };
-    eprintln!("eval_hipfire: computing sha256 of {} ...", ref_path.display());
-    let out = Command::new("sha256sum")
-        .arg(ref_path)
-        .output()
-        .expect("invoke sha256sum");
-    let actual = String::from_utf8_lossy(&out.stdout)
-        .split_whitespace()
-        .next()
-        .map(String::from)
-        .expect("empty sha256sum output");
-    if actual != expected {
-        eprintln!("ERROR: ref sha256 mismatch for {}", ref_path.display());
-        eprintln!("  expected: {expected}");
-        eprintln!("  actual:   {actual}");
-        std::process::exit(2);
-    }
-    eprintln!("eval_hipfire: verified ref sha256 = {actual}");
-}
+// (verify_ref_sha256 now lives in hipfire_runtime::eval_common — see
+// crates/hipfire-runtime/src/eval_common.rs)

--- a/crates/hipfire-runtime/src/eval_common.rs
+++ b/crates/hipfire-runtime/src/eval_common.rs
@@ -1,0 +1,212 @@
+//! Shared helpers for the KLD-eval example binaries (`build_kld_ref`,
+//! `eval_hipfire`, `eval_gguf`). Each of these examples re-verifies the
+//! same three invariants before doing work; centralising the helpers
+//! here so a fix to one applies to all three. See
+//! `docs/plans/issue-113-quant-quality-eval.md` §4 (Reference format &
+//! pipeline) for what these checks defend against.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Verify the reference file's sha256 against the in-tree
+/// `manifest.json` index.
+///
+/// Layout assumption: ref lives at `.../refs/<name>.kldref.bin`, manifest
+/// at `.../harness/manifest.json` (sibling to `refs/`).
+///
+/// Behaviour:
+/// - if the manifest is absent OR has no entry for `<name>`, emit a
+///   warning and return (developer pre-upload state);
+/// - if sha256 disagrees, print a clear error and `std::process::exit(2)`.
+///
+/// `tool_name` is the binary's short name (e.g. `"eval_hipfire"`) and is
+/// used only in log lines.
+pub fn verify_ref_sha256(ref_path: &Path, tool_name: &str) {
+    let manifest_path = match ref_path.parent().and_then(|p| p.parent()) {
+        Some(p) => p.join("harness").join("manifest.json"),
+        None => {
+            eprintln!(
+                "warning: cannot locate harness/manifest.json relative to {}; \
+                 skipping ref sha256 check",
+                ref_path.display()
+            );
+            return;
+        }
+    };
+    if !manifest_path.exists() {
+        eprintln!(
+            "warning: {} missing; skipping ref sha256 check",
+            manifest_path.display()
+        );
+        return;
+    }
+    let manifest_file = std::fs::File::open(&manifest_path).expect("open manifest.json");
+    let manifest: serde_json::Value =
+        serde_json::from_reader(manifest_file).expect("parse manifest.json");
+    let ref_name = ref_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    let expected = manifest
+        .get("references")
+        .and_then(|r| r.get(ref_name))
+        .and_then(|r| r.get("sha256"))
+        .and_then(|s| s.as_str())
+        .map(String::from);
+    let expected = match expected {
+        Some(s) => s,
+        None => {
+            eprintln!("warning: no manifest entry / sha256 for {ref_name}; skipping check");
+            return;
+        }
+    };
+    eprintln!("{tool_name}: computing sha256 of {} ...", ref_path.display());
+    let out = Command::new("sha256sum")
+        .arg(ref_path)
+        .output()
+        .expect("invoke sha256sum");
+    let actual = String::from_utf8_lossy(&out.stdout)
+        .split_whitespace()
+        .next()
+        .map(String::from)
+        .expect("empty sha256sum output");
+    if actual != expected {
+        eprintln!("ERROR: ref sha256 mismatch for {}", ref_path.display());
+        eprintln!("  expected: {expected}");
+        eprintln!("  actual:   {actual}");
+        std::process::exit(2);
+    }
+    eprintln!("{tool_name}: verified ref sha256 = {actual}");
+}
+
+/// Verify the slice file's md5 against the sibling `slice.md5` (one-line
+/// `<md5>` or `md5sum`-format output).
+///
+/// Behaviour:
+/// - if `<slice_dir>/slice.md5` is absent OR no recognisable hash on the
+///   first line, emit a warning and return;
+/// - if md5 disagrees, print a clear error and `std::process::exit(2)`.
+pub fn verify_slice_md5(slice_path: &Path, tool_name: &str) {
+    let md5_path = match slice_path.parent() {
+        Some(p) => p.join("slice.md5"),
+        None => return,
+    };
+    if !md5_path.exists() {
+        eprintln!(
+            "warning: {} missing; skipping slice md5 check",
+            md5_path.display()
+        );
+        return;
+    }
+    let expected_line = match std::fs::read_to_string(&md5_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("warning: cannot read {}: {e}; skipping slice md5", md5_path.display());
+            return;
+        }
+    };
+    let expected = match expected_line.split_whitespace().next() {
+        Some(s) => s.to_string(),
+        None => {
+            eprintln!("warning: {} empty; skipping", md5_path.display());
+            return;
+        }
+    };
+    let out = Command::new("md5sum")
+        .arg(slice_path)
+        .output()
+        .expect("invoke md5sum");
+    let actual = String::from_utf8_lossy(&out.stdout)
+        .split_whitespace()
+        .next()
+        .map(String::from)
+        .expect("empty md5sum output");
+    if actual != expected {
+        eprintln!("ERROR: slice md5 mismatch for {}", slice_path.display());
+        eprintln!("  expected: {expected}");
+        eprintln!("  actual:   {actual}");
+        std::process::exit(2);
+    }
+    eprintln!("{tool_name}: verified slice md5 = {actual}");
+}
+
+/// Verify that the supplied `llama-perplexity` binary's reported commit
+/// hash matches `pinned`.
+///
+/// Behaviour:
+/// - parses `<bin> --version`'s "version: N (hash)" line;
+/// - demands the binary's hash be ≥ 7 chars (collision floor on short
+///   git hashes);
+/// - compares an equal-length prefix of `pinned` to the binary's hash.
+///   The prior implementation used `pinned.starts_with(hash)`, which
+///   would accept arbitrarily short binary hashes (e.g. "9d" matching
+///   "9dcf83552…"). Surfaced by glm-5 review finding 2.5.
+///
+/// On any mismatch, `std::process::exit(2)`.
+pub fn verify_llama_commit(bin: &str, pinned: &str, tool_name: &str) {
+    let out = Command::new(bin).arg("--version").output();
+    let out = match out {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("ERROR: failed to invoke `{bin} --version`: {e}");
+            std::process::exit(2);
+        }
+    };
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let needle = "version: ";
+    let after_version = match combined.find(needle) {
+        Some(i) => &combined[i + needle.len()..],
+        None => {
+            eprintln!("ERROR: could not find 'version: ' in `{bin} --version` output");
+            std::process::exit(2);
+        }
+    };
+    let open = match after_version.find('(') {
+        Some(i) => i,
+        None => {
+            eprintln!("ERROR: malformed `--version` output: no '(' after version number");
+            std::process::exit(2);
+        }
+    };
+    let after_paren = &after_version[open + 1..];
+    let close = match after_paren.find(')') {
+        Some(i) => i,
+        None => {
+            eprintln!("ERROR: malformed `--version` output: no ')' after commit hash");
+            std::process::exit(2);
+        }
+    };
+    let hash = &after_paren[..close];
+    if hash.len() < 7 {
+        eprintln!(
+            "ERROR: llama-perplexity reported a {}-char hash; want ≥ 7",
+            hash.len()
+        );
+        eprintln!("  binary:    {bin}");
+        eprintln!("  reported:  {hash}");
+        std::process::exit(2);
+    }
+    if hash.len() > pinned.len() {
+        eprintln!(
+            "ERROR: llama-perplexity hash ({}) longer than pinned ({})",
+            hash.len(),
+            pinned.len()
+        );
+        std::process::exit(2);
+    }
+    let pinned_prefix = &pinned[..hash.len()];
+    if hash != pinned_prefix {
+        eprintln!("ERROR: llama-perplexity commit mismatch");
+        eprintln!("  binary:             {bin}");
+        eprintln!("  expected (pinned):  {pinned}");
+        eprintln!("  actual (--version): {hash}");
+        eprintln!("  Either rebuild llama.cpp at the pinned commit, or update");
+        eprintln!("  PINNED_LLAMACPP_COMMIT in this binary AND in the PRD.");
+        std::process::exit(2);
+    }
+    eprintln!("{tool_name}: verified llama.cpp commit prefix {hash}");
+}

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -10,6 +10,7 @@
 //! [`arch::Architecture`] trait.
 
 pub mod arch;
+pub mod eval_common;
 pub mod gguf;
 pub mod hfq;
 pub mod llama;

--- a/docs/plans/issue-113-quant-quality-eval.md
+++ b/docs/plans/issue-113-quant-quality-eval.md
@@ -26,7 +26,9 @@ PPL collapses the full output distribution at each position to one scalar — th
 
 llama.cpp's `llama-perplexity --kl-divergence` mode emits both PPL and mean/median/p99 KLD in one pass. PPL stays as a secondary sanity column in the result table.
 
-**Top-K=256 truncation caveat (M1).** Qwen 3.5/3.6 has a 248,320-token vocab. Top-K=256 covers ~0.103% of vocab IDs but typically the bulk of the probability mass: empirical sampling of the 9B BF16 reference shows median `sum_p_residual` = 0.41% (under the 0.5% gate), mean 1.81%, p99 17.94%, max 72.0%. The residual cross-term (§4.4) corrects mean-KLD in expectation; ~1% of all scored tokens have residual mass >17% (flat distributions) where the top-K approximation is loosest. Flagged in the result write-up.
+**Top-K=256 truncation caveat (M1).** Qwen 3.5/3.6 has a 248,320-token vocab. Top-K=256 covers ~0.103% of vocab IDs but typically the bulk of the probability mass: empirical sampling of the 9B BF16 reference shows median `sum_p_residual` = 0.41% (under the 0.5% gate), mean 1.81%, p99 17.94%, max 72.0%. The residual cross-term (§4.4) corrects mean-KLD in expectation; ~1% of all scored tokens have residual mass >17% (flat distributions) where the top-K approximation is loosest.
+
+**All reported KLD values are *lower bounds* on the true full-vocab KLD.** The residual cross-term assumes both distributions miss similarly in the tail — true for high-bit quants whose tail closely tracks BF16, less true for low-bit quants whose tail is precisely what gets scrambled. The bias is therefore **variant-dependent**: a coarser quant has more tail-mass divergence that the cross-term under-counts. Cross-variant ordering (e.g. "MQ4 worse than Q4_K_M") remains valid in direction; the *magnitude* of the gap is a lower bound and the true gap may be wider. Captured in the §8 result-table caveats preamble.
 
 ---
 
@@ -275,6 +277,10 @@ And the CLI default since 2026-05-11:
 - `Mode` column: hipfire MQ rows with mode="per-token" are historical
   and measure ~7% higher mean-KLD than prefill (kernel-path numerical
   difference, see §5.3). Do NOT cross-compare rows of different mode.
+- **All KLD values are lower bounds.** The top-K=256 residual cross-term
+  assumes both distributions miss similarly in the tail — looser for
+  coarser quants whose tail is more scrambled. Cross-variant ordering
+  (direction) is reliable; absolute magnitudes are conservative. See §2.
 ```
 
 ---
@@ -339,9 +345,13 @@ When a variant has been scored in two modes (e.g., MQ4 per-token vs prefill on g
 
 For prefill-vs-per-token A/B on hipfire MQ formats, the gates intentionally fail — that's how we discovered the kernel-path divergence is real (§5.3). The diff tool is the diagnostic; the verdict is editorial.
 
-### V2 — Canary-fixture pre-commit gate
+### V2 — Canary-fixture pre-commit gate (currently informational, not enforced)
 
-`eval_hipfire` on the 11-seq canary fixture, then `kld_diff.py` against the committed expected-KLDs in `canary.md`. Runs in a few minutes. Catches harness regressions on the live decode path. Limitation: cannot detect shared-mode bugs that affect both modes identically; issue-113's existing coherence-gate is the backstop.
+`eval_hipfire` on the 11-seq canary fixture, then `kld_diff.py` against the committed expected-KLDs in `canary.md`. Designed to run in a few minutes and catch harness regressions on the live decode path.
+
+**Status:** `canary.md` ships with expected-KLD slots TBD-populated. Until a baseline is run and the slots filled in, V2 cannot fire — it's informational only, not enforced. Populating the canary is on the deferred list (§13).
+
+Limitation acknowledged even once populated: V2 catches divergence between modes / between releases, but cannot detect a shared-mode bug that affects both paths identically. issue-113's existing coherence-gate is the backstop for shared regressions in the live decode path.
 
 ### V3 — Cross-arch sanity (gfx1100 ≡ gfx1151)
 
@@ -385,12 +395,12 @@ Two scope changes from rev-3.3:
 - BF16 references: 9B (gfx1151, 53 min, 375 reduced tok/s) + 27B (gfx1151, 2h 3m, 162 reduced tok/s). Uploaded to `hipfire-models/qwen-kldref` (dataset); manifest wired; fetch script smoke-tested end-to-end.
 - Hipfire data: 4 historical per-token kldseqs (MQ3, MQ4, MQ3-Lloyd, MQ6 on gfx1100); 1 canonical prefill kldseq (MQ4 on gfx1100 full slice = 0.817).
 - GGUF anchors: all 7 9B anchors on gfx1151 (Q8_0/Q6_K/Q4_K_M + UD-Q3/Q4/Q5/Q6_K_XL). Q8_0 establishes the near-lossless floor (KLD 0.0163); UD-Q4_K_XL beats vanilla Q4_K_M by ~1.9× (0.067 vs 0.125).
-- Scoring-mode A/B: V1 gfx1100 MQ4 full slice + gfx1151 MQ3/MQ4 partial (50 chunks). Kernel-path divergence confirmed cross-arch.
+- Scoring-mode A/B: V1 gfx1100 MQ4 full slice (canonical) + gfx1151 MQ3/MQ4 partial 50-chunk smoke runs (not archived; sign-test p<1e-100 on the gfx1100 result confirms kernel-path divergence is not noise).
 
 **Deferred (post-Pivot, not blocking PR):**
 - 27B hipfire matrix (~150 GPU-h).
 - 9B-Q8 + 9B-MQ4-Lloyd hipfire rows on gfx1100.
-- gfx1151 hipfire full-slice pass.
+- gfx1151 hipfire full-slice pass (the 50-chunk smoke runs from V1 development were not archived; reproducible via `--max-chunks 50`).
 - DFlash τ column (Step 8) — editorial signal mooted by Pivot.
 - Pareto writeup (Step 9) — wait until HFP4/MFP4 .hfq files exist.
 - HFP4G32 / MFP4G32 .hfq files for 9B (depends on `hipfire-quantize --format hfp4`; eval-side is wired through auto-fallback).

--- a/docs/plans/quant-code-rev-claude.md
+++ b/docs/plans/quant-code-rev-claude.md
@@ -1,0 +1,204 @@
+# Critical review — KLD eval branch (chore/113-quant-eval-plan)
+
+**Reviewer:** claude-opus-4-7
+**Date:** 2026-05-11
+**Scope:** all commits on this branch since `upstream/master`, plus the PRD rewrite.
+**Status:** scaffolding. Per `feedback_drop_review_files_after_fold_in.md`, delete after fold-in.
+
+---
+
+## Sibling-review action table (2026-05-11)
+
+Cross-references the glm-5 review at `quant-code-rev-glm5.md`. Each finding marked V (validated + fixed in this branch), V-D (validated + deferred), or R (rejected).
+
+| # | Severity | Finding | Status | Fix landed in |
+|---|---|---|---|---|
+| 2.1 | HIGH | `scored_per_chunk` shadow | V | eval_hipfire.rs:248 dedup |
+| 2.2 | HIGH | Negative-KLD clamp masks bugs | V | `.max(0.0)` + `debug_assert!(>= -1e-9)` in eval_hipfire.rs + eval_gguf.rs |
+| 2.3 | MED | `unsafe set_var` UB risk | V-D | env writes run before any thread spawn; ergonomic fix needs API restructure |
+| 2.4 | MED | FIFO `/tmp` PID collision | V-D | low-likelihood; defer to a `tempfile`-crate refactor |
+| 2.5 | MED | Commit prefix `starts_with` allows drift | V | Equal-length prefix compare in `eval_common::verify_llama_commit`; demand ≥ 7 chars |
+| 3.1 | HIGH | 5 copy-pasted helpers across examples | V | Extracted to `crates/hipfire-runtime/src/eval_common.rs`; all three examples call into it |
+| 3.2 | MED | Hand-rolled argv parsing | V-D | Invasive; clap migration is a separate refactor |
+| 3.3 | MED | `score_position` mutates captured state | V-D | Same finding as claude H1; cosmetic refactor deferred (works correctly) |
+| 3.4 | LOW | `tokenizer_parity.py` writes to `/tmp` | R | AGENTS.md rule #4 is about canonical *prompts*, not intermediate scratch |
+| 4.1 | HIGH | Top-K=256 bias is variant-dependent | V | PRD §2 + §8 caveat preamble updated; all KLD now framed as lower-bound |
+| 4.2 | MED | Mixed-mode rows in same table | V | `kld_reduce.py` emits mode-collision warning + groups by mode |
+| 4.3 | MED | Canary fixture all TBD | V | PRD §10 V2 now explicitly informational-not-enforced |
+| 4.4 | LOW | Slice size discrepancy | R | Misread of `git diff --stat` (shows lines, not bytes); actual slice is 10.5 MB |
+| 5.3 | MED | PRD references deleted plan | V | Last source-code docstring ref updated to point to PRD §5 |
+| 5.4 | MED | Deferred list lacks dates/owners | V-D | PRD stylistic; rev in next pass when matrix gets actively scheduled again |
+| 6.1 | LOW | External `sha256sum`/`md5sum` | V-D | Linux-only fine for now; `sha2` crate migration is a separate refactor |
+| 6.2 | LOW | Inline Python in shell scripts | V-D | Cosmetic |
+
+Plus from my own review:
+| # | Severity | Finding | Status |
+|---|---|---|---|
+| C-H2 | HIGH | `kld_diff.py` 90% one-sided heuristic missed canonical V1 | V — replaced with binomial sign-test (p < 0.001); confirmed firing at p=6.59e-101 on gfx1100 MQ4 |
+| C-H3 | HIGH | PRD §13 referenced `/tmp/smoke/` (now gone) | V — citation removed |
+| C-M3 | MED | `--max-chunks` progress shows `n_chunk` not `effective_n_chunk` | V — fixed in both branches of the chunk loop |
+
+Findings carried forward to follow-up work:
+- claude H1 (allocator churn in `score_position`) — deferred; perf invisible on full slice with ~1h prefill wall-clock.
+- claude H4 (HFP4/MFP4 readiness asserted not validated) — deferred; depends on .hfq files being produced.
+- claude H5 (V1 SOFT FAIL didn't trigger V0 microtests; methodology drift) — the sign-test fix to `kld_diff.py` now correctly fires HARD FAIL with a clear "expected for prefill-vs-per-token; investigate via V0 if you see this on same-mode A/B" verdict, so the methodology change is now self-documenting.
+- claude M1 (prefill-is-more-accurate framing) — PRD §5.3 unchanged; soften in next pass.
+- claude M5 (Q8 never V1-validated) — deferred; needs Q8 .hfq + a re-run.
+- claude M6 (no unit tests for KLD math / kld_diff gate logic) — separate PR.
+- All claude L items — opportunistic.
+
+Severity ladder: **C** (blocks merge) · **H** (must-fix before next data run) · **M** (resolve in rev-2 of PRD or in follow-up) · **L** (note, OK to wave through).
+
+The work is substantively sound — the eval pipeline is real, the data is committed, the PRD is honest about scope. The issues below are the things I'd want fixed before treating this as a permanent reference, not blockers to merging the PR.
+
+---
+
+## High findings
+
+### H1 — Allocator churn in `score_position` closure (eval_hipfire.rs:272-332)
+
+`score_position` is called 1,202,025 times per full-slice run (1175 chunks × 1023 scored positions). On each call it allocates two `Vec<u32>` and `Vec<f32>` of capacity 256, fills them by parsing the ref block, then drops them. That's ~600 MB of allocator churn across a run, plus an ``Vec::with_capacity`` + 256 push'es overhead per call.
+
+Per-call cost is probably <10 µs so not catastrophic, but the closure body is reading bytes that already exist in `block_buf` — there's no reason to allocate. Use `bytemuck::cast_slice::<u8, u32>` (or a manual unaligned load loop) to view the block buffer directly. Or hoist a single pair of reusable `Vec`s to outer scope, clear-and-fill.
+
+For a full-slice run at the new ~1 h prefill wall-clock, the closure's overhead is invisible. For the partial-canary-fast iteration loops, it matters more — and the bug is the same in both paths.
+
+### H2 — `kld_diff.py` one-sided heuristic mis-calibrated (kld_diff.py:117)
+
+The "systematic bias" alarm fires when `> 90%` of per-seq deltas are one-signed. On the canonical V1 gfx1100 MQ4 result (mean delta −6.75%, Pearson 0.949, CIs do NOT overlap) the verdict was `SOFT FAIL — no systematic bias detected`. That's wrong: the bias is statistically definitive but the one-signed fraction landed somewhere in 80–90%, so the heuristic didn't fire.
+
+The plan's escalation path uses this verdict to decide whether to root-cause via V0 microtests. If the heuristic misses real biases at this magnitude, the escalation tree is partially broken. Either:
+
+- Lower the threshold to 80% (more sensitive but more false positives on noise-dominated runs).
+- Replace with a sign-test p-value: under no-bias H0, sign-count follows Binomial(n, 0.5); for n=1175 a 9:1 split is wildly significant. Use a proper one-sample sign test or Wilcoxon.
+
+Also, the `>` should probably be `>=` so 90.0% counts.
+
+### H3 — PRD references `/tmp/smoke/` as authoritative
+
+PRD §13 "Current State" and §10 V3 still reference "partial 9B-MQ3 + 9B-MQ4 50-chunk data lives in /tmp/smoke/" — but those files were not committed and `/tmp/smoke/` is session-local on gfx1151. A reviewer reading the PRD will see broken citations.
+
+Fix: either commit the 50-chunk data under `results/2026-05-11/per-seq/` with a `-50c` suffix in the variant name (so it's a labeled-as-partial sample), or remove the `/tmp/smoke/` reference and rephrase as "gfx1151 50-chunk smoke runs were exercised during V1 development but not archived; reproducible via `--max-chunks 50`."
+
+### H4 — HFP4G32 / MFP4G32 readiness is asserted, not validated
+
+The PRD §5.4 eligibility table and §6 matrix both treat HFP4G32 / MFP4G32 as eval-ready (auto-fallback to per-token). But there is no committed evidence that `eval_hipfire` actually completes a run on an .hfq file of those types. The auto-fallback path in `forward_prefill_batch` is exercised via `is_batchable_la` returning false, fine — but other parts of `eval_hipfire` could fail before that point:
+
+- `Qwen35Scratch::new` allocates scratch sized for the model's config; if HFP4G32 introduces a new scratch path requirement it could panic at load.
+- `KvCache::new_gpu_asym3` doesn't depend on weight dtype, OK.
+- The lm_head row at `weights.output` is dispatched via `weight_gemv(...)` which has match arms for `DType::HFP4G32` and `DType::MFP4G32` (verified at llama.rs:565-572), good — but only if the model's lm_head is itself one of those types, which depends on what `hipfire-quantize --format hfp4` does to the output tensor.
+
+Mitigation: add a "smoke target" to the harness README — once a 9B HFP4G32 .hfq exists, the first run should be 5-chunk `--scoring-mode prefill` to confirm the load path completes. Until then the PRD claim that HFP4/MFP4 "slot into the matrix" is unverified.
+
+### H5 — V1 SOFT FAIL didn't trigger V0; the gate's purpose got rewritten in-flight
+
+The PRD §10's V0 block says microtests trigger "if V1 on any variant reports a HARD FAIL or persistent SOFT FAIL." The gfx1100 MQ4 V1 result *did* SOFT FAIL by the tolerance schedule (every gate except CI-overlap failed: rel delta 6.75% vs 1% threshold, Pearson 0.949 vs 0.9999, p99 27.7% vs 5%). We should have run V0 microtests as the root-cause step.
+
+We didn't. Instead, we re-interpreted V1 as a measurement, not a gate — by §5.3 "the gates intentionally fail … the diff tool is the diagnostic; the verdict is editorial." That's a defensible move, but it's a *change* to the validation methodology mid-stream. The PRD now reads coherently after the rewrite, but a reader doing the work fresh would follow §10's V0 trigger and run V0, only to find it's been removed.
+
+Either: (a) explicitly document the methodology change ("V1 PASS/FAIL applied to mode-equivalence questions; for hipfire MQ vs prefill MQ the verdict is editorial because the modes are known-different and we're characterising the difference"), or (b) restore V0 as a real gate and run it. Recommend (a).
+
+---
+
+## Medium findings
+
+### M1 — "Prefill is more accurate against BF16" is a hypothesis dressed as a finding
+
+PRD §5.3 says prefill produces "logits systematically closer to BF16 ground truth." This is true *by definition of the test* — we measure prefill-KLD-vs-BF16-ref and per-token-KLD-vs-BF16-ref, prefill comes out lower, "closer to BF16." But the BF16 reference was produced by llama-perplexity's float kernel chain, which has its own multi-acc accumulation pattern. The bias could equally be "prefill happens to round in the direction llama-perplexity's float code does, and per-token's GEMV rounds the other way." That's not "more accurate"; it's "aligned by happenstance to the reference's roundoff."
+
+To genuinely show prefill is more accurate, we'd need an *independent* ground truth — e.g., fp64 reference on a CPU implementation. We don't have that. The framing should soften: "prefill measures lower KLD than per-token against this BF16 reference; the direction is reproducible but whether it represents 'more accurate' inference is open until we cross-check against an independent oracle."
+
+This is a tone-of-claim issue, not a load-bearing error. The Pivot decision still stands (prefill is faster and the measured numbers are what hipfire's prefill path actually emits). But the editorial recommendation in §5 should not lean on the "more accurate" claim.
+
+### M2 — `scored_per_chunk` declared twice (eval_hipfire.rs:188, 248)
+
+Same value (`n_ctx - 1 - n_ctx / 2`), the second shadows the first. Compile passes, semantics unchanged, but it's a stink. Remove the second declaration; line 248 should reference the earlier binding.
+
+### M3 — `chunk` progress reports use `n_chunk` instead of `effective_n_chunk` (eval_hipfire.rs:372, 429)
+
+When `--max-chunks 50` is set, the progress line still reads "chunk 5/1175" instead of "chunk 5/50". Cosmetic, but confusing for users of `--max-chunks`.
+
+### M4 — `HIPFIRE_PREFILL_REUSE_PBS=1` ordering dependency
+
+`Qwen35Scratch::new` reads `HIPFIRE_PREFILL_REUSE_PBS` *during construction* and only then allocates `PrefillBatchScratch`. In `eval_hipfire`, the env var is set before `Gpu::init` (good), then scratch is allocated (good). But this is an implicit ordering contract: if a future contributor reorders code to allocate scratch before the env-var block, `prefill_batch` stays `None`, every chunk pays alloc/free for ~25 tensors, run gets ~10% slower, no warning.
+
+Add an `assert!(scratch.prefill_batch.is_some(), "PBS not pre-allocated; set HIPFIRE_PREFILL_REUSE_PBS=1 *before* Qwen35Scratch::new")` in the prefill mode branch. Compile-time cheap; catches the regression.
+
+### M5 — Q8 was never V1-validated; the canonical-mode claim is unproven for the lossless case
+
+The V1 measurement was only run on MQ4 (and partial on MQ3 / MQ3-Lloyd). The PRD treats prefill as canonical for ALL hipfire variants in §5, but Q8 — the lossless reference proxy where any kernel-path noise should be tiniest — has never had its prefill-vs-per-token bias measured. The 7% MQ-side bias might be 0.01% on Q8, or it might be 5% on Q8; we don't know.
+
+This matters because Q8 is the cleanest case to argue "prefill is canonical." If Q8 shows a tiny bias (<0.1%), it supports the broader case; if Q8 shows a large bias, the canonical decision is suspect.
+
+Suggested follow-up (not blocking): once an .hfq Q8 is on hand, a 50-chunk V1 A/B on gfx1100 takes ~25 min and resolves this.
+
+### M6 — KLD math has no unit tests
+
+The `score_position` closure's math is verified only by end-to-end runs (gfx1100 MQ4 prefill ≈ 0.817, eyeballed as "looks right"). A 10-line unit test with two hand-constructed distributions and a hand-computed expected KLD would lock the math down against future refactors. Same for the residual cross-term's edge cases (one residual zero, both zero, etc.).
+
+`kld_diff.py` similarly has no unit tests beyond the self-diff smoke. The gate-decision logic for boundary cases (epsilon-equal-to-threshold, etc.) is untested.
+
+### M7 — Storage & cost table mixes pre-Pivot and post-Pivot numbers (PRD §12)
+
+The cost table lists "Hipfire 9B per-token: ~7 h/run × 10 = ~70 GPU-h" alongside "Hipfire 9B prefill: ~1 h/run × 10 = ~10 GPU-h" — the per-token line is historical, the prefill line is the canonical path. Reading the table linearly, a stakeholder might think hipfire 9B costs 80 GPU-h. It costs ~10 GPU-h (prefill canonical) + the 28 GPU-h already spent on the historical per-token data.
+
+Restructure: split "future cost" (prefill canonical) from "historical cost already spent" (per-token rows committed).
+
+---
+
+## Low findings
+
+### L1 — Residual cross-term silently skips when `sum_p_residual_cand <= 1e-9`
+
+When the candidate believes all probability mass is concentrated in the reference's top-K (so `1 - Σ p_cand[ref_top_K] ≈ 0`), the cross-term is dropped. This is correct (the term goes to 0× anything-finite), but the asymmetric clamp introduces a tiny bias on near-deterministic positions toward "no residual penalty." Probably invisible in practice; document or tolerate.
+
+### L2 — Negative-KLD clamp range (eval_hipfire.rs:324)
+
+`if kld_token < 0.0 && kld_token > -1e-6 { kld_token = 0.0; }` clamps tiny fp roundoff. But KLD values below -1e-6 would survive untouched and propagate into the mean. KLD is mathematically ≥ 0; any negative value is roundoff. Better: clamp at 0 unconditionally, or `kld_token.max(0.0)`.
+
+### L3 — `chunk_klds.clone()` per chunk for p99 sorting (eval_hipfire.rs:443)
+
+Clones 8 KB per chunk for the sort. 10 MB churn over 1175 chunks. Sort in place with `chunk_klds.sort_by(...)` — order isn't needed after p99 is read, and the mean was already computed.
+
+### L4 — `eval_gguf` H7 token-equality assumes byte-identical tokenization
+
+`eval_gguf` aborts if the candidate GGUF's tokens (produced by llama-perplexity on the slice) don't byte-match the reference's tokens. This is correct for catching mismatched tokenizers, but the failure message at qwen35.rs's call site is "ERROR: cand n_vocab {cand} != ref n_vocab {ref}" — could be clearer about which side disagrees.
+
+### L5 — `fetch-eval-refs.sh` Python version unspecified
+
+The script requires `huggingface_hub`, which requires Python ≥ 3.8. On older systems the venv create succeeds but pip install or hf_hub_download fails with cryptic errors. Add a `python3 --version` check + `>= 3.8` guard.
+
+### L6 — HF upload recipe is undocumented
+
+The script downloads from HF but the corresponding upload step (`hf upload --repo-type dataset hipfire-models/qwen-kldref ...`) is not in any committed README. If anyone needs to upload a new ref, they have to reverse-engineer the recipe from the hf CLI docs. Add a §"Producing a new ref" subsection to the harness README.
+
+### L7 — No regression test for HFKSEQ output format
+
+`eval_hipfire` writes HFKSEQ v2 by hardcoding `version = 2` (eval_hipfire.rs:461). If the schema changes (e.g., a v3 adds median NLL), the writer must be updated in lockstep with the reader. No test enforces. Add a round-trip test: write a known HFKSEQ, read it back via `kldref_format.py`, assert per-seq values match.
+
+### L8 — `prefill_microbench` has no oracle
+
+The microbench measures dispatch time but doesn't check that `forward_prefill_batch` produced correct output. If a kernel regression returned zeros silently, the microbench would just measure "zero-write time." Add a single-position output comparison against `forward_scratch` on a synthetic input (5-line check, fp16 tolerance).
+
+### L9 — Auto-mkdir on output path (eval_hipfire.rs:457-461, eval_gguf.rs:382, build_kld_ref.rs:165)
+
+`create_dir_all` on the output's parent silently creates any missing chain. Saves the "lost run to typo" case the commit message describes, but if a user typos a path like `--output benchmark/quality-baseline/foo.kldseq` (singular instead of plural), they'll get a fresh tree created without warning. Probably fine since the run produces output regardless and the user can rm-rf the typo, but worth noting.
+
+### L10 — Slice fixture has single point of failure
+
+`benchmarks/quality-baselines/slice/wikitext2-1024s-2048ctx.txt` is committed and pinned by md5 in `slice.md5`. If wikitext-2 ever changes (the upstream HF dataset), or if `make_slice.sh` is re-run on a new machine and produces a byte-different slice, every reference becomes invalid and the eval matrix collapses. Mitigation is implicit (the slice IS committed, the md5 IS checked) but the failure mode would be catastrophic and silent until the first eval run fails with a SHA mismatch. Worth a sentence in the PRD: "the committed slice + md5 + sha256 references form a triple-pin; do NOT regenerate `make_slice.sh` casually."
+
+---
+
+## Summary
+
+The core eval pipeline works, the data flows are honest, and the PRD captures the substance well. The notable risks are:
+
+1. **Methodology drift on V1.** We re-defined V1 from "equivalence gate" to "characterisation measurement" mid-stream. Document the choice or it'll trip the next reviewer.
+2. **Bias-interpretation framing.** "Prefill is more accurate" is a charitable read of the V1 result; the careful read is "prefill is biased toward llama-perplexity's float roundoff direction." Soften.
+3. **HFP4/MFP4 unverified.** PRD claims they slot in; nothing has actually run end-to-end on those formats.
+4. **kld_diff.py systematic-bias detector mis-calibrated.** Missed the canonical V1 result; needs sensitivity bump.
+
+None of the above blocks merge. They're the things to fix before the eval matrix is treated as a permanent reference for HFP4/MFP4 results.
+
+Smaller polish (M2–M7, L1–L10) is opportunistic.


### PR DESCRIPTION
Follow-up to #233 (merged at `9cecc83`). The PR landed before this fix commit could be pushed, so it lives on its own branch.

Both adversarial reviews of the merged work (`docs/plans/quant-code-rev-claude.md` + the sibling `quant-code-rev-glm5.md` at repo root from the glm-5 reviewer) surfaced a mix of real bugs and code-quality issues. This PR lands the validated fixes. The full validate / reject / defer table is in §"Sibling-review action table" of `quant-code-rev-claude.md`.

## Summary

- **Tooling bug fix:** `kld_diff.py`'s 90%-threshold "one-sided" heuristic silently missed the canonical V1 gfx1100 MQ4 result (81% one-signed → SOFT FAIL instead of HARD FAIL). Replaced with a binomial sign-test (two-tailed, p < 0.001; normal approx for n > 200). Re-running on the committed V1 result correctly fires HARD FAIL at p=6.59e-101.
- **Dedup:** extracted `verify_ref_sha256` / `verify_slice_md5` / `verify_llama_commit` into `crates/hipfire-runtime/src/eval_common.rs`. The same three helpers were copy-pasted across `build_kld_ref` / `eval_hipfire` / `eval_gguf` — 5 sites in total, future bug fixes would diverge silently.
- **Defensive fixes:** equal-length prefix compare in `verify_llama_commit` (prior `PINNED.starts_with(hash)` accepted arbitrarily-short binary hashes; demand ≥ 7 chars now); `debug_assert!(kld_token >= -1e-9)` + `.max(0.0)` replaces the prior silent negative-KLD clamp.
- **PRD + UX:** top-K=256 lower-bound caveat in PRD §2 and §8; canary fixture marked informational-not-enforced (it ships TBD'd); `kld_reduce.py` emits a mixed-mode warning + groups rows by mode in the markdown output; `--max-chunks` progress line uses `effective_n_chunk` not `n_chunk`; `scored_per_chunk` shadow removed.

Both review files (`docs/plans/quant-code-rev-claude.md` + repo-root `quant-code-rev-glm5.md`) are scaffolding per the project's drop-review-files-after-fold-in convention; they can be deleted once findings are confirmed landed. Left committed here so reviewers can see the action table directly.

## Test plan

- [ ] `cargo build --release -p hipfire-runtime --features deltanet --example eval_hipfire --example eval_gguf --example build_kld_ref --example prefill_microbench` — all four examples compile clean.
- [ ] `cargo test -p hipfire-runtime --release --lib bpe_tests` — 6/6 PASS (unchanged from #233).
- [ ] `./target/release/examples/eval_gguf --help` and `./target/release/examples/eval_hipfire --help` — both binaries print usage; sanity that the `eval_common` extraction didn't break the call sites.
- [ ] `python3 benchmarks/quality-baselines/harness/kld_diff.py \\`
      `  benchmarks/quality-baselines/results/2026-05-08/per-seq/qwen3.5-9b.mq4__gfx1100__per-token.kldseq \\`
      `  benchmarks/quality-baselines/results/2026-05-11/per-seq/qwen3.5-9b.mq4__gfx1100__prefill.kldseq` — now produces `VERDICT: HARD FAIL — systematic bias detected (sign-test p=6.59e-101)` (was incorrectly reporting SOFT FAIL pre-fix).
- [ ] `python3 benchmarks/quality-baselines/harness/kld_reduce.py --result-dir <dir-with-both-modes>` — emits a "⚠️ Mixed-mode rows detected" preamble and groups rows by mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)