### PR TITLE
feat(gfx906): HFQ4 batched residual wave64+dp4a (#276 Gap 2 part 1)

### DIFF
--- a/crates/rdna-compute/examples/test_hfq4_residual_dp4a.rs
+++ b/crates/rdna-compute/examples/test_hfq4_residual_dp4a.rs
@@ -1,0 +1,204 @@
+//! Correctness test for `gemm_hfq4g256_residual_wave64_dp4a` (gfx906).
+//!
+//! Compares the new HFQ4 batched dp4a residual GEMM (issue #276 Gap 2)
+//! against `gemm_hfq4g256_residual_fp16_wave64` — the kernel it replaces
+//! at gfx906 B>1 below the MMQ cutover.
+//!
+//! Both kernels:
+//!   y[b,row] += A[row] · x[b]
+//! starting from the same non-zero Y. Differences come from Q8_1 vs FP16
+//! quantization noise; NRMSE should land at ~0.2% (Q8_1×HFQ4 floor),
+//! matching `test_gfx906_mmq_correctness`'s observed band.
+//!
+//! Usage: cargo run --release -p rdna-compute --example test_hfq4_residual_dp4a \
+//!        -- [M] [K] [N]
+//!
+//! Defaults: M=128 K=256 N=8 (matches BATCH_TILE=16 boundary at N≤16).
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let m: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(128);
+    let k: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(256);
+    let n: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(8);
+
+    assert!(k % 256 == 0, "K must be a multiple of 256");
+
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+
+    eprintln!("=== gfx906 HFQ4 residual_wave64_dp4a correctness test ===");
+    eprintln!("M={m} K={k} N={n}");
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    eprintln!("arch: {}", gpu.arch);
+
+    if gpu.arch != "gfx906" {
+        eprintln!("WARNING: this test is only meaningful on gfx906; skipping");
+        std::process::exit(0);
+    }
+
+    let weight_bytes = synth_hfq4g256_weights(m, groups_per_row, 0xC0DE_FACEu64);
+    let a_raw = gpu
+        .upload_raw(&weight_bytes, &[m * row_bytes])
+        .expect("upload weights");
+
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(1103515245).wrapping_add(12345)) as f32;
+            (v * 1e-9) % 2.0 - 1.0
+        })
+        .collect();
+    let x_tensor = gpu.upload_f32(&x_host, &[n * k]).expect("upload x");
+
+    // Non-zero starting Y so the residual `+=` is observable.
+    let y_init_host: Vec<f32> = (0..n * m)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(2147483647).wrapping_add(7)) as f32;
+            (v * 1e-7) % 1.0
+        })
+        .collect();
+
+    let y_dp4a = gpu.upload_f32(&y_init_host, &[n * m]).expect("alloc y_dp4a");
+    let y_fp16 = gpu.upload_f32(&y_init_host, &[n * m]).expect("alloc y_fp16");
+
+    let n_iter = std::env::var("HFQ_TEST_N_ITER")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(1);
+    eprintln!("running {n_iter} GEMM iteration(s) on the same Y buffer");
+
+    eprintln!("\n--- gemm_hfq4g256_residual_fp16_wave64 (reference) ---");
+    for _ in 0..n_iter {
+        gpu.gemm_hfq4g256_residual_fp16_wave64(&a_raw, &x_tensor, &y_fp16, m, k, n)
+            .expect("fp16 wave64 launch");
+    }
+    gpu.hip.device_synchronize().expect("sync after fp16");
+
+    eprintln!("--- gemm_hfq4g256_residual_wave64_dp4a (under test) ---");
+    for _ in 0..n_iter {
+        gpu.gemm_hfq4g256_residual_wave64_dp4a(&a_raw, &x_tensor, &y_dp4a, m, k, n)
+            .expect("dp4a launch");
+    }
+    gpu.hip.device_synchronize().expect("sync after dp4a");
+
+    let fp16_out = gpu.download_f32(&y_fp16).expect("download fp16");
+    let dp4a_out = gpu.download_f32(&y_dp4a).expect("download dp4a");
+
+    eprintln!("\n--- Comparing outputs ---");
+    let mut max_abs_err = 0.0f32;
+    let mut max_rel_err = 0.0f32;
+    let mut sum_sq_err = 0.0f64;
+    let mut sum_sq_ref = 0.0f64;
+    let mut worst_idx = 0usize;
+    let mut worst_pair = (0.0f32, 0.0f32);
+    for i in 0..n * m {
+        let r = fp16_out[i];
+        let q = dp4a_out[i];
+        let err = (r - q).abs();
+        if err > max_abs_err {
+            max_abs_err = err;
+            worst_idx = i;
+            worst_pair = (r, q);
+        }
+        let rel = if r.abs() > 1e-6 { err / r.abs() } else { 0.0 };
+        if rel > max_rel_err {
+            max_rel_err = rel;
+        }
+        sum_sq_err += (err as f64).powi(2);
+        sum_sq_ref += (r as f64).powi(2);
+    }
+
+    let rms_err = (sum_sq_err / (n * m) as f64).sqrt() as f32;
+    let rms_ref = (sum_sq_ref / (n * m) as f64).sqrt() as f32;
+    let nrmse = rms_err / rms_ref.max(1e-12);
+
+    let ref_min = fp16_out.iter().copied().fold(f32::INFINITY, f32::min);
+    let ref_max = fp16_out.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let dp_min = dp4a_out.iter().copied().fold(f32::INFINITY, f32::min);
+    let dp_max = dp4a_out.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+
+    let worst_col = worst_idx / m;
+    let worst_row = worst_idx % m;
+    eprintln!("max_abs_err  = {:.6e}", max_abs_err);
+    eprintln!("max_rel_err  = {:.4}%", max_rel_err * 100.0);
+    eprintln!("rms_err      = {:.6e}", rms_err);
+    eprintln!("rms_ref      = {:.6e}", rms_ref);
+    eprintln!("NRMSE        = {:.4}%", nrmse * 100.0);
+    eprintln!("worst (col,row) = ({worst_col}, {worst_row})");
+    eprintln!("                  fp16={:.6e}  dp4a={:.6e}", worst_pair.0, worst_pair.1);
+    eprintln!("ref range:  [{ref_min:.4e}, {ref_max:.4e}]");
+    eprintln!("dp4a range: [{dp_min:.4e}, {dp_max:.4e}]");
+
+    eprintln!("\n--- First 16 output cells (col=0, rows=0..15) ---");
+    for i in 0..16.min(m) {
+        eprintln!("  row {i}: fp16={:.6e}  dp4a={:.6e}  diff={:.6e}",
+            fp16_out[i], dp4a_out[i], (fp16_out[i] - dp4a_out[i]).abs());
+    }
+
+    // Pass criteria:
+    //  - NRMSE < 1e-2 (1%) for Q8_1×HFQ4 quantization noise (matches the
+    //    `test_gfx906_mmq_correctness` tolerance — same input format).
+    //  - dp4a output is non-zero (catches "kernel did nothing" bug).
+    //  - dp4a output differs from y_init (catches "no residual write" bug).
+    let dp4a_nonzero = dp4a_out.iter().any(|&v| v.abs() > 1e-12);
+    let dp4a_wrote_residual = dp4a_out
+        .iter()
+        .zip(y_init_host.iter())
+        .any(|(o, init)| (o - init).abs() > 1e-6);
+    let pass = nrmse < 1e-2 && dp4a_nonzero && dp4a_wrote_residual;
+    if pass {
+        eprintln!("\nPASS (NRMSE within tolerance, residual write observed)");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL");
+        if !dp4a_nonzero {
+            eprintln!("  dp4a output is all-zero — kernel may not have run");
+        }
+        if !dp4a_wrote_residual {
+            eprintln!("  dp4a output matches y_init — residual `+=` did not fire");
+        }
+        if nrmse >= 1e-2 {
+            eprintln!("  NRMSE {:.4}% exceeds 1% threshold", nrmse * 100.0);
+        }
+        std::process::exit(1);
+    }
+}
+
+/// Same generator as test_gfx906_mmq_correctness.rs. Reproduced here to
+/// keep the example standalone.
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    let scale_log10 = std::env::var("HFQ_TEST_SCALE_LOG10")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(-3.0);
+    let zp_max = std::env::var("HFQ_TEST_ZP_MAX")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(1.0);
+    let scale_target = 10.0f32.powf(scale_log10);
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            let scale = scale_target * (0.5 + (next() & 0xFFFF) as f32 / 65535.0 * 1.5);
+            let zp = ((next() & 0xFFFF) as f32 / 65535.0) * 2.0 * zp_max - zp_max;
+            out[gp..gp + 4].copy_from_slice(&scale.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    let _ = DType::HFQ4G256;
+    out
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -9028,6 +9028,23 @@ impl Gpu {
                 }
             }
 
+            // gfx906 dp4a batched residual (issue #276 Gap 2, HFQ4 sibling of
+            // HFQ6 Phase A.2). Fires for B>1 below the MMQ cutover (typically
+            // B ∈ [2, 7] on gfx906 by `should_use_mmq`'s gfx906 default of 8)
+            // and when MMQ screening rejects the weight (`use_mmq=false` above
+            // falls through here). Wins on per-call ALU (4× vs FP wave64's 2×)
+            // and reuses the existing Q8_1 scratch.
+            //
+            // The `!self.capture_mode` guard: `ensure_q8_1_mmq_x` (and the
+            // downstream `ensure_kernel` for this kernel) can fire `hipMalloc`
+            // / JIT-compile on first use, both unsafe inside an active capture.
+            // The internal Q8_1 quantize launch itself goes through
+            // `launch_maybe_blob` and IS recorded into the captured graph;
+            // the guard protects only first-use-only side effects.
+            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                return self.gemm_hfq4g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
+            }
+
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
             if is_gcn5_wave64(&self.arch) {
                 return self.gemm_hfq4g256_residual_fp16_wave64(a_raw, x, y, m, k, batch_size);
@@ -10271,6 +10288,81 @@ impl Gpu {
             [64, 1, 1],
             0,
             &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(xq); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// Batched HFQ4-G256 residual GEMM with fused dp4a inner loop on gfx906.
+    /// HFQ4 sibling of `gemm_hfq6g256_residual_wave64_dp4a` (HFQ6 Phase A.2,
+    /// commit 1b9f3747 → merged via #187). Closes the dispatch gap where MQ4
+    /// at gfx906 B>1 below the MMQ cutover (B ∈ [2, 7] per `should_use_mmq`'s
+    /// gfx906 default) falls to `gemm_hfq4g256_residual_fp16_wave64`; the
+    /// dp4a path wins on per-call ALU (4× vs FP wave64's 2×) and reuses the
+    /// existing Q8_1 activation scratch (shared with HFQ4 MMQ + the GEMV-
+    /// shape fused dp4a kernels).
+    ///
+    /// Issue #276 Gap 2. Ships with `BATCH_TILE = 16` from the start per the
+    /// HFQ6 Phase B.1.1 measurement (commit ff9e2105: BT=8→16 halves A-reload
+    /// trips per row, +7-17% per-call on the structurally identical HFQ6
+    /// sibling). MUST stay in sync with the kernel's `#define BATCH_TILE 16`
+    /// at `kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip:38`.
+    pub fn gemm_hfq4g256_residual_wave64_dp4a(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_wave64_dp4a",
+            kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_DP4A_SRC,
+            "gemm_hfq4g256_residual_wave64_dp4a",
+        )?;
+
+        let a_ptr = a_raw.buf.as_ptr();
+        let y_ptr = y.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &a_ptr as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &y_ptr as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        // BATCH_TILE MUST match the kernel's `#define BATCH_TILE 16`.
+        const BATCH_TILE: usize = 16;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let grid_x = ((m as u32) + 1) / 2;
+
+        // bytes = weight read (HFQ4: 136 B/group) + X read (Q8_1 scratch:
+        // ~1 byte/element + scale) + Y read+write (residual: 2× batch*m*4).
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_hfq4g256_residual_wave64_dp4a", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
                 b.push_ptr(a_ptr); b.push_ptr(xq); b.push_ptr(y_ptr);

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -284,6 +284,15 @@ pub const FUSED_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../ke
 /// per-layer wo + w_down at B>1.
 pub const GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_hfq6g256_residual_wave64_dp4a.hip");
 
+/// HFQ4 sibling of `GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC` (issue #276,
+/// Gap 2 from the HFQ4/HFQ6 dp4a parity audit). Same structural pattern
+/// as the HFQ4 lm-head `gemm_hfq4g256_wave64_dp4a` with `+=` residual
+/// write semantic. Closes the dispatch gap where MQ4 at gfx906 B>1 below
+/// the MMQ cutover (B ∈ [2, 7]) falls to FP16 wave64; the dp4a path wins
+/// on per-call ALU and reuses the Q8_1 scratch. Ships BATCH_TILE=16 from
+/// the start per the HFQ6 Phase B.1.1 measurement (commit ff9e2105).
+pub const GEMM_HFQ4G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip");
+
 /// Phase A.3 (plan v3.2.3 §5.1 item 3): wave64+dp4a batched fused
 /// GEMMs for HFQ6/MQ6 prefill. Sibling of A.2 with multi-output row
 /// routing (qkvza 4-way, qkv 3-way, gate_up 2-way). Overwrite output

--- a/kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip
+++ b/kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip
@@ -1,0 +1,146 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a port of gemm_hfq4g256_residual at GEMM-batched shape.
+// Activations pre-quantized to Q8_1 (block_q8_1_mmq layout, kblock-major:
+// [K/128 * batch_size]). Weights stay HFQ4-G256 (signed 4-bit nibbles +
+// per-256-group fp32 scale + zp).
+//
+// HFQ4 sibling of gemm_hfq6g256_residual_wave64_dp4a (HFQ6 Phase A.2,
+// commit 1b9f3747 on feat/gfx906-hfq6-hfq8-analysis). Closes the
+// dispatch gap where MQ4 at batch_size > 1 but below the MMQ cutover
+// (B ∈ [2, 7] on gfx906) falls to gemm_hfq4g256_residual_fp16_wave64;
+// the dp4a path wins on per-call ALU (4× vs FP wave64's 2×) and reuses
+// the existing Q8_1 scratch.
+//
+// Differs from gemm_hfq4g256_wave64_dp4a only in writeback semantic:
+//   gemm_hfq4g256_wave64_dp4a:          y[...]  = val  (set/lm-head)
+//   gemm_hfq4g256_residual_wave64_dp4a: y[...] += val  (residual fuse)
+//
+// Math identity (signed 4-bit HFQ4, see gemm_hfq4g256_wave64_dp4a.hip
+// header for the full derivation):
+//   acc[b] += sc * d_x[b] * sumi_dp4a + zp_eff * sum_x[b] * 0.25f
+// where zp_eff = zp + 8 * sc folds the unsigned-bias correction into a
+// single per-block term. The 0.25 factor distributes Q8_1's per-sub-
+// block sum_x across the 4 lanes that share the sub-block.
+//
+// Topology mirrors gemm_hfq4g256_wave64_dp4a:
+//   block = [64, 1, 1]   = 2 warps, each handles 1 row (warp_id = row offset)
+//   grid  = [(M+1)/2, ceil(N/BATCH_TILE), 1]
+//   BATCH_TILE = 16 — per HFQ6 Phase B.1.1 (commit ff9e2105): doubling
+//     BATCH_TILE 8→16 halved A-reload trips per row across grid_y
+//     batch tiles, recovering 7-17% per-call vs BT=8 on the structurally
+//     identical HFQ6 sibling. Shipping BT=16 from the start rather than
+//     repeating HFQ6's bisect.
+
+#define QK8_1 32
+#define BATCH_TILE 16
+
+struct block_q8_1_mmq {
+    half2 ds4[4];           // (d, sum_x) per 32-K sub-block, 4 sub-blocks/block
+    int8_t qs[4 * QK8_1];   // 128 int8 K-elements per block
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_hfq4g256_residual_wave64_dp4a(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,   // kblock-major: [K/128 * N]
+    float* __restrict__ y,                   // [batch_size, M]
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int row = blockIdx.x * 2 + warp_id;
+    if (row >= M) return;
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 136;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = lane * 4;
+
+    // Per-lane mapping inside one HFQ4-G256 group (256 K-elements):
+    //   K range: [8*lane, 8*lane+7]
+    //   sub-block index s(l) = l/4 (0..7)
+    //   Q8_1 block index within group b(l) = l/16 (0=A, 1=B)
+    //   ds4 slot within block i(l) = (l/4) % 4
+    //   qs byte offset within block: 8 * (lane % 16)
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136;
+
+        // Wave-uniform-per-warp scale + zp.
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const float zp_eff = zp + 8.0f * sc;
+
+        // Lane's 8 nibbles → 2 int8-packs. (n - 8) shifts unsigned [0,15]
+        // to signed [-8,7] so sdot4 consumes the same range as Q8_1's
+        // signed activations.
+        const unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        const unsigned int n0 = (pk >>  0) & 0xFu;
+        const unsigned int n1 = (pk >>  4) & 0xFu;
+        const unsigned int n2 = (pk >>  8) & 0xFu;
+        const unsigned int n3 = (pk >> 12) & 0xFu;
+        const unsigned int n4 = (pk >> 16) & 0xFu;
+        const unsigned int n5 = (pk >> 20) & 0xFu;
+        const unsigned int n6 = (pk >> 24) & 0xFu;
+        const unsigned int n7 = (pk >> 28) & 0xFu;
+        const int int_a = (int)(((n0 - 8) & 0xFF)
+                              | (((n1 - 8) & 0xFF) << 8)
+                              | (((n2 - 8) & 0xFF) << 16)
+                              | (((n3 - 8) & 0xFF) << 24));
+        const int int_b = (int)(((n4 - 8) & 0xFF)
+                              | (((n5 - 8) & 0xFF) << 8)
+                              | (((n6 - 8) & 0xFF) << 16)
+                              | (((n7 - 8) & 0xFF) << 24));
+
+        // Pick the lane's Q8_1 block (A or B). HFQ4 group g spans
+        // Q8_1 kblocks (2g, 2g+1).
+        const int kblock = 2 * g + block_within_group;
+
+        // Per-batch-token loop. Each iteration loads its own
+        // (d_x, sum_x, xq_a, xq_b) for this lane's sub-block view.
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp_eff * sum_x * 0.25f;
+        }
+    }
+
+    // Reduce + residual write-back. Same pyramid as the FP kernel.
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) y[(long long)(batch_start + b) * M + row] += val;
+    }
+}


### PR DESCRIPTION
Closes part 1 of **Gap 2** from #276 (HFQ4 batched dp4a parity).

## Summary

HFQ4 sibling of `gemm_hfq6g256_residual_wave64_dp4a` (HFQ6 Phase A.2, merged via #187). Closes the dispatch fallthrough where MQ4 on gfx906 at batch_size > 1 below the MMQ cutover (B ∈ [2, 7] per `should_use_mmq`'s gfx906 default of 8) drops to `gemm_hfq4g256_residual_fp16_wave64`. The dp4a path wins on per-call ALU (4× vs FP wave64's 2×) and reuses the existing Q8_1 activation scratch.

## Files

- `kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip` (new) — structurally identical to the HFQ4 lm-head sibling `gemm_hfq4g256_wave64_dp4a.hip` but with `+=` residual semantic. Ships `BATCH_TILE=16` from the start per HFQ6 Phase B.1.1 (commit `ff9e2105`). HFQ4 math: signed 4-bit nibbles unpacked via `(n - 8) & 0xFF`, `zp_eff = zp + 8*sc` folds the unsigned-bias correction.
- `crates/rdna-compute/examples/test_hfq4_residual_dp4a.rs` (new) — correctness vs `gemm_hfq4g256_residual_fp16_wave64`.
- `crates/rdna-compute/src/kernels.rs` — registers `GEMM_HFQ4G256_RESIDUAL_WAVE64_DP4A_SRC`.
- `crates/rdna-compute/src/dispatch.rs`:
  - `Gpu::gemm_hfq4g256_residual_wave64_dp4a` Rust dispatcher (mirrors HFQ6 sibling at `:10515`).
  - Wired into `gemm_hfq4g256_residual` between the MMQ block and FP16 wave64 fallback, gated `gemv_dp4a_enabled && !capture_mode`.

## Correctness

`test_hfq4_residual_dp4a` (M=256 K=512), NRMSE vs FP16 wave64 reference:

| N  | NRMSE  | Notes                                |
|----|--------|--------------------------------------|
| 2  | 0.317% | Smallest batch path                  |
| 4  | 0.347% |                                      |
| 5  | 0.331% |                                      |
| 7  | 0.362% | Last B before MMQ cutover            |
| 8  | 0.340% | BATCH_TILE boundary                  |
| 16 | 0.262% | Full BATCH_TILE                      |
| 17 | 0.258% | BATCH_TILE+1 partial tile            |
| 24 | 0.230% |                                      |

All within the Q8_1×HFQ4 quantization-noise floor (matches `test_gfx906_mmq_correctness`'s observed band). Residual `+=` write observed in all cases.

## Coherence

`./scripts/coherence-gate.sh` passes clean. 9B mq4 reason output is fluent and correct ("9 left"), 9B mq4 tool-call output produces well-formed `<tool_call>` JSON. No hard errors, no panics. Output fluency unchanged from master.

## Operating range — narrower than headline HFQ6 numbers

Per the #276 scope-correction analysis:
- **Decode (B=1)**: no change (gate `batch_size > 1` not entered).
- **Prefill at typical chunks (B≥8)**: no change — MMQ already wins per `should_use_mmq`'s gfx906 default. *This is most prefill workload on dense MQ4 models.*
- **Prefill at B ∈ [2, 7]**: routes through new dp4a instead of fp16_wave64. Mostly short prompts and chunked-prefill tail batches.
- **DFlash spec-decode verify when adaptive-b dips below 8**: routes through new kernel. Most impactful operating range.
- **MMQ screening fallback** (rare at gfx906 threshold=0.50): now dp4a instead of fp16_wave64. Marginal.

## Perf claim status — unverified

**No microbench in this PR.** The kernel's inner loop is structurally identical to the HFQ4 lm-head dp4a (`gemm_hfq4g256_wave64_dp4a`) which has had its own per-kernel PMC measurement since PR #158. The HFQ6 sibling's +30% prefill measurement (commit `1b9f3747`) was vs FP16 wave64 — same comparison this PR faces.

I attempted to validate via `coherence-gate.sh` mq4 prefill numbers but the prompts that exercise this branch's operating range (B<8) are too short to give stable per-prompt timings. **Re-bench on a model that exercises B ∈ [2, 7] (e.g. DFlash spec-decode verify) before claiming production wins.**

## Test plan

- [x] `cargo check -p rdna-compute` — clean
- [x] `test_hfq4_residual_dp4a` across N ∈ {2, 4, 5, 7, 8, 16, 17, 24}
- [x] `./scripts/coherence-gate.sh` — passes
- [ ] DFlash spec-decode bench at adaptive-b in B ∈ [2, 7] range — deferred
- [ ] Microbench at production shapes (M ∈ {2048, 4096, 5120}, K ∈ {4096, 5120, 17408}) — deferred

## Refs

- #276 — HFQ4/HFQ6 dp4a parity audit (this closes part 1 of Gap 2)
- #187 — HFQ6 Phase A wave64+dp4a kernel stack
- PR #158 — HFQ4 lm-head dp4a (math + structural reference)
- `1b9f3747` — HFQ6 Phase A.2 sibling commit (+30% prefill on HFQ6 at B≥2)

Remaining for #276 Gap 2 (separate PRs):
- `gemm_qkvza_hfq4g256_wave64_dp4a`
- `gemm_qkv_hfq4g256_wave64_dp4a`
- `gemm_gate_up_hfq4g256_wave64_dp4a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)