### PR TITLE
tools(qwen35): salvage engine drift diagnostics from #244

### DIFF
--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -163,6 +163,10 @@ name = "dump_logits_qwen35"
 required-features = ["arch-qwen35"]
 
 [[example]]
+name = "dump_qwen35_hidden_states"
+required-features = ["arch-qwen35", "deltanet"]
+
+[[example]]
 name = "greedy_dump"
 required-features = ["arch-qwen35"]
 

--- a/crates/hipfire-runtime/examples/dump_qwen35_hidden_states.rs
+++ b/crates/hipfire-runtime/examples/dump_qwen35_hidden_states.rs
@@ -1,0 +1,213 @@
+//! Dump per-layer hidden states from `qwen35::forward_scratch_with_hidden`
+//! for offline comparison against an HF transformers oracle.
+//!
+//! Used by the engine-drift-floor investigation tooling — see
+//! `docs/investigations/2026-05-12-engine-drift-floor/00-summary.md` for the
+//! methodology and the matching HF oracle script + comparator.
+//!
+//! Reads chunk-N tokens from a hipfire-β kldref so the input matches the
+//! eval pipeline byte-for-byte, runs `forward_scratch_with_hidden` per
+//! position with ALL layers configured as extraction targets, and writes a
+//! single HFHS binary containing post-layer hidden states for every layer +
+//! every position.
+//!
+//! Reuses the existing `HiddenStateRingBuffer` from spec-decode infra
+//! (which already supports per-layer extraction at arbitrary indices) —
+//! this example just overrides `extract_layers` to span the full layer
+//! range.
+//!
+//! Output format mirrors `scripts/dump_hf_hidden_states.py`:
+//!   magic 8B = b"HFHS\0\0\0\0"
+//!   n_layers u32
+//!   n_pos u32  (= n_ctx)
+//!   hidden_dim u32
+//!   reserved u32 = 0
+//!   body: n_layers * [n_pos, hidden_dim] f32 row-major
+//!
+//! Usage:
+//!   dump_qwen35_hidden_states --model <hfq> --ref <kldref> \
+//!                             --chunk N --out <path> \
+//!                             [--kv-mode q8|asym2|asym3|asym4|fp32]
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_arch_qwen35::qwen35::{self, DeltaNetState, Qwen35Scratch};
+    use hipfire_arch_qwen35::speculative::HiddenStateRingBuffer;
+    use hipfire_runtime::hfq::HfqFile;
+    use hipfire_runtime::llama::KvCache;
+    use std::fs::File;
+    use std::io::{BufReader, BufWriter, Read, Write};
+    use std::path::PathBuf;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model: Option<PathBuf> = None;
+    let mut ref_path: Option<PathBuf> = None;
+    let mut out_path: Option<PathBuf> = None;
+    let mut chunk: usize = 0;
+    let mut kv_mode: String = "q8".to_string();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model" => { model = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--ref" => { ref_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--out" => { out_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--chunk" => { chunk = argv[i + 1].parse().expect("--chunk"); i += 2; }
+            "--kv-mode" => {
+                let v = argv[i + 1].clone();
+                if !matches!(v.as_str(), "q8" | "asym2" | "asym3" | "asym4" | "fp32") {
+                    eprintln!("--kv-mode must be one of: q8 asym2 asym3 asym4 fp32 (got {v})");
+                    std::process::exit(1);
+                }
+                kv_mode = v;
+                i += 2;
+            }
+            "-h" | "--help" => {
+                eprintln!("Usage: dump_qwen35_hidden_states --model <hfq> --ref <kldref> --chunk N --out <path> [--kv-mode q8|asym3|fp32]");
+                std::process::exit(0);
+            }
+            other => { eprintln!("unknown arg: {other}"); std::process::exit(1); }
+        }
+    }
+    let model = model.expect("--model required");
+    let ref_path = ref_path.expect("--ref required");
+    let out_path = out_path.expect("--out required");
+
+    // Match eval_hipfire's env env setup so kernel paths align with the
+    // floor measurements we are localizing.
+    // SAFETY: single-threaded init phase; no other threads observing env.
+    unsafe {
+        std::env::set_var("HIPFIRE_NORMALIZE_PROMPT", "0");
+        std::env::set_var("HIPFIRE_GRAPH", "0");
+        std::env::set_var("HIPFIRE_KV_MODE", &kv_mode);
+    }
+
+    // -------- read tokens from ref --------
+    let ref_file = File::open(&ref_path).expect("open ref");
+    let mut ref_in = BufReader::new(ref_file);
+    let mut magic = [0u8; 8];
+    ref_in.read_exact(&mut magic).expect("magic");
+    if &magic != b"HFKLDR\0\0" {
+        eprintln!("bad ref magic"); std::process::exit(2);
+    }
+    let mut hdr = [0u8; 24];
+    ref_in.read_exact(&mut hdr).expect("hdr");
+    let n_ctx = u32::from_le_bytes(hdr[4..8].try_into().unwrap()) as usize;
+    let n_chunk = u32::from_le_bytes(hdr[12..16].try_into().unwrap()) as usize;
+    if chunk >= n_chunk {
+        eprintln!("chunk {chunk} >= n_chunk {n_chunk}"); std::process::exit(2);
+    }
+    let skip_bytes = chunk * n_ctx * 4;
+    if skip_bytes > 0 {
+        let mut skip = vec![0u8; skip_bytes];
+        ref_in.read_exact(&mut skip).expect("skip");
+    }
+    let mut token_bytes = vec![0u8; n_ctx * 4];
+    ref_in.read_exact(&mut token_bytes).expect("tokens");
+    let tokens: Vec<u32> = token_bytes
+        .chunks_exact(4)
+        .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+        .collect();
+    eprintln!("read {} tokens from chunk {} of {}", tokens.len(), chunk, ref_path.display());
+
+    // -------- load model --------
+    let mut hfq = HfqFile::open(&model).expect("open model");
+    let config = qwen35::config_from_hfq(&hfq).expect("config");
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    eprintln!("arch={} dim={} n_layers={}", gpu.arch, config.dim, config.n_layers);
+    let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
+
+    // -------- KV cache + DeltaNet state + scratch --------
+    let kv_max = n_ctx + 16;
+    let mut kv_cache = match kv_mode.as_str() {
+        "q8" => KvCache::new_gpu_q8(
+            &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max,
+        ).expect("kv cache q8"),
+        "asym3" => KvCache::new_gpu_asym3(
+            &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max,
+        ).expect("kv cache asym3"),
+        "asym4" => KvCache::new_gpu_asym4(
+            &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max,
+        ).expect("kv cache asym4"),
+        "asym2" => KvCache::new_gpu_asym2(
+            &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max,
+        ).expect("kv cache asym2"),
+        "fp32" => KvCache::new_gpu(
+            &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max,
+        ).expect("kv cache fp32"),
+        other => panic!("unknown --kv-mode: {other}"),
+    };
+    let scratch = Qwen35Scratch::new(&mut gpu, &config, 64).expect("scratch");
+    let mut dn_state = DeltaNetState::new(&mut gpu, &config).expect("dn state");
+
+    // -------- HiddenStateRingBuffer, overriding extract_layers to all layers --------
+    let mut hidden_rb = HiddenStateRingBuffer::new(
+        &mut gpu,
+        config.n_layers,    // num_target_layers
+        config.n_layers,    // num_extract == all
+        config.dim,         // hidden_dim
+        n_ctx,              // max_positions = exactly fits one chunk
+        1,                  // max_batch = 1 (per-token forward)
+    ).expect("hidden rb");
+    hidden_rb.extract_layers = (0..config.n_layers).collect();
+    eprintln!(
+        "hidden_rb: {} layers x {} positions x {} hidden = {:.1} MB",
+        hidden_rb.extract_layers.len(),
+        hidden_rb.max_positions,
+        hidden_rb.hidden_dim,
+        (hidden_rb.extract_layers.len() * hidden_rb.max_positions * hidden_rb.hidden_dim * 4) as f64
+            / (1024.0 * 1024.0)
+    );
+
+    // -------- per-token forward, head advances per call --------
+    let t0 = std::time::Instant::now();
+    for (pos, &tok) in tokens.iter().enumerate() {
+        qwen35::forward_scratch_with_hidden(
+            &mut gpu, &weights, &config, tok, pos,
+            &mut kv_cache, &mut dn_state, &scratch,
+            &mut hidden_rb,
+        ).expect("forward_scratch_with_hidden");
+        if pos == 0 || (pos + 1) % 256 == 0 {
+            eprintln!("  pos {:4}/{}: {:.1}s elapsed", pos + 1, n_ctx, t0.elapsed().as_secs_f64());
+        }
+    }
+    eprintln!("forward complete in {:.1}s", t0.elapsed().as_secs_f64());
+
+    // -------- download each layer's buffer + write HFHS file --------
+    if let Some(parent) = out_path.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir");
+    }
+    let out_file = File::create(&out_path).expect("create out");
+    let mut out = BufWriter::with_capacity(8 * 1024 * 1024, out_file);
+    out.write_all(b"HFHS\0\0\0\0").unwrap();
+    out.write_all(&(config.n_layers as u32).to_le_bytes()).unwrap();
+    out.write_all(&(n_ctx as u32).to_le_bytes()).unwrap();
+    out.write_all(&(config.dim as u32).to_le_bytes()).unwrap();
+    out.write_all(&0u32.to_le_bytes()).unwrap();
+
+    // Ring buffer is laid out as [max_positions, hidden_dim] row-major
+    // per layer. With max_positions == n_ctx and head advancing once per
+    // forward, layer_bufs[k] holds positions 0..n_ctx in order.
+    for (layer_idx, buf) in hidden_rb.layer_bufs.iter().enumerate() {
+        let f32_data = gpu.download_f32(buf).expect("download layer");
+        assert_eq!(f32_data.len(), n_ctx * config.dim,
+            "layer {layer_idx} got {} elements, expected {}",
+            f32_data.len(), n_ctx * config.dim);
+        let bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(f32_data.as_ptr() as *const u8, f32_data.len() * 4)
+        };
+        out.write_all(bytes).unwrap();
+        if layer_idx < 3 || layer_idx == config.n_layers - 1 {
+            let rms: f64 = (f32_data.iter().map(|&v| (v as f64) * (v as f64)).sum::<f64>()
+                / f32_data.len() as f64).sqrt();
+            eprintln!("  layer {layer_idx}: rms={rms:.4}");
+        }
+    }
+    out.flush().unwrap();
+    let size_mb = std::fs::metadata(&out_path).expect("stat").len() as f64 / (1024.0 * 1024.0);
+    eprintln!("wrote {} ({:.1} MB)", out_path.display(), size_mb);
+}

--- a/docs/investigations/2026-05-12-engine-drift-floor/00-summary.md
+++ b/docs/investigations/2026-05-12-engine-drift-floor/00-summary.md
@@ -1,0 +1,142 @@
+# Qwen3.5 Engine-Drift Hidden-State Diagnostics
+
+This directory preserves the reusable part of the 2026-05-12 engine-drift
+investigation tooling from PR #244. The old PR also carried several
+diagnostic-only runtime env gates and FP64 probe kernels. This salvage branch
+intentionally keeps the first landed surface narrower:
+
+- a hipfire hidden-state dump example,
+- an HF Transformers hidden-state oracle,
+- offline hidden-state comparators,
+- a cross-engine KLD sanity script,
+- the investigation notes needed to reproduce the workflow.
+
+Normal runtime behavior is unchanged.
+
+## Background
+
+The quality pipeline measures KLD between hipfire logits and a BF16 reference
+stored in hipfire beta `.kldref` format. On Qwen3.5 models, near-lossless Q8
+weights still showed a large engine-vs-reference floor, which meant quant
+candidate comparisons needed an engine-control row before their absolute KLD
+numbers could be interpreted.
+
+The investigation localized a major source of this floor to the Qwen3.5 RoPE
+pairing convention. HF uses half-split rotary pairs, while hipfire had been
+using the interleaved pairing for Qwen3.5 without a matching Q/K weight
+permutation. That root cause is already fixed in current master; the legacy
+path is retained behind `HIPFIRE_ROPE_INTERLEAVED_LEGACY=1`.
+
+The hidden-state dump tools are still useful for future drift work because they
+let us compare hipfire's post-layer residual stream against an HF oracle on the
+same `.kldref` chunk.
+
+## Shipped Tooling
+
+### Hipfire Dump
+
+`crates/hipfire-runtime/examples/dump_qwen35_hidden_states.rs`
+
+This example reads chunk `N` from a `.kldref`, runs Qwen3.5 token-by-token
+through `qwen35::forward_scratch_with_hidden`, and writes an `HFHS` binary:
+
+```text
+magic       8 bytes: HFHS\0\0\0\0
+n_layers    u32
+n_pos       u32
+hidden_dim  u32
+reserved    u32
+body        n_layers * [n_pos, hidden_dim] f32 row-major
+```
+
+It reuses the existing `HiddenStateRingBuffer` from spec-decode infrastructure
+and overrides `extract_layers` to capture every layer.
+
+### HF Oracle
+
+`scripts/dump_hf_hidden_states.py`
+
+This script runs the same `.kldref` chunk through HF Transformers and emits the
+same `HFHS` binary format. It uses a pre-hook on the final model norm so the
+last captured state matches hipfire's pre-final-norm capture point.
+
+### Comparators
+
+`scripts/compare_hidden_states.py`
+
+Computes per-layer relative L2 and cosine between two `HFHS` dumps.
+
+`scripts/compare_layer_positions.py`
+
+Buckets one layer's drift by position, which helps distinguish steady input
+bias from recurrent or long-context accumulation.
+
+`scripts/cross_engine_check.py`
+
+Checks whether the BF16 `.kldref` distribution and an HF Transformers run agree
+on the same token chunk. Use this before blaming hipfire if the external
+reference itself may have drifted.
+
+## Historical Findings
+
+These findings are preserved from the original investigation and have already
+been folded into `docs/plans/qwen35-mq4-quality-gap.md`.
+
+- The pre-fix Qwen3.5 RoPE path used interleaved rotary pairs against
+  half-split HF weight layout. This produced a large Qwen3.5-specific
+  engine-drift floor.
+- The current default half-split path removed the major floor component.
+- KV-cache quantization was not the primary layer-local divergence source.
+- The old PR used additional diagnostic-only probes to rule out lm-head Q8 vs
+  F16 precision, Qwen3.5 QK-norm accumulation precision, DeltaNet recurrent
+  state precision, and DeltaNet loader convention mismatches. Those probes are
+  not part of this first salvage PR.
+
+## Reproducer
+
+Build the hipfire dump example:
+
+```bash
+cargo build --release -p hipfire-runtime \
+  --example dump_qwen35_hidden_states \
+  --features deltanet
+```
+
+Dump hipfire hidden states from a local model and reference:
+
+```bash
+HIPFIRE_KV_MODE=q8 ./target/release/examples/dump_qwen35_hidden_states \
+  --model <path-to-qwen35-0.8b-q8f16.hfq> \
+  --ref <path-to-qwen3.5-0.8b-bf16.kldref.bin> \
+  --chunk 0 \
+  --kv-mode q8 \
+  --out /tmp/q3.5-0.8b-hipfire-hidden-chunk0.bin
+```
+
+Dump the HF oracle:
+
+```bash
+python3 scripts/dump_hf_hidden_states.py \
+  --model <path-to-Qwen3.5-0.8B-safetensors-snapshot> \
+  --ref <path-to-qwen3.5-0.8b-bf16.kldref.bin> \
+  --chunk 0 \
+  --device auto \
+  --out /tmp/q3.5-0.8b-hf-hidden-chunk0.bin
+```
+
+Compare:
+
+```bash
+python3 scripts/compare_hidden_states.py \
+  --hf /tmp/q3.5-0.8b-hf-hidden-chunk0.bin \
+  --hipfire /tmp/q3.5-0.8b-hipfire-hidden-chunk0.bin
+```
+
+For position-bucketed analysis:
+
+```bash
+python3 scripts/compare_layer_positions.py \
+  --hf /tmp/q3.5-0.8b-hf-hidden-chunk0.bin \
+  --hipfire /tmp/q3.5-0.8b-hipfire-hidden-chunk0.bin \
+  --layer 4
+```

--- a/scripts/compare_hidden_states.py
+++ b/scripts/compare_hidden_states.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Compare per-layer hidden states between HF transformers oracle and
+hipfire dump (Step A phase 3).
+
+Reads two HFHS-format binary dumps produced by
+  scripts/dump_hf_hidden_states.py    (HF transformers BF16 oracle)
+  examples/dump_qwen35_hidden_states  (hipfire forward, captured via
+                                       HiddenStateRingBuffer)
+
+Each dump must have the SAME (n_layers, n_pos, hidden_dim) for the same
+chunk. For each layer the comparator reports:
+
+  - RMS of HF, hipfire, and (HF - hipfire)
+  - mean cosine similarity per position
+  - relative L2 error  ||hf - hipfire|| / ||hf||  averaged over positions
+  - min cosine across positions (worst-case alignment per layer)
+
+The drift profile across layers tells us: (a) which layer first
+diverges materially, (b) whether the gap grows monotonically (drift
+accumulates layer-on-layer) or has a sharp step (one layer is broken).
+
+Usage:
+    compare_hidden_states.py --hf <hf_dump.bin> --hipfire <hipfire_dump.bin>
+"""
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--hf", required=True)
+    p.add_argument("--hipfire", required=True)
+    return p.parse_args()
+
+
+def read_hfhs(path: Path):
+    with open(path, "rb") as f:
+        magic = f.read(8)
+        if magic != b"HFHS\0\0\0\0":
+            sys.exit(f"{path}: bad magic {magic!r}")
+        n_layers, n_pos, hidden_dim, _reserved = struct.unpack("<IIII", f.read(16))
+        # body: n_layers * [n_pos, hidden_dim] f32
+        body = np.frombuffer(f.read(), dtype=np.float32)
+    expected = n_layers * n_pos * hidden_dim
+    if body.size != expected:
+        sys.exit(
+            f"{path}: body has {body.size} f32s, expected {expected} "
+            f"({n_layers}*{n_pos}*{hidden_dim})"
+        )
+    body = body.reshape(n_layers, n_pos, hidden_dim)
+    return n_layers, n_pos, hidden_dim, body
+
+
+def main():
+    args = parse_args()
+    n_layers_a, n_pos_a, hidden_a, hf = read_hfhs(Path(args.hf))
+    n_layers_b, n_pos_b, hidden_b, hip = read_hfhs(Path(args.hipfire))
+    if (n_layers_a, n_pos_a, hidden_a) != (n_layers_b, n_pos_b, hidden_b):
+        sys.exit(
+            f"shape mismatch HF {(n_layers_a, n_pos_a, hidden_a)} vs "
+            f"hipfire {(n_layers_b, n_pos_b, hidden_b)}"
+        )
+    n_layers, n_pos, hidden = n_layers_a, n_pos_a, hidden_a
+    print(
+        f"comparing {n_layers} layers x {n_pos} positions x {hidden} hidden",
+        flush=True,
+    )
+
+    print(
+        f"\n{'layer':>5} {'hf_rms':>10} {'hip_rms':>10} {'diff_rms':>10} "
+        f"{'rel_L2':>10} {'mean_cos':>10} {'min_cos':>10}",
+        flush=True,
+    )
+    print("-" * 70, flush=True)
+
+    for layer in range(n_layers):
+        h = hf[layer]  # [n_pos, hidden]
+        p = hip[layer]
+        diff = h - p
+        hf_rms = float(np.sqrt(np.mean(h.astype(np.float64) ** 2)))
+        hip_rms = float(np.sqrt(np.mean(p.astype(np.float64) ** 2)))
+        diff_rms = float(np.sqrt(np.mean(diff.astype(np.float64) ** 2)))
+        # Per-position relative L2 + cosine
+        h_norm = np.linalg.norm(h.astype(np.float64), axis=-1)
+        p_norm = np.linalg.norm(p.astype(np.float64), axis=-1)
+        diff_norm = np.linalg.norm(diff.astype(np.float64), axis=-1)
+        # Avoid div-by-zero (a layer-0-pre-RMSNorm row could be ~0)
+        rel_l2 = diff_norm / np.maximum(h_norm, 1e-12)
+        mean_rel_l2 = float(np.mean(rel_l2))
+        # Cosine via dot / (||h|| ||p||)
+        dot = np.einsum("ij,ij->i", h.astype(np.float64), p.astype(np.float64))
+        cos = dot / np.maximum(h_norm * p_norm, 1e-12)
+        mean_cos = float(np.mean(cos))
+        min_cos = float(np.min(cos))
+        print(
+            f"{layer:>5} {hf_rms:>10.4f} {hip_rms:>10.4f} {diff_rms:>10.4f} "
+            f"{mean_rel_l2:>10.4f} {mean_cos:>10.6f} {min_cos:>10.6f}",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_layer_positions.py
+++ b/scripts/compare_layer_positions.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Per-position drift breakdown for a single layer between HF oracle and
+hipfire dumps. Distinguishes "drift grows with state-step index" (recurrent
+accumulation) vs "drift roughly constant" (input-amplification at the layer
+level).
+
+Usage:
+    compare_layer_positions.py --hf <hf_dump.bin> --hipfire <hipfire_dump.bin> \
+                               --layer N
+"""
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--hf", required=True)
+    p.add_argument("--hipfire", required=True)
+    p.add_argument("--layer", type=int, required=True)
+    return p.parse_args()
+
+
+def read_hfhs(path):
+    with open(path, "rb") as f:
+        magic = f.read(8)
+        if magic != b"HFHS\0\0\0\0":
+            sys.exit(f"{path}: bad magic")
+        n_layers, n_pos, hidden, _ = struct.unpack("<IIII", f.read(16))
+        body = np.frombuffer(f.read(), dtype=np.float32)
+    return n_layers, n_pos, hidden, body.reshape(n_layers, n_pos, hidden)
+
+
+def main():
+    args = parse_args()
+    n_l_a, n_p_a, h_a, hf = read_hfhs(Path(args.hf))
+    n_l_b, n_p_b, h_b, hip = read_hfhs(Path(args.hipfire))
+    if (n_l_a, n_p_a, h_a) != (n_l_b, n_p_b, h_b):
+        sys.exit("shape mismatch")
+    if not (0 <= args.layer < n_l_a):
+        sys.exit(f"layer {args.layer} out of range [0, {n_l_a})")
+
+    h = hf[args.layer]  # [n_pos, hidden]
+    p = hip[args.layer]
+    diff = h - p
+    h_norm = np.linalg.norm(h.astype(np.float64), axis=-1)
+    p_norm = np.linalg.norm(p.astype(np.float64), axis=-1)
+    diff_norm = np.linalg.norm(diff.astype(np.float64), axis=-1)
+    rel_l2 = diff_norm / np.maximum(h_norm, 1e-12)
+    dot = np.einsum("ij,ij->i", h.astype(np.float64), p.astype(np.float64))
+    cos = dot / np.maximum(h_norm * p_norm, 1e-12)
+
+    n_pos = h.shape[0]
+    bucket_size = max(1, n_pos // 16)  # ~16 buckets
+    print(f"layer {args.layer}: per-position drift across {n_pos} positions")
+    print(f"{'pos_range':>14} {'mean_rel_L2':>12} {'min_cos':>10} {'mean_cos':>10}")
+    print("-" * 50)
+    for s in range(0, n_pos, bucket_size):
+        e = min(s + bucket_size, n_pos)
+        m_rel = float(np.mean(rel_l2[s:e]))
+        mn_cos = float(np.min(cos[s:e]))
+        mc = float(np.mean(cos[s:e]))
+        print(f"  [{s:4d}..{e:4d}] {m_rel:>12.4f} {mn_cos:>10.4f} {mc:>10.6f}")
+
+    print()
+    print(f"  overall mean rel_L2 = {float(np.mean(rel_l2)):.4f}")
+    print(f"  pos 0..127 mean = {float(np.mean(rel_l2[:128])):.4f}")
+    print(f"  pos 1024..1151 mean = {float(np.mean(rel_l2[1024:1152])):.4f}")
+    print(f"  pos 1920..2047 mean = {float(np.mean(rel_l2[1920:2048])):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cross_engine_check.py
+++ b/scripts/cross_engine_check.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Cross-engine sanity check (Step B for engine-drift floor investigation).
+
+Reads the first chunk's tokens from a llama.cpp-produced .kldref, runs
+those exact tokens through HF transformers BF16, and computes the per-
+position KL divergence between llama.cpp's top-K reference distribution
+and HF transformers' distribution on the same chunk.
+
+If KLD is small everywhere -> the two BF16 engines agree on Qwen3.5
+hidden-state evolution; hipfire's ~0.4-nat drift is fixable in
+principle. If KLD is large -> implementations diverge inherently; no
+ground truth to chase.
+
+Usage:
+    cross_engine_check.py --model <hf_snapshot_dir> \
+                          --ref <path-to-kldref.bin> \
+                          [--chunk N=0]
+"""
+import argparse
+import math
+import struct
+import sys
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", required=True, help="HF safetensors snapshot dir")
+    p.add_argument("--ref", required=True, help=".kldref binary from build_kld_ref")
+    p.add_argument("--chunk", type=int, default=0, help="chunk index to compare (default 0)")
+    return p.parse_args()
+
+
+def read_kldref_chunk(ref_path: Path, chunk_idx: int):
+    """Return (n_ctx, n_vocab, top_k, chunk_tokens, scored_blocks).
+
+    scored_blocks is a list of (indices, log_probs, residual_p) for each
+    scored position in the chunk. Mirrors the on-disk HFKLDR-beta layout
+    used by eval_hipfire/score_position.
+    """
+    with open(ref_path, "rb") as f:
+        magic = f.read(8)
+        if magic != b"HFKLDR\0\0":
+            sys.exit(f"bad ref magic: {magic!r}")
+        hdr = f.read(24)
+        version = struct.unpack("<I", hdr[0:4])[0]
+        n_ctx = struct.unpack("<I", hdr[4:8])[0]
+        n_vocab = struct.unpack("<I", hdr[8:12])[0]
+        n_chunk = struct.unpack("<I", hdr[12:16])[0]
+        top_k = struct.unpack("<H", hdr[16:18])[0]
+        if version != 1:
+            sys.exit(f"unsupported version {version}")
+        scored_per_chunk = n_ctx - 1 - n_ctx // 2
+        block_bytes = 8 + 8 * top_k
+
+        # Tokens: n_ctx * n_chunk u32s, all chunks contiguous
+        f.seek(32 + chunk_idx * n_ctx * 4)
+        if chunk_idx >= n_chunk:
+            sys.exit(f"chunk {chunk_idx} >= n_chunk {n_chunk}")
+        # Need to seek back to the START of tokens (offset 32) and
+        # skip to the desired chunk
+        f.seek(32)
+        all_token_bytes_to_skip = chunk_idx * n_ctx * 4
+        f.seek(32 + all_token_bytes_to_skip)
+        chunk_tokens = list(struct.unpack(f"<{n_ctx}I", f.read(n_ctx * 4)))
+
+        # Per-position blocks. Block stream starts after ALL tokens.
+        tokens_end = 32 + n_ctx * n_chunk * 4
+        blocks_start = tokens_end + chunk_idx * scored_per_chunk * block_bytes
+        f.seek(blocks_start)
+
+        scored_blocks = []
+        for _ in range(scored_per_chunk):
+            buf = f.read(block_bytes)
+            indices = list(struct.unpack(f"<{top_k}I", buf[: top_k * 4]))
+            log_probs = list(
+                struct.unpack(f"<{top_k}f", buf[top_k * 4 : top_k * 8])
+            )
+            residual = struct.unpack("<f", buf[top_k * 8 : top_k * 8 + 4])[0]
+            scored_blocks.append((indices, log_probs, residual))
+
+    return n_ctx, n_vocab, top_k, chunk_tokens, scored_blocks
+
+
+def main():
+    args = parse_args()
+
+    print(f"loading reference: {args.ref}", flush=True)
+    n_ctx, n_vocab, top_k, chunk_tokens, scored_blocks = read_kldref_chunk(
+        Path(args.ref), args.chunk
+    )
+    print(
+        f"  n_ctx={n_ctx} n_vocab={n_vocab} top_k={top_k} "
+        f"scored_per_chunk={len(scored_blocks)} chunk={args.chunk}",
+        flush=True,
+    )
+
+    print(f"loading HF model BF16 (CPU): {args.model}", flush=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype=torch.bfloat16, low_cpu_mem_usage=True
+    )
+    model.eval()
+    print(
+        f"  config: hidden={model.config.text_config.hidden_size if hasattr(model.config,'text_config') else model.config.hidden_size} "
+        f"layers={model.config.text_config.num_hidden_layers if hasattr(model.config,'text_config') else model.config.num_hidden_layers}",
+        flush=True,
+    )
+
+    print(f"running forward on {n_ctx} tokens...", flush=True)
+    input_ids = torch.tensor([chunk_tokens], dtype=torch.long)
+    with torch.no_grad():
+        out = model(input_ids)
+    # out.logits: [1, n_ctx, n_vocab]
+    logits_bf16 = out.logits[0].float()  # cast to f32 for stable math
+    print(f"  logits shape: {tuple(logits_bf16.shape)}", flush=True)
+
+    scoring_start = n_ctx // 2
+    klds_llama_to_hf = []
+    klds_hf_to_llama = []
+    for j, (ll_indices, ll_log_probs, ll_residual) in enumerate(scored_blocks):
+        pos = scoring_start + j
+        hf_logits = logits_bf16[pos]
+        # Compute HF's log-softmax once
+        hf_log_probs_all = torch.log_softmax(hf_logits, dim=-1)
+        # HF's top-K (for the reverse-direction KL)
+        hf_topk = torch.topk(hf_log_probs_all, top_k)
+        hf_top_indices = hf_topk.indices.tolist()
+        hf_top_log_probs = hf_topk.values.tolist()
+
+        # === KL(llama || HF) using llama's top-K as anchor ===
+        kld_a = 0.0
+        sum_p_hf_at_ll_top = 0.0
+        for i, idx in enumerate(ll_indices):
+            log_p_ll = ll_log_probs[i]
+            log_p_hf = hf_log_probs_all[idx].item()
+            p_ll = math.exp(log_p_ll)
+            kld_a += p_ll * (log_p_ll - log_p_hf)
+            sum_p_hf_at_ll_top += math.exp(log_p_hf)
+        p_resid_ll = ll_residual
+        p_resid_hf = max(1.0 - sum_p_hf_at_ll_top, 0.0)
+        if p_resid_ll > 1e-9 and p_resid_hf > 1e-9:
+            kld_a += p_resid_ll * (math.log(p_resid_ll) - math.log(p_resid_hf))
+        klds_llama_to_hf.append(max(kld_a, 0.0))
+
+        # === KL(HF || llama) using HF's top-K as anchor ===
+        # llama log_probs as a lookup: index -> log_prob
+        ll_lookup = dict(zip(ll_indices, ll_log_probs))
+        # Approximate llama log_prob for HF's top-K indices not in llama's top-K
+        # by uniformly spreading p_resid_ll over the missing vocab.
+        kld_b = 0.0
+        sum_p_ll_at_hf_top = 0.0
+        for i, idx in enumerate(hf_top_indices):
+            log_p_hf = hf_top_log_probs[i]
+            if idx in ll_lookup:
+                log_p_ll = ll_lookup[idx]
+            else:
+                # Best-effort estimate: uniform over residual.
+                remaining_vocab = max(n_vocab - len(ll_indices), 1)
+                p_uniform = max(p_resid_ll / remaining_vocab, 1e-30)
+                log_p_ll = math.log(p_uniform)
+            p_hf = math.exp(log_p_hf)
+            kld_b += p_hf * (log_p_hf - log_p_ll)
+            sum_p_ll_at_hf_top += math.exp(log_p_ll)
+        klds_hf_to_llama.append(max(kld_b, 0.0))
+
+        if j < 5 or j == len(scored_blocks) - 1:
+            print(
+                f"  pos {pos:4d}  KL(ll||hf)={kld_a:.6f}  KL(hf||ll)={kld_b:.6f}",
+                flush=True,
+            )
+
+    mean_a = sum(klds_llama_to_hf) / len(klds_llama_to_hf)
+    mean_b = sum(klds_hf_to_llama) / len(klds_hf_to_llama)
+    max_a = max(klds_llama_to_hf)
+    max_b = max(klds_hf_to_llama)
+    print()
+    print("=== cross-engine KL summary (chunk", args.chunk, ") ===", flush=True)
+    print(f"  KL(llama || HF):  mean={mean_a:.6f}  max={max_a:.6f}", flush=True)
+    print(f"  KL(HF || llama):  mean={mean_b:.6f}  max={max_b:.6f}", flush=True)
+    print(
+        f"  symmetric (mean of the two): {(mean_a + mean_b) / 2:.6f}",
+        flush=True,
+    )
+
+    # Context: matched hipfire q8f16 floor for Q3.5-0.8B per-token kv-q8 is 0.4945
+    print()
+    print(
+        "Context: hipfire q8f16 KLD (per-token kv-q8, n=20 chunks) for matched-arch "
+        "Q3.5-0.8B = 0.4945. If cross-engine KL << that, hipfire is the drifter."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dump_hf_hidden_states.py
+++ b/scripts/dump_hf_hidden_states.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""HF transformers per-layer hidden-state oracle (Step A phase 1).
+
+Loads the HF checkpoint in BF16, runs one chunk's tokens (extracted
+from a llama.cpp kldref so they match the hipfire eval pipeline byte-
+for-byte), and dumps each transformer layer's output hidden state to a
+binary file. Pair with a matching hipfire dumper + offline comparator
+to localize which layer first diverges by how much.
+
+Output format (raw little-endian):
+  - header: 16 bytes
+      magic 8B = b"HFHS\\0\\0\\0\\0"
+      n_layers u32
+      n_pos u32  (= n_ctx; we dump *every* position so cosine is
+                  per-position per-layer)
+      hidden_dim u32
+      reserved u32 = 0
+  - body: n_layers blocks, each block is [n_pos, hidden_dim] f32 row-major
+    (HF returns hidden_states tuple of length n_layers+1: the first is
+     the embedding; we dump layers 1..n_layers, i.e. POST-transformer
+     output per layer — to match what hipfire writes post-FFN residual.)
+
+Usage:
+    dump_hf_hidden_states.py --model <hf_dir> --ref <kldref> \
+                             --chunk N --out <path>
+"""
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", required=True)
+    p.add_argument("--ref", required=True)
+    p.add_argument("--chunk", type=int, default=0)
+    p.add_argument("--out", required=True)
+    p.add_argument(
+        "--device",
+        choices=("auto", "cpu", "cuda"),
+        default="auto",
+        help="forward device; 'cuda' is also the PyTorch ROCm device name",
+    )
+    return p.parse_args()
+
+
+def read_chunk_tokens(ref_path: Path, chunk_idx: int):
+    with open(ref_path, "rb") as f:
+        if f.read(8) != b"HFKLDR\0\0":
+            sys.exit("bad ref magic")
+        hdr = f.read(24)
+        n_ctx = struct.unpack("<I", hdr[4:8])[0]
+        n_chunk = struct.unpack("<I", hdr[12:16])[0]
+        if chunk_idx >= n_chunk:
+            sys.exit(f"chunk {chunk_idx} >= n_chunk {n_chunk}")
+        f.seek(32 + chunk_idx * n_ctx * 4)
+        tokens = list(struct.unpack(f"<{n_ctx}I", f.read(n_ctx * 4)))
+        return n_ctx, tokens
+
+
+def main():
+    args = parse_args()
+    n_ctx, tokens = read_chunk_tokens(Path(args.ref), args.chunk)
+    print(f"loaded {n_ctx} tokens from chunk {args.chunk}", flush=True)
+
+    device = "cuda" if args.device == "auto" and torch.cuda.is_available() else args.device
+    if device == "auto":
+        device = "cpu"
+
+    print(f"loading HF model BF16 ({device}): {args.model}", flush=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, dtype=torch.bfloat16, low_cpu_mem_usage=True
+    )
+    if device == "cuda":
+        model.to("cuda")
+    model.eval()
+
+    cfg = model.config
+    tcfg = getattr(cfg, "text_config", cfg)
+    hidden_dim = tcfg.hidden_size
+    n_layers = tcfg.num_hidden_layers
+    print(f"  hidden_dim={hidden_dim} n_layers={n_layers}", flush=True)
+
+    input_ids = torch.tensor([tokens], dtype=torch.long, device=device)
+    print(f"running forward with output_hidden_states=True...", flush=True)
+    with torch.no_grad():
+        out = model(input_ids, output_hidden_states=True)
+
+    # out.hidden_states is a tuple of length n_layers+1.
+    # transformers convention (see Qwen2Model.forward):
+    #   hidden_states[0]            = pre-layer-0  (= embedding output)
+    #   hidden_states[i] for 1..n   = pre-layer-i  (= POST decoder-layer-(i-1))
+    #   hidden_states[n_layers]     = POST FINAL NORM (model.norm applied)
+    #
+    # For an apples-to-apples comparison with hipfire's
+    # HiddenStateRingBuffer (which writes the post-residual state at the
+    # END of each decoder layer, BEFORE the final model norm), we want
+    # the post-layer-i value for i = 0..n_layers-1. That is:
+    #   hipfire layer k output  <->  hs[k + 1] for k = 0..n_layers-2
+    #   hipfire layer (n_layers-1) output  <->  has no direct entry in
+    #     the standard hidden_states tuple — hs[n_layers] is POST norm,
+    #     hs[n_layers-1] is BEFORE the last layer (not after).
+    #
+    # To get the post-last-layer-pre-norm state we hook the final norm
+    # and capture its input. Workaround: temporarily replace
+    # model.model.norm with an identity wrapper that records the input,
+    # rerun, then restore. Or simpler — read out via model.model.norm's
+    # forward via a forward hook before this main forward() returns.
+    hs = out.hidden_states
+    print(f"  hidden_states tuple length: {len(hs)}", flush=True)
+
+    # Capture pre-final-norm state via a forward-pre-hook on model.model.norm.
+    # We replay with the hook attached.
+    pre_norm_capture = {}
+    def _capture(module, inputs):
+        pre_norm_capture["x"] = inputs[0].detach()
+    norm_module = model.model.norm if hasattr(model, "model") and hasattr(model.model, "norm") else None
+    if norm_module is None:
+        # qwen3_5 wraps in model.language_model.norm
+        norm_module = model.model.language_model.norm
+    handle = norm_module.register_forward_pre_hook(_capture)
+    with torch.no_grad():
+        _ = model(input_ids, output_hidden_states=False)
+    handle.remove()
+    post_last_layer = pre_norm_capture["x"][0]  # [n_ctx, hidden_dim], pre-final-norm
+    print(
+        f"  captured pre-final-norm via hook: shape={tuple(post_last_layer.shape)} "
+        f"rms={float((post_last_layer.float() ** 2).mean() ** 0.5):.4f}",
+        flush=True,
+    )
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "wb") as f:
+        f.write(b"HFHS\0\0\0\0")
+        f.write(struct.pack("<IIII", n_layers, n_ctx, hidden_dim, 0))
+        for layer_idx in range(n_layers):
+            if layer_idx < n_layers - 1:
+                tensor = hs[layer_idx + 1][0]  # post-layer-`layer_idx` output
+            else:
+                tensor = post_last_layer       # post-last-layer, pre-norm
+            assert tensor.shape == (n_ctx, hidden_dim), f"layer {layer_idx} shape {tensor.shape}"
+            arr = tensor.detach().float().cpu().contiguous().numpy()
+            f.write(arr.tobytes())
+            if layer_idx < 3 or layer_idx == n_layers - 1:
+                norm = arr.reshape(-1).astype("float64")
+                rms = float((norm ** 2).mean() ** 0.5)
+                print(
+                    f"  layer {layer_idx}: shape={arr.shape} rms={rms:.4f}",
+                    flush=True,
+                )
+
+    size_mb = out_path.stat().st_size / (1024 * 1024)
+    print(f"wrote {out_path} ({size_mb:.1f} MB)", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Salvages the reusable diagnostics from stale/conflicted PR #244 without pulling its old runtime env-gate and FP64 probe-kernel changes into the current hot path.

This PR adds:

- `dump_qwen35_hidden_states` example, using the existing `HiddenStateRingBuffer` to emit per-layer `HFHS` hidden-state dumps for Qwen3.5 chunks.
- HF Transformers oracle dump script for the same `HFHS` format, now with `--device auto|cpu|cuda` so it can run on ROCm Torch (`cuda` is PyTorch's ROCm device name).
- Offline comparators for per-layer and per-position drift.
- Cross-engine KLD sanity script.
- A scoped investigation note that documents the salvaged workflow and explicitly says the old #244 runtime env-gates/probe kernels are not included here.

Normal runtime behavior is unchanged; this only registers a new example and adds scripts/docs.

## Validation

- `cargo check -p hipfire-runtime --example dump_qwen35_hidden_states --features deltanet`
- `cargo check -p hipfire-runtime --example eval_hipfire --features deltanet`
- `python3 -m py_compile scripts/dump_hf_hidden_states.py scripts/compare_hidden_states.py scripts/compare_layer_positions.py scripts/cross_engine_check.py`
- Hipfire-side full chunk smoke on local gfx1100:
  - model: `/mnt/nas/kaden/llama.cpp/models/archive-hfq/qwen35-0.8b-q8f16.hfq`
  - ref: `/tmp/hipfire-kldref/qwen3.5-0.8b-bf16.kldref.bin`
  - output: `/mnt/nas/kaden/tmp/pr244-salvage/hipfire-hidden-chunk0.bin`
  - wrote expected 192 MB HFHS dump.
- HF oracle smoke on `ssh hiptrx` with conda env `hipfire-rocm`:
  - Torch `2.12.0+rocm7.2`, HIP `7.2`, 4 devices visible.
  - model: `/mnt/nas/kaden/cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B/snapshots/2fc06364715b967f1860aea9cf38778875588b17`
  - output: `/mnt/nas/kaden/tmp/pr244-salvage/hf-hidden-chunk0.bin`
  - wrote expected 192 MB HFHS dump.
- Comparator smoke:
  - `compare_hidden_states.py` aligned both dumps and produced a 24-layer table.
  - layer 4 rel_L2 = `0.1310`, mean_cos = `0.990585`.
  - `compare_layer_positions.py --layer 4` produced the expected per-position bucket profile.