### PR TITLE
feat(atlas): typed AtlasRow + bench --emit-atlas (collection layer 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hipfire-atlas"
+version = "0.1.20"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hipfire-detect"
 version = "0.1.20"
 dependencies = [
@@ -191,6 +199,7 @@ dependencies = [
  "hipfire-arch-llama",
  "hipfire-arch-qwen35",
  "hipfire-arch-qwen35-vl",
+ "hipfire-atlas",
  "hipfire-detect",
  "libc",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/hipfire-arch-toy",
     "crates/hipfire-quantize",
     "crates/hipfire-detect",
+    "crates/hipfire-atlas",
     "crates/redline",
 ]
 

--- a/crates/hipfire-atlas/Cargo.toml
+++ b/crates/hipfire-atlas/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hipfire-atlas"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Kernel Atlas: typed measurement schema + JSONL writer for hipfire bench corpus"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[[bin]]
+name = "hipfire-atlas"
+path = "src/main.rs"

--- a/crates/hipfire-atlas/src/lib.rs
+++ b/crates/hipfire-atlas/src/lib.rs
@@ -1,0 +1,19 @@
+//! Kernel Atlas: typed schema + JSONL writer for hipfire bench corpus.
+//!
+//! This crate is the **Rust collection layer** of the three-layer Atlas
+//! architecture (see `docs/methodology/kernel-atlas-architecture.md`):
+//!
+//! 1. **Collection (this crate)** — bench tools emit typed `AtlasRow`
+//!    values directly. No stdout-scraping, no regex.
+//! 2. **Analysis** — `scripts/kernel_atlas.py` (on the HIPa branch)
+//!    handles ranking, render, suggest, task-bundle generation.
+//! 3. **Advisor** — future autotuner / advisor model consumes the corpus.
+//!
+//! The on-disk JSONL shape matches the Python harness so both layers
+//! share a corpus.
+
+pub mod schema;
+
+pub use schema::{
+    load_row, load_rows, truncate_jsonl, value_object, AtlasRow, ATLAS_SCHEMA,
+};

--- a/crates/hipfire-atlas/src/main.rs
+++ b/crates/hipfire-atlas/src/main.rs
@@ -1,0 +1,103 @@
+//! `hipfire-atlas` CLI — minimal entry-point for the Rust collection
+//! layer. Today this binary only handles **corpus reading** (verify a
+//! row, count rows, dump as pretty JSON). The collection itself happens
+//! inside the bench binaries (`bench_qwen35_mq4 --emit-atlas <path>`,
+//! etc.) which depend on the `hipfire-atlas` library directly.
+//!
+//! The Python harness `scripts/kernel_atlas.py` is the analysis layer
+//! and stays in Python — pandas-style ranking iterates faster there.
+
+use hipfire_atlas::load_rows;
+
+fn print_usage() {
+    eprintln!("hipfire-atlas — kernel atlas corpus tool");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("  hipfire-atlas read <path.jsonl>          show row count + first row pretty");
+    eprintln!("  hipfire-atlas count <path.jsonl>         print number of rows");
+    eprintln!("  hipfire-atlas head <path.jsonl> [N]      print first N rows (default 1)");
+    eprintln!();
+    eprintln!("For collection: use the bench tools' --emit-atlas <path> flag.");
+    eprintln!("For analysis: scripts/kernel_atlas.py on the HIPa branch.");
+}
+
+fn cmd_count(path: &str) -> Result<(), String> {
+    let rows = load_rows(path)?;
+    println!("{}", rows.len());
+    Ok(())
+}
+
+fn cmd_head(path: &str, n: usize) -> Result<(), String> {
+    let rows = load_rows(path)?;
+    for row in rows.iter().take(n) {
+        let pretty = serde_json::to_string_pretty(row)
+            .map_err(|e| format!("serialize row: {e}"))?;
+        println!("{pretty}");
+    }
+    Ok(())
+}
+
+fn cmd_read(path: &str) -> Result<(), String> {
+    let rows = load_rows(path)?;
+    println!("rows: {}", rows.len());
+    if let Some(first) = rows.first() {
+        let pretty = serde_json::to_string_pretty(first)
+            .map_err(|e| format!("serialize first row: {e}"))?;
+        println!("first row:");
+        println!("{pretty}");
+    }
+    Ok(())
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        print_usage();
+        return Err("missing subcommand".into());
+    }
+    match args[1].as_str() {
+        "read" if args.len() == 3 => cmd_read(&args[2]),
+        "count" if args.len() == 3 => cmd_count(&args[2]),
+        "head" if args.len() == 3 => cmd_head(&args[2], 1),
+        "head" if args.len() == 4 => {
+            let n: usize = args[3].parse().map_err(|e| format!("invalid N: {e}"))?;
+            cmd_head(&args[2], n)
+        }
+        "-h" | "--help" | "help" => {
+            print_usage();
+            Ok(())
+        }
+        other => {
+            print_usage();
+            Err(format!("unknown or malformed subcommand: {other}"))
+        }
+    }
+}
+
+fn main() {
+    if let Err(msg) = run() {
+        eprintln!("error: {msg}");
+        std::process::exit(1);
+    }
+}
+
+// Self-check: AtlasRow round-trips through JSONL without losing the
+// flatten'd extra fields.
+#[cfg(test)]
+mod tests {
+    use hipfire_atlas::AtlasRow;
+    use serde_json::json;
+
+    #[test]
+    fn row_roundtrip() {
+        let mut row = AtlasRow::new("ar", "qwen3.5-9b");
+        row.set_metric_f64("prefill_tok_s", 1432.5)
+            .set_metric_f64("prefill_kernel_ms", 88.4)
+            .set_extra("git_sha", json!("46632a35"));
+        let text = serde_json::to_string(&row).unwrap();
+        let back: AtlasRow = serde_json::from_str(&text).unwrap();
+        assert_eq!(back.workload_kind, "qwen3.5-9b");
+        assert_eq!(back.metric_f64("prefill_tok_s"), Some(1432.5));
+        assert_eq!(back.extra.get("git_sha"), Some(&json!("46632a35")));
+    }
+}

--- a/crates/hipfire-atlas/src/schema.rs
+++ b/crates/hipfire-atlas/src/schema.rs
@@ -1,0 +1,152 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+pub const ATLAS_SCHEMA: &str = "hipfire.kernel_atlas.v0";
+
+/// A single row in the kernel atlas corpus. Mirrors the JSONL shape
+/// emitted by `scripts/kernel_atlas.py` so this Rust crate and the
+/// Python analysis layer share the same on-disk format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AtlasRow {
+    #[serde(default = "default_schema")]
+    pub schema: String,
+    #[serde(default)]
+    pub phase: String,
+    #[serde(default)]
+    pub workload_kind: String,
+    #[serde(default)]
+    pub model_size: String,
+    #[serde(default)]
+    pub quant: String,
+    #[serde(default)]
+    pub shape_bucket: String,
+    #[serde(default)]
+    pub run_index: Option<u32>,
+    #[serde(default)]
+    pub metrics: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub artifacts: BTreeMap<String, Value>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+fn default_schema() -> String {
+    ATLAS_SCHEMA.to_string()
+}
+
+impl AtlasRow {
+    pub fn new(phase: impl Into<String>, workload_kind: impl Into<String>) -> Self {
+        Self {
+            schema: default_schema(),
+            phase: phase.into(),
+            workload_kind: workload_kind.into(),
+            model_size: String::new(),
+            quant: String::new(),
+            shape_bucket: String::new(),
+            run_index: None,
+            metrics: BTreeMap::new(),
+            artifacts: BTreeMap::new(),
+            extra: BTreeMap::new(),
+        }
+    }
+
+    /// Insert a numeric metric. `f64` is the canonical numeric type for
+    /// throughput / latency / bandwidth measurements.
+    pub fn set_metric_f64(&mut self, key: impl Into<String>, value: f64) -> &mut Self {
+        self.metrics.insert(key.into(), Value::from(value));
+        self
+    }
+
+    pub fn set_metric_u64(&mut self, key: impl Into<String>, value: u64) -> &mut Self {
+        self.metrics.insert(key.into(), Value::from(value));
+        self
+    }
+
+    pub fn set_metric_str(&mut self, key: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.metrics.insert(key.into(), Value::String(value.into()));
+        self
+    }
+
+    pub fn set_extra(&mut self, key: impl Into<String>, value: Value) -> &mut Self {
+        self.extra.insert(key.into(), value);
+        self
+    }
+
+    pub fn metric_f64(&self, key: &str) -> Option<f64> {
+        self.metrics.get(key).and_then(Value::as_f64)
+    }
+
+    pub fn metric_u64(&self, key: &str) -> Option<u64> {
+        self.metrics.get(key).and_then(Value::as_u64)
+    }
+
+    pub fn artifact_array(&self, key: &str) -> Option<&Vec<Value>> {
+        self.artifacts.get(key).and_then(Value::as_array)
+    }
+
+    pub fn to_value(&self) -> serde_json::Result<Value> {
+        serde_json::to_value(self)
+    }
+
+    /// Append this row to a JSONL file, creating it if it doesn't exist.
+    /// The file is opened in append mode so concurrent writers from
+    /// independent processes coexist without overwriting each other.
+    pub fn append_to_jsonl(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        let line = serde_json::to_string(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        writeln!(file, "{line}")?;
+        Ok(())
+    }
+}
+
+/// Load all rows from a JSONL (or single-line JSON, or JSON array) file.
+pub fn load_rows(path: impl AsRef<Path>) -> Result<Vec<AtlasRow>, String> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let trimmed = text.trim_start();
+    if trimmed.starts_with('[') {
+        serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))
+    } else if trimmed.starts_with('{') && text.lines().count() == 1 {
+        let row: AtlasRow =
+            serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))?;
+        Ok(vec![row])
+    } else {
+        let mut rows = Vec::new();
+        for (idx, line) in text.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let row: AtlasRow = serde_json::from_str(line)
+                .map_err(|e| format!("parse {} line {}: {e}", path.display(), idx + 1))?;
+            rows.push(row);
+        }
+        Ok(rows)
+    }
+}
+
+pub fn load_row(path: impl AsRef<Path>, row_index: usize) -> Result<AtlasRow, String> {
+    let rows = load_rows(path)?;
+    rows.get(row_index)
+        .cloned()
+        .ok_or_else(|| format!("row index {row_index} out of range; rows={}", rows.len()))
+}
+
+pub fn value_object(pairs: impl IntoIterator<Item = (String, Value)>) -> Value {
+    Value::Object(Map::from_iter(pairs))
+}
+
+/// Open a fresh JSONL file for writing, truncating any existing content.
+/// Use this when starting a new collection run; subsequent rows append
+/// via `AtlasRow::append_to_jsonl`.
+pub fn truncate_jsonl(path: impl AsRef<Path>) -> std::io::Result<()> {
+    let _ = File::create(path)?;
+    Ok(())
+}

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -83,6 +83,7 @@ hipfire-arch-qwen35 = { path = "../hipfire-arch-qwen35" }
 hipfire-arch-qwen35-vl = { path = "../hipfire-arch-qwen35-vl" }
 hipfire-arch-llama = { path = "../hipfire-arch-llama" }
 hipfire-detect = { path = "../hipfire-detect" }
+hipfire-atlas = { path = "../hipfire-atlas" }
 
 # Each example below carries `required-features` listing the cargo
 # features its `use hipfire_arch_*` imports depend on. This documents

--- a/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
+++ b/crates/hipfire-runtime/examples/bench_qwen35_mq4.rs
@@ -19,7 +19,7 @@ fn main() {
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: bench_qwen35_mq4 <model.hfq> [--prefill N] [--prefill-runs N] [--gen N] [--warmup N]");
+        eprintln!("Usage: bench_qwen35_mq4 <model.hfq> [--prefill N] [--prefill-runs N] [--gen N] [--warmup N] [--emit-atlas <path.jsonl>]");
         std::process::exit(1);
     }
     let model_path = &args[1];
@@ -29,6 +29,10 @@ fn main() {
     let mut prefill_runs: usize = 1;
     let mut gen_len: usize = 100;
     let mut warmup_len: usize = 5;
+    // Optional kernel-atlas emission: when set, write one typed AtlasRow
+    // per timed phase (prefill, decode_ar) to this JSONL file. Replaces
+    // stdout-scraping by external collectors like scripts/kernel_atlas.py.
+    let mut atlas_out: Option<String> = None;
     let mut i = 2;
     while i < args.len() {
         match args[i].as_str() {
@@ -36,6 +40,7 @@ fn main() {
             "--prefill-runs" => { prefill_runs = args[i + 1].parse::<usize>().unwrap().max(1); i += 2; }
             "--gen"     => { gen_len     = args[i + 1].parse().unwrap(); i += 2; }
             "--warmup"  => { warmup_len  = args[i + 1].parse().unwrap(); i += 2; }
+            "--emit-atlas" => { atlas_out = Some(args[i + 1].clone()); i += 2; }
             other => { eprintln!("unknown arg: {other}"); std::process::exit(1); }
         }
     }
@@ -200,6 +205,39 @@ fn main() {
     eprintln!("PREFILL_SUMMARY  prefill_tok_s={prefill_tok_s:.1}  prefill_wall_ms={prefill_ms:.2}{}",
         split_prefill_summary(prefill_len, prefill_ms, prefill_kernel_ms));
 
+    // Atlas row: typed prefill measurement. Emitted right here so it
+    // survives any panic in the gen phase. Eliminates the stdout-scrape
+    // round-trip the Python harness would otherwise do.
+    if let Some(ref atlas_path) = atlas_out {
+        let mut row = hipfire_atlas::AtlasRow::new("prefill", "bench_qwen35_mq4");
+        row.set_metric_f64("prefill_tok_s", prefill_tok_s)
+            .set_metric_f64("prefill_wall_ms", prefill_ms)
+            .set_metric_u64("prefill_tokens", prefill_len as u64)
+            .set_metric_u64("prefill_runs", prefill_runs as u64)
+            .set_metric_str("kv_mode", &kv_mode)
+            .set_metric_str("arch", &gpu.arch)
+            .set_metric_str("model_path", model_path)
+            .set_metric_u64("model_bytes", model_bytes)
+            .set_extra("captured_at_unix_s", serde_json::Value::from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+            ));
+        if let Some(kernel_ms) = prefill_kernel_ms {
+            let prefill_tok_s_kernel = prefill_len as f64 / (kernel_ms / 1000.0);
+            row.set_metric_f64("prefill_kernel_ms", kernel_ms);
+            row.set_metric_f64("prefill_tok_s_kernel", prefill_tok_s_kernel);
+            row.set_metric_f64("startup_overhead_ms", prefill_ms - kernel_ms);
+            if prefill_ms > 0.0 {
+                row.set_metric_f64("cold_overhead_pct", (prefill_ms - kernel_ms) / prefill_ms * 100.0);
+            }
+        }
+        if let Err(e) = row.append_to_jsonl(atlas_path) {
+            eprintln!("WARN: failed to append atlas row to {atlas_path}: {e}");
+        }
+    }
+
     // (deferred-conversion mode removed with givens — asym modes are natively
     //  batched so there's no prefill/decode cache swap to measure.)
 
@@ -316,6 +354,28 @@ fn main() {
     eprintln!();
     eprintln!("SUMMARY  gen_tok_s={gen_tok_s:.1}  bw_gib_s={bw_gbps:.1}  prefill_tok_s={prefill_tok_s:.1}  avg_ms={avg_ms:.2}  p50_ms={p50_ms:.2}{}",
         split_prefill_summary(prefill_len, prefill_ms, prefill_kernel_ms));
+
+    // Decode atlas row (gen phase). Pairs with the prefill row emitted
+    // earlier so a single bench invocation produces two phase-tagged rows.
+    if let Some(ref atlas_path) = atlas_out {
+        let mut row = hipfire_atlas::AtlasRow::new("decode_ar", "bench_qwen35_mq4");
+        row.set_metric_f64("gen_tok_s", gen_tok_s)
+            .set_metric_f64("bw_gib_s", bw_gbps)
+            .set_metric_f64("avg_ms", avg_ms)
+            .set_metric_f64("p50_ms", p50_ms)
+            .set_metric_f64("p90_ms", p90_ms)
+            .set_metric_f64("p99_ms", p99_ms)
+            .set_metric_f64("min_ms", min_ms)
+            .set_metric_f64("max_ms", max_ms)
+            .set_metric_u64("gen_tokens", n as u64)
+            .set_metric_str("kv_mode", &kv_mode)
+            .set_metric_str("arch", &gpu.arch)
+            .set_metric_str("model_path", model_path)
+            .set_metric_u64("model_bytes", model_bytes);
+        if let Err(e) = row.append_to_jsonl(atlas_path) {
+            eprintln!("WARN: failed to append atlas row to {atlas_path}: {e}");
+        }
+    }
 }
 
 /// Emit the latency-class split for prefill when profiling captured the

--- a/docs/methodology/kernel-atlas-architecture.md
+++ b/docs/methodology/kernel-atlas-architecture.md
@@ -1,0 +1,170 @@
+# Kernel Atlas — three-layer architecture
+
+The Kernel Atlas is hipfire's **measurement corpus for kernel performance
+data**. It's separate from Astrea, which is the **measurement corpus for
+quantization quality**. Astrea's PR explicitly documents an "Atlas
+handoff" — once a quant passes Astrea's KLD/MSE quality gates, Atlas
+takes over to measure how fast its kernels actually run.
+
+This doc captures the three-layer split that survived discovery, why
+each layer ends up in the language it does, and the migration path
+from "stdout-scrape" collection to typed in-process emission.
+
+## The three layers
+
+### Layer 1 — Collection (Rust, in-process)
+
+**Job:** Capture per-row measurements from running bench/inference
+binaries. One row per (workload × phase × variant). Each row is a typed
+`AtlasRow` struct serialized to JSONL.
+
+**Why Rust:** The data comes from the bench binaries themselves
+(`bench_qwen35_mq4`, `dflash_spec_demo`, …). Having those binaries emit
+typed `AtlasRow` values directly — via the `hipfire-atlas` crate — is
+strictly safer than the legacy approach of:
+
+1. Bench binary prints `SUMMARY  prefill_tok_s=1432 …` to stderr
+2. Python wrapper regexes the line into a dict
+3. Python wrapper writes JSONL
+
+The regex contract is silently fragile: a new metric requires changes
+in both places, and a format drift breaks Python collection without
+the bench noticing. Today's `PREFILL_SUMMARY` addition is a recent
+example — adding a new field worked by *luck* (the regex
+`[A-Za-z0-9_]+=[0-9.]+` happened to match it). Typed in-process
+emission eliminates that whole class of breakage.
+
+**API surface:**
+
+```rust
+use hipfire_atlas::AtlasRow;
+
+let mut row = AtlasRow::new("prefill", "bench_qwen35_mq4");
+row.set_metric_f64("prefill_tok_s", 1432.5)
+   .set_metric_f64("prefill_kernel_ms", 88.4)
+   .set_metric_str("arch", "gfx1100")
+   .set_metric_u64("prefill_tokens", 128);
+row.append_to_jsonl(atlas_path)?;
+```
+
+**Wired today:**
+- `bench_qwen35_mq4 --emit-atlas <path.jsonl>` writes a `prefill` row
+  after the prefill phase and a `decode_ar` row after the gen phase.
+
+**Wired tomorrow (deferred):**
+- `dflash_spec_demo --emit-atlas <path.jsonl>` writes a `decode_dflash`
+  row including τ, accepted tokens, cycle count.
+- Per-kernel profile capture inside the binary — instead of grepping
+  the `=== PROFILE ===` stdout block, the binary writes
+  `artifacts.profile_kernels` directly from `rdna_compute::profile::stop()`.
+- ISA manifest capture via in-process `clang-offload-bundler` +
+  `llvm-readelf` invocations — replaces the current Python subprocess
+  chain in `scripts/kernel_atlas.py`.
+
+### Layer 2 — Analysis (Python, out-of-process)
+
+**Job:** Rank rows, render ASCII fit tables, suggest tuning targets,
+generate optimization-task JSON bundles for an agent or human.
+
+**Why Python:** Ad-hoc analysis iterates faster in Python. The pandas
+ecosystem, matplotlib for plotting, jupyter for poking — these are
+*much* nicer than equivalent Rust setups for the
+"load 1000 rows, group by quant × arch × shape, show the median"
+workflow that dominates Atlas analysis.
+
+**Tool:** `scripts/kernel_atlas.py` on the HIPa branch. Keep it.
+
+**The migration:** Once Layer 1 is wired everywhere, the Python tool
+stops being a *collector* (no more subprocess `bench && grep`) and
+becomes purely an *analyzer* (`load_rows(path)` + ranking + render).
+That removes ~200 lines of subprocess plumbing from the Python script
+and makes it a much smaller surface.
+
+### Layer 3 — Advisor (future, language TBD)
+
+**Job:** Consume the corpus and *suggest* tuning changes — register-
+budget retunes, K-unroll factors, dispatch heuristics — either via a
+hand-coded ranker or an autotuner / LLM advisor pipeline.
+
+**Why not committed yet:** We don't have enough corpus volume to make
+this worth building. When we do, it'll likely live in Rust for the
+embed-in-engine case (advisor runs alongside inference) and Python for
+the offline-research case (advisor runs in a notebook).
+
+## Concrete migration steps
+
+| Step | Change | Status |
+|---|---|---|
+| 1 | `crates/hipfire-atlas/` crate with typed `AtlasRow` + JSONL writer | ✓ this PR |
+| 2 | `bench_qwen35_mq4 --emit-atlas <path>` writes prefill + decode_ar rows | ✓ this PR |
+| 3 | `dflash_spec_demo --emit-atlas <path>` writes decode_dflash rows | TODO |
+| 4 | Profile capture in-process (no `=== PROFILE ===` stdout grepping) | TODO |
+| 5 | `scripts/kernel_atlas.py` switches from subprocess+grep to `subprocess hipfire-atlas` for collection orchestration; analysis stays Python | TODO |
+| 6 | ISA manifest capture in-process via Rust wrappers around `clang-offload-bundler` | TODO |
+
+## On-disk schema invariants
+
+- One row per line (JSONL)
+- `schema` field always reads `"hipfire.kernel_atlas.v0"` (semver later)
+- `phase` is one of: `"prefill"`, `"decode_ar"`, `"decode_dflash"`
+- `workload_kind` identifies the binary or workload class
+  (`"bench_qwen35_mq4"`, `"dflash_spec_demo"`, etc.)
+- `metrics` holds numeric measurements (canonical types: `f64` for
+  throughput/latency/bandwidth, `u64` for counts, `String` for
+  categorical labels like `arch` or `kv_mode`)
+- `artifacts` holds nested-structure data (per-kernel profile tables,
+  ISA manifests, lineage refs)
+- Extra fields flatten into the row object — useful for
+  `captured_at_unix_s`, `git_sha`, `hostname` etc. without polluting
+  `metrics`
+
+Compatible with the JSONL emitted by `scripts/kernel_atlas.py` so a
+mixed corpus from both layers is parseable by either tool.
+
+## Why not pick one language?
+
+Because the layers have genuinely different workloads:
+
+- **Collection needs trust.** A regex-fragile Python parser that
+  silently drops a new field is worse than no collection. The bench
+  binary that knows the metric should write it directly.
+- **Analysis needs iteration speed.** Re-running a Rust analyzer to
+  change one ranking heuristic is friction; Python is a notebook away.
+- **Advisor needs both.** When we get there, the in-engine variant
+  goes in Rust (no Python in the inference hot path, per the
+  project rule), and the offline variant stays Python.
+
+## Relationship to Astrea
+
+Astrea (`scripts/astrea.py`, agent skill at `.agents/skills/astrea/`)
+covers the **quality** axis: KLD vs BF16 reference, per-layer error
+attribution, PyTorch oracle replay, calibration recipes.
+
+Atlas covers the **performance** axis: tok/s, GiB/s, per-kernel timing,
+ISA manifests.
+
+The two are designed to compose:
+
+1. Astrea picks a candidate quant variant, verifies its KLD floor.
+2. Astrea hands off to Atlas via a workflow contract documented in the
+   skill (`Atlas handoff` section).
+3. Atlas measures the kernels for that variant, writes rows.
+4. Both corpora indexed by `git_sha` + workload, so a single experiment
+   joins to one Astrea row + N Atlas rows.
+
+Neither tool duplicates the other; merging them would force a single
+language choice that hurts both axes.
+
+## Open follow-ups
+
+- **AOT-shipped HSACOs per gfx ID.** The Atlas
+  `startup_overhead_ms` and `cold_overhead_pct` fields will collapse
+  to ~0 when bench tools no longer pay JIT compile cost on first call.
+  See PR #253 description for the perf gap this would close (~50% on
+  both gfx1100 and gfx1201 today).
+- **`bench_qwen35_mq4` argmax-NaN panic at `llama.rs:3549`** during
+  graph-captured gen warmup blocks the decode_ar atlas row from
+  emitting. Prefill row still writes (emitted before the panic).
+  Filing as its own bug.
+- **`dflash_spec_demo --emit-atlas`** and **profile-capture-in-process**
+  are the next concrete deliverables for Layer 1.


### PR DESCRIPTION
See commit message for details + `docs/methodology/kernel-atlas-architecture.md` for the full three-layer architecture writeup.

## TL;DR

- Introduces `crates/hipfire-atlas/` — the **Rust collection layer** of Kernel Atlas. Bench binaries emit typed `AtlasRow` to JSONL directly, replacing the stdout-scrape + Python-regex contract.
- `bench_qwen35_mq4 --emit-atlas <path.jsonl>` writes prefill and decode_ar rows in one invocation.
- `hipfire-atlas read|count|head` CLI binary for corpus inspection.
- Methodology doc explains why **collection lives in Rust** (regex-fragile parsers silently drop new fields; typed in-process emission eliminates that) but **analysis stays Python** (`scripts/kernel_atlas.py` on HIPa) for pandas-style iteration speed.
- Astrea handles quality, Atlas handles perf — they compose, neither duplicates the other.

## Verified

End-to-end smoke on k9lin gfx1100: `bench_qwen35_mq4 --emit-atlas /tmp/atlas.jsonl` produces a typed row with all metrics (wall + kernel split, overhead %, arch, kv_mode, etc.), readable by `hipfire-atlas head` and structurally compatible with the JSONL written by `scripts/kernel_atlas.py`.

## Test plan

- [x] `cargo build --release -p hipfire-atlas` clean
- [x] `cargo build --release -p hipfire-runtime --example bench_qwen35_mq4 --features deltanet` clean
- [x] `bench_qwen35_mq4 --emit-atlas` writes well-formed JSONL on gfx1100
- [x] `hipfire-atlas head` reads the emitted row back
- [ ] Reviewer to verify on gfx1201 / gfx1151

## Follow-ups (documented in the methodology doc)

- `dflash_spec_demo --emit-atlas` (same pattern, decode_dflash phase)
- In-process profile + ISA manifest capture (replaces clang-offload-bundler subprocess chain in scripts/kernel_atlas.py)
- Once collection is fully wired in-process, the Python harness sheds ~200 lines of subprocess plumbing and becomes pure analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)