### PR TITLE
Codex/serve bind host upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ in the hot path. Ollama-style UX.
 ```bash
 hipfire pull qwen3.5:9b
 hipfire run  qwen3.5:9b "What is the capital of France?"
-hipfire serve -d        # background daemon, OpenAI-compatible API on :11435
+hipfire serve -d        # background daemon, OpenAI-compatible API on 0.0.0.0:11435
 ```
 
 Current release: **v0.1.20** — engine modularization. See [CHANGELOG.md](CHANGELOG.md).

--- a/cli/chat.ts
+++ b/cli/chat.ts
@@ -1,5 +1,5 @@
 import type { HipfireConfig } from "./index.ts";
-import { findModel, resolveModelTag, isServeUp } from "./index.ts";
+import { findModel, resolveModelTag, isServeUp, serveProbeHost, formatServeBind } from "./index.ts";
 import {
   graphemes, sanitizePaste, estimateTokens,
   computeTokPerSec, trimTokenWindow,
@@ -22,6 +22,7 @@ interface ChatState {
   lastAbortTime: number | null;
   modelTag: string;
   daemonPid: number | null;
+  daemonHost: string;
   daemonPort: number;
   paste: PasteParserState;        // bracketed-paste accumulator
   escBuf: string;
@@ -76,6 +77,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig, opts: ChatTuiOpti
     lastAbortTime: null,
     modelTag,
     daemonPid: null,
+    daemonHost: cfg.host,
     daemonPort: cfg.port,
     paste: { inPaste: false, buf: "" },
     escBuf: "",
@@ -107,16 +109,18 @@ export async function chatTui(tag: string, cfg: HipfireConfig, opts: ChatTuiOpti
 
   // ─── Daemon management ──────────────────────────────────
 
-  const existingServe = await isServeUp(cfg.port);
+  const existingServe = await isServeUp(cfg.port, cfg.host);
   if (existingServe) {
+    state.daemonHost = cfg.host;
     state.daemonPort = cfg.port;
-    we(`[hipfire] Using existing serve on port ${cfg.port}\n`);
+    we(`[hipfire] Using existing serve on ${formatServeBind(cfg.host, cfg.port)}\n`);
   } else {
+    state.daemonHost = cfg.host;
     state.daemonPort = cfg.port;
-    we(`[hipfire] Starting serve on port ${state.daemonPort}...\n`);
+    we(`[hipfire] Starting serve on ${formatServeBind(state.daemonHost, state.daemonPort)}...\n`);
 
     const proc = Bun.spawn(
-      [process.argv[0], process.argv[1], "serve", String(state.daemonPort)],
+      [process.argv[0], process.argv[1], "serve", state.daemonHost, String(state.daemonPort)],
       {
         stdout: "pipe",
         // Pipe instead of inherit so daemon log lines don't bleed into the chat UI.
@@ -145,20 +149,20 @@ export async function chatTui(tag: string, cfg: HipfireConfig, opts: ChatTuiOpti
     let si = 0;
     while (Date.now() < deadline) {
       await new Promise<void>(r => setTimeout(r, 500));
-      if (await isServeUp(state.daemonPort)) break;
+      if (await isServeUp(state.daemonPort, state.daemonHost)) break;
       si = (si + 1) % 4;
       we(`\r  Waiting for serve... ${spin[si]}       `);
     }
     we("\r\x1b[K");
 
-    if (!await isServeUp(state.daemonPort)) {
+    if (!await isServeUp(state.daemonPort, state.daemonHost)) {
       we("Daemon failed to start within 120s. Check logs.\n");
       if (state.daemonPid) {
         try { process.kill(state.daemonPid, "SIGTERM"); } catch {}
       }
       process.exit(1);
     }
-    we(`[hipfire] Serve ready on port ${state.daemonPort}\n`);
+    we(`[hipfire] Serve ready on ${formatServeBind(state.daemonHost, state.daemonPort)}\n`);
   }
 
   // ─── Raw mode setup ─────────────────────────────────────
@@ -413,7 +417,7 @@ export async function chatTui(tag: string, cfg: HipfireConfig, opts: ChatTuiOpti
     let resp: Response;
     try {
       resp = await fetch(
-        `http://127.0.0.1:${state.daemonPort}/v1/chat/completions`,
+        `http://${serveProbeHost(state.daemonHost)}:${state.daemonPort}/v1/chat/completions`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -857,11 +857,17 @@ function readServePid(): number | null {
   } catch { return null; }
 }
 
+function serveProbeHost(host: string): string {
+  if (host === "0.0.0.0" || host === "::" || host === "") return "127.0.0.1";
+  if (host.includes(":") && !host.startsWith("[")) return `[${host}]`;
+  return host;
+}
+
 // Cheap liveness probe: 500ms health check. Used by `run` to decide HTTP vs local spawn.
-export async function isServeUp(port: number): Promise<boolean> {
+export async function isServeUp(port: number, host = "127.0.0.1"): Promise<boolean> {
   try {
     const ctl = AbortSignal.timeout(500);
-    const r = await fetch(`http://127.0.0.1:${port}/health`, { signal: ctl });
+    const r = await fetch(`http://${serveProbeHost(host)}:${port}/health`, { signal: ctl });
     return r.ok;
   } catch { return false; }
 }
@@ -1299,7 +1305,7 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   await e.stop();
 }
 
-async function serve(port: number) {
+async function serve(port: number, host?: string) {
   applyConfigEnv(cfg);
   // Write the PID so `hipfire stop` / `hipfire ps` / `hipfire run` can find us.
   // Cleanup on normal exit; stale PID on crash is tolerated (isPidAlive catches it).
@@ -1411,9 +1417,10 @@ async function serve(port: number) {
     else busy = false;
   }
 
-  console.error(`[hipfire] http://localhost:${port}/v1/chat/completions`);
+  console.error(`[hipfire] http://${host ?? "localhost"}:${port}/v1/chat/completions`);
 
   Bun.serve({
+    ...(host ? { hostname: host } : {}),
     port,
     idleTimeout: 255, // max allowed — model loading can take 30s+
     async fetch(req) {
@@ -4046,23 +4053,61 @@ function listConfig(cfg: HipfireConfig): void {
 const [cmd, ...rest] = process.argv.slice(2);
 switch (cmd) {
   case "serve": {
-    // Parse flags: `hipfire serve [port] [-d|--detach]`. Port can be anywhere.
+    // Parse flags: `hipfire serve [host] [port] [-d|--detach]`.
+    // Also accepts `host:port`, e.g. `hipfire serve 0.0.0.0:11435`.
     let port: number | null = null;
+    let host: string | null = null;
     let detach = false;
+    const setPort = (raw: string) => {
+      const n = parseInt(raw, 10);
+      if (!Number.isInteger(n) || n < 1 || n > 65535) {
+        console.error(`Invalid serve port: ${raw}`);
+        process.exit(1);
+      }
+      if (port !== null && port !== n) {
+        console.error(`Serve port specified more than once: ${port} and ${n}`);
+        process.exit(1);
+      }
+      port = n;
+    };
+    const setHost = (raw: string) => {
+      if (!raw) {
+        console.error("Serve host cannot be empty");
+        process.exit(1);
+      }
+      if (host !== null && host !== raw) {
+        console.error(`Serve host specified more than once: ${host} and ${raw}`);
+        process.exit(1);
+      }
+      host = raw;
+    };
     for (const a of rest) {
       if (a === "-d" || a === "--detach" || a === "--background") detach = true;
-      else if (/^\d+$/.test(a)) port = parseInt(a, 10);
+      else if (/^\d+$/.test(a)) setPort(a);
+      else if (/^\[[^\]]+\]:\d+$/.test(a)) {
+        const m = a.match(/^\[([^\]]+)\]:(\d+)$/)!;
+        setHost(m[1]);
+        setPort(m[2]);
+      }
+      else if (/^[^:]+:\d+$/.test(a)) {
+        const idx = a.lastIndexOf(":");
+        setHost(a.slice(0, idx));
+        setPort(a.slice(idx + 1));
+      }
       else if (a === "-h" || a === "--help") {
-        console.error(`Usage: hipfire serve [port] [-d|--detach]\n\n`
+        console.error(`Usage: hipfire serve [host] [port] [-d|--detach]\n\n`
+          + `  [host]     Bind address (examples: 127.0.0.1, 0.0.0.0, ::1)\n`
           + `  [port]     HTTP port (default: cfg.port = ${cfg.port})\n`
+          + `  host:port  Shorthand bind address and port (example: 0.0.0.0:11435)\n`
           + `  -d, --detach   Fork to background; log to ${SERVE_LOG_FILE}, PID in ${SERVE_PID_FILE}\n\n`
           + `Background daemon:\n`
           + `  hipfire serve -d           # start in background\n`
+          + `  hipfire serve 0.0.0.0:11435 -d\n`
           + `  hipfire stop               # kill it\n`
           + `  hipfire ps                 # check if running\n`
           + `  tail -f ${SERVE_LOG_FILE}  # follow log\n`);
         process.exit(0);
-      } else { console.error(`Unknown serve arg: ${a}`); process.exit(1); }
+      } else setHost(a);
     }
     port = port ?? cfg.port;
 
@@ -4070,7 +4115,7 @@ switch (cmd) {
       // Refuse to start a second one.
       const existing = readServePid();
       if (existing) {
-        console.error(`hipfire serve already running (PID ${existing}) on port ${cfg.port}.`);
+        console.error(`hipfire serve already running (PID ${existing}) on port ${port}.`);
         console.error(`  Stop it: hipfire stop`);
         process.exit(1);
       }
@@ -4081,7 +4126,8 @@ switch (cmd) {
       const self = process.argv[0];
       const script = process.argv[1];
       const logFd = require("fs").openSync(SERVE_LOG_FILE, "a");
-      const child = Bun.spawn([...runBg, self, script, "serve", String(port)], {
+      const childArgs = host ? ["serve", host, String(port)] : ["serve", String(port)];
+      const child = Bun.spawn([...runBg, self, script, ...childArgs], {
         stdin: "ignore",
         stdout: logFd,
         stderr: logFd,
@@ -4097,15 +4143,16 @@ switch (cmd) {
       console.log(`Waiting for serve to become ready (up to ${READINESS_TIMEOUT_MS / 1000}s for first-run kernel JIT)...`);
       while (Date.now() < deadline) {
         await new Promise(r => setTimeout(r, 500));
-        if (await isServeUp(port)) break;
+        if (await isServeUp(port, host ?? "127.0.0.1")) break;
         // Show progress every 30s
         const elapsed = Math.floor((Date.now() - (deadline - READINESS_TIMEOUT_MS)) / 1000);
         if (elapsed > 0 && elapsed % 30 === 0) {
           process.stderr.write(`  ...still starting (${elapsed}s — tail ${SERVE_LOG_FILE} to watch)\r`);
         }
       }
-      if (await isServeUp(port)) {
-        console.log(`hipfire serve started in background (PID ${child.pid}, port ${port})`);
+      if (await isServeUp(port, host ?? "127.0.0.1")) {
+        const bind = host ? `${host}:${port}` : String(port);
+        console.log(`hipfire serve started in background (PID ${child.pid}, bind ${bind})`);
         console.log(`  log:  ${SERVE_LOG_FILE}`);
         console.log(`  stop: hipfire stop`);
       } else {
@@ -4114,7 +4161,7 @@ switch (cmd) {
       }
       break;
     }
-    await serve(port);
+    await serve(port, host ?? undefined);
     break;
   }
   case "stop": {
@@ -5213,7 +5260,8 @@ depending on model size. HF downloads cache at ~/.hipfire/hf-cache/.`);
 
   pull <model>          Download model from HuggingFace
   run <model> [prompt]  Generate text (auto-pulls; uses running serve if any)
-  serve [port] [-d]     Start OpenAI-compatible server (-d = background daemon)
+  serve [host] [port] [-d]
+                        Start OpenAI-compatible server (-d = background daemon)
   stop                  Stop the background serve daemon
   quantize <hf-id|dir>  Quantize to MQ4/MQ6 (CPU) — with optional HF upload
   bench <model> [opts]  Benchmark tok/s (--exp for RDNA2 variant sweep, --runs N)

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -14,6 +14,7 @@ import { homedir } from "os";
 const HIPFIRE_DIR = join(homedir(), ".hipfire");
 const MODELS_DIR = join(HIPFIRE_DIR, "models");
 const CONFIG_PATH = join(HIPFIRE_DIR, "config.json");
+const DEFAULT_HOST = "0.0.0.0";
 const DEFAULT_PORT = 11435;
 const TEMP_CORRECTION = 0.82;
 
@@ -31,6 +32,7 @@ export interface HipfireConfig {
   max_seq: number;        // KV cache capacity allocated at model load (shared across turns)
   thinking: string;       // "on" (model reasons in <think>, stripped from display) | "off" (suppress thinking)
   max_think_tokens: number; // per-turn budget for <think>...</think> reasoning (0 = unlimited)
+  host: string;           // default serve bind address
   port: number;           // default serve port
   idle_timeout: number;   // serve: seconds of inactivity before unloading the model (0 = never)
   // ── Experimental / research knobs (OFF by default, no stable contract) ──
@@ -169,6 +171,7 @@ const CONFIG_DEFAULTS: HipfireConfig = {
   max_seq: 32768,
   thinking: "on",
   max_think_tokens: 0,
+  host: DEFAULT_HOST,
   port: DEFAULT_PORT,
   idle_timeout: 300,
   experimental_budget_alert: false,
@@ -221,6 +224,7 @@ function validateConfigValue(key: string, value: any): boolean {
     case "max_seq": return typeof value === "number" && Number.isInteger(value) && value >= 512 && value <= 524288;
     case "thinking": return ["on", "off"].includes(value);
     case "max_think_tokens": return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 32768;
+    case "host": return typeof value === "string" && value.trim() === value && value.length > 0 && value.length <= 255 && !/\s/.test(value);
     case "port": return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
     case "idle_timeout": return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 86400;
     case "default_model": return typeof value === "string" && value.trim().length > 0;
@@ -289,7 +293,7 @@ const cfg = loadConfig();
 
 const PER_MODEL_CONFIG_PATH = join(HIPFIRE_DIR, "per_model_config.json");
 
-// Fields that make sense to override per-model. port + idle_timeout + default_model
+// Fields that make sense to override per-model. host + port + idle_timeout + default_model
 // are serve-wide so they stay global-only.
 const PER_MODEL_KEYS = [
   "kv_cache", "flash_mode", "temperature", "top_p",
@@ -857,10 +861,15 @@ function readServePid(): number | null {
   } catch { return null; }
 }
 
-function serveProbeHost(host: string): string {
+export function serveProbeHost(host: string): string {
   if (host === "0.0.0.0" || host === "::" || host === "") return "127.0.0.1";
   if (host.includes(":") && !host.startsWith("[")) return `[${host}]`;
   return host;
+}
+
+export function formatServeBind(host: string, port: number): string {
+  const h = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return `${h}:${port}`;
 }
 
 // Cheap liveness probe: 500ms health check. Used by `run` to decide HTTP vs local spawn.
@@ -875,7 +884,7 @@ export async function isServeUp(port: number, host = "127.0.0.1"): Promise<boole
 // Drive `hipfire run` through an existing serve's /v1/chat/completions stream.
 // Returns false if it couldn't connect (caller falls back to local spawn).
 async function runViaHttp(
-  port: number, model: string, prompt: string,
+  port: number, host: string, model: string, prompt: string,
   image: string | undefined,
   temp: number, maxTokens: number, repeatPenalty: number, topP: number,
   system?: string,
@@ -896,7 +905,7 @@ async function runViaHttp(
 
   let resp: Response;
   try {
-    resp = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+    resp = await fetch(`http://${serveProbeHost(host)}:${port}/v1/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -1224,8 +1233,8 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   // API — saves the 2-5s cold-start cost of loading the model every invocation.
   // Local spawn falls through only when no serve is present (or HTTP errors out).
   const useLocal = process.env.HIPFIRE_LOCAL === "1" || image !== undefined;
-  if (!useLocal && await isServeUp(cfg.port)) {
-    const ok = await runViaHttp(cfg.port, model, prompt, image, temp, maxTokens, repeatPenalty, topP, system);
+  if (!useLocal && await isServeUp(cfg.port, cfg.host)) {
+    const ok = await runViaHttp(cfg.port, cfg.host, model, prompt, image, temp, maxTokens, repeatPenalty, topP, system);
     if (ok) return;
     // runViaHttp logged its own failure reason; fall back to local spawn.
   }
@@ -1305,7 +1314,7 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   await e.stop();
 }
 
-async function serve(port: number, host?: string) {
+async function serve(port: number, host: string) {
   applyConfigEnv(cfg);
   // Write the PID so `hipfire stop` / `hipfire ps` / `hipfire run` can find us.
   // Cleanup on normal exit; stale PID on crash is tolerated (isPidAlive catches it).
@@ -1417,10 +1426,10 @@ async function serve(port: number, host?: string) {
     else busy = false;
   }
 
-  console.error(`[hipfire] http://${host ?? "localhost"}:${port}/v1/chat/completions`);
+  console.error(`[hipfire] http://${formatServeBind(host, port)}/v1/chat/completions`);
 
   Bun.serve({
-    ...(host ? { hostname: host } : {}),
+    hostname: host,
     port,
     idleTimeout: 255, // max allowed — model loading can take 30s+
     async fetch(req) {
@@ -3348,6 +3357,10 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       desc: "Budget for reasoning inside <think>...</think> (0 = unlimited). Truncates if exceeded.",
       range: [0, 32768], step: 128,
     },
+    host: {
+      label: "host",
+      desc: "listen address for `hipfire serve` (examples: 127.0.0.1, 0.0.0.0, ::1)",
+    },
     port: {
       label: "port",
       desc: "HTTP port for `hipfire serve` (OpenAI-compatible API)",
@@ -4096,7 +4109,7 @@ switch (cmd) {
       }
       else if (a === "-h" || a === "--help") {
         console.error(`Usage: hipfire serve [host] [port] [-d|--detach]\n\n`
-          + `  [host]     Bind address (examples: 127.0.0.1, 0.0.0.0, ::1)\n`
+          + `  [host]     Bind address (default: cfg.host = ${cfg.host}; examples: 127.0.0.1, 0.0.0.0, ::1)\n`
           + `  [port]     HTTP port (default: cfg.port = ${cfg.port})\n`
           + `  host:port  Shorthand bind address and port (example: 0.0.0.0:11435)\n`
           + `  -d, --detach   Fork to background; log to ${SERVE_LOG_FILE}, PID in ${SERVE_PID_FILE}\n\n`
@@ -4109,6 +4122,7 @@ switch (cmd) {
         process.exit(0);
       } else setHost(a);
     }
+    host = host ?? cfg.host;
     port = port ?? cfg.port;
 
     if (detach) {
@@ -4126,7 +4140,7 @@ switch (cmd) {
       const self = process.argv[0];
       const script = process.argv[1];
       const logFd = require("fs").openSync(SERVE_LOG_FILE, "a");
-      const childArgs = host ? ["serve", host, String(port)] : ["serve", String(port)];
+      const childArgs = ["serve", host, String(port)];
       const child = Bun.spawn([...runBg, self, script, ...childArgs], {
         stdin: "ignore",
         stdout: logFd,
@@ -4143,15 +4157,15 @@ switch (cmd) {
       console.log(`Waiting for serve to become ready (up to ${READINESS_TIMEOUT_MS / 1000}s for first-run kernel JIT)...`);
       while (Date.now() < deadline) {
         await new Promise(r => setTimeout(r, 500));
-        if (await isServeUp(port, host ?? "127.0.0.1")) break;
+        if (await isServeUp(port, host)) break;
         // Show progress every 30s
         const elapsed = Math.floor((Date.now() - (deadline - READINESS_TIMEOUT_MS)) / 1000);
         if (elapsed > 0 && elapsed % 30 === 0) {
           process.stderr.write(`  ...still starting (${elapsed}s — tail ${SERVE_LOG_FILE} to watch)\r`);
         }
       }
-      if (await isServeUp(port, host ?? "127.0.0.1")) {
-        const bind = host ? `${host}:${port}` : String(port);
+      if (await isServeUp(port, host)) {
+        const bind = formatServeBind(host, port);
         console.log(`hipfire serve started in background (PID ${child.pid}, bind ${bind})`);
         console.log(`  log:  ${SERVE_LOG_FILE}`);
         console.log(`  stop: hipfire stop`);
@@ -4161,7 +4175,7 @@ switch (cmd) {
       }
       break;
     }
-    await serve(port, host ?? undefined);
+    await serve(port, host);
     break;
   }
   case "stop": {
@@ -4330,16 +4344,18 @@ switch (cmd) {
       for (const e of g.entries) console.log(e);
     }
     // Show local serve port availability + detached PID (if any)
+    const host = cfg.host;
     const port = cfg.port;
     const portInUse = sh(`ss -tlnp 2>/dev/null | grep :${port}`);
     const detachedPid = readServePid();
+    const bind = formatServeBind(host, port);
     if (detachedPid) {
-      console.log(`\nserve port ${port}: ACTIVE (detached, PID ${detachedPid})`);
+      console.log(`\nserve ${bind}: ACTIVE (detached, PID ${detachedPid})`);
       console.log(`  stop: hipfire stop    |    log: tail -f ${SERVE_LOG_FILE}`);
     } else if (portInUse) {
-      console.log(`\nserve port ${port}: ACTIVE (foreground)`);
+      console.log(`\nserve ${bind}: ACTIVE (foreground)`);
     } else {
-      console.log(`\nserve port ${port}: free`);
+      console.log(`\nserve ${bind}: free`);
     }
     break;
   }
@@ -5125,6 +5141,7 @@ depending on model size. HF downloads cache at ~/.hipfire/hf-cache/.`);
           max_seq: "KV cache capacity (tokens). Integer 512-524288",
           thinking: "one of: on, off. Controls whether the model reasons in <think> blocks.",
           max_think_tokens: "integer 0-32768. Budget for reasoning tokens (0 = unlimited).",
+          host: "non-empty bind address without whitespace (examples: 127.0.0.1, 0.0.0.0, ::1)",
           port: "integer between 1 and 65535",
           idle_timeout: "seconds of inactivity before serve unloads the model (0 = never, max 86400)",
           default_model: "non-empty model tag",

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -663,7 +663,10 @@ fn main() {
                     }
                 }
 
-                match load_model(path, max_seq, draft_path.as_deref(), kv_mode_override.as_deref(), &cask, pp, &mut gpu) {
+                let state_quant_override = msg.get("params").and_then(|p| p.get("state_quant")).and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty()).map(|s| s.to_string());
+
+                match load_model(path, max_seq, draft_path.as_deref(), kv_mode_override.as_deref(), state_quant_override.as_deref(), &cask, pp, &mut gpu) {
                     Ok(m) => {
                         let arch = match m.arch_id {
                             5 => "qwen3_5",
@@ -1300,14 +1303,57 @@ fn resolve_chat_template(
     hfq.chat_template()
 }
 
-fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_override: Option<&str>, cask: &CaskConfig, pp: usize, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
+fn parse_state_quant(mode: Option<&str>) -> Result<hipfire_arch_qwen35::qwen35::StateQuant, String> {
+    use hipfire_arch_qwen35::qwen35::StateQuant;
+    match mode.unwrap_or("q8").to_ascii_lowercase().as_str() {
+        "" | "auto" | "q8" | "int8" => Ok(StateQuant::Q8),
+        "fp32" | "f32" => Ok(StateQuant::FP32),
+        "q4" | "int4" => Ok(StateQuant::Q4),
+        other => Err(format!("unsupported DeltaNet state_quant '{other}' (expected q8|fp32|q4)")),
+    }
+}
+
+fn state_quant_label(q: hipfire_arch_qwen35::qwen35::StateQuant) -> &'static str {
+    use hipfire_arch_qwen35::qwen35::StateQuant;
+    match q {
+        StateQuant::FP32 => "FP32",
+        StateQuant::Q8 => "Q8",
+        StateQuant::Q4 => "Q4",
+    }
+}
+
+fn hfq_parameter_count(hfq: &HfqFile) -> u128 {
+    hfq.tensors()
+        .iter()
+        .map(|t| {
+            t.shape
+                .iter()
+                .fold(1u128, |acc, &dim| acc.saturating_mul(dim as u128))
+        })
+        .sum()
+}
+
+fn warn_tiny_model_state(hfq: &HfqFile, q: hipfire_arch_qwen35::qwen35::StateQuant) {
+    use hipfire_arch_qwen35::qwen35::StateQuant;
+    const TINY_MODEL_PARAMS: u128 = 2_000_000_000;
+    let params = hfq_parameter_count(hfq);
+    if params < TINY_MODEL_PARAMS && q != StateQuant::FP32 {
+        eprintln!(
+            "  warning: model has ~{:.2}B params; FP32 DeltaNet state is recommended below 2B for long-generation coherence (current: {})",
+            params as f64 / 1.0e9,
+            state_quant_label(q)
+        );
+    }
+}
+
+fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_override: Option<&str>, state_quant_override: Option<&str>, cask: &CaskConfig, pp: usize, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
     if pp > 1 {
         // Refusal contracts (DFlash, CASK sidecar) are enforced upstream in
         // the "load" event handler so the operator gets a structured error
         // before any HFQ open / weight allocation. By the time we get here
         // with pp>1, draft_path is None and cask.sidecar is None.
         let _ = (draft_path, cask);
-        return load_model_pp(path, max_seq, kv_mode_override, pp, gpu);
+        return load_model_pp(path, max_seq, kv_mode_override, state_quant_override, pp, gpu);
     }
     // Per-load kv_mode (sent in load message params) overrides the env var.
     // Lets the CLI set size-aware defaults — e.g. Qwen3.5-27B prefers asym4
@@ -1522,16 +1568,11 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                 llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
             }
         };
-        // MoE models (num_experts > 0) have ~10x smaller hidden-state
-        // magnitudes than dense models, making Q8 DeltaNet state quantization
-        // error proportionally larger. Use FP32 state to avoid cumulative
-        // drift that degenerates output after ~200 tokens.
-        let dn_quant = if config.num_experts > 0 {
-            eprintln!("  DeltaNet state: FP32 (MoE model — Q8 drift mitigation)");
-            hipfire_arch_qwen35::qwen35::StateQuant::FP32
-        } else {
-            hipfire_arch_qwen35::qwen35::StateQuant::Q8
-        };
+        // Q8 DeltaNet state can accumulate quality drift on long generation.
+        // The load-time override exists for coherence A/B probes.
+        let dn_quant = parse_state_quant(state_quant_override)?;
+        eprintln!("  DeltaNet state: {}", state_quant_label(dn_quant));
+        warn_tiny_model_state(&hfq, dn_quant);
         let dn = DeltaNetState::new_with_quant(gpu, &config, dn_quant).map_err(|e| format!("{e}"))?;
         // Flash partials size with physical_cap (bounds the max_tiles the
         // flash kernel must address). When physical_cap == max_seq this is
@@ -1658,6 +1699,7 @@ fn load_model_pp(
     path: &str,
     max_seq: usize,
     kv_mode_override: Option<&str>,
+    state_quant_override: Option<&str>,
     pp: usize,
     _gpu: &mut rdna_compute::Gpu,
 ) -> Result<LoadedModel, String> {
@@ -1732,15 +1774,11 @@ fn load_model_pp(
         }
     };
 
-    // MoE state-quant rule mirrors the pp=1 path (Q8 drift on small hidden
-    // states); apply at the multi entry point so bit-equivalence with pp=1
-    // forward output holds when both run on the same model.
-    let dn_quant = if config.num_experts > 0 {
-        eprintln!("  DeltaNet state: FP32 (MoE model — Q8 drift mitigation)");
-        qwen35::StateQuant::FP32
-    } else {
-        qwen35::StateQuant::Q8
-    };
+    // Mirror the pp=1 state-mode parser so pp parity probes can force the
+    // same DeltaNet state representation.
+    let dn_quant = parse_state_quant(state_quant_override)?;
+    eprintln!("  DeltaNet state: {}", state_quant_label(dn_quant));
+    warn_tiny_model_state(&hfq, dn_quant);
     let (dn, la_to_device) =
         DeltaNetState::new_with_quant_multi(&mut gpus, &config, dn_quant).map_err(|e| format!("{e}"))?;
 

--- a/crates/hipfire-runtime/examples/run.rs
+++ b/crates/hipfire-runtime/examples/run.rs
@@ -7,15 +7,43 @@ fn main() { eprintln!("Build with --features deltanet"); }
 #[cfg(feature = "deltanet")]
 fn main() {
     use hipfire_runtime::hfq::HfqFile;
-    use hipfire_arch_qwen35::qwen35::{self, DeltaNetState, Qwen35Scratch};
+    use hipfire_arch_qwen35::qwen35;
     use hipfire_runtime::llama;
     use std::io::Write;
     use std::path::Path;
     use std::time::Instant;
 
+    fn hfq_parameter_count(hfq: &HfqFile) -> u128 {
+        hfq.tensors()
+            .iter()
+            .map(|t| {
+                t.shape
+                    .iter()
+                    .fold(1u128, |acc, &dim| acc.saturating_mul(dim as u128))
+            })
+            .sum()
+    }
+
+    fn warn_tiny_model_state(path: &str, q: qwen35::StateQuant) {
+        const TINY_MODEL_PARAMS: u128 = 2_000_000_000;
+        if q == qwen35::StateQuant::FP32 {
+            return;
+        }
+        if let Ok(hfq) = HfqFile::open(Path::new(path)) {
+            let params = hfq_parameter_count(&hfq);
+            if params < TINY_MODEL_PARAMS {
+                eprintln!(
+                    "warning: model has ~{:.2}B params; FP32 DeltaNet state is recommended below 2B for long-generation coherence (current: {:?})",
+                    params as f64 / 1.0e9,
+                    q
+                );
+            }
+        }
+    }
+
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: run <model.hfq> [--draft-model <path>] [--system \"prompt\"] [--kv givens4|givens2] [--temp F] [--max-seq N]");
+        eprintln!("Usage: run <model.hfq> [--draft-model <path>] [--system \"prompt\"] [--kv givens4|givens2] [--temp F] [--max-seq N] [--fp32-state|--q8-state|--q4-state]");
         std::process::exit(1);
     }
     let model_path = &args[1];
@@ -25,7 +53,7 @@ fn main() {
     let mut kv_mode_str: String = "q8".to_string();
     let mut temp: f32 = 0.3;
     let mut max_seq: usize = 4096;
-    let mut q4_state = false;
+    let mut state_quant = qwen35::StateQuant::Q8;
     let mut draft_model: Option<String> = None;
     let mut speculative = false;
     let mut spec_k: usize = 4;
@@ -35,7 +63,9 @@ fn main() {
         match args[i].as_str() {
             "--system" | "-s" => { i += 1; system_prompt = Some(args[i].clone()); }
             "--kv" => { i += 1; kv_mode_str = args[i].clone(); }
-            "--q4-state" => { q4_state = true; }
+            "--fp32-state" => { state_quant = qwen35::StateQuant::FP32; }
+            "--q8-state" => { state_quant = qwen35::StateQuant::Q8; }
+            "--q4-state" => { state_quant = qwen35::StateQuant::Q4; }
             "--temp" => { i += 1; temp = args[i].parse().unwrap_or(0.3); }
             "--max-seq" => { i += 1; max_seq = args[i].parse().unwrap_or(4096); }
             "--draft-model" => { i += 1; draft_model = Some(args[i].clone()); }
@@ -52,8 +82,12 @@ fn main() {
     eprintln!("Loading {}...", model_path);
 
     use hipfire_arch_qwen35::speculative::{KvMode, ModelSlot, ModelSlotConfig};
-    let state_quant = if q4_state { qwen35::StateQuant::Q4 } else { qwen35::StateQuant::Q8 };
-    if q4_state { eprintln!("DeltaNet state: Q4 (half VRAM vs Q8)"); }
+    match state_quant {
+        qwen35::StateQuant::FP32 => eprintln!("DeltaNet state: FP32"),
+        qwen35::StateQuant::Q8 => eprintln!("DeltaNet state: Q8"),
+        qwen35::StateQuant::Q4 => eprintln!("DeltaNet state: Q4 (half VRAM vs Q8)"),
+    }
+    warn_tiny_model_state(model_path, state_quant);
     eprintln!("KV cache: {kv_mode_str}");
     let target_kv_mode = KvMode::Q8;
     let target_cfg = ModelSlotConfig {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,7 +18,7 @@ flag-level detail; this page is the index.
 |---|---|
 | `hipfire run <tag\|path> [prompt...]` | Generate. Auto-pulls if missing. Routes through the running `serve` daemon if one is up; otherwise spawns a one-shot daemon. |
 | `hipfire chat <tag>` | Interactive TUI chat with streaming, markdown, multi-line input. Reuses running serve or spawns a dedicated daemon. |
-| `hipfire serve [host] [port] [-d]` | Start the OpenAI-compatible HTTP server. Accepts `host port` or `host:port` such as `hipfire serve 0.0.0.0:11435`. `-d` detaches into the background and writes a pid file. Default port `11435`. |
+| `hipfire serve [host] [port] [-d]` | Start the OpenAI-compatible HTTP server. Accepts `host port` or `host:port` such as `hipfire serve 0.0.0.0:11435`. `-d` detaches into the background and writes a pid file. Defaults: host `0.0.0.0`, port `11435` (`hipfire config set host ...`, `hipfire config set port ...`). |
 | `hipfire stop` | Graceful shutdown of the background daemon. |
 | `hipfire bench <tag>` | Measure prefill + decode tok/s on a fixed prompt set. |
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,7 +18,7 @@ flag-level detail; this page is the index.
 |---|---|
 | `hipfire run <tag\|path> [prompt...]` | Generate. Auto-pulls if missing. Routes through the running `serve` daemon if one is up; otherwise spawns a one-shot daemon. |
 | `hipfire chat <tag>` | Interactive TUI chat with streaming, markdown, multi-line input. Reuses running serve or spawns a dedicated daemon. |
-| `hipfire serve [port] [-d]` | Start the OpenAI-compatible HTTP server. `-d` detaches into the background and writes a pid file. Default port `11435`. |
+| `hipfire serve [host] [port] [-d]` | Start the OpenAI-compatible HTTP server. Accepts `host port` or `host:port` such as `hipfire serve 0.0.0.0:11435`. `-d` detaches into the background and writes a pid file. Default port `11435`. |
 | `hipfire stop` | Graceful shutdown of the background daemon. |
 | `hipfire bench <tag>` | Measure prefill + decode tok/s on a fixed prompt set. |
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -274,6 +274,7 @@ profile, sparse_threshold).
 
 | Key | Default | Range |
 |---|---|---|
+| `host` | 0.0.0.0 | bind address / hostname |
 | `port` | 11435 | 1–65535 |
 | `idle_timeout` | 300 | 0–86400 (seconds) |
 | `default_model` | "" (none) | tag or path |

--- a/scripts/astrea.py
+++ b/scripts/astrea.py
@@ -384,6 +384,7 @@ def summarize_gguf(path, *, max_tensors=32):
     all_names = []
     imatrix_suffix_counts = {}
     imatrix_logical_names = set()
+    imatrix_logical_tensors = {}
     for i in range(tensor_count):
         name = reader.string()
         n_dims = reader.u32()
@@ -394,14 +395,34 @@ def summarize_gguf(path, *, max_tensors=32):
         all_names.append(name)
         dtype_counts[dtype] = dtype_counts.get(dtype, 0) + 1
         if name.endswith(".in_sum2"):
+            logical_name = name[: -len(".in_sum2")]
             imatrix_suffix_counts["in_sum2"] = imatrix_suffix_counts.get("in_sum2", 0) + 1
-            imatrix_logical_names.add(name[: -len(".in_sum2")])
+            imatrix_logical_names.add(logical_name)
+            imatrix_logical_tensors.setdefault(logical_name, {})["in_sum2"] = {
+                "name": name,
+                "shape": shape,
+                "dtype": dtype,
+                "offset": offset,
+            }
         elif name.endswith(".counts"):
+            logical_name = name[: -len(".counts")]
             imatrix_suffix_counts["counts"] = imatrix_suffix_counts.get("counts", 0) + 1
-            imatrix_logical_names.add(name[: -len(".counts")])
+            imatrix_logical_names.add(logical_name)
+            imatrix_logical_tensors.setdefault(logical_name, {})["counts"] = {
+                "name": name,
+                "shape": shape,
+                "dtype": dtype,
+                "offset": offset,
+            }
         else:
             imatrix_suffix_counts["other"] = imatrix_suffix_counts.get("other", 0) + 1
             imatrix_logical_names.add(name)
+            imatrix_logical_tensors.setdefault(name, {})["other"] = {
+                "name": name,
+                "shape": shape,
+                "dtype": dtype,
+                "offset": offset,
+            }
         if i < max_tensors:
             tensors.append(
                 {
@@ -426,6 +447,10 @@ def summarize_gguf(path, *, max_tensors=32):
         "tensor_names_md5": names_md5,
         "imatrix_logical_tensor_count": len(imatrix_logical_names),
         "imatrix_logical_names": sorted(imatrix_logical_names),
+        "imatrix_logical_tensors": {
+            name: imatrix_logical_tensors[name]
+            for name in sorted(imatrix_logical_tensors)
+        },
         "imatrix_suffix_counts": dict(sorted(imatrix_suffix_counts.items())),
         "tensors": tensors,
         "tensors_truncated": tensor_count > len(tensors),
@@ -606,15 +631,171 @@ def gguf_to_hfq_candidates(gguf_name):
     return candidates
 
 
+def gguf_expert_to_hfq_candidates(gguf_name, expert_index):
+    if not gguf_name.startswith("blk."):
+        return []
+    rest = gguf_name[len("blk.") :]
+    dot = rest.find(".")
+    if dot < 0:
+        return []
+    layer_idx = rest[:dot]
+    slot_full = rest[dot + 1 :]
+    slot = slot_full[: -len(".weight")] if slot_full.endswith(".weight") else slot_full
+    slot_map = {
+        "ffn_gate_exps": ["gate_up_proj"],
+        "ffn_up_exps": ["gate_up_proj"],
+        "ffn_down_exps": ["down_proj"],
+    }
+    translated = slot_map.get(slot)
+    if not translated:
+        return []
+    candidates = []
+    for prefix in ("model.language_model.layers", "model.layers"):
+        for item in translated:
+            candidates.append(f"{prefix}.{layer_idx}.mlp.experts.{expert_index}.{item}.weight")
+    return candidates
+
+
+def hfq_k_dim(tensor):
+    shape = tensor.get("shape") or []
+    if len(shape) >= 2:
+        return int(shape[-1])
+    if shape:
+        return int(shape[0])
+    return None
+
+
+def awq_runtime_eligible(name):
+    return (
+        name.endswith("q_proj.weight")
+        or name.endswith("k_proj.weight")
+        or name.endswith("v_proj.weight")
+        or name.endswith("qkv_proj.weight")
+        or name.endswith("wqkv.weight")
+        or name.endswith("gate_proj.weight")
+        or name.endswith("up_proj.weight")
+        or name.endswith("w_gate.weight")
+        or name.endswith("w_up.weight")
+        or name.endswith("gate_up_proj.weight")
+        or ".in_proj_" in name
+        or name.endswith("mlp.gate.weight")
+        or name.endswith("router.weight")
+    )
+
+
+def imatrix_slot(logical_name):
+    parts = logical_name.split(".")
+    if logical_name.startswith("blk.") and len(parts) > 2:
+        return parts[2]
+    return "top_level"
+
+
+def imatrix_dims(logical_info):
+    in_sum2 = logical_info.get("in_sum2") or {}
+    shape = in_sum2.get("shape") or []
+    k = int(shape[0]) if shape else None
+    columns = int(shape[1]) if len(shape) >= 2 else 1
+    return k, columns
+
+
 def match_imatrix_to_hfq(model, imatrix, *, max_tensors=32):
     hfq_summary, hfq_tensors = read_hfq_index(model, max_tensors=max_tensors)
     imatrix_summary = summarize_gguf(imatrix, max_tensors=max_tensors)
 
     matches = []
     unmatched = []
+    skipped = []
+    k_dim_mismatches = []
+    expert_coverage = []
     matched_quant_type_counts = {}
     matched_by_slot = {}
     for logical_name in imatrix_summary["imatrix_logical_names"]:
+        logical_info = imatrix_summary.get("imatrix_logical_tensors", {}).get(logical_name, {})
+        in_sum2 = logical_info.get("in_sum2")
+        if not in_sum2:
+            skipped.append({"imatrix_name": logical_name, "reason": "missing_in_sum2"})
+            continue
+        if in_sum2.get("dtype") != "F32":
+            skipped.append({
+                "imatrix_name": logical_name,
+                "reason": "non_f32_in_sum2",
+                "dtype": in_sum2.get("dtype"),
+            })
+            continue
+
+        imatrix_k, imatrix_columns = imatrix_dims(logical_info)
+        slot = imatrix_slot(logical_name)
+        is_expert_matrix = imatrix_columns > 1 or slot.endswith("_exps")
+        if is_expert_matrix:
+            matched_experts = []
+            missing_experts = []
+            for expert_index in range(imatrix_columns):
+                candidates = gguf_expert_to_hfq_candidates(logical_name, expert_index)
+                if not candidates:
+                    skipped.append({
+                        "imatrix_name": logical_name,
+                        "reason": "unsupported_multi_matrix_name",
+                        "shape": in_sum2.get("shape"),
+                    })
+                    break
+                hfq_name = next((name for name in candidates if name in hfq_tensors), None)
+                if hfq_name is None:
+                    missing_experts.append(expert_index)
+                    unmatched.append({
+                        "imatrix_name": logical_name,
+                        "expert_index": expert_index,
+                        "candidates": candidates,
+                    })
+                    continue
+                tensor = hfq_tensors[hfq_name]
+                quant_type_name = tensor["quant_type_name"]
+                matched_quant_type_counts[quant_type_name] = matched_quant_type_counts.get(quant_type_name, 0) + 1
+                matched_by_slot[slot] = matched_by_slot.get(slot, 0) + 1
+                tensor_k = hfq_k_dim(tensor)
+                k_dim_match = imatrix_k is None or tensor_k == imatrix_k
+                if not k_dim_match:
+                    k_dim_mismatches.append({
+                        "imatrix_name": logical_name,
+                        "expert_index": expert_index,
+                        "hfq_name": hfq_name,
+                        "imatrix_k": imatrix_k,
+                        "hfq_k": tensor_k,
+                    })
+                matched_experts.append(expert_index)
+                matches.append(
+                    {
+                        "imatrix_name": logical_name,
+                        "hfq_name": hfq_name,
+                        "expert_index": expert_index,
+                        "quant_type": tensor["quant_type"],
+                        "quant_type_name": quant_type_name,
+                        "shape": tensor["shape"],
+                        "group_size": tensor["group_size"],
+                        "data_offset": tensor["data_offset"],
+                        "data_size": tensor["data_size"],
+                        "imatrix_shape": in_sum2.get("shape"),
+                        "counts_shape": (logical_info.get("counts") or {}).get("shape"),
+                        "imatrix_k": imatrix_k,
+                        "imatrix_columns": imatrix_columns,
+                        "hfq_k": tensor_k,
+                        "k_dim_match": k_dim_match,
+                        "awq_eligible": awq_runtime_eligible(hfq_name),
+                        "calibration_supported": False,
+                    }
+                )
+            if imatrix_columns > 1:
+                expert_coverage.append({
+                    "imatrix_name": logical_name,
+                    "slot": slot,
+                    "expert_count": imatrix_columns,
+                    "matched_expert_count": len(matched_experts),
+                    "missing_expert_count": len(missing_experts),
+                    "matched_experts": matched_experts[:32],
+                    "missing_experts": missing_experts[:32],
+                    "truncated": len(matched_experts) > 32 or len(missing_experts) > 32,
+                })
+            continue
+
         candidates = gguf_to_hfq_candidates(logical_name)
         hfq_name = next((name for name in candidates if name in hfq_tensors), None)
         if hfq_name is None:
@@ -623,8 +804,16 @@ def match_imatrix_to_hfq(model, imatrix, *, max_tensors=32):
         tensor = hfq_tensors[hfq_name]
         quant_type_name = tensor["quant_type_name"]
         matched_quant_type_counts[quant_type_name] = matched_quant_type_counts.get(quant_type_name, 0) + 1
-        slot = logical_name.split(".")[2] if logical_name.startswith("blk.") and len(logical_name.split(".")) > 2 else "top_level"
         matched_by_slot[slot] = matched_by_slot.get(slot, 0) + 1
+        tensor_k = hfq_k_dim(tensor)
+        k_dim_match = imatrix_k is None or tensor_k == imatrix_k
+        if not k_dim_match:
+            k_dim_mismatches.append({
+                "imatrix_name": logical_name,
+                "hfq_name": hfq_name,
+                "imatrix_k": imatrix_k,
+                "hfq_k": tensor_k,
+            })
         matches.append(
             {
                 "imatrix_name": logical_name,
@@ -635,6 +824,14 @@ def match_imatrix_to_hfq(model, imatrix, *, max_tensors=32):
                 "group_size": tensor["group_size"],
                 "data_offset": tensor["data_offset"],
                 "data_size": tensor["data_size"],
+                "imatrix_shape": in_sum2.get("shape"),
+                "counts_shape": (logical_info.get("counts") or {}).get("shape"),
+                "imatrix_k": imatrix_k,
+                "imatrix_columns": imatrix_columns,
+                "hfq_k": tensor_k,
+                "k_dim_match": k_dim_match,
+                "awq_eligible": awq_runtime_eligible(hfq_name),
+                "calibration_supported": True,
             }
         )
 
@@ -654,11 +851,17 @@ def match_imatrix_to_hfq(model, imatrix, *, max_tensors=32):
         "imatrix_suffix_counts": imatrix_summary["imatrix_suffix_counts"],
         "matched_count": len(matches),
         "unmatched_count": len(unmatched),
+        "skipped_count": len(skipped),
+        "k_dim_mismatch_count": len(k_dim_mismatches),
+        "awq_eligible_count": sum(1 for item in matches if item.get("awq_eligible")),
         "matched_quant_type_counts": dict(sorted(matched_quant_type_counts.items())),
         "matched_by_slot": dict(sorted(matched_by_slot.items())),
+        "expert_coverage": expert_coverage,
+        "k_dim_mismatches": k_dim_mismatches,
         "matches": matches,
         "unmatched": unmatched,
-        "ready": len(matches) > 0 and len(unmatched) == 0,
+        "skipped": skipped,
+        "ready": len(matches) > 0 and len(unmatched) == 0 and len(skipped) == 0 and len(k_dim_mismatches) == 0,
     }
 
 
@@ -1717,6 +1920,8 @@ def select_imatrix_scale_matches(join, *, max_tensors=None, tensor_filter=None):
     filters = [item.strip() for item in (tensor_filter or "").split(",") if item.strip()]
     selected = []
     for item in join["matches"]:
+        if not item.get("calibration_supported", True):
+            continue
         if item["quant_type_name"] != "MFP4G32":
             continue
         if filters and not any(f in item["imatrix_name"] or f in item["hfq_name"] for f in filters):
@@ -1731,6 +1936,8 @@ def select_awq_mq4_matches(join, *, max_tensors=None, tensor_filter=None):
     filters = [item.strip() for item in (tensor_filter or "").split(",") if item.strip()]
     selected = []
     for item in join["matches"]:
+        if not item.get("calibration_supported", True):
+            continue
         if item["quant_type_name"] != "MQ4G256":
             continue
         if filters and not any(f in item["imatrix_name"] or f in item["hfq_name"] for f in filters):
@@ -1784,6 +1991,29 @@ def build_imatrix_scale_patch(task):
     }
 
 
+def run_patch_tasks(tasks, worker_fn, parallel_workers):
+    if parallel_workers == 1:
+        return [worker_fn(task) for task in tasks], "serial"
+
+    def run_with_executor(executor_cls):
+        by_index = {}
+        with executor_cls(max_workers=parallel_workers) as pool:
+            futures = {pool.submit(worker_fn, task): task["index"] for task in tasks}
+            for future in concurrent.futures.as_completed(futures):
+                result = future.result()
+                by_index[result["index"]] = result
+        return [by_index[i] for i in range(len(tasks))]
+
+    try:
+        return run_with_executor(concurrent.futures.ProcessPoolExecutor), "process"
+    except PermissionError:
+        return run_with_executor(concurrent.futures.ThreadPoolExecutor), "thread"
+    except OSError as exc:
+        if getattr(exc, "errno", None) == 1:
+            return run_with_executor(concurrent.futures.ThreadPoolExecutor), "thread"
+        raise
+
+
 def write_imatrix_scale_candidate(
     plan,
     join,
@@ -1826,17 +2056,9 @@ def write_imatrix_scale_candidate(
             }
         )
 
+    worker_mode = "serial"
     try:
-        if parallel_workers == 1:
-            results = [build_imatrix_scale_patch(task) for task in tasks]
-        else:
-            by_index = {}
-            with concurrent.futures.ProcessPoolExecutor(max_workers=parallel_workers) as pool:
-                futures = {pool.submit(build_imatrix_scale_patch, task): task["index"] for task in tasks}
-                for future in concurrent.futures.as_completed(futures):
-                    result = future.result()
-                    by_index[result["index"]] = result
-            results = [by_index[i] for i in range(len(tasks))]
+        results, worker_mode = run_patch_tasks(tasks, build_imatrix_scale_patch, parallel_workers)
 
         mutations = []
         for result in results:
@@ -1856,7 +2078,7 @@ def write_imatrix_scale_candidate(
         "candidate_bytes": Path(candidate).stat().st_size,
         "mutated_tensor_count": len(mutations),
         "parallel_workers": parallel_workers,
-        "worker_mode": "process" if parallel_workers > 1 else "serial",
+        "worker_mode": worker_mode,
         "mutations": mutations,
     }
 
@@ -2008,17 +2230,9 @@ def write_mq4_ls_candidate(
             }
         )
 
+    worker_mode = "serial"
     try:
-        if parallel_workers == 1:
-            results = [build_mq4_ls_patch(task) for task in tasks]
-        else:
-            by_index = {}
-            with concurrent.futures.ProcessPoolExecutor(max_workers=parallel_workers) as pool:
-                futures = {pool.submit(build_mq4_ls_patch, task): task["index"] for task in tasks}
-                for future in concurrent.futures.as_completed(futures):
-                    result = future.result()
-                    by_index[result["index"]] = result
-            results = [by_index[i] for i in range(len(tasks))]
+        results, worker_mode = run_patch_tasks(tasks, build_mq4_ls_patch, parallel_workers)
 
         mutations = []
         for result in results:
@@ -2039,7 +2253,7 @@ def write_mq4_ls_candidate(
         "candidate_bytes": Path(candidate).stat().st_size,
         "mutated_tensor_count": len(mutations),
         "parallel_workers": parallel_workers,
-        "worker_mode": "process" if parallel_workers > 1 else "serial",
+        "worker_mode": worker_mode,
         "mean_sample_mse_delta_pct": mean_delta,
         "clip_ratio": clip_ratio,
         "mutations": mutations,
@@ -2090,17 +2304,9 @@ def write_awq_mq4_candidate(
             }
         )
 
+    worker_mode = "serial"
     try:
-        if parallel_workers == 1:
-            results = [build_awq_mq4_patch(task) for task in tasks]
-        else:
-            by_index = {}
-            with concurrent.futures.ProcessPoolExecutor(max_workers=parallel_workers) as pool:
-                futures = {pool.submit(build_awq_mq4_patch, task): task["index"] for task in tasks}
-                for future in concurrent.futures.as_completed(futures):
-                    result = future.result()
-                    by_index[result["index"]] = result
-            results = [by_index[i] for i in range(len(tasks))]
+        results, worker_mode = run_patch_tasks(tasks, build_awq_mq4_patch, parallel_workers)
 
         mutations = []
         for result in results:
@@ -2120,7 +2326,7 @@ def write_awq_mq4_candidate(
         "candidate_bytes": Path(candidate).stat().st_size,
         "mutated_tensor_count": len(mutations),
         "parallel_workers": parallel_workers,
-        "worker_mode": "process" if parallel_workers > 1 else "serial",
+        "worker_mode": worker_mode,
         "awq_clip_ratio_grid": ratio_grid,
         "mutations": mutations,
     }
@@ -3284,6 +3490,13 @@ def build_parser():
     inspect.add_argument("--pretty", action="store_true")
     inspect.add_argument("--out", help="Write JSON to this path instead of stdout.")
 
+    imatrix_join = sub.add_parser("imatrix-join", help="Report imatrix to HFQ tensor coverage.")
+    imatrix_join.add_argument("--model", required=True)
+    imatrix_join.add_argument("--imatrix", required=True)
+    imatrix_join.add_argument("--max-tensors", type=int, default=32)
+    imatrix_join.add_argument("--pretty", action="store_true")
+    imatrix_join.add_argument("--out", help="Write JSON to this path instead of stdout.")
+
     fingerprint = sub.add_parser("fingerprint", help="Fingerprint the hipfire engine path.")
     fingerprint.add_argument("--engine-root")
     fingerprint.add_argument("--pretty", action="store_true")
@@ -3394,6 +3607,12 @@ def run(argv=None):
     if args.command == "inspect":
         write_json(
             inspect_model(args.model, imatrix=args.imatrix, quant_format=args.quant_format),
+            pretty=args.pretty,
+            out=args.out,
+        )
+    elif args.command == "imatrix-join":
+        write_json(
+            match_imatrix_to_hfq(args.model, args.imatrix, max_tensors=args.max_tensors),
             pretty=args.pretty,
             out=args.out,
         )

--- a/scripts/test_astrea.py
+++ b/scripts/test_astrea.py
@@ -43,8 +43,11 @@ class AstreaTests(unittest.TestCase):
         buf += struct.pack("<I", 8)  # string
         buf += gguf_string("synthetic-imatrix")
         for i, name in enumerate(tensor_names):
-            shape = [4] if name.endswith(".in_sum2") else [1]
-            offset = i * 16
+            shape = [256] if name.endswith(".in_sum2") else [1]
+            offset = 0 if i == 0 else sum(
+                (256 if prior.endswith(".in_sum2") else 1) * 4
+                for prior in tensor_names[:i]
+            )
             buf += gguf_string(name)
             buf += struct.pack("<I", len(shape))
             for dim in shape:
@@ -53,7 +56,8 @@ class AstreaTests(unittest.TestCase):
             buf += struct.pack("<Q", offset)
         pad = (-len(buf)) % 32
         buf += b"\0" * pad
-        buf += b"\0" * (16 * len(tensor_names))
+        payload_bytes = sum((256 if name.endswith(".in_sum2") else 1) * 4 for name in tensor_names)
+        buf += b"\0" * payload_bytes
         path.write_bytes(buf)
 
     def write_minimal_hfq(self, path, tensors=None):
@@ -168,6 +172,44 @@ class AstreaTests(unittest.TestCase):
             buf += payload
         path.write_bytes(buf)
 
+    def write_expert_imatrix_gguf(self, path, logical_name, k, n_experts):
+        def gguf_string(text):
+            raw = text.encode("utf-8")
+            return struct.pack("<Q", len(raw)) + raw
+
+        names = [f"{logical_name}.in_sum2", f"{logical_name}.counts"]
+        payloads = [
+            b"".join(struct.pack("<f", 1.0 + i / max(k, 1)) for i in range(k * n_experts)),
+            b"".join(struct.pack("<f", 8.0) for _ in range(n_experts)),
+        ]
+        shapes = [[k, n_experts], [1, n_experts]]
+        offsets = []
+        cursor = 0
+        for payload in payloads:
+            offsets.append(cursor)
+            cursor += len(payload)
+
+        buf = bytearray()
+        buf += b"GGUF"
+        buf += struct.pack("<I", 3)
+        buf += struct.pack("<Q", len(names))
+        buf += struct.pack("<Q", 1)
+        buf += gguf_string("general.alignment")
+        buf += struct.pack("<I", 4)
+        buf += struct.pack("<I", 32)
+        for name, shape, offset in zip(names, shapes, offsets):
+            buf += gguf_string(name)
+            buf += struct.pack("<I", len(shape))
+            for dim in shape:
+                buf += struct.pack("<Q", dim)
+            buf += struct.pack("<I", 0)
+            buf += struct.pack("<Q", offset)
+        pad = (-len(buf)) % 32
+        buf += b"\0" * pad
+        for payload in payloads:
+            buf += payload
+        path.write_bytes(buf)
+
     def test_inspect_records_model_and_imatrix_fingerprints(self):
         astrea = load_astrea()
         with tempfile.TemporaryDirectory() as td:
@@ -264,6 +306,38 @@ class AstreaTests(unittest.TestCase):
             matched["blk.0.attn_gate.weight"],
             "model.language_model.layers.0.linear_attn.in_proj_z.weight",
         )
+        self.assertEqual(result["k_dim_mismatch_count"], 0)
+
+    def test_match_imatrix_expert_matrix_expands_per_expert(self):
+        astrea = load_astrea()
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            model = root / "synthetic.mq4"
+            imatrix = root / "imatrix.gguf"
+            self.write_minimal_hfq(
+                model,
+                tensors=[
+                    ("model.language_model.layers.0.mlp.experts.0.gate_up_proj.weight", 13, [512, 256], 256, 272),
+                    ("model.language_model.layers.0.mlp.experts.1.gate_up_proj.weight", 13, [512, 256], 256, 272),
+                ],
+            )
+            self.write_expert_imatrix_gguf(
+                imatrix,
+                "blk.0.ffn_gate_exps.weight",
+                k=256,
+                n_experts=2,
+            )
+
+            result = astrea.match_imatrix_to_hfq(str(model), str(imatrix))
+
+        self.assertEqual(result["matched_count"], 2)
+        self.assertEqual(result["unmatched_count"], 0)
+        self.assertEqual(result["k_dim_mismatch_count"], 0)
+        self.assertEqual(result["awq_eligible_count"], 2)
+        self.assertEqual(result["matched_by_slot"], {"ffn_gate_exps": 2})
+        self.assertEqual(result["expert_coverage"][0]["matched_expert_count"], 2)
+        self.assertFalse(result["matches"][0]["calibration_supported"])
+        self.assertEqual(result["matches"][0]["imatrix_columns"], 2)
 
     def test_calibrate_dry_run_reports_matching_readiness(self):
         astrea = load_astrea()


### PR DESCRIPTION
## Summary

<one or two sentences>

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [ ] `cargo build --release --workspace --features deltanet` clean
- [ ] `cargo test --lib --workspace --features deltanet` passes
- [ ] If kernel/dispatch changed: `./scripts/coherence-gate.sh` clean
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines

## Architecture-trait change?

If this PR changes the `Architecture` trait surface in
`crates/hipfire-runtime/src/arch.rs`, note here. Trait changes ripple
to every arch crate.
