### PR TITLE
feat(q8-wmma-gfx12): gfx12 (RDNA4) sibling kernels for Q8 fused prefill — 1448 tok/s on R9700

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -4247,13 +4247,12 @@ fn forward_prefill_chunk(
     // per-token gather/scatter via run_fa_layer_body.
     let fa_arch = gpu.arch.as_str();
     // Q8 WMMA gate: the fused Q8 WMMA family (gemm_qkv/qkvza/gate_up/residual
-    // _q8_0_wmma) uses the `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`
-    // builtin, which only pattern-matches on gfx11 (see dispatch.rs:155 —
-    // gfx12 errors with "Cannot select: intrinsic" at codegen time and needs
-    // the `_w32_gfx12` builtin variant in a `*.gfx12.hip` sibling kernel,
-    // which we have not authored yet). Routing gfx12 here would crash at JIT.
-    // On non-WMMA archs we keep the Tier 2 chunked-substrate path.
-    let q8_wmma_arch = rdna_compute::has_wmma_f16(fa_arch);
+    // _q8_0_wmma) uses the gfx11 `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`
+    // builtin; the sibling `*.gfx12.hip` kernels use the `_w32_gfx12` variant
+    // (silicon-validated on R9700, 2026-05-14, 4/4 unit tests PASS). Each
+    // call site below selects the right variant via an `arch.starts_with`
+    // branch. On non-WMMA archs we keep the Tier 2 chunked-substrate path.
+    let q8_wmma_arch = rdna_compute::has_wmma_f16(fa_arch) || fa_arch.starts_with("gfx12");
     let fa_batched_ok = (kv_cache.quant_q8 || kv_cache.quant_asym4 || kv_cache.quant_asym3 || kv_cache.quant_asym2)
         && weights.layers.iter().all(|lw| match lw {
             LayerWeights::FullAttn(l) =>

--- a/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
+++ b/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
@@ -154,6 +154,9 @@ fn main() {
         }
     }
     let prefill_ms = *prefill_samples_ms.last().unwrap();
+    // Captured outside `do_profile` so SUMMARY can split kernel vs wall.
+    // None when profiling is disabled (HIPFIRE_PROFILE != 1).
+    let mut prefill_kernel_ms: Option<f64> = None;
     if do_profile {
         if let Some(entries) = rdna_compute::profile::stop() {
             let mut by_kernel: std::collections::HashMap<&str, (f64, usize, usize)> = Default::default();
@@ -177,6 +180,7 @@ fn main() {
                     us / 1000.0, us / *n as f64, us / total_us * 100.0, gib_s);
             }
             eprintln!("  {:45} {:5}   {:.1}ms", "TOTAL (serialized)", "", total_us / 1000.0);
+            prefill_kernel_ms = Some(total_us / 1000.0);
         }
     }
     let prefill_tok_s = prefill_len as f64 / (prefill_ms / 1000.0);
@@ -189,6 +193,12 @@ fn main() {
     eprintln!("  total: {prefill_ms:.1}ms");
     eprintln!("  tok/s: {prefill_tok_s:.1}");
     eprintln!("  NOTE: first prefill run includes kernel JIT compile cost");
+
+    // Emit prefill-only SUMMARY right here so prefill metrics survive any
+    // failure in the gen phase that follows (the existing argmax-on-NaN
+    // panic in graph-captured gen warmup blocks the end-of-run SUMMARY).
+    eprintln!("PREFILL_SUMMARY  prefill_tok_s={prefill_tok_s:.1}  prefill_wall_ms={prefill_ms:.2}{}",
+        split_prefill_summary(prefill_len, prefill_ms, prefill_kernel_ms));
 
     // (deferred-conversion mode removed with givens — asym modes are natively
     //  batched so there's no prefill/decode cache swap to measure.)
@@ -280,7 +290,8 @@ fn main() {
         eprintln!("  total: {gen_total_ms:.1}ms over 0 tokens");
         eprintln!("  tok/s (gen): 0.0");
         eprintln!();
-        eprintln!("SUMMARY  gen_tok_s=0.0  bw_gib_s=0.0  prefill_tok_s={prefill_tok_s:.1}  avg_ms=0.00  p50_ms=0.00");
+        eprintln!("SUMMARY  gen_tok_s=0.0  bw_gib_s=0.0  prefill_tok_s={prefill_tok_s:.1}  avg_ms=0.00  p50_ms=0.00{}",
+            split_prefill_summary(prefill_len, prefill_ms, prefill_kernel_ms));
         return;
     }
     let sum: f64 = sorted.iter().sum();
@@ -303,5 +314,29 @@ fn main() {
     eprintln!("  effective BW: {bw_gbps:.1} GiB/s (model {:.2} GiB × {gen_tok_s:.1} tok/s)",
         model_bytes as f64 / (1024.0 * 1024.0 * 1024.0));
     eprintln!();
-    eprintln!("SUMMARY  gen_tok_s={gen_tok_s:.1}  bw_gib_s={bw_gbps:.1}  prefill_tok_s={prefill_tok_s:.1}  avg_ms={avg_ms:.2}  p50_ms={p50_ms:.2}");
+    eprintln!("SUMMARY  gen_tok_s={gen_tok_s:.1}  bw_gib_s={bw_gbps:.1}  prefill_tok_s={prefill_tok_s:.1}  avg_ms={avg_ms:.2}  p50_ms={p50_ms:.2}{}",
+        split_prefill_summary(prefill_len, prefill_ms, prefill_kernel_ms));
+}
+
+/// Emit the latency-class split for prefill when profiling captured the
+/// per-kernel time. `prefill_tok_s` in the main SUMMARY is the wall-clock
+/// figure (includes first-process JIT compile + graph capture). The
+/// `*_kernel` figures here are steady-state kernel throughput — what every
+/// call after the first one converges to once JIT amortizes. The gap is
+/// `startup_overhead_ms`. AOT-shipped HSACOs should drop that gap to ~0.
+///
+/// Returns an empty string if profiling was disabled so the SUMMARY line
+/// stays parseable by older tooling.
+#[cfg(feature = "deltanet")]
+fn split_prefill_summary(prefill_len: usize, prefill_ms: f64, prefill_kernel_ms: Option<f64>) -> String {
+    if let Some(kernel_ms) = prefill_kernel_ms {
+        let prefill_tok_s_kernel = prefill_len as f64 / (kernel_ms / 1000.0);
+        let startup_overhead_ms = prefill_ms - kernel_ms;
+        let cold_pct = if prefill_ms > 0.0 { (startup_overhead_ms / prefill_ms) * 100.0 } else { 0.0 };
+        format!(
+            "  prefill_tok_s_kernel={prefill_tok_s_kernel:.1}  prefill_kernel_ms={kernel_ms:.2}  startup_overhead_ms={startup_overhead_ms:.2}  cold_overhead_pct={cold_pct:.1}"
+        )
+    } else {
+        String::new()
+    }
 }

--- a/crates/rdna-compute/examples/test_gemm_q8_gate_up_wmma.rs
+++ b/crates/rdna-compute/examples/test_gemm_q8_gate_up_wmma.rs
@@ -49,7 +49,11 @@ fn main() {
             let gr = d_yg_r.sub_offset(0, n * gate_m);
             let ur = d_yu_r.sub_offset(0, n * up_m);
 
-            gpu.gemm_gate_up_q8_0_wmma(&d_g, &d_u, &x_n, &gw, &uw, gate_m, up_m, k, n).unwrap();
+            if arch.starts_with("gfx12") {
+                gpu.gemm_gate_up_q8_0_wmma_gfx12(&d_g, &d_u, &x_n, &gw, &uw, gate_m, up_m, k, n).unwrap();
+            } else {
+                gpu.gemm_gate_up_q8_0_wmma(&d_g, &d_u, &x_n, &gw, &uw, gate_m, up_m, k, n).unwrap();
+            }
             gpu.gemm_q8_0_batched_chunked(&d_g, &x_n, &gr, gate_m, k, n).unwrap();
             gpu.gemm_q8_0_batched_chunked(&d_u, &x_n, &ur, up_m, k, n).unwrap();
 

--- a/crates/rdna-compute/examples/test_gemm_q8_qkv_wmma.rs
+++ b/crates/rdna-compute/examples/test_gemm_q8_qkv_wmma.rs
@@ -78,13 +78,23 @@ fn main() {
             let yk_r = d_yk_ref.sub_offset(0, n * k_m);
             let yv_r = d_yv_ref.sub_offset(0, n * v_m);
 
-            // Production fused call.
-            gpu.gemm_qkv_q8_0_wmma(
-                &d_aq, &d_ak, &d_av,
-                &x_n,
-                &yq_w, &yk_w, &yv_w,
-                q_m, k_m, v_m, k, n,
-            ).unwrap();
+            // Production fused call — gfx11 uses the canonical _w32 kernel;
+            // gfx12 routes to the _w32_gfx12 sibling (half8_t lane-grp split).
+            if arch.starts_with("gfx12") {
+                gpu.gemm_qkv_q8_0_wmma_gfx12(
+                    &d_aq, &d_ak, &d_av,
+                    &x_n,
+                    &yq_w, &yk_w, &yv_w,
+                    q_m, k_m, v_m, k, n,
+                ).unwrap();
+            } else {
+                gpu.gemm_qkv_q8_0_wmma(
+                    &d_aq, &d_ak, &d_av,
+                    &x_n,
+                    &yq_w, &yk_w, &yv_w,
+                    q_m, k_m, v_m, k, n,
+                ).unwrap();
+            }
 
             // Reference: 3 separate substrate calls (single-output each).
             gpu.gemm_q8_0_batched_chunked(&d_aq, &x_n, &yq_r, q_m, k, n).unwrap();
@@ -155,8 +165,13 @@ fn main() {
     let d_yv = gpu.zeros(&[n * v_m], DType::F32).unwrap();
     let d_yq_ref = gpu.zeros(&[n * q_m], DType::F32).unwrap();
 
-    gpu.gemm_qkv_q8_0_wmma(&d_aq, &d_ak, &d_av, &d_x, &d_yq, &d_yk, &d_yv,
-                           q_m, k_m, v_m, k, n).unwrap();
+    if arch.starts_with("gfx12") {
+        gpu.gemm_qkv_q8_0_wmma_gfx12(&d_aq, &d_ak, &d_av, &d_x, &d_yq, &d_yk, &d_yv,
+                                     q_m, k_m, v_m, k, n).unwrap();
+    } else {
+        gpu.gemm_qkv_q8_0_wmma(&d_aq, &d_ak, &d_av, &d_x, &d_yq, &d_yk, &d_yv,
+                               q_m, k_m, v_m, k, n).unwrap();
+    }
     gpu.gemm_q8_0_batched_chunked(&d_aq, &d_x, &d_yq_ref, q_m, k, n).unwrap();
 
     let yq = gpu.download_f32(&d_yq).unwrap();

--- a/crates/rdna-compute/examples/test_gemm_q8_qkvza_wmma.rs
+++ b/crates/rdna-compute/examples/test_gemm_q8_qkvza_wmma.rs
@@ -61,12 +61,21 @@ fn main() {
             let br = d_y_beta_r.sub_offset(0, n * beta_m);
             let ar = d_y_alpha_r.sub_offset(0, n * alpha_m);
 
-            gpu.gemm_qkvza_q8_0_wmma(
-                &d_qkv, &d_z, &d_beta, &d_alpha,
-                &x_n,
-                &qw, &zw, &bw, &aw,
-                qkv_m, z_m, beta_m, alpha_m, k, n,
-            ).unwrap();
+            if arch.starts_with("gfx12") {
+                gpu.gemm_qkvza_q8_0_wmma_gfx12(
+                    &d_qkv, &d_z, &d_beta, &d_alpha,
+                    &x_n,
+                    &qw, &zw, &bw, &aw,
+                    qkv_m, z_m, beta_m, alpha_m, k, n,
+                ).unwrap();
+            } else {
+                gpu.gemm_qkvza_q8_0_wmma(
+                    &d_qkv, &d_z, &d_beta, &d_alpha,
+                    &x_n,
+                    &qw, &zw, &bw, &aw,
+                    qkv_m, z_m, beta_m, alpha_m, k, n,
+                ).unwrap();
+            }
             gpu.gemm_q8_0_batched_chunked(&d_qkv, &x_n, &qr, qkv_m, k, n).unwrap();
             gpu.gemm_q8_0_batched_chunked(&d_z, &x_n, &zr, z_m, k, n).unwrap();
             gpu.gemm_q8_0_batched_chunked(&d_beta, &x_n, &br, beta_m, k, n).unwrap();

--- a/crates/rdna-compute/examples/test_gemm_q8_residual_wmma.rs
+++ b/crates/rdna-compute/examples/test_gemm_q8_residual_wmma.rs
@@ -47,7 +47,11 @@ fn main() {
 
             // Test path: seed Y with residual, run fused kernel.
             let d_y_test = gpu.upload_f32(&r_host[..n * m], &[n * m]).unwrap();
-            gpu.gemm_q8_0_residual_wmma(&d_a, &x_n, &d_y_test, m, k, n).unwrap();
+            if arch.starts_with("gfx12") {
+                gpu.gemm_q8_0_residual_wmma_gfx12(&d_a, &x_n, &d_y_test, m, k, n).unwrap();
+            } else {
+                gpu.gemm_q8_0_residual_wmma(&d_a, &x_n, &d_y_test, m, k, n).unwrap();
+            }
 
             // Ref path: substrate into tmp, add_inplace into separately-seeded Y_ref.
             let d_tmp = gpu.zeros(&[n * m], DType::F32).unwrap();

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -12424,6 +12424,85 @@ impl Gpu {
         result
     }
 
+    /// gfx12 (RDNA4) sister of `gemm_qkv_q8_0_wmma`. Uses
+    /// `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)
+    /// and half8_t operands with K split across 2 lane-groups. Mirrors the
+    /// `gemm_qkv_hfq4g256_wmma_gfx12` pattern.
+    pub fn gemm_qkv_q8_0_wmma_gfx12(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        debug_assert_eq!(k % 32, 0, "gemm_qkv_q8_0_wmma_gfx12: K must be a multiple of 32 (got K={k})");
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkv_q8_0_wmma_gfx12",
+            kernels::GEMM_QKV_Q8_0_WMMA_GFX12_SRC,
+            "gemm_qkv_q8_0_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut aq = a_q.buf.as_ptr();
+        let mut ak = a_k.buf.as_ptr();
+        let mut av = a_v.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut yq = y_q.buf.as_ptr();
+        let mut yk = y_k.buf.as_ptr();
+        let mut yv = y_v.buf.as_ptr();
+        let mut q_m_val = q_m as i32;
+        let mut k_m_val = k_m as i32;
+        let mut v_m_val = v_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut aq as *mut _ as *mut c_void,
+            &mut ak as *mut _ as *mut c_void,
+            &mut av as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut yq as *mut _ as *mut c_void,
+            &mut yk as *mut _ as *mut c_void,
+            &mut yv as *mut _ as *mut c_void,
+            &mut q_m_val as *mut _ as *mut c_void,
+            &mut k_m_val as *mut _ as *mut c_void,
+            &mut v_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = q_m + k_m + v_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let q8_bytes = |m: usize| m * (k / 32) * 34;
+        let bytes = q8_bytes(q_m) + q8_bytes(k_m) + q8_bytes(v_m)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkv_q8_0_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_q8_0_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// y = A_q8hfq * x (split-metadata Q8 GEMV, row_stride = padded row bytes)
     pub fn gemv_q8hfq(
         &mut self,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -12131,7 +12131,7 @@ impl Gpu {
     }
 
     /// WMMA 4-way fused Q8_0 GEMM (wqkv + wz + w_beta + w_alpha).
-    /// DeltaNet LA preamble. gfx1100+ only.
+    /// DeltaNet LA preamble. Auto-routes to gfx12 sibling on RDNA4.
     pub fn gemm_qkvza_q8_0_wmma(
         &mut self,
         a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
@@ -12141,6 +12141,12 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if self.arch.starts_with("gfx12") {
+            return self.gemm_qkvza_q8_0_wmma_gfx12(
+                a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha,
+                qkv_m, z_m, beta_m, alpha_m, k, batch_size,
+            );
+        }
         // Q8_0 packs 32 elements per block (34 bytes); the kernel iterates
         // `K/32` blocks per row and silently drops any tail if K is not a
         // multiple of 32. All current production shapes satisfy this; guard
@@ -12217,6 +12223,7 @@ impl Gpu {
     }
 
     /// WMMA 2-way fused Q8_0 GEMM (w_gate + w_up). FFN preamble.
+    /// Auto-routes to gfx12 sibling on RDNA4.
     pub fn gemm_gate_up_q8_0_wmma(
         &mut self,
         a_gate: &GpuTensor, a_up: &GpuTensor,
@@ -12226,6 +12233,11 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if self.arch.starts_with("gfx12") {
+            return self.gemm_gate_up_q8_0_wmma_gfx12(
+                a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
+            );
+        }
         debug_assert_eq!(k % 32, 0, "gemm_gate_up_q8_0_wmma: K must be a multiple of 32 (got K={k})");
         self.bind_thread()?;
         self.ensure_kernel(
@@ -12286,7 +12298,8 @@ impl Gpu {
     }
 
     /// WMMA Q8_0 GEMM with fused residual add (Y += X @ A^T).
-    /// Caller seeds Y with the residual. gfx1100+ only.
+    /// Caller seeds Y with the residual. Auto-routes to gfx12 sibling
+    /// on RDNA4.
     pub fn gemm_q8_0_residual_wmma(
         &mut self,
         a: &GpuTensor,
@@ -12296,6 +12309,9 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if self.arch.starts_with("gfx12") {
+            return self.gemm_q8_0_residual_wmma_gfx12(a, x, y, m, k, batch_size);
+        }
         debug_assert_eq!(k % 32, 0, "gemm_q8_0_residual_wmma: K must be a multiple of 32 (got K={k})");
         self.bind_thread()?;
         self.ensure_kernel(
@@ -12345,8 +12361,9 @@ impl Gpu {
     }
 
     /// WMMA-accelerated batched 3-way fused Q8_0 GEMM (Q + K + V projections).
-    /// gfx1100+ only (RDNA3 wave32 WMMA). Mirrors `gemm_qkv_hfq4g256_wmma`.
-    /// X is converted from F32 to FP16 on entry (via `ensure_fp16_x`).
+    /// Auto-routes to the gfx12 sibling on RDNA4 archs; gfx11 path is the
+    /// canonical implementation (X is converted from F32 to FP16 via
+    /// `ensure_fp16_x`). Mirrors `gemm_qkv_hfq4g256_wmma`.
     pub fn gemm_qkv_q8_0_wmma(
         &mut self,
         a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
@@ -12356,6 +12373,11 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<()> {
+        if self.arch.starts_with("gfx12") {
+            return self.gemm_qkv_q8_0_wmma_gfx12(
+                a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
+            );
+        }
         debug_assert_eq!(k % 32, 0, "gemm_qkv_q8_0_wmma: K must be a multiple of 32 (got K={k})");
         self.bind_thread()?;
         self.ensure_kernel(

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -12503,6 +12503,215 @@ impl Gpu {
         result
     }
 
+    /// gfx12 sister of `gemm_qkvza_q8_0_wmma` (DeltaNet LA preamble).
+    pub fn gemm_qkvza_q8_0_wmma_gfx12(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        debug_assert_eq!(k % 32, 0, "gemm_qkvza_q8_0_wmma_gfx12: K must be a multiple of 32 (got K={k})");
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_qkvza_q8_0_wmma_gfx12",
+            kernels::GEMM_QKVZA_Q8_0_WMMA_GFX12_SRC,
+            "gemm_qkvza_q8_0_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_qkv_p = a_qkv.buf.as_ptr();
+        let mut a_z_p = a_z.buf.as_ptr();
+        let mut a_beta_p = a_beta.buf.as_ptr();
+        let mut a_alpha_p = a_alpha.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut y_qkv_p = y_qkv.buf.as_ptr();
+        let mut y_z_p = y_z.buf.as_ptr();
+        let mut y_beta_p = y_beta.buf.as_ptr();
+        let mut y_alpha_p = y_alpha.buf.as_ptr();
+        let mut qkv_m_val = qkv_m as i32;
+        let mut z_m_val = z_m as i32;
+        let mut beta_m_val = beta_m as i32;
+        let mut alpha_m_val = alpha_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_qkv_p as *mut _ as *mut c_void,
+            &mut a_z_p as *mut _ as *mut c_void,
+            &mut a_beta_p as *mut _ as *mut c_void,
+            &mut a_alpha_p as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut y_qkv_p as *mut _ as *mut c_void,
+            &mut y_z_p as *mut _ as *mut c_void,
+            &mut y_beta_p as *mut _ as *mut c_void,
+            &mut y_alpha_p as *mut _ as *mut c_void,
+            &mut qkv_m_val as *mut _ as *mut c_void,
+            &mut z_m_val as *mut _ as *mut c_void,
+            &mut beta_m_val as *mut _ as *mut c_void,
+            &mut alpha_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = qkv_m + z_m + beta_m + alpha_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+        let q8_bytes = |m: usize| m * (k / 32) * 34;
+        let bytes = q8_bytes(qkv_m) + q8_bytes(z_m) + q8_bytes(beta_m) + q8_bytes(alpha_m)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_q8_0_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_q8_0_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_qkv_p); b.push_ptr(a_z_p); b.push_ptr(a_beta_p); b.push_ptr(a_alpha_p);
+                b.push_ptr(xp);
+                b.push_ptr(y_qkv_p); b.push_ptr(y_z_p); b.push_ptr(y_beta_p); b.push_ptr(y_alpha_p);
+                b.push_i32(qkv_m_val); b.push_i32(z_m_val); b.push_i32(beta_m_val); b.push_i32(alpha_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// gfx12 sister of `gemm_gate_up_q8_0_wmma` (FFN preamble).
+    pub fn gemm_gate_up_q8_0_wmma_gfx12(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        debug_assert_eq!(k % 32, 0, "gemm_gate_up_q8_0_wmma_gfx12: K must be a multiple of 32 (got K={k})");
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_gate_up_q8_0_wmma_gfx12",
+            kernels::GEMM_GATE_UP_Q8_0_WMMA_GFX12_SRC,
+            "gemm_gate_up_q8_0_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_g = a_gate.buf.as_ptr();
+        let mut a_u = a_up.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut y_g = y_gate.buf.as_ptr();
+        let mut y_u = y_up.buf.as_ptr();
+        let mut gate_m_val = gate_m as i32;
+        let mut up_m_val = up_m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_g as *mut _ as *mut c_void,
+            &mut a_u as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut y_g as *mut _ as *mut c_void,
+            &mut y_u as *mut _ as *mut c_void,
+            &mut gate_m_val as *mut _ as *mut c_void,
+            &mut up_m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let total_m = gate_m + up_m;
+        let row_tiles = (total_m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+        let q8_bytes = |m: usize| m * (k / 32) * 34;
+        let bytes = q8_bytes(gate_m) + q8_bytes(up_m)
+                  + batch_size * k * 2
+                  + batch_size * total_m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_gate_up_q8_0_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_q8_0_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_g); b.push_ptr(a_u);
+                b.push_ptr(xp);
+                b.push_ptr(y_g); b.push_ptr(y_u);
+                b.push_i32(gate_m_val); b.push_i32(up_m_val);
+                b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// gfx12 sister of `gemm_q8_0_residual_wmma` (wo / w_down post-projection).
+    /// Caller seeds Y with the residual; kernel does `Y += X @ A^T`.
+    pub fn gemm_q8_0_residual_wmma_gfx12(
+        &mut self,
+        a: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        debug_assert_eq!(k % 32, 0, "gemm_q8_0_residual_wmma_gfx12: K must be a multiple of 32 (got K={k})");
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_q8_0_residual_wmma_gfx12",
+            kernels::GEMM_Q8_0_RESIDUAL_WMMA_GFX12_SRC,
+            "gemm_q8_0_residual_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_p = a.buf.as_ptr();
+        let mut xp = x_f16_ptr;
+        let mut y_p = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut n_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_p as *mut _ as *mut c_void,
+            &mut xp as *mut _ as *mut c_void,
+            &mut y_p as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+        let bytes = m * (k / 32) * 34
+                  + batch_size * k * 2
+                  + batch_size * m * 4 * 2; // residual read + write
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_q8_0_residual_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_q8_0_residual_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_p); b.push_ptr(xp); b.push_ptr(y_p);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// y = A_q8hfq * x (split-metadata Q8 GEMV, row_stride = padded row bytes)
     pub fn gemv_q8hfq(
         &mut self,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -876,9 +876,22 @@ pub const GEMM_Q8_0_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src
 // `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)
 // and half8_t operands (vs half16_t). Lane-grp K split (tid>>4 selects
 // K-half) and `acc[j] = C[8*(tid>>4) + j][tid & 15]` C-output mapping —
-// pattern mirrors gemm_qkv_hfq4g256_wmma.gfx12. SCAFFOLD until validated
-// on R9700.
+// pattern mirrors gemm_qkv_hfq4g256_wmma.gfx12 and is silicon-validated
+// on R9700 (test_gemm_q8_qkv_wmma 22/22 PASS, 2026-05-14).
 pub const GEMM_QKV_Q8_0_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip");
+
+/// gfx12 sister of GEMM_QKVZA_Q8_0_WMMA_SRC. Same lane-grp + half8_t
+/// pattern as the QKV gfx12 sibling.
+pub const GEMM_QKVZA_Q8_0_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip");
+
+/// gfx12 sister of GEMM_GATE_UP_Q8_0_WMMA_SRC. Same lane-grp + half8_t
+/// pattern as the QKV gfx12 sibling.
+pub const GEMM_GATE_UP_Q8_0_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip");
+
+/// gfx12 sister of GEMM_Q8_0_RESIDUAL_WMMA_SRC. Same lane-grp + half8_t
+/// pattern; preserves the non-overlapping-write invariant under the new
+/// lane-group row partition (lane group 0 → rows 0..7, group 1 → rows 8..15).
+pub const GEMM_Q8_0_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_q8_0_residual_wmma.gfx12.hip");
 
 
 /// GEMV Q6_K: matrix-vector multiply with on-the-fly Q6_K dequantization.

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -872,6 +872,14 @@ pub const GEMM_GATE_UP_Q8_0_WMMA_SRC: &str = include_str!("../../../kernels/src/
 /// WMMA Q8_0 GEMM with fused residual add (wo, w_down post-projection).
 pub const GEMM_Q8_0_RESIDUAL_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_q8_0_residual_wmma.hip");
 
+// gfx12 (RDNA4) sister of GEMM_QKV_Q8_0_WMMA_SRC. Uses
+// `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` (vs the gfx11 `_w32`)
+// and half8_t operands (vs half16_t). Lane-grp K split (tid>>4 selects
+// K-half) and `acc[j] = C[8*(tid>>4) + j][tid & 15]` C-output mapping —
+// pattern mirrors gemm_qkv_hfq4g256_wmma.gfx12. SCAFFOLD until validated
+// on R9700.
+pub const GEMM_QKV_Q8_0_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip");
+
 
 /// GEMV Q6_K: matrix-vector multiply with on-the-fly Q6_K dequantization.
 /// Q6_K block: ql[128] + qh[64] + scales[16] + d[2] = 210 bytes per 256 elements.

--- a/kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip
@@ -4,10 +4,37 @@
 // WMMA-accelerated batched 2-way fused Q8_0 GEMM for the Qwen3.5 FFN
 // preamble (w_gate + w_up projections from the same normed X).
 //
-// **gfx12 (RDNA4) variant** — sister of gemm_gate_up_q8_0_wmma.hip.
-// SCAFFOLD STATUS (2026-05-14): mirrors gemm_qkv_q8_0_wmma.gfx12 pattern
-// (silicon-validated for the QKV sibling on R9700). See that file for
-// the gfx11 → gfx12 port summary.
+// **gfx12 (RDNA4) variant — K4 unroll**. Mirrors the HFQ4 sibling
+// `gemm_gate_up_hfq4g256_wmma.gfx12.hip` (issue #65 lever 2), which
+// measured 2.0× on R9700 9B pp=128 gate_up (1842 → 922 µs/call,
+// 39 → 80 GiB/s effective). The same pattern should help Q8: the
+// kernel_atlas profile on R9700 (2026-05-14, single-block loop)
+// showed only 191 GiB/s effective (30% of peak) and 51.7% of total
+// prefill time — deep-pipelining the loads above the WMMA chain is
+// the obvious next lever.
+//
+// Pattern (same shape as the HFQ4 K4 unroll):
+//   1. Outer loop iterates 2 Q8 blocks (= 4 WMMA-K-tiles) per body
+//   2. All 4 X reads + all 4 weight reads issued up-front
+//   3. Weight bytes are loaded as uint64 packs (8 int8 per pack) so
+//      each WMMA tile = 1 VMEM op instead of 8 byte loads
+//   4. 4 dequant + WMMA pairs follow back-to-back; s_waitcnt vmcnt(>0)
+//      lets the compiler overlap VMEM with WMMA
+//
+// Block-pair semantics:
+//   - blocks_per_row = K/32 must be EVEN for the clean K2-block unroll.
+//     For Qwen3.5 9B production shapes K ∈ {4096, 11008}, blocks_per_row
+//     ∈ {128, 344}, both even. A debug_assert in the dispatch wrapper
+//     enforces this; if a future shape is odd we'd need a tail handler.
+//
+// gfx12 vs gfx11 differences (carried over from the single-block port):
+//   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
+//   2. half8_t A/B operands instead of half16_t
+//   3. K dim split across 2 lane-groups (k_grp = tid >> 4)
+//   4. C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
+//      (silicon-validated on R9700, 2026-05-14)
+//
+// Grid: [ceil((gate_m + up_m)/16), ceil(N/16)]. Block: [32]. LDS: 0.
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -53,40 +80,61 @@ extern "C" __global__ void gemm_gate_up_q8_0_wmma_gfx12(
 
     float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-    for (int bi = 0; bi < blocks_per_row; bi++) {
-        const char* bp = row_base + bi * 34;
+    // Dequant macro: unpack one uint64 of 8 int8 weights, multiply by scale.
+    // Cast through `signed char` so the high bit is sign-extended (Q8_0 is
+    // signed [-128, 127]).
+    #define DQ8_Q(pk, sc) \
+        a_reg[0] = (sc) * (_Float16)(float)(signed char)(((pk) >>  0) & 0xFFu); \
+        a_reg[1] = (sc) * (_Float16)(float)(signed char)(((pk) >>  8) & 0xFFu); \
+        a_reg[2] = (sc) * (_Float16)(float)(signed char)(((pk) >> 16) & 0xFFu); \
+        a_reg[3] = (sc) * (_Float16)(float)(signed char)(((pk) >> 24) & 0xFFu); \
+        a_reg[4] = (sc) * (_Float16)(float)(signed char)(((pk) >> 32) & 0xFFu); \
+        a_reg[5] = (sc) * (_Float16)(float)(signed char)(((pk) >> 40) & 0xFFu); \
+        a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
+        a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-        _Float16 sc;
+    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+        const char* bp_a = row_base + bi * 34;
+        const char* bp_b = row_base + (bi + 1) * 34;
+
+        _Float16 sc_a, sc_b;
         {
             unsigned short s_bits;
-            __builtin_memcpy(&s_bits, bp, 2);
-            __builtin_memcpy(&sc, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_a, 2); __builtin_memcpy(&sc_a, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_b, 2); __builtin_memcpy(&sc_b, &s_bits, 2);
         }
 
-        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_a = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_b = X + (long long)safe_batch * K + (bi + 1) * 32;
 
-        // Tile 0
-        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
-        half8_t a0;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a0[i] = sc * (_Float16)(float)(int)w0[i];
-        }
-        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+        // 4 weight packs (one uint64 = 8 int8 weights per WMMA tile), all up-front.
+        unsigned long long pk0a, pk1a, pk0b, pk1b;
+        __builtin_memcpy(&pk0a, bp_a + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1a, bp_a + 2 + 16 + k_grp * 8, 8);
+        __builtin_memcpy(&pk0b, bp_b + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1b, bp_b + 2 + 16 + k_grp * 8, 8);
 
-        // Tile 1
-        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
-        half8_t a1;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a1[i] = sc * (_Float16)(float)(int)w1[i];
-        }
-        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+        // 4 X tiles, all up-front.
+        half8_t b0a = *(const half8_t*)(x_a +  0 + k_grp * 8);
+        half8_t b1a = *(const half8_t*)(x_a + 16 + k_grp * 8);
+        half8_t b0b = *(const half8_t*)(x_b +  0 + k_grp * 8);
+        half8_t b1b = *(const half8_t*)(x_b + 16 + k_grp * 8);
+
+        // 4 dequant + WMMA pairs, back-to-back.
+        half8_t a_reg;
+        DQ8_Q(pk0a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0a, acc);
+        DQ8_Q(pk1a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1a, acc);
+        DQ8_Q(pk0b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
+        DQ8_Q(pk1b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
     }
+    #undef DQ8_Q
 
-    // gfx12 C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
+    // gfx12 C-output mapping (silicon-validated 2026-05-14):
+    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
     const int out_col = batch_start + m_lane;
     if (out_col >= N) return;
 

--- a/kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip
@@ -21,11 +21,10 @@
 //   4. 4 dequant + WMMA pairs follow back-to-back; s_waitcnt vmcnt(>0)
 //      lets the compiler overlap VMEM with WMMA
 //
-// Block-pair semantics:
-//   - blocks_per_row = K/32 must be EVEN for the clean K2-block unroll.
-//     For Qwen3.5 9B production shapes K ∈ {4096, 11008}, blocks_per_row
-//     ∈ {128, 344}, both even. A debug_assert in the dispatch wrapper
-//     enforces this; if a future shape is odd we'd need a tail handler.
+// Block-pair plus tail: the K4 unroll processes 2 Q8 blocks per body,
+// and a final single-block tail handles odd `blocks_per_row`. Production
+// 9B shapes (K=4096 → 128 blocks, K=11008 → 344 blocks) take the fast
+// path with no tail; the tail exists for correctness on small/odd K.
 //
 // gfx12 vs gfx11 differences (carried over from the single-block port):
 //   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
@@ -93,7 +92,8 @@ extern "C" __global__ void gemm_gate_up_q8_0_wmma_gfx12(
         a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
         a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+    int bi = 0;
+    for (; bi + 1 < blocks_per_row; bi += 2) {
         const char* bp_a = row_base + bi * 34;
         const char* bp_b = row_base + (bi + 1) * 34;
 
@@ -130,6 +130,33 @@ extern "C" __global__ void gemm_gate_up_q8_0_wmma_gfx12(
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
         DQ8_Q(pk1b, sc_b);
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
+    }
+
+    // Tail: one unpaired block if blocks_per_row is odd. Production
+    // shapes never enter this path.
+    if (bi < blocks_per_row) {
+        const char* bp = row_base + bi * 34;
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        unsigned long long pk0, pk1;
+        __builtin_memcpy(&pk0, bp + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1, bp + 2 + 16 + k_grp * 8, 8);
+
+        half8_t b0 = *(const half8_t*)(x_base +  0 + k_grp * 8);
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0, acc);
+        DQ8_Q(pk1, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1, acc);
     }
     #undef DQ8_Q
 

--- a/kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_gate_up_q8_0_wmma.gfx12.hip
@@ -1,0 +1,108 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 2-way fused Q8_0 GEMM for the Qwen3.5 FFN
+// preamble (w_gate + w_up projections from the same normed X).
+//
+// **gfx12 (RDNA4) variant** — sister of gemm_gate_up_q8_0_wmma.hip.
+// SCAFFOLD STATUS (2026-05-14): mirrors gemm_qkv_q8_0_wmma.gfx12 pattern
+// (silicon-validated for the QKV sibling on R9700). See that file for
+// the gfx11 → gfx12 port summary.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_q8_0_wmma_gfx12(
+    const char*     __restrict__ A_gate,
+    const char*     __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*          __restrict__ Y_gate,
+    float*          __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m     = gate_m + up_m;
+    const int row_start   = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid         = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N)     return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row   = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate;  local_row = safe_row;
+    } else {
+        A = A_up;    local_row = safe_row - gate_m;
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = (long long)blocks_per_row * 34;
+    const char* row_base = A + (long long)local_row * row_stride;
+
+    const int safe_batch = ((batch_start + m_lane) < N)
+                           ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int bi = 0; bi < blocks_per_row; bi++) {
+        const char* bp = row_base + bi * 34;
+
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        // Tile 0
+        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
+        half8_t a0;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a0[i] = sc * (_Float16)(float)(int)w0[i];
+        }
+        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+
+        // Tile 1
+        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
+        half8_t a1;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a1[i] = sc * (_Float16)(float)(int)w1[i];
+        }
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+    }
+
+    // gfx12 C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
+    const int out_col = batch_start + m_lane;
+    if (out_col >= N) return;
+
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        const int out_row = row_start + 8 * k_grp + j;
+        if (out_row < total_m) {
+            float* Y;
+            int proj_row;
+            int proj_m;
+            if (out_row < gate_m) {
+                Y = Y_gate; proj_row = out_row;            proj_m = gate_m;
+            } else {
+                Y = Y_up;   proj_row = out_row - gate_m;   proj_m = up_m;
+            }
+            Y[(long long)out_col * proj_m + proj_row] = acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_q8_0_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_q8_0_residual_wmma.gfx12.hip
@@ -19,9 +19,10 @@
 // non-overlapping by construction. Any K-split sibling would still
 // need atomicAdd.
 //
-// Block-pair invariant: blocks_per_row = K/32 must be EVEN. Production
-// Qwen3.5 9B shapes (wo K=4096 → 128 blocks; w_down K=11008 → 344
-// blocks) satisfy this.
+// Block-pair plus tail: 2 Q8 blocks per K4-unrolled body, plus a single-
+// block tail for odd blocks_per_row (correctness on small/odd K).
+// Production 9B shapes (wo K=4096 → 128 blocks; w_down K=11008 → 344
+// blocks) take the fast path with no tail.
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -65,7 +66,8 @@ extern "C" __global__ void gemm_q8_0_residual_wmma_gfx12(
         a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
         a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+    int bi = 0;
+    for (; bi + 1 < blocks_per_row; bi += 2) {
         const char* bp_a = row_base + bi * 34;
         const char* bp_b = row_base + (bi + 1) * 34;
 
@@ -99,6 +101,32 @@ extern "C" __global__ void gemm_q8_0_residual_wmma_gfx12(
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
         DQ8_Q(pk1b, sc_b);
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
+    }
+
+    // Tail: one unpaired block if blocks_per_row is odd.
+    if (bi < blocks_per_row) {
+        const char* bp = row_base + bi * 34;
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        unsigned long long pk0, pk1;
+        __builtin_memcpy(&pk0, bp + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1, bp + 2 + 16 + k_grp * 8, 8);
+
+        half8_t b0 = *(const half8_t*)(x_base +  0 + k_grp * 8);
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0, acc);
+        DQ8_Q(pk1, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1, acc);
     }
     #undef DQ8_Q
 

--- a/kernels/src/gemm_q8_0_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_q8_0_residual_wmma.gfx12.hip
@@ -3,20 +3,25 @@
 
 // WMMA-accelerated batched Q8_0 GEMM with fused residual add.
 //
-// **gfx12 (RDNA4) variant** — sister of gemm_q8_0_residual_wmma.hip.
-// SCAFFOLD STATUS (2026-05-14): mirrors gemm_qkv_q8_0_wmma.gfx12 pattern
-// (silicon-validated for the QKV sibling on R9700).
+// **gfx12 (RDNA4) variant — K4 unroll**. Same pattern as the other Q8
+// gfx12 siblings: 2 Q8 blocks (= 4 WMMA tiles) per loop iter, all loads
+// up-front, 4 dequant+WMMA pairs back-to-back. Validated numerically
+// identical to the single-block port via test_gemm_q8_residual_wmma.
 //
 // Y[N, M] += X[N, K] @ A_q8[M, K]^T
 //
 // === Non-overlapping-write invariant (DO NOT BREAK) ===
-// The `Y[i] += acc[j]` at the end is **NOT atomic**. Race-free only because
-// each (out_row, out_col) cell is written by exactly one lane in exactly
-// one block under this kernel's grid. With the gfx12 mapping
+// The `Y[i] += acc[j]` at the end is **NOT atomic**. Race-free only
+// because each (out_row, out_col) cell is written by exactly one lane
+// in exactly one block under this kernel's grid. With the gfx12 mapping
 //   acc[j] → C[8*(tid>>4) + j][tid & 15]
-// lane group 0 writes rows 0..7 of the 16-row tile and lane group 1
-// writes rows 8..15 — also non-overlapping by construction. The HFQ4-style
-// K-split variant (if ever added on gfx12) would still need atomicAdd.
+// lane group 0 writes rows 0..7, lane group 1 writes rows 8..15 — also
+// non-overlapping by construction. Any K-split sibling would still
+// need atomicAdd.
+//
+// Block-pair invariant: blocks_per_row = K/32 must be EVEN. Production
+// Qwen3.5 9B shapes (wo K=4096 → 128 blocks; w_down K=11008 → 344
+// blocks) satisfy this.
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -50,36 +55,52 @@ extern "C" __global__ void gemm_q8_0_residual_wmma_gfx12(
 
     float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-    for (int bi = 0; bi < blocks_per_row; bi++) {
-        const char* bp = row_base + bi * 34;
+    #define DQ8_Q(pk, sc) \
+        a_reg[0] = (sc) * (_Float16)(float)(signed char)(((pk) >>  0) & 0xFFu); \
+        a_reg[1] = (sc) * (_Float16)(float)(signed char)(((pk) >>  8) & 0xFFu); \
+        a_reg[2] = (sc) * (_Float16)(float)(signed char)(((pk) >> 16) & 0xFFu); \
+        a_reg[3] = (sc) * (_Float16)(float)(signed char)(((pk) >> 24) & 0xFFu); \
+        a_reg[4] = (sc) * (_Float16)(float)(signed char)(((pk) >> 32) & 0xFFu); \
+        a_reg[5] = (sc) * (_Float16)(float)(signed char)(((pk) >> 40) & 0xFFu); \
+        a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
+        a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-        _Float16 sc;
+    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+        const char* bp_a = row_base + bi * 34;
+        const char* bp_b = row_base + (bi + 1) * 34;
+
+        _Float16 sc_a, sc_b;
         {
             unsigned short s_bits;
-            __builtin_memcpy(&s_bits, bp, 2);
-            __builtin_memcpy(&sc, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_a, 2); __builtin_memcpy(&sc_a, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_b, 2); __builtin_memcpy(&sc_b, &s_bits, 2);
         }
 
-        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_a = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_b = X + (long long)safe_batch * K + (bi + 1) * 32;
 
-        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
-        half8_t a0;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a0[i] = sc * (_Float16)(float)(int)w0[i];
-        }
-        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+        unsigned long long pk0a, pk1a, pk0b, pk1b;
+        __builtin_memcpy(&pk0a, bp_a + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1a, bp_a + 2 + 16 + k_grp * 8, 8);
+        __builtin_memcpy(&pk0b, bp_b + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1b, bp_b + 2 + 16 + k_grp * 8, 8);
 
-        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
-        half8_t a1;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a1[i] = sc * (_Float16)(float)(int)w1[i];
-        }
-        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+        half8_t b0a = *(const half8_t*)(x_a +  0 + k_grp * 8);
+        half8_t b1a = *(const half8_t*)(x_a + 16 + k_grp * 8);
+        half8_t b0b = *(const half8_t*)(x_b +  0 + k_grp * 8);
+        half8_t b1b = *(const half8_t*)(x_b + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0a, acc);
+        DQ8_Q(pk1a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1a, acc);
+        DQ8_Q(pk0b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
+        DQ8_Q(pk1b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
     }
+    #undef DQ8_Q
 
     // gfx12 C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
     // += semantics fuses the residual.

--- a/kernels/src/gemm_q8_0_residual_wmma.gfx12.hip
+++ b/kernels/src/gemm_q8_0_residual_wmma.gfx12.hip
@@ -1,0 +1,96 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched Q8_0 GEMM with fused residual add.
+//
+// **gfx12 (RDNA4) variant** — sister of gemm_q8_0_residual_wmma.hip.
+// SCAFFOLD STATUS (2026-05-14): mirrors gemm_qkv_q8_0_wmma.gfx12 pattern
+// (silicon-validated for the QKV sibling on R9700).
+//
+// Y[N, M] += X[N, K] @ A_q8[M, K]^T
+//
+// === Non-overlapping-write invariant (DO NOT BREAK) ===
+// The `Y[i] += acc[j]` at the end is **NOT atomic**. Race-free only because
+// each (out_row, out_col) cell is written by exactly one lane in exactly
+// one block under this kernel's grid. With the gfx12 mapping
+//   acc[j] → C[8*(tid>>4) + j][tid & 15]
+// lane group 0 writes rows 0..7 of the 16-row tile and lane group 1
+// writes rows 8..15 — also non-overlapping by construction. The HFQ4-style
+// K-split variant (if ever added on gfx12) would still need atomicAdd.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_q8_0_residual_wmma_gfx12(
+    const char*     __restrict__ A_q8,
+    const _Float16* __restrict__ X,
+    float*          __restrict__ Y,      // caller seeds with residual
+    int M, int K, int N
+) {
+    const int row_start   = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid         = threadIdx.x;
+
+    if (row_start >= M)   return;
+    if (batch_start >= N) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row   = row_start + m_lane;
+    const int safe_row = (my_row < M) ? my_row : (M - 1);
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = (long long)blocks_per_row * 34;
+    const char* row_base = A_q8 + (long long)safe_row * row_stride;
+
+    const int safe_batch = ((batch_start + m_lane) < N)
+                           ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int bi = 0; bi < blocks_per_row; bi++) {
+        const char* bp = row_base + bi * 34;
+
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
+        half8_t a0;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a0[i] = sc * (_Float16)(float)(int)w0[i];
+        }
+        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+
+        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
+        half8_t a1;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a1[i] = sc * (_Float16)(float)(int)w1[i];
+        }
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+    }
+
+    // gfx12 C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
+    // += semantics fuses the residual.
+    const int out_col = batch_start + m_lane;
+    if (out_col >= N) return;
+
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        const int out_row = row_start + 8 * k_grp + j;
+        if (out_row < M) {
+            Y[(long long)out_col * M + out_row] += acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip
@@ -1,0 +1,159 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 3-way fused Q8_0 GEMM for the Qwen3.5
+// FullAttention preamble (Q + K + V projections from one normed X).
+//
+// **gfx12 (RDNA4) variant** — sister kernel to gemm_qkv_q8_0_wmma.hip
+// (gfx11 / RDNA3). Compile this file with
+//   hipcc --offload-arch=gfx1200  (or gfx1201, ...).
+//
+// SCAFFOLD STATUS (2026-05-14):
+//   First-pass port from gemm_qkv_q8_0_wmma.hip following the canonical
+//   pattern in gemm_qkv_hfq4g256_wmma.gfx12.hip. C-output mapping is
+//   the same HYPOTHESIS the HFQ4 sibling uses (derived from CK trait
+//   kCM0/kCM1PerLane swap). MUST be runtime-validated on real RDNA4
+//   silicon (R9700 / 9070 XT) via test_gemm_q8_qkv_wmma before this
+//   file is allowed to win on any production dispatch site.
+//
+// Differences from the gfx11 Q8 kernel:
+//   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
+//      (gfx11 uses _w32 without the _gfx12 suffix).
+//   2. A and B operands: half8_t (8 fp16 per lane) instead of half16_t
+//      (16 fp16 per lane). Accumulator C is unchanged at float8_t.
+//   3. K dimension is split across 2 lane-groups (kABKLane=2) instead
+//      of replicated across all 32 lanes (gfx11 kABKLane=1):
+//        lane (tid >> 4) = 0  -> carries K = [0..7]  of the 16-K tile
+//        lane (tid >> 4) = 1  -> carries K = [8..15] of the 16-K tile
+//      Each lane therefore loads HALF as much per WMMA tile as gfx11.
+//   4. C-output mapping (HYPOTHESIS — see below):
+//        gfx11 (validated, commit b7ac66a):
+//          acc[j] = C[2*j + (tid>>4)][tid & 15]
+//        gfx12 (UNVERIFIED, derived from CK kCM0/kCM1PerLane swap):
+//          acc[j] = C[8*(tid>>4) + j][tid & 15]
+//
+// Per Q8_0 block (K=32 elements, 34 bytes): 1 fp16 scale + 32 int8 weights.
+// One Q8 block = 2 WMMA-K-tiles (each tile is 16 K-elements). Each gfx12
+// lane carries 8 of those 16 K-elements per WMMA tile.
+//
+// Grid:  [ceil((q_m + k_m + v_m)/16), ceil(N/16)]
+// Block: [32] (wave32).  LDS: 0.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_q8_0_wmma_gfx12(
+    const char*     __restrict__ A_q,    // [q_m, K/32 * 34] Q8_0
+    const char*     __restrict__ A_k,    // [k_m, K/32 * 34] Q8_0
+    const char*     __restrict__ A_v,    // [v_m, K/32 * 34] Q8_0
+    const _Float16* __restrict__ X,      // [N, K] FP16
+    float*          __restrict__ Y_q,    // [N, q_m] FP32
+    float*          __restrict__ Y_k,    // [N, k_m] FP32
+    float*          __restrict__ Y_v,    // [N, v_m] FP32
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m     = q_m + k_m + v_m;
+    const int row_start   = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid         = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N)     return;
+
+    // Lane decomposition (gfx12 wave32 WMMA):
+    //   m_lane = tid & 15   (0..15)  -> row index within the 16-row tile
+    //   k_grp  = tid >> 4   (0 or 1) -> which K half-tile this lane carries
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row   = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    // Route to the correct weight matrix for this thread's row.
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = (long long)blocks_per_row * 34;
+    const char* row_base = A + (long long)local_row * row_stride;
+
+    const int safe_batch = ((batch_start + m_lane) < N)
+                           ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int bi = 0; bi < blocks_per_row; bi++) {
+        const char* bp = row_base + bi * 34;
+
+        // fp16 scale at byte offset 0 (2 bytes). May be 2-byte aligned but
+        // not 4-byte — load via memcpy to avoid unaligned-access UB.
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        // === WMMA tile 0 (K-elements 0..16, split between lane-groups) ===
+        //   lane_grp 0 carries weights bp[2 + 0..7] and X[bi*32 + 0..7]
+        //   lane_grp 1 carries weights bp[2 + 8..15] and X[bi*32 + 8..15]
+        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
+        half8_t a0;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a0[i] = sc * (_Float16)(float)(int)w0[i];
+        }
+        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+
+        // === WMMA tile 1 (K-elements 16..32, split between lane-groups) ===
+        //   lane_grp 0 carries weights bp[2 + 16 + 0..7] and X[bi*32 + 16 + 0..7]
+        //   lane_grp 1 carries weights bp[2 + 16 + 8..15] and X[bi*32 + 16 + 8..15]
+        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
+        half8_t a1;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a1[i] = sc * (_Float16)(float)(int)w1[i];
+        }
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+    }
+
+    // C-output mapping HYPOTHESIS — mirrors gemm_qkv_hfq4g256_wmma.gfx12:
+    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
+    // i.e. lane group 0 holds output rows 0..7, lane group 1 rows 8..15.
+    // Validate against gfx11 reference for a small golden case before
+    // trusting at scale.
+    const int out_col = batch_start + m_lane;
+    if (out_col >= N) return;
+
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        const int out_row = row_start + 8 * k_grp + j;
+        if (out_row < total_m) {
+            // Route this row to the correct output matrix.
+            float* Y;
+            int proj_row;
+            int proj_m;
+            if (out_row < q_m) {
+                Y = Y_q;  proj_row = out_row;                 proj_m = q_m;
+            } else if (out_row < q_m + k_m) {
+                Y = Y_k;  proj_row = out_row - q_m;            proj_m = k_m;
+            } else {
+                Y = Y_v;  proj_row = out_row - q_m - k_m;      proj_m = v_m;
+            }
+            Y[(long long)out_col * proj_m + proj_row] = acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip
@@ -4,40 +4,19 @@
 // WMMA-accelerated batched 3-way fused Q8_0 GEMM for the Qwen3.5
 // FullAttention preamble (Q + K + V projections from one normed X).
 //
-// **gfx12 (RDNA4) variant** — sister kernel to gemm_qkv_q8_0_wmma.hip
-// (gfx11 / RDNA3). Compile this file with
-//   hipcc --offload-arch=gfx1200  (or gfx1201, ...).
+// **gfx12 (RDNA4) variant — K4 unroll**. Mirrors the HFQ4 gfx12 sibling
+// pattern (issue #65 lever 2). Original single-block port was
+// silicon-validated on R9700 in commit 79976dac; this K-unrolled
+// version preserves the same C-output mapping and validates
+// numerically identical via test_gemm_q8_qkv_wmma.
 //
-// SCAFFOLD STATUS (2026-05-14):
-//   First-pass port from gemm_qkv_q8_0_wmma.hip following the canonical
-//   pattern in gemm_qkv_hfq4g256_wmma.gfx12.hip. C-output mapping is
-//   the same HYPOTHESIS the HFQ4 sibling uses (derived from CK trait
-//   kCM0/kCM1PerLane swap). MUST be runtime-validated on real RDNA4
-//   silicon (R9700 / 9070 XT) via test_gemm_q8_qkv_wmma before this
-//   file is allowed to win on any production dispatch site.
+// Pattern: outer loop processes 2 Q8 blocks (= 4 WMMA-K-tiles) per
+// body. All 4 X reads + 4 weight reads (uint64 packs of 8 int8 each)
+// issued up-front; 4 dequant+WMMA pairs follow back-to-back so the
+// compiler can deep-pipeline VMEM behind WMMA execution.
 //
-// Differences from the gfx11 Q8 kernel:
-//   1. WMMA builtin: __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
-//      (gfx11 uses _w32 without the _gfx12 suffix).
-//   2. A and B operands: half8_t (8 fp16 per lane) instead of half16_t
-//      (16 fp16 per lane). Accumulator C is unchanged at float8_t.
-//   3. K dimension is split across 2 lane-groups (kABKLane=2) instead
-//      of replicated across all 32 lanes (gfx11 kABKLane=1):
-//        lane (tid >> 4) = 0  -> carries K = [0..7]  of the 16-K tile
-//        lane (tid >> 4) = 1  -> carries K = [8..15] of the 16-K tile
-//      Each lane therefore loads HALF as much per WMMA tile as gfx11.
-//   4. C-output mapping (HYPOTHESIS — see below):
-//        gfx11 (validated, commit b7ac66a):
-//          acc[j] = C[2*j + (tid>>4)][tid & 15]
-//        gfx12 (UNVERIFIED, derived from CK kCM0/kCM1PerLane swap):
-//          acc[j] = C[8*(tid>>4) + j][tid & 15]
-//
-// Per Q8_0 block (K=32 elements, 34 bytes): 1 fp16 scale + 32 int8 weights.
-// One Q8 block = 2 WMMA-K-tiles (each tile is 16 K-elements). Each gfx12
-// lane carries 8 of those 16 K-elements per WMMA tile.
-//
-// Grid:  [ceil((q_m + k_m + v_m)/16), ceil(N/16)]
-// Block: [32] (wave32).  LDS: 0.
+// Block-pair invariant: blocks_per_row = K/32 must be EVEN. Production
+// Qwen3.5 9B shapes (K=4096, blocks=128) satisfy this.
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -62,16 +41,12 @@ extern "C" __global__ void gemm_qkv_q8_0_wmma_gfx12(
     if (row_start >= total_m) return;
     if (batch_start >= N)     return;
 
-    // Lane decomposition (gfx12 wave32 WMMA):
-    //   m_lane = tid & 15   (0..15)  -> row index within the 16-row tile
-    //   k_grp  = tid >> 4   (0 or 1) -> which K half-tile this lane carries
     const int m_lane = tid & 15;
     const int k_grp  = tid >> 4;
 
     const int my_row   = row_start + m_lane;
     const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
 
-    // Route to the correct weight matrix for this thread's row.
     const char* A;
     int local_row;
     if (safe_row < q_m) {
@@ -91,50 +66,54 @@ extern "C" __global__ void gemm_qkv_q8_0_wmma_gfx12(
 
     float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-    for (int bi = 0; bi < blocks_per_row; bi++) {
-        const char* bp = row_base + bi * 34;
+    #define DQ8_Q(pk, sc) \
+        a_reg[0] = (sc) * (_Float16)(float)(signed char)(((pk) >>  0) & 0xFFu); \
+        a_reg[1] = (sc) * (_Float16)(float)(signed char)(((pk) >>  8) & 0xFFu); \
+        a_reg[2] = (sc) * (_Float16)(float)(signed char)(((pk) >> 16) & 0xFFu); \
+        a_reg[3] = (sc) * (_Float16)(float)(signed char)(((pk) >> 24) & 0xFFu); \
+        a_reg[4] = (sc) * (_Float16)(float)(signed char)(((pk) >> 32) & 0xFFu); \
+        a_reg[5] = (sc) * (_Float16)(float)(signed char)(((pk) >> 40) & 0xFFu); \
+        a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
+        a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-        // fp16 scale at byte offset 0 (2 bytes). May be 2-byte aligned but
-        // not 4-byte — load via memcpy to avoid unaligned-access UB.
-        _Float16 sc;
+    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+        const char* bp_a = row_base + bi * 34;
+        const char* bp_b = row_base + (bi + 1) * 34;
+
+        _Float16 sc_a, sc_b;
         {
             unsigned short s_bits;
-            __builtin_memcpy(&s_bits, bp, 2);
-            __builtin_memcpy(&sc, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_a, 2); __builtin_memcpy(&sc_a, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_b, 2); __builtin_memcpy(&sc_b, &s_bits, 2);
         }
 
-        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_a = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_b = X + (long long)safe_batch * K + (bi + 1) * 32;
 
-        // === WMMA tile 0 (K-elements 0..16, split between lane-groups) ===
-        //   lane_grp 0 carries weights bp[2 + 0..7] and X[bi*32 + 0..7]
-        //   lane_grp 1 carries weights bp[2 + 8..15] and X[bi*32 + 8..15]
-        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
-        half8_t a0;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a0[i] = sc * (_Float16)(float)(int)w0[i];
-        }
-        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+        unsigned long long pk0a, pk1a, pk0b, pk1b;
+        __builtin_memcpy(&pk0a, bp_a + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1a, bp_a + 2 + 16 + k_grp * 8, 8);
+        __builtin_memcpy(&pk0b, bp_b + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1b, bp_b + 2 + 16 + k_grp * 8, 8);
 
-        // === WMMA tile 1 (K-elements 16..32, split between lane-groups) ===
-        //   lane_grp 0 carries weights bp[2 + 16 + 0..7] and X[bi*32 + 16 + 0..7]
-        //   lane_grp 1 carries weights bp[2 + 16 + 8..15] and X[bi*32 + 16 + 8..15]
-        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
-        half8_t a1;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a1[i] = sc * (_Float16)(float)(int)w1[i];
-        }
-        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+        half8_t b0a = *(const half8_t*)(x_a +  0 + k_grp * 8);
+        half8_t b1a = *(const half8_t*)(x_a + 16 + k_grp * 8);
+        half8_t b0b = *(const half8_t*)(x_b +  0 + k_grp * 8);
+        half8_t b1b = *(const half8_t*)(x_b + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0a, acc);
+        DQ8_Q(pk1a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1a, acc);
+        DQ8_Q(pk0b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
+        DQ8_Q(pk1b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
     }
+    #undef DQ8_Q
 
-    // C-output mapping HYPOTHESIS — mirrors gemm_qkv_hfq4g256_wmma.gfx12:
-    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
-    // i.e. lane group 0 holds output rows 0..7, lane group 1 rows 8..15.
-    // Validate against gfx11 reference for a small golden case before
-    // trusting at scale.
+    // gfx12 C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
     const int out_col = batch_start + m_lane;
     if (out_col >= N) return;
 
@@ -142,7 +121,6 @@ extern "C" __global__ void gemm_qkv_q8_0_wmma_gfx12(
     for (int j = 0; j < 8; j++) {
         const int out_row = row_start + 8 * k_grp + j;
         if (out_row < total_m) {
-            // Route this row to the correct output matrix.
             float* Y;
             int proj_row;
             int proj_m;

--- a/kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkv_q8_0_wmma.gfx12.hip
@@ -15,8 +15,11 @@
 // issued up-front; 4 dequant+WMMA pairs follow back-to-back so the
 // compiler can deep-pipeline VMEM behind WMMA execution.
 //
-// Block-pair invariant: blocks_per_row = K/32 must be EVEN. Production
-// Qwen3.5 9B shapes (K=4096, blocks=128) satisfy this.
+// Block-pair plus tail: the K4 unroll processes 2 Q8 blocks per body,
+// and a final single-block tail handles odd `blocks_per_row`. Production
+// 9B shapes (K=4096, blocks=128) take the fast path with no tail; the
+// tail exists for correctness on small/odd K test shapes (e.g. the
+// every-int8-value-once pattern at K=32 → blocks_per_row=1).
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -76,7 +79,8 @@ extern "C" __global__ void gemm_qkv_q8_0_wmma_gfx12(
         a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
         a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+    int bi = 0;
+    for (; bi + 1 < blocks_per_row; bi += 2) {
         const char* bp_a = row_base + bi * 34;
         const char* bp_b = row_base + (bi + 1) * 34;
 
@@ -110,6 +114,33 @@ extern "C" __global__ void gemm_qkv_q8_0_wmma_gfx12(
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
         DQ8_Q(pk1b, sc_b);
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
+    }
+
+    // Tail: one unpaired block if blocks_per_row is odd. Production
+    // shapes (K=4096, blocks=128) never enter this path.
+    if (bi < blocks_per_row) {
+        const char* bp = row_base + bi * 34;
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        unsigned long long pk0, pk1;
+        __builtin_memcpy(&pk0, bp + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1, bp + 2 + 16 + k_grp * 8, 8);
+
+        half8_t b0 = *(const half8_t*)(x_base +  0 + k_grp * 8);
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0, acc);
+        DQ8_Q(pk1, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1, acc);
     }
     #undef DQ8_Q
 

--- a/kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip
@@ -1,0 +1,131 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// WMMA-accelerated batched 4-way fused Q8_0 GEMM for the Qwen3.5
+// DeltaNet LA preamble (wqkv + wz + w_beta + w_alpha projections).
+//
+// **gfx12 (RDNA4) variant** — sister kernel to gemm_qkvza_q8_0_wmma.hip.
+// Compile with `hipcc --offload-arch=gfx1200` (or gfx1201, ...).
+//
+// SCAFFOLD STATUS (2026-05-14):
+//   First-pass port from gemm_qkvza_q8_0_wmma.hip following the canonical
+//   pattern in gemm_qkv_hfq4g256_wmma.gfx12.hip. C-output mapping is
+//   silicon-validated for the Q8 QKV sibling (test_gemm_q8_qkv_wmma on
+//   R9700 / gfx1201 — 22/22 PASS, 2026-05-14). Mapping reused here.
+//
+// Differences from the gfx11 Q8 kernel: see gemm_qkv_q8_0_wmma.gfx12.hip.
+//   1. _w32_gfx12 builtin
+//   2. half8_t A/B
+//   3. K split across 2 lane-groups (k_grp = tid >> 4)
+//   4. C mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_q8_0_wmma_gfx12(
+    const char*     __restrict__ A_qkv,
+    const char*     __restrict__ A_z,
+    const char*     __restrict__ A_beta,
+    const char*     __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*          __restrict__ Y_qkv,
+    float*          __restrict__ Y_z,
+    float*          __restrict__ Y_beta,
+    float*          __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m     = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start   = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid         = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N)     return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int my_row   = row_start + m_lane;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int blocks_per_row = K / 32;
+    const long long row_stride = (long long)blocks_per_row * 34;
+    const char* row_base = A + (long long)local_row * row_stride;
+
+    const int safe_batch = ((batch_start + m_lane) < N)
+                           ? (batch_start + m_lane) : 0;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int bi = 0; bi < blocks_per_row; bi++) {
+        const char* bp = row_base + bi * 34;
+
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        // Tile 0: K[0..16], split between lane-groups.
+        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
+        half8_t a0;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a0[i] = sc * (_Float16)(float)(int)w0[i];
+        }
+        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+
+        // Tile 1: K[16..32], split between lane-groups.
+        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
+        half8_t a1;
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            a1[i] = sc * (_Float16)(float)(int)w1[i];
+        }
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+    }
+
+    // gfx12 C-output mapping (silicon-validated on R9700, 2026-05-14):
+    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
+    const int out_col = batch_start + m_lane;
+    if (out_col >= N) return;
+
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        const int out_row = row_start + 8 * k_grp + j;
+        if (out_row < total_m) {
+            float* Y;
+            int proj_row;
+            int proj_m;
+            if (out_row < qkv_m) {
+                Y = Y_qkv;   proj_row = out_row;                         proj_m = qkv_m;
+            } else if (out_row < qkv_m + z_m) {
+                Y = Y_z;     proj_row = out_row - qkv_m;                  proj_m = z_m;
+            } else if (out_row < qkv_m + z_m + beta_m) {
+                Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);          proj_m = beta_m;
+            } else {
+                Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m); proj_m = alpha_m;
+            }
+            Y[(long long)out_col * proj_m + proj_row] = acc[j];
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip
@@ -4,20 +4,12 @@
 // WMMA-accelerated batched 4-way fused Q8_0 GEMM for the Qwen3.5
 // DeltaNet LA preamble (wqkv + wz + w_beta + w_alpha projections).
 //
-// **gfx12 (RDNA4) variant** — sister kernel to gemm_qkvza_q8_0_wmma.hip.
-// Compile with `hipcc --offload-arch=gfx1200` (or gfx1201, ...).
+// **gfx12 (RDNA4) variant — K4 unroll**. Same pattern as the gate_up
+// sibling: 2 Q8 blocks (= 4 WMMA tiles) per outer-loop iter, all loads
+// up-front, 4 dequant+WMMA pairs back-to-back. Validated numerically
+// identical to the single-block port via test_gemm_q8_qkvza_wmma.
 //
-// SCAFFOLD STATUS (2026-05-14):
-//   First-pass port from gemm_qkvza_q8_0_wmma.hip following the canonical
-//   pattern in gemm_qkv_hfq4g256_wmma.gfx12.hip. C-output mapping is
-//   silicon-validated for the Q8 QKV sibling (test_gemm_q8_qkv_wmma on
-//   R9700 / gfx1201 — 22/22 PASS, 2026-05-14). Mapping reused here.
-//
-// Differences from the gfx11 Q8 kernel: see gemm_qkv_q8_0_wmma.gfx12.hip.
-//   1. _w32_gfx12 builtin
-//   2. half8_t A/B
-//   3. K split across 2 lane-groups (k_grp = tid >> 4)
-//   4. C mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
+// Block-pair invariant: blocks_per_row = K/32 must be EVEN.
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -71,41 +63,54 @@ extern "C" __global__ void gemm_qkvza_q8_0_wmma_gfx12(
 
     float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-    for (int bi = 0; bi < blocks_per_row; bi++) {
-        const char* bp = row_base + bi * 34;
+    #define DQ8_Q(pk, sc) \
+        a_reg[0] = (sc) * (_Float16)(float)(signed char)(((pk) >>  0) & 0xFFu); \
+        a_reg[1] = (sc) * (_Float16)(float)(signed char)(((pk) >>  8) & 0xFFu); \
+        a_reg[2] = (sc) * (_Float16)(float)(signed char)(((pk) >> 16) & 0xFFu); \
+        a_reg[3] = (sc) * (_Float16)(float)(signed char)(((pk) >> 24) & 0xFFu); \
+        a_reg[4] = (sc) * (_Float16)(float)(signed char)(((pk) >> 32) & 0xFFu); \
+        a_reg[5] = (sc) * (_Float16)(float)(signed char)(((pk) >> 40) & 0xFFu); \
+        a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
+        a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-        _Float16 sc;
+    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+        const char* bp_a = row_base + bi * 34;
+        const char* bp_b = row_base + (bi + 1) * 34;
+
+        _Float16 sc_a, sc_b;
         {
             unsigned short s_bits;
-            __builtin_memcpy(&s_bits, bp, 2);
-            __builtin_memcpy(&sc, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_a, 2); __builtin_memcpy(&sc_a, &s_bits, 2);
+            __builtin_memcpy(&s_bits, bp_b, 2); __builtin_memcpy(&sc_b, &s_bits, 2);
         }
 
-        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_a = X + (long long)safe_batch * K + bi * 32;
+        const _Float16* x_b = X + (long long)safe_batch * K + (bi + 1) * 32;
 
-        // Tile 0: K[0..16], split between lane-groups.
-        const signed char* w0 = (const signed char*)(bp + 2 + k_grp * 8);
-        half8_t a0;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a0[i] = sc * (_Float16)(float)(int)w0[i];
-        }
-        half8_t b0 = *(const half8_t*)(x_base + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a0, b0, acc);
+        unsigned long long pk0a, pk1a, pk0b, pk1b;
+        __builtin_memcpy(&pk0a, bp_a + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1a, bp_a + 2 + 16 + k_grp * 8, 8);
+        __builtin_memcpy(&pk0b, bp_b + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1b, bp_b + 2 + 16 + k_grp * 8, 8);
 
-        // Tile 1: K[16..32], split between lane-groups.
-        const signed char* w1 = (const signed char*)(bp + 2 + 16 + k_grp * 8);
-        half8_t a1;
-        #pragma unroll
-        for (int i = 0; i < 8; i++) {
-            a1[i] = sc * (_Float16)(float)(int)w1[i];
-        }
-        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a1, b1, acc);
+        half8_t b0a = *(const half8_t*)(x_a +  0 + k_grp * 8);
+        half8_t b1a = *(const half8_t*)(x_a + 16 + k_grp * 8);
+        half8_t b0b = *(const half8_t*)(x_b +  0 + k_grp * 8);
+        half8_t b1b = *(const half8_t*)(x_b + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0a, acc);
+        DQ8_Q(pk1a, sc_a);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1a, acc);
+        DQ8_Q(pk0b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
+        DQ8_Q(pk1b, sc_b);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
     }
+    #undef DQ8_Q
 
-    // gfx12 C-output mapping (silicon-validated on R9700, 2026-05-14):
-    //   acc[j] = C[8*(tid>>4) + j][tid & 15]
+    // gfx12 C-output mapping: acc[j] = C[8*(tid>>4) + j][tid & 15]
     const int out_col = batch_start + m_lane;
     if (out_col >= N) return;
 

--- a/kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip
+++ b/kernels/src/gemm_qkvza_q8_0_wmma.gfx12.hip
@@ -9,7 +9,8 @@
 // up-front, 4 dequant+WMMA pairs back-to-back. Validated numerically
 // identical to the single-block port via test_gemm_q8_qkvza_wmma.
 //
-// Block-pair invariant: blocks_per_row = K/32 must be EVEN.
+// Block-pair plus tail: 2 Q8 blocks per K4-unrolled body, plus a single-
+// block tail for odd blocks_per_row (correctness on small/odd K).
 
 typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
 typedef float    __attribute__((ext_vector_type(8))) float8_t;
@@ -73,7 +74,8 @@ extern "C" __global__ void gemm_qkvza_q8_0_wmma_gfx12(
         a_reg[6] = (sc) * (_Float16)(float)(signed char)(((pk) >> 48) & 0xFFu); \
         a_reg[7] = (sc) * (_Float16)(float)(signed char)(((pk) >> 56) & 0xFFu)
 
-    for (int bi = 0; bi < blocks_per_row; bi += 2) {
+    int bi = 0;
+    for (; bi + 1 < blocks_per_row; bi += 2) {
         const char* bp_a = row_base + bi * 34;
         const char* bp_b = row_base + (bi + 1) * 34;
 
@@ -107,6 +109,32 @@ extern "C" __global__ void gemm_qkvza_q8_0_wmma_gfx12(
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0b, acc);
         DQ8_Q(pk1b, sc_b);
         acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1b, acc);
+    }
+
+    // Tail: one unpaired block if blocks_per_row is odd.
+    if (bi < blocks_per_row) {
+        const char* bp = row_base + bi * 34;
+        _Float16 sc;
+        {
+            unsigned short s_bits;
+            __builtin_memcpy(&s_bits, bp, 2);
+            __builtin_memcpy(&sc, &s_bits, 2);
+        }
+
+        const _Float16* x_base = X + (long long)safe_batch * K + bi * 32;
+
+        unsigned long long pk0, pk1;
+        __builtin_memcpy(&pk0, bp + 2 +  0 + k_grp * 8, 8);
+        __builtin_memcpy(&pk1, bp + 2 + 16 + k_grp * 8, 8);
+
+        half8_t b0 = *(const half8_t*)(x_base +  0 + k_grp * 8);
+        half8_t b1 = *(const half8_t*)(x_base + 16 + k_grp * 8);
+
+        half8_t a_reg;
+        DQ8_Q(pk0, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b0, acc);
+        DQ8_Q(pk1, sc);
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b1, acc);
     }
     #undef DQ8_Q
 


### PR DESCRIPTION
## Summary

Adds the gfx12 (RDNA4) sibling kernels for the 4 fused Q8_0 WMMA prefill kernels introduced by #248. PR #248's cross-review correctly removed gfx12 from the `has_wmma_f16` gate because the gfx11-only `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32` builtin JIT-panics on gfx12 codegen; this PR fills that gap with `*.gfx12.hip` siblings using the gfx12 `_w32_gfx12` builtin, then auto-routes the dispatch on gfx12 arch.

**Result on hiptrx R9700 (gfx1201, 64 CU, ~640 GB/s):**
- Q8 9B prefill kernel-only throughput: **1448 tok/s** at prefill=128, **1441 tok/s** at prefill=256
- Within **95–96% of k9lin Nitro+ 7900 XTX kernel throughput** (1525 / 1494 at the same shapes)
- gfx12's 2× per-CU WMMA throughput compensates for R9700's 67% CU/BW ratio vs XTX

Prior to this PR, gfx12 archs fell through to the Tier 2 substrate at ~49 tok/s prefill on the same hardware (29× slower than after this PR).

## What's in the diff (depends on #248)

7 commits on top of `feat/q8-prefill-tier2`:

1. `a2e1c68e feat(q8-wmma): gfx12 sibling for gemm_qkv_q8_0_wmma — scaffold`
2. `79976dac feat(q8-wmma): gfx12 siblings for qkvza / gate_up / residual`
3. `5cfd6351 feat(q8-wmma): auto-route gfx11 Q8 WMMA dispatch to gfx12 sibling`
4. `33098f43 perf(q8-wmma-gfx12): K4 unroll on gate_up gfx12 sibling`
5. `8f56aa93 perf(q8-wmma-gfx12): K4 unroll on qkv / qkvza / residual gfx12 siblings`
6. `0a81fb55 fix(q8-wmma-gfx12): K4 tail handler for odd blocks_per_row`
7. `3aabe5ca bench(q8): split prefill SUMMARY into wall vs kernel-only metrics`

### 4 new gfx12 sibling kernels (kernels/src/)

- `gemm_qkv_q8_0_wmma.gfx12.hip` (FullAttention preamble, 3-way fused)
- `gemm_qkvza_q8_0_wmma.gfx12.hip` (DeltaNet LA preamble, 4-way fused)
- `gemm_gate_up_q8_0_wmma.gfx12.hip` (FFN preamble, 2-way fused)
- `gemm_q8_0_residual_wmma.gfx12.hip` (wo / w_down post-projection, `+=` semantics)

All four follow the canonical pattern from `gemm_qkv_hfq4g256_wmma.gfx12.hip` (HIPa branch, issue #65 lever 2):
1. WMMA builtin: `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12`
2. `half8_t` A/B operands instead of `half16_t` (gfx12 splits K across 2 lane-groups)
3. K dim split: `tid >> 4 == 0` carries K[0..7], `tid >> 4 == 1` carries K[8..15]
4. C-output mapping: `acc[j] = C[8*(tid>>4) + j][tid & 15]`
5. **K4 unroll** (2 Q8 blocks = 4 WMMA tiles per loop body), with uint64 weight packs for single-VMEM-op weight loads; single-block tail handler for odd `blocks_per_row`

### Dispatch wiring (`crates/rdna-compute/src/dispatch.rs`)

Each of `gemm_qkv_q8_0_wmma`, `gemm_qkvza_q8_0_wmma`, `gemm_gate_up_q8_0_wmma`, `gemm_q8_0_residual_wmma` early-outs to its `_gfx12` sibling when `self.arch.starts_with("gfx12")`. gfx11 path is byte-identical to #248; gfx12 path now uses the new kernels. The qwen35.rs `q8_wmma_arch` predicate is extended to admit gfx12.

### Bench SUMMARY split (`crates/hipfire-runtime/examples/bench_qwen35_mq4.rs`)

The single `prefill_tok_s` field on the SUMMARY line conflated wall-clock first-call throughput (includes JIT compile + hipGraph capture) with steady-state kernel throughput. New `PREFILL_SUMMARY` emits both:

```
PREFILL_SUMMARY  prefill_tok_s=689.5  prefill_wall_ms=185.65  prefill_tok_s_kernel=1448.8  prefill_kernel_ms=88.35  startup_overhead_ms=97.30  cold_overhead_pct=52.4
```

Emits right after the prefill PROFILE block — so prefill metrics survive even if the gen phase trips the pre-existing `argmax` panic at `llama.rs:3549` (latent bug in graph-captured gen warmup; unrelated to this PR).

## Validation

### Unit tests on hiptrx R9700 (gfx1201)

| Test | shapes × N | Verdict |
|---|---|---|
| `test_gemm_q8_qkv_wmma` | tiny / medium / 9B FA × {1, 4, 16, 32, 64, 128, 256} + every-int8-value-once | **PASS** — 0 failures, max_rel 1.92e-2 (< 3.5e-2 bound) |
| `test_gemm_q8_qkvza_wmma` | tiny / medium / 9B LA × {1..256} | **PASS** — 0 failures |
| `test_gemm_q8_gate_up_wmma` | tiny / medium / 9B FFN × {1..256} | **PASS** — 0 failures |
| `test_gemm_q8_residual_wmma` | tiny / 9B wo / 9B w_down × {1..256} | **PASS** — 0 failures |

Numerical results within 5–10% relative error of the gfx11 kernels on the same shapes (FP16 WMMA precision floor).

### End-to-end bench (3 fresh-process runs each, `HIPFIRE_DPM_WARMUP_SECS=10`)

| Metric | k9lin gfx1100 (Nitro+ 7900 XTX) | hiptrx gfx1201 (R9700) | R9700 / XTX |
|---|---:|---:|---:|
| **prefill=128 kernel-only** | **1525 tok/s** (±0.6%) | **1448 tok/s** (±0.1%) | **95.0%** |
| prefill=128 wall (cold-start) | 748 tok/s (±0.6%) | 689 tok/s (±0.1%) | 92.2% |
| **prefill=256 kernel-only** | **1494 tok/s** (±0.1%) | **1441 tok/s** (±0.05%) | **96.5%** |
| prefill=256 wall (cold-start) | 750 tok/s (±0.2%) | 700 tok/s (±0.05%) | 93.3% |
| cold-start overhead | ~50% of wall | ~52% of wall | matched |

### Kernel-atlas profile (per-kernel breakdown)

After this PR, the 4 Q8 WMMA kernels dominate gfx1201 prefill time at healthy BW utilization:

```
gemm_gate_up_q8_0_wmma_gfx12    32x  354µs/call  41.4%  290 GiB/s   (45% of R9700 peak)
gemm_q8_0_residual_wmma_gfx12   64x   82µs/call  19.3%  421 GiB/s   (66% of peak)
gemm_qkvza_q8_0_wmma_gfx12      24x  134µs/call  11.8%  387 GiB/s   (60% of peak)
gemm_qkv_q8_0_wmma_gfx12         8x  104µs/call   3.1%  411 GiB/s   (64% of peak)
```

Without the K4 unroll, gate_up sat at 191 GiB/s (30% of peak) and dominated 51.7% of prefill. K4 unroll dropped it to 290 GiB/s / 41.4%.

## Out of scope (deferred)

- **AOT-shipped HSACOs per gfx ID.** Both k9lin (gfx1100) and hiptrx (gfx1201) show ~50% cold-start overhead in wall-clock. Shipping pre-compiled `.hsaco` blobs under `~/.hipfire/bin/kernels/compiled/<arch>/` would collapse that overhead to ~0 from first call. The bench SUMMARY split surfaces this gap; the shipping infra is its own PR.
- **gate_up tuning to close the remaining BW gap.** 290 GiB/s = 45% of R9700 peak vs other 3 kernels at 60–66%. Possible levers: K8 unroll (more registers available; would double X+weight VGPR pressure but stays under launch_bound budget), LDS staging for X across lane groups, or per-shape `__launch_bounds__` tuning. Diminishing returns from here.
- **The `bench_qwen35_mq4` argmax panic at `llama.rs:3549`** when graph-captured gen warmup produces NaN logits — pre-existing, blocks `--prefill-runs > 1`. Worth filing as its own bug; this PR works around it by emitting PREFILL_SUMMARY before the gen phase.

## Suggested kernel_atlas.py patch (separate from this PR)

The HIPa-branch `scripts/kernel_atlas.py` should be extended to capture PREFILL_SUMMARY fields:

```python
def parse_bench_summary(text):
    summary = None
    prefill_summary = None
    for line in text.splitlines():
        if line.startswith("SUMMARY"):
            summary = line
        elif line.startswith("PREFILL_SUMMARY"):
            prefill_summary = line
    if summary is None and prefill_summary is None:
        raise ValueError("bench output did not contain a SUMMARY or PREFILL_SUMMARY line")
    values = {}
    if prefill_summary is not None:
        for key, value in re.findall(r"([A-Za-z0-9_]+)=([0-9.]+)", prefill_summary):
            values[key] = float(value)
    if summary is not None:
        for key, value in re.findall(r"([A-Za-z0-9_]+)=([0-9.]+)", summary):
            values[key] = float(value)
        ...
```

## Test plan

- [x] All 4 Q8 WMMA gfx12 unit tests PASS on hiptrx R9700 (gfx1201)
- [x] gfx11 path byte-identical (no regression on k9lin gfx1100 vs PR #248 base)
- [x] Cross-process A/B with `--prefill 128 --prefill-runs 1 --warmup 10 HIPFIRE_DPM_WARMUP_SECS=10` × 3 invocations on both archs; numbers tight (±0.6% k9lin, ±0.1% hiptrx)
- [x] kernel_atlas profile confirms the new kernels are firing (80%+ of prefill time on gfx1201)
- [x] Output text on hiptrx byte-identical to k9lin on the long-prefill-q8-9b coherence prompt (LRU-cache reasoning, no attractor, no special-token leakage)
- [ ] Reviewer to verify on a second gfx12 variant (9070 XT or 9070 GRE) if available
- [ ] Coherence-gate on hiptrx with this branch (gate ran into the pre-existing argmax-NaN panic; planning to fix separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
