### PR TITLE
fix(gfx906): disable mmq_screen default — removes 145 ms first-prefill overhead

### DIFF
--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -584,7 +584,8 @@ fn main() {
 
                 // MMQ per-weight screening (#87): detect outlier rows that
                 // cause Q8_1 precision loss and fall back to WMMA for those
-                // weights. Enabled by default; disable with mmq_screen=false.
+                // weights. Disabled by default; enable with mmq_screen=true
+                // (or HIPFIRE_MMQ_SCREEN=1) when adding new quant formats.
                 if let Some(v) = msg.get("params").and_then(|p| p.get("mmq_screen")).and_then(|v| v.as_bool()) {
                     gpu.mmq_screen = v;
                 }
@@ -1481,7 +1482,11 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // MMQ per-weight screening (#87): pre-screen all weight matrices at
         // load time so the first prefill doesn't pay the screening overhead.
         // Results are cached by device pointer in gpu.mmq_screen_cache.
-        if gpu.mmq_screen && matches!(gpu.arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152") {
+        // Disabled by default on all arches; opt-in via mmq_screen=true or
+        // HIPFIRE_MMQ_SCREEN=1. gfx906 is included for the opt-in case so
+        // its ~700 µs/weight screening-reference dispatch doesn't surprise
+        // first prefill if a user enables it.
+        if gpu.mmq_screen && matches!(gpu.arch.as_str(), "gfx906" | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152") {
             let t0 = std::time::Instant::now();
             let (n_safe, n_unsafe) = screen_weights_qwen35(&weights, gpu);
             let elapsed = t0.elapsed();

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -501,15 +501,15 @@ pub struct Gpu {
     // small synthetic comparison (batch=16, WMMA vs MMQ) checks per-row
     // max abs error. Weights exceeding the threshold fall back to WMMA.
     //
-    // Enabled by default on RDNA3/3.5. Configurable via:
+    // Disabled by default on all arches as of 2026-05-18; opt-in for
+    // defensive screening when adding new quant formats. Configurable via:
     //   - config.json: `mmq_screen` (bool), `mmq_screen_threshold` (float)
     //   - per-model config overlay
     //   - daemon load params: `mmq_screen`, `mmq_screen_threshold`
-    //   - env override: `HIPFIRE_MMQ_SCREEN=0` to disable,
+    //   - env override: `HIPFIRE_MMQ_SCREEN=1` to enable,
     //     `HIPFIRE_MMQ_SCREEN_THRESHOLD=0.05` to tune
     mmq_screen_cache: HashMap<usize, bool>,
-    /// Whether MMQ per-weight screening is enabled.
-    /// Per-arch default (set in `Gpu::init`): true on gfx906, false elsewhere.
+    /// Whether MMQ per-weight screening is enabled. Default: false on all arches.
     pub mmq_screen: bool,
     /// Max per-row abs error threshold for screening. Weights with any row
     /// exceeding this fall back to WMMA.
@@ -744,7 +744,22 @@ impl Gpu {
 
         // Per-arch defaults for MMQ screening. See the mmq_screen and
         // mmq_screen_threshold fields below for rationale.
-        let mmq_screen_default: bool = arch == "gfx906";
+        //
+        // gfx906 was previously default-on out of caution because the MMQ
+        // kernels were ported from the gfx11xx i8-WMMA path that motivated
+        // #87, but gfx906 uses dp4a (`__builtin_amdgcn_sdot4`), not WMMA,
+        // and empirically tolerates the row-3994 weight outliers within the
+        // 0.50 threshold. Audit on 2026-05-18 across qwen3.5-{0.8B, 9B} mq4
+        // (AWQ + non-AWQ) showed 0/248 weights flagged at threshold 0.50 —
+        // the screen reference dispatch (~700 µs/weight via
+        // `gemm_hfq4g256_residual_fp16_wave64`) was pure overhead, costing
+        // ~145 ms on the first prefill. Users on new quant formats can
+        // re-enable defensively via `HIPFIRE_MMQ_SCREEN=1`.
+        //
+        // RDNA3/3.5: unchanged behavior. Already default-off here; clients
+        // that need #87 protection (daemon callers loading on i8-WMMA archs)
+        // explicitly pass `mmq_screen: true` at load time.
+        let mmq_screen_default: bool = false;
         let mmq_screen_threshold_default: f32 = if arch == "gfx906" { 0.50 } else { 0.10 };
 
         Ok(Self {


### PR DESCRIPTION
## Summary

- `mmq_screen` was default-on for **gfx906 only** (since #158 PR review fixed the threshold to 0.50 for gfx906); the screen reference path is `gemm_hfq4g256_residual_fp16_wave64` at ~700 µs/weight, costing **~145 ms on every first prefill** on gfx906/MI50.
- 2026-05-18 audit across qwen3.5-{0.8B, 9B} mq4 (both AWQ and non-AWQ) shows **0/248 weights flagged at threshold 0.50** — the screen was pure overhead on these production models on gfx906.
- The #87 i8-WMMA Q8_1 corruption it was originally added for is arch-specific to gfx11xx; gfx906 uses `__builtin_amdgcn_sdot4` (dp4a), not WMMA.

## Changes

| File | Change |
|---|---|
| `crates/rdna-compute/src/dispatch.rs` | `mmq_screen_default = false` (was `arch == \"gfx906\"`). Comment + struct-docstring updated. |
| `crates/hipfire-runtime/examples/daemon.rs` | Add `gfx906` to the pre-screen-at-load arm list so the opt-in case (`HIPFIRE_MMQ_SCREEN=1`) lands screening cost at load, not first prefill. Comment update on the `mmq_screen` client param. |

**RDNA3/3.5 behavior is unchanged.** Previous default was already `false` there; clients that need #87 protection (daemon callers on i8-WMMA archs) pass `mmq_screen: true` explicitly at load — that path still works identically.

## Audit data (gfx906, 2026-05-18)

| Model | Threshold | Safe | Unsafe |
|---|---:|---:|---:|
| qwen3.5-9b.mq4-awq-current | 0.50 (gfx906 default) | 248 | **0** |
| qwen3.5-9b.mq4-awq-current | 0.30 | 246 | 2 |
| qwen3.5-9b.mq4-awq-current | 0.10 (gfx11xx default) | 188 | 60 |
| qwen3.5-9b.mq4 (non-AWQ) | 0.50 | 248 | 0 |
| qwen3.5-9b.mq4 (non-AWQ) | 0.30 | 246 | 2 |
| qwen3.5-0.8b.mq4-awq-current | 0.50 | 186 | 0 |

The two weights that trip at threshold 0.30 are the known row-3994 outliers in `Wo` (the same hidden-dim outlier from #87 on 9B) — dp4a tolerates them within the 0.50 calibration where i8-WMMA does not.

## Measured impact (gfx906/MI50, qwen3.5-9B mq4 AWQ, fresh process)

| Metric | Before | After |
|---|---:|---:|
| `fp16_wave64` calls in 1-prefill rocprof | 200 (~145 ms wall) | **0** |
| Single-prefill `prefill_tok_s` (fresh process) | 314 | **354** (+13%) |
| 3-prefill `prefill_tok_s` (steady) | 371.8 | 371.8 (unchanged) |
| `gen_tok_s` (30 tokens AR decode) | 56.4 | 56.4 (unchanged) |

Cold-daemon prefill numbers from `coherence-gate.sh` jumped significantly because the screen used to fire on first prefill:
- `qwen3.5-9b.mq4 reason` — `prefill_tok_s` 26.0 → **354.4** (13.6×)
- `qwen3.5-9b.mq4 tool-call` — `prefill_tok_s` 109.8 → **600.2** (5.5×)

Steady-state perf is unchanged — the win is entirely in eliminating the first-prefill screening dispatch.

## Risk mitigation

1. **Coherence-gate passes 9/9 OK** post-change, including the `9b.mq4 tool-call` test (the #87 auto-MMQ regression detector). `<tool_call>` JSON emission is intact.
2. **Env knob preserved**: `HIPFIRE_MMQ_SCREEN=1` still works and is honored at `Gpu::init` (env read at `dispatch.rs:796`). Users adding new quant formats can re-enable defensively.
3. **Per-arch threshold unchanged**: 0.50 on gfx906, 0.10 elsewhere. If anyone opts back in, they get identical screening verdicts to before this PR.
4. **Daemon pre-screen extended to gfx906**: when a user does opt in via `HIPFIRE_MMQ_SCREEN=1`, the ~145 ms cost now lands at model-load time (where it belongs) rather than on first prefill.

## Test plan

- [x] Build clean (`cargo build --release --features deltanet -p hipfire-runtime --example bench_qwen35_mq4 --example daemon`).
- [x] `rocprof --hsa-trace` on fresh process confirms **0** `fp16_wave64` calls in decode + 1-prefill window.
- [x] `scripts/coherence-gate.sh` short battery: 9/9 OK (including `9b.mq4 tool-call` for #87 coverage).
- [x] Single-prefill bench tok/s up; steady-state bench tok/s unchanged.
- [x] `HIPFIRE_MMQ_SCREEN=1` still enables screening when set (verified via `gpu.mmq_screen_threshold` reads + no UNSAFE warnings at threshold 0.50, matching the audit table above).
- [ ] Reviewer: please re-run coherence-gate on your gfx906 hardware before merging.
- [ ] Reviewer: confirm RDNA3/3.5 daemon clients that need #87 protection are passing `mmq_screen: true` at load (was already required pre-PR; verifying nothing relied on the gfx906-only default-on as a side-channel signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)