### PR TITLE
feat(awq): AWQ-aware lm_head dispatch runtime

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -904,7 +904,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         // pread_buf borrow, but the weight bytes have already been
         // uploaded to GPU (owned by `wt.buf`) so the borrow no longer
         // matters.
-        if matches!(wt.gpu_dtype, DType::MQ4G256) {
+        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }
@@ -916,7 +916,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
             .or_else(|| hfq.tensor_data(name))
             .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
         let mut wt = load_weight_tensor_raw(gpu, info.quant_type, data, m, k)?;
-        if matches!(wt.gpu_dtype, DType::MQ4G256) {
+        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1377,7 +1377,7 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
     // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens
     let lm_head_info = hfq.tensor_data_vec("lm_head.weight")
         .or_else(|| hfq.tensor_data_vec("model.language_model.lm_head.weight"));
-    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1409,6 +1409,21 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
+    // lm_head / tied embed_tokens AWQ sidecar attachment. Today no
+    // quantizer in the tree emits sidecars for these tensors (AWQ
+    // targets per-channel input scaling, which is iffy on
+    // vocab-sized matrices), but the inline `load_weight_tensor_raw`
+    // call above hardcodes `awq_scale: None` and bypasses the
+    // `load_weight_tensor` wrapper — so a future quantizer change
+    // would silently regress here the same way `qwen35.rs:907`
+    // regressed on MQ3 in May 2026. Try each plausible tensor name;
+    // `load_awq_scale_for` returns None when no sidecar exists, so
+    // this is a no-op for current files.
+    if output.gpu_dtype.supports_awq_sidecar() {
+        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+    }
 
     let is_moe = config.num_experts > 0;
     let mut layers = Vec::with_capacity(config.n_layers);
@@ -1606,7 +1621,7 @@ fn load_output_into(
     let lm_head_info = hfq
         .tensor_data("lm_head.weight")
         .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
-    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1645,6 +1660,18 @@ fn load_output_into(
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
+    // Same lm_head / tied embed_tokens AWQ attachment as the
+    // multimodal load_weights above. Sister fix — both code paths
+    // construct WeightTensor directly with `awq_scale: None` outside
+    // the `load_weight_tensor` wrapper, so they need explicit
+    // helper-gated attachment here. No-op on current files; defends
+    // against a future quantizer change that emits sidecars for the
+    // embedding matrix.
+    if output.gpu_dtype.supports_awq_sidecar() {
+        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+    }
     Ok((output_norm, output))
 }
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -899,12 +899,12 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         } else {
             panic!("tensor not found: {name} or {full_name}");
         };
-        // Phase A Stage A — populate awq_scale for MQ4G256 weights when
-        // a sidecar is present. The pread call invalidates the prior
-        // pread_buf borrow, but the weight bytes have already been
-        // uploaded to GPU (owned by `wt.buf`) so the borrow no longer
-        // matters.
-        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
+        // Phase A Stage A — populate awq_scale when the dtype is on
+        // the AWQ allow-list (centralized at `DType::supports_awq_sidecar`).
+        // The pread call invalidates the prior pread_buf borrow, but
+        // the weight bytes have already been uploaded to GPU (owned by
+        // `wt.buf`) so the borrow no longer matters.
+        if wt.gpu_dtype.supports_awq_sidecar() {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }
@@ -916,7 +916,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
             .or_else(|| hfq.tensor_data(name))
             .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
         let mut wt = load_weight_tensor_raw(gpu, info.quant_type, data, m, k)?;
-        if matches!(wt.gpu_dtype, DType::MQ4G256 | DType::MQ3G256) {
+        if wt.gpu_dtype.supports_awq_sidecar() {
             wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
         }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1374,10 +1374,25 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
         load_norm_weight(hfq, gpu, "norm.weight", &[config.dim])?
     };
 
-    // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens
+    // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens.
+    //
+    // **No AWQ sidecar attachment on this path.** The runtime
+    // dispatch for lm_head goes through `gemm_*_batched_lmhead`
+    // kernels which have NO AWQ inverse — they do not divide `x`
+    // by the sidecar before the matmul. Attaching a sidecar here
+    // (today: no-op since the quantizer's `awq_eligible` whitelist
+    // at `hipfire-quantize/src/main.rs:3849` excludes lm_head and
+    // embed_tokens; future: would silently produce `(W·s)·x ≠ W·x`
+    // with KLD blowup of the 0.67 → 13.5 class documented at
+    // `docs/plans/awq_fix_claude.md`) is the exact failure mode the
+    // quantizer-side whitelist is fail-closed against. Routing
+    // `output.gpu_dtype` through `DType::supports_awq_sidecar` would
+    // remove that fail-closed property. When AWQ-aware lm_head
+    // dispatch lands (kernel + fused-norm path), add `output.awq_scale`
+    // attachment AT THAT POINT, not before.
     let lm_head_info = hfq.tensor_data_vec("lm_head.weight")
         .or_else(|| hfq.tensor_data_vec("model.language_model.lm_head.weight"));
-    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1409,21 +1424,6 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
-    // lm_head / tied embed_tokens AWQ sidecar attachment. Today no
-    // quantizer in the tree emits sidecars for these tensors (AWQ
-    // targets per-channel input scaling, which is iffy on
-    // vocab-sized matrices), but the inline `load_weight_tensor_raw`
-    // call above hardcodes `awq_scale: None` and bypasses the
-    // `load_weight_tensor` wrapper — so a future quantizer change
-    // would silently regress here the same way `qwen35.rs:907`
-    // regressed on MQ3 in May 2026. Try each plausible tensor name;
-    // `load_awq_scale_for` returns None when no sidecar exists, so
-    // this is a no-op for current files.
-    if output.gpu_dtype.supports_awq_sidecar() {
-        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
-    }
 
     let is_moe = config.num_experts > 0;
     let mut layers = Vec::with_capacity(config.n_layers);
@@ -1621,7 +1621,14 @@ fn load_output_into(
     let lm_head_info = hfq
         .tensor_data("lm_head.weight")
         .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
-    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
+    // No AWQ sidecar attachment here — see the sister load_weights
+    // function's lm_head block for the full rationale. TL;DR: the
+    // `gemm_*_batched_lmhead` runtime dispatch lacks an AWQ inverse,
+    // so attaching a sidecar would silently corrupt logits (KLD
+    // 0.67 → 13.5 class per `docs/plans/awq_fix_claude.md`). The
+    // quantizer's `awq_eligible` whitelist is the only fail-closed
+    // safety — keep this path consistent with it.
+    let output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1660,18 +1667,6 @@ fn load_output_into(
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
-    // Same lm_head / tied embed_tokens AWQ attachment as the
-    // multimodal load_weights above. Sister fix — both code paths
-    // construct WeightTensor directly with `awq_scale: None` outside
-    // the `load_weight_tensor` wrapper, so they need explicit
-    // helper-gated attachment here. No-op on current files; defends
-    // against a future quantizer change that emits sidecars for the
-    // embedding matrix.
-    if output.gpu_dtype.supports_awq_sidecar() {
-        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
-    }
     Ok((output_norm, output))
 }
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1375,24 +1375,9 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
     };
 
     // Try separate lm_head first (untied embeddings, e.g. 9B), fall back to tied embed_tokens.
-    //
-    // **No AWQ sidecar attachment on this path.** The runtime
-    // dispatch for lm_head goes through `gemm_*_batched_lmhead`
-    // kernels which have NO AWQ inverse — they do not divide `x`
-    // by the sidecar before the matmul. Attaching a sidecar here
-    // (today: no-op since the quantizer's `awq_eligible` whitelist
-    // at `hipfire-quantize/src/main.rs:3849` excludes lm_head and
-    // embed_tokens; future: would silently produce `(W·s)·x ≠ W·x`
-    // with KLD blowup of the 0.67 → 13.5 class documented at
-    // `docs/plans/awq_fix_claude.md`) is the exact failure mode the
-    // quantizer-side whitelist is fail-closed against. Routing
-    // `output.gpu_dtype` through `DType::supports_awq_sidecar` would
-    // remove that fail-closed property. When AWQ-aware lm_head
-    // dispatch lands (kernel + fused-norm path), add `output.awq_scale`
-    // attachment AT THAT POINT, not before.
     let lm_head_info = hfq.tensor_data_vec("lm_head.weight")
         .or_else(|| hfq.tensor_data_vec("model.language_model.lm_head.weight"));
-    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1424,6 +1409,21 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
+    // AWQ sidecar attachment for lm_head / tied embed_tokens. Safe now
+    // that both decode (`weight_gemv` → `rotate_x_mq_for`) AND spec-
+    // decode verify (`speculative.rs::rotate_x_mq_batched_for`) apply
+    // the `x /= s` inverse when `output.awq_scale.is_some()`. Pre-fix,
+    // attaching a sidecar here would have driven the 0.67 → 13.5 KLD
+    // corruption documented at `docs/plans/awq_fix_claude.md` because
+    // the spec-verify path used the non-AWQ `rotate_x_mq_batched`.
+    // Try each plausible tensor name; `load_awq_scale_for` returns
+    // None when no sidecar exists, so this is a no-op for current
+    // pre-CUDA-pipeline files.
+    if output.gpu_dtype.supports_awq_sidecar() {
+        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+    }
 
     let is_moe = config.num_experts > 0;
     let mut layers = Vec::with_capacity(config.n_layers);
@@ -1621,14 +1621,7 @@ fn load_output_into(
     let lm_head_info = hfq
         .tensor_data("lm_head.weight")
         .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"));
-    // No AWQ sidecar attachment here — see the sister load_weights
-    // function's lm_head block for the full rationale. TL;DR: the
-    // `gemm_*_batched_lmhead` runtime dispatch lacks an AWQ inverse,
-    // so attaching a sidecar would silently corrupt logits (KLD
-    // 0.67 → 13.5 class per `docs/plans/awq_fix_claude.md`). The
-    // quantizer's `awq_eligible` whitelist is the only fail-closed
-    // safety — keep this path consistent with it.
-    let output = if let Some((lm_info, lm_data)) = lm_head_info {
+    let mut output = if let Some((lm_info, lm_data)) = lm_head_info {
         eprintln!("  loading output (separate lm_head, qt={})...", lm_info.quant_type);
         load_weight_tensor_raw(gpu, lm_info.quant_type, lm_data, config.vocab_size, config.dim)?
     } else {
@@ -1667,6 +1660,15 @@ fn load_output_into(
             WeightTensor { buf, gpu_dtype: DType::F32, m: config.vocab_size, k: config.dim, row_stride: 0, awq_scale: None }
         }
     };
+    // AWQ sidecar attachment — sister of the `load_weights` block.
+    // Safe because both `weight_gemv` (decode) and `speculative.rs`
+    // (spec-verify) route through AWQ-aware rotations on
+    // `output.awq_scale.is_some()`. No-op on current files.
+    if output.gpu_dtype.supports_awq_sidecar() {
+        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+    }
     Ok((output_norm, output))
 }
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -1423,6 +1423,8 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
         output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
             .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
             .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+        eprintln!("  lm_head AWQ sidecar: {}",
+            if output.awq_scale.is_some() { "attached" } else { "absent (no-op)" });
     }
 
     let is_moe = config.num_experts > 0;
@@ -1668,6 +1670,8 @@ fn load_output_into(
         output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
             .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
             .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+        eprintln!("  lm_head AWQ sidecar: {}",
+            if output.awq_scale.is_some() { "attached" } else { "absent (no-op)" });
     }
     Ok((output_norm, output))
 }

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -2178,7 +2178,11 @@ fn verify_dflash_block_inner(
                     "verify_scratch.rot undersized: b*k={} > max_n*hidden_k={}",
                     b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
                 let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                gpu.rotate_x_mq_batched(&final_hidden, &rot, w_out.k, b)?;
+                // AWQ-aware rotation: when `w_out.awq_scale.is_some()` (lm_head
+                // has an AWQ sidecar attached), `_for` dispatches the AWQ
+                // variant that divides x by s before FWHT. Numerically
+                // identical to `rotate_x_mq_batched` when no sidecar exists.
+                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
                 gpu.gemm_hfq4g256_batched_lmhead(
                     &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
                 )?;
@@ -2188,7 +2192,8 @@ fn verify_dflash_block_inner(
                     "verify_scratch.rot undersized for MQ3 lm_head: b*k={} > max_n*hidden_k={}",
                     b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
                 let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                gpu.rotate_x_mq_batched(&final_hidden, &rot, w_out.k, b)?;
+                // AWQ-aware rotation; see the MQ4 arm above for rationale.
+                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
                 gpu.gemm_hfq3g256_batched_lmhead(
                     &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
                 )?;
@@ -2736,7 +2741,9 @@ pub fn spec_step_dflash(
                 assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
                     "verify_scratch.rot undersized for draft lm_head");
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                // AWQ-aware rotation; same rationale as the target-verify
+                // arms above.
+                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
                 gpu.gemm_hfq4g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
@@ -2745,7 +2752,7 @@ pub fn spec_step_dflash(
                 assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
                     "verify_scratch.rot undersized for MQ3 draft lm_head");
                 let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch)?;
+                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
                 gpu.gemm_hfq3g256_batched_lmhead(
                     &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
                 )?;
@@ -3363,7 +3370,9 @@ fn run_dflash_draft_for_logits(
         }
         rdna_compute::DType::MQ4G256 => {
             let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
-            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            // AWQ-aware rotation; see the target-verify dispatch above for the
+            // rationale (numerically identical when `w_out.awq_scale` is None).
+            let r1 = llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch);
             if let Err(e) = r1 {
                 let _ = gpu.free_tensor(rotated);
                 let _ = gpu.free_tensor(logits_batch);
@@ -3377,7 +3386,7 @@ fn run_dflash_draft_for_logits(
         }
         rdna_compute::DType::MQ3G256 => {
             let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
-            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            let r1 = llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch);
             if let Err(e) = r1 {
                 let _ = gpu.free_tensor(rotated);
                 let _ = gpu.free_tensor(logits_batch);
@@ -3526,7 +3535,9 @@ fn run_dflash_draft_for_topk_gpu(
         }
         rdna_compute::DType::MQ4G256 => {
             let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
-            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            // AWQ-aware rotation for the target lm_head when an AWQ
+            // sidecar is attached. Sister of the spec-verify dispatch above.
+            let r1 = llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch);
             if let Err(e) = r1 {
                 let _ = gpu.free_tensor(rotated);
                 let _ = gpu.free_tensor(logits_batch);
@@ -3540,7 +3551,7 @@ fn run_dflash_draft_for_topk_gpu(
         }
         rdna_compute::DType::MQ3G256 => {
             let rotated = gpu.alloc_tensor(&[batch * h], rdna_compute::DType::F32)?;
-            let r1 = gpu.rotate_x_mq_batched(&hidden_rows, &rotated, h, batch);
+            let r1 = llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch);
             if let Err(e) = r1 {
                 let _ = gpu.free_tensor(rotated);
                 let _ = gpu.free_tensor(logits_batch);

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -195,7 +195,7 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
     let (info, data) = hfq
         .tensor_data(name)
         .unwrap_or_else(|| panic!("dflash tensor missing: {name}"));
-    match info.quant_type {
+    let mut wt = match info.quant_type {
         1 => {
             // F16 on disk. Default: upload as F16 (no lift) and dispatch through
             // the mw16 WMMA kernel — 3-5× faster draft at B=16 on gfx1100 than
@@ -242,7 +242,39 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale: None })
         }
         q => panic!("dflash: unsupported matrix quant_type {q} for {name}"),
+    }?;
+    // AWQ sidecar attachment — same pattern as hfq.rs::load_weight_tensor
+    // and qwen35.rs::load_weight_tensor. Routed through the centralized
+    // `DType::supports_awq_sidecar` allow-list so future widening (MQ6,
+    // MQ2, MQ3-Lloyd, MFP4) is a single helper edit. Sidecar absent →
+    // `awq_scale` stays None, dispatch path matches the pre-fix behavior.
+    //
+    // Logic is inlined rather than calling out to hfq.rs's closure or
+    // qwen35.rs's `load_awq_scale_for` to avoid pulling in a cross-crate
+    // dependency for what is structurally a third copy of the same load.
+    // Factor-out (one shared `pub fn load_awq_scale_for` in this crate)
+    // is tracked as a follow-up.
+    if wt.gpu_dtype.supports_awq_sidecar() {
+        let sidecar_name = match name.strip_suffix(".weight") {
+            Some(stem) => format!("{stem}.awq_scale.weight"),
+            None => format!("{name}.awq_scale.weight"),
+        };
+        if let Some((sc_info, sc_data)) = hfq.tensor_data(&sidecar_name) {
+            if sc_info.quant_type != 1 {
+                eprintln!("warning: AWQ sidecar {sidecar_name} has quant_type={} (expected 1=F16); skipping", sc_info.quant_type);
+            } else if sc_info.shape.len() != 1 || sc_info.shape[0] as usize != k {
+                eprintln!("warning: AWQ sidecar {sidecar_name} shape mismatch ({:?} vs expected [{}]); skipping", sc_info.shape, k);
+            } else {
+                let f32_data: Vec<f32> = sc_data
+                    .chunks_exact(2)
+                    .map(|c| crate::llama::f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+                    .collect();
+                let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
+                wt.awq_scale = gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok();
+            }
+        }
     }
+    Ok(wt)
 }
 
 impl DflashWeights {
@@ -619,7 +651,12 @@ fn gemm_dispatch(
                 let x_chunk = x.sub_offset(row * w.k, n * w.k);
                 let y_chunk = y.sub_offset(row * w.m, n * w.m);
                 let rot_view = scratch.sub_offset(0, n * w.k);
-                if let Err(e) = gpu.rotate_x_mq_batched(&x_chunk, &rot_view, w.k, n) {
+                // AWQ-aware FWHT rotation. When the drafter weight ships an
+                // AWQ sidecar (`w.awq_scale.is_some()`), `_for` dispatches
+                // the `x /= awq_scale` + FWHT kernel; otherwise falls
+                // through to the plain `rotate_x_mq_batched` and is
+                // numerically identical to the prior dispatch.
+                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
                     chunked = Err(e);
                     break;
                 }
@@ -655,7 +692,12 @@ fn gemm_dispatch(
                 let x_chunk = x.sub_offset(row * w.k, n * w.k);
                 let y_chunk = y.sub_offset(row * w.m, n * w.m);
                 let rot_view = scratch.sub_offset(0, n * w.k);
-                if let Err(e) = gpu.rotate_x_mq_batched(&x_chunk, &rot_view, w.k, n) {
+                // Same AWQ-aware FWHT rotation as the MQ4 arm. Drafters
+                // that ship MQ3 AWQ sidecars (via the loader fix in
+                // `hfq_weight`) now actually receive the `x /= s` divide
+                // before the HFQ3 GEMM; pre-fix this silently produced
+                // wrong drafts on AWQ-calibrated drafters.
+                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
                     chunked = Err(e);
                     break;
                 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -588,7 +588,8 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         }
         17 => { // MQ3-G256 — MagnumQuant FWHT-rotated 3-bit, 104 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale: None })
+            let awq_scale = load_awq_scale();
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale })
         }
         18 => { // MQ2-G256 — MagnumQuant FWHT-rotated 2-bit, 72 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -529,7 +529,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok()
     };
 
-    match info.quant_type {
+    let mut wt = match info.quant_type {
         0 => { // Q4F16G64
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::Q4F16G64, m, k, row_stride: 0, awq_scale: None })
@@ -579,8 +579,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         }
         13 => { // MQ4-G256 — MagnumQuant FWHT-rotated 4-bit
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            let awq_scale = load_awq_scale();
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, awq_scale })
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, awq_scale: None })
         }
         14 => { // MQ8-G256 — MagnumQuant FWHT-rotated symmetric INT8, dp4a
             let buf = gpu.upload_raw(data, &[data.len()])?;
@@ -588,8 +587,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
         }
         17 => { // MQ3-G256 — MagnumQuant FWHT-rotated 3-bit, 104 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            let awq_scale = load_awq_scale();
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale })
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, awq_scale: None })
         }
         18 => { // MQ2-G256 — MagnumQuant FWHT-rotated 2-bit, 72 bytes per 256 elements
             let buf = gpu.upload_raw(data, &[data.len()])?;
@@ -630,7 +628,18 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
             Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, awq_scale: None })
         }
         _ => panic!("unsupported quant_type {} for weight {st_name}", info.quant_type),
+    }?;
+    // Centralized AWQ sidecar attachment. Replaces the prior per-arm
+    // inline `load_awq_scale()` calls at the qt=13 / qt=17 arms — those
+    // were the only loaders touching `awq_scale` and missing arms (qt=15
+    // MQ6, qt=18 MQ2, qt=19/20 Lloyd, qt=24 MFP4) would silently drop
+    // sidecars if added later. Routed through `DType::supports_awq_sidecar`
+    // so future widening is a single helper edit, not a scattered
+    // per-loader hunt. See dispatch.rs for the allow-list rationale.
+    if wt.gpu_dtype.supports_awq_sidecar() {
+        wt.awq_scale = load_awq_scale();
     }
+    Ok(wt)
 }
 
 /// Load LLaMA weights from an HFQ file onto GPU.

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -601,11 +601,11 @@ pub fn weight_gemv(
                 dtype: DType::F32,
             };
             // Preserve the gfx12 dual-FP8 fast path inside
-            // `gemv_mfp4g32_with_rotate` when AWQ is not in play. The
-            // quantizer cannot emit AWQ sidecars for MFP4G32 today (AWQ
-            // is gated to MQ4G256), so the `is_some()` branch is
-            // unreachable from today's pipeline — kept for forward
-            // compatibility if AWQ is ever widened to MFP4.
+            // `gemv_mfp4g32_with_rotate` when AWQ is not in play. AWQ
+            // is currently gated by `DType::supports_awq_sidecar`
+            // (`MQ4G256 | MQ3G256` today), so the `is_some()` branch
+            // is unreachable from today's pipeline — kept for forward
+            // compatibility if MFP4G32 ever joins the AWQ allow-list.
             if w.awq_scale.is_some() {
                 rotate_x_mq_for(gpu, w, x, &x_rot_alias, w.k)?;
                 gpu.gemv_mfp4g32_prerotated(&w.buf, &x_rot_alias, y, w.m, w.k)

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -446,6 +446,44 @@ impl DType {
             DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd | DType::HFP4G32 | DType::MFP4G32 | DType::Raw => 1, // byte-level
         }
     }
+
+    /// Whether a `WeightTensor` of this dtype should have the
+    /// `<weight>.awq_scale.weight` F16 sidecar attached at load time.
+    ///
+    /// Centralizes the gate that previously lived inline at every
+    /// loader call site (qwen35.rs `load_weight_tensor`, etc.). The
+    /// motivation is the May 2026 regression where `qwen35.rs:907`
+    /// gated on `matches!(wt.gpu_dtype, DType::MQ4G256)` and silently
+    /// dropped AWQ sidecars for `MQ3G256`-quantized Qwen3.5 weights,
+    /// producing fluent-but-nonsensical token soup for ~5 hours
+    /// before the missing arm was traced. Adding a new AWQ-eligible
+    /// dtype is now a one-line edit here instead of two scattered
+    /// edits per loader.
+    ///
+    /// Current allow-list = the empirical truth of which dtypes ship
+    /// AWQ sidecars from the quantizer AND have an AWQ-aware forward
+    /// path (`rotate_x_mq_for` etc., wired through `awq_scale.is_some()`).
+    ///
+    /// **Forward-path-ready candidates not currently in the allow-list**
+    /// (forward kernels exist but no `.hfq` file in tree ships sidecars
+    /// for them — widen only after the quantizer side is verified to
+    /// emit sidecars and at least one coherence-gate row exercises the
+    /// combination):
+    /// - `MQ6G256`
+    /// - `MQ2G256`, `MQ2G256Lloyd`
+    /// - `MQ3G256Lloyd`
+    /// - `MFP4G32` (forward path has explicit `awq_scale.is_some()`
+    ///   branching at llama.rs:609 but the quantizer comment says
+    ///   "AWQ is gated to MQ4G256 today" — confirm before widening)
+    ///
+    /// `MQ8G256` is explicitly **not** a candidate: it uses its own
+    /// INT8-quantized scratch path (`gemv_mq8g256_with_rotate`,
+    /// `rotate_quantize_x_mq8`) and does not flow through
+    /// `rotate_x_mq_for`, so there is no AWQ-aware kernel to dispatch
+    /// to.
+    pub fn supports_awq_sidecar(self) -> bool {
+        matches!(self, DType::MQ4G256 | DType::MQ3G256)
+    }
 }
 
 /// High-level GPU context. Owns the HIP runtime, compiler, and loaded kernels.

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -481,6 +481,22 @@ impl DType {
     /// `rotate_quantize_x_mq8`) and does not flow through
     /// `rotate_x_mq_for`, so there is no AWQ-aware kernel to dispatch
     /// to.
+    ///
+    /// **Important — this helper governs per-layer linear projection
+    /// loaders ONLY.** It must NOT be applied to `lm_head` or tied
+    /// `embed_tokens` constructors. Their forward dispatch goes
+    /// through `gemm_*_batched_lmhead` kernels which have no AWQ
+    /// inverse (no `x /= s` divide before the matmul), so attaching
+    /// a sidecar would silently produce `(W·s)·x ≠ W·x` — the
+    /// KLD 0.67 → 13.5 corruption class documented at
+    /// `docs/plans/awq_fix_claude.md`. The quantizer's `awq_eligible`
+    /// whitelist (`hipfire-quantize/src/main.rs:3849`) is the single
+    /// source of truth for which tensors should ever ship sidecars,
+    /// and it excludes lm_head / embed_tokens. The loader sites at
+    /// `qwen35.rs::load_weights` / `load_weights_vl`'s `output`
+    /// construction intentionally do not call this helper — keep
+    /// them consistent with the whitelist until an AWQ-aware
+    /// lm_head dispatch path lands.
     pub fn supports_awq_sidecar(self) -> bool {
         matches!(self, DType::MQ4G256 | DType::MQ3G256)
     }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -482,21 +482,23 @@ impl DType {
     /// `rotate_x_mq_for`, so there is no AWQ-aware kernel to dispatch
     /// to.
     ///
-    /// **Important — this helper governs per-layer linear projection
-    /// loaders ONLY.** It must NOT be applied to `lm_head` or tied
-    /// `embed_tokens` constructors. Their forward dispatch goes
-    /// through `gemm_*_batched_lmhead` kernels which have no AWQ
-    /// inverse (no `x /= s` divide before the matmul), so attaching
-    /// a sidecar would silently produce `(W·s)·x ≠ W·x` — the
-    /// KLD 0.67 → 13.5 corruption class documented at
-    /// `docs/plans/awq_fix_claude.md`. The quantizer's `awq_eligible`
-    /// whitelist (`hipfire-quantize/src/main.rs:3849`) is the single
-    /// source of truth for which tensors should ever ship sidecars,
-    /// and it excludes lm_head / embed_tokens. The loader sites at
-    /// `qwen35.rs::load_weights` / `load_weights_vl`'s `output`
-    /// construction intentionally do not call this helper — keep
-    /// them consistent with the whitelist until an AWQ-aware
-    /// lm_head dispatch path lands.
+    /// **lm_head / embed_tokens callers:** as of the lm_head-AWQ
+    /// runtime PR, this helper IS safe for the `output` weight in
+    /// `qwen35.rs::load_weights` / `load_weights_vl`. Both dispatch
+    /// paths that consume `weights.output` now route through
+    /// AWQ-aware rotations when a sidecar is attached:
+    /// - Decode: `weight_gemv` → `rotate_x_mq_for` (llama.rs)
+    /// - Spec-decode verify: `speculative.rs::rotate_x_mq_batched_for`
+    ///
+    /// Pre-runtime-fix, attaching a sidecar on lm_head would have
+    /// produced `(W·s)·x ≠ W·x` via the spec-verify path's plain
+    /// `rotate_x_mq_batched` and driven the KLD 0.67 → 13.5
+    /// corruption documented at `docs/plans/awq_fix_claude.md`. The
+    /// quantizer-side `awq_eligible` whitelist
+    /// (`hipfire-quantize/src/main.rs:3849`) still gates which
+    /// tensors actually receive `W' = W·s` pre-multiplication at
+    /// quant time — this helper governs only whether the loader
+    /// attaches an already-emitted sidecar.
     pub fn supports_awq_sidecar(self) -> bool {
         matches!(self, DType::MQ4G256 | DType::MQ3G256)
     }

--- a/scripts/coherence-gate.sh
+++ b/scripts/coherence-gate.sh
@@ -134,6 +134,21 @@ SHORT_TESTS=(
     #   ln -s /data/hipfire/mq3-sweep/qwen3.5-4b.mq3-awq-only.hfq \
     #         "${HIPFIRE_DIR:-$HOME/.hipfire}/models/qwen3.5-4b.mq3-awq-only"
     "qwen3.5-4b.mq3-awq-only|mq3-awq-paris|What is the capital of France? Answer in one short sentence.|80"
+    # lm_head AWQ coverage — regression catcher for the AWQ-aware lm_head
+    # dispatch landed in 2026-05-18's lm-head-awq-runtime PR. The 9B file
+    # ships `lm_head.awq_scale.weight` alongside the 248 per-layer
+    # sidecars; the runtime applies `x /= s` before the lm_head matmul
+    # via `weight_gemv` → `rotate_x_mq_for` (decode) and
+    # `speculative.rs::rotate_x_mq_batched_for` (spec-verify). With
+    # those wirings in place, the model produces coherent output;
+    # without them, the lm_head computes `(W·s)·x ≠ W·x` and emits
+    # gibberish at the output projection (KLD 0.67 → 13.5 class —
+    # see docs/plans/awq_fix_claude.md). max_tokens=300 because 9B
+    # Qwen3.5 thinking mode spends more tokens in `<think>` before
+    # emitting the final answer. Symlink to enable:
+    #   ln -s /data/hipfire/qwen3.5-9b.mq4-awq-gptq-f2-lmhead-a100.hfq \
+    #         "${HIPFIRE_DIR:-$HOME/.hipfire}/models/qwen3.5-9b.mq4-awq-gptq-f2-lmhead"
+    "qwen3.5-9b.mq4-awq-gptq-f2-lmhead|lmhead-awq-paris|What is the capital of France? Answer in one short sentence.|300"
 )
 FULL_EXTRA=(
     "qwen3.5-35b-a3b.mq4|moe-sheep|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|500"
@@ -257,21 +272,27 @@ print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))'
                 status="OK (soft: no <tool_call> emitted; model answered inline)"
             fi
             ;;
-        mq3-awq-paris)
-            # Regression catcher for the AWQ-sidecar load-gate bug
-            # (2026-05-18: `qwen35.rs:907` had `matches!(_, DType::MQ4G256)`
-            # and silently dropped MQ3 sidecars → fluent-but-nonsensical
-            # multi-language token soup). A healthy 4B Qwen3.5 MQ3-AWQ-GPTQ
-            # answer always contains "Paris" verbatim — even the lowest
-            # KLD variant (mq3-awq-gptq, PPL 11.18) gets the capital right
-            # at temp=0.0. Anything else means the AWQ rescale is not
-            # being applied. Hard-fail to catch the regression before it
-            # ships.
+        mq3-awq-paris|lmhead-awq-paris)
+            # Regression catcher for AWQ-sidecar load + dispatch bugs.
+            # Two flavors share this hard-fail check:
+            #   - mq3-awq-paris (4B): catches the 2026-05-18 loader bug
+            #     where `qwen35.rs:907` gated AWQ-sidecar attachment on
+            #     `matches!(_, DType::MQ4G256)` and silently dropped MQ3
+            #     sidecars.
+            #   - lmhead-awq-paris (9B): catches the 2026-05-18 spec-verify
+            #     dispatch bug where `speculative.rs`'s lm_head path
+            #     called the non-AWQ `rotate_x_mq_batched` even when an
+            #     lm_head sidecar was attached. Same dispatch class as
+            #     the DFlash drafter bug fixed in PR #290.
+            # A healthy Qwen3.5 MQ4-AWQ answer always contains "Paris"
+            # verbatim at temp=0 — even the lowest-PPL calibration gets
+            # the capital right. Anything else means the AWQ rescale is
+            # not being applied at some stage.
             text=$(grep -a '"type":"token"' "$out_file" | python3 -c '
 import sys, json
 print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))')
             if ! printf '%s' "$text" | grep -q 'Paris'; then
-                status="HARD_ERROR (MQ3-AWQ regression: answer missing 'Paris' — AWQ sidecar likely not applied; check DType::supports_awq_sidecar gate)"
+                status="HARD_ERROR (AWQ regression: answer missing 'Paris' — AWQ rescale likely not applied; check DType::supports_awq_sidecar gate and rotate_x_mq_for / rotate_x_mq_batched_for dispatch)"
                 hard_errors=$((hard_errors + 1))
             fi
             ;;

--- a/scripts/coherence-gate.sh
+++ b/scripts/coherence-gate.sh
@@ -120,6 +120,20 @@ SHORT_TESTS=(
     # defaults don't disturb the mq6 dispatch routing. Skipped if model
     # absent (download via `hipfire pull qwen3.5-9b.mq6`).
     "qwen3.5-9b.mq6|reason-mq6|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|300"
+    # MQ3-AWQ coverage — regression catcher for the 2026-05-18 loader bug
+    # where `qwen35.rs:907` gated AWQ-sidecar attachment on
+    # `matches!(wt.gpu_dtype, DType::MQ4G256)` and silently dropped sidecars
+    # for MQ3G256 weights (fixed by extending to MQ4G256|MQ3G256 and then
+    # centralized behind `DType::supports_awq_sidecar` — see the
+    # `mq3-awq-paris` case below for the corresponding hard-fail check).
+    # Uses the 4B-awq-only variant because it produces a verbose answer
+    # containing "Paris" reliably at temp=0 + repeat_penalty=1.05; the
+    # awq-gptq sibling terses out on this prompt (7 tokens, no Paris), so
+    # it would false-positive the gate. Skipped if the canonical file
+    # isn't symlinked into MODELS_DIR — symlink it as:
+    #   ln -s /data/hipfire/mq3-sweep/qwen3.5-4b.mq3-awq-only.hfq \
+    #         "${HIPFIRE_DIR:-$HOME/.hipfire}/models/qwen3.5-4b.mq3-awq-only"
+    "qwen3.5-4b.mq3-awq-only|mq3-awq-paris|What is the capital of France? Answer in one short sentence.|80"
 )
 FULL_EXTRA=(
     "qwen3.5-35b-a3b.mq4|moe-sheep|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|500"
@@ -241,6 +255,24 @@ print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))'
                 # be quantization noise (small model decided to answer
                 # directly); not a corruption signal.
                 status="OK (soft: no <tool_call> emitted; model answered inline)"
+            fi
+            ;;
+        mq3-awq-paris)
+            # Regression catcher for the AWQ-sidecar load-gate bug
+            # (2026-05-18: `qwen35.rs:907` had `matches!(_, DType::MQ4G256)`
+            # and silently dropped MQ3 sidecars → fluent-but-nonsensical
+            # multi-language token soup). A healthy 4B Qwen3.5 MQ3-AWQ-GPTQ
+            # answer always contains "Paris" verbatim — even the lowest
+            # KLD variant (mq3-awq-gptq, PPL 11.18) gets the capital right
+            # at temp=0.0. Anything else means the AWQ rescale is not
+            # being applied. Hard-fail to catch the regression before it
+            # ships.
+            text=$(grep -a '"type":"token"' "$out_file" | python3 -c '
+import sys, json
+print("".join(json.loads(l).get("text","") for l in sys.stdin if "token" in l))')
+            if ! printf '%s' "$text" | grep -q 'Paris'; then
+                status="HARD_ERROR (MQ3-AWQ regression: answer missing 'Paris' — AWQ sidecar likely not applied; check DType::supports_awq_sidecar gate)"
+                hard_errors=$((hard_errors + 1))
             fi
             ;;
     esac


### PR DESCRIPTION
Stacks on top of `fix/mq3-awq-loader` (PR #290). Should land after that PR merges, or be rebased on `master` post-merge.

## Summary

- Wires AWQ-aware rotation into the 8 MQ4/MQ3 lm_head dispatch sites in `crates/hipfire-arch-qwen35/src/speculative.rs` (target verify, draft verify, and two batched-lm_head sister paths). Each site swaps `gpu.rotate_x_mq_batched(...)` → `llama::rotate_x_mq_batched_for(gpu, w_out, ..., batch)` — same shape as the DFlash drafter fix in PR #290's `67eeb0fc`.
- Re-adds the loader-side `weights.output.awq_scale` attachment in `qwen35.rs::load_weights` and `load_weights_vl`. PR #290 reverted this in `1183dcb9` because the spec-decode path was unsafe; that's now resolved.
- Updates `DType::supports_awq_sidecar`'s doc comment: removes the "must NOT apply to lm_head" carve-out, replaces with a positive table of which dispatch paths consume `weights.output` and where each is wired.
- Adds a load-time `eprintln!("  lm_head AWQ sidecar: {attached|absent}")` in both `load_weights` and `load_weights_vl` so the load log carries a definitive signal of whether the AWQ rescale is in play. Fires only when `gpu_dtype.supports_awq_sidecar()` is true.
- Adds a coherence-gate row `qwen3.5-9b.mq4-awq-gptq-f2-lmhead | lmhead-awq-paris` (max=300) and extends the existing `mq3-awq-paris` case branch into a unified `*-awq-paris` hard-fail that checks for "Paris" in the answer.

End-to-end AWQ-aware lm_head dispatch coverage after this PR:

| Path | Function | AWQ awareness wired in |
|---|---|---|
| Single-token decode | `weight_gemv` (llama.rs) → `rotate_x_mq_for` | Pre-existing |
| Spec-verify target lm_head | `speculative.rs` → `rotate_x_mq_batched_for` | This PR (`54d9107a`) |
| Spec-verify draft lm_head | `speculative.rs` → `rotate_x_mq_batched_for` | This PR (`54d9107a`) |
| DFlash drafter per-layer | `dflash.rs::gemm_dispatch` → `rotate_x_mq_batched_for` | PR #290 (`67eeb0fc`) |

MQ6 sites in speculative.rs are intentionally untouched — MQ6 is not in `supports_awq_sidecar`'s allow-list so its `awq_scale` is never populated; a `_for` swap would be defensive churn.

## Empirical validation on the 9B test artifact

Test file: `/data/hipfire/qwen3.5-9b.mq4-awq-gptq-f2-lmhead-a100.hfq` (5.3 GB, 248 per-layer AWQ sidecars + 1 `lm_head.awq_scale.weight`), produced by the CUDA pipeline branch 2026-05-18.

**Sidecar attachment confirmed via load log:**
```
loading output (separate lm_head, qt=13)...
lm_head AWQ sidecar: attached
loading layer 0/32 (LinearAttention)...
```

**Generation samples on gfx1031, temp=0:**

| Prompt | Tokens | Output |
|---|---|---|
| "Capital of France?" (max=300) | full | `<think>` trace + `"The capital of France is Paris."` ✓ |
| "17 sheep / all but 9 die" | 70 | `<think></think> **Reasoning:** ... **Final Number:** 9` ✓ (model considered 17-9=8 in `<think>`, explicitly rejected for the idiomatic answer) |
| "One-line square fn" | 124 | structured thinking trace, stopped mid-`<think>` at limit |
| "Explain AWQ briefly" | 100 | on-topic thinking trace, stopped mid-`<think>` at limit |

All four prompts produced fluent English thinking traces. Coherence-gate row passes ("Paris" substring present).

**KLD eval (gfx1031, eval_hipfire, n=256, kv-mode=q8):**

| Metric | Value |
|---|---|
| slice-mean KLD | **0.084056** |
| mean NLL | 2.237187 |
| PPL | 9.3669 |
| Tokens scored | 261,888 (256 chunks × 1023 per chunk) |
| Wall | 3668.9s (~61 min on gfx1031, 71 reduced tok/s) |
| Output | `results/2026-05-18/qwen3.5-9b.mq4-awq-gptq-f2-lmhead__kv-q8__n-256.kldseq` |

For context: the historical "AWQ-runtime-missing-inverse" failure mode at `docs/plans/awq_fix_claude.md` produced KLD ~13.5 on 0.8B Qwen3.5. The 9B file here measures 0.084 — three orders of magnitude away from that failure mode, and well within the "AWQ correctly applied, model is healthy" band. PPL 9.37 is in the right neighborhood for a 9B Qwen3.5 4-bit quant against the BF16 reference.

A true delta-vs-Q8-head requires the `qwen3.5-9b.mq4-awq-gptq-f2-q8head` baseline (not local). The absolute KLD here is sufficient to confirm the AWQ inverse is being applied correctly across both decode (`weight_gemv` path, exercised by eval_hipfire) and would catch any spec-verify regression once that path also gets exercised.

**No regression** on the existing `mq3-sweep/*.hfq` files: identical detector verdicts pre/post commit (none of those files ship lm_head sidecars, so the new code paths are no-ops on that surface).

## Test plan

- [x] Build clean: `cargo build --release --example daemon --features deltanet`
- [x] gfx1031 sweep on `/data/hipfire/mq3-sweep/*.hfq` — no regression (new code paths are no-ops on files without lm_head sidecars)
- [x] **Functional acceptance** — load `qwen3.5-9b.mq4-awq-gptq-f2-lmhead-a100.hfq`. Confirm `weights.output.awq_scale.is_some()` via the new load-log line. Decode at temp=0, output coherent across 4 representative prompts (Paris, sheep riddle, code, AWQ explanation).
- [x] **Coherence-gate** passes via the new `lmhead-awq-paris` row (gfx1031).
- [x] **KLD eval** — n=256, kv-mode=q8 → slice-mean KLD 0.084, PPL 9.37 (see table above). Healthy; no AWQ-corruption signature.
- [ ] **NLL paired-t** vs `qwen3.5-9b.mq4-awq-gptq-f2-q8head` baseline at q8-KV n=512. Per the handoff doc's reference to master-doc §6 rule 9 — note that exact rule doesn't grep in AGENTS.md / CLAUDE.md / docs/methodology, so I can't verify the protocol details. **Blocked: baseline file not local.**
- [ ] **Token-level diff probe** at temp=0, first 200 tokens vs Q8-head baseline, < 5% position disagreement target. **Blocked: baseline file.**

## Deviations from the handoff doc

The handoff plan at `/tmp/awq_lm_head_handoff.md` proposed a `weight_gemv_with_optional_awq` helper that would wrap `weight_gemv` and pre-rotate via `rotate_x_mq_awq`. That approach would double-rotate (`weight_gemv`'s MQ4G256 arm at `llama.rs:616-625` already calls `rotate_x_mq_for`), and the proposed helper had API errors (`gpu.x_rotated` field doesn't exist — actual is `mq_x_rot`; borrow conflict on `gpu.rotate_x_mq_awq(x, awq, &gpu.x_rotated)`). The actually-broken path was the `speculative.rs` lm_head dispatch, not `weight_gemv` — fixing that was the missing piece.

The handoff also asks us to "drop the `HIPFIRE_LM_HEAD_AWQ_UNSAFE=1` requirement in the kmap_resolve_mode + precomputed-gptq-path env gate chains." Neither `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ` nor `HIPFIRE_LM_HEAD_AWQ_UNSAFE` exists in the current tree (verified with grep across `crates/**` and `docs/**`). That part of the handoff appears to describe upstream work on `feat/configurable-kmap-pair` / `feat/mq-v2-quant-format-cuda` branches that haven't merged here yet. Once they land, a follow-up PR can drop those gates; this PR does not touch them.

## Follow-ups

- NLL paired-t + token-diff probe vs Q8-head baseline (requires pulling that artifact onto a box with the daemon built — handing off to whoever has it)
- KLD eval on gfx1100 / gfx1151 for cross-arch confirmation (gfx1031 took 61 min for n=256; gfx1151 would be ~25 min for the same workload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)