### PR TITLE
[codex] fix-forward MQ4 cleanup from #277

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -288,14 +288,18 @@ fn has_mmq_dp4a_or_wmma(arch: &str) -> bool {
 ///   `0` / `off`            — force MMQ off (debug / regression bisect)
 ///   `1` / `on`             — force MMQ on at every batch (legacy behavior)
 ///   `auto` / unset / other — auto-route by batch_size threshold (default)
+///
+/// Both env reads (`HIPFIRE_MMQ`, `HIPFIRE_MMQ_MIN_BATCH`) cache via
+/// `OnceLock` — no per-dispatch syscalls on the hot path (called from
+/// 9+ dispatch sites, ~288+ syscalls/chunk on 27B prefill otherwise).
 fn should_use_mmq(arch: &str, batch_size: usize) -> bool {
     if !has_mmq_dp4a_or_wmma(arch) {
         return false;
     }
-    match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
-        Some("0") | Some("off") => false,
-        Some("1") | Some("on") => true,
-        _ => {
+    match mmq_env_override() {
+        Some(false) => false,
+        Some(true) => true,
+        None => {
             // Per-arch default min_batch:
             //   gfx906: 8 — empirically validated for both prefill (pp512
             //     within noise of min_batch=16) and DFlash 27B verify
@@ -313,13 +317,61 @@ fn should_use_mmq(arch: &str, batch_size: usize) -> bool {
             //     than MMQ at small batches; flip only when MMQ amortization
             //     dominates.
             let arch_min_batch: usize = if arch == "gfx906" { 8 } else { 256 };
-            let min_batch = std::env::var("HIPFIRE_MMQ_MIN_BATCH")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
-                .unwrap_or(arch_min_batch);
+            let min_batch = mmq_min_batch_override().unwrap_or(arch_min_batch);
             batch_size >= min_batch
         }
     }
+}
+
+/// Cached env-var read for `HIPFIRE_MMQ`. `Some(true)` = force on,
+/// `Some(false)` = force off, `None` = auto.
+fn mmq_env_override() -> Option<bool> {
+    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
+            Some("0") | Some("off") => Some(false),
+            Some("1") | Some("on") => Some(true),
+            _ => None,
+        }
+    })
+}
+
+/// Cached env-var read for `HIPFIRE_MMQ_MIN_BATCH` (per-arch min-batch override).
+fn mmq_min_batch_override() -> Option<usize> {
+    static CACHE: OnceLock<Option<usize>> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("HIPFIRE_MMQ_MIN_BATCH")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+    })
+}
+
+/// Cached env-var read for `HIPFIRE_FP16=0` (disable FP16 fast paths).
+/// Called from 12+ dispatch sites on the prefill hot path; uncached read
+/// is one syscall + String alloc per dispatch.
+fn fp16_disabled() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
+    })
+}
+
+/// Cached env-var read for `HIPFIRE_WO_MMQ=1` (opt-in MMQ for the wo path
+/// on RDNA3+/RDNA3.5 while the tiled path is validated).
+fn wo_mmq_enabled() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
+    })
+}
+
+/// Cached env-var read for `HIPFIRE_LM_HEAD_WMMA=0` (disable the gfx11
+/// LM-head WMMA fast path).
+fn lm_head_wmma_disabled() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0")
+    })
 }
 
 /// Tensor stored on the GPU. Tracks shape and element type.
@@ -4901,7 +4953,7 @@ impl Gpu {
             }
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
             if is_gcn5_wave64(&self.arch) {
                 // gfx906 dp4a MMQ split: qkv + z route through the new MMQ
@@ -5364,7 +5416,7 @@ impl Gpu {
             }
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
             if is_gcn5_wave64(&self.arch) {
                 // gfx906 dp4a MMQ: route q+k+v through the new MMQ kernel.
@@ -5766,7 +5818,7 @@ impl Gpu {
             }
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             // gfx906 dp4a MMQ — default-on at batch_size ≥ 8 (per
             // should_use_mmq's gfx906 default). Quantize X once, screen
             // both weights, dispatch MMQ for each in set mode (add=0).
@@ -9071,7 +9123,7 @@ impl Gpu {
         }
 
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             // gfx906 dp4a MMQ residual path — default-on at batch ≥ 8 per
             // should_use_mmq's gfx906 default. Distinguishes two reasons
             // MMQ might NOT fire:
@@ -9122,8 +9174,7 @@ impl Gpu {
             }
 
             // Opt-in MMQ path (RDNA3/3.5, HIPFIRE_MMQ=1 or HIPFIRE_WO_MMQ=1).
-            if std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
-                || should_use_mmq(&self.arch, batch_size)
+            if wo_mmq_enabled() || should_use_mmq(&self.arch, batch_size)
             {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_raw, m, k)
@@ -9530,6 +9581,16 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // Caller (fused dispatcher) is expected to gate via `should_use_mmq`;
+        // the assert below enforces that contract so a future caller can't
+        // silently route a non-winning batch through MMQ. Mirrors the MQ6
+        // sibling's `hfq6_mmq_route` assert added in 5ea9050.
+        debug_assert!(
+            should_use_mmq(&self.arch, batch_size) || self.capture_mode,
+            "_mmq_set_gfx906 called at non-winning B={} (capture={}) — \
+             caller must gate via should_use_mmq first",
+            batch_size, self.capture_mode,
+        );
         let mmq_x = if batch_size <= 8 { 8 }
             else if batch_size <= 16 { 16 }
             else if batch_size <= 24 { 24 }
@@ -9599,7 +9660,9 @@ impl Gpu {
         debug_assert!(shared_mem as usize <= 32 * 1024,
             "gfx906 MMQ LDS budget exceeded: {} B > 32 KiB", shared_mem);
 
+        // bytes = weight read + X read (Q8_1, ~1 byte/element + scale) + Y write (set, no read).
         let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k
             + batch_size * m * 4;
         let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_mmq_set_gfx906", bytes);
         let result = self.launch_maybe_blob(
@@ -10873,8 +10936,8 @@ impl Gpu {
         self.bind_thread()?;
         let wmma_eligible = batch_size > 1
             && self.arch.starts_with("gfx11")
-            && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
-            && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
+            && !fp16_disabled()
+            && !lm_head_wmma_disabled();
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
             match self.active_stream.as_ref() {
@@ -10917,8 +10980,8 @@ impl Gpu {
         // gfx11+: WMMA residual + zero-init.
         let wmma_eligible = batch_size > 1
             && self.arch.starts_with("gfx11")
-            && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
-            && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
+            && !fp16_disabled()
+            && !lm_head_wmma_disabled();
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
             match self.active_stream.as_ref() {
@@ -10962,8 +11025,8 @@ impl Gpu {
         // through to the per-row GEMV path.
         let wmma_eligible = batch_size > 1
             && (has_wmma_f16(&self.arch) || has_wmma_f16_gfx12(&self.arch))
-            && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
-            && !std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0");
+            && !fp16_disabled()
+            && !lm_head_wmma_disabled();
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
             match self.active_stream.as_ref() {
@@ -11061,7 +11124,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             // WMMA on gfx11+ (RDNA3): 16x16 tiled
             if self.arch.starts_with("gfx11") {
                 return self.gemm_hfq6g256_residual_wmma(a_raw, x, y, m, k, batch_size);
@@ -11242,7 +11305,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkvza_hfq6g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
@@ -11727,7 +11790,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_qkv_hfq6g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
@@ -12167,7 +12230,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0") {
+        if batch_size > 1 && !fp16_disabled() {
             if has_wmma_f16_gfx12(&self.arch) {
                 return self.gemm_gate_up_hfq6g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }

--- a/kernels/src/gemm_hfq4g256_residual_mmq_gfx906_body.cuh
+++ b/kernels/src/gemm_hfq4g256_residual_mmq_gfx906_body.cuh
@@ -26,6 +26,47 @@
 // the optimum stride differs at small vs large mmq_x. PMC validation
 // is in docs/perf-checkpoints/2026-05-05-gfx906-mmq-redesign-final.md
 // §5.
+//
+// ═══ KERNEL INVARIANTS — caller MUST satisfy ═══
+//
+//   1. K must be a multiple of 256 (= group_size). Body assumes
+//      `groups_per_row = K / 256`; not asserted at runtime (caller's job).
+//
+//   2. M alignment depends on the kernel variant:
+//        `_x{N}`            (need_check=true)  → ANY M ≥ 1 is safe.
+//                                                OOB rows clamp to M-1
+//                                                weights in shared memory
+//                                                and accumulate spurious
+//                                                sums, but write_back skips
+//                                                them so observable Y is
+//                                                correct.
+//        `_full_add_x{N}`   (need_check=false, add=1) → CALLER MUST GUARANTEE
+//                                                       `M % 128 == 0`.
+//        `_full_set_x{N}`   (need_check=false, add=0) → CALLER MUST GUARANTEE
+//                                                       `M % 128 == 0`.
+//      The `_full_*` variants drop the `(row >= M ? skip)` check from
+//      writeback for ~5 % perf — they will write GARBAGE to OOB rows
+//      otherwise. The dispatcher enforces `is_full = m % 128 == 0 &&
+//      batch_size % mmq_x == 0` before naming a `_full_*` kernel; do not
+//      bypass that gate.
+//
+//   3. N (batch_size) alignment depends on the kernel variant:
+//        `_x{N}`        → ANY N ≥ 1 is safe (need_check=true skips OOB cols).
+//        `_full_*_x{N}` → CALLER MUST GUARANTEE `batch_size % mmq_x == 0`.
+//
+//   4. Body's row-clamp at lines `(row0 + i < M) ? (row0 + i) : (M - 1)`
+//      means non-`_full_*` variants over-fetch row M-1 weights into the
+//      LDS slots that correspond to OOB rows. This costs ~0 % perf (cache-
+//      hot reads) but breaks if M==0 (would index row -1 underflowing
+//      to 2^64-1). Caller must also guarantee M ≥ 1.
+//
+//   5. HFQ4-specific (vs HFQ6 sibling):
+//        - 136 B/group (= 8 B scale/zero header + 128 B nibbles), not 200.
+//        - Nibbles are SIGNED 4-bit; the accumulation uses `zp_eff =
+//          zp + 8 * scale` to fold the unsigned-bias correction into a
+//          single per-block term (avoids a per-lane subtraction in the
+//          inner loop). The `_full_*` writeback formula assumes
+//          `acc + zp_eff * sum_x` with no additional shift.
 
 #define MMQ_Y 128
 #define MMQ_NWARPS 4

--- a/kernels/src/gemv_hfq4g256_residual_wave64.hip
+++ b/kernels/src/gemv_hfq4g256_residual_wave64.hip
@@ -6,8 +6,18 @@
 //
 // block=[64,1,1] packs two rows per block (one per warp); grid halves from
 // M to (M + 1) / 2. Each warp's 32-lane reduction is byte-exact with the
-// wave32 base kernel's pyramid (lane 0 per warp writes output; the
-// `__shfl_down` chain stays within the 32-lane warp).
+// wave32 base kernel's pyramid: only lane 0 of each half-warp writes its
+// row's output, so only lanes 0 and 32 need a correct partial sum.
+//
+// CAUTION on the `__shfl_down` width: on wave64 archs `__shfl_down`
+// defaults to `width=warpSize=64`, so `offset=16` reads from `lane+16`
+// which crosses the 32-lane boundary. The math is still byte-exact
+// with the wave32 base kernel because lanes 16-31 read cross-warp data
+// but DON'T write output — only lanes 0 and 32 write their row's
+// result, and each lane-0 final reduction only consumes values from
+// its own 32-lane half. Do NOT add `width=32` to "match" this comment
+// — the current code intentionally relies on the default width=64
+// semantics; changing it would alter the pyramid's read pattern.
 //
 // Identical math to gemv_hfq4g256_residual: 4-accumulator interleave + tail
 // per-quad-bucket + final pairwise combine. Output line at the end uses


### PR DESCRIPTION
## Summary

Fix-forward of @unverbraucht's #277 onto current `master` after #277 became dirty against the newer gfx906/HFQ4 parity work from #281.

This keeps the cleanup intent from #277 while preserving the current `master` dispatch behavior:

- cache hot-path env reads for `HIPFIRE_MMQ`, `HIPFIRE_MMQ_MIN_BATCH`, `HIPFIRE_FP16`, `HIPFIRE_WO_MMQ`, and `HIPFIRE_LM_HEAD_WMMA`
- keep current gfx906 `B >= 8` MMQ routing and #281's `mmq_screen_rejected`/dp4a fallback behavior
- add the gfx906 set-mode MMQ defensive `debug_assert!`
- fix the gfx906 set-mode MMQ profile byte accounting to include the Q8_1 X read
- carry over the HFQ4 gfx906 kernel invariants docs and wave64 shuffle comment clarification

Supersedes #277 after conflict resolution. Closes #208's cleanup-track subset represented by #277 if merged.

## Validation

- `git diff --check`
- `cargo check -p rdna-compute`
- `cargo check --tests -p rdna-compute`
- `MAX_TOKENS=2 HIPFIRE_VERIFY_GRAPH=0 cargo run --release --features deltanet --example greedy_dump -p hipfire-runtime -- ~/.hipfire/models/qwen3.5-0.8b.mq4 /tmp/pr277-fixforward-greedy-default.txt "Say OK."`
- `MAX_TOKENS=2 HIPFIRE_VERIFY_GRAPH=0 HIPFIRE_FP16=0 HIPFIRE_LM_HEAD_WMMA=0 cargo run --release --features deltanet --example greedy_dump -p hipfire-runtime -- ~/.hipfire/models/qwen3.5-0.8b.mq4 /tmp/pr277-fixforward-greedy-fp16off.txt "Say OK."`

Both runtime smokes completed on local `gfx1100`, loaded `qwen3.5-0.8b.mq4`, captured `338` graph blobs, and ended with `done`.