### PR TITLE
feat(atlas): full tooling — parse / render / suggest / task / eval modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
 name = "hipfire-atlas"
 version = "0.1.20"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/crates/hipfire-atlas/Cargo.toml
+++ b/crates/hipfire-atlas/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Kernel Atlas: typed measurement schema + JSONL writer for hipfire bench corpus"
 
 [dependencies]
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/hipfire-atlas/src/eval.rs
+++ b/crates/hipfire-atlas/src/eval.rs
@@ -1,0 +1,64 @@
+use crate::task::TaskBundle;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandResult {
+    pub command: String,
+    pub status: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalResult {
+    pub schema: String,
+    pub task_id: String,
+    pub status: String,
+    pub commands: Vec<CommandResult>,
+}
+
+pub fn eval_task_file(path: impl AsRef<Path>, cwd: Option<&str>) -> Result<EvalResult, String> {
+    let text = fs::read_to_string(path.as_ref())
+        .map_err(|e| format!("read task {}: {e}", path.as_ref().display()))?;
+    let task: TaskBundle = serde_json::from_str(&text)
+        .map_err(|e| format!("parse task {}: {e}", path.as_ref().display()))?;
+    eval_task(&task, cwd)
+}
+
+pub fn eval_task(task: &TaskBundle, cwd: Option<&str>) -> Result<EvalResult, String> {
+    let mut commands = Vec::new();
+    for command in task
+        .correctness_commands
+        .iter()
+        .chain(task.eval_commands.iter())
+    {
+        commands.push(run_shell(command, cwd)?);
+    }
+    let pass = commands.iter().all(|result| result.status == 0);
+    Ok(EvalResult {
+        schema: "hipfire.kernel_atlas.eval.v0".to_string(),
+        task_id: task.task_id.clone(),
+        status: if pass { "pass" } else { "fail" }.to_string(),
+        commands,
+    })
+}
+
+fn run_shell(command: &str, cwd: Option<&str>) -> Result<CommandResult, String> {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-lc").arg(command);
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("run command {command:?}: {e}"))?;
+    Ok(CommandResult {
+        command: command.to_string(),
+        status: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}

--- a/crates/hipfire-atlas/src/lib.rs
+++ b/crates/hipfire-atlas/src/lib.rs
@@ -1,18 +1,24 @@
-//! Kernel Atlas: typed schema + JSONL writer for hipfire bench corpus.
+//! Kernel Atlas: typed schema + JSONL writer + analysis helpers for the
+//! hipfire bench corpus.
 //!
-//! This crate is the **Rust collection layer** of the three-layer Atlas
-//! architecture (see `docs/methodology/kernel-atlas-architecture.md`):
+//! See `docs/methodology/kernel-atlas-architecture.md` for the
+//! three-layer split:
 //!
-//! 1. **Collection (this crate)** — bench tools emit typed `AtlasRow`
-//!    values directly. No stdout-scraping, no regex.
+//! 1. **Collection (this crate)** — bench/inference binaries emit typed
+//!    [`AtlasRow`] values via `--emit-atlas <path>`. No stdout-scraping.
 //! 2. **Analysis** — `scripts/kernel_atlas.py` (on the HIPa branch)
-//!    handles ranking, render, suggest, task-bundle generation.
+//!    handles ranking and pandas-style iteration.
 //! 3. **Advisor** — future autotuner / advisor model consumes the corpus.
 //!
-//! The on-disk JSONL shape matches the Python harness so both layers
-//! share a corpus.
+//! The legacy stdout parsers in [`parse`] remain as a migration bridge
+//! for captures from binaries not yet wired with `--emit-atlas`.
 
+pub mod eval;
+pub mod parse;
+pub mod render;
 pub mod schema;
+pub mod suggest;
+pub mod task;
 
 pub use schema::{
     load_row, load_rows, truncate_jsonl, value_object, AtlasRow, ATLAS_SCHEMA,

--- a/crates/hipfire-atlas/src/main.rs
+++ b/crates/hipfire-atlas/src/main.rs
@@ -1,24 +1,54 @@
-//! `hipfire-atlas` CLI — minimal entry-point for the Rust collection
-//! layer. Today this binary only handles **corpus reading** (verify a
-//! row, count rows, dump as pretty JSON). The collection itself happens
-//! inside the bench binaries (`bench_qwen35_mq4 --emit-atlas <path>`,
-//! etc.) which depend on the `hipfire-atlas` library directly.
+//! `hipfire-atlas` CLI — corpus inspection, legacy stdout parsing,
+//! render-fit, suggestion, and task-bundle generation.
 //!
-//! The Python harness `scripts/kernel_atlas.py` is the analysis layer
-//! and stays in Python — pandas-style ranking iterates faster there.
+//! Collection itself happens inside bench/inference binaries via
+//! `--emit-atlas <path>`. This binary covers everything *around* that
+//! collection: reading corpora, parsing legacy bench captures into rows,
+//! ranking, rendering, and generating task bundles.
+//!
+//! For ad-hoc analysis at scale, use `scripts/kernel_atlas.py` on the
+//! HIPa branch instead — pandas/notebook iteration is faster there for
+//! large rankings.
 
-use hipfire_atlas::load_rows;
+use hipfire_atlas::{
+    eval::eval_task_file,
+    load_rows,
+    parse::{bench_rows_from_output, dflash_row_from_output},
+    render::render_fit_view,
+    schema::{load_row, AtlasRow},
+    suggest::{suggestions_for_row, suggestions_markdown},
+    task::{pytorch_task, task_from_row},
+};
+use std::fs;
 
 fn print_usage() {
     eprintln!("hipfire-atlas — kernel atlas corpus tool");
     eprintln!();
-    eprintln!("Usage:");
-    eprintln!("  hipfire-atlas read <path.jsonl>          show row count + first row pretty");
-    eprintln!("  hipfire-atlas count <path.jsonl>         print number of rows");
-    eprintln!("  hipfire-atlas head <path.jsonl> [N]      print first N rows (default 1)");
+    eprintln!("Corpus inspection:");
+    eprintln!("  hipfire-atlas read <path.jsonl>             show row count + first row pretty");
+    eprintln!("  hipfire-atlas count <path.jsonl>            print number of rows");
+    eprintln!("  hipfire-atlas head <path.jsonl> [N]         print first N rows (default 1)");
     eprintln!();
-    eprintln!("For collection: use the bench tools' --emit-atlas <path> flag.");
-    eprintln!("For analysis: scripts/kernel_atlas.py on the HIPa branch.");
+    eprintln!("Legacy stdout parsing (migration bridge):");
+    eprintln!("  hipfire-atlas parse-bench <bench_stdout.txt> <out.jsonl>");
+    eprintln!("                                              parse a captured bench_qwen35_mq4");
+    eprintln!("                                              stdout into prefill + decode_ar rows");
+    eprintln!("  hipfire-atlas parse-dflash <dflash_stdout.txt> <out.jsonl>");
+    eprintln!("                                              parse a captured dflash_spec_demo");
+    eprintln!("                                              stdout into a decode_dflash row");
+    eprintln!();
+    eprintln!("Analysis:");
+    eprintln!("  hipfire-atlas render-fit <path.jsonl> [INDEX]  ASCII fit view of one row");
+    eprintln!("  hipfire-atlas suggest <path.jsonl> [INDEX] [MAX]  ranked tuning suggestions");
+    eprintln!("  hipfire-atlas task <path.jsonl> [INDEX]     emit TaskBundle JSON for a row");
+    eprintln!("  hipfire-atlas task-pytorch <name> <op> <shape> <dtype> <eval_cmd>");
+    eprintln!("                                              emit a TaskBundle for a PyTorch shape");
+    eprintln!();
+    eprintln!("Eval:");
+    eprintln!("  hipfire-atlas eval <task.json> [CWD]        run task's correctness+eval commands");
+    eprintln!();
+    eprintln!("For collection itself: bench binaries' --emit-atlas <path> flag.");
+    eprintln!("For large-scale analysis: scripts/kernel_atlas.py on the HIPa branch.");
 }
 
 fn cmd_count(path: &str) -> Result<(), String> {
@@ -49,6 +79,98 @@ fn cmd_read(path: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn cmd_parse_bench(stdout_path: &str, out_path: &str) -> Result<(), String> {
+    let text = fs::read_to_string(stdout_path)
+        .map_err(|e| format!("read {stdout_path}: {e}"))?;
+    let rows = bench_rows_from_output(&text)?;
+    write_rows_jsonl(&rows, out_path)?;
+    println!("wrote {} rows to {out_path}", rows.len());
+    Ok(())
+}
+
+fn cmd_parse_dflash(stdout_path: &str, out_path: &str) -> Result<(), String> {
+    let text = fs::read_to_string(stdout_path)
+        .map_err(|e| format!("read {stdout_path}: {e}"))?;
+    let row = dflash_row_from_output(&text)?;
+    write_rows_jsonl(&[row], out_path)?;
+    println!("wrote 1 row to {out_path}");
+    Ok(())
+}
+
+fn cmd_render_fit(path: &str, idx: usize) -> Result<(), String> {
+    let row = load_row(path, idx)?;
+    println!("{}", render_fit_view(&row));
+    Ok(())
+}
+
+fn cmd_suggest(path: &str, idx: usize, max: usize) -> Result<(), String> {
+    let row = load_row(path, idx)?;
+    let suggestions = suggestions_for_row(&row, max);
+    if suggestions.is_empty() {
+        println!("(no suggestions for row {idx})");
+    } else {
+        println!("{}", suggestions_markdown(&suggestions));
+    }
+    Ok(())
+}
+
+fn cmd_task(path: &str, idx: usize) -> Result<(), String> {
+    let row = load_row(path, idx)?;
+    let bundle = task_from_row(&row, None, Vec::new(), Vec::new());
+    let pretty = serde_json::to_string_pretty(&bundle)
+        .map_err(|e| format!("serialize task: {e}"))?;
+    println!("{pretty}");
+    Ok(())
+}
+
+fn cmd_task_pytorch(
+    name: &str,
+    op: &str,
+    shape: &str,
+    dtype: &str,
+    eval_cmd: &str,
+) -> Result<(), String> {
+    let shapes = shape
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let bundle = pytorch_task(
+        name.to_string(),
+        op.to_string(),
+        shapes,
+        dtype.to_string(),
+        eval_cmd.to_string(),
+        None,
+        Vec::new(),
+    );
+    let pretty = serde_json::to_string_pretty(&bundle)
+        .map_err(|e| format!("serialize task: {e}"))?;
+    println!("{pretty}");
+    Ok(())
+}
+
+fn cmd_eval(task_path: &str, cwd: Option<&str>) -> Result<(), String> {
+    let result = eval_task_file(task_path, cwd)?;
+    let pretty = serde_json::to_string_pretty(&result)
+        .map_err(|e| format!("serialize eval result: {e}"))?;
+    println!("{pretty}");
+    if result.status != "pass" {
+        return Err(format!("task {} failed", result.task_id));
+    }
+    Ok(())
+}
+
+fn write_rows_jsonl(rows: &[AtlasRow], path: &str) -> Result<(), String> {
+    let lines: Vec<String> = rows
+        .iter()
+        .map(|row| serde_json::to_string(row))
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("serialize row: {e}"))?;
+    let body = lines.join("\n") + "\n";
+    fs::write(path, body).map_err(|e| format!("write {path}: {e}"))
+}
+
 fn run() -> Result<(), String> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
@@ -63,6 +185,42 @@ fn run() -> Result<(), String> {
             let n: usize = args[3].parse().map_err(|e| format!("invalid N: {e}"))?;
             cmd_head(&args[2], n)
         }
+        "parse-bench" if args.len() == 4 => cmd_parse_bench(&args[2], &args[3]),
+        "parse-dflash" if args.len() == 4 => cmd_parse_dflash(&args[2], &args[3]),
+        "render-fit" if args.len() >= 3 && args.len() <= 4 => {
+            let idx: usize = if args.len() == 4 {
+                args[3].parse().map_err(|e| format!("invalid INDEX: {e}"))?
+            } else {
+                0
+            };
+            cmd_render_fit(&args[2], idx)
+        }
+        "suggest" if args.len() >= 3 && args.len() <= 5 => {
+            let idx: usize = if args.len() >= 4 {
+                args[3].parse().map_err(|e| format!("invalid INDEX: {e}"))?
+            } else {
+                0
+            };
+            let max: usize = if args.len() == 5 {
+                args[4].parse().map_err(|e| format!("invalid MAX: {e}"))?
+            } else {
+                4
+            };
+            cmd_suggest(&args[2], idx, max)
+        }
+        "task" if args.len() >= 3 && args.len() <= 4 => {
+            let idx: usize = if args.len() == 4 {
+                args[3].parse().map_err(|e| format!("invalid INDEX: {e}"))?
+            } else {
+                0
+            };
+            cmd_task(&args[2], idx)
+        }
+        "task-pytorch" if args.len() == 7 => {
+            cmd_task_pytorch(&args[2], &args[3], &args[4], &args[5], &args[6])
+        }
+        "eval" if args.len() == 3 => cmd_eval(&args[2], None),
+        "eval" if args.len() == 4 => cmd_eval(&args[2], Some(&args[3])),
         "-h" | "--help" | "help" => {
             print_usage();
             Ok(())
@@ -81,8 +239,6 @@ fn main() {
     }
 }
 
-// Self-check: AtlasRow round-trips through JSONL without losing the
-// flatten'd extra fields.
 #[cfg(test)]
 mod tests {
     use hipfire_atlas::AtlasRow;

--- a/crates/hipfire-atlas/src/parse.rs
+++ b/crates/hipfire-atlas/src/parse.rs
@@ -1,0 +1,262 @@
+//! Legacy stdout parsers for bench/dflash output.
+//!
+//! These exist so the Atlas can ingest captures from binaries that
+//! haven't yet been wired with `--emit-atlas`. New consumers should
+//! prefer emitting `AtlasRow` values directly; this module remains as
+//! a bridge during the migration documented in
+//! `docs/methodology/kernel-atlas-architecture.md`.
+
+use crate::schema::{value_object, AtlasRow};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KernelOp {
+    pub family: String,
+    pub role: String,
+    pub phase_hint: String,
+}
+
+pub fn parse_bench_summary(text: &str) -> Result<BTreeMap<String, f64>, String> {
+    let summary = text
+        .lines()
+        .filter(|line| line.starts_with("SUMMARY"))
+        .last()
+        .ok_or_else(|| "bench output did not contain a SUMMARY line".to_string())?;
+    let pair_re = Regex::new(r"([A-Za-z0-9_]+)=([0-9.]+)").expect("valid regex");
+    let mut values = BTreeMap::new();
+    for cap in pair_re.captures_iter(summary) {
+        let key = cap[1].to_string();
+        let value = cap[2]
+            .parse::<f64>()
+            .map_err(|e| format!("invalid SUMMARY value {key}={}: {e}", &cap[2]))?;
+        values.insert(key, value);
+    }
+    for required in ["gen_tok_s", "bw_gib_s", "prefill_tok_s", "avg_ms", "p50_ms"] {
+        if !values.contains_key(required) {
+            return Err(format!("bench SUMMARY missing key: {required}"));
+        }
+    }
+    // Also merge PREFILL_SUMMARY fields if present (latency split metrics
+    // emitted by bench_qwen35_mq4 starting 2026-05-14).
+    if let Some(prefill_line) = text.lines().find(|line| line.starts_with("PREFILL_SUMMARY")) {
+        for cap in pair_re.captures_iter(prefill_line) {
+            let key = cap[1].to_string();
+            if let Ok(v) = cap[2].parse::<f64>() {
+                values.entry(key).or_insert(v);
+            }
+        }
+    }
+    Ok(values)
+}
+
+pub fn parse_dflash_summary(text: &str) -> Result<BTreeMap<String, Value>, String> {
+    let mut metrics = BTreeMap::new();
+    for (key, prefix) in [
+        ("decode_tok_s", "decode_tok_s:"),
+        ("tau", "decode_tau:"),
+        ("ttft_ms", "ttft_ms:"),
+    ] {
+        for line in text.lines() {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                if let Some(token) = rest.split_whitespace().next() {
+                    if let Ok(v) = token.parse::<f64>() {
+                        metrics.insert(key.to_string(), json!(v));
+                    }
+                }
+            }
+        }
+    }
+
+    let emitted_re = Regex::new(
+        r"emitted:\s*([0-9]+)\s+tokens\s+in\s+([0-9.]+)s\s+\(([0-9.]+)\s+tok/s\)",
+    )
+    .expect("valid regex");
+    if let Some(cap) = emitted_re.captures(text) {
+        metrics.insert("emitted_tokens".to_string(), json!(cap[1].parse::<u64>().unwrap_or(0)));
+        metrics.insert("elapsed_s".to_string(), json!(cap[2].parse::<f64>().unwrap_or(0.0)));
+        metrics
+            .entry("decode_tok_s".to_string())
+            .or_insert_with(|| json!(cap[3].parse::<f64>().unwrap_or(0.0)));
+    }
+
+    if !metrics.contains_key("tau") {
+        let tau_re = Regex::new(r"(?:tau|τ)=([0-9.]+)").expect("valid regex");
+        if let Some(cap) = tau_re.captures(text) {
+            metrics.insert("tau".to_string(), json!(cap[1].parse::<f64>().unwrap_or(0.0)));
+        }
+    }
+
+    for key in ["cycles", "accepted"] {
+        let re = Regex::new(&format!(r"(?m)^{key}:\s*([0-9]+)")).expect("valid regex");
+        if let Some(cap) = re.captures(text) {
+            metrics.insert(key.to_string(), json!(cap[1].parse::<u64>().unwrap_or(0)));
+        }
+    }
+
+    for required in ["decode_tok_s", "tau"] {
+        if !metrics.contains_key(required) {
+            return Err(format!("dflash output missing metric: {required}"));
+        }
+    }
+    Ok(metrics)
+}
+
+pub fn parse_profile_sections(text: &str) -> BTreeMap<String, Vec<Value>> {
+    let line_re = Regex::new(
+        r"^\s+([A-Za-z0-9_.$]+)\s+([0-9]+)x\s+([0-9.]+)ms\s+\(([0-9.]+)(?:µ|u)s/call\)\s+([0-9.]+)%\s+([0-9.]+)\s+GiB/s",
+    )
+    .expect("valid regex");
+    let mut sections: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+    let mut current: Option<&str> = None;
+    for line in text.lines() {
+        if line.starts_with("=== DECODE PROFILE") {
+            current = Some("decode_ar");
+            continue;
+        }
+        if line.starts_with("=== PROFILE") {
+            current = Some("prefill");
+            continue;
+        }
+        if line.starts_with("===") && !line.contains("PROFILE") {
+            current = None;
+            continue;
+        }
+        let Some(section) = current else { continue };
+        let Some(cap) = line_re.captures(line) else { continue };
+        sections.entry(section.to_string()).or_default().push(json!({
+            "name": &cap[1],
+            "calls": cap[2].parse::<u64>().unwrap_or(0),
+            "total_ms": cap[3].parse::<f64>().unwrap_or(0.0),
+            "avg_us": cap[4].parse::<f64>().unwrap_or(0.0),
+            "pct": cap[5].parse::<f64>().unwrap_or(0.0),
+            "gib_s": cap[6].parse::<f64>().unwrap_or(0.0),
+            "op": classify_kernel_op(&cap[1]),
+        }));
+    }
+    sections
+}
+
+pub fn classify_kernel_op(name: &str) -> KernelOp {
+    let lowered = name.to_ascii_lowercase();
+    let (family, role, phase_hint) = if lowered.contains("fused_qkvza") {
+        ("attention", "qkvza_projection", "prefill/decode")
+    } else if lowered.contains("fused_qkv") {
+        ("attention", "qkv_projection", "prefill/decode")
+    } else if lowered.contains("attention_flash") || lowered.contains("flash") {
+        ("attention", "flash_attention", "prefill/decode")
+    } else if lowered.contains("kv_cache") {
+        ("attention", "kv_cache", "decode")
+    } else if lowered.contains("rope") || lowered.contains("rotate") {
+        ("position", "rope_rotate", "prefill/decode")
+    } else if lowered.contains("rmsnorm") || lowered.contains("norm") {
+        ("norm", "normalization", "prefill/decode")
+    } else if lowered.contains("gate_up") {
+        ("mlp", "gate_up_projection", "prefill/decode")
+    } else if lowered.contains("swiglu") {
+        ("mlp", "swiglu", "prefill/decode")
+    } else if lowered.contains("gemv") && lowered.contains("residual") {
+        ("linear", "residual_gemv", "decode")
+    } else if lowered.contains("gemv") && lowered.contains("multirow") {
+        ("linear", "multirow_gemv", "decode")
+    } else if lowered.contains("gemv") {
+        ("linear", "gemv", "decode")
+    } else if lowered.contains("gemm") && lowered.contains("residual") {
+        ("linear", "residual_gemm", "prefill")
+    } else if lowered.contains("gemm") {
+        ("linear", "gemm", "prefill")
+    } else {
+        ("unknown", "unknown", "unknown")
+    };
+    KernelOp {
+        family: family.to_string(),
+        role: role.to_string(),
+        phase_hint: phase_hint.to_string(),
+    }
+}
+
+pub fn bench_rows_from_output(text: &str) -> Result<Vec<AtlasRow>, String> {
+    let summary = parse_bench_summary(text)?;
+    let profiles = parse_profile_sections(text);
+    let mut prefill = AtlasRow::new("prefill", "ar");
+    prefill.shape_bucket = "parsed_bench".to_string();
+    prefill.metrics.insert(
+        "prefill_tok_s".to_string(),
+        json!(summary["prefill_tok_s"]),
+    );
+    // Carry the latency split if present.
+    for k in [
+        "prefill_tok_s_kernel",
+        "prefill_kernel_ms",
+        "prefill_wall_ms",
+        "startup_overhead_ms",
+        "cold_overhead_pct",
+    ] {
+        if let Some(v) = summary.get(k) {
+            prefill.metrics.insert(k.to_string(), json!(v));
+        }
+    }
+    if let Some(kernels) = profiles.get("prefill") {
+        prefill
+            .artifacts
+            .insert("profile_kernels".to_string(), Value::Array(kernels.clone()));
+    }
+
+    let mut decode = AtlasRow::new("decode_ar", "ar");
+    decode.shape_bucket = "parsed_bench".to_string();
+    for key in ["gen_tok_s", "bw_gib_s", "avg_ms", "p50_ms"] {
+        decode.metrics.insert(key.to_string(), json!(summary[key]));
+    }
+    if let Some(kernels) = profiles.get("decode_ar") {
+        decode
+            .artifacts
+            .insert("profile_kernels".to_string(), Value::Array(kernels.clone()));
+    }
+    Ok(vec![prefill, decode])
+}
+
+pub fn dflash_row_from_output(text: &str) -> Result<AtlasRow, String> {
+    let mut row = AtlasRow::new("decode_dflash", "dflash");
+    row.shape_bucket = "parsed_dflash".to_string();
+    row.metrics = parse_dflash_summary(text)?;
+    Ok(row)
+}
+
+pub fn row_summary_value(row: &AtlasRow) -> Value {
+    value_object([
+        ("schema".to_string(), json!(row.schema)),
+        ("phase".to_string(), json!(row.phase)),
+        ("workload_kind".to_string(), json!(row.workload_kind)),
+        ("metrics".to_string(), json!(row.metrics)),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bench_summary() {
+        let out = "noise\nSUMMARY gen_tok_s=123.4 bw_gib_s=55.0 prefill_tok_s=999.0 avg_ms=1.2 p50_ms=1.1\n";
+        let values = parse_bench_summary(out).unwrap();
+        assert_eq!(values["gen_tok_s"], 123.4);
+    }
+
+    #[test]
+    fn parses_prefill_summary_split() {
+        let out = "PREFILL_SUMMARY  prefill_tok_s=750.0  prefill_wall_ms=170.0  prefill_tok_s_kernel=1500.0  prefill_kernel_ms=85.0  startup_overhead_ms=85.0  cold_overhead_pct=50.0\nSUMMARY gen_tok_s=50.0 bw_gib_s=400.0 prefill_tok_s=750.0 avg_ms=20.0 p50_ms=20.0\n";
+        let values = parse_bench_summary(out).unwrap();
+        assert_eq!(values["prefill_tok_s_kernel"], 1500.0);
+        assert_eq!(values["startup_overhead_ms"], 85.0);
+    }
+
+    #[test]
+    fn parses_dflash_summary() {
+        let out = "decode_tok_s: 88.5\ndecode_tau: 7.25\nemitted: 120 tokens in 1.4s (85.7 tok/s)\n";
+        let values = parse_dflash_summary(out).unwrap();
+        assert_eq!(values["tau"].as_f64().unwrap(), 7.25);
+        assert_eq!(values["emitted_tokens"].as_u64().unwrap(), 120);
+    }
+}

--- a/crates/hipfire-atlas/src/render.rs
+++ b/crates/hipfire-atlas/src/render.rs
@@ -1,0 +1,70 @@
+use crate::schema::AtlasRow;
+use serde_json::Value;
+
+pub fn render_fit_view(row: &AtlasRow) -> String {
+    let mut out = Vec::new();
+    out.push("HIPFIRE KERNEL ATLAS".to_string());
+    out.push(format!(
+        "phase={} workload={} model={} quant={} shape={}",
+        empty_dash(&row.phase),
+        empty_dash(&row.workload_kind),
+        empty_dash(&row.model_size),
+        empty_dash(&row.quant),
+        empty_dash(&row.shape_bucket)
+    ));
+    out.push(String::new());
+    out.push("metrics".to_string());
+    for (key, value) in &row.metrics {
+        out.push(format!("  {:24} {}", key, scalar(value)));
+    }
+    if let Some(kernels) = row.artifact_array("profile_kernels") {
+        out.push(String::new());
+        out.push("hot kernels".to_string());
+        for kernel in kernels.iter().take(8) {
+            let name = kernel.get("name").and_then(Value::as_str).unwrap_or("?");
+            let pct = kernel.get("pct").and_then(Value::as_f64).unwrap_or(0.0);
+            let gib_s = kernel.get("gib_s").and_then(Value::as_f64).unwrap_or(0.0);
+            let avg_us = kernel.get("avg_us").and_then(Value::as_f64).unwrap_or(0.0);
+            let role = kernel
+                .get("op")
+                .and_then(|op| op.get("role"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            out.push(format!(
+                "  {:42} {:>6.2}% {:>9.2}us {:>8.1} GiB/s  {}",
+                truncate(name, 42),
+                pct,
+                avg_us,
+                gib_s,
+                role
+            ));
+        }
+    }
+    out.join("\n")
+}
+
+fn empty_dash(s: &str) -> &str {
+    if s.is_empty() {
+        "-"
+    } else {
+        s
+    }
+}
+
+fn scalar(value: &Value) -> String {
+    if let Some(v) = value.as_f64() {
+        format!("{v:.4}")
+    } else if let Some(v) = value.as_str() {
+        v.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        format!("{s:max$}")
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}

--- a/crates/hipfire-atlas/src/suggest.rs
+++ b/crates/hipfire-atlas/src/suggest.rs
@@ -1,0 +1,85 @@
+use crate::schema::AtlasRow;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Suggestion {
+    pub id: String,
+    pub title: String,
+    pub rationale: String,
+    pub expected_effect: String,
+    pub confidence: String,
+}
+
+pub fn suggestions_for_row(row: &AtlasRow, max_suggestions: usize) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+    if row.phase == "decode_ar" || row.workload_kind == "ar" {
+        if let Some(gen_tok_s) = row.metric_f64("gen_tok_s") {
+            out.push(Suggestion {
+                id: "decode-hotpath-profile".to_string(),
+                title: "Rank decode hot kernels before editing".to_string(),
+                rationale: format!("AR row reports gen_tok_s={gen_tok_s:.2}; focus on the largest decode kernel share first."),
+                expected_effect: "Avoids tuning cold kernels; produces a bounded Atlas task.".to_string(),
+                confidence: "high".to_string(),
+            });
+        }
+    }
+    if row.phase == "prefill" {
+        out.push(Suggestion {
+            id: "prefill-shape-sweep".to_string(),
+            title: "Sweep prefill shape buckets".to_string(),
+            rationale: "Prefill kernels are often shape-sensitive; compare pp32/pp128/pp512 before changing ISA.".to_string(),
+            expected_effect: "Separates kernel weakness from shape artifact.".to_string(),
+            confidence: "medium".to_string(),
+        });
+    }
+    if row.workload_kind == "dflash" {
+        let tau = row.metric_f64("tau").unwrap_or(0.0);
+        out.push(Suggestion {
+            id: "dflash-tau-vs-wall".to_string(),
+            title: "Optimize DFlash only when tau and wall time agree".to_string(),
+            rationale: format!("DFlash row has tau={tau:.2}; high tau without output sanity is not a win."),
+            expected_effect: "Keeps Atlas from ranking attractor failures as speedups.".to_string(),
+            confidence: "high".to_string(),
+        });
+    }
+    if let Some(kernels) = row.artifact_array("profile_kernels") {
+        if let Some(kernel) = kernels.first() {
+            let name = kernel.get("name").and_then(Value::as_str).unwrap_or("unknown");
+            let pct = kernel.get("pct").and_then(Value::as_f64).unwrap_or(0.0);
+            out.push(Suggestion {
+                id: "hot-kernel-task".to_string(),
+                title: format!("Create task for hot kernel {name}"),
+                rationale: format!("{name} is first in the profile list at {pct:.2}% of measured time."),
+                expected_effect: "Most likely single-kernel tuning target.".to_string(),
+                confidence: if pct >= 15.0 { "high" } else { "medium" }.to_string(),
+            });
+        }
+    }
+    if out.is_empty() {
+        out.push(Suggestion {
+            id: "collect-profile".to_string(),
+            title: "Collect profile kernels for this row".to_string(),
+            rationale: "The row has metrics but no profile_kernels artifact.".to_string(),
+            expected_effect: "Enables ISA/object join and concrete task generation.".to_string(),
+            confidence: "high".to_string(),
+        });
+    }
+    out.truncate(max_suggestions);
+    out
+}
+
+pub fn suggestions_markdown(suggestions: &[Suggestion]) -> String {
+    let mut out = Vec::new();
+    for (idx, suggestion) in suggestions.iter().enumerate() {
+        out.push(format!(
+            "{}. {} [{}]\n   {}\n   Expected: {}",
+            idx + 1,
+            suggestion.title,
+            suggestion.confidence,
+            suggestion.rationale,
+            suggestion.expected_effect
+        ));
+    }
+    out.join("\n")
+}

--- a/crates/hipfire-atlas/src/task.rs
+++ b/crates/hipfire-atlas/src/task.rs
@@ -1,0 +1,88 @@
+use crate::schema::AtlasRow;
+use crate::suggest::suggestions_for_row;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskBundle {
+    pub schema: String,
+    pub task_id: String,
+    pub objective: String,
+    pub source: Value,
+    pub allowed_files: Vec<String>,
+    pub correctness_commands: Vec<String>,
+    pub eval_commands: Vec<String>,
+    pub constraints: Vec<String>,
+    pub created_unix_s: u64,
+}
+
+pub fn task_from_row(
+    row: &AtlasRow,
+    task_id: Option<String>,
+    allowed_files: Vec<String>,
+    correctness_commands: Vec<String>,
+) -> TaskBundle {
+    let suggestion = suggestions_for_row(row, 1).into_iter().next();
+    let objective = suggestion
+        .as_ref()
+        .map(|s| s.title.clone())
+        .unwrap_or_else(|| "Optimize profiled hipfire kernel under Atlas gates".to_string());
+    TaskBundle {
+        schema: "hipfire.kernel_atlas.task.v0".to_string(),
+        task_id: task_id.unwrap_or_else(|| generated_id("atlas-task")),
+        objective,
+        source: row.to_value().unwrap_or_else(|_| json!({})),
+        allowed_files,
+        correctness_commands,
+        eval_commands: Vec::new(),
+        constraints: vec![
+            "Do not change model semantics without a correctness gate.".to_string(),
+            "Record benchmark command, output, git diff, and lineage.".to_string(),
+            "Keep edits inside allowed_files when provided.".to_string(),
+        ],
+        created_unix_s: now_unix_s(),
+    }
+}
+
+pub fn pytorch_task(
+    name: String,
+    op: String,
+    input_shapes: Vec<String>,
+    dtype: String,
+    eval_command: String,
+    task_id: Option<String>,
+    allowed_files: Vec<String>,
+) -> TaskBundle {
+    TaskBundle {
+        schema: "hipfire.kernel_atlas.task.v0".to_string(),
+        task_id: task_id.unwrap_or_else(|| generated_id("atlas-pytorch")),
+        objective: format!("Implement or tune HIP kernel for PyTorch op {op} ({name})"),
+        source: json!({
+            "kind": "pytorch_shape",
+            "name": name,
+            "op": op,
+            "input_shapes": input_shapes,
+            "dtype": dtype,
+        }),
+        allowed_files,
+        correctness_commands: Vec::new(),
+        eval_commands: vec![eval_command],
+        constraints: vec![
+            "Preserve numerical tolerance stated by the eval command.".to_string(),
+            "Report target arch, shape, dtype, and measured speedup.".to_string(),
+        ],
+        created_unix_s: now_unix_s(),
+    }
+}
+
+pub fn now_unix_s() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn generated_id(prefix: &str) -> String {
+    format!("{prefix}-{}", now_unix_s())
+}


### PR DESCRIPTION
Follow-up to #255 (which landed schema + main stub). This PR adds the 5 remaining modules so the atlas crate has the full analysis surface mirroring `scripts/kernel_atlas.py`.

## What's added

- `src/parse.rs` — legacy bench/dflash stdout → AtlasRow vec (regex-based migration bridge for un-wired binaries)
- `src/render.rs` — ASCII fit view of a row
- `src/suggest.rs` — rule-based tuning suggestions per row
- `src/task.rs` — TaskBundle generator (from-row + pytorch-shape variants)
- `src/eval.rs` — run a TaskBundle's correctness/eval commands

Plus 7 new `hipfire-atlas` CLI subcommands wired in main.rs: parse-bench, parse-dflash, render-fit, suggest, task, task-pytorch, eval.

## Verified end-to-end

- `cargo test -p hipfire-atlas`: 4/4 pass (schema roundtrip + 3 parse tests including the new PREFILL_SUMMARY split format)
- `cargo build --workspace`: clean
- All 9 CLI subcommands smoke-tested with synthetic and real captures (see commit body for the full matrix)
- On-disk JSONL shape matches `scripts/kernel_atlas.py` so a mixed corpus parses with either tool

## Migration status

After this PR, Atlas's three layers are:

1. **Collection** ✓ partial — `bench_qwen35_mq4 --emit-atlas` (from #255). dflash_spec_demo wiring is a follow-up.
2. **Analysis** ✓ Rust analysis surface complete in this PR. Python `scripts/kernel_atlas.py` on HIPa stays for pandas-style work; both produce/consume the same JSONL.
3. **Advisor** — TBD, deferred until corpus volume justifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)