### PR TITLE
fix(qwen35): guard hipGraph capture against TriAttention eviction stream conflict

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -3053,13 +3053,19 @@ pub fn forward_scratch(
         _ => panic!("unsupported embedding format"),
     }
 
-    if use_graph && gpu.graph_exec.is_some() {
+    // Compact offset (TriAttention eviction) breaks graph capture/replay:
+    // during replay, stream_write_value32 updates pos_buf but the captured
+    // H2D copy of (pos + compact_offset) inside FA layers overwrites it,
+    // causing RoPE to read stale positions. Fall back to direct execution.
+    let no_compact = kv_cache.compact_offset == 0;
+
+    if use_graph && gpu.graph_exec.is_some() && no_compact {
         // ── Graph replay path ──
         // Update pos_buf on the device via stream write (no host→device copy).
         let stream = gpu.active_stream.as_ref().unwrap();
         gpu.hip.stream_write_value32(stream, &scratch.pos_buf, pos as u32, 0)?;
         gpu.graph_launch()?;
-    } else if use_graph && gpu.graph_exec.is_none() {
+    } else if use_graph && gpu.graph_exec.is_none() && no_compact {
         let pos_i32 = pos as i32;
         if !gpu.ar_forward_warmed_up {
             // ── Warmup: run direct so kernel JIT and lazy scratch

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -5342,7 +5342,7 @@ fn forward_prefill_chunk(
                     let pos = start_pos + i;
                     gpu.hip.memcpy_dtod_at(&s.x.buf, 0, &pbs.x_batch.buf, i * dim_row_bytes, dim_row_bytes)?;
                     let pos_i32 = pos as i32;
-                    gpu.hip.memcpy_htod(&s.pos_buf, &pos_i32.to_ne_bytes())?;
+                    gpu.memcpy_htod_auto(&s.pos_buf, &pos_i32.to_ne_bytes())?;
                     run_fa_layer_body(gpu, weights, config, layer_idx, kv_layer_idx, pos, kv_cache, s)?;
                     gpu.hip.memcpy_dtod_at(&pbs.x_batch.buf, i * dim_row_bytes, &s.x.buf, 0, dim_row_bytes)?;
                 }
@@ -5960,14 +5960,14 @@ fn run_fa_layer_body(
     // for kv_cache_write + flash attention (which both want the write slot).
     if kv_cache.compact_offset > 0 {
         let abs = (pos + kv_cache.compact_offset) as i32;
-        gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+        gpu.memcpy_htod_auto(&s.pos_buf, &abs.to_ne_bytes())?;
     }
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
     gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
         config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
     if kv_cache.compact_offset > 0 {
         let phys = pos as i32;
-        gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+        gpu.memcpy_htod_auto(&s.pos_buf, &phys.to_ne_bytes())?;
     }
 
     if kv_cache.quant_asym4 {
@@ -6526,14 +6526,14 @@ fn forward_scratch_layers(
 
                 if kv_cache.compact_offset > 0 {
                     let abs = (pos + kv_cache.compact_offset) as i32;
-                    gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+                    gpu.memcpy_htod_auto(&s.pos_buf, &abs.to_ne_bytes())?;
                 }
                 let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
                 gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
                     config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
                 if kv_cache.compact_offset > 0 {
                     let phys = pos as i32;
-                    gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+                    gpu.memcpy_htod_auto(&s.pos_buf, &phys.to_ne_bytes())?;
                 }
 
                 if kv_cache.quant_asym4 {
@@ -6917,14 +6917,14 @@ fn forward_scratch_layers(
 
                 if kv_cache.compact_offset > 0 {
                     let abs = (pos + kv_cache.compact_offset) as i32;
-                    gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+                    gpu.memcpy_htod_auto(&s.pos_buf, &abs.to_ne_bytes())?;
                 }
                 let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
                 gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
                     config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
                 if kv_cache.compact_offset > 0 {
                     let phys = pos as i32;
-                    gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+                    gpu.memcpy_htod_auto(&s.pos_buf, &phys.to_ne_bytes())?;
                 }
 
                 if kv_cache.quant_asym4 {
@@ -7289,14 +7289,14 @@ fn forward_scratch_layers_multi(
 
                     if kv_cache.compact_offset > 0 {
                         let abs = (pos + kv_cache.compact_offset) as i32;
-                        gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+                        gpu.memcpy_htod_auto(&s.pos_buf, &abs.to_ne_bytes())?;
                     }
                     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
                     gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
                         config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
                     if kv_cache.compact_offset > 0 {
                         let phys = pos as i32;
-                        gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+                        gpu.memcpy_htod_auto(&s.pos_buf, &phys.to_ne_bytes())?;
                     }
 
                     if kv_cache.quant_asym4 {
@@ -7570,14 +7570,14 @@ fn forward_scratch_layers_multi(
 
                     if kv_cache.compact_offset > 0 {
                         let abs = (pos + kv_cache.compact_offset) as i32;
-                        gpu.hip.memcpy_htod(&s.pos_buf, &abs.to_ne_bytes())?;
+                        gpu.memcpy_htod_auto(&s.pos_buf, &abs.to_ne_bytes())?;
                     }
                     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
                     gpu.rope_partial_interleaved_f32(&s.fa_q, &s.fa_k, &s.pos_buf,
                         config.n_heads, config.n_kv_heads, config.head_dim, n_rot, config.rope_theta)?;
                     if kv_cache.compact_offset > 0 {
                         let phys = pos as i32;
-                        gpu.hip.memcpy_htod(&s.pos_buf, &phys.to_ne_bytes())?;
+                        gpu.memcpy_htod_auto(&s.pos_buf, &phys.to_ne_bytes())?;
                     }
 
                     if kv_cache.quant_asym4 {

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1153,6 +1153,28 @@ impl Gpu {
         self.memcpy_dtod_at_auto(dst, 0, src, 0, size)
     }
 
+    /// H→D copy that picks async on the active stream when capturing.
+    ///
+    /// During hipGraph capture (`capture_mode == true`), operations on the
+    /// legacy/null stream are forbidden because they would create a blocking
+    /// dependency with the capturing stream. This method routes to
+    /// `memcpy_htod_async` on the active (capturing) stream when in capture
+    /// mode, falling back to sync `memcpy_htod` otherwise.
+    pub fn memcpy_htod_auto(
+        &self,
+        dst: &hip_bridge::DeviceBuffer,
+        src: &[u8],
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        if self.capture_mode {
+            let stream = self.active_stream.as_ref()
+                .expect("capture mode requires an active stream");
+            self.hip.memcpy_htod_async(dst, src, stream)
+        } else {
+            self.hip.memcpy_htod(dst, src)
+        }
+    }
+
     /// Helper: launch a kernel using the blob path during graph capture,
     /// or the normal kernelParams path otherwise. The `blob_builder` closure
     /// constructs the KernargBlob; it's only called when capturing.


### PR DESCRIPTION
## Summary

Fix a hipGraph capture-stream conflict crash and a silent-garbage-output bug when TriAttention eviction (KV cache compaction) is active on gfx12 (RDNA4). The daemon panics with hipError 906 ("operation would make the legacy stream depend on a capturing blocking stream") during generation with qwen3.6-27b.mq4 on RX 9070 XT.

## Which crate(s) does this touch?

- [x] `crates/rdna-compute` — new `memcpy_htod_auto()` dispatch helper
- [x] `crates/hipfire-arch-qwen35` — graph capture guard + 11 FA-layer H2D copy replacements

## The Bug (two parts)

**Part 1 — Capture-time crash:** TriAttention eviction compacts the KV cache, setting `compact_offset > 0`. FA layer handlers then update RoPE position buffers via synchronous `gpu.hip.memcpy_htod()` on the legacy/null stream. During HIP graph capture (default-ON for gfx12), this conflicts with the capturing blocking stream → hipError 906.

**Part 2 — Silent garbage output:** Even if the crash were fixed, during *graph replay* the `stream_write_value32` path updates pos_buf before launch, but the captured H2D copy inside FA layers then overwrites it with the stale position from capture time. RoPE reads wrong positions → garbled output that passes no error check.

## The Fix (two commits)

### 1. Capture-aware H2D memcpy (`crates/rdna-compute/src/dispatch.rs`)

Added `memcpy_htod_auto()` — routes to `memcpy_htod_async` on the active (capturing) stream when `capture_mode == true`, falling back to sync `memcpy_htod` otherwise. Prevents hipError 906 during graph capture. Replaced 11 occurrences of `gpu.hip.memcpy_htod(&s.pos_buf, ...)` across FA layer handlers in both MQ4 and MQ3 Lloyd branches.

### 2. Gate graph capture/replay on eviction status (`crates/hipfire-arch-qwen35/src/qwen35.rs`)

Added a `no_compact` guard: skip graph capture/replay when `kv_cache.compact_offset > 0`, falling back to direct execution where sync H2D copies work correctly. This is the real fix for Part 2 (stale positions during replay). Commit 1 is defensive for any future code paths doing H2D during capture.

**Total: ~40 lines changed across 2 files.**

## Test plan

- [x] `cargo build --release --workspace --features deltanet` clean
- [x] Model loads and generates without panic on gfx1201 with TriAttention sidecar auto-attached
- [x] Graph replay path still activates when `compact_offset == 0` (no perf regression in normal operation)
- [ ] `./scripts/coherence-gate-dflash.sh` — not yet tested (no RDNA3 card available; tested on gfx1201 only)

## Open questions

1. **Perf impact of disabling graphs during eviction:** graph replay gives ~0.6–0.7% decode win on gfx11 and ~2.4–2.7% on gfx12. Disabling it when `compact_offset > 0` loses this during active eviction periods. Future work could compute absolute RoPE positions on-device, allowing graph capture to coexist with eviction.
2. **Other archs:** tested only on gfx1201. gfx11 behavior may differ — graph capture is also ON by default there but the mechanics vary slightly. Worth verifying on RDNA3.
3. **Prefill path:** `forward_prefill_batch` has similar FA-layer code paths with compact_offset H2D copies. Prefill doesn't currently use graph capture, but worth auditing if someone adds it later.
