### PR TITLE
feat(gfx906): HFQ4 dp4a parity — b128 cliff + residual + 3 fused (#276)

### DIFF
--- a/crates/rdna-compute/examples/test_hfq4_fused_dp4a.rs
+++ b/crates/rdna-compute/examples/test_hfq4_fused_dp4a.rs
@@ -1,0 +1,291 @@
+//! Correctness test for the 3 new HFQ4 fused dp4a kernels (gfx906).
+//!
+//! Issue #276 Gap 2:
+//!   - `gemm_qkvza_hfq4g256_wave64_dp4a` (4-way)
+//!   - `gemm_qkv_hfq4g256_wave64_dp4a`    (3-way)
+//!   - `gemm_gate_up_hfq4g256_wave64_dp4a` (2-way)
+//!
+//! Each compared against its `gemm_*_hfq4g256_fp16_wave64` reference.
+//! NRMSE should land at the Q8_1×HFQ4 quantization-noise floor
+//! (~0.2-0.4%), matching the residual sibling's observed band.
+//!
+//! Usage: cargo run --release -p rdna-compute --example test_hfq4_fused_dp4a \
+//!        -- [K] [N]
+//!
+//! Defaults: K=512 N=8 (exercises BT=16 partial-tile boundary).
+//! Tests row-routing for 4-way/3-way/2-way fan-out.
+
+use rdna_compute::{DType, Gpu, GpuTensor};
+
+const QKV_M: usize = 64;
+const Z_M: usize = 32;
+const BETA_M: usize = 32;
+const ALPHA_M: usize = 32;
+// QKV variant uses Q/K/V sizes
+const Q_M: usize = 128;
+const K_M: usize = 64;
+const V_M: usize = 64;
+// gate_up uses gate/up sizes
+const GATE_M: usize = 128;
+const UP_M: usize = 128;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let k: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(8);
+
+    assert!(k % 256 == 0, "K must be a multiple of 256");
+    let groups_per_row = k / 256;
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    eprintln!("arch: {} K={k} N={n}", gpu.arch);
+    if gpu.arch != "gfx906" {
+        eprintln!("WARNING: this test is only meaningful on gfx906; skipping");
+        std::process::exit(0);
+    }
+
+    let mut all_pass = true;
+
+    // ── qkvza (4-way) ─────────────────────────────────────────────────
+    {
+        eprintln!("\n=== gemm_qkvza_hfq4g256_wave64_dp4a (4-way) ===");
+        let a_qkv = upload_weights(&mut gpu, QKV_M, groups_per_row, 0xAA01);
+        let a_z = upload_weights(&mut gpu, Z_M, groups_per_row, 0xAA02);
+        let a_beta = upload_weights(&mut gpu, BETA_M, groups_per_row, 0xAA03);
+        let a_alpha = upload_weights(&mut gpu, ALPHA_M, groups_per_row, 0xAA04);
+        let x = upload_x(&mut gpu, n, k);
+
+        let y_q_dp = gpu.zeros(&[n * QKV_M], DType::F32).unwrap();
+        let y_z_dp = gpu.zeros(&[n * Z_M], DType::F32).unwrap();
+        let y_b_dp = gpu.zeros(&[n * BETA_M], DType::F32).unwrap();
+        let y_a_dp = gpu.zeros(&[n * ALPHA_M], DType::F32).unwrap();
+        let y_q_ref = gpu.zeros(&[n * QKV_M], DType::F32).unwrap();
+        let y_z_ref = gpu.zeros(&[n * Z_M], DType::F32).unwrap();
+        let y_b_ref = gpu.zeros(&[n * BETA_M], DType::F32).unwrap();
+        let y_a_ref = gpu.zeros(&[n * ALPHA_M], DType::F32).unwrap();
+
+        gpu.gemm_qkvza_hfq4g256_wave64_dp4a(
+            &a_qkv, &a_z, &a_beta, &a_alpha, &x,
+            &y_q_dp, &y_z_dp, &y_b_dp, &y_a_dp,
+            QKV_M, Z_M, BETA_M, ALPHA_M, k, n,
+        ).expect("qkvza dp4a");
+        gpu.gemm_qkvza_hfq4g256_fp16_wave64(
+            &a_qkv, &a_z, &a_beta, &a_alpha, &x,
+            &y_q_ref, &y_z_ref, &y_b_ref, &y_a_ref,
+            QKV_M, Z_M, BETA_M, ALPHA_M, k, n,
+        ).expect("qkvza fp16_wave64");
+        gpu.hip.device_synchronize().expect("sync");
+
+        let pass = compare(&mut gpu, &y_q_dp, &y_q_ref, "qkv")
+            && compare(&mut gpu, &y_z_dp, &y_z_ref, "z")
+            && compare(&mut gpu, &y_b_dp, &y_b_ref, "beta")
+            && compare(&mut gpu, &y_a_dp, &y_a_ref, "alpha");
+        all_pass &= pass;
+    }
+
+    // ── qkvza tail case: qkv_m=0, z_m=0 (exercised by the MMQ-split path
+    //    where MMQ handles qkv+z and the tail runs beta+alpha only). This
+    //    also exercises the `_prequant` entry point used by the dispatcher
+    //    to skip re-quantization. ─────────────────────────────────────────
+    {
+        eprintln!("\n=== qkvza tail (qkv_m=0, z_m=0) — exercises row-routing prologue + _prequant ===");
+        let a_qkv = upload_weights(&mut gpu, QKV_M, groups_per_row, 0xAA01);
+        let a_z = upload_weights(&mut gpu, Z_M, groups_per_row, 0xAA02);
+        let a_beta = upload_weights(&mut gpu, BETA_M, groups_per_row, 0xAA03);
+        let a_alpha = upload_weights(&mut gpu, ALPHA_M, groups_per_row, 0xAA04);
+        let x = upload_x(&mut gpu, n, k);
+
+        // For the tail path, only beta/alpha get written. qkv/z buffers are
+        // passed (since the kernel takes them as kernargs) but the kernel's
+        // row-routing prologue should not touch their outputs when M=0.
+        let y_q_dp = gpu.zeros(&[n * QKV_M], DType::F32).unwrap();
+        let y_z_dp = gpu.zeros(&[n * Z_M], DType::F32).unwrap();
+        let y_b_dp = gpu.zeros(&[n * BETA_M], DType::F32).unwrap();
+        let y_a_dp = gpu.zeros(&[n * ALPHA_M], DType::F32).unwrap();
+        let y_q_ref = gpu.zeros(&[n * QKV_M], DType::F32).unwrap();
+        let y_z_ref = gpu.zeros(&[n * Z_M], DType::F32).unwrap();
+        let y_b_ref = gpu.zeros(&[n * BETA_M], DType::F32).unwrap();
+        let y_a_ref = gpu.zeros(&[n * ALPHA_M], DType::F32).unwrap();
+
+        // qkv/z outputs are zero-initialised via `gpu.zeros` above; if the
+        // kernel respects the row-routing prologue (gid >= total_m skip),
+        // they stay zero after the call.
+
+        // Call _prequant directly — the path used by the dispatcher's MMQ-tail.
+        let xq_ptr = gpu.ensure_q8_1_mmq_x(&x, n, k).expect("quantize x");
+        gpu.gemm_qkvza_hfq4g256_wave64_dp4a_prequant(
+            &a_qkv, &a_z, &a_beta, &a_alpha,
+            xq_ptr,
+            &y_q_dp, &y_z_dp, &y_b_dp, &y_a_dp,
+            0, 0, BETA_M, ALPHA_M, k, n,
+        ).expect("qkvza dp4a tail prequant");
+        gpu.gemm_qkvza_hfq4g256_fp16_wave64(
+            &a_qkv, &a_z, &a_beta, &a_alpha, &x,
+            &y_q_ref, &y_z_ref, &y_b_ref, &y_a_ref,
+            0, 0, BETA_M, ALPHA_M, k, n,
+        ).expect("qkvza fp16_wave64 tail");
+        gpu.hip.device_synchronize().expect("sync");
+
+        // qkv + z outputs should remain zero (kernel skipped them via gid >= total_m).
+        let yq_dp_host = gpu.download_f32(&y_q_dp).expect("download yq_dp");
+        let yz_dp_host = gpu.download_f32(&y_z_dp).expect("download yz_dp");
+        let qkv_untouched = yq_dp_host.iter().all(|&v| v == 0.0);
+        let z_untouched = yz_dp_host.iter().all(|&v| v == 0.0);
+        if !qkv_untouched {
+            eprintln!("  [qkv  ] FAIL — kernel wrote into qkv output despite qkv_m=0");
+        } else {
+            eprintln!("  [qkv  ] PASS — untouched (qkv_m=0 skip works)");
+        }
+        if !z_untouched {
+            eprintln!("  [z    ] FAIL — kernel wrote into z output despite z_m=0");
+        } else {
+            eprintln!("  [z    ] PASS — untouched (z_m=0 skip works)");
+        }
+        let pass_routing = qkv_untouched && z_untouched;
+
+        // beta + alpha should match the fp16_wave64 reference within
+        // Q8_1×HFQ4 quantization-noise tolerance.
+        let pass_beta = compare(&mut gpu, &y_b_dp, &y_b_ref, "beta");
+        let pass_alpha = compare(&mut gpu, &y_a_dp, &y_a_ref, "alpha");
+
+        all_pass &= pass_routing && pass_beta && pass_alpha;
+    }
+
+    // ── qkv (3-way) ───────────────────────────────────────────────────
+    {
+        eprintln!("\n=== gemm_qkv_hfq4g256_wave64_dp4a (3-way) ===");
+        let a_q = upload_weights(&mut gpu, Q_M, groups_per_row, 0xBB01);
+        let a_k = upload_weights(&mut gpu, K_M, groups_per_row, 0xBB02);
+        let a_v = upload_weights(&mut gpu, V_M, groups_per_row, 0xBB03);
+        let x = upload_x(&mut gpu, n, k);
+
+        let y_q_dp = gpu.zeros(&[n * Q_M], DType::F32).unwrap();
+        let y_k_dp = gpu.zeros(&[n * K_M], DType::F32).unwrap();
+        let y_v_dp = gpu.zeros(&[n * V_M], DType::F32).unwrap();
+        let y_q_ref = gpu.zeros(&[n * Q_M], DType::F32).unwrap();
+        let y_k_ref = gpu.zeros(&[n * K_M], DType::F32).unwrap();
+        let y_v_ref = gpu.zeros(&[n * V_M], DType::F32).unwrap();
+
+        gpu.gemm_qkv_hfq4g256_wave64_dp4a(
+            &a_q, &a_k, &a_v, &x, &y_q_dp, &y_k_dp, &y_v_dp,
+            Q_M, K_M, V_M, k, n,
+        ).expect("qkv dp4a");
+        gpu.gemm_qkv_hfq4g256_fp16_wave64(
+            &a_q, &a_k, &a_v, &x, &y_q_ref, &y_k_ref, &y_v_ref,
+            Q_M, K_M, V_M, k, n,
+        ).expect("qkv fp16_wave64");
+        gpu.hip.device_synchronize().expect("sync");
+
+        let pass = compare(&mut gpu, &y_q_dp, &y_q_ref, "q")
+            && compare(&mut gpu, &y_k_dp, &y_k_ref, "k")
+            && compare(&mut gpu, &y_v_dp, &y_v_ref, "v");
+        all_pass &= pass;
+    }
+
+    // ── gate_up (2-way) ───────────────────────────────────────────────
+    {
+        eprintln!("\n=== gemm_gate_up_hfq4g256_wave64_dp4a (2-way) ===");
+        let a_g = upload_weights(&mut gpu, GATE_M, groups_per_row, 0xCC01);
+        let a_u = upload_weights(&mut gpu, UP_M, groups_per_row, 0xCC02);
+        let x = upload_x(&mut gpu, n, k);
+
+        let y_g_dp = gpu.zeros(&[n * GATE_M], DType::F32).unwrap();
+        let y_u_dp = gpu.zeros(&[n * UP_M], DType::F32).unwrap();
+        let y_g_ref = gpu.zeros(&[n * GATE_M], DType::F32).unwrap();
+        let y_u_ref = gpu.zeros(&[n * UP_M], DType::F32).unwrap();
+
+        gpu.gemm_gate_up_hfq4g256_wave64_dp4a(
+            &a_g, &a_u, &x, &y_g_dp, &y_u_dp, GATE_M, UP_M, k, n,
+        ).expect("gate_up dp4a");
+        gpu.gemm_gate_up_hfq4g256_fp16_wave64(
+            &a_g, &a_u, &x, &y_g_ref, &y_u_ref, GATE_M, UP_M, k, n,
+        ).expect("gate_up fp16_wave64");
+        gpu.hip.device_synchronize().expect("sync");
+
+        let pass = compare(&mut gpu, &y_g_dp, &y_g_ref, "gate")
+            && compare(&mut gpu, &y_u_dp, &y_u_ref, "up");
+        all_pass &= pass;
+    }
+
+    if all_pass {
+        eprintln!("\nALL PASS");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL");
+        std::process::exit(1);
+    }
+}
+
+fn upload_weights(gpu: &mut Gpu, m: usize, groups_per_row: usize, seed: u64) -> GpuTensor {
+    let bytes = synth_hfq4g256_weights(m, groups_per_row, seed);
+    gpu.upload_raw(&bytes, &[m * groups_per_row * 136]).expect("upload weights")
+}
+
+fn upload_x(gpu: &mut Gpu, n: usize, k: usize) -> GpuTensor {
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(1103515245).wrapping_add(12345)) as f32;
+            (v * 1e-9) % 2.0 - 1.0
+        })
+        .collect();
+    gpu.upload_f32(&x_host, &[n * k]).expect("upload x")
+}
+
+fn compare(gpu: &mut Gpu, dp4a: &GpuTensor, ref_: &GpuTensor, label: &str) -> bool {
+    let dp = gpu.download_f32(dp4a).expect("download dp4a");
+    let rf = gpu.download_f32(ref_).expect("download ref");
+    assert_eq!(dp.len(), rf.len());
+    let n = dp.len();
+
+    let mut sum_sq_err = 0.0f64;
+    let mut sum_sq_ref = 0.0f64;
+    let mut max_abs_err = 0.0f32;
+    for i in 0..n {
+        let err = (dp[i] - rf[i]).abs();
+        if err > max_abs_err { max_abs_err = err; }
+        sum_sq_err += (err as f64).powi(2);
+        sum_sq_ref += (rf[i] as f64).powi(2);
+    }
+    let rms_err = (sum_sq_err / n as f64).sqrt() as f32;
+    let rms_ref = (sum_sq_ref / n as f64).sqrt() as f32;
+    let nrmse = rms_err / rms_ref.max(1e-12);
+
+    let dp_nonzero = dp.iter().any(|&v| v.abs() > 1e-12);
+    let pass = nrmse < 1e-2 && dp_nonzero;
+    let verdict = if pass { "PASS" } else { "FAIL" };
+    eprintln!(
+        "  [{label:5}] NRMSE={:.4}%  max_abs_err={:.4e}  rms_ref={:.4e}  {verdict}",
+        nrmse * 100.0, max_abs_err, rms_ref
+    );
+    if !dp_nonzero {
+        eprintln!("    dp4a output is all-zero — kernel may not have run");
+    }
+    pass
+}
+
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    let scale_target = 1e-3f32;
+    let zp_max = 1.0f32;
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            let scale = scale_target * (0.5 + (next() & 0xFFFF) as f32 / 65535.0 * 1.5);
+            let zp = ((next() & 0xFFFF) as f32 / 65535.0) * 2.0 * zp_max - zp_max;
+            out[gp..gp + 4].copy_from_slice(&scale.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    out
+}

--- a/crates/rdna-compute/examples/test_hfq4_residual_dp4a.rs
+++ b/crates/rdna-compute/examples/test_hfq4_residual_dp4a.rs
@@ -1,0 +1,204 @@
+//! Correctness test for `gemm_hfq4g256_residual_wave64_dp4a` (gfx906).
+//!
+//! Compares the new HFQ4 batched dp4a residual GEMM (issue #276 Gap 2)
+//! against `gemm_hfq4g256_residual_fp16_wave64` — the kernel it replaces
+//! at gfx906 B>1 below the MMQ cutover.
+//!
+//! Both kernels:
+//!   y[b,row] += A[row] · x[b]
+//! starting from the same non-zero Y. Differences come from Q8_1 vs FP16
+//! quantization noise; NRMSE should land at ~0.2% (Q8_1×HFQ4 floor),
+//! matching `test_gfx906_mmq_correctness`'s observed band.
+//!
+//! Usage: cargo run --release -p rdna-compute --example test_hfq4_residual_dp4a \
+//!        -- [M] [K] [N]
+//!
+//! Defaults: M=128 K=256 N=8 (matches BATCH_TILE=16 boundary at N≤16).
+
+use rdna_compute::{DType, Gpu};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let m: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(128);
+    let k: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(256);
+    let n: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(8);
+
+    assert!(k % 256 == 0, "K must be a multiple of 256");
+
+    let groups_per_row = k / 256;
+    let row_bytes = groups_per_row * 136;
+
+    eprintln!("=== gfx906 HFQ4 residual_wave64_dp4a correctness test ===");
+    eprintln!("M={m} K={k} N={n}");
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    eprintln!("arch: {}", gpu.arch);
+
+    if gpu.arch != "gfx906" {
+        eprintln!("WARNING: this test is only meaningful on gfx906; skipping");
+        std::process::exit(0);
+    }
+
+    let weight_bytes = synth_hfq4g256_weights(m, groups_per_row, 0xC0DE_FACEu64);
+    let a_raw = gpu
+        .upload_raw(&weight_bytes, &[m * row_bytes])
+        .expect("upload weights");
+
+    let x_host: Vec<f32> = (0..n * k)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(1103515245).wrapping_add(12345)) as f32;
+            (v * 1e-9) % 2.0 - 1.0
+        })
+        .collect();
+    let x_tensor = gpu.upload_f32(&x_host, &[n * k]).expect("upload x");
+
+    // Non-zero starting Y so the residual `+=` is observable.
+    let y_init_host: Vec<f32> = (0..n * m)
+        .map(|i| {
+            let v = ((i as i64).wrapping_mul(2147483647).wrapping_add(7)) as f32;
+            (v * 1e-7) % 1.0
+        })
+        .collect();
+
+    let y_dp4a = gpu.upload_f32(&y_init_host, &[n * m]).expect("alloc y_dp4a");
+    let y_fp16 = gpu.upload_f32(&y_init_host, &[n * m]).expect("alloc y_fp16");
+
+    let n_iter = std::env::var("HFQ_TEST_N_ITER")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(1);
+    eprintln!("running {n_iter} GEMM iteration(s) on the same Y buffer");
+
+    eprintln!("\n--- gemm_hfq4g256_residual_fp16_wave64 (reference) ---");
+    for _ in 0..n_iter {
+        gpu.gemm_hfq4g256_residual_fp16_wave64(&a_raw, &x_tensor, &y_fp16, m, k, n)
+            .expect("fp16 wave64 launch");
+    }
+    gpu.hip.device_synchronize().expect("sync after fp16");
+
+    eprintln!("--- gemm_hfq4g256_residual_wave64_dp4a (under test) ---");
+    for _ in 0..n_iter {
+        gpu.gemm_hfq4g256_residual_wave64_dp4a(&a_raw, &x_tensor, &y_dp4a, m, k, n)
+            .expect("dp4a launch");
+    }
+    gpu.hip.device_synchronize().expect("sync after dp4a");
+
+    let fp16_out = gpu.download_f32(&y_fp16).expect("download fp16");
+    let dp4a_out = gpu.download_f32(&y_dp4a).expect("download dp4a");
+
+    eprintln!("\n--- Comparing outputs ---");
+    let mut max_abs_err = 0.0f32;
+    let mut max_rel_err = 0.0f32;
+    let mut sum_sq_err = 0.0f64;
+    let mut sum_sq_ref = 0.0f64;
+    let mut worst_idx = 0usize;
+    let mut worst_pair = (0.0f32, 0.0f32);
+    for i in 0..n * m {
+        let r = fp16_out[i];
+        let q = dp4a_out[i];
+        let err = (r - q).abs();
+        if err > max_abs_err {
+            max_abs_err = err;
+            worst_idx = i;
+            worst_pair = (r, q);
+        }
+        let rel = if r.abs() > 1e-6 { err / r.abs() } else { 0.0 };
+        if rel > max_rel_err {
+            max_rel_err = rel;
+        }
+        sum_sq_err += (err as f64).powi(2);
+        sum_sq_ref += (r as f64).powi(2);
+    }
+
+    let rms_err = (sum_sq_err / (n * m) as f64).sqrt() as f32;
+    let rms_ref = (sum_sq_ref / (n * m) as f64).sqrt() as f32;
+    let nrmse = rms_err / rms_ref.max(1e-12);
+
+    let ref_min = fp16_out.iter().copied().fold(f32::INFINITY, f32::min);
+    let ref_max = fp16_out.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let dp_min = dp4a_out.iter().copied().fold(f32::INFINITY, f32::min);
+    let dp_max = dp4a_out.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+
+    let worst_col = worst_idx / m;
+    let worst_row = worst_idx % m;
+    eprintln!("max_abs_err  = {:.6e}", max_abs_err);
+    eprintln!("max_rel_err  = {:.4}%", max_rel_err * 100.0);
+    eprintln!("rms_err      = {:.6e}", rms_err);
+    eprintln!("rms_ref      = {:.6e}", rms_ref);
+    eprintln!("NRMSE        = {:.4}%", nrmse * 100.0);
+    eprintln!("worst (col,row) = ({worst_col}, {worst_row})");
+    eprintln!("                  fp16={:.6e}  dp4a={:.6e}", worst_pair.0, worst_pair.1);
+    eprintln!("ref range:  [{ref_min:.4e}, {ref_max:.4e}]");
+    eprintln!("dp4a range: [{dp_min:.4e}, {dp_max:.4e}]");
+
+    eprintln!("\n--- First 16 output cells (col=0, rows=0..15) ---");
+    for i in 0..16.min(m) {
+        eprintln!("  row {i}: fp16={:.6e}  dp4a={:.6e}  diff={:.6e}",
+            fp16_out[i], dp4a_out[i], (fp16_out[i] - dp4a_out[i]).abs());
+    }
+
+    // Pass criteria:
+    //  - NRMSE < 1e-2 (1%) for Q8_1×HFQ4 quantization noise (matches the
+    //    `test_gfx906_mmq_correctness` tolerance — same input format).
+    //  - dp4a output is non-zero (catches "kernel did nothing" bug).
+    //  - dp4a output differs from y_init (catches "no residual write" bug).
+    let dp4a_nonzero = dp4a_out.iter().any(|&v| v.abs() > 1e-12);
+    let dp4a_wrote_residual = dp4a_out
+        .iter()
+        .zip(y_init_host.iter())
+        .any(|(o, init)| (o - init).abs() > 1e-6);
+    let pass = nrmse < 1e-2 && dp4a_nonzero && dp4a_wrote_residual;
+    if pass {
+        eprintln!("\nPASS (NRMSE within tolerance, residual write observed)");
+        std::process::exit(0);
+    } else {
+        eprintln!("\nFAIL");
+        if !dp4a_nonzero {
+            eprintln!("  dp4a output is all-zero — kernel may not have run");
+        }
+        if !dp4a_wrote_residual {
+            eprintln!("  dp4a output matches y_init — residual `+=` did not fire");
+        }
+        if nrmse >= 1e-2 {
+            eprintln!("  NRMSE {:.4}% exceeds 1% threshold", nrmse * 100.0);
+        }
+        std::process::exit(1);
+    }
+}
+
+/// Same generator as test_gfx906_mmq_correctness.rs. Reproduced here to
+/// keep the example standalone.
+fn synth_hfq4g256_weights(m: usize, groups_per_row: usize, seed: u64) -> Vec<u8> {
+    let total = m * groups_per_row * 136;
+    let mut out = vec![0u8; total];
+    let mut state = seed;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    let scale_log10 = std::env::var("HFQ_TEST_SCALE_LOG10")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(-3.0);
+    let zp_max = std::env::var("HFQ_TEST_ZP_MAX")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(1.0);
+    let scale_target = 10.0f32.powf(scale_log10);
+    for row in 0..m {
+        for g in 0..groups_per_row {
+            let gp = (row * groups_per_row + g) * 136;
+            let scale = scale_target * (0.5 + (next() & 0xFFFF) as f32 / 65535.0 * 1.5);
+            let zp = ((next() & 0xFFFF) as f32 / 65535.0) * 2.0 * zp_max - zp_max;
+            out[gp..gp + 4].copy_from_slice(&scale.to_le_bytes());
+            out[gp + 4..gp + 8].copy_from_slice(&zp.to_le_bytes());
+            for i in 0..128 {
+                out[gp + 8 + i] = (next() & 0xFF) as u8;
+            }
+        }
+    }
+    let _ = DType::HFQ4G256;
+    out
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -4919,6 +4919,14 @@ impl Gpu {
                 // should_use_mmq's gfx906 default). Falls through to the
                 // fused wave64 if any of qkv/z screening rejects (matches
                 // gate_up's behavior in gemm_gate_up_hfq4g256).
+                // gfx906 MMQ split — qkv + z through MMQ (large-M), beta + alpha
+                // through a fused-projection kernel (tail M typically 32, below
+                // MMQ_Y=128). Distinguishes two reasons MMQ might not fire:
+                //   (a) batch_size below cutover → fall to dp4a 4-way fused
+                //   (b) qkv or z screening rejected → fall to fp16 4-way fused
+                //       (screen-reject path preserves higher-precision intent;
+                //       dp4a shares Q8_1 quant step that MMQ failed on).
+                let mut mmq_screen_rejected = false;
                 if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
                     let qz_safe = if self.mmq_screen {
                         self.mmq_screen_weight(a_qkv, qkv_m, k)
@@ -4930,21 +4938,44 @@ impl Gpu {
                         let r2 = if r1.is_ok() {
                             self.gemm_hfq4g256_mmq_set_gfx906(a_z, xq, y_z, z_m, k, batch_size)
                         } else { Ok(()) };
-                        // Tail: beta+alpha through the fused wave64 with
-                        // qkv_m=0, z_m=0. a_qkv/a_z pointers are passed but
-                        // unread because no thread satisfies gid<qkv_m or
-                        // gid<qkv_m+z_m when both are zero.
+                        // Tail: beta+alpha. Use dp4a-prequant when available
+                        // (reuses the Q8_1 scratch we just produced above, no
+                        // re-quantize). Falls back to fp16_wave64 in capture
+                        // mode (ensure_kernel first-use JIT is unsafe inside
+                        // capture; the dp4a kernel may not be compiled yet on
+                        // a fresh process).
                         let r3 = if r2.is_ok() {
-                            self.gemm_qkvza_hfq4g256_fp16_wave64(
-                                a_qkv, a_z, a_beta, a_alpha, x,
-                                y_qkv, y_z, y_beta, y_alpha,
-                                0, 0, beta_m, alpha_m, k, batch_size,
-                            )
+                            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                                self.gemm_qkvza_hfq4g256_wave64_dp4a_prequant(
+                                    a_qkv, a_z, a_beta, a_alpha,
+                                    xq,
+                                    y_qkv, y_z, y_beta, y_alpha,
+                                    0, 0, beta_m, alpha_m, k, batch_size,
+                                )
+                            } else {
+                                self.gemm_qkvza_hfq4g256_fp16_wave64(
+                                    a_qkv, a_z, a_beta, a_alpha, x,
+                                    y_qkv, y_z, y_beta, y_alpha,
+                                    0, 0, beta_m, alpha_m, k, batch_size,
+                                )
+                            }
                         } else { Ok(()) };
                         return r1.and(r2).and(r3);
                     }
-                    // else: qkv or z screening rejected — fall through
-                    // to fused wave64 (handles all 4 outputs together).
+                    mmq_screen_rejected = self.mmq_screen;
+                    // qkv or z screening rejected — fall through; screen-reject
+                    // path goes to fp16, NOT dp4a.
+                }
+                // gfx906 dp4a 4-way fused (issue #276 Gap 2). Fires when
+                // batch_size > 1 below the MMQ cutover or when capture mode
+                // prevents MMQ. Skipped on screen-reject to preserve the
+                // higher-precision fallback intent.
+                if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                    return self.gemm_qkvza_hfq4g256_wave64_dp4a(
+                        a_qkv, a_z, a_beta, a_alpha, x,
+                        y_qkv, y_z, y_beta, y_alpha,
+                        qkv_m, z_m, beta_m, alpha_m, k, batch_size,
+                    );
                 }
                 return self.gemm_qkvza_hfq4g256_fp16_wave64(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
@@ -5344,6 +5375,7 @@ impl Gpu {
                 // Routes through MMQ at batch_size ≥ 16 (per
                 // should_use_mmq's gfx906 default). Falls through to the
                 // fused wave64 if any of q/k/v screening rejects.
+                let mut mmq_screen_rejected = false;
                 if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
                     let qkv_safe = if self.mmq_screen {
                         self.mmq_screen_weight(a_q, q_m, k)
@@ -5361,7 +5393,19 @@ impl Gpu {
                         } else { Ok(()) };
                         return r1.and(r2).and(r3);
                     }
-                    // else: fall through to fused wave64
+                    mmq_screen_rejected = self.mmq_screen;
+                    // q/k/v screening rejected — fall through; screen-reject
+                    // path goes to fp16, NOT dp4a (preserves the screen's
+                    // higher-precision fallback intent).
+                }
+                // gfx906 dp4a 3-way fused (issue #276 Gap 2). Fires when
+                // batch_size > 1 below the MMQ cutover or in capture mode.
+                // Skipped on screen-reject (dp4a shares Q8_1 quant step with
+                // MMQ; routing rejected weights here would defeat the screen).
+                if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                    return self.gemm_qkv_hfq4g256_wave64_dp4a(
+                        a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
+                    );
                 }
                 return self.gemm_qkv_hfq4g256_fp16_wave64(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
@@ -5723,11 +5767,11 @@ impl Gpu {
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            // gfx906 dp4a MMQ — default-on at batch_size ≥ 16 (per
+            // gfx906 dp4a MMQ — default-on at batch_size ≥ 8 (per
             // should_use_mmq's gfx906 default). Quantize X once, screen
             // both weights, dispatch MMQ for each in set mode (add=0).
-            // Falls through to fused FP16 wave64 if either screening
-            // rejects. See docs/plans/gfx906-mmq-prd.md for context.
+            // See docs/plans/gfx906-mmq-prd.md for context.
+            let mut mmq_screen_rejected = false;
             if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_gate, gate_m, k)
@@ -5741,7 +5785,19 @@ impl Gpu {
                     } else { Ok(()) };
                     return r1.and(r2);
                 }
-                // else: screening rejected at least one weight — fall through to wave64.
+                mmq_screen_rejected = self.mmq_screen;
+                // screening rejected at least one weight — fall through; the
+                // screen-reject path skips dp4a and lands on fp16 to preserve
+                // the higher-precision fallback intent (dp4a shares the Q8_1
+                // quant step that MMQ already failed on for this weight).
+            }
+            // gfx906 dp4a 2-way fused (issue #276 Gap 2). Fires for B>1
+            // below the MMQ cutover or in capture mode. Skipped on
+            // screen-reject.
+            if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                return self.gemm_gate_up_hfq4g256_wave64_dp4a(
+                    a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
+                );
             }
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
             if is_gcn5_wave64(&self.arch) {
@@ -9016,7 +9072,15 @@ impl Gpu {
 
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
         if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
-            // gfx906 dp4a MMQ residual path — default-on at batch ≥ 16.
+            // gfx906 dp4a MMQ residual path — default-on at batch ≥ 8 per
+            // should_use_mmq's gfx906 default. Distinguishes two reasons
+            // MMQ might NOT fire:
+            //   (a) batch_size below cutover → fall to dp4a batched residual
+            //   (b) mmq_screen_weight rejected the weight → fall to fp16
+            //       (preserves screen's design intent: rejected weights go
+            //       to a higher-precision fallback, NOT to dp4a which has
+            //       the same Q8_1 quantization step that MMQ failed on).
+            let mut mmq_screen_rejected = false;
             if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_raw, m, k)
@@ -9026,9 +9090,33 @@ impl Gpu {
                 if use_mmq {
                     return self.gemm_hfq4g256_residual_mmq_gfx906(a_raw, x, y, m, k, batch_size);
                 }
+                mmq_screen_rejected = self.mmq_screen;
+            }
+
+            // gfx906 dp4a batched residual (issue #276 Gap 2, HFQ4 sibling of
+            // HFQ6 Phase A.2). Fires for B>1 below the MMQ cutover (B ∈
+            // [2, 7] on gfx906 by should_use_mmq's default). Wins on
+            // per-call ALU (dp4a issues 4 int8 multiplies + 4 accumulates
+            // per cycle, vs FP wave64 hybrid's hfma2 at 2 mul + 2 add per
+            // cycle → 2× FLOPs/cycle) and reuses the existing Q8_1 scratch.
+            //
+            // Skipped when MMQ screening rejected (preserves screen's
+            // higher-precision fallback intent — dp4a has the same Q8_1
+            // quantization step that MMQ already failed on for this
+            // weight).
+            //
+            // The `!self.capture_mode` guard: `ensure_q8_1_mmq_x` (and the
+            // downstream `ensure_kernel` for this kernel) can fire `hipMalloc`
+            // / JIT-compile on first use, both unsafe inside an active capture.
+            // The internal Q8_1 quantize launch itself goes through
+            // `launch_maybe_blob` and IS recorded into the captured graph;
+            // the guard protects only first-use-only side effects.
+            if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                return self.gemm_hfq4g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
             }
 
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
+            // Also the safe fallback when MMQ screen rejected the weight.
             if is_gcn5_wave64(&self.arch) {
                 return self.gemm_hfq4g256_residual_fp16_wave64(a_raw, x, y, m, k, batch_size);
             }
@@ -9390,11 +9478,11 @@ impl Gpu {
         ];
 
         // Option C streaming topology — KEEP IN SYNC WITH body.cuh:
-        //   x_qs   : MMQ_Y * x_stride ints  (per-mmq_x: 40 if mmq_x≥64 else 33)
+        //   x_qs   : MMQ_Y * x_stride ints  (per-mmq_x: 40 if mmq_x≥32 else 33)
         //   x_dm   : MMQ_Y float2
         //   tile_y : mmq_x * Y_STRIDE ints
         const MMQ_Y: usize = 128;
-        let x_stride: usize = if mmq_x >= 64 { 40 } else { 33 };
+        let x_stride: usize = if mmq_x >= 32 { 40 } else { 33 };
         const Y_STRIDE: usize = 36;
         const X_DM_HALF2: usize = 128;
         let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
@@ -9497,7 +9585,7 @@ impl Gpu {
         // Option C streaming topology — KEEP IN SYNC WITH body.cuh
         // (same layout invariant as residual variant above).
         const MMQ_Y: usize = 128;
-        let x_stride: usize = if mmq_x >= 64 { 40 } else { 33 };
+        let x_stride: usize = if mmq_x >= 32 { 40 } else { 33 };
         const Y_STRIDE: usize = 36;
         const X_DM_HALF2: usize = 128;
         let row_tiles = (m + MMQ_Y - 1) / MMQ_Y;
@@ -10275,6 +10363,401 @@ impl Gpu {
                 let mut b = hip_bridge::KernargBlob::new();
                 b.push_ptr(a_ptr); b.push_ptr(xq); b.push_ptr(y_ptr);
                 b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// Batched HFQ4-G256 residual GEMM with fused dp4a inner loop on gfx906.
+    /// HFQ4 sibling of `gemm_hfq6g256_residual_wave64_dp4a` (HFQ6 Phase A.2,
+    /// commit 1b9f3747 → merged via #187). Closes the dispatch gap where MQ4
+    /// at gfx906 B>1 below the MMQ cutover (B ∈ [2, 7] per `should_use_mmq`'s
+    /// gfx906 default) falls to `gemm_hfq4g256_residual_fp16_wave64`; the
+    /// dp4a path wins on per-call ALU (sdot4 issues 4 int8 mul + 4 acc-add
+    /// per cycle, vs FP wave64 hybrid's hfma2 at 2 mul + 2 add per cycle →
+    /// ~2× FLOPs/cycle) and reuses the existing Q8_1 activation scratch
+    /// (shared with HFQ4 MMQ + the GEMV-shape fused dp4a kernels).
+    ///
+    /// Issue #276 Gap 2. Ships with `BATCH_TILE = 16` from the start per the
+    /// HFQ6 Phase B.1.1 measurement (commit ff9e2105: BT=8→16 halves A-reload
+    /// trips per row, +7-17% per-call on the structurally identical HFQ6
+    /// sibling). MUST stay in sync with the kernel's `#define BATCH_TILE 16`
+    /// at `kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip:38`.
+    pub fn gemm_hfq4g256_residual_wave64_dp4a(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+        self.gemm_hfq4g256_residual_wave64_dp4a_prequant(
+            a_raw, xq_ptr, y, m, k, batch_size,
+        )
+    }
+
+    /// Prequant entry point: caller has already populated the Q8_1 scratch
+    /// (see `ensure_q8_1_mmq_x`). Skips the Q8_1 conversion. Use when X has
+    /// just been quantized for a sibling kernel (e.g. MMQ split or fused
+    /// QKVZA tail) to avoid a redundant ~k·batch_size byte memset+convert.
+    pub fn gemm_hfq4g256_residual_wave64_dp4a_prequant(
+        &mut self,
+        a_raw: &GpuTensor,
+        xq_ptr: *mut c_void,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_wave64_dp4a",
+            kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_DP4A_SRC,
+            "gemm_hfq4g256_residual_wave64_dp4a",
+        )?;
+
+        let a_ptr = a_raw.buf.as_ptr();
+        let y_ptr = y.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &a_ptr as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &y_ptr as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        // BATCH_TILE MUST match the kernel's `#define BATCH_TILE 16`.
+        const BATCH_TILE: usize = 16;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let grid_x = ((m as u32) + 1) / 2;
+
+        // bytes = weight (HFQ4: 136 B/group, 0.53 B/weight) + Q8_1 X scratch
+        // (~33 B per Q8_1 block of 32 K-elems = ~1.03 B/element, but for
+        // bandwidth accounting use the dominant int8 qs term: batch*k bytes)
+        // + Y read+write (residual: batch*m*4 each way).
+        let bytes = crate::profile::hfq4g256_weight_bytes(m, k)
+            + batch_size * k
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_hfq4g256_residual_wave64_dp4a", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(xq); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// Batched HFQ4-G256 fused 4-way QKVZA (qkv + z + beta + alpha) GEMM
+    /// with dp4a inner loop on gfx906. HFQ4 sibling of
+    /// `gemm_qkvza_hfq6g256_wave64_dp4a` (HFQ6 Phase A.3, merged via #187).
+    /// Closes the dispatch fallthrough where MQ4 at gfx906 batched DeltaNet
+    /// preamble (B>1) drops to `gemm_qkvza_hfq4g256_fp16_wave64`. Issue #276
+    /// Gap 2 part 2. Uses `BATCH_TILE=16` matching the kernel's `#define`.
+    pub fn gemm_qkvza_hfq4g256_wave64_dp4a(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        x: &GpuTensor,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+        self.gemm_qkvza_hfq4g256_wave64_dp4a_prequant(
+            a_qkv, a_z, a_beta, a_alpha, xq_ptr,
+            y_qkv, y_z, y_beta, y_alpha,
+            qkv_m, z_m, beta_m, alpha_m, k, batch_size,
+        )
+    }
+
+    /// Prequant entry point: caller has already populated the Q8_1 scratch.
+    /// Skips the Q8_1 conversion. Use when X has just been quantized for a
+    /// sibling kernel (e.g. the MMQ-split qkv+z path's beta+alpha tail) to
+    /// avoid a redundant FP32→Q8_1 conversion of the entire X tensor.
+    pub fn gemm_qkvza_hfq4g256_wave64_dp4a_prequant(
+        &mut self,
+        a_qkv: &GpuTensor, a_z: &GpuTensor, a_beta: &GpuTensor, a_alpha: &GpuTensor,
+        xq_ptr: *mut c_void,
+        y_qkv: &GpuTensor, y_z: &GpuTensor, y_beta: &GpuTensor, y_alpha: &GpuTensor,
+        qkv_m: usize, z_m: usize, beta_m: usize, alpha_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_qkvza_hfq4g256_wave64_dp4a",
+            kernels::GEMM_QKVZA_HFQ4G256_WAVE64_DP4A_SRC,
+            "gemm_qkvza_hfq4g256_wave64_dp4a",
+        )?;
+
+        let aq = a_qkv.buf.as_ptr();
+        let az = a_z.buf.as_ptr();
+        let ab = a_beta.buf.as_ptr();
+        let aa = a_alpha.buf.as_ptr();
+        let yq = y_qkv.buf.as_ptr();
+        let yz = y_z.buf.as_ptr();
+        let yb = y_beta.buf.as_ptr();
+        let ya = y_alpha.buf.as_ptr();
+        let qkv_m_val = qkv_m as i32;
+        let z_m_val = z_m as i32;
+        let beta_m_val = beta_m as i32;
+        let alpha_m_val = alpha_m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aq as *const _ as *mut c_void,
+            &az as *const _ as *mut c_void,
+            &ab as *const _ as *mut c_void,
+            &aa as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yq as *const _ as *mut c_void,
+            &yz as *const _ as *mut c_void,
+            &yb as *const _ as *mut c_void,
+            &ya as *const _ as *mut c_void,
+            &qkv_m_val as *const _ as *mut c_void,
+            &z_m_val as *const _ as *mut c_void,
+            &beta_m_val as *const _ as *mut c_void,
+            &alpha_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        // BATCH_TILE MUST match the kernel's `#define BATCH_TILE 16`.
+        const BATCH_TILE: usize = 16;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let total_m = (qkv_m + z_m + beta_m + alpha_m) as u32;
+        let grid_x = (total_m + 1) / 2;
+
+        // bytes = weight (4 matrices, 136 B/group each) + Q8_1 X read +
+        // 4× Y writes (overwrite semantic, no read).
+        let bytes = crate::profile::hfq4g256_weight_bytes(qkv_m, k)
+            + crate::profile::hfq4g256_weight_bytes(z_m, k)
+            + crate::profile::hfq4g256_weight_bytes(beta_m, k)
+            + crate::profile::hfq4g256_weight_bytes(alpha_m, k)
+            + batch_size * k
+            + batch_size * (qkv_m + z_m + beta_m + alpha_m) * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_qkvza_hfq4g256_wave64_dp4a", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_qkvza_hfq4g256_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(az); b.push_ptr(ab); b.push_ptr(aa);
+                b.push_ptr(xq);
+                b.push_ptr(yq); b.push_ptr(yz); b.push_ptr(yb); b.push_ptr(ya);
+                b.push_i32(qkv_m_val); b.push_i32(z_m_val);
+                b.push_i32(beta_m_val); b.push_i32(alpha_m_val);
+                b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// Batched HFQ4-G256 fused 3-way QKV GEMM with dp4a inner loop on
+    /// gfx906. HFQ4 sibling of `gemm_qkv_hfq6g256_wave64_dp4a`. Closes the
+    /// dispatch fallthrough where MQ4 at gfx906 batched FullAttention
+    /// preamble drops to `gemm_qkv_hfq4g256_fp16_wave64`. Issue #276 Gap 2.
+    pub fn gemm_qkv_hfq4g256_wave64_dp4a(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+        self.gemm_qkv_hfq4g256_wave64_dp4a_prequant(
+            a_q, a_k, a_v, xq_ptr, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
+        )
+    }
+
+    /// Prequant entry point — see `gemm_qkvza_hfq4g256_wave64_dp4a_prequant`
+    /// for rationale. Skips the FP32→Q8_1 conversion of X; caller must have
+    /// populated the Q8_1 scratch beforehand.
+    pub fn gemm_qkv_hfq4g256_wave64_dp4a_prequant(
+        &mut self,
+        a_q: &GpuTensor, a_k: &GpuTensor, a_v: &GpuTensor,
+        xq_ptr: *mut c_void,
+        y_q: &GpuTensor, y_k: &GpuTensor, y_v: &GpuTensor,
+        q_m: usize, k_m: usize, v_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_qkv_hfq4g256_wave64_dp4a",
+            kernels::GEMM_QKV_HFQ4G256_WAVE64_DP4A_SRC,
+            "gemm_qkv_hfq4g256_wave64_dp4a",
+        )?;
+
+        let aq = a_q.buf.as_ptr();
+        let ak = a_k.buf.as_ptr();
+        let av = a_v.buf.as_ptr();
+        let yq = y_q.buf.as_ptr();
+        let yk = y_k.buf.as_ptr();
+        let yv = y_v.buf.as_ptr();
+        let q_m_val = q_m as i32;
+        let k_m_val = k_m as i32;
+        let v_m_val = v_m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aq as *const _ as *mut c_void,
+            &ak as *const _ as *mut c_void,
+            &av as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yq as *const _ as *mut c_void,
+            &yk as *const _ as *mut c_void,
+            &yv as *const _ as *mut c_void,
+            &q_m_val as *const _ as *mut c_void,
+            &k_m_val as *const _ as *mut c_void,
+            &v_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        const BATCH_TILE: usize = 16;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let total_m = (q_m + k_m + v_m) as u32;
+        let grid_x = (total_m + 1) / 2;
+
+        let bytes = crate::profile::hfq4g256_weight_bytes(q_m, k)
+            + crate::profile::hfq4g256_weight_bytes(k_m, k)
+            + crate::profile::hfq4g256_weight_bytes(v_m, k)
+            + batch_size * k
+            + batch_size * (q_m + k_m + v_m) * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_qkv_hfq4g256_wave64_dp4a", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_qkv_hfq4g256_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq); b.push_ptr(ak); b.push_ptr(av);
+                b.push_ptr(xq);
+                b.push_ptr(yq); b.push_ptr(yk); b.push_ptr(yv);
+                b.push_i32(q_m_val); b.push_i32(k_m_val); b.push_i32(v_m_val);
+                b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// Batched HFQ4-G256 fused 2-way gate_up GEMM with dp4a inner loop on
+    /// gfx906. HFQ4 sibling of `gemm_gate_up_hfq6g256_wave64_dp4a`. Closes
+    /// the dispatch fallthrough where MQ4 at gfx906 batched FFN preamble
+    /// drops to `gemm_gate_up_hfq4g256_fp16_wave64`. Issue #276 Gap 2.
+    pub fn gemm_gate_up_hfq4g256_wave64_dp4a(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let xq_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+        self.gemm_gate_up_hfq4g256_wave64_dp4a_prequant(
+            a_gate, a_up, xq_ptr, y_gate, y_up, gate_m, up_m, k, batch_size,
+        )
+    }
+
+    /// Prequant entry point — see `gemm_qkvza_hfq4g256_wave64_dp4a_prequant`
+    /// for rationale.
+    pub fn gemm_gate_up_hfq4g256_wave64_dp4a_prequant(
+        &mut self,
+        a_gate: &GpuTensor, a_up: &GpuTensor,
+        xq_ptr: *mut c_void,
+        y_gate: &GpuTensor, y_up: &GpuTensor,
+        gate_m: usize, up_m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.ensure_kernel(
+            "gemm_gate_up_hfq4g256_wave64_dp4a",
+            kernels::GEMM_GATE_UP_HFQ4G256_WAVE64_DP4A_SRC,
+            "gemm_gate_up_hfq4g256_wave64_dp4a",
+        )?;
+
+        let ag = a_gate.buf.as_ptr();
+        let au = a_up.buf.as_ptr();
+        let yg = y_gate.buf.as_ptr();
+        let yu = y_up.buf.as_ptr();
+        let gate_m_val = gate_m as i32;
+        let up_m_val = up_m as i32;
+        let k_val = k as i32;
+        let bs_val = batch_size as i32;
+        let mut xq = xq_ptr;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &ag as *const _ as *mut c_void,
+            &au as *const _ as *mut c_void,
+            &mut xq as *mut _ as *mut c_void,
+            &yg as *const _ as *mut c_void,
+            &yu as *const _ as *mut c_void,
+            &gate_m_val as *const _ as *mut c_void,
+            &up_m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &bs_val as *const _ as *mut c_void,
+        ];
+
+        const BATCH_TILE: usize = 16;
+        let batch_tiles = (batch_size + BATCH_TILE - 1) / BATCH_TILE;
+        let total_m = (gate_m + up_m) as u32;
+        let grid_x = (total_m + 1) / 2;
+
+        let bytes = crate::profile::hfq4g256_weight_bytes(gate_m, k)
+            + crate::profile::hfq4g256_weight_bytes(up_m, k)
+            + batch_size * k
+            + batch_size * (gate_m + up_m) * 4;
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemm", "gemm_gate_up_hfq4g256_wave64_dp4a", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemm_gate_up_hfq4g256_wave64_dp4a",
+            [grid_x, batch_tiles as u32, 1],
+            [64, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ag); b.push_ptr(au);
+                b.push_ptr(xq);
+                b.push_ptr(yg); b.push_ptr(yu);
+                b.push_i32(gate_m_val); b.push_i32(up_m_val);
+                b.push_i32(k_val); b.push_i32(bs_val);
                 b
             },
         );

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -284,6 +284,15 @@ pub const FUSED_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../ke
 /// per-layer wo + w_down at B>1.
 pub const GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_hfq6g256_residual_wave64_dp4a.hip");
 
+/// HFQ4 sibling of `GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC` (issue #276,
+/// Gap 2 from the HFQ4/HFQ6 dp4a parity audit). Same structural pattern
+/// as the HFQ4 lm-head `gemm_hfq4g256_wave64_dp4a` with `+=` residual
+/// write semantic. Closes the dispatch gap where MQ4 at gfx906 B>1 below
+/// the MMQ cutover (B ∈ [2, 7]) falls to FP16 wave64; the dp4a path wins
+/// on per-call ALU and reuses the Q8_1 scratch. Ships BATCH_TILE=16 from
+/// the start per the HFQ6 Phase B.1.1 measurement (commit ff9e2105).
+pub const GEMM_HFQ4G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip");
+
 /// Phase A.3 (plan v3.2.3 §5.1 item 3): wave64+dp4a batched fused
 /// GEMMs for HFQ6/MQ6 prefill. Sibling of A.2 with multi-output row
 /// routing (qkvza 4-way, qkv 3-way, gate_up 2-way). Overwrite output
@@ -292,6 +301,19 @@ pub const GEMM_HFQ6G256_RESIDUAL_WAVE64_DP4A_SRC: &str = include_str!("../../../
 pub const GEMM_QKVZA_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq6g256_wave64_dp4a.hip");
 pub const GEMM_QKV_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq6g256_wave64_dp4a.hip");
 pub const GEMM_GATE_UP_HFQ6G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq6g256_wave64_dp4a.hip");
+
+/// HFQ4 siblings of the HFQ6 Phase A.3 fused dp4a kernels (issue #276
+/// Gap 2 part 2 of 4). Wave64+dp4a batched fused GEMMs at gfx906 for
+/// MQ4 prefill at B>1. Close the dispatch fallthroughs where MQ4 today
+/// drops to `gemm_*_hfq4g256_fp16_wave64` for the multi-output paths.
+/// Ship `BATCH_TILE=16` from the start per HFQ6 Phase B.1.1 (commits
+/// 2bee6e6b / ff9e2105). Math identity: signed 4-bit nibble unpack +
+/// `zp_eff = zp + 8*sc` matching the HFQ4 lm-head dp4a sibling
+/// `gemm_hfq4g256_wave64_dp4a.hip` and the HFQ4 residual dp4a
+/// `gemm_hfq4g256_residual_wave64_dp4a.hip`.
+pub const GEMM_QKVZA_HFQ4G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_hfq4g256_wave64_dp4a.hip");
+pub const GEMM_QKV_HFQ4G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_hfq4g256_wave64_dp4a.hip");
+pub const GEMM_GATE_UP_HFQ4G256_WAVE64_DP4A_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wave64_dp4a.hip");
 
 
 /// HFQ3-G256: flat 3-bit with 256-weight groups.

--- a/kernels/src/gemm_gate_up_hfq4g256_wave64_dp4a.hip
+++ b/kernels/src/gemm_gate_up_hfq4g256_wave64_dp4a.hip
@@ -1,0 +1,134 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a batched 2-way fused gate_up GEMM for HFQ4/MQ4, gfx906.
+// FFN preamble (gate + up) at B>1.
+//
+// HFQ4 sibling of gemm_gate_up_hfq6g256_wave64_dp4a (HFQ6 Phase A.3,
+// commit c070dbb3 → merged via #187). Issue #276 Gap 2.
+//
+// Closes the dispatch fallthrough where MQ4 at gfx906 batched prefill
+// drops to gemm_gate_up_hfq4g256_fp16_wave64. Wins on per-call ALU
+// (sdot4 4 mul + 4 acc-add per cycle vs hfma2 2 mul + 2 add ≈ 2×
+// FLOPs/cycle) and reuses the existing Q8_1 scratch.
+//
+// Math identity (signed HFQ4) — see gemm_qkvza_hfq4g256_wave64_dp4a.hip
+// for the full derivation. Same per-row inner loop; differs only in the
+// row-routing prologue (2-way gate/up vs 4-way qkv/z/beta/alpha).
+//
+// BATCH_TILE = 16 from start per HFQ6 Phase B.1.1 measurement
+// (commit 2bee6e6b: BT=8→16 measured -16.7% per-call on the HFQ6
+// gate_up sibling — the largest of the 4 BT improvements).
+//
+// Output semantics: y[b][row] = acc (overwrite).
+
+#define QK8_1 32
+#define BATCH_TILE 16
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_gate_up_hfq4g256_wave64_dp4a(
+    const char*  __restrict__ A_gate,
+    const char*  __restrict__ A_up,
+    const block_q8_1_mmq* __restrict__ Xq,    // kblock-major: [K/128 * batch_size]
+    float*       __restrict__ Y_gate,          // [batch_size, gate_m]
+    float*       __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = gate_m + up_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* Y;
+    int row;
+    int out_stride;
+    if (gid < gate_m) {
+        A = A_gate; Y = Y_gate; row = gid;            out_stride = gate_m;
+    } else {
+        A = A_up;   Y = Y_up;   row = gid - gate_m;   out_stride = up_m;
+    }
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 136;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = lane * 4;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const float zp_eff = zp + 8.0f * sc;
+
+        const unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        const unsigned int n0 = (pk >>  0) & 0xFu;
+        const unsigned int n1 = (pk >>  4) & 0xFu;
+        const unsigned int n2 = (pk >>  8) & 0xFu;
+        const unsigned int n3 = (pk >> 12) & 0xFu;
+        const unsigned int n4 = (pk >> 16) & 0xFu;
+        const unsigned int n5 = (pk >> 20) & 0xFu;
+        const unsigned int n6 = (pk >> 24) & 0xFu;
+        const unsigned int n7 = (pk >> 28) & 0xFu;
+        const int int_a = (int)(((n0 - 8) & 0xFF)
+                              | (((n1 - 8) & 0xFF) << 8)
+                              | (((n2 - 8) & 0xFF) << 16)
+                              | (((n3 - 8) & 0xFF) << 24));
+        const int int_b = (int)(((n4 - 8) & 0xFF)
+                              | (((n5 - 8) & 0xFF) << 8)
+                              | (((n6 - 8) & 0xFF) << 16)
+                              | (((n7 - 8) & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp_eff * sum_x * 0.25f;
+        }
+    }
+
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) Y[(long long)(batch_start + b) * out_stride + row] = val;
+    }
+}

--- a/kernels/src/gemm_hfq4g256_residual_mmq_gfx906_body.cuh
+++ b/kernels/src/gemm_hfq4g256_residual_mmq_gfx906_body.cuh
@@ -35,17 +35,26 @@
 #define QI8_1 8
 
 // X_STRIDE chosen per-mmq_x to balance two LDS effects:
-//   - mmq_x >= 64: stride 40 (32 data ints + 8 pad). 40 × 4 = 160 B
+//   - mmq_x >= 32: stride 40 (32 data ints + 8 pad). 40 × 4 = 160 B
 //     is 16-B aligned every row → 100% ds_read_b128. 40 % 32 = 8 →
 //     4-way bank conflict, but the b128 issue rate dominates.
-//   - mmq_x < 64: stride 33 (32 data ints + 1 pad). 33 × 4 = 132 B
+//   - mmq_x < 32: stride 33 (32 data ints + 1 pad). 33 × 4 = 132 B
 //     is 16-B aligned every 4th row only. 33 % 32 = 1 → 0-way bank
 //     conflict. Smaller-mmq_x kernels (used at small batch sizes,
 //     e.g. _full_add_x16 in attn-out residual) regressed under
 //     stride-40 due to the bank conflict cost outweighing the b128
 //     win when j0 has few iterations. PMC-validated.
+//
+// Cliff moved from mmq_x>=64 to mmq_x>=32 mirroring the HFQ6 audit
+// fix in 3ac7a3d8: PMC on the HFQ6 sibling at mmq_x=32 showed
+// MemUnitBusy collapsing to 13.8% (vs 28.8% at mmq_x=16 and 16.0% at
+// mmq_x=40) — kernel idle, not stalled. The b32 path's 8 ds_read_b32
+// per inner ALU iter was choking the LDS pipeline. Activating b128
+// from mmq_x=32 upward (2 ds_read_b128 per iter) recovers 16-20%
+// per-call at mmq_x ∈ {32, 40, 48, 56}. The HFQ4 sibling has the
+// structurally identical inner loop so the same physics applies.
 template <int mmq_x>
-constexpr int x_stride_for() { return mmq_x >= 64 ? 40 : 33; }
+constexpr int x_stride_for() { return mmq_x >= 32 ? 40 : 33; }
 
 #define Y_STRIDE 36
 
@@ -54,6 +63,8 @@ constexpr int x_stride_for() { return mmq_x >= 64 ? 40 : 33; }
 //   [x_dm:   float2 × MMQ_Y                  ]  = 128 * 8     =  1,024 B
 //   [tile_y: i32    × mmq_x * Y_STRIDE       ]  = mmq_x * 144 B
 // At mmq_x=64 (stride 40):  20,480 + 1,024 + 9,216 = 30,720 B per WG.
+// At mmq_x=32 (stride 40):  20,480 + 1,024 + 4,608 = 26,112 B per WG.
+// At mmq_x=24 (stride 33):  16,896 + 1,024 + 3,456 = 21,376 B per WG.
 // At mmq_x=8  (stride 33):  16,896 + 1,024 + 1,152 = 19,072 B per WG.
 // Budget: ≤ 32 KiB/WG so 2 WGs/CU fit in 64 KiB cap. Verified ✅.
 
@@ -183,13 +194,18 @@ static __device__ __forceinline__ void vec_dot_dp4a_streaming(
             const int i = i0 + threadIdx.x;
 
             int sumi = 0;
-            if constexpr (mmq_x >= 64) {
+            if constexpr (mmq_x >= 32) {
                 // b128 path: issue 8 ints per operand as 2× int4 (b128)
                 // reads. With X_STRIDE=40 (160 B/row, 16-B aligned every
                 // row) the compiler emits 100% ds_read_b128 — no b32-quad
-                // fallback. Threshold mmq_x≥64 empirically determined
-                // (see plan v2.16): at smaller mmq_x the int4-unpack
-                // overhead exceeds the issue-rate win.
+                // fallback. Threshold mmq_x≥32 per HFQ6 audit (3ac7a3d8):
+                // the prior `mmq_x≥64` cliff left mmq_x ∈ {32,40,48,56}
+                // on the b32 path with MemUnitBusy collapsing to 13.8%
+                // (LDS pipeline starvation under 8 ds_read_b32 per
+                // inner-ALU iter). Moving the cliff to mmq_x≥32 activates
+                // 2 ds_read_b128 per iter and recovers 16-20% per-call.
+                // MUST stay in lockstep with `x_stride_for<>()` above —
+                // b128 reads need stride=40 for 16-B alignment.
                 const int4 x_v0 = *(const int4*)&x_qs[i * x_stride + kx_start + 0];
                 const int4 x_v1 = *(const int4*)&x_qs[i * x_stride + kx_start + 4];
                 const int4 y_v0 = *(const int4*)&tile_y[j * Y_STRIDE + ky_start + 0];

--- a/kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip
+++ b/kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip
@@ -1,0 +1,147 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a port of gemm_hfq4g256_residual at GEMM-batched shape.
+// Activations pre-quantized to Q8_1 (block_q8_1_mmq layout, kblock-major:
+// [K/128 * batch_size]). Weights stay HFQ4-G256 (signed 4-bit nibbles +
+// per-256-group fp32 scale + zp).
+//
+// HFQ4 sibling of gemm_hfq6g256_residual_wave64_dp4a (HFQ6 Phase A.2,
+// commit 1b9f3747 on feat/gfx906-hfq6-hfq8-analysis). Closes the
+// dispatch gap where MQ4 at batch_size > 1 but below the MMQ cutover
+// (B ∈ [2, 7] on gfx906) falls to gemm_hfq4g256_residual_fp16_wave64;
+// the dp4a path wins on per-call ALU (sdot4 issues 4 int8 mul + 4
+// acc-add per cycle vs hfma2's 2 mul + 2 add → ~2× FLOPs/cycle) and
+// reuses the existing Q8_1 scratch.
+//
+// Differs from gemm_hfq4g256_wave64_dp4a only in writeback semantic:
+//   gemm_hfq4g256_wave64_dp4a:          y[...]  = val  (set/lm-head)
+//   gemm_hfq4g256_residual_wave64_dp4a: y[...] += val  (residual fuse)
+//
+// Math identity (signed 4-bit HFQ4, see gemm_hfq4g256_wave64_dp4a.hip
+// header for the full derivation):
+//   acc[b] += sc * d_x[b] * sumi_dp4a + zp_eff * sum_x[b] * 0.25f
+// where zp_eff = zp + 8 * sc folds the unsigned-bias correction into a
+// single per-block term. The 0.25 factor distributes Q8_1's per-sub-
+// block sum_x across the 4 lanes that share the sub-block.
+//
+// Topology mirrors gemm_hfq4g256_wave64_dp4a:
+//   block = [64, 1, 1]   = 2 warps, each handles 1 row (warp_id = row offset)
+//   grid  = [(M+1)/2, ceil(N/BATCH_TILE), 1]
+//   BATCH_TILE = 16 — per HFQ6 Phase B.1.1 (commit ff9e2105): doubling
+//     BATCH_TILE 8→16 halved A-reload trips per row across grid_y
+//     batch tiles, recovering 7-17% per-call vs BT=8 on the structurally
+//     identical HFQ6 sibling. Shipping BT=16 from the start rather than
+//     repeating HFQ6's bisect.
+
+#define QK8_1 32
+#define BATCH_TILE 16
+
+struct block_q8_1_mmq {
+    half2 ds4[4];           // (d, sum_x) per 32-K sub-block, 4 sub-blocks/block
+    int8_t qs[4 * QK8_1];   // 128 int8 K-elements per block
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_hfq4g256_residual_wave64_dp4a(
+    const char* __restrict__ A,
+    const block_q8_1_mmq* __restrict__ Xq,   // kblock-major: [K/128 * N]
+    float* __restrict__ y,                   // [batch_size, M]
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int row = blockIdx.x * 2 + warp_id;
+    if (row >= M) return;
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 136;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = lane * 4;
+
+    // Per-lane mapping inside one HFQ4-G256 group (256 K-elements):
+    //   K range: [8*lane, 8*lane+7]
+    //   sub-block index s(l) = l/4 (0..7)
+    //   Q8_1 block index within group b(l) = l/16 (0=A, 1=B)
+    //   ds4 slot within block i(l) = (l/4) % 4
+    //   qs byte offset within block: 8 * (lane % 16)
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136;
+
+        // Wave-uniform-per-warp scale + zp.
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const float zp_eff = zp + 8.0f * sc;
+
+        // Lane's 8 nibbles → 2 int8-packs. (n - 8) shifts unsigned [0,15]
+        // to signed [-8,7] so sdot4 consumes the same range as Q8_1's
+        // signed activations.
+        const unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        const unsigned int n0 = (pk >>  0) & 0xFu;
+        const unsigned int n1 = (pk >>  4) & 0xFu;
+        const unsigned int n2 = (pk >>  8) & 0xFu;
+        const unsigned int n3 = (pk >> 12) & 0xFu;
+        const unsigned int n4 = (pk >> 16) & 0xFu;
+        const unsigned int n5 = (pk >> 20) & 0xFu;
+        const unsigned int n6 = (pk >> 24) & 0xFu;
+        const unsigned int n7 = (pk >> 28) & 0xFu;
+        const int int_a = (int)(((n0 - 8) & 0xFF)
+                              | (((n1 - 8) & 0xFF) << 8)
+                              | (((n2 - 8) & 0xFF) << 16)
+                              | (((n3 - 8) & 0xFF) << 24));
+        const int int_b = (int)(((n4 - 8) & 0xFF)
+                              | (((n5 - 8) & 0xFF) << 8)
+                              | (((n6 - 8) & 0xFF) << 16)
+                              | (((n7 - 8) & 0xFF) << 24));
+
+        // Pick the lane's Q8_1 block (A or B). HFQ4 group g spans
+        // Q8_1 kblocks (2g, 2g+1).
+        const int kblock = 2 * g + block_within_group;
+
+        // Per-batch-token loop. Each iteration loads its own
+        // (d_x, sum_x, xq_a, xq_b) for this lane's sub-block view.
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp_eff * sum_x * 0.25f;
+        }
+    }
+
+    // Reduce + residual write-back. Same pyramid as the FP kernel.
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) y[(long long)(batch_start + b) * M + row] += val;
+    }
+}

--- a/kernels/src/gemm_qkv_hfq4g256_wave64_dp4a.hip
+++ b/kernels/src/gemm_qkv_hfq4g256_wave64_dp4a.hip
@@ -1,0 +1,137 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a batched 3-way fused qkv GEMM for HFQ4/MQ4, gfx906.
+// FullAttention preamble (q + k + v) at B>1.
+//
+// HFQ4 sibling of gemm_qkv_hfq6g256_wave64_dp4a (HFQ6 Phase A.3,
+// commit c070dbb3 → merged via #187). Issue #276 Gap 2.
+//
+// Closes the dispatch fallthrough where MQ4 at gfx906 batched prefill
+// drops to gemm_qkv_hfq4g256_fp16_wave64. Wins on per-call ALU (sdot4
+// 4 mul + 4 acc-add per cycle vs hfma2 2 mul + 2 add ≈ 2× FLOPs/cycle)
+// and reuses the existing Q8_1 scratch.
+//
+// Math identity (signed HFQ4) — see gemm_qkvza_hfq4g256_wave64_dp4a.hip
+// for the full derivation. Same per-row inner loop; differs only in the
+// row-routing prologue (3-way q/k/v vs 4-way qkv/z/beta/alpha).
+//
+// BATCH_TILE = 16 from start per HFQ6 Phase B.1.1 measurement.
+//
+// Output semantics: y[b][row] = acc (overwrite). Caller's wo fuses the
+// residual separately via gemm_hfq4g256_residual_wave64_dp4a.
+
+#define QK8_1 32
+#define BATCH_TILE 16
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_qkv_hfq4g256_wave64_dp4a(
+    const char*  __restrict__ A_q,
+    const char*  __restrict__ A_k,
+    const char*  __restrict__ A_v,
+    const block_q8_1_mmq* __restrict__ Xq,    // kblock-major: [K/128 * batch_size]
+    float*       __restrict__ Y_q,             // [batch_size, q_m]
+    float*       __restrict__ Y_k,
+    float*       __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = q_m + k_m + v_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* Y;
+    int row;
+    int out_stride;
+    if (gid < q_m) {
+        A = A_q; Y = Y_q; row = gid;                              out_stride = q_m;
+    } else if (gid < q_m + k_m) {
+        A = A_k; Y = Y_k; row = gid - q_m;                         out_stride = k_m;
+    } else {
+        A = A_v; Y = Y_v; row = gid - q_m - k_m;                    out_stride = v_m;
+    }
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 136;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = lane * 4;
+
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136;
+
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const float zp_eff = zp + 8.0f * sc;
+
+        const unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        const unsigned int n0 = (pk >>  0) & 0xFu;
+        const unsigned int n1 = (pk >>  4) & 0xFu;
+        const unsigned int n2 = (pk >>  8) & 0xFu;
+        const unsigned int n3 = (pk >> 12) & 0xFu;
+        const unsigned int n4 = (pk >> 16) & 0xFu;
+        const unsigned int n5 = (pk >> 20) & 0xFu;
+        const unsigned int n6 = (pk >> 24) & 0xFu;
+        const unsigned int n7 = (pk >> 28) & 0xFu;
+        const int int_a = (int)(((n0 - 8) & 0xFF)
+                              | (((n1 - 8) & 0xFF) << 8)
+                              | (((n2 - 8) & 0xFF) << 16)
+                              | (((n3 - 8) & 0xFF) << 24));
+        const int int_b = (int)(((n4 - 8) & 0xFF)
+                              | (((n5 - 8) & 0xFF) << 8)
+                              | (((n6 - 8) & 0xFF) << 16)
+                              | (((n7 - 8) & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp_eff * sum_x * 0.25f;
+        }
+    }
+
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) Y[(long long)(batch_start + b) * out_stride + row] = val;
+    }
+}

--- a/kernels/src/gemm_qkvza_hfq4g256_wave64_dp4a.hip
+++ b/kernels/src/gemm_qkvza_hfq4g256_wave64_dp4a.hip
@@ -1,0 +1,163 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Wave64+dp4a batched 4-way fused qkvza GEMM for HFQ4/MQ4, gfx906.
+// DeltaNet preamble (qkv + z + beta + alpha) at B>1.
+//
+// HFQ4 sibling of gemm_qkvza_hfq6g256_wave64_dp4a (HFQ6 Phase A.3,
+// commit c070dbb3 → merged via #187). Issue #276 Gap 2.
+//
+// Closes the dispatch fallthrough where MQ4 at gfx906 batched prefill
+// drops to gemm_qkvza_hfq4g256_fp16_wave64. Wins on per-call ALU
+// (sdot4 4 mul + 4 acc-add per cycle vs hfma2 2 mul + 2 add ≈ 2×
+// FLOPs/cycle) and reuses the existing Q8_1 scratch.
+//
+// Math identity (signed HFQ4):
+//   acc[b] += sc * d_x[b] * sumi_dp4a + zp_eff * sum_x[b] * 0.25f
+// where zp_eff = zp + 8 * sc folds the unsigned-bias correction. The
+// 0.25 factor distributes Q8_1's per-sub-block sum_x across the 4
+// lanes that share the sub-block.
+//
+// Topology mirrors gemm_qkvza_hfq6g256_wave64_dp4a:
+//   block = [64, 1, 1]  = 2 warps, each handles 1 row
+//   grid  = [(total_m+1)/2, ceil(N/BATCH_TILE), 1]
+//   BATCH_TILE = 16 — per HFQ6 Phase B.1.1 (commit ff9e2105): BT=8→16
+//     halves A-reload trips per row, +14.4% per-call on the HFQ6 qkvza
+//     sibling. Shipping BT=16 from the start rather than repeating the
+//     bisect.
+//
+// Output semantics: y[b][row] = acc (overwrite). Residual fuse happens
+// at wo + w_down through gemm_hfq4g256_residual_wave64_dp4a, not here.
+
+#define QK8_1 32
+#define BATCH_TILE 16
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+extern "C" __global__ void gemm_qkvza_hfq4g256_wave64_dp4a(
+    const char*  __restrict__ A_qkv,
+    const char*  __restrict__ A_z,
+    const char*  __restrict__ A_beta,
+    const char*  __restrict__ A_alpha,
+    const block_q8_1_mmq* __restrict__ Xq,    // kblock-major: [K/128 * batch_size]
+    float*       __restrict__ Y_qkv,           // [batch_size, qkv_m]
+    float*       __restrict__ Y_z,
+    float*       __restrict__ Y_beta,
+    float*       __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 2 + warp_id;
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    if (gid >= total_m) return;
+
+    // Route to target matrix + output stride.
+    const char* A;
+    float* Y;
+    int row;
+    int out_stride;
+    if (gid < qkv_m) {
+        A = A_qkv;   Y = Y_qkv;   row = gid;                                out_stride = qkv_m;
+    } else if (gid < qkv_m + z_m) {
+        A = A_z;     Y = Y_z;     row = gid - qkv_m;                         out_stride = z_m;
+    } else if (gid < qkv_m + z_m + beta_m) {
+        A = A_beta;  Y = Y_beta;  row = gid - (qkv_m + z_m);                  out_stride = beta_m;
+    } else {
+        A = A_alpha; Y = Y_alpha; row = gid - (qkv_m + z_m + beta_m);          out_stride = alpha_m;
+    }
+
+    const int batch_start = blockIdx.y * BATCH_TILE;
+    int local_bs = batch_size - batch_start;
+    if (local_bs > BATCH_TILE) local_bs = BATCH_TILE;
+    if (local_bs <= 0) return;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 136;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = lane * 4;
+
+    // Per-lane mapping inside one HFQ4-G256 group (256 K-elements):
+    //   K range: [8*lane, 8*lane+7]
+    //   sub-block index s(l) = l/4 (0..7)
+    //   Q8_1 block index within group b(l) = l/16 (0=A, 1=B)
+    //   ds4 slot within block i(l) = (l/4) % 4
+    //   qs byte offset within block: 8 * (lane % 16)
+    const int sub_in_block       = (lane / 4) % 4;
+    const int block_within_group = lane / 16;
+    const int qs_byte_off        = 8 * (lane % 16);
+
+    float acc[BATCH_TILE];
+    #pragma unroll
+    for (int b = 0; b < BATCH_TILE; b++) acc[b] = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + (long long)g * 136;
+
+        // Wave-uniform-per-warp scale + zp.
+        const float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        const float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const float zp_eff = zp + 8.0f * sc;
+
+        // Lane's 8 nibbles → 2 int8-packs. (n - 8) shifts unsigned [0,15]
+        // to signed [-8,7] so sdot4 consumes the same range as Q8_1's
+        // signed activations.
+        const unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        const unsigned int n0 = (pk >>  0) & 0xFu;
+        const unsigned int n1 = (pk >>  4) & 0xFu;
+        const unsigned int n2 = (pk >>  8) & 0xFu;
+        const unsigned int n3 = (pk >> 12) & 0xFu;
+        const unsigned int n4 = (pk >> 16) & 0xFu;
+        const unsigned int n5 = (pk >> 20) & 0xFu;
+        const unsigned int n6 = (pk >> 24) & 0xFu;
+        const unsigned int n7 = (pk >> 28) & 0xFu;
+        const int int_a = (int)(((n0 - 8) & 0xFF)
+                              | (((n1 - 8) & 0xFF) << 8)
+                              | (((n2 - 8) & 0xFF) << 16)
+                              | (((n3 - 8) & 0xFF) << 24));
+        const int int_b = (int)(((n4 - 8) & 0xFF)
+                              | (((n5 - 8) & 0xFF) << 8)
+                              | (((n6 - 8) & 0xFF) << 16)
+                              | (((n7 - 8) & 0xFF) << 24));
+
+        const int kblock = 2 * g + block_within_group;
+
+        // Per-batch-token loop.
+        for (int b = 0; b < local_bs; b++) {
+            const int token = batch_start + b;
+            const block_q8_1_mmq* xb = Xq + (long long)kblock * batch_size + token;
+
+            const int* xqs = (const int*)(xb->qs + qs_byte_off);
+            const int xq_a = xqs[0];
+            const int xq_b = xqs[1];
+
+            int sumi = 0;
+            sumi = __builtin_amdgcn_sdot4(int_a, xq_a, sumi, false);
+            sumi = __builtin_amdgcn_sdot4(int_b, xq_b, sumi, false);
+
+            const half2 ds = xb->ds4[sub_in_block];
+            const float2 dsf = __half22float2(ds);
+            const float d_x   = dsf.x;
+            const float sum_x = dsf.y;
+
+            acc[b] += sc * d_x * (float)sumi + zp_eff * sum_x * 0.25f;
+        }
+    }
+
+    // Reduce + write-back. Overwrite semantics for the fused-projection
+    // family (caller adds residual at wo + w_down sites separately).
+    for (int b = 0; b < local_bs; b++) {
+        float val = acc[b];
+        for (int offset = 16; offset > 0; offset >>= 1)
+            val += __shfl_down(val, offset);
+        if (lane == 0) Y[(long long)(batch_start + b) * out_stride + row] = val;
+    }
+}


### PR DESCRIPTION
Closes #276.

## Summary

Consolidates the four kernel-side changes from the HFQ4/HFQ6 dp4a parity audit into one PR. Originally split as #278/#279/#280 for granular review; collapsed at maintainer request to reduce open-PR count. All three changes are in the same gfx906 HFQ4 batched-dp4a subsystem and were always intended to land together (they close one issue).

Three independent but related changes, all gfx906-only, all gated behind existing arch / batch checks so non-gfx906 paths are byte-identical to master.

## 1. b128 LDS-read cliff `mmq_x>=64 → mmq_x>=32`

Existing HFQ4 MMQ kernel had its b128 cliff at `mmq_x >= 64`, leaving `mmq_x ∈ {32, 40, 48, 56}` on the b32 LDS path. HFQ6 audit (`3ac7a3d8`) measured the cliff at 64 was too conservative — dropping to 32 gave **16-20% per-call improvement** at those mmq_x values (LDS pipeline starvation under 8 ds_read_b32 per inner-ALU iter, kernel idle not stalled). HFQ4 body.cuh comment already claimed "mmq_x≥32 wins"; the code just never matched.

**Verified on HFQ4** (this PR, `bench-cold.sh` 5-run median, see Perf section): **+19.1% prefill at pp32 on 9b.mq4**, consistent with HFQ6 PMC prediction.

Files:
- `kernels/src/gemm_hfq4g256_residual_mmq_gfx906_body.cuh` — `x_stride_for` cliff + `if constexpr` guard
- `crates/rdna-compute/src/dispatch.rs` — x_stride computation at 2 call sites in lockstep

## 2. `gemm_hfq4g256_residual_wave64_dp4a` (new kernel)

HFQ4 sibling of `gemm_hfq6g256_residual_wave64_dp4a` (HFQ6 Phase A.2, `1b9f3747` → merged via #187). Closes the dispatch fallthrough where MQ4 at gfx906 B>1 below the MMQ cutover (B ∈ [2, 7]) drops to `gemm_hfq4g256_residual_fp16_wave64`. Per-call ALU win: sdot4 issues 4 int8 mul + 4 acc-add per cycle vs hfma2's 2 mul + 2 add ≈ 2× FLOPs/cycle.

Files added:
- `kernels/src/gemm_hfq4g256_residual_wave64_dp4a.hip` (140 LOC)
- `crates/rdna-compute/examples/test_hfq4_residual_dp4a.rs`

Math identity (signed 4-bit HFQ4): `(n - 8) & 0xFF` shifts unsigned [0,15] to signed [-8,7]; `zp_eff = zp + 8*sc` folds the unsigned-bias correction. Same math as the existing HFQ4 lm-head sibling; differs only in `+=` residual write semantic. Ships BATCH_TILE=16 from start per HFQ6 Phase B.1.1.

## 3. Three fused dp4a kernels (qkvza / qkv / gate_up)

Three more HFQ4 siblings of HFQ6 Phase A.3 fused kernels (`c070dbb3`):

- `gemm_qkvza_hfq4g256_wave64_dp4a` — 4-way (DeltaNet preamble)
- `gemm_qkv_hfq4g256_wave64_dp4a` — 3-way (FullAttention preamble)
- `gemm_gate_up_hfq4g256_wave64_dp4a` — 2-way (FFN preamble)

Unlike the residual sibling these fire on production paths that run every layer for every prefill token. Most impactful operating range: **DeltaNet QKVZA's beta+alpha tail** (M=32 — below MMQ_Y=128 — so MMQ wastes work; the dispatcher today splits MMQ-for-qkv+z plus fp16_wave64-for-beta+alpha; now the tail runs through dp4a). Also catches capture-mode prefill, MMQ screen-reject paths (after the self-review fix below), sub-MMQ-cutover batches.

Each kernel ships with both a public entry (does its own Q8_1 quantization) and a `_prequant` variant (accepts a pre-quantized Q8_1 scratch pointer). The MMQ-split tail path uses `_prequant` to avoid re-quantizing X.

Files added:
- `kernels/src/gemm_qkvza_hfq4g256_wave64_dp4a.hip` (147 LOC)
- `kernels/src/gemm_qkv_hfq4g256_wave64_dp4a.hip` (131 LOC)
- `kernels/src/gemm_gate_up_hfq4g256_wave64_dp4a.hip` (126 LOC)
- `crates/rdna-compute/examples/test_hfq4_fused_dp4a.rs` (includes a zero-M tail test for the row-routing prologue)

## Self-review fixes (folded into the commit)

Critical review of the consolidated diff surfaced 7 issues. All fixed in-place:

**[correctness] #1 — MMQ screen-reject routing.** The screen mechanism's design intent is to route weights that fail `mmq_screen_weight`'s MMQ-vs-FP16 comparison to a higher-precision fallback (per the existing `eprintln "falling back to WMMA"`). The initial wiring routed rejected weights through dp4a — which uses the same Q8_1 quantization step that MMQ failed on, so dp4a would fail in the same way. Fixed: track screen-reject explicitly with `mmq_screen_rejected` flag in all 4 dispatchers; gate the dp4a path on `!mmq_screen_rejected`. Rejected weights now correctly fall to fp16_wave64. Rare at threshold=0.50 in practice but protects the screen's whole reason for existing.

**[perf] #2 — redundant X re-quantization.** QKVZA tail path quantized X for MMQ, then the new dp4a tail call re-quantized X internally. Fixed by adding `_prequant` Rust variants (4 of them) that accept the q8 pointer directly. The QKVZA MMQ-split tail now calls `_prequant` — zero redundant conversion.

**[convention] #3-5** — added `self.bind_thread()?` to all 4 public dispatchers, added `begin_timer + t.finish` for rocprof attribution, corrected the bytes formula to use `hfq4g256_weight_bytes` (weight-only) instead of double-counting via `gemv_hfq4g256_bytes`.

**[test coverage] #6 — zero-M tail case.** Added explicit test exercising `_prequant(qkv_m=0, z_m=0, BETA_M, ALPHA_M, ...)` plus checks that qkv/z outputs stay zero (row-routing prologue correctness).

**[docs] #7 — incorrect "4× ALU" claim.** Replaced with accurate "sdot4 8 ops/cycle vs hfma2 4 ops/cycle ≈ 2× FLOPs/cycle" in 4 docstrings + 4 kernel-file headers.

## Correctness

All synthetic microbench tests pass with NRMSE in the Q8_1×HFQ4 quantization-noise band (~0.2-0.4%), well below the 1% tolerance:

**`test_gfx906_mmq_correctness`** (b128 cliff verification): mmq_x ∈ {24, 32, 40, 48, 56, 64} all PASS, NRMSE [0.19%, 0.23%].

**`test_hfq4_residual_dp4a`**: N ∈ {2, 4, 5, 7, 8, 16, 17, 24} all PASS, NRMSE [0.23%, 0.36%]. Residual `+=` write observed in all cases.

**`test_hfq4_fused_dp4a`** (3 kernels + zero-M tail, 11 outputs total): N ∈ {1, 2, 7, 8, 16, 17, 24, 32} all 11 outputs PASS at every N. Zero-M tail test confirms `qkv_m=0, z_m=0` skips qkv/z outputs and writes only beta/alpha.

## Coherence

`./scripts/coherence-gate.sh` passes clean — 9 OK / 3 SKIPPED / 0 errors. 9B mq4 reason output fluent and correct ("9 left"); 9B mq4 tool-call produces well-formed `<tool_call>` JSON with `{"name": "read", "arguments": {"path": "/tmp/fibonacci.c"}}` format. mq3, mq3-lloyd, mq6 prompts all coherent.

## Perf — verified via `bench-cold.sh` 5-run fresh-process median

**Hardware:** gfx906 (MI50, 32 GB HBM2, ROCm 6.4). **Model:** `/local/hipfire/qwen3.5-9b.mq4`. **Methodology:** per `2026-05-06-mq6-baselines.md` + CLAUDE.md Δ≥5% rule. All spreads < 5% (deterministic regime).

| pp | Master prefill | PR #281 prefill | Δ% | Notes |
|----|---------------:|----------------:|---:|-------|
| pp8 | 196.5 tok/s | 195.9 tok/s | −0.3% | within noise; B=8 routes to MMQ on both branches |
| pp16 | 292.6 tok/s | 285.9 tok/s | −2.3% | within noise; B=16 routes to MMQ on both |
| **pp32** | 309.3 tok/s | **368.5 tok/s** | **+19.1%** ✓ | **b128 cliff fix landing** — B=32 picks mmq_x=32 which moves to b128 path |
| pp128 | 596.2 tok/s | 592.3 tok/s | −0.7% | within noise; B=128 picks mmq_x=64, unchanged by cliff move |

Decode (B=1) unchanged across all pp sizes (within ±0.7% session noise) — confirms the new dp4a paths' `batch_size > 1` gate protects decode structurally.

### Attribution

- **pp32 +19.1%** is the b128 cliff fix (Gap 1) landing on HFQ4, consistent with the HFQ6 PMC prediction of 16-20% per-call at mmq_x ∈ {32, 40, 48, 56}. **Defensible headline number.**
- **The residual dp4a + 3 fused dp4a kernels** (Gap 2) are functionally correct (per the correctness sweeps above) but don't fire at standard pp shapes — MMQ wins at all B ≥ 8 on the dense gfx906 path. Their operating range is **B ∈ [2, 7]** (sub-MMQ-cutover, DFlash spec-decode verify) and the **QKVZA beta+alpha tail** (M=32, M < MMQ_Y, currently routes through fp16_wave64). A DFlash spec-decode bench would expose those gains separately; not run in this PR.

## Test plan

- [x] `cargo check -p rdna-compute --tests` — clean
- [x] `test_gfx906_mmq_correctness` mmq_x sweep — PASS
- [x] `test_hfq4_residual_dp4a` N sweep — PASS
- [x] `test_hfq4_fused_dp4a` 9-output × N sweep + zero-M tail — PASS
- [x] `./scripts/coherence-gate.sh` — 9 OK / 3 SKIPPED / 0 errors
- [x] **`bench-cold.sh` 5-run fresh-process median** — +19.1% pp32 (defensible)
- [ ] DFlash spec-decode bench for residual + fused dp4a operating range — deferred

## Stats

- 4 new kernel files (~545 LOC)
- 2 new correctness examples (~380 LOC, includes zero-M tail test)
- Dispatcher: 4 public + 4 prequant Rust fns + 5 dispatch-site wirings + b128 cliff updates + screen-reject routing fix (~440 LOC)

## Refs

- #276 — HFQ4/HFQ6 dp4a parity audit (closed by this PR)
- #187 — HFQ6 Phase A wave64+dp4a kernel stack
- PR #158 — HFQ4 lm-head dp4a (math reference for ports)
- `3ac7a3d8` — HFQ6 b128 cliff fix (PMC data, this PR's prediction source)
- `1b9f3747` — HFQ6 Phase A.2 residual dp4a
- `c070dbb3` — HFQ6 Phase A.3 fused dp4a
- `2bee6e6b` / `ff9e2105` — HFQ6 BT=8→16 measurements (rationale for BT=16 from start)
- Supersedes: #278 (b128 cliff), #279 (residual dp4a), #280 (fused dp4a) — closed in favor of this consolidated PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)