### PR TITLE
fix(qwen35): add F16 lm_head mode shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,7 @@ For dataclass benches:
 | `HIPFIRE_KV_MODE` | Override kv_cache config | (config) |
 | `HIPFIRE_ATTN_FLASH` | Override flash_mode config | (config) |
 | `HIPFIRE_DFLASH_DRAFT` | Force a specific draft path. Empty string = explicit opt-out | (filename auto-match alongside target) |
+| `HIPFIRE_LM_HEAD_F16` | `auto`/`native` keeps qt=1 lm_head as F16; `f32`/`legacy` expands to F32 | auto/native |
 | `HIPFIRE_LOCAL` | Force local-spawn (skip serve HTTP) | OFF |
 | `HIPFIRE_HOST_TIMING` | Per-cycle host timing probe | OFF |
 | `HIPFIRE_VERIFY_GRAPH` | Verify-forward graph capture (0 = off) | ON |

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -18,6 +18,24 @@ pub enum LayerType {
     FullAttention,    // Standard MHA with gated output
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum F16LmHeadMode {
+    Native,
+    F32,
+}
+
+fn parse_f16_lm_head_mode(value: Option<&str>) -> F16LmHeadMode {
+    match value.map(|v| v.trim().to_ascii_lowercase()) {
+        Some(v) if matches!(v.as_str(), "0" | "f32" | "fp32" | "legacy") => F16LmHeadMode::F32,
+        _ => F16LmHeadMode::Native,
+    }
+}
+
+fn f16_lm_head_mode_from_env() -> F16LmHeadMode {
+    let value = std::env::var("HIPFIRE_LM_HEAD_F16").ok();
+    parse_f16_lm_head_mode(value.as_deref())
+}
+
 /// Optional tree-attention context for `forward_prefill_batch` — activates
 /// DDTree batched verify when `Some`.
 ///
@@ -792,17 +810,27 @@ fn load_weight_tensor_raw(gpu: &Gpu, quant_type: u8, data: &[u8], m: usize, k: u
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::Q8_0, m, k, row_stride: 0 })
         }
-        1 => {
-            // qt=1 is F16. Keep raw F16 on GPU (previously decompressed host-
-            // side to F32). Native F16 storage halves the lm_head bandwidth
-            // and lets the dispatch path hit the WMMA-backed
-            // `gemm_f16_batched_lmhead` kernel on gfx11. Required to make
-            // F16 lm_head usable at scale — the F32-fallback path runs the
-            // 1023-position prefill lm_head fan-out at ~280 s/chunk vs
-            // ~0.79 s/chunk via WMMA.
-            let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::F16, m, k, row_stride: 0 })
-        }
+        1 => match f16_lm_head_mode_from_env() {
+            F16LmHeadMode::Native => {
+                // qt=1 is F16. Keep raw F16 on GPU (previously decompressed
+                // host-side to F32). Native F16 storage halves the lm_head
+                // bandwidth and lets the dispatch path hit the WMMA-backed
+                // `gemm_f16_batched_lmhead` kernel on gfx11. Set
+                // HIPFIRE_LM_HEAD_F16=f32 to force the legacy F32 expansion.
+                let buf = gpu.upload_raw(data, &[data.len()])?;
+                Ok(WeightTensor { buf, gpu_dtype: DType::F16, m, k, row_stride: 0 })
+            }
+            F16LmHeadMode::F32 => {
+                let f32_data: Vec<f32> = data.chunks_exact(2)
+                    .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+                    .collect();
+                let bytes: &[u8] = unsafe {
+                    std::slice::from_raw_parts(f32_data.as_ptr() as *const u8, f32_data.len() * 4)
+                };
+                let buf = gpu.upload_raw(bytes, &[m, k])?;
+                Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0 })
+            }
+        },
         _ => panic!("unsupported quant_type {} for lm_head", quant_type),
     }
 }
@@ -7719,4 +7747,31 @@ pub fn forward_with_embedding(
 ) -> HipResult<Vec<f32>> {
     let x = gpu.upload_f32(embedding_data, &[config.dim])?;
     forward_from_x(gpu, weights, config, x, pos, kv_cache, dn_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f16_lm_head_mode_defaults_to_native() {
+        assert_eq!(parse_f16_lm_head_mode(None), F16LmHeadMode::Native);
+        assert_eq!(parse_f16_lm_head_mode(Some("auto")), F16LmHeadMode::Native);
+        assert_eq!(parse_f16_lm_head_mode(Some("1")), F16LmHeadMode::Native);
+        assert_eq!(parse_f16_lm_head_mode(Some("native")), F16LmHeadMode::Native);
+        assert_eq!(parse_f16_lm_head_mode(Some("f16")), F16LmHeadMode::Native);
+    }
+
+    #[test]
+    fn f16_lm_head_mode_allows_legacy_f32() {
+        assert_eq!(parse_f16_lm_head_mode(Some("0")), F16LmHeadMode::F32);
+        assert_eq!(parse_f16_lm_head_mode(Some("f32")), F16LmHeadMode::F32);
+        assert_eq!(parse_f16_lm_head_mode(Some("fp32")), F16LmHeadMode::F32);
+        assert_eq!(parse_f16_lm_head_mode(Some("legacy")), F16LmHeadMode::F32);
+    }
+
+    #[test]
+    fn f16_lm_head_mode_unknown_falls_back_to_native() {
+        assert_eq!(parse_f16_lm_head_mode(Some("surprise")), F16LmHeadMode::Native);
+    }
 }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -10122,10 +10122,10 @@ impl Gpu {
     /// elements per WMMA iteration). All 27B/9B draft shapes satisfy this
     /// (hidden=5120, intermediate=17408, q_dim=4096, kv_dim=1024, fc-K=25600).
     ///
-    /// Non-gfx11 falls through to `gemm_f32_batched` — same semantics but
-    /// weight is read as F16 bytes, so the caller must have uploaded it that
-    /// way. (Currently only gfx11 is expected to hit this path; other archs
-    /// should use MQ4/HFQ4 drafts.)
+    /// Non-gfx11 falls through to row-by-row F16 GEMM so lm_head output keeps
+    /// the `[batch, vocab]` layout expected by callers. Set
+    /// `HIPFIRE_LM_HEAD_F16=f32` at load time to use the legacy F32-expanded
+    /// storage and bypass this path entirely.
     pub fn gemm_f16_batched_lmhead(
         &mut self,
         w_f16: &GpuTensor,

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -8,7 +8,7 @@ This document is the single canonical reference for every environment variable h
 
 | Layer | Count | Notes |
 |---|---|---|
-| `HIPFIRE_*` env vars | 117 | 14 plumbed through TUI, 44 mentioned in some doc, 59 silent |
+| `HIPFIRE_*` env vars | 118 | 14 plumbed through TUI, 45 mentioned in some doc, 59 silent |
 | Non-`HIPFIRE_*` project env vars | 21 | Test/example/diag scaffolding. Should be renamed `HIPFIRE_*` for consistency. |
 | `config.json` schema (`HipfireConfig`) | ~40 keys | Validated by `validateConfigValue()` in `cli/index.ts`. Some keys map 1:1 to env vars set at daemon spawn. |
 | `per_model_config.json` overrides | same surface | Sparse overrides on top of the base config, applied per model tag. |
@@ -108,6 +108,7 @@ Categories are best-effort, derived from naming + source location. See the categ
 | `HIPFIRE_KV_PHYSICAL_CAP` | KV-CACHE | — | `crates/hipfire-runtime/examples/daemon.rs:1211` |
 | `HIPFIRE_LLOYD_FORCE_BASELINE` | KERNEL-SELECTOR | "" (set to "1" to enable) | `crates/rdna-compute/src/kernels.rs:76` |
 | `HIPFIRE_LLOYD_GFX12` | KERNEL-SELECTOR | "" (set to "1" to enable) | `crates/hipfire-arch-qwen35/src/qwen35.rs:3779` |
+| `HIPFIRE_LM_HEAD_F16` | KERNEL-SELECTOR | auto/native | `crates/hipfire-arch-qwen35/src/qwen35.rs:35` |
 | `HIPFIRE_LM_HEAD_WMMA` | KERNEL-SELECTOR | — | `crates/rdna-compute/src/dispatch.rs:7954` |
 | `HIPFIRE_LOCAL` | DAEMON-RUNTIME | — | `cli/index.ts:1205` |
 | `HIPFIRE_MEMSET_DUMP` | DIAG-DUMP | "" (set to "1" to enable) | `crates/hip-bridge/src/ffi.rs:669` |
@@ -200,7 +201,7 @@ Mixed-precision GEMM (Q8_1 activation × 4-bit weight on dp4a, RDNA3+/gfx906). ~
 - `HIPFIRE_MMQ_SCREEN_THRESHOLD` — float; reject Q8_1 quantize when error exceeds this. Default `0.10`.
 - `HIPFIRE_MMQ_DIAG_QUANTIZE_ONLY` — diag flag isolating Q8_1 quantize cost from dp4a kernel cost. Read once at init via the read-once-cache pattern.
 
-### `KERNEL-SELECTOR` (15)
+### `KERNEL-SELECTOR` (16)
 
 Hot-path kernel choice levers. **All silent today.** Power users who tune for specific arches need to read source.
 
@@ -211,6 +212,7 @@ Hot-path kernel choice levers. **All silent today.** Power users who tune for sp
 - `HIPFIRE_GPU_TOPK` — opt-in GPU-resident topk folding (Gemma4 perf lever). Set `1` to enable.
 - `HIPFIRE_LLOYD_FORCE_BASELINE` — disable Lloyd-MQ3 K4+LDS fast variants on gfx11. Used to bisect drift.
 - `HIPFIRE_LLOYD_GFX12=1` — opt-in dispatch of Lloyd-MQ3 WMMA kernels on gfx12 (RDNA4) inside `is_batchable_la`. Default off because the gfx12 sibling kernels ship code-complete but runtime-unvalidated locally; gfx12 reviewers set this to exercise parity / coherence-gate on RDNA4. Once external CI confirms gfx12 parity, the gate can be dropped or default-flipped. Ships with PR #195 (MQ3-Lloyd WMMA prefill).
+- `HIPFIRE_LM_HEAD_F16` — qt=1 lm_head storage shim. Default `auto`/`native` keeps raw F16 and routes through the native F16 dispatch path; `f32`/`fp32`/`legacy` expands to F32 at load time.
 - `HIPFIRE_LM_HEAD_WMMA` — lm_head dispatch lever.
 - `HIPFIRE_RDNA2_VARIANT` — RDNA2 (gfx10x0) variant override. Plumbed via TUI + `cfg.rdna2_variant`.
 - `HIPFIRE_ROCBLAS_ALL_ARCHS`, `HIPFIRE_ROCBLAS_MIN_BATCH`, `HIPFIRE_ROCBLAS_OFF` — rocBLAS dispatch gates.


### PR DESCRIPTION
## Summary
- Add `HIPFIRE_LM_HEAD_F16` as a loader-time shim for qt=1 lm_head weights.
- Default remains `auto`/`native`, preserving the post-#242 raw-F16 path on gfx11.
- `HIPFIRE_LM_HEAD_F16=f32`, `fp32`, `legacy`, or `0` restores the old expand-to-F32 storage path.
- Document the new flag in `AGENTS.md` and `docs/env-vars.md`, and update the stale F16 lm_head fallback comment.

## Validation
- `CARGO_TARGET_DIR=/tmp/hipfire-target-f16-shim cargo test -p hipfire-arch-qwen35 f16_lm_head_mode --lib`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/hipfire-target-f16-shim cargo build --release -p hipfire-runtime --example eval_hipfire`

Note: repo-wide `cargo fmt --check` still reports broad pre-existing rustfmt drift across unrelated files, so it was not used as a merge gate for this narrow follow-up.