### PR TITLE
fix(awq): load + apply MQ3 AWQ sidecars (and centralize the gate)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -904,7 +904,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         // pread_buf borrow, but the weight bytes have already been
         // uploaded to GPU (owned by `wt.buf`) so the borrow no longer
         // matters.
-        if matches!(wt.gpu_dtype, DType::MQ4G256) {
+        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }
@@ -916,7 +916,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
             .or_else(|| hfq.tensor_data(name))
             .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
         let mut wt = load_weight_tensor_raw(gpu, info.quant_type, data, m, k)?;
-        if matches!(wt.gpu_dtype, DType::MQ4G256) {
+        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1377,7 +1377,7 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
     // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens
     let lm_head_info = hfq.tensor_data_vec("lm_head.weight")
         .or_else(|| hfq.tensor_data_vec("model.language_model.lm_head.weight"));
-    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1409,6 +1409,21 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
+    // lm_head / tied embed_tokens AWQ sidecar attachment. Today no
+    // quantizer in the tree emits sidecars for these tensors (AWQ
+    // targets per-channel input scaling, which is iffy on
+    // vocab-sized matrices), but the inline `load_weight_tensor_raw`
+    // call above hardcodes `awq_scale: None` and bypasses the
+    // `load_weight_tensor` wrapper — so a future quantizer change
+    // would silently regress here the same way `qwen35.rs:907`
+    // regressed on MQ3 in May 2026. Try each plausible tensor name;
+    // `load_awq_scale_for` returns None when no sidecar exists, so
+    // this is a no-op for current files.
+    if output.gpu_dtype.supports_awq_sidecar() {
+        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+    }
 
     let is_moe = config.num_experts > 0;
     let mut layers = Vec::with_capacity(config.n_layers);
@@ -1606,7 +1621,7 @@ fn load_output_into(
     let lm_head_info = hfq
         .tensor_data("lm_head.weight")
         .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
-    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1645,6 +1660,18 @@ fn load_output_into(
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
+    // Same lm_head / tied embed_tokens AWQ attachment as the
+    // multimodal load_weights above. Sister fix — both code paths
+    // construct WeightTensor directly with `awq_scale: None` outside
+    // the `load_weight_tensor` wrapper, so they need explicit
+    // helper-gated attachment here. No-op on current files; defends
+    // against a future quantizer change that emits sidecars for the
+    // embedding matrix.
+    if output.gpu_dtype.supports_awq_sidecar() {
+        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+    }
     Ok((output_norm, output))
 }
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -899,12 +899,12 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         } else {
             panic!("tensor not found: {name} or {full_name}");
         };
-        // Phase A Stage A — populate awq_scale for MQ4G256 weights when
-        // a sidecar is present. The pread call invalidates the prior
-        // pread_buf borrow, but the weight bytes have already been
-        // uploaded to GPU (owned by `wt.buf`) so the borrow no longer
-        // matters.
-        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
+        // Phase A Stage A — populate awq_scale when the dtype is on
+        // the AWQ allow-list (centralized at `DType::supports_awq_sidecar`).
+        // The pread call invalidates the prior pread_buf borrow, but
+        // the weight bytes have already been uploaded to GPU (owned by
+        // `wt.buf`) so the borrow no longer matters.
+        if wt.gpu_dtype.supports_awq_sidecar() {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }
@@ -916,7 +916,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
             .or_else(|| hfq.tensor_data(name))
             .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
         let mut wt = load_weight_tensor_raw(gpu, info.quant_type, data, m, k)?;
-        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
+        if wt.gpu_dtype.supports_awq_sidecar() {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1374,10 +1374,25 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
         load_norm_weight(hfq, gpu, "norm.weight", &[config.dim])?
     };
 
-    // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens
+    // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens.
+    //
+    // **No AWQ sidecar attachment on this path.** The runtime
+    // dispatch for lm_head goes through `gemm_*_batched_lmhead`
+    // kernels which have NO AWQ inverse — they do not divide `x`
+    // by the sidecar before the matmul. Attaching a sidecar here
+    // (today: no-op since the quantizer's `awq_eligible` whitelist
+    // at `hipfire-quantize/src/main.rs:3849` excludes lm_head and
+    // embed_tokens; future: would silently produce `(W·s)·x ≠ W·x`
+    // with KLD blowup of the 0.67 → 13.5 class documented at
+    // `docs/plans/awq_fix_claude.md`) is the exact failure mode the
+    // quantizer-side whitelist is fail-closed against. Routing
+    // `output.gpu_dtype` through `DType::supports_awq_sidecar` would
+    // remove that fail-closed property. When AWQ-aware lm_head
+    // dispatch lands (kernel + fused-norm path), add `output.awq_scale`
+    // attachment AT THAT POINT, not before.
     let lm_head_info = hfq.tensor_data_vec("lm_head.weight")
         .or_else(|| hfq.tensor_data_vec("model.language_model.lm_head.weight"));
-    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1409,21 +1424,6 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
-    // lm_head / tied embed_tokens AWQ sidecar attachment. Today no
-    // quantizer in the tree emits sidecars for these tensors (AWQ
-    // targets per-channel input scaling, which is iffy on
-    // vocab-sized matrices), but the inline `load_weight_tensor_raw`
-    // call above hardcodes `awq_scale: None` and bypasses the
-    // `load_weight_tensor` wrapper — so a future quantizer change
-    // would silently regress here the same way `qwen35.rs:907`
-    // regressed on MQ3 in May 2026. Try each plausible tensor name;
-    // `load_awq_scale_for` returns None when no sidecar exists, so
-    // this is a no-op for current files.
-    if output.gpu_dtype.supports_awq_sidecar() {
-        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
-    }
 
     let is_moe = config.num_experts > 0;
     let mut layers = Vec::with_capacity(config.n_layers);
@@ -1621,7 +1621,14 @@ fn load_output_into(
     let lm_head_info = hfq
         .tensor_data("lm_head.weight")
         .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
-    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
+    // No AWQ sidecar attachment here — see the sister load_weights
+    // function's lm_head block for the full rationale. TL;DR: the
+    // `gemm_*_batched_lmhead` runtime dispatch lacks an AWQ inverse,
+    // so attaching a sidecar would silently corrupt logits (KLD
+    // 0.67 → 13.5 class per `docs/plans/awq_fix_claude.md`). The
+    // quantizer's `awq_eligible` whitelist is the only fail-closed
+    // safety — keep this path consistent with it.
+    let output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1660,18 +1667,6 @@ fn load_output_into(
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
-    // Same lm_head / tied embed_tokens AWQ attachment as the
-    // multimodal load_weights above. Sister fix — both code paths
-    // construct WeightTensor directly with `awq_scale: None` outside
-    // the `load_weight_tensor` wrapper, so they need explicit
-    // helper-gated attachment here. No-op on current files; defends
-    // against a future quantizer change that emits sidecars for the
-    // embedding matrix.
-    if output.gpu_dtype.supports_awq_sidecar() {
-        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
-    }
     Ok((output_norm, output))
 }
 

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -195,7 +195,7 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
     let (info, data) = hfq
         .tensor_data(name)
         .unwrap_or_else(|| panic!("dflash tensor missing: {name}"));
-    match info.quant_type {
+    let mut wt = match info.quant_type {
         1 => {
             // F16 on disk. Default: upload as F16 (no lift) and dispatch through
             // the mw16 WMMA kernel — 3-5× faster draft at B=16 on gfx1100 than
@@ -242,7 +242,39 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale: None })
         }
         q => panic!("dflash: unsupported matrix quant_type {q} for {name}"),
+    }?;
+    // AWQ sidecar attachment — same pattern as hfq.rs::load_weight_tensor
+    // and qwen35.rs::load_weight_tensor. Routed through the centralized
+    // `DType::supports_awq_sidecar` allow-list so future widening (MQ6,
+    // MQ2, MQ3-Lloyd, MFP4) is a single helper edit. Sidecar absent →
+    // `awq_scale` stays None, dispatch path matches the pre-fix behavior.
+    //
+    // Logic is inlined rather than calling out to hfq.rs's closure or
+    // qwen35.rs's `load_awq_scale_for` to avoid pulling in a cross-crate
+    // dependency for what is structurally a third copy of the same load.
+    // Factor-out (one shared `pub fn load_awq_scale_for` in this crate)
+    // is tracked as a follow-up.
+    if wt.gpu_dtype.supports_awq_sidecar() {
+        let sidecar_name = match name.strip_suffix(".weight") {
+            Some(stem) => format!("{stem}.awq_scale.weight"),
+            None => format!("{name}.awq_scale.weight"),
+        };
+        if let Some((sc_info, sc_data)) = hfq.tensor_data(&sidecar_name) {
+            if sc_info.quant_type != 1 {
+                eprintln!("warning: AWQ sidecar {sidecar_name} has quant_type={} (expected 1=F16); skipping", sc_info.quant_type);
+            } else if sc_info.shape.len() != 1 || sc_info.shape[0] as usize != k {
+                eprintln!("warning: AWQ sidecar {sidecar_name} shape mismatch ({:?} vs expected [{}]); skipping", sc_info.shape, k);
+            } else {
+                let f32_data: Vec<f32> = sc_data
+                    .chunks_exact(2)
+                    .map(|c| crate::llama::f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+                    .collect();
+                let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
+                wt.awq_scale = gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok();
+            }
+        }
     }
+    Ok(wt)
 }
 
 impl DflashWeights {
@@ -619,7 +651,12 @@ fn gemm_dispatch(
                 let x_chunk = x.sub_offset(row * w.k, n * w.k);
                 let y_chunk = y.sub_offset(row * w.m, n * w.m);
                 let rot_view = scratch.sub_offset(0, n * w.k);
-                if let Err(e) = gpu.rotate_x_mq_batched(&x_chunk, &rot_view, w.k, n) {
+                // AWQ-aware FWHT rotation. When the drafter weight ships an
+                // AWQ sidecar (`w.awq_scale.is_some()`), `_for` dispatches
+                // the `x /= awq_scale` + FWHT kernel; otherwise falls
+                // through to the plain `rotate_x_mq_batched` and is
+                // numerically identical to the prior dispatch.
+                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
                     chunked = Err(e);
                     break;
                 }
@@ -655,7 +692,12 @@ fn gemm_dispatch(
                 let x_chunk = x.sub_offset(row * w.k, n * w.k);
                 let y_chunk = y.sub_offset(row * w.m, n * w.m);
                 let rot_view = scratch.sub_offset(0, n * w.k);
-                if let Err(e) = gpu.rotate_x_mq_batched(&x_chunk, &rot_view, w.k, n) {
+                // Same AWQ-aware FWHT rotation as the MQ4 arm. Drafters
+                // that ship MQ3 AWQ sidecars (via the loader fix in
+                // `hfq_weight`) now actually receive the `x /= s` divide
+                // before the HFQ3 GEMM; pre-fix this silently produced
+                // wrong drafts on AWQ-calibrated drafters.
+                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
                     chunked = Err(e);
                     break;
                 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -588,7 +588,8 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         }
         17 => { // MQ3-G256 — MagnumQuant FWHT-rotated 3-bit, 104 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale: None })
+            let awq_scale = load_awq_scale();
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale })
         }
         18 => { // MQ2-G256 — MagnumQuant FWHT-rotated 2-bit, 72 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -529,7 +529,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok()
     };
 
-    match info.quant_type {
+    let mut wt = match info.quant_type {
         0 => { // Q4F16G64
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::Q4F16G64, m, k, row_stride: 0, awq_scale: None })
@@ -579,8 +579,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         }
         13 => { // MQ4-G256 — MagnumQuant FWHT-rotated 4-bit
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            let awq_scale = load_awq_scale();
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, awq_scale })
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, awq_scale: None })
         }
         14 => { // MQ8-G256 — MagnumQuant FWHT-rotated symmetric INT8, dp4a
             let buf = gpu.upload_raw(data, &[data.len()])?;
@@ -588,8 +587,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         }
         17 => { // MQ3-G256 — MagnumQuant FWHT-rotated 3-bit, 104 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            let awq_scale = load_awq_scale();
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale })
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale: None })
         }
         18 => { // MQ2-G256 — MagnumQuant FWHT-rotated 2-bit, 72 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;
@@ -630,7 +628,18 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
             Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, awq_scale: None })
         }
         _ => panic!("unsupported quant_type {} for weight {st_name}", info.quant_type),
+    }?;
+    // Centralized AWQ sidecar attachment. Replaces the prior per-arm
+    // inline `load_awq_scale()` calls at the qt=13 / qt=17 arms — those
+    // were the only loaders touching `awq_scale` and missing arms (qt=15
+    // MQ6, qt=18 MQ2, qt=19/20 Lloyd, qt=24 MFP4) would silently drop
+    // sidecars if added later. Routed through `DType::supports_awq_sidecar`
+    // so future widening is a single helper edit, not a scattered
+    // per-loader hunt. See dispatch.rs for the allow-list rationale.
+    if wt.gpu_dtype.supports_awq_sidecar() {
+        wt.awq_scale = load_awq_scale();
     }
+    Ok(wt)
 }
 
 /// Load LLaMA weights from an HFQ file onto GPU.

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -601,11 +601,11 @@ pub fn weight_gemv(
                 dtype: DType::F32,
             };
             // Preserve the gfx12 dual-FP8 fast path inside
-            // `gemv_mfp4g32_with_rotate` when AWQ is not in play. The
-            // quantizer cannot emit AWQ sidecars for MFP4G32 today (AWQ
-            // is gated to MQ4G256), so the `is_some()` branch is
-            // unreachable from today's pipeline — kept for forward
-            // compatibility if AWQ is ever widened to MFP4.
+            // `gemv_mfp4g32_with_rotate` when AWQ is not in play. AWQ
+            // is currently gated by `DType::supports_awq_sidecar`
+            // (`MQ4G256 | MQ3G256` today), so the `is_some()` branch
+            // is unreachable from today's pipeline — kept for forward
+            // compatibility if MFP4G32 ever joins the AWQ allow-list.
             if w.awq_scale.is_some() {
                 rotate_x_mq_for(gpu, w, x, &x_rot_alias, w.k)?;
                 gpu.gemv_mfp4g32_prerotated(&w.buf, &x_rot_alias, y, w.m, w.k)

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -446,6 +446,44 @@ impl DType {
             DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd | DType::HFP4G32 | DType::MFP4G32 | DType::Raw => 1, // byte-level
         }
     }
+
+    /// Whether a `WeightTensor` of this dtype should have the
+    /// `<weight>.awq_scale.weight` F16 sidecar attached at load time.
+    ///
+    /// Centralizes the gate that previously lived inline at every
+    /// loader call site (qwen35.rs `load_weight_tensor`, etc.). The
+    /// motivation is the May 2026 regression where `qwen35.rs:907`
+    /// gated on `matches!(wt.gpu_dtype, DType::MQ4G256)` and silently
+    /// dropped AWQ sidecars for `MQ3G256`-quantized Qwen3.5 weights,
+    /// producing fluent-but-nonsensical token soup for ~5 hours
+    /// before the missing arm was traced. Adding a new AWQ-eligible
+    /// dtype is now a one-line edit here instead of two scattered
+    /// edits per loader.
+    ///
+    /// Current allow-list = the empirical truth of which dtypes ship
+    /// AWQ sidecars from the quantizer AND have an AWQ-aware forward
+    /// path (`rotate_x_mq_for` etc., wired through `awq_scale.is_some()`).
+    ///
+    /// **Forward-path-ready candidates not currently in the allow-list**
+    /// (forward kernels exist but no `.hfq` file in tree ships sidecars
+    /// for them — widen only after the quantizer side is verified to
+    /// emit sidecars and at least one coherence-gate row exercises the
+    /// combination):
+    /// - `MQ6G256`
+    /// - `MQ2G256`, `MQ2G256Lloyd`
+    /// - `MQ3G256Lloyd`
+    /// - `MFP4G32` (forward path has explicit `awq_scale.is_some()`
+    ///   branching at llama.rs:609 but the quantizer comment says
+    ///   "AWQ is gated to MQ4G256 today" — confirm before widening)
+    ///
+    /// `MQ8G256` is explicitly **not** a candidate: it uses its own
+    /// INT8-quantized scratch path (`gemv_mq8g256_with_rotate`,
+    /// `rotate_quantize_x_mq8`) and does not flow through
+    /// `rotate_x_mq_for`, so there is no AWQ-aware kernel to dispatch
+    /// to.
+    pub fn supports_awq_sidecar(self) -> bool {
+        matches!(self, DType::MQ4G256 | DType::MQ3G256)
+    }
 }
 
 /// High-level GPU context. Owns the HIP runtime, compiler, and loaded kernels.

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -481,6 +481,22 @@ impl DType {
     /// `rotate_quantize_x_mq8`) and does not flow through
     /// `rotate_x_mq_for`, so there is no AWQ-aware kernel to dispatch
     /// to.
+    ///
+    /// **Important — this helper governs per-layer linear projection
+    /// loaders ONLY.** It must NOT be applied to `lm_head` or tied
+    /// `embed_tokens` constructors. Their forward dispatch goes
+    /// through `gemm_*_batched_lmhead` kernels which have no AWQ
+    /// inverse (no `x /= s` divide before the matmul), so attaching
+    /// a sidecar would silently produce `(W·s)·x ≠ W·x` — the
+    /// KLD 0.67 → 13.5 corruption class documented at
+    /// `docs/plans/awq_fix_claude.md`. The quantizer's `awq_eligible`
+    /// whitelist (`hipfire-quantize/src/main.rs:3849`) is the single
+    /// source of truth for which tensors should ever ship sidecars,
+    /// and it excludes lm_head / embed_tokens. The loader sites at
+    /// `qwen35.rs::load_weights` / `load_weights_vl`'s `output`
+    /// construction intentionally do not call this helper — keep
+    /// them consistent with the whitelist until an AWQ-aware
+    /// lm_head dispatch path lands.
     pub fn supports_awq_sidecar(self) -> bool {
         matches!(self, DType::MQ4G256 | DType::MQ3G256)
     }

--- a/scripts/coherence-gate.sh
+++ b/scripts/coherence-gate.sh
@@ -120,6 +120,20 @@ SHORT_TESTS=(
     # defaults don't disturb the mq6 dispatch routing. Skipped if model
     # absent (download via `hipfire pull qwen3.5-9b.mq6`).
     "qwen3.5-9b.mq6|reason-mq6|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|300"
+    # MQ3-AWQ coverage — regression catcher for the 2026-05-18 loader bug
+    # where `qwen35.rs:907` gated AWQ-sidecar attachment on
+    # `matches!(wt.gpu_dtype, DType::MQ4G256)` and silently dropped sidecars
+    # for MQ3G256 weights (fixed by extending to MQ4G256|MQ3G256 and then
+    # centralized behind `DType::supports_awq_sidecar` — see the
+    # `mq3-awq-paris` case below for the corresponding hard-fail check).
+    # Uses the 4B-awq-only variant because it produces a verbose answer
+    # containing "Paris" reliably at temp=0 + repeat_penalty=1.05; the
+    # awq-gptq sibling terses out on this prompt (7 tokens, no Paris), so
+    # it would false-positive the gate. Skipped if the canonical file
+    # isn't symlinked into MODELS_DIR — symlink it as:
+    #   ln -s /data/hipfire/mq3-sweep/qwen3.5-4b.mq3-awq-only.hfq \
+    #         "${HIPFIRE_DIR:-$HOME/.hipfire}/models/qwen3.5-4b.mq3-awq-only"
+    "qwen3.5-4b.mq3-awq-only|mq3-awq-paris|What is the capital of France? Answer in one short sentence.|80"
 )
 FULL_EXTRA=(
     "qwen3.5-35b-a3b.mq4|moe-sheep|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|500"
@@ -241,6 +255,24 @@ print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))'
                 # be quantization noise (small model decided to answer
                 # directly); not a corruption signal.
                 status="OK (soft: no <tool_call> emitted; model answered inline)"
+            fi
+            ;;
+        mq3-awq-paris)
+            # Regression catcher for the AWQ-sidecar load-gate bug
+            # (2026-05-18: `qwen35.rs:907` had `matches!(_, DType::MQ4G256)`
+            # and silently dropped MQ3 sidecars → fluent-but-nonsensical
+            # multi-language token soup). A healthy 4B Qwen3.5 MQ3-AWQ-GPTQ
+            # answer always contains "Paris" verbatim — even the lowest
+            # KLD variant (mq3-awq-gptq, PPL 11.18) gets the capital right
+            # at temp=0.0. Anything else means the AWQ rescale is not
+            # being applied. Hard-fail to catch the regression before it
+            # ships.
+            text=$(grep -a '"type":"token"' "$out_file" | python3 -c '
+import sys, json
+print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))')
+            if ! printf '%s' "$text" | grep -q 'Paris'; then
+                status="HARD_ERROR (MQ3-AWQ regression: answer missing 'Paris' — AWQ sidecar likely not applied; check DType::supports_awq_sidecar gate)"
+                hard_errors=$((hard_errors + 1))
             fi
             ;;
     esac


### PR DESCRIPTION
## Summary

- Fixes `qwen35.rs:907` silently dropping AWQ sidecars on MQ3G256 weights — the load gate was `matches!(_, DType::MQ4G256)`, so AWQ-calibrated MQ3 quants computed `(W·s)·x` instead of `(W·s)·(x/s) = W·x` and emitted fluent-but-nonsensical multi-language token soup. Empirically reproduced on the four `/data/hipfire/mq3-sweep/qwen3.5-4b.mq3-*.hfq` files; post-fix all four produce coherent output on gfx1031.
- Sibling fix for the LLaMA arch loader (`hfq.rs:589`) which also hardcoded `awq_scale: None` for qt=17 — empirically inert on the current test surface (no LLaMA-arch MQ3-AWQ file exists), but structurally correct.
- Centralizes the loader-side allow-list behind `DType::supports_awq_sidecar()`. Future widening to MQ6 / MQ2 / Lloyd / MFP4 is now a one-line helper edit instead of a per-loader hunt.
- Same-class bug fixed in the DFlash drafter path (`dflash.rs::hfq_weight` loader + `gemm_dispatch` rotation). Today no AWQ-calibrated drafter ships, so the fix is preventive — it would otherwise produce silently-wrong drafts (low acceptance, no token-soup symptom).
- lm_head / embed_tokens tied-embedding paths in `qwen35.rs:1394` and `:1629` had post-construction sidecar attachment added in `f7367368`, then **reverted in `1183dcb9`** after reviewer feedback that the lm_head runtime dispatch (`gemm_*_batched_lmhead`) has no `x /= s` inverse — attaching a sidecar would produce `(W·s)·x ≠ W·x` for any future quantizer that emits `lm_head.awq_scale.weight`. The right pattern is to attach the sidecar AT THE SAME TIME as landing the AWQ-aware lm_head dispatch (tracked in PR #292). `DType::supports_awq_sidecar`'s doc comment now explicitly carves out lm_head / embed_tokens so the next reviewer doesn't repeat the mistake.
- New `mq3-awq-paris` row in `scripts/coherence-gate.sh` exercising `qwen3.5-4b.mq3-awq-only`, with a hard-fail check that the answer to "What is the capital of France?" contains the substring "Paris" — regression catcher for this class of AWQ-gate-gap bug. Skipped cleanly when the file isn't symlinked into `MODELS_DIR`; symlink instructions live in the comment block above the row.

KLD n=20 against the 4B bf16 reference (from the original fix commit message):

| variant | mean KLD | p99 KLD | PPL |
|---|---|---|---|
| mq3-awq-gptq | 0.1891 | 8.711 | 11.18 ← best |
| mq3-gptq-only | 0.1995 | 9.497 | 11.68 |
| mq3-awq-only | 0.5584 | 11.497 | 15.91 |
| mq3-rtn | 0.5688 | 16.409 | 14.12 |

GPTQ drives mean KLD; AWQ's contribution is concentrated at p99 (-29% over RTN, consistent with AWQ's outlier-preserving design).

## Test plan

- [x] Build clean: `cargo build --release --example daemon --features deltanet`
- [x] gfx1031 sweep — all four `mq3-sweep/*.hfq` variants produce coherent English (pre-fix: multilingual token soup across the board)
- [x] Detector verdicts identical between the pre-refactor inline `matches!` and the helper-based dispatch (same token counts, same unique-token ratios, same wall-time) — refactor is behaviorally equivalent
- [x] `mq3-awq-paris` gate row passes on current binary (output contains "Paris")
- [x] MQ4 / Q8 / HFQ4 paths untouched — only the AWQ-load gate widened; non-MQ dtypes return false from the helper and skip sidecar attachment entirely
- [x] **`coherence-gate.sh` on gfx1100** (2026-05-18, freshly built daemon + wiped JIT cache + freshly compiled `gfx1100/*.hsaco` against branch HEAD `1183dcb9`): no hard errors, 7 tests pass, 6 skip on absent models. **`mq3-awq-paris` regression catcher PASSED** — clean `<think>` block + "The capital of France is Paris." Report: `/tmp/coherence-20260518-180605.md`.
- [ ] `coherence-gate-dflash.sh` on gfx11 — **deferred**: the gate's `qwen3.5-27b.mq4` target is not present on the local gfx1100 box (only qwen3.6-27b variants available); the gfx11 DFlash drafter `qwen35-27b-dflash-mq4.hfq` is present. Per the summary above, the `dflash.rs` fix is preventive (no AWQ-calibrated drafter exists today), so this gate would not exercise the new code path even if it ran. Reviewer with a gfx11 box and the qwen3.5-27b target can satisfy this checkbox; not a merge-blocker for the stated scope.
- [ ] Cross-arch verification on gfx906 / gfx1010 / gfx1100 / gfx1150/1151 / gfx1200/1201 — tracked separately in #289

## Follow-ups (tracked in #289)

- Cross-arch MQ3 verification (gfx906 / gfx1010 / gfx1100 / gfx1150-1 / gfx1200-1)
- Daemon MQ3 arch gate scope (move out of `if draft_path.is_some()` so plain inference also refuses MQ3 cleanly on unsupported archs)
- MagnumQuant audit + widen helper for MQ6 / MQ2 / Lloyd / MFP4 once quantizer-side emission is verified
- Factor inlined AWQ-sidecar loader logic (currently duplicated in qwen35.rs / hfq.rs / dflash.rs) into a single shared helper

## Post-mortem

Full diagnostic-journey writeup in `docs/plans/mq3_gfx10.md` §12 (kept untracked locally — happy to commit it as part of this PR if useful). TL;DR: the symptom was initially misdiagnosed as a gfx10 dispatch bug because three independent adversarial reviews (including the original author's self-review) all read `qwen35.rs:773`'s raw constructor with `awq_scale: None` and concluded "MQ4 also drops AWQ on Qwen3.5 and works fine — AWQ-missing can't be the bug." None of the three traced upward to the wrapping `load_weight_tensor` at qwen35.rs:888 that *did* attach the sidecar (gated on MQ4G256). Lesson: when rejecting a hypothesis with "X works without Y too," verify Y is actually absent at runtime — not just absent in the first constructor you read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)