### PR TITLE
fix(hfq): tensor-name prefix fallback for Qwen3.5 safetensors files

### DIFF
--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -214,16 +214,58 @@ impl HfqFile {
             .map(|s| s.to_string())
     }
 
+    /// Resolve a tensor name, trying common prefix variants.
+    ///
+    /// Qwen3.5 safetensors-converted files store tensors under
+    /// `model.language_model.layers.N.` while the canonical GGUF-derived
+    /// hipfire-quantize path produces `model.layers.N.`. Callers consistently
+    /// pass one prefix style; this helper tries the exact name first, then
+    /// strips or adds the `model.language_model.` prefix so a model file
+    /// from either pipeline loads cleanly. Returns `None` only when no
+    /// variant matches — the per-callsite `?` early-return is preserved.
+    fn resolve_idx(&self, name: &str) -> Option<usize> {
+        if let Some(&idx) = self.tensor_map.get(name) {
+            return Some(idx);
+        }
+        // Strip "model.language_model." → "model."
+        if let Some(rest) = name.strip_prefix("model.language_model.") {
+            let short = format!("model.{rest}");
+            if let Some(&idx) = self.tensor_map.get(&short) {
+                return Some(idx);
+            }
+        }
+        // Add "model.language_model." prefix: "model.X" → "model.language_model.X"
+        if let Some(rest) = name.strip_prefix("model.") {
+            let long = format!("model.language_model.{rest}");
+            if let Some(&idx) = self.tensor_map.get(&long) {
+                return Some(idx);
+            }
+        }
+        // Try with `model.` / `model.language_model.` added when name has no
+        // `model.` prefix at all (e.g. `lm_head.weight`).
+        if !name.starts_with("model.") {
+            let with_model = format!("model.{name}");
+            if let Some(&idx) = self.tensor_map.get(&with_model) {
+                return Some(idx);
+            }
+            let with_lm = format!("model.language_model.{name}");
+            if let Some(&idx) = self.tensor_map.get(&with_lm) {
+                return Some(idx);
+            }
+        }
+        None
+    }
+
     /// Look up a tensor's metadata (name, quant_type, shape, byte offset/size)
     /// without copying its data. The weight pager calls this at load time to
     /// register byte ranges without forcing eager VRAM allocation.
     pub fn find_tensor_info(&self, name: &str) -> Option<&HfqTensorInfo> {
-        let idx = *self.tensor_map.get(name)?;
+        let idx = self.resolve_idx(name)?;
         Some(&self.tensors[idx])
     }
 
     pub fn tensor_data(&self, name: &str) -> Option<(&HfqTensorInfo, &[u8])> {
-        let idx = *self.tensor_map.get(name)?;
+        let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
         debug_assert!(
             self.mmap.is_some(),
@@ -243,7 +285,7 @@ impl HfqFile {
     #[cfg(unix)]
     pub fn tensor_data_pread(&self, name: &str) -> Option<(&HfqTensorInfo, std::cell::Ref<'_, Vec<u8>>)> {
         use std::os::unix::io::AsRawFd;
-        let idx = *self.tensor_map.get(name)?;
+        let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
         let fd = self._file.as_raw_fd();
         {
@@ -280,7 +322,7 @@ impl HfqFile {
     ///
     /// Returns owned Vec<u8> to avoid lifetime issues with the pread RefCell.
     pub fn tensor_data_vec(&self, name: &str) -> Option<(&HfqTensorInfo, Vec<u8>)> {
-        let idx = *self.tensor_map.get(name)?;
+        let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
 
         #[cfg(unix)]
@@ -341,7 +383,7 @@ impl HfqFile {
     }
 
     fn find_tensor(&self, name: &str) -> Option<&HfqTensorInfo> {
-        self.tensor_map.get(name).map(|&i| &self.tensors[i])
+        self.resolve_idx(name).map(|i| &self.tensors[i])
     }
 
     /// Returns the name of the first tensor whose `quant_type` matches `qt`,


### PR DESCRIPTION
## Summary

Cherry-picked from #238 (`fivetide/feat-imatrix-quantization`) so the runtime loader fix can land independently of the imatrix/MFP4 portion of that PR, which the project is currently re-evaluating after the 2026-05-15 MFP/HFP-formats-dead decision.

## What's broken on master

Qwen3.5 safetensors-converted `.hfq` files store tensors under `model.language_model.layers.N.`, while the canonical GGUF-derived `hipfire-quantize` path produces `model.layers.N.`. Loader callers in `qwen35.rs` consistently pass one prefix style, so a file from the "wrong" pipeline fails to load — the affected `find_tensor_info` / `tensor_data*` calls return `None` and load falls through to error.

This is the production-impacting fix from #238 that has nothing to do with imatrix or MFP4 (which is paused per `feedback_mfp_hfp_dead`).

## What this PR does

Adds `HfqFile::resolve_idx` which:

1. Tries the exact name first (zero-cost on the happy path)
2. Strips `model.language_model.` → `model.`
3. Adds `model.language_model.` to a `model.X` name
4. Prepends `model.` / `model.language_model.` for unprefixed names (e.g. `lm_head.weight`)
5. Returns `None` only when every variant misses

Routes five call sites through the new resolver:
- `find_tensor_info`
- `tensor_data`
- `tensor_data_pread` (unix)
- `tensor_data_vec`
- private `find_tensor`

## Why this is safe to merge under the gating rule

Pure additive fallback. When the direct lookup succeeds (every existing model file), behavior is byte-identical to before. The new code path only fires when `tensor_map.get(name)` returns `None` — a state that previously meant "load fails", so any new lookup that succeeds via the fallback is strictly additional coverage.

No env vars, no flags, no format-byte changes. Five `?`-preserving call-site swaps + one helper method.

## Test plan

- [ ] Build clean (`cargo build --release -p hipfire-runtime --lib`) — verified locally
- [ ] Existing `.hfq` files load with byte-identical tensor lookup behavior (direct-hit path unchanged)
- [ ] Qwen3.5 safetensors-quantized `.hfq` file loads where it previously failed (fivetide's reproducer)

## Attribution

Code is fivetide's from #238; this PR is just the cherry-pick + commit message rewrite. #238's remaining content (imatrix, MFP4 strategy, formats refactor) is unaffected and stays on `feat/imatrix-quantization` for separate disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)