### PR TITLE
feat: Jinja-everywhere phase 1-3a — structured tools/messages

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1479,6 +1479,67 @@ async function serve(port: number) {
           return "";
         };
 
+        // Strip <think>...</think> blocks from historical assistant text. Same
+        // rationale as the inline-ChatML builder below (line 1513): the Qwen3.5
+        // chat template doesn't carry thinking forward, and including it in
+        // history-shaped structured messages pollutes the KV cache.
+        const stripThinkingInline = (s: string): string =>
+          s.replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+           .replace(/<think>[\s\S]*$/, "");
+
+        // Map OpenAI chat-completion messages to the daemon's structured
+        // `messages` JSONL field (Phase 2 of Jinja-everywhere). Roles:
+        //   developer → system (OpenAI o1/o3 alias — chat templates
+        //                       only know system/user/assistant/tool).
+        //   tool_calls.function.arguments is JSON-string in OpenAI;
+        //   the daemon expects a raw JSON value, so we parse here and
+        //   pass through any non-string `arguments` unchanged.
+        //
+        // The daemon arbitrates whether to consume `messages` or fall
+        // back to the legacy inline-ChatML `prompt` based on
+        // HIPFIRE_JINJA_CHAT — clients don't need to know which path
+        // fires. We always send both shapes so backward-compat with
+        // Jinja-off daemons holds.
+        const mapMessagesToStructured = (msgs: any[]): any[] => {
+          const out: any[] = [];
+          for (const m of msgs) {
+            if (!m || typeof m !== "object") continue;
+            let role: string = m.role;
+            if (role === "developer") role = "system";
+            if (role !== "system" && role !== "user" && role !== "assistant" && role !== "tool") {
+              continue;
+            }
+            const entry: any = { role, content: "" };
+            if (role === "assistant") {
+              entry.content = stripThinkingInline(extractText(m.content));
+              if (Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+                const tcs: any[] = [];
+                for (const tc of m.tool_calls) {
+                  const fn = tc?.function ?? tc ?? {};
+                  let args: any = {};
+                  if (typeof fn.arguments === "string") {
+                    try { args = JSON.parse(fn.arguments); }
+                    catch { args = { _raw: fn.arguments }; }
+                  } else if (fn.arguments !== undefined) {
+                    args = fn.arguments;
+                  }
+                  tcs.push({ name: fn.name ?? "unknown", arguments: args });
+                }
+                if (tcs.length > 0) entry.tool_calls = tcs;
+              }
+            } else if (role === "tool") {
+              entry.content = extractText(m.content);
+              if (typeof m.tool_call_id === "string" && m.tool_call_id.length > 0) {
+                entry.tool_call_id = m.tool_call_id;
+              }
+            } else {
+              entry.content = extractText(m.content);
+            }
+            out.push(entry);
+          }
+          return out;
+        };
+
         // Extract system message. OpenAI's o1/o3-style reasoning surface
         // (and pi-coding-agent) sends `role:"developer"` instead of
         // `role:"system"` for the same purpose — strict instructions that
@@ -1692,6 +1753,24 @@ async function serve(port: number) {
         }
         if (systemPrompt) genParams.system = systemPrompt;
 
+        // Phase 2: structured tools + messages passed alongside the
+        // legacy prompt/system text. Under HIPFIRE_JINJA_CHAT=1 the
+        // daemon's Jinja path renders `messages` + `tools` through the
+        // model's upstream chat_template (XML tool-call format on
+        // Qwen3.5/3.6 etc.) and ignores `prompt`/`system`. Under
+        // HIPFIRE_JINJA_CHAT=0 (default) the daemon ignores the
+        // structured fields and falls back to the inline-ChatML prompt
+        // + text-rendered tools-block already built above. We send both
+        // shapes so the same OpenAI request works against either
+        // daemon mode without per-client awareness.
+        if (Array.isArray(body.tools) && body.tools.length > 0) {
+          genParams.tools = body.tools;
+        }
+        const structuredMessages = mapMessagesToStructured(messages);
+        if (structuredMessages.length > 0) {
+          genParams.messages = structuredMessages;
+        }
+
         // Parse tool calls from model output: <tool_call>{"name":..., "arguments":...}</tool_call>
         //
         // Defensive against MQ4 quantization drift on structured-token positions
@@ -1784,28 +1863,87 @@ async function serve(port: number) {
             }
           } catch {}
 
-          // Form 3: XML-tag corruption. Look for a function name in
-          //   <plain>NAME</param>  or  <function=NAME>  or  <NAME>
-          // patterns at the head of the block, followed by a JSON object.
+          // Form 3: XML-tag forms.
+          //
+          // Originally introduced as a defensive repair for MQ4
+          // quantization drift (`<plain>NAME</param> {ARGS}`), this branch
+          // now also serves as the primary path for Qwen3.5/3.6's
+          // upstream chat_template, which emits a fully-structured
+          //   <function=NAME>
+          //     <parameter=KEY>VALUE</parameter>
+          //     <parameter=KEY>VALUE</parameter>
+          //   </function>
+          // shape under the Jinja-everywhere path (Phase 2).
+          //
+          // Order of probes:
+          //   1) `<function=NAME>` followed by `<parameter=K>V</parameter>`
+          //       siblings — Qwen3.5/3.6 native (Jinja path).
+          //   2) Any of the 3 legacy XML name patterns + a JSON-object
+          //       args tail — MQ4-corruption repair shape.
+          //   3) Any of the 3 name patterns w/ empty args — last-resort
+          //       so we never silently drop a call we can identify by name.
           const xmlPatterns = [
             /^<\s*plain\s*>\s*([A-Za-z_][\w.]*)\s*<\s*\/\s*param\s*>/,
             /^<\s*function\s*=\s*([A-Za-z_][\w.]*)\s*>/,
             /^<\s*tool\s*name\s*=\s*"?([A-Za-z_][\w.]*)"?\s*>/,
           ];
+          // Probe (1): Qwen3.5/3.6 `<function=NAME>...<parameter=K>V</parameter>...</function>`.
+          const fnMatch = raw.match(/^<\s*function\s*=\s*([A-Za-z_][\w.]*)\s*>([\s\S]*?)(?:<\s*\/\s*function\s*>|$)/);
+          if (fnMatch) {
+            const fname = fnMatch[1];
+            const body = fnMatch[2];
+            const params: Record<string, any> = {};
+            const paramRe = /<\s*parameter\s*=\s*([A-Za-z_][\w.]*)\s*>([\s\S]*?)<\s*\/\s*parameter\s*>/g;
+            let anyParam = false;
+            for (const pm of body.matchAll(paramRe)) {
+              const key = pm[1];
+              // VALUE often arrives with one leading + one trailing newline
+              // (the template emits `<parameter=K>\nVALUE\n</parameter>`).
+              // Trim whitespace; coerce strings that look like JSON values
+              // (numbers, booleans, null, objects, arrays) so downstream
+              // tool runners see typed args instead of stringy "42".
+              const valueRaw = pm[2].trim();
+              params[key] = coerceParamValue(valueRaw);
+              anyParam = true;
+            }
+            if (anyParam) {
+              return { name: fname, arguments: params, repaired: true };
+            }
+            // No parameter siblings: fall through to JSON-object probe
+            // below (the JSON-corruption repair case may still apply).
+          }
+          // Probe (2): name pattern + JSON-object args tail (legacy
+          // MQ4-corruption repair).
           for (const pat of xmlPatterns) {
             const nm = raw.match(pat);
             if (!nm) continue;
             const after = raw.slice(nm[0].length).trim();
-            // Find the first balanced JSON object in the remainder.
             const args = extractFirstJsonObject(after);
             if (args !== null) {
               return { name: nm[1], arguments: args, repaired: true };
             }
-            // Even if we cannot parse args, the function name is usable;
-            // emit empty args rather than dropping the call entirely.
+            // Probe (3): emit empty args so the call isn't silently
+            // dropped when only the name is recoverable.
             return { name: nm[1], arguments: {}, repaired: true };
           }
           return null;
+        }
+
+        // Coerce a `<parameter=K>VALUE</parameter>` body. Strings that
+        // parse as JSON (numbers, booleans, null, objects, arrays)
+        // become typed values; everything else stays as a string.
+        function coerceParamValue(s: string): any {
+          if (s === "") return "";
+          if (s === "true" || s === "false" || s === "null") return JSON.parse(s);
+          if (/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(s)) {
+            const n = Number(s);
+            if (Number.isFinite(n)) return n;
+          }
+          // Object/array literal — try a strict parse; on fail keep raw.
+          if ((s.startsWith("{") && s.endsWith("}")) || (s.startsWith("[") && s.endsWith("]"))) {
+            try { return JSON.parse(s); } catch {}
+          }
+          return s;
         }
 
         // Best-effort balanced-brace JSON extraction. Returns the parsed

--- a/cli/parse_tool_calls.test.ts
+++ b/cli/parse_tool_calls.test.ts
@@ -37,6 +37,20 @@ function parseOneToolCall(raw: string): { name: string; arguments: any; repaired
     /^<\s*function\s*=\s*([A-Za-z_][\w.]*)\s*>/,
     /^<\s*tool\s*name\s*=\s*"?([A-Za-z_][\w.]*)"?\s*>/,
   ];
+  // Probe (1): Qwen3.5/3.6 native `<function=NAME>...<parameter=K>V</parameter>...</function>`.
+  const fnMatch = raw.match(/^<\s*function\s*=\s*([A-Za-z_][\w.]*)\s*>([\s\S]*?)(?:<\s*\/\s*function\s*>|$)/);
+  if (fnMatch) {
+    const fname = fnMatch[1];
+    const body = fnMatch[2];
+    const params: Record<string, any> = {};
+    const paramRe = /<\s*parameter\s*=\s*([A-Za-z_][\w.]*)\s*>([\s\S]*?)<\s*\/\s*parameter\s*>/g;
+    let anyParam = false;
+    for (const pm of body.matchAll(paramRe)) {
+      params[pm[1]] = coerceParamValue(pm[2].trim());
+      anyParam = true;
+    }
+    if (anyParam) return { name: fname, arguments: params, repaired: true };
+  }
   for (const pat of xmlPatterns) {
     const nm = raw.match(pat);
     if (!nm) continue;
@@ -46,6 +60,19 @@ function parseOneToolCall(raw: string): { name: string; arguments: any; repaired
     return { name: nm[1], arguments: {}, repaired: true };
   }
   return null;
+}
+
+function coerceParamValue(s: string): any {
+  if (s === "") return "";
+  if (s === "true" || s === "false" || s === "null") return JSON.parse(s);
+  if (/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(s)) {
+    const n = Number(s);
+    if (Number.isFinite(n)) return n;
+  }
+  if ((s.startsWith("{") && s.endsWith("}")) || (s.startsWith("[") && s.endsWith("]"))) {
+    try { return JSON.parse(s); } catch {}
+  }
+  return s;
 }
 
 function extractFirstJsonObject(s: string): any | null {
@@ -209,4 +236,71 @@ test("nested openers with empty body returns null (no false-positive call)", () 
   const raw = '<tool_call>\n<tool_call>\n<tool_call>';
   const r = parseToolCallsBlock(raw);
   expect(r).toBeNull();
+});
+
+// --- Qwen3.5/3.6 native XML output (Phase 2, Jinja path) ---
+
+test("Qwen3.6 native <function=NAME>...<parameter=K>V</parameter>...</function> shape", () => {
+  // Bytes captured from the daemon smoke (qwen3.6-27b + DFlash drafter
+  // + HIPFIRE_JINJA_CHAT=1) — the template emits parameter siblings
+  // separated by newlines, with one leading + one trailing newline
+  // inside each <parameter> body.
+  const raw = '<function=get_weather>\n<parameter=city>\nSan Francisco\n</parameter>\n<parameter=unit>\nf\n</parameter>\n</function>';
+  const r = parseOneToolCall(raw);
+  expect(r).not.toBeNull();
+  expect(r!.name).toBe("get_weather");
+  expect(r!.arguments).toEqual({ city: "San Francisco", unit: "f" });
+  expect(r!.repaired).toBe(true);
+});
+
+test("Qwen3.6 XML coerces typed parameter values (numbers / bool / null / json)", () => {
+  // Tool runners downstream expect typed args — coerce string bodies
+  // that look like JSON primitives so `{"count": 42}` doesn't arrive
+  // as `{"count": "42"}`. Strings that don't match a JSON shape stay
+  // strings (Qwen often emits e.g. paths or free-text).
+  const raw = '<function=execute>'
+    + '<parameter=count>42</parameter>'
+    + '<parameter=ratio>3.14</parameter>'
+    + '<parameter=enabled>true</parameter>'
+    + '<parameter=missing>null</parameter>'
+    + '<parameter=cfg>{"k":1}</parameter>'
+    + '<parameter=tags>["a","b"]</parameter>'
+    + '<parameter=path>/tmp/x.txt</parameter>'
+    + '</function>';
+  const r = parseOneToolCall(raw);
+  expect(r).not.toBeNull();
+  expect(r!.arguments).toEqual({
+    count: 42,
+    ratio: 3.14,
+    enabled: true,
+    missing: null,
+    cfg: { k: 1 },
+    tags: ["a", "b"],
+    path: "/tmp/x.txt",
+  });
+});
+
+test("Qwen3.6 XML with zero parameters (no-arg call)", () => {
+  // `<function=NAME></function>` with no parameter siblings — the
+  // probe-(1) anyParam guard must NOT fire (else `arguments` would be
+  // {} but `repaired` set spuriously). Should fall through to the
+  // legacy probe-(3) shape which emits empty args + repaired=true.
+  const raw = '<function=list_dirs></function>';
+  const r = parseOneToolCall(raw);
+  expect(r).not.toBeNull();
+  expect(r!.name).toBe("list_dirs");
+  expect(r!.arguments).toEqual({});
+});
+
+test("<function=NAME>{JSON} (MQ4 corruption shape) still parses via probe-(2)", () => {
+  // Regression: the existing MQ4 XML-corruption repair must still work
+  // — probe-(1)'s parameter-sibling logic falls through cleanly when
+  // there are no <parameter=...> blocks but a JSON-object args body
+  // is present.
+  const raw = '<function=read>{"path": "/etc/passwd"}';
+  const r = parseOneToolCall(raw);
+  expect(r).not.toBeNull();
+  expect(r!.name).toBe("read");
+  expect(r!.arguments).toEqual({ path: "/etc/passwd" });
+  expect(r!.repaired).toBe(true);
 });

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2603,6 +2603,8 @@ fn generate_multi(
     budget_alert_text: &str,
     max_think_tokens: usize,
     assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
 ) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
@@ -2701,17 +2703,82 @@ fn generate_multi(
         raw_q_tokens
     };
 
-    // ChatML framing via the canonical hipfire_runtime::prompt_frame module.
-    // Identical to the pp=1 path so multi-turn behavior matches byte-for-byte
-    // when both paths run the same model on the same prompt history.
-    let new_tokens = hipfire_runtime::prompt_frame::ChatFrame {
-        tokenizer,
-        system: if m.seq_pos == 0 { system_prompt } else { None },
-        user: "",
-        assistant_prefix,
-        raw: false,
-    }
-    .build_with_user_tokens(&q_tokens);
+    // ChatML framing — two paths, same shape as the single-GPU AR
+    // generate() (line 3147+):
+    //
+    //   1) HIPFIRE_JINJA_CHAT=1 + model has chat_template + seq_pos==0
+    //      → render via JinjaChatFrame so structured tools/messages
+    //      reach the upstream template. PFlash compression is bypassed
+    //      under Jinja (q_tokens is unused; the rendered prompt string
+    //      is re-tokenized straight through).
+    //
+    //   2) Default: hand-rolled ChatFrame::Plain scaffold, byte-
+    //      identical to the pp=1 default path so multi-turn behavior
+    //      matches between pp=1 and pp>1 when both run the same prompt.
+    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
+    let try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some();
+    let new_tokens = if try_jinja {
+        let template = m.chat_template.as_ref().unwrap();
+        let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+            tokenizer,
+            template,
+            system: system_prompt,
+            user: prompt,
+            enable_thinking: max_think_tokens != 1,
+            bos_token: None,
+        };
+        let render_result = if tools.is_some() || messages_history.is_some() {
+            let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;
+            let messages_slice: &[hipfire_runtime::prompt_frame::Message] = match messages_history {
+                Some(m) => m,
+                None => {
+                    let mut v = Vec::new();
+                    if let Some(sys) = system_prompt {
+                        v.push(hipfire_runtime::prompt_frame::Message {
+                            role: hipfire_runtime::prompt_frame::Role::System,
+                            content: sys.to_string(),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                    }
+                    v.push(hipfire_runtime::prompt_frame::Message {
+                        role: hipfire_runtime::prompt_frame::Role::User,
+                        content: prompt.to_string(),
+                        tool_calls: Vec::new(),
+                        tool_call_id: None,
+                    });
+                    synthesized = v;
+                    &synthesized
+                }
+            };
+            frame.render_messages(messages_slice, tools, None)
+        } else {
+            frame.render()
+        };
+        match render_result {
+            Ok(rendered) => tokenizer.encode(&rendered),
+            Err(e) => {
+                eprintln!("[daemon] jinja render failed in pp path ({e}) — falling back to Plain");
+                hipfire_runtime::prompt_frame::ChatFrame {
+                    tokenizer,
+                    system: if m.seq_pos == 0 { system_prompt } else { None },
+                    user: "",
+                    assistant_prefix,
+                    raw: false,
+                }
+                .build_with_user_tokens(&q_tokens)
+            }
+        }
+    } else {
+        hipfire_runtime::prompt_frame::ChatFrame {
+            tokenizer,
+            system: if m.seq_pos == 0 { system_prompt } else { None },
+            user: "",
+            assistant_prefix,
+            raw: false,
+        }
+        .build_with_user_tokens(&q_tokens)
+    };
 
     let trailer = nl.len();
     if m.seq_pos + new_tokens.len() + max_tokens + trailer > m.physical_cap {
@@ -3011,16 +3078,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     // at load when DFlash / CASK / PFlash / VL is requested, so this branch
     // doesn't need to thread any of those args through.
     if m.pp > 1 {
-        // tools / messages_history are silently dropped on the multi-GPU
-        // PP path for Phase 1; Jinja-everywhere is wired through the
-        // single-GPU AR generate path first. PP-with-tools follows once
-        // the AR path is stable.
-        let _ = (tools, messages_history);
         generate_multi(
             m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
             temp, top_p, max_tokens, repeat_penalty, repeat_window,
             budget_alert_at_tok, budget_alert_text, max_think_tokens,
             assistant_prefix,
+            tools, messages_history,
         );
         return;
     }

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -808,6 +808,51 @@ fn main() {
                 }
                 let system = msg.get("system").and_then(|v| v.as_str());
                 let image = msg.get("image").and_then(|v| v.as_str());
+
+                // Structured-tools + structured-messages support (Phase 1 of
+                // Jinja-everywhere migration). When present, both fields are
+                // routed through `JinjaChatFrame::render_messages` so the
+                // model sees the upstream template's `{% if tools %}` and
+                // multi-turn branches (XML/JSON tool-call format per arch,
+                // tool-response role mapping, etc.).
+                //
+                // Backward compat: when neither is present, legacy
+                // `prompt`+`system` continues to drive a synthesized
+                // [system?, user] slice — byte-identical to today's
+                // `JinjaChatFrame::render()` single-turn path.
+                //
+                // Parse errors emit a structured error event and skip the
+                // request (rather than silently dropping the fields).
+                let tools_json: Option<Vec<serde_json::Value>> = match msg.get("tools") {
+                    Some(v) => match serde_json::from_value::<Vec<serde_json::Value>>(v.clone()) {
+                        Ok(t) => Some(t),
+                        Err(e) => {
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"error","id":"{}","message":"invalid tools field: {}"}}"#,
+                                id, e.to_string().replace('"', "'"),
+                            );
+                            let _ = stdout.flush();
+                            continue;
+                        }
+                    },
+                    None => None,
+                };
+                let messages_history: Option<Vec<hipfire_runtime::prompt_frame::Message>> = match msg.get("messages") {
+                    Some(v) => match serde_json::from_value::<Vec<hipfire_runtime::prompt_frame::Message>>(v.clone()) {
+                        Ok(m) => Some(m),
+                        Err(e) => {
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"error","id":"{}","message":"invalid messages field: {}"}}"#,
+                                id, e.to_string().replace('"', "'"),
+                            );
+                            let _ = stdout.flush();
+                            continue;
+                        }
+                    },
+                    None => None,
+                };
                 let temp = msg.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.3) as f32;
                 let max_tokens = msg.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(512) as usize;
                 let top_p = msg.get("top_p").and_then(|v| v.as_f64()).unwrap_or(0.8) as f32;
@@ -928,6 +973,8 @@ fn main() {
                         assistant_prefix,
                         pflash_state.as_mut(),
                         pf_cfg_owned.as_ref(),
+                        tools_json.as_deref(),
+                        messages_history.as_deref(),
                     );
                 }
             }
@@ -2047,23 +2094,89 @@ fn generate_dflash(
     assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
     pflash_bypass_reason: Option<&str>,
     pflash_alpha: Option<f32>,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
 ) {
     use hipfire_arch_qwen35::speculative::{
         spec_step_ddtree_batched, spec_step_ddtree_path_c, spec_step_dflash, ModelSlot,
         ModelSlotConfig, Phase2Snapshots, SpecStats,
     };
 
-    // Tokenize with ChatML wrapping (identical to the AR path). System prompt
-    // is always prepended because this fast path is single-turn.
+    // Prompt build: same two-path branch as the AR-path generate() — when
+    // `HIPFIRE_JINJA_CHAT=1` AND the model carries a chat_template, render
+    // via `JinjaChatFrame` so structured `tools` / `messages` can reach
+    // the upstream template's `{% if tools %}` / multi-turn branches.
+    // Otherwise fall back to the hand-rolled `ChatFrame::Plain` scaffold
+    // (byte-identical to the prior DFlash-path build).
+    //
+    // DFlash is single-turn by construction — `seq_pos` is reset to 0
+    // below before seed_target_hidden_from_prompt runs — so we never
+    // need to guard on `seq_pos == 0` here.
     let tokenizer = m.tokenizer.as_ref().unwrap();
-    let prompt_tokens = hipfire_runtime::prompt_frame::ChatFrame {
-        tokenizer,
-        system: system_prompt,
-        user: prompt,
-        assistant_prefix,
-        raw: false,
-    }
-    .build();
+    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
+    let try_jinja = jinja_enabled && m.chat_template.is_some();
+    let prompt_tokens: Vec<u32> = if try_jinja {
+        let template = m.chat_template.as_ref().unwrap();
+        let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+            tokenizer,
+            template,
+            system: system_prompt,
+            user: prompt,
+            enable_thinking: max_think_tokens != 1,
+            bos_token: None,
+        };
+        let render_result = if tools.is_some() || messages_history.is_some() {
+            let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;
+            let messages_slice: &[hipfire_runtime::prompt_frame::Message] = match messages_history {
+                Some(m) => m,
+                None => {
+                    let mut v = Vec::new();
+                    if let Some(sys) = system_prompt {
+                        v.push(hipfire_runtime::prompt_frame::Message {
+                            role: hipfire_runtime::prompt_frame::Role::System,
+                            content: sys.to_string(),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                    }
+                    v.push(hipfire_runtime::prompt_frame::Message {
+                        role: hipfire_runtime::prompt_frame::Role::User,
+                        content: prompt.to_string(),
+                        tool_calls: Vec::new(),
+                        tool_call_id: None,
+                    });
+                    synthesized = v;
+                    &synthesized
+                }
+            };
+            frame.render_messages(messages_slice, tools, None)
+        } else {
+            frame.render()
+        };
+        match render_result {
+            Ok(rendered) => tokenizer.encode(&rendered),
+            Err(e) => {
+                eprintln!("[daemon] jinja render failed in dflash path ({e}) — falling back to Plain");
+                hipfire_runtime::prompt_frame::ChatFrame {
+                    tokenizer,
+                    system: system_prompt,
+                    user: prompt,
+                    assistant_prefix,
+                    raw: false,
+                }
+                .build()
+            }
+        }
+    } else {
+        hipfire_runtime::prompt_frame::ChatFrame {
+            tokenizer,
+            system: system_prompt,
+            user: prompt,
+            assistant_prefix,
+            raw: false,
+        }
+        .build()
+    };
 
     // `im_end_token` is still needed downstream for the EOS check.
     let im_end = tokenizer.encode("<|im_end|>");
@@ -2893,11 +3006,16 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>) {
     // Multi-GPU pipeline-parallel dispatch (Stage 7 of #58). pp>1 is refused
     // at load when DFlash / CASK / PFlash / VL is requested, so this branch
     // doesn't need to thread any of those args through.
     if m.pp > 1 {
+        // tools / messages_history are silently dropped on the multi-GPU
+        // PP path for Phase 1; Jinja-everywhere is wired through the
+        // single-GPU AR generate path first. PP-with-tools follows once
+        // the AR path is stable.
+        let _ = (tools, messages_history);
         generate_multi(
             m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
             temp, top_p, max_tokens, repeat_penalty, repeat_window,
@@ -2942,8 +3060,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         // mirrors the AR path's <think>/</think> counter). The "ignored
         // on DFlash" warning that used to live here is gone -- the cap
         // is real on both paths now.
-        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, assistant_prefix, dflash_bypass_reason, dflash_alpha);
-        // Silence unused-variable warnings for the params we didn't need.
+        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, assistant_prefix, dflash_bypass_reason, dflash_alpha, tools, messages_history);
+        // Silence unused-variable warnings for the params DFlash doesn't
+        // consume (top_p / repeat penalties are AR-only sampling knobs;
+        // pflash_state is bypassed on the DFlash decode path).
         let _ = (top_p, repeat_penalty, repeat_window, budget_alert_at_tok, budget_alert_text, pflash_state);
         return;
     }
@@ -3156,7 +3276,45 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
             enable_thinking: max_think_tokens != 1,
             bos_token: None,
         };
-        match frame.render() {
+        // Phase 1 of Jinja-everywhere migration: when the caller supplies
+        // either a `tools` array or a `messages` history (or both), route
+        // through `render_messages` so the upstream template's
+        // `{% if tools %}` / multi-turn branches fire. With neither
+        // supplied, fall through to the single-turn `render()` convenience,
+        // which is byte-identical to the synthesized [system?, user]
+        // path that shipped under HIPFIRE_JINJA_CHAT=1 before this change.
+        let render_result = if tools.is_some() || messages_history.is_some() {
+            // Synthesize [system?, user] when no explicit history was
+            // provided. Tools-with-legacy-prompt is the natural OpenAI
+            // function-calling shape (one turn + tool definitions).
+            let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;
+            let messages_slice: &[hipfire_runtime::prompt_frame::Message] = match messages_history {
+                Some(m) => m,
+                None => {
+                    let mut v = Vec::new();
+                    if let Some(sys) = system_prompt {
+                        v.push(hipfire_runtime::prompt_frame::Message {
+                            role: hipfire_runtime::prompt_frame::Role::System,
+                            content: sys.to_string(),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                    }
+                    v.push(hipfire_runtime::prompt_frame::Message {
+                        role: hipfire_runtime::prompt_frame::Role::User,
+                        content: prompt.to_string(),
+                        tool_calls: Vec::new(),
+                        tool_call_id: None,
+                    });
+                    synthesized = v;
+                    &synthesized
+                }
+            };
+            frame.render_messages(messages_slice, tools, None)
+        } else {
+            frame.render()
+        };
+        match render_result {
             Ok(rendered) => tokenizer.encode(&rendered),
             Err(e) => {
                 eprintln!("[daemon] jinja render failed ({e}) — falling back to Plain");

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -73,7 +73,7 @@ pub enum AssistantPrefix {
 ///
 /// Lowercase serialization matches what the Qwen3.5/3.6 + Gemma 4
 /// templates compare against.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     System,
@@ -357,9 +357,10 @@ pub struct JinjaChatFrame<'a> {
 /// `message['tool_call_id']` under strict-undefined mode; all four fields
 /// are always present (defaults: empty content, empty tool_calls vec, no
 /// tool_call_id) so probes never raise.
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Message {
     pub role: Role,
+    #[serde(default)]
     pub content: String,
     #[serde(default)]
     pub tool_calls: Vec<ToolCall>,
@@ -368,7 +369,7 @@ pub struct Message {
     /// this field; OpenAI-spec clients and some other templates require
     /// it. Skipped from the serialized JSON when None so templates that
     /// `is defined` against it don't see a misleading null.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
 }
 
@@ -376,9 +377,10 @@ pub struct Message {
 /// `arguments` is a free-form JSON value (typically an object). Templates
 /// that render in XML format (Qwen3.5/3.6's `<function=NAME><parameter=ARG>`
 /// shape) walk this with `arguments | items` under pycompat.
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ToolCall {
     pub name: String,
+    #[serde(default)]
     pub arguments: serde_json::Value,
 }
 
@@ -838,6 +840,173 @@ mod tests {
         let via_string = frame.build();
         let via_tokens = frame.build_with_user_tokens(&t.encode(user_text));
         assert_eq!(via_string, via_tokens, "build_with_user_tokens must match build() when tokens align");
+    }
+
+    #[test]
+    fn message_deserializes_minimal_shape() {
+        // The daemon's stdin schema must accept the smallest valid
+        // message: role + content, no tool_calls, no tool_call_id.
+        let json = r#"{"role":"user","content":"hi"}"#;
+        let m: Message = serde_json::from_str(json).expect("minimal message parses");
+        assert_eq!(m.role, Role::User);
+        assert_eq!(m.content, "hi");
+        assert!(m.tool_calls.is_empty());
+        assert!(m.tool_call_id.is_none());
+    }
+
+    #[test]
+    fn message_deserializes_assistant_tool_call() {
+        // OpenAI-style assistant turn that emitted a tool call. The
+        // template path consumes `tool_calls[]` to render the model's
+        // own prior call (XML on Qwen3.5/3.6, JSON on others).
+        let json = r#"{
+            "role":"assistant",
+            "content":"",
+            "tool_calls":[{"name":"get_weather","arguments":{"city":"SF","unit":"f"}}]
+        }"#;
+        let m: Message = serde_json::from_str(json).expect("assistant w/ tool_call parses");
+        assert_eq!(m.role, Role::Assistant);
+        assert_eq!(m.tool_calls.len(), 1);
+        assert_eq!(m.tool_calls[0].name, "get_weather");
+        assert_eq!(
+            m.tool_calls[0].arguments,
+            serde_json::json!({"city":"SF","unit":"f"}),
+        );
+    }
+
+    #[test]
+    fn message_deserializes_tool_response() {
+        // Tool-role response carries a `tool_call_id` referencing the
+        // assistant call it answers. Field must round-trip through
+        // serde so templates that read it (OpenAI-spec ones) see it.
+        let json = r#"{"role":"tool","content":"72F","tool_call_id":"call_42"}"#;
+        let m: Message = serde_json::from_str(json).expect("tool response parses");
+        assert_eq!(m.role, Role::Tool);
+        assert_eq!(m.content, "72F");
+        assert_eq!(m.tool_call_id.as_deref(), Some("call_42"));
+    }
+
+    #[test]
+    fn render_messages_with_tools_fires_tools_block() {
+        // Smoke test: a minimal template gated on `{% if tools %}`
+        // must render the tools branch when the caller supplies a
+        // non-empty tools array — and skip it when tools is None.
+        // This is the architectural invariant Phase 1 unblocks:
+        // structured tools from daemon stdin reach the Jinja template's
+        // `{% if tools %}` predicate.
+        let t = make_tokenizer();
+        let template = "{% if tools %}TOOLS:{% for f in tools %}{{ f.function.name }};{% endfor %}{% endif %}MSGS:{% for m in messages %}{{ m.role }}={{ m.content }};{% endfor %}";
+        let frame = JinjaChatFrame {
+            tokenizer: &t,
+            template,
+            system: None,
+            user: "",
+            enable_thinking: true,
+            bos_token: Some(""),
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: "hi".to_string(),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+        }];
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        })];
+
+        let with_tools = frame
+            .render_messages(&messages, Some(&tools), None)
+            .expect("render_messages w/ tools succeeds");
+        assert!(
+            with_tools.contains("TOOLS:get_weather;"),
+            "tools-block must fire when tools is Some: got {with_tools:?}",
+        );
+        assert!(
+            with_tools.contains("MSGS:user=hi;"),
+            "messages must still render: got {with_tools:?}",
+        );
+
+        // None branch: empty tools array means `{% if tools %}` evaluates false.
+        let without_tools = frame
+            .render_messages(&messages, None, None)
+            .expect("render_messages w/o tools succeeds");
+        assert!(
+            !without_tools.contains("TOOLS:"),
+            "tools-block must NOT fire when tools is None: got {without_tools:?}",
+        );
+        assert!(
+            without_tools.contains("MSGS:user=hi;"),
+            "messages must still render w/o tools: got {without_tools:?}",
+        );
+    }
+
+    #[test]
+    fn render_messages_with_history_and_tools_includes_assistant_call() {
+        // Full agentic round-trip shape: system + user + assistant w/
+        // tool_calls + tool response. The template walks tool_calls and
+        // tool_call_id so the trip-record must reach it.
+        let t = make_tokenizer();
+        // `tool_call_id` is serialize-skipped when None, so under
+        // strict-undefined the template MUST guard with `is defined`
+        // (matching how the upstream Qwen3.5/3.6 + Hermes templates
+        // probe the field). The Message doc comment on this struct
+        // describes the same convention.
+        let template = "{% for m in messages %}{{ m.role }}:{% if m.tool_calls %}call={% for tc in m.tool_calls %}{{ tc.name }}({{ tc.arguments.city }});{% endfor %}{% else %}{{ m.content }}{% endif %}{% if m.tool_call_id is defined %}[id={{ m.tool_call_id }}]{% endif %};{% endfor %}";
+        let frame = JinjaChatFrame {
+            tokenizer: &t,
+            template,
+            system: None,
+            user: "",
+            enable_thinking: true,
+            bos_token: Some(""),
+        };
+        let messages = vec![
+            Message {
+                role: Role::System,
+                content: "be brief".to_string(),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            },
+            Message {
+                role: Role::User,
+                content: "weather?".to_string(),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: "".to_string(),
+                tool_calls: vec![ToolCall {
+                    name: "get_weather".to_string(),
+                    arguments: serde_json::json!({"city":"SF"}),
+                }],
+                tool_call_id: None,
+            },
+            Message {
+                role: Role::Tool,
+                content: "72F".to_string(),
+                tool_calls: Vec::new(),
+                tool_call_id: Some("call_1".to_string()),
+            },
+        ];
+        let out = frame
+            .render_messages(&messages, None, None)
+            .expect("multi-turn render succeeds");
+        assert!(out.contains("system:be brief;"), "system content visible: {out:?}");
+        assert!(out.contains("user:weather?;"), "user content visible: {out:?}");
+        assert!(
+            out.contains("assistant:call=get_weather(SF);"),
+            "assistant tool_call rendered: {out:?}",
+        );
+        assert!(
+            out.contains("tool:72F[id=call_1];"),
+            "tool response w/ tool_call_id rendered: {out:?}",
+        );
     }
 
     #[test]

--- a/scripts/agentic-gate-jinja-tools.sh
+++ b/scripts/agentic-gate-jinja-tools.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Agentic gate (Jinja + structured tools) — Phase 1 smoke for the
+# daemon-side `tools` / `messages` JSONL fields.
+#
+# Why this gate exists:
+#   `scripts/agentic-gate.sh` sends tool definitions as TEXT inside the
+#   system prompt (the same shape cli/index.ts pre-renders today). The
+#   model's Jinja template `{% if tools %}` block is therefore unreachable
+#   from the daemon — there is no way to A/B the upstream tools-block
+#   against the hand-rolled system-prompt-text path.
+#
+#   Phase 1 of the Jinja-everywhere migration adds `tools` and `messages`
+#   to the daemon's stdin JSONL "generate" schema. This script proves the
+#   end-to-end path fires:
+#     1. JSONL with structured `tools` parses without daemon error.
+#     2. `HIPFIRE_JINJA_CHAT=1` + structured tools routes through
+#        `JinjaChatFrame::render_messages(messages, Some(&tools), None)`.
+#     3. Model emits non-zero tokens (proves prompt was built and decoded).
+#
+# What this script does NOT cover (by design today):
+#   - Tool-call body schema validation (XML vs JSON, name/arguments).
+#     That is Phase 3 once `messages` history and tool-response role are
+#     wired through the Plain ChatML fallback path too.
+#   - Comparing tools-block-rendered text vs hand-rolled system-prompt-
+#     text output quality. Phase 2 work after `cli/index.ts` switches to
+#     structured tools.
+#
+# Exit codes:
+#   0 - daemon emitted tokens for the structured-tools request
+#   1 - daemon panicked / zero tokens / Jinja render failed back to Plain
+#   2 - build / env failure (model absent, daemon won't build, etc.)
+
+set -u
+cd "$(dirname "$0")/.."
+
+# ---- Setup -----------------------------------------------------------------
+EXE="./target/release/examples/daemon"
+MODELS_DIR="${HIPFIRE_MODELS_DIR:-${HIPFIRE_DIR:-$HOME/.hipfire}/models}"
+LOCK_SCRIPT="./scripts/gpu-lock.sh"
+
+# Model preference order: prefer Qwen3.6 over 3.5 (newer chat_template),
+# dense over MoE (lower VRAM ceiling), and within each family the
+# largest variant that's plausibly host-fitting. The point of this gate
+# is to exercise the daemon's structured-tools JSONL path end-to-end,
+# not to stress a specific arch — any Qwen3.5/3.6 model carries the
+# upstream chat_template the Jinja branch needs.
+#
+# Override with HIPFIRE_JINJA_TOOLS_MODEL=<path> for hosts where the
+# default-selected file doesn't fit (or for picking A3B explicitly).
+CANDIDATES=(
+    "$MODELS_DIR/qwen3.6-27b.mq4"
+    "$MODELS_DIR/qwen3.5-27b.mq4"
+    "$MODELS_DIR/qwen3.5-9b.mq4"
+    "$MODELS_DIR/qwen3.6-35b-a3b.mq4"
+    "$MODELS_DIR/qwen3.5-35b-a3b.mq4"
+)
+MODEL=""
+LABEL=""
+if [ -n "${HIPFIRE_JINJA_TOOLS_MODEL:-}" ]; then
+    if [ -f "$HIPFIRE_JINJA_TOOLS_MODEL" ]; then
+        MODEL="$HIPFIRE_JINJA_TOOLS_MODEL"
+        LABEL="$(basename "$MODEL" .mq4)_jinja_tools"
+    else
+        echo "agentic-gate-jinja-tools: HIPFIRE_JINJA_TOOLS_MODEL=$HIPFIRE_JINJA_TOOLS_MODEL not found" >&2
+        exit 2
+    fi
+else
+    for cand in "${CANDIDATES[@]}"; do
+        if [ -f "$cand" ]; then
+            MODEL="$cand"
+            LABEL="$(basename "$MODEL" .mq4)_jinja_tools"
+            break
+        fi
+    done
+fi
+if [ -z "$MODEL" ]; then
+    echo "agentic-gate-jinja-tools: no Qwen3.5/3.6 model present in $MODELS_DIR — SKIPPED"
+    echo "  (set HIPFIRE_JINJA_TOOLS_MODEL=<path> to point at a non-default model)"
+    exit 0
+fi
+echo "agentic-gate-jinja-tools: using $LABEL ($(du -h "$MODEL" | cut -f1))"
+
+# Rebuild daemon if any tracked source is newer than the binary. Mirrors
+# the rebuild gate in agentic-gate.sh.
+rebuild=0
+if [ ! -x "$EXE" ]; then
+    rebuild=1
+else
+    for src in crates/hipfire-arch-qwen35/src/qwen35.rs crates/hipfire-runtime/src/llama.rs \
+               crates/hipfire-runtime/src/hfq.rs crates/hipfire-runtime/examples/daemon.rs \
+               crates/hipfire-runtime/src/prompt_frame.rs \
+               crates/rdna-compute/src/dispatch.rs; do
+        if [ -f "$src" ] && [ "$src" -nt "$EXE" ]; then
+            rebuild=1; break
+        fi
+    done
+fi
+if [ "$rebuild" -eq 1 ]; then
+    echo "agentic-gate-jinja-tools: rebuilding daemon..."
+    if ! cargo build --release --example daemon --features deltanet >&2; then
+        echo "agentic-gate-jinja-tools: build failed" >&2
+        exit 2
+    fi
+fi
+
+# GPU lock — same pattern as the other gates so parallel agents don't
+# stomp each other's GPU.
+DAEMON_PID=""
+cleanup() {
+    if [ -n "$DAEMON_PID" ] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+        kill "$DAEMON_PID" 2>/dev/null
+        sleep 1
+        kill -9 "$DAEMON_PID" 2>/dev/null
+    fi
+    DAEMON_PID=""
+    gpu_release 2>/dev/null || true
+}
+if [ -r "$LOCK_SCRIPT" ]; then
+    # shellcheck disable=SC1090
+    . "$LOCK_SCRIPT"
+    gpu_acquire "agentic-gate-jinja-tools" || { echo "could not acquire GPU lock" >&2; exit 2; }
+    trap cleanup EXIT
+fi
+
+# ---- Build JSONL session ---------------------------------------------------
+# load + 1 generate w/ structured tools + unload. The tools array carries
+# one OpenAI-style function def with required+optional args — exercises
+# the template's `tools | rejectattr` / `parameters.required` walks on
+# Qwen3.5/3.6.
+JSONL_FILE="$(mktemp /tmp/agentic-gate-jinja-tools.XXXXXX.jsonl)"
+OUTPUT_FILE="$(mktemp /tmp/agentic-gate-jinja-tools.XXXXXX.out)"
+
+python3 - "$MODEL" "$JSONL_FILE" <<'PY' >/dev/null
+import sys, json
+
+model_path, jsonl_path = sys.argv[1], sys.argv[2]
+
+load_msg = {
+    "type": "load",
+    "model": model_path,
+    # Single-turn smoke; 1024 ctx is plenty for sys+user+tools-block+
+    # response and keeps KV cache headroom usable on hosts where the
+    # weight blob already takes most of the VRAM (e.g., 22 GB A3B-36
+    # on a 24 GB card OOMs at max_seq=4096).
+    "params": {"max_seq": 1024},
+}
+
+# Structured tools: one function with description + a typed parameters
+# schema. The Qwen3.5/3.6 template walks `function.parameters.properties`
+# and `function.parameters.required` to render the tools-block prompt
+# the model was trained on.
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name."},
+                "unit": {"type": "string", "enum": ["c", "f"], "description": "Temperature unit."},
+            },
+            "required": ["city"],
+        },
+    },
+}]
+
+# Single-turn structured request: terse system + a user message that
+# clearly needs the tool. No Hermes-shape system text — the template's
+# tools-block carries the tool catalog.
+gen_msg = {
+    "type": "generate",
+    "id": "jinja_tools_t1",
+    "system": "You are a helpful assistant. Use tools when appropriate.",
+    "prompt": "What's the weather in San Francisco?",
+    "tools": tools,
+    "max_tokens": 192,
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "repeat_penalty": 1.0,
+    "max_think_tokens": 1,
+    "assistant_prefix": "closed_think",
+}
+
+with open(jsonl_path, "w") as f:
+    f.write(json.dumps(load_msg) + "\n")
+    f.write(json.dumps(gen_msg) + "\n")
+    f.write(json.dumps({"type": "unload"}) + "\n")
+PY
+
+# ---- Spawn daemon with Jinja path forced on --------------------------------
+STDIN_FIFO="$(mktemp -u /tmp/agentic-gate-jinja-tools-fifo.XXXXXX)"
+mkfifo "$STDIN_FIFO"
+
+env HIPFIRE_JINJA_CHAT=1 \
+    HIPFIRE_KV_MODE=asym3 \
+    HIPFIRE_GRAPH=1 \
+    "$EXE" < "$STDIN_FIFO" > "$OUTPUT_FILE" 2>&1 &
+DAEMON_PID=$!
+
+# Pace: load (~90s), generate (~30s for 192 tokens), unload (~2s).
+(
+    while IFS= read -r line; do
+        printf '%s\n' "$line"
+        type="$(echo "$line" | python3 -c 'import sys,json;d=json.loads(sys.stdin.read());print(d["type"])' 2>/dev/null)"
+        case "$type" in
+            load)     sleep 90 ;;
+            generate) sleep 45 ;;
+            unload)   sleep 2  ;;
+        esac
+    done < "$JSONL_FILE"
+) > "$STDIN_FIFO"
+
+# Give the daemon a beat to flush, then kill by tracked PID if still alive.
+for _ in 1 2 3 4 5; do
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then break; fi
+    sleep 1
+done
+if kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null
+    sleep 1
+    kill -9 "$DAEMON_PID" 2>/dev/null
+fi
+wait "$DAEMON_PID" 2>/dev/null || true
+DAEMON_PID=""
+rm -f "$STDIN_FIFO" "$JSONL_FILE"
+
+# ---- Verdict ---------------------------------------------------------------
+python3 - "$OUTPUT_FILE" "$LABEL" <<'PY'
+import sys, json, pathlib
+
+out_path, label = sys.argv[1], sys.argv[2]
+raw = pathlib.Path(out_path).read_text()
+
+events = []
+for line in raw.splitlines():
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        events.append(json.loads(line))
+    except json.JSONDecodeError:
+        pass
+
+panic = next((ev for ev in events if ev.get("type") == "error"), None)
+fatal_singleton = "FATAL: hipfire daemon already running" in raw
+toks = [ev["text"] for ev in events if ev.get("type") == "token" and ev.get("id") == "jinja_tools_t1"]
+text = "".join(toks)
+
+print(f"# Agentic gate (Jinja + structured tools): {label}")
+print()
+print(f"- model        : {label}")
+print(f"- jinja env    : HIPFIRE_JINJA_CHAT=1")
+print(f"- tools field  : structured (1 function: get_weather)")
+print(f"- tokens emit  : {len(toks)}")
+print(f"- daemon panic : {panic['message'] if panic else 'none'}")
+print()
+
+verdict = "PASS"
+if fatal_singleton:
+    print("HARD_FAIL: another hipfire daemon was holding the singleton flock — release it and retry")
+    verdict = "HARD_FAIL"
+elif panic is not None:
+    print(f"HARD_FAIL: daemon emitted error event: {panic.get('message')!r}")
+    verdict = "HARD_FAIL"
+elif len(toks) == 0:
+    print("HARD_FAIL: zero tokens emitted — Jinja render failed silently, or tools schema rejected by template")
+    verdict = "HARD_FAIL"
+else:
+    print("PASS: structured-tools JSONL accepted, Jinja path rendered, model emitted tokens")
+
+print()
+print("## Model output")
+print("```")
+print(text if text else "(no tokens)")
+print("```")
+
+sys.exit(0 if verdict == "PASS" else 1)
+PY
+res=$?
+rm -f "$OUTPUT_FILE"
+exit $res

--- a/scripts/agentic-gate-jinja-tools.sh
+++ b/scripts/agentic-gate-jinja-tools.sh
@@ -78,7 +78,46 @@ if [ -z "$MODEL" ]; then
     echo "  (set HIPFIRE_JINJA_TOOLS_MODEL=<path> to point at a non-default model)"
     exit 0
 fi
+
+# DFlash drafter: when a per-family drafter is present alongside the
+# chosen base, attach it via params.draft so the daemon's DFlash fast
+# path fires at temp=0. Without a drafter the daemon routes through
+# AR — both paths now carry the structured-tools Jinja wiring, but
+# exercising DFlash specifically is the more production-relevant
+# signal (agentic workloads on Qwen3.5/3.6 default to temp=0 →
+# DFlash).
+#
+# Mapping is base-specific. 3.5 and 3.6 ship distinct drafters — the
+# legacy `qwen35-27b-dflash.mq4` is 3.5-only despite being the original
+# DFlash drafter that shipped before 3.6 trained its own.
+#
+# Override with HIPFIRE_JINJA_TOOLS_DRAFTER=<path|"none"> when the
+# auto-pairing is wrong on your host or you want to force the AR branch.
+DRAFTER=""
+if [ -n "${HIPFIRE_JINJA_TOOLS_DRAFTER:-}" ]; then
+    if [ "$HIPFIRE_JINJA_TOOLS_DRAFTER" != "none" ] && [ -f "$HIPFIRE_JINJA_TOOLS_DRAFTER" ]; then
+        DRAFTER="$HIPFIRE_JINJA_TOOLS_DRAFTER"
+    fi
+else
+    case "$(basename "$MODEL")" in
+        qwen3.6-27b.mq4)         DRAFTER_CAND="$MODELS_DIR/qwen36-27b-dflash-mq4.hf4" ;;
+        qwen3.5-27b.mq4)         DRAFTER_CAND="$MODELS_DIR/qwen35-27b-dflash-mq4.hf4" ;;
+        qwen3.5-9b.mq4)          DRAFTER_CAND="$MODELS_DIR/qwen35-9b-dflash-mq4.hf4" ;;
+        qwen3.6-35b-a3b.mq4)     DRAFTER_CAND="$MODELS_DIR/qwen36-35b-a3b-dflash-mq4.hf4" ;;
+        qwen3.5-35b-a3b.mq4)     DRAFTER_CAND="$MODELS_DIR/qwen35-35b-a3b-dflash-mq4.hf4" ;;
+        *)                       DRAFTER_CAND="" ;;
+    esac
+    if [ -n "$DRAFTER_CAND" ] && [ -f "$DRAFTER_CAND" ]; then
+        DRAFTER="$DRAFTER_CAND"
+    fi
+fi
+
 echo "agentic-gate-jinja-tools: using $LABEL ($(du -h "$MODEL" | cut -f1))"
+if [ -n "$DRAFTER" ]; then
+    echo "agentic-gate-jinja-tools: DFlash drafter: $(basename "$DRAFTER") ($(du -h "$DRAFTER" | cut -f1))"
+else
+    echo "agentic-gate-jinja-tools: no DFlash drafter — AR-path only"
+fi
 
 # Rebuild daemon if any tracked source is newer than the binary. Mirrors
 # the rebuild gate in agentic-gate.sh.
@@ -130,19 +169,27 @@ fi
 JSONL_FILE="$(mktemp /tmp/agentic-gate-jinja-tools.XXXXXX.jsonl)"
 OUTPUT_FILE="$(mktemp /tmp/agentic-gate-jinja-tools.XXXXXX.out)"
 
-python3 - "$MODEL" "$JSONL_FILE" <<'PY' >/dev/null
+python3 - "$MODEL" "$JSONL_FILE" "$DRAFTER" <<'PY' >/dev/null
 import sys, json
 
-model_path, jsonl_path = sys.argv[1], sys.argv[2]
+model_path, jsonl_path, drafter_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Single-turn smoke; 1024 ctx is plenty for sys+user+tools-block+
+# response and keeps KV cache headroom usable on hosts where the
+# weight blob already takes most of the VRAM (e.g., 22 GB A3B-36
+# on a 24 GB card OOMs at max_seq=4096).
+params = {"max_seq": 1024}
+if drafter_path:
+    # `params.draft` triggers the daemon's DFlash drafter load (see
+    # daemon.rs:520). With a drafter attached and temperature=0 the
+    # generate dispatch lands on the DFlash fast path, exercising the
+    # `generate_dflash()` Jinja branch added in Phase 1.
+    params["draft"] = drafter_path
 
 load_msg = {
     "type": "load",
     "model": model_path,
-    # Single-turn smoke; 1024 ctx is plenty for sys+user+tools-block+
-    # response and keeps KV cache headroom usable on hosts where the
-    # weight blob already takes most of the VRAM (e.g., 22 GB A3B-36
-    # on a 24 GB card OOMs at max_seq=4096).
-    "params": {"max_seq": 1024},
+    "params": params,
 }
 
 # Structured tools: one function with description + a typed parameters
@@ -226,10 +273,11 @@ DAEMON_PID=""
 rm -f "$STDIN_FIFO" "$JSONL_FILE"
 
 # ---- Verdict ---------------------------------------------------------------
-python3 - "$OUTPUT_FILE" "$LABEL" <<'PY'
+python3 - "$OUTPUT_FILE" "$LABEL" "$DRAFTER" <<'PY'
 import sys, json, pathlib
 
-out_path, label = sys.argv[1], sys.argv[2]
+out_path, label, drafter_path = sys.argv[1], sys.argv[2], sys.argv[3]
+expect_dflash = bool(drafter_path)
 raw = pathlib.Path(out_path).read_text()
 
 events = []
@@ -247,12 +295,24 @@ fatal_singleton = "FATAL: hipfire daemon already running" in raw
 toks = [ev["text"] for ev in events if ev.get("type") == "token" and ev.get("id") == "jinja_tools_t1"]
 text = "".join(toks)
 
+# DFlash signature on the `done` event. When the DFlash branch fired,
+# the daemon's done payload includes `"dflash":true,"tau":<f>,"cycles":<i>`
+# (see daemon.rs:2570). Plain AR done lacks all three. Reading the
+# signature tells us which path the request actually took — independent
+# of whether a drafter was offered at load time.
+done_ev = next((ev for ev in events if ev.get("type") == "done"
+                and ev.get("id") == "jinja_tools_t1"), None)
+took_dflash = bool(done_ev and done_ev.get("dflash") is True)
+
 print(f"# Agentic gate (Jinja + structured tools): {label}")
 print()
 print(f"- model        : {label}")
+print(f"- drafter      : {pathlib.Path(drafter_path).name if drafter_path else '(none — AR path)'}")
 print(f"- jinja env    : HIPFIRE_JINJA_CHAT=1")
 print(f"- tools field  : structured (1 function: get_weather)")
 print(f"- tokens emit  : {len(toks)}")
+print(f"- path taken   : {'DFlash' if took_dflash else 'AR'}"
+      + (f" (τ={done_ev.get('tau')}, cycles={done_ev.get('cycles')})" if took_dflash else ""))
 print(f"- daemon panic : {panic['message'] if panic else 'none'}")
 print()
 
@@ -266,8 +326,15 @@ elif panic is not None:
 elif len(toks) == 0:
     print("HARD_FAIL: zero tokens emitted — Jinja render failed silently, or tools schema rejected by template")
     verdict = "HARD_FAIL"
+elif expect_dflash and not took_dflash:
+    print("HARD_FAIL: drafter was supplied at load but the `done` event has no DFlash signature — "
+          "request fell through to AR instead of `generate_dflash()`. The DFlash Jinja branch did not actually run.")
+    verdict = "HARD_FAIL"
 else:
-    print("PASS: structured-tools JSONL accepted, Jinja path rendered, model emitted tokens")
+    msg = "PASS: structured-tools JSONL accepted, Jinja path rendered, model emitted tokens"
+    if took_dflash:
+        msg += " — DFlash branch confirmed via done.dflash signature"
+    print(msg)
 
 print()
 print("## Model output")


### PR DESCRIPTION
## Summary

Opens the daemon's chat-templating path to **structured tools and multi-turn
messages**, replacing the hand-rolled Hermes-block-in-system-prompt rendering
the CLI ships today. Lifts hipfire's tool-call support from "the one format
the system-prompt instructs" toward "whatever the upstream chat_template
emits" — XML for Qwen3.5/3.6, JSON for Hermes-trained models, etc.
Backward-compat invariant: gated on `HIPFIRE_JINJA_CHAT=1` (still off by
default); Jinja-off daemons consume the exact same legacy `prompt`+`system`
text as today, byte-identical.

Phase breakdown (one commit per layer, easy per-layer review):

- **Phase 1** (`6f94d8af`) — Daemon JSONL schema gains `tools` and
  `messages` fields. AR and DFlash paths both render through
  `JinjaChatFrame::render_messages` when present, synthesizing
  `[system?, user]` if no explicit history was passed.
- **Phase 1 smoke** (`eadf1007`) — `scripts/agentic-gate-jinja-tools.sh`
  drives an end-to-end smoke that actually exercises the DFlash branch
  (with the matching per-family DFlash drafter) and asserts the
  `done.dflash` signature so silent fall-through to AR is caught.
- **Phase 2** (`198cebcf`) — CLI `/v1/chat/completions` now passes
  `body.tools` structurally and maps `body.messages` to the daemon's
  typed `Message[]` shape. Legacy inline-ChatML + text-rendered
  tools-block are still sent so HIPFIRE_JINJA_CHAT=0 daemons see no
  behavior change. `parseOneToolCall` gains a probe for Qwen3.5/3.6's
  native `<function=NAME><parameter=K>V</parameter>...</function>` shape
  with typed value coercion (numbers / bools / null / nested JSON).
- **Phase 3a** (`abcfe7da`) — Multi-GPU PP path (`generate_multi`) gets
  the same Jinja branch as AR and DFlash. Compile-verified locally;
  runtime needs multi-GPU hardware.

VL path (`generate_vl`) and the Jinja-default-flip are explicitly punted to
follow-up PRs.

## Test plan

- [x] **Unit tests**: 161 Rust runtime lib tests pass (5 new in
      `prompt_frame`: minimal/assistant-tool-call/tool-response
      deserialize round-trip, `{% if tools %}` block firing,
      multi-turn render with assistant `tool_calls` + tool response
      carrying `tool_call_id`).
- [x] **Unit tests**: 18 TS parser tests pass (14 prior + 4 new XML cases:
      Qwen3.6 native shape with `<parameter=K>V</parameter>` siblings,
      typed-value coercion, zero-arg call, regression coverage for
      `<function=NAME>{JSON}` corruption shape).
- [x] **End-to-end daemon smoke** (AR + DFlash): `qwen3.6-27b.mq4` +
      `qwen36-27b-dflash-mq4.hf4` under `HIPFIRE_JINJA_CHAT=1` emits
      native XML `<function=get_weather><parameter=city>...` —
      `done.dflash=true`, τ=2.25, cycles=12.
- [x] **End-to-end CLI smoke** (full pipeline): `hipfire serve` + curl
      `/v1/chat/completions` with structured tools → daemon → Jinja →
      XML output → CLI parser → standard OpenAI `tool_calls` response
      with typed `arguments={"city":"San Francisco","unit":"f"}`,
      `finish_reason="tool_calls"`, `content=null`.
- [x] **Regression battery** (4 cells × 2 envs on `qwen3.5-35b-a3b.mq4`):
      `scripts/agentic-gate.sh` produces **identical per-cell outcomes**
      with and without `HIPFIRE_JINJA_CHAT=1` (2 PASS + 2 SOFT_WARN; the
      SOFT_WARN cells are pre-existing fragility from the gate's
      no-reset-between-cells design + daemon-honors-system-only-on-
      seq_pos==0 — reproduces on master).
- [ ] **Phase 3a runtime** (multi-GPU PP): needs hiptrx/hipx hardware
      to actually execute. Compile-verified only in this PR.
- [ ] **VL path**: deferred to follow-up (image-pad token positioning
      non-trivial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)