### PR TITLE
feat(quantize): --kmap-promote + --lm-head-format CLI (configurable kmap pair, Phase 1)

### DIFF
--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3475,15 +3475,24 @@ fn main() {
     // applies regardless of base. Validated against the promote-pair allowlist
     // when both sides are known GgufFormat values. See
     // docs/plans/configurable-kmap-pair.md Phase 1a.
-    let kmap_promote: Option<GgufFormat> = args.iter().position(|a| a == "--kmap-promote")
-        .and_then(|i| args.get(i + 1))
-        .map(|v| GgufFormat::from_flag(v).unwrap_or_else(|| {
+    let kmap_promote: Option<GgufFormat> = if let Some(i) = args.iter().position(|a| a == "--kmap-promote") {
+        let v = args.get(i + 1).unwrap_or_else(|| {
+            eprintln!(
+                "error: --kmap-promote requires a value (e.g. --kmap-promote mq4). \
+                 Supported: mq2, mq3, mq4, mq6, mq2-lloyd, mq3-lloyd, hfq4, hfq6, mfp4, hfp4."
+            );
+            std::process::exit(2);
+        });
+        Some(GgufFormat::from_flag(v).unwrap_or_else(|| {
             eprintln!(
                 "error: --kmap-promote '{v}' is not a recognized format. \
                  Supported: mq2, mq3, mq4, mq6, mq2-lloyd, mq3-lloyd, hfq4, hfq6, mfp4, hfp4."
             );
             std::process::exit(2);
-        }));
+        }))
+    } else {
+        None
+    };
     if let Some(promote) = kmap_promote {
         if let Some(base) = GgufFormat::from_flag(format) {
             if !is_promote_pair_supported(base, promote) {
@@ -3722,9 +3731,18 @@ fn main() {
     // Deprecated alias: `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ=1` (CUDA branch's
     // env-var path) is treated as `--lm-head-format mq4` for one release
     // cycle; emits a deprecation warning. Removed in the next release.
-    let lm_head_format_cli: Option<&str> = args.iter().position(|a| a == "--lm-head-format")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.as_str());
+    let lm_head_format_cli: Option<&str> = if let Some(i) = args.iter().position(|a| a == "--lm-head-format") {
+        let v = args.get(i + 1).unwrap_or_else(|| {
+            eprintln!(
+                "error: --lm-head-format requires a value (e.g. --lm-head-format mq4). \
+                 Supported: q8, f16, mq4, mq6, mq3, mfp4, hfq4, hfq6."
+            );
+            std::process::exit(2);
+        });
+        Some(v.as_str())
+    } else {
+        None
+    };
     let cuda_env_alias = std::env::var("HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ")
         .ok().as_deref() == Some("1");
     let lm_head_format_arg: Option<&str> = if let Some(v) = lm_head_format_cli {

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3349,11 +3349,11 @@ fn main() {
 
     let input_dir = args.iter().position(|a| a == "--input")
         .map(|i| &args[i + 1])
-        .unwrap_or_else(|| { eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq>"); std::process::exit(1); });
+        .unwrap_or_else(|| { eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq> [--format <fmt>] [--kmap-mode 0|1|2] [--kmap-promote <fmt>] [--lm-head-format <fmt>]"); std::process::exit(1); });
 
     let output_path = args.iter().position(|a| a == "--output")
         .map(|i| &args[i + 1])
-        .unwrap_or_else(|| { eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq> [--format q8f16|q4f16]"); std::process::exit(1); });
+        .unwrap_or_else(|| { eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq> [--format <fmt>] [--kmap-mode 0|1|2] [--kmap-promote <fmt>] [--lm-head-format <fmt>]"); std::process::exit(1); });
 
     let format = args.iter().position(|a| a == "--format")
         .map(|i| args[i + 1].as_str())
@@ -4400,12 +4400,12 @@ fn main() {
                             (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
                         }
                         GgufFormat::Mfp4 => {
-                            let m = meta.shape[0];
+                            let m = if meta.shape.len() == 2 { meta.shape[0] } else { 1 };
                             let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
                             (q, QuantType::MFP4G32, 32u32, "MFP4G32")
                         }
                         GgufFormat::Hfp4 => {
-                            let m = meta.shape[0];
+                            let m = if meta.shape.len() == 2 { meta.shape[0] } else { 1 };
                             let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
                             (q, QuantType::HFP4G32, 32u32, "HFP4G32")
                         }

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3867,11 +3867,25 @@ fn main() {
         );
         let _ = LM_HEAD_FORMAT.set(fmt);
         // Mark AWQ on lm_head as enabled iff --awq is also set AND the chosen
-        // format is one we have AWQ pre-scaling wired for (today: MQ4 only).
+        // format is one the runtime can AWQ-load. `DType::supports_awq_sidecar`
+        // (see fix/lm-head-awq-runtime branch) returns true for MQ4G256 + MQ3G256
+        // today. Wider runtime support → wider matching here.
         // awq_eligible reads this lock to add lm_head/output to the F1 set.
         let awq_set = AWQ_ALPHA.get().copied().map(|a| a > 0.0).unwrap_or(false);
-        if awq_set && fmt == GgufFormat::Mq4 {
-            let _ = LM_HEAD_AWQ_ENABLED.set(true);
+        if awq_set {
+            if matches!(fmt, GgufFormat::Mq4 | GgufFormat::Mq3) {
+                let _ = LM_HEAD_AWQ_ENABLED.set(true);
+            } else {
+                // Format the runtime can't AWQ-load. Warn instead of silently
+                // producing a non-AWQ-scaled lm_head when --awq is set
+                // (combined-review C4 / Gemini §5b).
+                eprintln!(
+                    "warning: AWQ pre-scaling for --lm-head-format {} is not yet wired \
+                     (runtime supports MQ4/MQ3 only via DType::supports_awq_sidecar). \
+                     lm_head will be plain {} without an AWQ sidecar.",
+                    fmt.label(), fmt.label()
+                );
+            }
         }
     }
 
@@ -4219,11 +4233,53 @@ fn main() {
                             (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
                         }
                         GgufFormat::Mq4 => {
-                            let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                            // MQ4 promote target: wire AWQ inline-quantize when
+                            // --awq is set and the tensor is on the F1/F2
+                            // whitelist (q_proj, k_proj, v_proj, gate_proj,
+                            // up_proj, o_proj, down_proj, wo, w_down, etc.).
+                            // Runtime supports MQ4G256 AWQ sidecars
+                            // (DType::supports_awq_sidecar). Without this,
+                            // promoted tensors miss AWQ and the kmap-pair
+                            // model loses quality on the precisely the layers
+                            // kmap was supposed to protect (combined-review G5).
+                            let q = if let (Some(alpha), Some(im_weights))
+                                = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                            {
+                                if awq_eligible(name) {
+                                    let scales = compute_awq_scales(im_weights, alpha);
+                                    awq_sidecar_scales = Some(scales.clone());
+                                    let m_dim = meta.shape[0];
+                                    let mut scaled = f32_data.clone();
+                                    awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                    quantize_mq4g256(&scaled, &signs1, &signs2)
+                                } else {
+                                    quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                }
+                            } else {
+                                quantize_mq4g256(&f32_data, &signs1, &signs2)
+                            };
                             (q, QuantType::MQ4G256, 256u32, "MQ4G256")
                         }
                         GgufFormat::Mq3 => {
-                            let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                            // MQ3 promote target: same AWQ wiring as MQ4.
+                            // Runtime supports MQ3G256 AWQ sidecars too
+                            // (DType::supports_awq_sidecar).
+                            let q = if let (Some(alpha), Some(im_weights))
+                                = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                            {
+                                if awq_eligible(name) {
+                                    let scales = compute_awq_scales(im_weights, alpha);
+                                    awq_sidecar_scales = Some(scales.clone());
+                                    let m_dim = meta.shape[0];
+                                    let mut scaled = f32_data.clone();
+                                    awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                    quantize_mq3g256(&scaled, &signs1, &signs2)
+                                } else {
+                                    quantize_mq3g256(&f32_data, &signs1, &signs2)
+                                }
+                            } else {
+                                quantize_mq3g256(&f32_data, &signs1, &signs2)
+                            };
                             (q, QuantType::MQ3G256, 256u32, "MQ3G256")
                         }
                         GgufFormat::Mq2 => {
@@ -4298,7 +4354,26 @@ fn main() {
                             (q, QuantType::MQ6G256, 256u32, "MQ6G256")
                         }
                         GgufFormat::Mq3 => {
-                            let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                            // MQ3 + AWQ on lm_head: runtime supports the sidecar via
+                            // DType::supports_awq_sidecar(MQ3G256)=true (per the
+                            // fix/lm-head-awq-runtime branch). Wire the same AWQ
+                            // inline-quantize dance as the MQ4 arm.
+                            let q = if let (Some(alpha), Some(im_weights))
+                                = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                            {
+                                if awq_eligible(name) {
+                                    let scales = compute_awq_scales(im_weights, alpha);
+                                    awq_sidecar_scales = Some(scales.clone());
+                                    let m_dim = meta.shape[0];
+                                    let mut scaled = f32_data.clone();
+                                    awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                    quantize_mq3g256(&scaled, &signs1, &signs2)
+                                } else {
+                                    quantize_mq3g256(&f32_data, &signs1, &signs2)
+                                }
+                            } else {
+                                quantize_mq3g256(&f32_data, &signs1, &signs2)
+                            };
                             (q, QuantType::MQ3G256, 256u32, "MQ3G256")
                         }
                         GgufFormat::Hfq4 => {

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1872,13 +1872,26 @@ fn is_promote_pair_supported(base: GgufFormat, promote: GgufFormat) -> bool {
         return true; // no-op promotion is always safe
     }
     match (base, promote) {
-        // MQ-family upward bit-width
-        (Mq2 | Mq2Lloyd, Mq3 | Mq3Lloyd | Mq4 | Mq6) => true,
-        (Mq3 | Mq3Lloyd, Mq4 | Mq6) => true,
+        // Lloyd-to-Lloyd only — Lloyd variants use different codebooks +
+        // different runtime kernel families from standard MQ. Lloyd→non-Lloyd
+        // mixed-format dispatch has no runtime support today; the plan's
+        // "Future expansion" section targets the MQ2-Lloyd + MQ3-Lloyd pair
+        // specifically. Tightened per combined-review finding G2.
+        (Mq2Lloyd, Mq3Lloyd) => true,
+        (Mq2Lloyd | Mq3Lloyd, _) => false,
+        (_, Mq2Lloyd | Mq3Lloyd) => false,
+
+        // MQ-family upward bit-width (non-Lloyd)
+        (Mq2, Mq3 | Mq4 | Mq6) => true,
+        (Mq3, Mq4 | Mq6) => true,
         (Mq4, Mq6) => true,
+
         // HFQ-family upward bit-width
         (Hfq4, Hfq6) => true,
-        // Everything else: explicitly not in the supported matrix
+
+        // Everything else: explicitly not in the supported matrix.
+        // Cross-family (MQ↔HFQ↔FP4) rejected — runtime mixed-format dispatch
+        // (post-#257) is only same-rotation-family-safe.
         _ => false,
     }
 }
@@ -4784,12 +4797,25 @@ mod tests {
         assert!(is_promote_pair_supported(GgufFormat::Mq3, GgufFormat::Mq4));
         assert!(is_promote_pair_supported(GgufFormat::Mq3, GgufFormat::Mq6));
         assert!(is_promote_pair_supported(GgufFormat::Mq4, GgufFormat::Mq6));
-        // MQ2 base + MQ3 promote (Future expansion section)
+        // MQ2 base + MQ3 promote (Future expansion section, non-Lloyd)
         assert!(is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq3));
         assert!(is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq4));
         assert!(is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq6));
-        // Lloyd variants
+    }
+
+    #[test]
+    fn promote_pair_lloyd_only_within_family() {
+        // Lloyd → Lloyd allowed (the Future expansion target).
         assert!(is_promote_pair_supported(GgufFormat::Mq2Lloyd, GgufFormat::Mq3Lloyd));
+        // Lloyd → non-Lloyd rejected — different codebooks, no runtime path.
+        assert!(!is_promote_pair_supported(GgufFormat::Mq2Lloyd, GgufFormat::Mq3));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq2Lloyd, GgufFormat::Mq4));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq2Lloyd, GgufFormat::Mq6));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq3Lloyd, GgufFormat::Mq4));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq3Lloyd, GgufFormat::Mq6));
+        // non-Lloyd → Lloyd also rejected (would need Lloyd codebook fitting at runtime).
+        assert!(!is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq3Lloyd));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq3, GgufFormat::Mq3Lloyd));
     }
 
     #[test]

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3605,9 +3605,30 @@ fn main() {
     // Llama-style model produces correct output (the FWHT cancels in
     // `gemv_mq4g256_with_rotate`) but adds runtime rotation overhead
     // with no quality benefit.
+    //
+    // GGUF + `--lm-head-format` is currently **refused** (configurable-
+    // kmap-pair plan + combined-review finding C1). The safety contract
+    // around `--lm-head-format` requires reading `tie_word_embeddings`
+    // from the source model's config; the GGUF pipeline pulls config
+    // from the GGUF metadata blob, not config.json, and we haven't
+    // wired the tied-embed lookup for that path yet. Refusing here
+    // avoids the silent no-op where the operator's flag goes ignored
+    // through the GGUF pipeline.
     {
         let raw_input = Path::new(input_dir.as_str());
         if is_gguf_input(raw_input) {
+            let lm_head_format_set = args.iter().any(|a| a == "--lm-head-format");
+            if lm_head_format_set {
+                eprintln!(
+                    "error: --lm-head-format is not yet supported with a GGUF input. \
+                     The tied-embedding safety check reads `tie_word_embeddings` from \
+                     `config.json`, which the GGUF pipeline doesn't carry. Use a \
+                     safetensors input (HuggingFace directory layout), or wait for \
+                     GGUF-side lm_head plumbing to land. See docs/plans/\
+                     configurable-kmap-pair.md."
+                );
+                std::process::exit(2);
+            }
             let gguf_format = GgufFormat::from_flag(format).unwrap_or_else(|| {
                 eprintln!(
                     "GGUF input: --format '{format}' not recognized. \

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3995,10 +3995,21 @@ fn main() {
             // (e.g. "...mlp.experts.gate_up_proj") contains "mlp.experts."
             // so kmap_resolve rule 4 matches it. The kmap HashMap was built
             // from all_tensors which has these parent names as keys.
-            let kmap_promote = matches!(kmap.get(*name), Some(QuantLevel::Promote(_)));
-            let expert_mq6 = (use_mq6g256 || use_mq4_mq6exp || (kmap_promote && use_mq4g256)) && supports_g256;
-            let expert_hfq6 = (use_hfq6 || (kmap_promote && use_hfq4g256)) && supports_g256;
-            let expert_hfq4 = use_hfq4g256 && !kmap_promote && supports_g256;
+            //
+            // When promoted, dispatch on the carried `Promote(<fmt>)` target
+            // (commit fix for combined-review G1 — pre-fix this path ignored
+            // the carried format and always fell through to MQ4G256 for any
+            // promoted expert, breaking `--kmap-promote` on MoE models).
+            //
+            // When not promoted, preserve the existing `use_*` boolean
+            // dispatch — byte-exact for `--kmap-promote`-unset runs.
+            let expert_promote_fmt: Option<GgufFormat> = match kmap.get(*name).copied() {
+                Some(QuantLevel::Promote(fmt)) => Some(fmt),
+                _ => None,
+            };
+            let expert_mq6 = (use_mq6g256 || use_mq4_mq6exp) && supports_g256;
+            let expert_hfq6 = use_hfq6 && supports_g256;
+            let expert_hfq4 = use_hfq4g256 && expert_promote_fmt.is_none() && supports_g256;
 
             // Parallelize across the 256 expert slices via rayon. Each slice
             // dequant→FWHT→quant→pack is a CPU-bound, self-contained job.
@@ -4012,7 +4023,62 @@ fn main() {
                 let slice_off = x * inner_bytes;
                 let slice = &raw_data[slice_off..slice_off + inner_bytes];
                 let f32_slice = to_f32(slice, &dtype);
-                let (quantized, qt, gs) = if expert_mq6 {
+                let (quantized, qt, gs) = if let Some(fmt) = expert_promote_fmt {
+                    // Promoted: dispatch on the carried Promote(<fmt>) target.
+                    // Non-256-aligned promoted tensors fall to HFQ4G128 (same as
+                    // the base catchall below) — kmap promote was never wired
+                    // for sub-256 expert geometry, preserving prior behavior.
+                    if !supports_g256 {
+                        let q = quantize_hfq4g128(&f32_slice);
+                        (q, QuantType::HFQ4G128, 128u32)
+                    } else {
+                        match fmt {
+                            GgufFormat::Mq6 => {
+                                let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ6G256, 256u32)
+                            }
+                            GgufFormat::Hfq6 => {
+                                let q = quantize_hfq6g256(&f32_slice);
+                                (q, QuantType::HFQ6G256, 256u32)
+                            }
+                            GgufFormat::Mq4 => {
+                                let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ4G256, 256u32)
+                            }
+                            GgufFormat::Mq3 => {
+                                let q = quantize_mq3g256(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ3G256, 256u32)
+                            }
+                            GgufFormat::Mq2 => {
+                                let q = quantize_mq2g256(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ2G256, 256u32)
+                            }
+                            GgufFormat::Mq2Lloyd => {
+                                let q = quantize_mq2g256_lloyd(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ2G256Lloyd, 256u32)
+                            }
+                            GgufFormat::Mq3Lloyd => {
+                                let q = quantize_mq3g256_lloyd(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ3G256Lloyd, 256u32)
+                            }
+                            GgufFormat::Hfq4 => {
+                                let q = quantize_hfq4g256(&f32_slice);
+                                (q, QuantType::HFQ4G256, 256u32)
+                            }
+                            GgufFormat::Hfp4 | GgufFormat::Mfp4 => {
+                                // FP4 expert promotion not exercised today;
+                                // expert tensors are 2D in this slice context.
+                                // Fall to MQ4 with a warning rather than panic.
+                                eprintln!(
+                                    "warning: FP4 promote target for MoE expert tensor \
+                                     {parent_owned}.{base_owned} not yet wired; falling back to MQ4G256."
+                                );
+                                let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
+                                (q, QuantType::MQ4G256, 256u32)
+                            }
+                        }
+                    }
+                } else if expert_mq6 {
                     let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
                     (q, QuantType::MQ6G256, 256u32)
                 } else if expert_hfq6 {
@@ -4039,7 +4105,13 @@ fn main() {
             }).collect();
             quantized_params += inner_n as u64 * n_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
-            let label = if expert_mq6 { "MQ6G256" } else if expert_hfq6 { "HFQ6G256" } else if expert_hfq4 { "HFQ4G256" } else if supports_g256 { "MQ4G256" } else { "HFQ4G128" };
+            let label = if let Some(fmt) = expert_promote_fmt {
+                if supports_g256 { fmt.label() } else { "HFQ4G128" }
+            } else if expert_mq6 { "MQ6G256" }
+              else if expert_hfq6 { "HFQ6G256" }
+              else if expert_hfq4 { "HFQ4G256" }
+              else if supports_g256 { "MQ4G256" }
+              else { "HFQ4G128" };
             let bytes_per = new_tensors.first().map(|t| t.data.len()).unwrap_or(0);
             eprintln!("  {label:>8}: {parent_owned}{{0..{n_experts}}}.{base_owned}.weight {:?} (×{n_experts} experts || {:.1} KB/expert, parallel)",
                 inner_shape, bytes_per as f64 / 1024.0);

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1813,18 +1813,34 @@ enum QuantType {
 }
 
 /// Per-tensor precision level assigned by the K-map pre-pass.
-/// Determines whether a tensor gets the base format, a 6-bit promotion,
-/// Q8, or F16. See docs/superpowers/specs/2026-05-08-mixed-quant-kmap-design.md.
+/// Determines whether a tensor gets the base format, a kmap promotion,
+/// Q8, or F16. See docs/superpowers/specs/2026-05-08-mixed-quant-kmap-design.md
+/// and docs/plans/configurable-kmap-pair.md.
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum QuantLevel {
     /// Store as F16 (norms, biases, 1D tensors).
     F16,
     /// Store as Q8_F16 (embeddings, lm_head, MoE routers).
     Q8,
-    /// Promote to 6-bit variant of the base format (edge layers, MoE expert FFN).
-    Promote6,
+    /// Promote to the carried format (edge layers, MoE expert FFN).
+    /// The target was historically hardcoded to MQ6; now parameterized
+    /// per `--kmap-promote` (introduced in the configurable-kmap-pair plan).
+    Promote(GgufFormat),
     /// Use the base format as-is.
     Base,
+}
+
+/// Default kmap promote target for a given base format. Preserves the
+/// pre-`--kmap-promote` behavior byte-for-byte: MQ-family bases promote to
+/// MQ6, HFQ-family to HFQ6, FP4-family is a no-op (no FP6 sibling).
+fn default_promote_target(base: GgufFormat) -> GgufFormat {
+    match base {
+        GgufFormat::Mq2 | GgufFormat::Mq3 | GgufFormat::Mq4 | GgufFormat::Mq6
+        | GgufFormat::Mq2Lloyd | GgufFormat::Mq3Lloyd => GgufFormat::Mq6,
+        GgufFormat::Hfq4 | GgufFormat::Hfq6 => GgufFormat::Hfq6,
+        GgufFormat::Hfp4 => GgufFormat::Hfp4,
+        GgufFormat::Mfp4 => GgufFormat::Mfp4,
+    }
 }
 
 /// Extract layer index from a tensor name.
@@ -1877,10 +1893,19 @@ fn is_positional_promote(idx: usize, n_layers: usize, stride: usize) -> bool {
 /// Note: In the safetensors path, norms/biases are filtered by `should_quantize()`
 /// before this function is called. Rules 1-2 exist for the GGUF path and completeness.
 fn kmap_resolve(name: &str, n_layers: usize, is_moe: bool) -> QuantLevel {
-    kmap_resolve_mode(name, n_layers, is_moe, 0)
+    // Test-and-internal wrapper. Defaults to MQ6 promote target (the
+    // pre-`--kmap-promote` behavior). Real callers should use
+    // `kmap_resolve_mode` directly with a CLI-driven promote target.
+    kmap_resolve_mode(name, n_layers, is_moe, 0, GgufFormat::Mq6)
 }
 
-fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -> QuantLevel {
+fn kmap_resolve_mode(
+    name: &str,
+    n_layers: usize,
+    is_moe: bool,
+    kmap_mode: u8,
+    promote_to: GgufFormat,
+) -> QuantLevel {
     // Rule 1: norms, biases, 1D (GGUF path mainly)
     if name.contains("norm") || name.contains("bias") {
         return QuantLevel::F16;
@@ -1907,12 +1932,12 @@ fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -
             // Alternating: promote expert groups only in positional layers
             if let Some(idx) = parse_layer_idx(name) {
                 if is_positional_promote(idx, n_layers, ALTERNATING_STRIDE) {
-                    return QuantLevel::Promote6;
+                    return QuantLevel::Promote(promote_to);
                 }
                 return QuantLevel::Base;
             }
         }
-        return QuantLevel::Promote6;
+        return QuantLevel::Promote(promote_to);
     }
 
     // Mode 2 (typed): promote ffn_down and attn_v in all layers.
@@ -1920,12 +1945,12 @@ fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -
         let is_down = name.contains("down_proj") || name.contains("ffn_down");
         let is_v = name.contains("v_proj") || name.contains("attn_v");
         if is_down || is_v {
-            return QuantLevel::Promote6;
+            return QuantLevel::Promote(promote_to);
         }
         if n_layers > 0 {
             if let Some(idx) = parse_layer_idx(name) {
                 if idx < 2 || idx >= n_layers.saturating_sub(2) {
-                    return QuantLevel::Promote6;
+                    return QuantLevel::Promote(promote_to);
                 }
             }
         }
@@ -1942,16 +1967,16 @@ fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -
         if n_layers > 0 {
             if let Some(idx) = parse_layer_idx(name) {
                 if is_down && is_positional_promote(idx, n_layers, ALTERNATING_STRIDE) {
-                    return QuantLevel::Promote6;
+                    return QuantLevel::Promote(promote_to);
                 }
                 // Edge layers: attn+FFN for MoE, FFN only for dense.
                 if idx < 2 || idx >= n_layers.saturating_sub(2) {
                     if is_moe {
-                        return QuantLevel::Promote6;
+                        return QuantLevel::Promote(promote_to);
                     }
                     let is_ffn = name.contains("mlp.") || name.contains("ffn");
                     if is_ffn {
-                        return QuantLevel::Promote6;
+                        return QuantLevel::Promote(promote_to);
                     }
                 }
             }
@@ -1968,12 +1993,12 @@ fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -
             if idx < 2 || idx >= n_layers.saturating_sub(2) {
                 if is_moe {
                     // MoE: promote all tensors in edge layers (attn + FFN)
-                    return QuantLevel::Promote6;
+                    return QuantLevel::Promote(promote_to);
                 }
                 // Dense: promote FFN only — attn stays at Base
                 let is_ffn = name.contains("mlp.") || name.contains("ffn");
                 if is_ffn {
-                    return QuantLevel::Promote6;
+                    return QuantLevel::Promote(promote_to);
                 }
             }
         }
@@ -2814,7 +2839,7 @@ fn mv_to_json(v: &gguf_input::MetaValue) -> serde_json::Value {
 /// `rotate_x_mq` overhead with no quality benefit — those rotations were
 /// calibrated for Qwen3.5+ training.** Default is HFQ4 for dense GGUFs;
 /// pass `--format mq4` only when the source is a Qwen3.5+ family model.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum GgufFormat {
     Hfq4,
     Hfq6,
@@ -2927,6 +2952,7 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
     // ship-default is the conservative shape per maintainer directive
     // (2026-05-08): never silently change dense quantization. Users who
     // want K-map on dense pass `--kmap-dense` (see flag parsing below).
+    let promote_to = default_promote_target(format);
     let kmap: HashMap<String, QuantLevel> = if no_kmap || (!is_moe && !kmap_dense) {
         HashMap::new()
     } else {
@@ -2935,23 +2961,24 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
         for info in &gguf.tensors {
             let out_name = gguf_to_safetensors_name(&info.name)
                 .unwrap_or_else(|| info.name.clone());
-            let level = kmap_resolve_mode(&out_name, n_layers, is_moe, kmap_mode);
+            let level = kmap_resolve_mode(&out_name, n_layers, is_moe, kmap_mode, promote_to);
             match level {
                 QuantLevel::F16 => counts[0] += 1,
                 QuantLevel::Q8 => counts[1] += 1,
-                QuantLevel::Promote6 => counts[2] += 1,
+                QuantLevel::Promote(_) => counts[2] += 1,
                 QuantLevel::Base => counts[3] += 1,
             }
             map.insert(out_name, level);
         }
         if !map.is_empty() {
             let mode_label = match kmap_mode { 0 => "full", 1 => "alternating", 2 => "typed", _ => "?" };
-            eprintln!("K-map plan ({} base, {n_layers} layers{}, mode={mode_label}):",
+            eprintln!("K-map plan ({} base → {} promote, {n_layers} layers{}, mode={mode_label}):",
                 format.label(),
+                promote_to.label(),
                 if is_moe { ", MoE" } else { "" });
             eprintln!("  F16:       {:>4} tensors", counts[0]);
             eprintln!("  Q8:        {:>4} tensors", counts[1]);
-            eprintln!("  Promote6:  {:>4} tensors", counts[2]);
+            eprintln!("  Promote:   {:>4} tensors (→ {})", counts[2], promote_to.label());
             eprintln!("  Base:      {:>4} tensors", counts[3]);
         }
         map
@@ -2999,33 +3026,61 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
             let q = quantize_q8f16(&f32_data);
             quant_params += n_elements as u64;
             (q, QuantType::Q8F16, 32u32, "Q8_F16")
-        } else if kmap_level == QuantLevel::Promote6 && k_dim % 256 == 0 {
-            // K-map promote to 6-bit
+        } else if let (QuantLevel::Promote(promote_fmt), true) = (kmap_level, k_dim % 256 == 0) {
+            // K-map promote to the carried format. Default mapping for each
+            // base format is documented in `default_promote_target`; a future
+            // `--kmap-promote` CLI flag will let users override.
             let f32_data = gguf_input::tensor_to_f32(info, raw);
             quant_params += n_elements as u64;
-            match format {
-                GgufFormat::Mq4 | GgufFormat::Mq3 | GgufFormat::Mq2
-                | GgufFormat::Mq2Lloyd | GgufFormat::Mq3Lloyd | GgufFormat::Mq6 => {
+            match promote_fmt {
+                GgufFormat::Mq6 => {
                     let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
                     (q, QuantType::MQ6G256, 256u32, "MQ6G256")
                 }
-                GgufFormat::Hfq4 | GgufFormat::Hfq6 => {
+                GgufFormat::Hfq6 => {
                     let q = quantize_hfq6g256(&f32_data);
                     (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
                 }
                 GgufFormat::Hfp4 => {
-                    // No HFP6 variant in v1. Promote6 for HFP4 stays at HFP4G32 (4.25 bpw).
+                    // No HFP6 variant in v1. Promote-to-HFP4 stays at HFP4G32 (4.25 bpw, no-op).
                     let m = info.shape[0] as usize;
                     let k = info.shape[1] as usize;
                     let q = quantize_hfp4g32_2d(&f32_data, m, k);
                     (q, QuantType::HFP4G32, 32u32, "HFP4G32")
                 }
                 GgufFormat::Mfp4 => {
-                    // No MFP6 variant. Promote6 for MFP4 stays at MFP4G32 (4.25 bpw).
+                    // No MFP6 variant. Promote-to-MFP4 stays at MFP4G32 (4.25 bpw, no-op).
                     let m = info.shape[0] as usize;
                     let k = info.shape[1] as usize;
                     let q = quantize_mfp4g32_2d(&f32_data, m, k, &signs1, &signs2);
                     (q, QuantType::MFP4G32, 32u32, "MFP4G32")
+                }
+                // Sub-6-bit promote targets: available for `--kmap-promote mq{2,3,4}`
+                // pairings (e.g. MQ2 base + MQ3 promote alternating). Same kernels
+                // as the Base arm below; just dispatched via the promote target.
+                GgufFormat::Mq4 => {
+                    let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                }
+                GgufFormat::Mq3 => {
+                    let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ3G256, 256u32, "MQ3G256")
+                }
+                GgufFormat::Mq2 => {
+                    let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                }
+                GgufFormat::Mq2Lloyd => {
+                    let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                }
+                GgufFormat::Mq3Lloyd => {
+                    let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                }
+                GgufFormat::Hfq4 => {
+                    let q = quantize_hfq4g256(&f32_data);
+                    (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
                 }
             }
         } else if k_dim % 256 == 0 {
@@ -3478,28 +3533,38 @@ fn main() {
     // the K-map default-on path because the routed-expert promotion is
     // the headline win and the empirical regression there is tighter
     // (+1.7% PPL at 2K, gated below the dense regression threshold).
+    // Promote target carried in `QuantLevel::Promote(<fmt>)`. Default is
+    // `default_promote_target(base)` — same as the pre-`--kmap-promote`
+    // hardcoded behavior. If `format` doesn't parse to a GgufFormat (e.g.
+    // `--format q8` or `--format mixed`), use Mq6 as a placeholder; the
+    // Promote arm's `use_*` boolean dispatch below ignores the carried
+    // format and falls through to its existing Q8 fallback for non-promotable
+    // bases. Byte-exact behavior on this path.
+    let parsed_base = GgufFormat::from_flag(format).unwrap_or(GgufFormat::Mq4);
+    let promote_to = default_promote_target(parsed_base);
     let kmap: HashMap<String, QuantLevel> = if no_kmap || (!is_moe && !kmap_dense) {
         HashMap::new()
     } else {
         let mut map = HashMap::new();
-        let mut counts = [0u32; 4]; // F16, Q8, Promote6, Base
+        let mut counts = [0u32; 4]; // F16, Q8, Promote, Base
         for (name, _fi) in &all_tensors {
-            let level = kmap_resolve_mode(name, n_layers, is_moe, kmap_mode);
+            let level = kmap_resolve_mode(name, n_layers, is_moe, kmap_mode, promote_to);
             match level {
                 QuantLevel::F16 => counts[0] += 1,
                 QuantLevel::Q8 => counts[1] += 1,
-                QuantLevel::Promote6 => counts[2] += 1,
+                QuantLevel::Promote(_) => counts[2] += 1,
                 QuantLevel::Base => counts[3] += 1,
             }
             map.insert(name.to_string(), level);
         }
         if !map.is_empty() {
             let mode_label = match kmap_mode { 0 => "full", 1 => "alternating", 2 => "typed", _ => "?" };
-            eprintln!("K-map plan ({format} base, {n_layers} layers{}, mode={mode_label}):",
+            eprintln!("K-map plan ({format} base → {} promote, {n_layers} layers{}, mode={mode_label}):",
+                promote_to.label(),
                 if is_moe { ", MoE" } else { "" });
             eprintln!("  F16:       {:>4} tensors (norms, biases)", counts[0]);
             eprintln!("  Q8:        {:>4} tensors (embed, lm_head, routers)", counts[1]);
-            eprintln!("  Promote6:  {:>4} tensors", counts[2]);
+            eprintln!("  Promote:   {:>4} tensors (→ {})", counts[2], promote_to.label());
             eprintln!("  Base:      {:>4} tensors (remaining)", counts[3]);
         }
         map
@@ -3582,7 +3647,7 @@ fn main() {
             // (e.g. "...mlp.experts.gate_up_proj") contains "mlp.experts."
             // so kmap_resolve rule 4 matches it. The kmap HashMap was built
             // from all_tensors which has these parent names as keys.
-            let kmap_promote = kmap.get(*name) == Some(&QuantLevel::Promote6);
+            let kmap_promote = matches!(kmap.get(*name), Some(QuantLevel::Promote(_)));
             let expert_mq6 = (use_mq6g256 || use_mq4_mq6exp || (kmap_promote && use_mq4g256)) && supports_g256;
             let expert_hfq6 = (use_hfq6 || (kmap_promote && use_hfq4g256)) && supports_g256;
             let expert_hfq4 = use_hfq4g256 && !kmap_promote && supports_g256;
@@ -3716,8 +3781,14 @@ fn main() {
                     .flat_map(|&v| f32_to_f16(v).to_le_bytes())
                     .collect();
                 (f16_bytes, QuantType::F16, 0u32, "F16")
-            } else if kmap_level == QuantLevel::Promote6 {
-                // K-map says promote to 6-bit
+            } else if matches!(kmap_level, QuantLevel::Promote(_)) {
+                // K-map says promote. The carried format (in Promote(<fmt>))
+                // is the target, used by the GGUF pipeline's dispatcher.
+                // The safetensors path's dispatcher uses the pre-existing
+                // `use_*` boolean fall-through below; behavior is byte-exact
+                // with the pre-refactor code. The `--kmap-promote` CLI flag
+                // (next commit) will rewrite this arm to read the carried
+                // format directly.
                 let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
                 if (use_mq4g256 || use_mq4_mq6exp || use_mq3g256 || use_mq2g256
                     || use_mq2g256_lloyd || use_mq3g256_lloyd) && k_dim % 256 == 0
@@ -4320,21 +4391,21 @@ mod tests {
     fn kmap_moe_expert_ffn_promote6() {
         assert_eq!(
             kmap_resolve("model.language_model.layers.30.mlp.experts.5.gate_up_proj.weight", 64, true),
-            QuantLevel::Promote6
+            QuantLevel::Promote(GgufFormat::Mq6)
         );
         assert_eq!(
             kmap_resolve("model.language_model.layers.30.mlp.experts.5.down_proj.weight", 64, true),
-            QuantLevel::Promote6
+            QuantLevel::Promote(GgufFormat::Mq6)
         );
     }
 
     #[test]
     fn kmap_edge_layers_dense_ffn_only() {
         // Dense: FFN in edge layers — promoted
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.1.mlp.down_proj.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.62.mlp.up_proj.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.63.mlp.down_proj.weight", 64, false), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 64, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.1.mlp.down_proj.weight", 64, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.62.mlp.up_proj.weight", 64, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.63.mlp.down_proj.weight", 64, false), QuantLevel::Promote(GgufFormat::Mq6));
         // Dense: attn in edge layers — NOT promoted
         assert_eq!(kmap_resolve("model.layers.0.self_attn.q_proj.weight", 64, false), QuantLevel::Base);
         assert_eq!(kmap_resolve("model.layers.63.self_attn.v_proj.weight", 64, false), QuantLevel::Base);
@@ -4344,10 +4415,10 @@ mod tests {
     #[test]
     fn kmap_edge_layers_moe_attn_and_ffn() {
         // MoE: both attn and FFN in edge layers — promoted
-        assert_eq!(kmap_resolve("model.language_model.layers.0.self_attn.q_proj.weight", 64, true), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.language_model.layers.0.mlp.gate_proj.weight", 64, true), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.language_model.layers.0.linear_attn.in_proj_qkv.weight", 64, true), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.language_model.layers.63.self_attn.v_proj.weight", 64, true), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("model.language_model.layers.0.self_attn.q_proj.weight", 64, true), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.language_model.layers.0.mlp.gate_proj.weight", 64, true), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.language_model.layers.0.linear_attn.in_proj_qkv.weight", 64, true), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.language_model.layers.63.self_attn.v_proj.weight", 64, true), QuantLevel::Promote(GgufFormat::Mq6));
     }
 
     #[test]
@@ -4360,11 +4431,11 @@ mod tests {
     #[test]
     fn kmap_edge_layers_small_model_24_layers() {
         // 24 layers: edge = 0,1 and 22,23
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.1.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 24, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.1.mlp.gate_proj.weight", 24, false), QuantLevel::Promote(GgufFormat::Mq6));
         assert_eq!(kmap_resolve("model.layers.2.mlp.gate_proj.weight", 24, false), QuantLevel::Base);
-        assert_eq!(kmap_resolve("model.layers.22.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.23.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("model.layers.22.mlp.gate_proj.weight", 24, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.23.mlp.gate_proj.weight", 24, false), QuantLevel::Promote(GgufFormat::Mq6));
     }
 
     #[test]
@@ -4375,9 +4446,9 @@ mod tests {
     #[test]
     fn kmap_edge_layers_tiny_model_3_layers() {
         // 3 layers: first-2 = {0,1}, last-2 = {1,2}. All layers promoted.
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 3, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.1.mlp.gate_proj.weight", 3, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.2.mlp.gate_proj.weight", 3, false), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 3, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.1.mlp.gate_proj.weight", 3, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("model.layers.2.mlp.gate_proj.weight", 3, false), QuantLevel::Promote(GgufFormat::Mq6));
     }
 
     #[test]
@@ -4392,12 +4463,12 @@ mod tests {
     #[test]
     fn kmap_gguf_names() {
         // GGUF edge-layer FFN (dense) — promoted
-        assert_eq!(kmap_resolve("blk.0.ffn_gate.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("blk.63.ffn_gate.weight", 64, false), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("blk.0.ffn_gate.weight", 64, false), QuantLevel::Promote(GgufFormat::Mq6));
+        assert_eq!(kmap_resolve("blk.63.ffn_gate.weight", 64, false), QuantLevel::Promote(GgufFormat::Mq6));
         // GGUF edge-layer attn (dense) — NOT promoted
         assert_eq!(kmap_resolve("blk.0.attn_q.weight", 64, false), QuantLevel::Base);
         // GGUF edge-layer attn (MoE) — promoted
-        assert_eq!(kmap_resolve("blk.0.attn_q.weight", 64, true), QuantLevel::Promote6);
+        assert_eq!(kmap_resolve("blk.0.attn_q.weight", 64, true), QuantLevel::Promote(GgufFormat::Mq6));
         // GGUF middle-layer — base
         assert_eq!(kmap_resolve("blk.30.ffn_gate.weight", 64, false), QuantLevel::Base);
     }
@@ -4428,15 +4499,15 @@ mod tests {
     fn kmap_alternating_moe_experts() {
         // MoE experts: promoted in positional layers, base in others
         assert_eq!(
-            kmap_resolve_mode("model.language_model.layers.0.mlp.experts.5.gate_up_proj.weight", 40, true, 1),
-            QuantLevel::Promote6 // edge layer
+            kmap_resolve_mode("model.language_model.layers.0.mlp.experts.5.gate_up_proj.weight", 40, true, 1, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6) // edge layer
         );
         assert_eq!(
-            kmap_resolve_mode("model.language_model.layers.5.mlp.experts.5.gate_up_proj.weight", 40, true, 1),
-            QuantLevel::Promote6 // stride hit (5-2=3, 3%3==0)
+            kmap_resolve_mode("model.language_model.layers.5.mlp.experts.5.gate_up_proj.weight", 40, true, 1, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6) // stride hit (5-2=3, 3%3==0)
         );
         assert_eq!(
-            kmap_resolve_mode("model.language_model.layers.3.mlp.experts.5.gate_up_proj.weight", 40, true, 1),
+            kmap_resolve_mode("model.language_model.layers.3.mlp.experts.5.gate_up_proj.weight", 40, true, 1, GgufFormat::Mq6),
             QuantLevel::Base // not on stride
         );
     }
@@ -4445,20 +4516,20 @@ mod tests {
     fn kmap_alternating_ffn_down() {
         // ffn_down promoted in positional layers, base in others
         assert_eq!(
-            kmap_resolve_mode("model.layers.0.mlp.down_proj.weight", 40, false, 1),
-            QuantLevel::Promote6 // edge
+            kmap_resolve_mode("model.layers.0.mlp.down_proj.weight", 40, false, 1, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6) // edge
         );
         assert_eq!(
-            kmap_resolve_mode("model.layers.5.mlp.down_proj.weight", 40, false, 1),
-            QuantLevel::Promote6 // stride
+            kmap_resolve_mode("model.layers.5.mlp.down_proj.weight", 40, false, 1, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6) // stride
         );
         assert_eq!(
-            kmap_resolve_mode("model.layers.3.mlp.down_proj.weight", 40, false, 1),
+            kmap_resolve_mode("model.layers.3.mlp.down_proj.weight", 40, false, 1, GgufFormat::Mq6),
             QuantLevel::Base // not on stride
         );
         // gate_proj NOT promoted in middle layers
         assert_eq!(
-            kmap_resolve_mode("model.layers.5.mlp.gate_proj.weight", 40, false, 1),
+            kmap_resolve_mode("model.layers.5.mlp.gate_proj.weight", 40, false, 1, GgufFormat::Mq6),
             QuantLevel::Base
         );
     }
@@ -4467,7 +4538,7 @@ mod tests {
     fn kmap_alternating_n_layers_zero() {
         // With n_layers=0, alternating mode should return Base for everything
         assert_eq!(
-            kmap_resolve_mode("model.layers.0.mlp.down_proj.weight", 0, false, 1),
+            kmap_resolve_mode("model.layers.0.mlp.down_proj.weight", 0, false, 1, GgufFormat::Mq6),
             QuantLevel::Base
         );
     }
@@ -4476,17 +4547,17 @@ mod tests {
     fn kmap_alternating_gguf_names() {
         // GGUF ffn_down in edge layer
         assert_eq!(
-            kmap_resolve_mode("blk.0.ffn_down.weight", 40, false, 1),
-            QuantLevel::Promote6
+            kmap_resolve_mode("blk.0.ffn_down.weight", 40, false, 1, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6)
         );
         // GGUF ffn_down in middle non-stride layer
         assert_eq!(
-            kmap_resolve_mode("blk.3.ffn_down.weight", 40, false, 1),
+            kmap_resolve_mode("blk.3.ffn_down.weight", 40, false, 1, GgufFormat::Mq6),
             QuantLevel::Base
         );
         // GGUF ffn_gate stays base in middle
         assert_eq!(
-            kmap_resolve_mode("blk.5.ffn_gate.weight", 40, false, 1),
+            kmap_resolve_mode("blk.5.ffn_gate.weight", 40, false, 1, GgufFormat::Mq6),
             QuantLevel::Base
         );
     }
@@ -4494,16 +4565,16 @@ mod tests {
     #[test]
     fn kmap_typed_promotes_down_and_v() {
         assert_eq!(
-            kmap_resolve_mode("model.layers.15.mlp.down_proj.weight", 40, false, 2),
-            QuantLevel::Promote6
+            kmap_resolve_mode("model.layers.15.mlp.down_proj.weight", 40, false, 2, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6)
         );
         assert_eq!(
-            kmap_resolve_mode("model.layers.15.self_attn.v_proj.weight", 40, false, 2),
-            QuantLevel::Promote6
+            kmap_resolve_mode("model.layers.15.self_attn.v_proj.weight", 40, false, 2, GgufFormat::Mq6),
+            QuantLevel::Promote(GgufFormat::Mq6)
         );
         // gate_proj stays base
         assert_eq!(
-            kmap_resolve_mode("model.layers.15.mlp.gate_proj.weight", 40, false, 2),
+            kmap_resolve_mode("model.layers.15.mlp.gate_proj.weight", 40, false, 2, GgufFormat::Mq6),
             QuantLevel::Base
         );
     }

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -57,6 +57,20 @@ static IMATRIX: OnceLock<HashMap<String, Vec<f32>>> = OnceLock::new();
 // alpha=1 is pure activation-magnitude scaling (no smoothing).
 static AWQ_ALPHA: OnceLock<f32> = OnceLock::new();
 
+// `--lm-head-format <fmt>` override. Unset = default Q8 behavior (lm_head and
+// output force-quantized to Q8 by kmap_resolve_mode rule 2). When Some(<fmt>),
+// kmap_resolve_mode returns `QuantLevel::Override(<fmt>)` for lm_head /
+// output, and the dispatcher quantizes those tensors to that format.
+// See configurable-kmap-pair.md Phase 1b.
+static LM_HEAD_FORMAT: OnceLock<GgufFormat> = OnceLock::new();
+
+// True if `--lm-head-format != Q8 && --awq` AND the runtime UNSAFE gate is set.
+// Read by `awq_eligible` so lm_head / output tensors join the F1 whitelist
+// and receive AWQ pre-scaling + sidecar. Without this set, lm_head bytes
+// would be MQ4-quantized but NOT AWQ-scaled — runtime would read them as
+// AWQ-scaled and corrupt logits (0.67 → 13.5 KLD blowup, master-doc §6 rule 5).
+static LM_HEAD_AWQ_ENABLED: OnceLock<bool> = OnceLock::new();
+
 // ─── Safetensors Parser ─────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -1820,12 +1834,17 @@ enum QuantType {
 enum QuantLevel {
     /// Store as F16 (norms, biases, 1D tensors).
     F16,
-    /// Store as Q8_F16 (embeddings, lm_head, MoE routers).
+    /// Store as Q8_F16 (embeddings, lm_head default, MoE routers).
     Q8,
     /// Promote to the carried format (edge layers, MoE expert FFN).
     /// The target was historically hardcoded to MQ6; now parameterized
-    /// per `--kmap-promote` (introduced in the configurable-kmap-pair plan).
+    /// per `--kmap-promote` (configurable-kmap-pair plan Phase 1a).
     Promote(GgufFormat),
+    /// Override the default (Q8) for a specific tensor class (today: lm_head)
+    /// to a CLI-specified format. Separate from `Promote` so the lm_head
+    /// override takes precedence over kmap mode 0/1/2's tensor-name rules.
+    /// configurable-kmap-pair plan Phase 1b.
+    Override(GgufFormat),
     /// Use the base format as-is.
     Base,
 }
@@ -1932,10 +1951,27 @@ fn kmap_resolve_mode(
         return QuantLevel::F16;
     }
 
-    // Rule 2: embeddings, lm_head, output projection
-    if name.contains("embed_tokens") || name.contains("token_embd")
-        || name.contains("lm_head") || name.ends_with("output.weight")
-    {
+    // Rule 2a: lm_head / output projection.
+    // - When `--lm-head-format <fmt>` is set (LM_HEAD_FORMAT populated),
+    //   return Override(fmt). The Override dispatcher arm quantizes to
+    //   the carried format and (for MQ4 + --awq) applies AWQ pre-scaling.
+    // - Otherwise: default to Q8.
+    // The lm_head sub-arm is checked BEFORE embed (rule 2b) so the
+    // `--lm-head-format` override doesn't accidentally trigger on
+    // `embed_tokens.weight`. See configurable-kmap-pair.md §"Dispatcher
+    // precedence in fn kmap_resolve_mode".
+    if name.contains("lm_head") || name.ends_with("output.weight") {
+        if let Some(fmt) = LM_HEAD_FORMAT.get().copied() {
+            return QuantLevel::Override(fmt);
+        }
+        return QuantLevel::Q8;
+    }
+
+    // Rule 2b: token embeddings — always Q8 (out of scope for
+    // --lm-head-format; embeddings are a lookup not a matmul, AWQ has no
+    // x to divide). See configurable-kmap-pair.md §"Embeddings are
+    // intentionally untouched".
+    if name.contains("embed_tokens") || name.contains("token_embd") {
         return QuantLevel::Q8;
     }
 
@@ -2628,6 +2664,19 @@ fn awq_scales_to_f16_bytes(scales: &[f32]) -> Vec<u8> {
 /// in a future arch fails closed (no AWQ) until someone confirms its
 /// runtime path is AWQ-aware.
 fn awq_eligible(name: &str) -> bool {
+    // lm_head / output projection: AWQ-eligible iff `--lm-head-format mq4 --awq`
+    // was set AND the safety gates passed (LM_HEAD_AWQ_ENABLED OnceLock).
+    // Semantically input-side: lm_head's "activation" is the post-final-RMSNorm
+    // hidden state. Without this guard, lm_head would be MQ4-quantized but
+    // NOT AWQ-pre-scaled, while the runtime (once the CUDA-branch AWQ-aware
+    // lm_head dispatch lands) would assume scaling — silent corruption.
+    // See configurable-kmap-pair.md §1b(ii).
+    if LM_HEAD_AWQ_ENABLED.get().copied().unwrap_or(false) {
+        if name.ends_with("lm_head.weight") || name == "output.weight" {
+            return true;
+        }
+    }
+
     // F1-vs-F2 A/B gate. When `HIPFIRE_AWQ_F1_ONLY=1` is set, the F2
     // additions below (o_proj / wo / out_proj / down_proj / w_down)
     // are excluded — produces an F1-equivalent quant for comparison
@@ -2986,7 +3035,7 @@ fn run_gguf_pipeline(
         HashMap::new()
     } else {
         let mut map = HashMap::new();
-        let mut counts = [0u32; 4];
+        let mut counts = [0u32; 5];
         for info in &gguf.tensors {
             let out_name = gguf_to_safetensors_name(&info.name)
                 .unwrap_or_else(|| info.name.clone());
@@ -2995,7 +3044,8 @@ fn run_gguf_pipeline(
                 QuantLevel::F16 => counts[0] += 1,
                 QuantLevel::Q8 => counts[1] += 1,
                 QuantLevel::Promote(_) => counts[2] += 1,
-                QuantLevel::Base => counts[3] += 1,
+                QuantLevel::Override(_) => counts[3] += 1,
+                QuantLevel::Base => counts[4] += 1,
             }
             map.insert(out_name, level);
         }
@@ -3008,7 +3058,11 @@ fn run_gguf_pipeline(
             eprintln!("  F16:       {:>4} tensors", counts[0]);
             eprintln!("  Q8:        {:>4} tensors", counts[1]);
             eprintln!("  Promote:   {:>4} tensors (→ {})", counts[2], promote_to.label());
-            eprintln!("  Base:      {:>4} tensors", counts[3]);
+            if counts[3] > 0 {
+                eprintln!("  Override:  {:>4} tensors (lm_head → {})", counts[3],
+                    LM_HEAD_FORMAT.get().map(|f| f.label()).unwrap_or("?"));
+            }
+            eprintln!("  Base:      {:>4} tensors", counts[4]);
         }
         map
     };
@@ -3110,6 +3164,56 @@ fn run_gguf_pipeline(
                 GgufFormat::Hfq4 => {
                     let q = quantize_hfq4g256(&f32_data);
                     (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                }
+            }
+        } else if let (QuantLevel::Override(override_fmt), true) = (kmap_level, k_dim % 256 == 0) {
+            // K-map says override (lm_head when --lm-head-format set).
+            // GGUF pipeline has no AWQ wiring (AWQ is safetensors-only today),
+            // so this is a plain quantize on the carried target format.
+            let f32_data = gguf_input::tensor_to_f32(info, raw);
+            quant_params += n_elements as u64;
+            match override_fmt {
+                GgufFormat::Mq6 => {
+                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                }
+                GgufFormat::Hfq6 => {
+                    let q = quantize_hfq6g256(&f32_data);
+                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                }
+                GgufFormat::Mq4 => {
+                    let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                }
+                GgufFormat::Hfq4 => {
+                    let q = quantize_hfq4g256(&f32_data);
+                    (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                }
+                GgufFormat::Mq3 => {
+                    let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ3G256, 256u32, "MQ3G256")
+                }
+                GgufFormat::Mq2 => {
+                    let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                }
+                GgufFormat::Mq2Lloyd => {
+                    let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                }
+                GgufFormat::Mq3Lloyd => {
+                    let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                }
+                GgufFormat::Hfp4 => {
+                    let m = info.shape[0] as usize;
+                    let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
+                    (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                }
+                GgufFormat::Mfp4 => {
+                    let m = info.shape[0] as usize;
+                    let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
+                    (q, QuantType::MFP4G32, 32u32, "MFP4G32")
                 }
             }
         } else if k_dim % 256 == 0 {
@@ -3598,6 +3702,127 @@ fn main() {
     // the K-map default-on path because the routed-expert promotion is
     // the headline win and the empirical regression there is tighter
     // (+1.7% PPL at 2K, gated below the dense regression threshold).
+    // ── `--lm-head-format <fmt>` + safety gates (configurable-kmap-pair Phase 1b)
+    //
+    // Parse the CLI value, then enforce two safety contracts before populating
+    // the LM_HEAD_FORMAT OnceLock that `kmap_resolve_mode` rule 2a reads:
+    //
+    //   (a) Tied-embedding refusal (hardened per CUDA branch dbcb050): if
+    //       `tie_word_embeddings: true` in the source config, AWQ-scaling
+    //       lm_head would corrupt the shared embed_tokens lookup. If the
+    //       field is missing from BOTH top-level config AND text_config,
+    //       abort with operator instructions — fail-loud, not fail-silent.
+    //
+    //   (b) HIPFIRE_LM_HEAD_AWQ_UNSAFE=1 gate: required for non-Q8 non-F16
+    //       lm-head-format until the AWQ-aware lm_head runtime dispatch
+    //       lands on the CUDA branch. Without that runtime, AWQ-pre-scaled
+    //       bytes feed a non-AWQ-aware kernel and produce `(W·s)·x ≠ W·x`
+    //       (0.67 → 13.5 KLD blowup, master-doc §6 rule 5).
+    //
+    // Deprecated alias: `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ=1` (CUDA branch's
+    // env-var path) is treated as `--lm-head-format mq4` for one release
+    // cycle; emits a deprecation warning. Removed in the next release.
+    let lm_head_format_cli: Option<&str> = args.iter().position(|a| a == "--lm-head-format")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str());
+    let cuda_env_alias = std::env::var("HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ")
+        .ok().as_deref() == Some("1");
+    let lm_head_format_arg: Option<&str> = if let Some(v) = lm_head_format_cli {
+        Some(v)
+    } else if cuda_env_alias {
+        eprintln!(
+            "deprecation: HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ=1 is the legacy alias \
+             for `--lm-head-format mq4`. The env var continues to work for one \
+             release cycle; please migrate to the CLI flag."
+        );
+        Some("mq4")
+    } else {
+        None
+    };
+    let lm_head_format: Option<GgufFormat> = match lm_head_format_arg {
+        None => None,
+        Some("q8") | Some("Q8") => None, // explicit Q8 == default
+        Some("f16") | Some("F16") => {
+            // F16 lm_head support is a follow-up — F16 isn't in `GgufFormat`
+            // and the Override arm has no F16 case. For now, warn and fall
+            // back to default Q8 so the operator's intent (F16 lm_head)
+            // doesn't silently produce something else.
+            eprintln!(
+                "warning: --lm-head-format f16 is not yet wired through the \
+                 dispatch (follow-up). Falling back to default Q8 lm_head."
+            );
+            None
+        }
+        Some(other) => Some(GgufFormat::from_flag(other).unwrap_or_else(|| {
+            eprintln!(
+                "error: --lm-head-format '{other}' is not a recognized format. \
+                 Supported: q8, f16, mq4, mq6, mq3, mfp4, hfq4, hfq6."
+            );
+            std::process::exit(2);
+        })),
+    };
+
+    if let Some(fmt) = lm_head_format {
+        // (a) Tied-embedding refusal (hardened: explicit match on the field).
+        let tied_embed_field = config.get("tie_word_embeddings")
+            .or_else(|| config.get("text_config").and_then(|tc| tc.get("tie_word_embeddings")));
+        match tied_embed_field.and_then(|v| v.as_bool()) {
+            Some(true) => {
+                eprintln!(
+                    "error: --lm-head-format {} but the source model has \
+                     tie_word_embeddings=true. lm_head shares storage with \
+                     embed_tokens; quantizing (and AWQ-scaling) lm_head would \
+                     corrupt the embedding lookup. Refusing to produce a broken \
+                     .hfq. To force, untie the model first — out of scope here.",
+                    fmt.label()
+                );
+                std::process::exit(2);
+            }
+            Some(false) => { /* untied — proceed */ }
+            None => {
+                eprintln!(
+                    "error: --lm-head-format {} requires `tie_word_embeddings` in \
+                     the source config (top-level or under text_config). The field \
+                     is missing from both locations. Either add it explicitly \
+                     (after verifying tied vs untied) or untie the model first. \
+                     See docs/plans/configurable-kmap-pair.md §1b(i).",
+                    fmt.label()
+                );
+                std::process::exit(2);
+            }
+        }
+        // (b) UNSAFE runtime gate: any non-Q8 lm-head-format requires the
+        // operator to acknowledge that the AWQ-aware lm_head runtime kernel
+        // hasn't shipped yet. Drops in lockstep with the CUDA branch landing.
+        let unsafe_gate = std::env::var("HIPFIRE_LM_HEAD_AWQ_UNSAFE")
+            .ok().as_deref() == Some("1");
+        if !unsafe_gate {
+            eprintln!(
+                "error: --lm-head-format {} requires HIPFIRE_LM_HEAD_AWQ_UNSAFE=1 \
+                 until the runtime-side AWQ-aware lm_head dispatch lands on the \
+                 CUDA branch (feat/mq-v2-quant-format-cuda Phase 2). Without that \
+                 runtime, AWQ-pre-scaled lm_head bytes feed a non-AWQ-aware kernel \
+                 and produce `(W·s)·x ≠ W·x` — master-doc §6 rule 5 corruption \
+                 pattern. Drops in the same commit that lands the runtime.",
+                fmt.label()
+            );
+            std::process::exit(2);
+        }
+        eprintln!(
+            "lm-head-format: ENABLED (target={}, model is untied, UNSAFE gate \
+             acknowledged). lm_head will route through the Override dispatch.",
+            fmt.label()
+        );
+        let _ = LM_HEAD_FORMAT.set(fmt);
+        // Mark AWQ on lm_head as enabled iff --awq is also set AND the chosen
+        // format is one we have AWQ pre-scaling wired for (today: MQ4 only).
+        // awq_eligible reads this lock to add lm_head/output to the F1 set.
+        let awq_set = AWQ_ALPHA.get().copied().map(|a| a > 0.0).unwrap_or(false);
+        if awq_set && fmt == GgufFormat::Mq4 {
+            let _ = LM_HEAD_AWQ_ENABLED.set(true);
+        }
+    }
+
     // Promote target carried in `QuantLevel::Promote(<fmt>)`.
     // - If `--kmap-promote` is set explicitly, use that (validated upstream).
     // - Otherwise fall back to `default_promote_target(base)` — same legacy
@@ -3612,14 +3837,15 @@ fn main() {
         HashMap::new()
     } else {
         let mut map = HashMap::new();
-        let mut counts = [0u32; 4]; // F16, Q8, Promote, Base
+        let mut counts = [0u32; 5]; // F16, Q8, Promote, Override, Base
         for (name, _fi) in &all_tensors {
             let level = kmap_resolve_mode(name, n_layers, is_moe, kmap_mode, promote_to);
             match level {
                 QuantLevel::F16 => counts[0] += 1,
                 QuantLevel::Q8 => counts[1] += 1,
                 QuantLevel::Promote(_) => counts[2] += 1,
-                QuantLevel::Base => counts[3] += 1,
+                QuantLevel::Override(_) => counts[3] += 1,
+                QuantLevel::Base => counts[4] += 1,
             }
             map.insert(name.to_string(), level);
         }
@@ -3629,9 +3855,13 @@ fn main() {
                 promote_to.label(),
                 if is_moe { ", MoE" } else { "" });
             eprintln!("  F16:       {:>4} tensors (norms, biases)", counts[0]);
-            eprintln!("  Q8:        {:>4} tensors (embed, lm_head, routers)", counts[1]);
+            eprintln!("  Q8:        {:>4} tensors (embed, routers, default lm_head)", counts[1]);
             eprintln!("  Promote:   {:>4} tensors (→ {})", counts[2], promote_to.label());
-            eprintln!("  Base:      {:>4} tensors (remaining)", counts[3]);
+            if counts[3] > 0 {
+                eprintln!("  Override:  {:>4} tensors (lm_head → {})", counts[3],
+                    LM_HEAD_FORMAT.get().map(|f| f.label()).unwrap_or("?"));
+            }
+            eprintln!("  Base:      {:>4} tensors (remaining)", counts[4]);
         }
         map
     };
@@ -3903,6 +4133,86 @@ fn main() {
                     }
                 } else {
                     // Non-256-aligned fallback: Q8
+                    let q = quantize_q8f16(&f32_data);
+                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                }
+            } else if let QuantLevel::Override(override_fmt) = kmap_level {
+                // K-map says override (today: lm_head when --lm-head-format set).
+                // Dispatch on the carried format. For MQ4 with AWQ enabled,
+                // apply AWQ pre-scaling + emit a sidecar so the runtime
+                // (once the CUDA-branch AWQ-aware lm_head dispatch lands)
+                // sees scaled bytes and inverse-divides correctly. For any
+                // other format, plain quantize (the AWQ wiring outside MQ4
+                // is a follow-up).
+                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
+                if k_dim % 256 == 0 {
+                    let signs1 = gen_fwht_signs(42, 256);
+                    let signs2 = gen_fwht_signs(1042, 256);
+                    match override_fmt {
+                        GgufFormat::Mq4 => {
+                            // Inline AWQ + MQ4 dance (mirrors the Base MQ4 arm).
+                            let q = if let (Some(alpha), Some(im_weights))
+                                = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                            {
+                                if awq_eligible(name) {
+                                    let scales = compute_awq_scales(im_weights, alpha);
+                                    awq_sidecar_scales = Some(scales.clone());
+                                    let m_dim = meta.shape[0];
+                                    let mut scaled = f32_data.clone();
+                                    awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                    quantize_mq4g256(&scaled, &signs1, &signs2)
+                                } else {
+                                    quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                }
+                            } else {
+                                quantize_mq4g256(&f32_data, &signs1, &signs2)
+                            };
+                            (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                        }
+                        GgufFormat::Mq6 => {
+                            let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                        }
+                        GgufFormat::Mq3 => {
+                            let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ3G256, 256u32, "MQ3G256")
+                        }
+                        GgufFormat::Hfq4 => {
+                            let q = quantize_hfq4g256(&f32_data);
+                            (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                        }
+                        GgufFormat::Hfq6 => {
+                            let q = quantize_hfq6g256(&f32_data);
+                            (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                        }
+                        // Other Override targets: not yet wired with AWQ;
+                        // emit plain quantization. Used in Phase 0 sweeps
+                        // for non-AWQ lm_head experiments.
+                        GgufFormat::Mq2 => {
+                            let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                        }
+                        GgufFormat::Mq2Lloyd => {
+                            let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                        }
+                        GgufFormat::Mq3Lloyd => {
+                            let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                        }
+                        GgufFormat::Mfp4 => {
+                            let m = meta.shape[0];
+                            let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
+                            (q, QuantType::MFP4G32, 32u32, "MFP4G32")
+                        }
+                        GgufFormat::Hfp4 => {
+                            let m = meta.shape[0];
+                            let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
+                            (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                        }
+                    }
+                } else {
+                    // Non-256-aligned override target: Q8 fallback.
                     let q = quantize_q8f16(&f32_data);
                     (q, QuantType::Q8F16, 32u32, "Q8_F16")
                 }
@@ -4481,6 +4791,58 @@ mod tests {
         assert!(!is_promote_pair_supported(GgufFormat::Hfq4, GgufFormat::Mq6));
         assert!(!is_promote_pair_supported(GgufFormat::Mq4, GgufFormat::Hfp4));
         assert!(!is_promote_pair_supported(GgufFormat::Mfp4, GgufFormat::Mq6));
+    }
+
+    #[test]
+    fn lm_head_default_q8_when_format_unset() {
+        // LM_HEAD_FORMAT OnceLock is not set in unit tests → lm_head should
+        // resolve to Q8 (default behavior, byte-exact with pre-refactor).
+        assert_eq!(
+            kmap_resolve_mode("lm_head.weight", 64, false, 2, GgufFormat::Mq6),
+            QuantLevel::Q8
+        );
+        assert_eq!(
+            kmap_resolve_mode("output.weight", 64, false, 2, GgufFormat::Mq6),
+            QuantLevel::Q8
+        );
+        assert_eq!(
+            kmap_resolve_mode("model.lm_head.weight", 64, false, 2, GgufFormat::Mq6),
+            QuantLevel::Q8
+        );
+    }
+
+    #[test]
+    fn embed_remains_q8_independent_of_lm_head() {
+        // The rule 2 split means embed always resolves to Q8 regardless of
+        // LM_HEAD_FORMAT (configurable-kmap-pair §"Embeddings are intentionally
+        // untouched").
+        assert_eq!(
+            kmap_resolve_mode("model.embed_tokens.weight", 64, false, 2, GgufFormat::Mq6),
+            QuantLevel::Q8
+        );
+        assert_eq!(
+            kmap_resolve_mode("token_embd.weight", 64, false, 2, GgufFormat::Mq6),
+            QuantLevel::Q8
+        );
+    }
+
+    #[test]
+    fn awq_eligible_default_excludes_lm_head() {
+        // Without LM_HEAD_AWQ_ENABLED, lm_head/output are NOT awq-eligible.
+        // This matches the pre-flag behavior — silent-corruption-safe default.
+        assert!(!awq_eligible("lm_head.weight"));
+        assert!(!awq_eligible("output.weight"));
+        assert!(!awq_eligible("model.lm_head.weight"));
+    }
+
+    #[test]
+    fn awq_eligible_keeps_existing_whitelist() {
+        // Sanity: the LM_HEAD_AWQ_ENABLED gate doesn't break the existing
+        // F1/F2 suffix matches.
+        assert!(awq_eligible("model.layers.0.self_attn.q_proj.weight"));
+        assert!(awq_eligible("model.layers.0.mlp.gate_proj.weight"));
+        assert!(awq_eligible("model.layers.0.mlp.down_proj.weight"));  // F2
+        assert!(awq_eligible("model.layers.0.self_attn.o_proj.weight")); // F2
     }
 
     #[test]

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -1843,6 +1843,27 @@ fn default_promote_target(base: GgufFormat) -> GgufFormat {
     }
 }
 
+/// Allowlist for explicit `--kmap-promote` overrides. Runtime mixed-format
+/// dispatch (post-#257) is validated only within same-rotation-family,
+/// upward-in-bit-width pairings. Cross-family (MQ↔HFQ, MQ↔HFP) and
+/// downward-in-bits promotions are rejected at parse time.
+fn is_promote_pair_supported(base: GgufFormat, promote: GgufFormat) -> bool {
+    use GgufFormat::*;
+    if base == promote {
+        return true; // no-op promotion is always safe
+    }
+    match (base, promote) {
+        // MQ-family upward bit-width
+        (Mq2 | Mq2Lloyd, Mq3 | Mq3Lloyd | Mq4 | Mq6) => true,
+        (Mq3 | Mq3Lloyd, Mq4 | Mq6) => true,
+        (Mq4, Mq6) => true,
+        // HFQ-family upward bit-width
+        (Hfq4, Hfq6) => true,
+        // Everything else: explicitly not in the supported matrix
+        _ => false,
+    }
+}
+
 /// Extract layer index from a tensor name.
 /// Handles both safetensors (`layers.{N}.`) and GGUF (`blk.{N}.`) patterns.
 /// Uses unanchored search to handle any prefix (model.layers, model.language_model.layers, etc.).
@@ -2891,7 +2912,15 @@ impl GgufFormat {
 /// (Q4-grade is too lossy for embeddings) and 1D norms stay F16. Tensor
 /// names are translated GGUF → safetensors style so the engine's existing
 /// `load_weights_hfq` can consume the output.
-fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: bool, kmap_dense: bool, kmap_mode: u8) -> std::io::Result<()> {
+fn run_gguf_pipeline(
+    input: &Path,
+    output: &Path,
+    format: GgufFormat,
+    no_kmap: bool,
+    kmap_dense: bool,
+    kmap_mode: u8,
+    kmap_promote_override: Option<GgufFormat>,
+) -> std::io::Result<()> {
     eprintln!("=== GGUF → {} conversion ===", format.label());
     eprintln!("Input:  {}", input.display());
     eprintln!("Output: {}", output.display());
@@ -2952,7 +2981,7 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
     // ship-default is the conservative shape per maintainer directive
     // (2026-05-08): never silently change dense quantization. Users who
     // want K-map on dense pass `--kmap-dense` (see flag parsing below).
-    let promote_to = default_promote_target(format);
+    let promote_to = kmap_promote_override.unwrap_or_else(|| default_promote_target(format));
     let kmap: HashMap<String, QuantLevel> = if no_kmap || (!is_moe && !kmap_dense) {
         HashMap::new()
     } else {
@@ -3336,6 +3365,42 @@ fn main() {
         })
         .unwrap_or(1);
 
+    // ── --kmap-promote: explicit promote target (overrides default_promote_target) ──
+    // Default (flag unset): legacy per-base-family target (mq6 for MQ-family,
+    // hfq6 for HFQ, no-op for FP4). With --kmap-promote, the carried target
+    // applies regardless of base. Validated against the promote-pair allowlist
+    // when both sides are known GgufFormat values. See
+    // docs/plans/configurable-kmap-pair.md Phase 1a.
+    let kmap_promote: Option<GgufFormat> = args.iter().position(|a| a == "--kmap-promote")
+        .and_then(|i| args.get(i + 1))
+        .map(|v| GgufFormat::from_flag(v).unwrap_or_else(|| {
+            eprintln!(
+                "error: --kmap-promote '{v}' is not a recognized format. \
+                 Supported: mq2, mq3, mq4, mq6, mq2-lloyd, mq3-lloyd, hfq4, hfq6, mfp4, hfp4."
+            );
+            std::process::exit(2);
+        }));
+    if let Some(promote) = kmap_promote {
+        if let Some(base) = GgufFormat::from_flag(format) {
+            if !is_promote_pair_supported(base, promote) {
+                eprintln!(
+                    "error: --kmap-promote {} not allowed for --format {}. \
+                     Promote target must be same-family upward-in-bits. \
+                     See docs/plans/configurable-kmap-pair.md for the supported pair matrix.",
+                    promote.label(), base.label()
+                );
+                std::process::exit(2);
+            }
+        } else {
+            eprintln!(
+                "warning: --kmap-promote {} ignored — --format '{format}' is not \
+                 a promote-capable base (q8/mixed/q4k/q8hfq have no kmap promotion). \
+                 Drop --kmap-promote or switch to a promote-capable base format.",
+                promote.label()
+            );
+        }
+    }
+
     // ── Sub-4-bit guards (2026-04-30 sweep) ─────────────────────────────
     // MQ2 with the current uniform 4-level codebook collapses at every
     // model size validated locally (0.8B / 4B / 9B Qwen 3.5 → multilingual
@@ -3426,7 +3491,7 @@ fn main() {
                 GgufFormat::Hfq4
             });
             let out = Path::new(output_path);
-            if let Err(e) = run_gguf_pipeline(raw_input, out, gguf_format, no_kmap, kmap_dense, kmap_mode) {
+            if let Err(e) = run_gguf_pipeline(raw_input, out, gguf_format, no_kmap, kmap_dense, kmap_mode, kmap_promote) {
                 eprintln!("GGUF pipeline failed: {e}");
                 std::process::exit(2);
             }
@@ -3533,16 +3598,17 @@ fn main() {
     // the K-map default-on path because the routed-expert promotion is
     // the headline win and the empirical regression there is tighter
     // (+1.7% PPL at 2K, gated below the dense regression threshold).
-    // Promote target carried in `QuantLevel::Promote(<fmt>)`. Default is
-    // `default_promote_target(base)` — same as the pre-`--kmap-promote`
-    // hardcoded behavior. If `format` doesn't parse to a GgufFormat (e.g.
-    // `--format q8` or `--format mixed`), use Mq6 as a placeholder; the
-    // Promote arm's `use_*` boolean dispatch below ignores the carried
-    // format and falls through to its existing Q8 fallback for non-promotable
-    // bases. Byte-exact behavior on this path.
-    let parsed_base = GgufFormat::from_flag(format).unwrap_or(GgufFormat::Mq4);
-    let promote_to = default_promote_target(parsed_base);
-    let kmap: HashMap<String, QuantLevel> = if no_kmap || (!is_moe && !kmap_dense) {
+    // Promote target carried in `QuantLevel::Promote(<fmt>)`.
+    // - If `--kmap-promote` is set explicitly, use that (validated upstream).
+    // - Otherwise fall back to `default_promote_target(base)` — same legacy
+    //   per-base-family behavior.
+    // - If `format` doesn't parse to a GgufFormat (q8/mixed/q4k/q8hfq), kmap
+    //   is disabled entirely below: no promotion is meaningful for those
+    //   bases (byte-exact with the pre-refactor q8-fallback path).
+    let parsed_base_opt = GgufFormat::from_flag(format);
+    let parsed_base = parsed_base_opt.unwrap_or(GgufFormat::Mq4);
+    let promote_to = kmap_promote.unwrap_or_else(|| default_promote_target(parsed_base));
+    let kmap: HashMap<String, QuantLevel> = if no_kmap || (!is_moe && !kmap_dense) || parsed_base_opt.is_none() {
         HashMap::new()
     } else {
         let mut map = HashMap::new();
@@ -3781,37 +3847,60 @@ fn main() {
                     .flat_map(|&v| f32_to_f16(v).to_le_bytes())
                     .collect();
                 (f16_bytes, QuantType::F16, 0u32, "F16")
-            } else if matches!(kmap_level, QuantLevel::Promote(_)) {
-                // K-map says promote. The carried format (in Promote(<fmt>))
-                // is the target, used by the GGUF pipeline's dispatcher.
-                // The safetensors path's dispatcher uses the pre-existing
-                // `use_*` boolean fall-through below; behavior is byte-exact
-                // with the pre-refactor code. The `--kmap-promote` CLI flag
-                // (next commit) will rewrite this arm to read the carried
-                // format directly.
+            } else if let QuantLevel::Promote(promote_fmt) = kmap_level {
+                // K-map says promote. The carried format (from `--kmap-promote`
+                // or `default_promote_target(base)`) drives the dispatch.
+                // Non-256-aligned tensors fall back to Q8.
                 let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if (use_mq4g256 || use_mq4_mq6exp || use_mq3g256 || use_mq2g256
-                    || use_mq2g256_lloyd || use_mq3g256_lloyd) && k_dim % 256 == 0
-                {
+                if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
-                } else if (use_hfq4g256 || use_hfq3g256 || use_hfq3g128
-                    || use_hfq2g256 || use_hfq2g128) && k_dim % 256 == 0
-                {
-                    let q = quantize_hfq6g256(&f32_data);
-                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
-                } else if use_mq6g256 && k_dim % 256 == 0 {
-                    // Already 6-bit MQ — no-op promotion
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
-                } else if use_hfq6 && k_dim % 256 == 0 {
-                    // Already 6-bit HFQ — no-op promotion
-                    let q = quantize_hfq6g256(&f32_data);
-                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                    match promote_fmt {
+                        GgufFormat::Mq6 => {
+                            let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                        }
+                        GgufFormat::Hfq6 => {
+                            let q = quantize_hfq6g256(&f32_data);
+                            (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                        }
+                        GgufFormat::Mq4 => {
+                            let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                        }
+                        GgufFormat::Mq3 => {
+                            let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ3G256, 256u32, "MQ3G256")
+                        }
+                        GgufFormat::Mq2 => {
+                            let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                        }
+                        GgufFormat::Mq2Lloyd => {
+                            let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                        }
+                        GgufFormat::Mq3Lloyd => {
+                            let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                        }
+                        GgufFormat::Hfq4 => {
+                            let q = quantize_hfq4g256(&f32_data);
+                            (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                        }
+                        GgufFormat::Hfp4 => {
+                            // No FP6 sibling — Promote-to-HFP4 is the no-op identity.
+                            let m = if meta.shape.len() == 2 { meta.shape[0] } else { 1 };
+                            let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
+                            (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                        }
+                        GgufFormat::Mfp4 => {
+                            // No FP6 sibling — Promote-to-MFP4 is the no-op identity.
+                            let m = if meta.shape.len() == 2 { meta.shape[0] } else { 1 };
+                            let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
+                            (q, QuantType::MFP4G32, 32u32, "MFP4G32")
+                        }
+                    }
                 } else {
                     // Non-256-aligned fallback: Q8
                     let q = quantize_q8f16(&f32_data);
@@ -4326,6 +4415,100 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_promote_target_mq_family() {
+        assert_eq!(default_promote_target(GgufFormat::Mq2), GgufFormat::Mq6);
+        assert_eq!(default_promote_target(GgufFormat::Mq3), GgufFormat::Mq6);
+        assert_eq!(default_promote_target(GgufFormat::Mq4), GgufFormat::Mq6);
+        assert_eq!(default_promote_target(GgufFormat::Mq6), GgufFormat::Mq6);
+        assert_eq!(default_promote_target(GgufFormat::Mq2Lloyd), GgufFormat::Mq6);
+        assert_eq!(default_promote_target(GgufFormat::Mq3Lloyd), GgufFormat::Mq6);
+    }
+
+    #[test]
+    fn default_promote_target_hfq_family() {
+        assert_eq!(default_promote_target(GgufFormat::Hfq4), GgufFormat::Hfq6);
+        assert_eq!(default_promote_target(GgufFormat::Hfq6), GgufFormat::Hfq6);
+    }
+
+    #[test]
+    fn default_promote_target_fp4_noop() {
+        // No FP6 siblings — promote stays at base
+        assert_eq!(default_promote_target(GgufFormat::Hfp4), GgufFormat::Hfp4);
+        assert_eq!(default_promote_target(GgufFormat::Mfp4), GgufFormat::Mfp4);
+    }
+
+    #[test]
+    fn promote_pair_no_op_always_allowed() {
+        // base == promote is always supported (identity promotion)
+        for fmt in [GgufFormat::Mq2, GgufFormat::Mq3, GgufFormat::Mq4, GgufFormat::Mq6,
+                    GgufFormat::Mq2Lloyd, GgufFormat::Mq3Lloyd,
+                    GgufFormat::Hfq4, GgufFormat::Hfq6,
+                    GgufFormat::Hfp4, GgufFormat::Mfp4] {
+            assert!(is_promote_pair_supported(fmt, fmt), "{:?} → {:?} should be allowed", fmt, fmt);
+        }
+    }
+
+    #[test]
+    fn promote_pair_mq_upward_allowed() {
+        // The primary target: MQ3 base + MQ4 promote alternating
+        assert!(is_promote_pair_supported(GgufFormat::Mq3, GgufFormat::Mq4));
+        assert!(is_promote_pair_supported(GgufFormat::Mq3, GgufFormat::Mq6));
+        assert!(is_promote_pair_supported(GgufFormat::Mq4, GgufFormat::Mq6));
+        // MQ2 base + MQ3 promote (Future expansion section)
+        assert!(is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq3));
+        assert!(is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq4));
+        assert!(is_promote_pair_supported(GgufFormat::Mq2, GgufFormat::Mq6));
+        // Lloyd variants
+        assert!(is_promote_pair_supported(GgufFormat::Mq2Lloyd, GgufFormat::Mq3Lloyd));
+    }
+
+    #[test]
+    fn promote_pair_downward_rejected() {
+        // Promoting downward in bits is not a "promotion" — reject
+        assert!(!is_promote_pair_supported(GgufFormat::Mq6, GgufFormat::Mq3));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq6, GgufFormat::Mq4));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq4, GgufFormat::Mq3));
+        assert!(!is_promote_pair_supported(GgufFormat::Hfq6, GgufFormat::Hfq4));
+    }
+
+    #[test]
+    fn promote_pair_cross_family_rejected() {
+        // MQ ↔ HFQ ↔ FP4: different rotation families, runtime mixed-format
+        // dispatch is only same-family-safe (post-#257). Reject.
+        assert!(!is_promote_pair_supported(GgufFormat::Mq4, GgufFormat::Hfq6));
+        assert!(!is_promote_pair_supported(GgufFormat::Hfq4, GgufFormat::Mq6));
+        assert!(!is_promote_pair_supported(GgufFormat::Mq4, GgufFormat::Hfp4));
+        assert!(!is_promote_pair_supported(GgufFormat::Mfp4, GgufFormat::Mq6));
+    }
+
+    #[test]
+    fn kmap_promote_threading_default_mq6() {
+        // Default promote (no --kmap-promote) keeps MQ4→MQ6 mapping
+        let level = kmap_resolve_mode(
+            "model.layers.0.mlp.down_proj.weight", 40, false, 2, GgufFormat::Mq6,
+        );
+        assert_eq!(level, QuantLevel::Promote(GgufFormat::Mq6));
+    }
+
+    #[test]
+    fn kmap_promote_threading_explicit_mq4() {
+        // --kmap-promote mq4 on an MQ3 base: carries MQ4 in the variant
+        let level = kmap_resolve_mode(
+            "model.layers.0.mlp.down_proj.weight", 40, false, 2, GgufFormat::Mq4,
+        );
+        assert_eq!(level, QuantLevel::Promote(GgufFormat::Mq4));
+    }
+
+    #[test]
+    fn kmap_promote_threading_explicit_mq3() {
+        // --kmap-promote mq3 on an MQ2 base: carries MQ3
+        let level = kmap_resolve_mode(
+            "model.layers.0.mlp.down_proj.weight", 40, false, 2, GgufFormat::Mq3,
+        );
+        assert_eq!(level, QuantLevel::Promote(GgufFormat::Mq3));
+    }
 
     #[test]
     fn parse_layer_idx_safetensors_dense() {

--- a/docs/plans/configurable-kmap-pair.md
+++ b/docs/plans/configurable-kmap-pair.md
@@ -152,19 +152,31 @@ Accepted vocabulary: `q8`, `f16`, `mq4`, `mq6`, `mq3`, `hfq4`, `hfq6`, `mfp4`. *
 
 **Required code changes that arrive in this PR (not "preserve verbatim" — write fresh)**:
 
-(i) **Tied-embedding refusal**. Mirror the contract from CUDA branch commit `4b0693d6`:
+(i) **Tied-embedding refusal**. Implement the **hardened** version from CUDA branch commit `dbcb050` directly (skip the original `unwrap_or(false)` version at `4b0693d6` which silently treated missing config fields as untied):
 
 ```rust
-let tied_embed = config.get("tie_word_embeddings")
-    .or_else(|| config.get("text_config").and_then(|tc| tc.get("tie_word_embeddings")))
-    .and_then(|v| v.as_bool())
-    .unwrap_or(false);
-if tied_embed && !matches!(lm_head_format, GgufFormat::Q8 | GgufFormat::F16) {
-    abort("lm_head AWQ-scaling corrupts shared embed_tokens — refuse.");
+let tied_embed_field = config.get("tie_word_embeddings")
+    .or_else(|| config.get("text_config").and_then(|tc| tc.get("tie_word_embeddings")));
+match tied_embed_field.and_then(|v| v.as_bool()) {
+    Some(true) => abort("lm_head AWQ-scaling corrupts shared embed_tokens — refuse."),
+    Some(false) => { /* proceed */ }
+    None => abort(
+        "tie_word_embeddings field missing from both top-level config and \
+         text_config. Either add the field explicitly after verifying tied vs \
+         untied status, or untie the model first."
+    ),
 }
 ```
 
-Documented limitation (GLM5/Gemini §3): the `unwrap_or(false)` default catches the common case (`tie_word_embeddings: true|false` set in config). Models that omit the field but ARE tied silently default to "untied" and can corrupt. The CUDA branch accepts this risk; we inherit it. A pointer-alias scan beyond the config flag is **future hardening, out of scope here**.
+Verdict matrix per CUDA branch's plan §3.4:
+
+| Config state | Action |
+|---|---|
+| `tie_word_embeddings: true` | abort (would corrupt) |
+| `tie_word_embeddings: false` | proceed |
+| field missing from both top-level + text_config | **abort** (fail-loud, not fail-silent) |
+
+Residual risk (acknowledged on both branches, future work): a model whose config falsely says `tie_word_embeddings: false` but whose safetensors index actually shares storage between `lm_head.weight` and `embed_tokens.weight` would still corrupt. The architecturally correct fallback is a safetensors-structural scan (compare `data_offsets` across the manifest) — out of scope for both branches now, tracked.
 
 (ii) **awq_eligible whitelist extension**. `fn awq_eligible` in master does **not** include `lm_head.weight` / `output.weight` (GLM5 §3, verified at `main.rs::awq_eligible`). Without this fix, `--lm-head-format mq4 --awq` produces an MQ4 lm_head **without** AWQ pre-scaling, which the runtime will read as if it were AWQ-scaled once the CUDA branch's runtime lands — silent corruption. The fix: add `lm_head.weight` and `output.weight` to the F1 suffix set, gated on `--lm-head-format != Q8 && --awq`.
 
@@ -319,7 +331,7 @@ Coherence-gate (`scripts/coherence-gate.sh`) is **not** in this PR's acceptance 
 - **CUDA branch's runtime AWQ-aware lm_head dispatch doesn't ship within the next quarter**: per user, this is the CUDA branch owner's responsibility post-merge. Our Phase 1 produces files that error out at runtime (or are gated by UNSAFE) until that lands. If timeline slips significantly, escalate.
 - **Llama-arch port introduces subtle behavior changes**: although the same-dtype gate is byte-exact-no-op for uniform models, ~120 LOC of dispatch refactor in a less-touched file is non-trivial. Mitigation: run any existing llama smoke test (we have `smoke_llama_prefill_batch.rs`) before/after to confirm no drift.
 - **AWQ α=0.55 untuned for MQ3**: real risk. Phase 0 measures at default α; if KLD looks borderline, add an α∈{0.4, 0.5, 0.55, 0.6, 0.7} sweep on the winning kmap mode at n=20. Out of scope to do unconditionally.
-- **Tied-embedding default-untied behavior**: a model that omits `tie_word_embeddings` from config but is actually tied corrupts silently with `--lm-head-format mq4 --awq`. Documented limitation; matches CUDA branch's contract. Exhaustive pointer-alias check is future hardening.
+- **Tied-embedding via safetensors-structural alias (residual)**: post-CUDA-`dbcb050`, the config-flag check fails loudly when `tie_word_embeddings` is missing from both top-level + `text_config`. The remaining residual risk is a model whose config explicitly says `tie_word_embeddings: false` but whose safetensors index aliases the lm_head and embed_tokens storage anyway. The safetensors-structural scan (compare `data_offsets` across the manifest) is the architecturally correct fallback; out of scope for both branches now, tracked as future hardening.
 - **No new HIP kernel files**, but ~300 LOC of runtime dispatch wiring needs writing + testing. "No kernel work" is technically correct but misleading (GLM5 §15.4 — addressed by the §"Phase 2 perf impact estimate" + §"Phase 2 sequencing" tables).
 
 ## Out of scope (this PR)

--- a/docs/plans/configurable-kmap-pair.md
+++ b/docs/plans/configurable-kmap-pair.md
@@ -419,23 +419,29 @@ Companion PR; not standalone.
 
 ## Coordination with `feat/mq-v2-quant-format-cuda`
 
-Our work lands first; their branch merges ours and implements the runtime-side AWQ-aware lm_head + vision dispatch. Touch-points:
+**Ownership is explicitly partitioned** (confirmed with CUDA-branch agent 2026-05-18):
+- **We own the CLI surface** (`--kmap-promote`, `--lm-head-format`) — no work in flight from the CUDA side on these flags.
+- **They own the AWQ-aware runtime kernels** (lm_head dispatch — their Phase 2 with gfx1151 investigation underway; vision-tower kernels — their Phase 3).
+
+Our work lands first; their branch merges ours and implements the runtime-side AWQ-aware lm_head + vision dispatch.
 
 | Surface | This PR | CUDA branch (post-merge) | Final state |
 |---|---|---|---|
+| `--kmap-promote <fmt>` CLI | added | inherited | canonical |
 | `--lm-head-format <fmt>` CLI | added | inherited | canonical |
 | `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ` env var | deprecated-alias-with-warning | removed | gone |
-| Tied-embed refusal check | written fresh | reused | canonical |
+| Tied-embed refusal check (hardened per `dbcb050`) | written fresh | reused | canonical |
 | `awq_eligible` lm_head extension | written fresh | reused | canonical |
-| `HIPFIRE_LM_HEAD_AWQ_UNSAFE` gate | introduced | removed when runtime lands | gone after runtime PR |
+| `HIPFIRE_LM_HEAD_AWQ_UNSAFE` gate | introduced | removed when runtime lands | gone after their lm_head PR |
+| AWQ-aware lm_head runtime kernels | **out of scope** | their Phase 2 (gfx1151 investigation in flight) | canonical |
 | `--vision-format` CLI | **not added** (phased out) | added by them with runtime | canonical |
 | `HIPFIRE_VISION_AWQ_UNSAFE` gate | **not introduced** here | introduced + removed in same PR | n/a from our side |
 | Vision hessian-collector | reuse their suffix list (mirror `gptq_gpu_pkg/names.py` in Rust when we add `--vision-format`) | unchanged | canonical |
+| AWQ-aware vision runtime kernels | **out of scope** | their Phase 3 | canonical |
 | GPTQ manifest format (`--precomputed-gptq-path`) | unchanged | extended for new formats | canonical |
 
-When CUDA's Phase 3 runtime PR lands:
+When their lm_head runtime PR lands:
 1. The `HIPFIRE_LM_HEAD_AWQ_UNSAFE` requirement drops; their PR includes the gate removal.
-2. The default of `--lm-head-format` can flip from `q8` to `mq4` if their n=512 NLL paired-t shows a strict win (per their §1.2 acceptance).
-3. `--vision-format` ships in the same PR.
+2. The default of `--lm-head-format` can flip from `q8` to `mq4` if their n=512 NLL paired-t shows a strict win (per their `gptq_lm_head_awq.md` §1.2 acceptance).
 
-Notify the CUDA-branch owner once Phase 1 is in flight so we don't duplicate gate-naming.
+When their vision Phase 3 runtime PR lands, `--vision-format` ships in the same PR.

--- a/docs/plans/configurable-kmap-pair.md
+++ b/docs/plans/configurable-kmap-pair.md
@@ -32,39 +32,56 @@ Three independent gaps in the current quantizer CLI:
 
 The 4B-MQ3+AWQ+GPTQ result demonstrates MQ3-base + AWQ is empirically viable. Cross-family mixed-format dispatch (`HFQ4+HFQ6 ↔ MQ4+MQ6`) was validated by the user post-#257 (works but at high bpw). The mechanism #257 added (`qkv_same_dtype` + `batched_gemm_single_weight`) is the same mechanism this plan extends: adding MQ3 to that helper's match arms is the only runtime change for the primary target.
 
-## Phase 0 — research (mandatory; results gate the recommendation)
+## Phase 0 — research (results gate the recommendation)
 
-Smaller than the previous MQ2-Lloyd-led sweep because MQ3+MQ4 doesn't need kernel work — only runtime dispatch wiring. Tighter Pareto gate.
+**Phase 0 splits into two parts.** Most of the anchor measurements the original plan asked for are **already done** in the `data/kld-measurements` branch (`docs/plans/kld-measurements-master.md`). Phase 0a is the gap-fill + reproducibility smoke that can run immediately; Phase 0b is the MQ3+MQ4 kmap sweep, which is **blocked on Phase 1 CLI** (the sweep produces alternating quants via `--kmap-promote`, which doesn't exist until Phase 1 lands). The original sequencing ("Phase 0 mandatory before Phase 1") was internally contradictory — the CLI is the prerequisite for the sweep.
 
-Deliverables:
-1. **Reproducibility check (anchor)**: re-run `eval_hipfire` at q8 KV n=20 on `qwen3.5-9b.mq4-kmd2-q8conv1d`. Confirms post-#257 baseline (`KLD=0.155438, NLL=2.220, PPL=9.207`) reproduces before sweeping. Drift > 0 here means the gfx1151 environment changed and Phase 0 is unreliable until investigated.
-2. **MQ3-uniform-AWQ at 9B + 27B**: `qwen3.5-{9b,27b}.mq3 --awq`, eval at q8 KV n=20. Sets the floor.
-3. **MQ4-uniform-AWQ at 9B + 27B**: `qwen3.5-{9b,27b}.mq4 --awq`, eval at q8 KV n=20. Sets the ceiling.
-4. **kmap-mode sweep at 27B**: three quants `--format mq3 --kmap-promote mq4 --awq --kmap-dense --kmap-mode {0,1,2}`. Eval at q8 KV n=20. Selection criterion: **lowest mean KLD with `NLL paired-t < -3` vs MQ3-uniform-AWQ** (statistically significant improvement; per master-doc §6 rule 9 paired-t is the primary NLL test). Ties broken by lowest p99 KLD. Record seeds: AWQ calibration uses the calibration set fixed in `main.rs::AWQ_ALPHA` (default α=0.55); no other randomness.
-5. **27B n=512 finale** on the winning mode. The gating number.
+References (KLD master doc):
+- 9B kldref: `/data/hipfire/qwen3.5-9b-bf16.kldref.bin`
+- 27B kldref: `/data/hipfire-refs/qwen3.6-27b-bf16.kldref.bin` (sha256 `8af83b38…`, 2.48 GB, HF mirror at `hipfire-models/qwen-kldref`)
+- 27B model family is **Qwen3.6-27B**, not Qwen3.5-27B (the latter ships only as `tclf90/Qwen3.5-27B-AWQ` pre-quantized; the BF16 source is Qwen3.6 at `/data/cache/huggingface/hub/models--Qwen--Qwen3.6-27B/snapshots/...`).
 
-**Pareto hard gate** for "recommend MQ3+MQ4 as a config":
-- Mean KLD on the winning mode at n=512 ≤ uniform-MQ4-AWQ KLD + 0.05 (within 0.05 of the more-expensive uniform variant), **AND**
-- Bpw saving ≥ 0.4 bpw vs uniform MQ4.
+### Phase 0a — gap-fill + smoke (runs immediately)
 
-Outcomes:
-| n=512 KLD vs uniform MQ4 | Bpw saving | Action |
+| Anchor | Existing measurement (data branch) | Status |
+|---|---|---|
+| 9B kmd2 baseline (kmd2 alone) | §1.1g — KLD 0.1613 @ n=512 gfx1151 kv-q8 | ✅ matches our #257's 0.155438 within drift; re-run as smoke (~5 min) |
+| 9B MQ3-uniform-AWQ-GPTQ (floor) | §1.4 — `mq3-awq-gptq-kvq8-c256` = **0.1967** @ n=256 gfx1151 | ✅ cite, no new work |
+| 9B MQ4-uniform-AWQ-GPTQ (ceiling) | §1.1j — `mq4-awq-gptq-f2-q8head` = **0.1727** @ n=256 gfx1100 | ✅ cite |
+| 27B MQ4-uniform-AWQ-GPTQ (ceiling) | §3.2 — `mq4-awq-gptq-f2-q8head-v100` = **0.1257** @ n=256 gfx1100 | ✅ cite. CUDA pipeline's incoming 27B uniform-MQ4 reproduces this on gfx1151 (per-arch confirmation). |
+| **27B MQ3-uniform-AWQ-GPTQ (floor)** | **not measured anywhere** | ❌ **gap-fill**: CUDA pipeline has this enqueued after MQ4 |
+| Per-arch reproducibility on gfx1151 | most anchors are gfx1100; cohort §1.4 is gfx1151 | partial — eval the incoming 27B quants on gfx1151 |
+
+**Phase 0a deliverables**:
+1. **kmd2 reproducibility smoke**: re-run `eval_hipfire` at q8 KV n=20 on `qwen3.5-9b.mq4-kmd2-q8conv1d`. Confirms post-#257 baseline reproduces on current master. Drift > 0 means the env shifted; investigate before any sweep.
+2. **27B MQ4-uniform-AWQ-GPTQ on gfx1151** (when CUDA pipeline delivers): eval at n=20 first, n=512 second. Confirms §3.2's 0.1257 reproduces on bench arch; the n=512 number becomes the canonical 27B MQ4 ceiling for our gate.
+3. **27B MQ3-uniform-AWQ-GPTQ on gfx1151** (when CUDA pipeline delivers, enqueued after MQ4): eval at n=20. Fills the missing 27B floor anchor.
+
+GPU time: ~5 min (smoke) + ~12 min + ~5 hours (27B MQ4 n=20 + n=512) + ~12 min (27B MQ3 n=20). The dominant cost is the 27B n=512 final — single overnight batch.
+
+### Phase 0b — kmap-mode sweep (blocked on Phase 1 CLI)
+
+When Phase 1 ships `--kmap-promote`:
+4. **Sweep**: three quants `--format mq3 --kmap-promote mq4 --awq --kmap-dense --kmap-mode {0,1,2}`. AWQ at default α=0.55. GPTQ if the CUDA pipeline's `--precomputed-gptq-path` is available. Eval each at q8 KV n=20 on gfx1151.
+5. **Selection criterion**: lowest mean KLD with `NLL paired-t < -3` vs the Phase 0a 27B-MQ3-uniform baseline (statistically significant improvement; per master-doc §6 rule 9 paired-t is the primary NLL test). Ties broken by lowest p99 KLD. AWQ calibration is deterministic against a fixed input set (`AWQ_ALPHA` env var); no random-seed control needed.
+6. **27B n=512 finale** on the winner. The gating number.
+
+GPU time: ~3 hours quantize (3 × 27B at ~30 min) + ~30 min n=20 evals + ~5 hours n=512 finale ≈ ~9 hours.
+
+### Pareto hard gate (applies to Phase 0c finale)
+
+| n=512 KLD on winning mode vs **27B MQ4 ceiling** (`0.1257` or its re-confirmed gfx1151 value) | Bpw saving vs uniform MQ4 | Action |
 |---|---|---|
 | within +0.05 | ≥ 0.4 | **Recommended default config.** Ship CLI; flip docs to MQ3+MQ4-AWQ. |
 | within +0.05 | < 0.4 | Ship CLI; document but don't recommend (uniform MQ4 dominates). |
 | > +0.05 | ≥ 0.4 | Ship CLI as opt-in research config; don't ship as default. |
 | > +0.05 | < 0.4 | Ship CLI as plumbing only; explicitly warn against the pair. |
 
-**Total Phase 0 GPU time on gfx1151**: dominated by quantize + n=512 final, not eval iterations. Honest breakdown:
-- 9B n=20 evals: 3 × ~5 min ≈ 15 min
-- 27B n=20 evals: 3 + 3 = 6 × ~12 min ≈ 72 min
-- 27B quantize: 6 quants × ~30 min ≈ 3 hours
-- 27B n=512 final: ~5 hours (scaled from 9B's 104 min)
-- **~9 hours total**, single overnight batch.
+Output: `docs/perf-checkpoints/<date>-mq3-mq4-awq-kmap-sweep.md` with the per-mode numbers + Pareto-gate decision.
 
-GPTQ track: if `feat/mq-v2-quant-format-cuda`'s GPTQ pipeline is runtime-validated at 27B by Phase 0 time, repeat (2-5) with GPTQ. **Phase 0's gate stays AWQ-only**; GPTQ is a strict improvement layered on top, recorded but not blocking.
+### Parallelism note
 
-Output: `docs/perf-checkpoints/<date>-mq3-mq4-awq-kmap-sweep.md` with the numbers + the Pareto-gate decision.
+Phase 0a (gap-fill) and Phase 1 (CLI) can run in parallel — they touch disjoint surfaces (eval scripts vs `main.rs` CLI). When Phase 1 lands AND Phase 0a delivers the 27B floor, Phase 0b/0c become unblocked.
 
 ## Phase 1 — quantizer CLI (ships standalone)
 

--- a/docs/plans/configurable-kmap-pair.md
+++ b/docs/plans/configurable-kmap-pair.md
@@ -441,7 +441,24 @@ Our work lands first; their branch merges ours and implements the runtime-side A
 | GPTQ manifest format (`--precomputed-gptq-path`) | unchanged | extended for new formats | canonical |
 
 When their lm_head runtime PR lands:
-1. The `HIPFIRE_LM_HEAD_AWQ_UNSAFE` requirement drops; their PR includes the gate removal.
+1. The `HIPFIRE_LM_HEAD_AWQ_UNSAFE` requirement drops; this happens in a **follow-up PR** after the runtime side merges, not in the runtime PR itself (verified against PR #292's description — the runtime PR explicitly does not touch the gate since the gate doesn't exist on master yet).
 2. The default of `--lm-head-format` can flip from `q8` to `mq4` if their n=512 NLL paired-t shows a strict win (per their `gptq_lm_head_awq.md` §1.2 acceptance).
 
 When their vision Phase 3 runtime PR lands, `--vision-format` ships in the same PR.
+
+### Runtime coordination — concrete PR pointers (2026-05-18)
+
+The CUDA-branch's runtime-side AWQ-aware lm_head work has materialized as a two-PR stack against `master`, independent of `feat/mq-v2-quant-format-cuda`:
+
+| PR | Branch | Role |
+|---|---|---|
+| #290 | `fix/mq3-awq-loader` | Loader: parse + attach `awq_scale` sidecars for MQ3G256, centralize the gate. |
+| #292 | `fix/lm-head-awq-runtime` | Dispatch: wires AWQ-aware rotation into the 8 lm_head sites in `speculative.rs` + DFlash. Stacks on #290. |
+
+Merge order:
+1. **#290 lands first** (or rebases on master after #292 follow-ups).
+2. **#292 lands next** (acceptance-blocked on a `qwen3.5-9b.mq4-awq-gptq-f2-lmhead-a100.hfq` artifact from the CUDA pipeline; PR is in draft).
+3. **Our PR (`feat/configurable-kmap-pair`)** lands — introduces `HIPFIRE_LM_HEAD_AWQ_UNSAFE` for forward compatibility.
+4. **Follow-up PR drops the `HIPFIRE_LM_HEAD_AWQ_UNSAFE` gate** once the loader (#290) + dispatch (#292) are both on master. This PR is small (delete the env-var check in `main.rs`); it can be cut as soon as the merge order above completes.
+
+This sequence is robust to our PR landing before, after, or interleaved with #290/#292 — the gate is opt-in by default, so a `.hfq` produced with the gate set is loadable by old daemons (refuses with a clear error) and by new daemons (works because the runtime now consumes the sidecar). The gate-drop follow-up only flips the default, it doesn't change file format.

--- a/docs/plans/configurable-kmap-pair.md
+++ b/docs/plans/configurable-kmap-pair.md
@@ -1,0 +1,412 @@
+# Configurable kmap pair + per-tensor lm_head quant — `--kmap-promote`, `--lm-head-format`
+
+**Branch:** `feat/configurable-kmap-pair`.
+**Primary target:** MQ3+MQ4 alternating dense quant with AWQ. The 4B-MQ3+AWQ+GPTQ result (mean KLD 0.197, p99 9.7, PPL 11.65) survived where uniform sub-4-bit PTQ usually collapses; the hypothesis is that at 9B/27B the same recipe + kmap promotion of a few precision-sensitive tensors to MQ4 produces a meaningfully cheaper Pareto point than uniform MQ4 with comparable quality.
+**Companion configurability:** independent `lm_head` format selection (currently force-Q8 in `kmap_resolve_mode` rule 2).
+**Vision encoder:** **explicitly deferred to a follow-up plan** — vision-tower runtime has no AWQ-aware kernel dispatch today (`hipfire-arch-qwen35-vl` calls `gemm_f16` only), and shipping a CLI flag that produces unloadable models is a foot-shoot. Vision quantization is the CUDA branch's Phase 3 (`gptq_lm_head_awq.md §3.3`); we add `--vision-format` in the same PR that lands their vision runtime.
+**Targets:** gfx906, gfx1010–1102, gfx1100–1102, gfx1150–1152, gfx1200–1201 (per-arch fast-path coverage of each constituent format).
+**Companion branch coordination:** `feat/mq-v2-quant-format-cuda` is concurrently developing AWQ on lm_head + vision. **This branch lands first and is the canonical CLI surface.** The CUDA branch then merges our work and implements the AWQ-aware runtime kernels for lm_head (their Phase 3); the env-var path they had on their branch (`HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ`) is replaced by our `--lm-head-format` flag in the merge.
+
+*Plan folds three adversarial reviews: Claude self-review, GLM5, Gemini. Rev files dropped after fold-in per the memory rule.*
+
+## Reference disambiguation: what exists where
+
+A `kmap_resolve_mode` extension was prototyped on `feat/mq-v2-quant-format-cuda` (commits `4b0693d6` for lm_head, `2e06a649` for hessian-collector). **None of this is in `master` today.** When this plan references "the CUDA branch's safety check" or "the CUDA branch's awq_eligible modification", those refer to code on that branch that **must arrive in our PR via re-implementation** — either we write it fresh in this branch, or we wait for CUDA to merge first and rebase (current decision: we land first, so we write it fresh).
+
+Specifically:
+- `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ`, `HIPFIRE_LM_HEAD_AWQ_UNSAFE` — env vars on CUDA branch only.
+- `awq_eligible` whitelist (`main.rs::awq_eligible`) **does not include** `lm_head.weight` or `output.weight` in master (GLM5 §3, verified). Must be added in our Phase 1.
+- `docs/plans/gptq_lm_head_awq.md` — on CUDA branch only; we mirror their tied-embedding safety contract.
+
+All line numbers in this plan are anchored to function names (`fn kmap_resolve_mode`, `fn awq_eligible`, `fn batched_gemm_single_weight`) since line numbers drift between commits.
+
+## Why
+
+Three independent gaps in the current quantizer CLI:
+
+1. **Promote target is hardcoded to MQ6** — `QuantLevel::Promote6` (`fn kmap_resolve_mode` returns this for promoted tensors; the dispatcher in `run_safetensors_pipeline` / `run_gguf_pipeline` maps it unconditionally to `quantize_mq6g256`). `--format mq3 --kmap-dense --kmap-mode 2` produces MQ3+MQ6, not MQ3+MQ4. No CLI path today produces an MQ3+MQ4 alternating quant.
+
+2. **lm_head is hardcoded to Q8** — `fn kmap_resolve_mode` rule 2 force-promotes `lm_head.weight` / `output.weight` to Q8 regardless of `--format`. No way to pick e.g. MQ4 lm_head when the dense model is MQ3-base.
+
+3. **awq_eligible whitelist excludes lm_head** — `fn awq_eligible` matches by suffix against `q_proj.weight`, `gate_proj.weight`, `o_proj.weight`, `down_proj.weight`, etc. `lm_head.weight` matches none. Even if rule 2 were relaxed, AWQ pre-scaling would silently not apply.
+
+The 4B-MQ3+AWQ+GPTQ result demonstrates MQ3-base + AWQ is empirically viable. Cross-family mixed-format dispatch (`HFQ4+HFQ6 ↔ MQ4+MQ6`) was validated by the user post-#257 (works but at high bpw). The mechanism #257 added (`qkv_same_dtype` + `batched_gemm_single_weight`) is the same mechanism this plan extends: adding MQ3 to that helper's match arms is the only runtime change for the primary target.
+
+## Phase 0 — research (mandatory; results gate the recommendation)
+
+Smaller than the previous MQ2-Lloyd-led sweep because MQ3+MQ4 doesn't need kernel work — only runtime dispatch wiring. Tighter Pareto gate.
+
+Deliverables:
+1. **Reproducibility check (anchor)**: re-run `eval_hipfire` at q8 KV n=20 on `qwen3.5-9b.mq4-kmd2-q8conv1d`. Confirms post-#257 baseline (`KLD=0.155438, NLL=2.220, PPL=9.207`) reproduces before sweeping. Drift > 0 here means the gfx1151 environment changed and Phase 0 is unreliable until investigated.
+2. **MQ3-uniform-AWQ at 9B + 27B**: `qwen3.5-{9b,27b}.mq3 --awq`, eval at q8 KV n=20. Sets the floor.
+3. **MQ4-uniform-AWQ at 9B + 27B**: `qwen3.5-{9b,27b}.mq4 --awq`, eval at q8 KV n=20. Sets the ceiling.
+4. **kmap-mode sweep at 27B**: three quants `--format mq3 --kmap-promote mq4 --awq --kmap-dense --kmap-mode {0,1,2}`. Eval at q8 KV n=20. Selection criterion: **lowest mean KLD with `NLL paired-t < -3` vs MQ3-uniform-AWQ** (statistically significant improvement; per master-doc §6 rule 9 paired-t is the primary NLL test). Ties broken by lowest p99 KLD. Record seeds: AWQ calibration uses the calibration set fixed in `main.rs::AWQ_ALPHA` (default α=0.55); no other randomness.
+5. **27B n=512 finale** on the winning mode. The gating number.
+
+**Pareto hard gate** for "recommend MQ3+MQ4 as a config":
+- Mean KLD on the winning mode at n=512 ≤ uniform-MQ4-AWQ KLD + 0.05 (within 0.05 of the more-expensive uniform variant), **AND**
+- Bpw saving ≥ 0.4 bpw vs uniform MQ4.
+
+Outcomes:
+| n=512 KLD vs uniform MQ4 | Bpw saving | Action |
+|---|---|---|
+| within +0.05 | ≥ 0.4 | **Recommended default config.** Ship CLI; flip docs to MQ3+MQ4-AWQ. |
+| within +0.05 | < 0.4 | Ship CLI; document but don't recommend (uniform MQ4 dominates). |
+| > +0.05 | ≥ 0.4 | Ship CLI as opt-in research config; don't ship as default. |
+| > +0.05 | < 0.4 | Ship CLI as plumbing only; explicitly warn against the pair. |
+
+**Total Phase 0 GPU time on gfx1151**: dominated by quantize + n=512 final, not eval iterations. Honest breakdown:
+- 9B n=20 evals: 3 × ~5 min ≈ 15 min
+- 27B n=20 evals: 3 + 3 = 6 × ~12 min ≈ 72 min
+- 27B quantize: 6 quants × ~30 min ≈ 3 hours
+- 27B n=512 final: ~5 hours (scaled from 9B's 104 min)
+- **~9 hours total**, single overnight batch.
+
+GPTQ track: if `feat/mq-v2-quant-format-cuda`'s GPTQ pipeline is runtime-validated at 27B by Phase 0 time, repeat (2-5) with GPTQ. **Phase 0's gate stays AWQ-only**; GPTQ is a strict improvement layered on top, recorded but not blocking.
+
+Output: `docs/perf-checkpoints/<date>-mq3-mq4-awq-kmap-sweep.md` with the numbers + the Pareto-gate decision.
+
+## Phase 1 — quantizer CLI (ships standalone)
+
+### `QuantLevel` enum redesign (committed design)
+
+Replace the current 4-variant enum:
+
+```rust
+enum QuantLevel {
+    F16,
+    Q8,
+    Promote(GgufFormat),       // was: Promote6 — carries the promote target
+    Override(GgufFormat),      // NEW — for lm_head when --lm-head-format != Q8
+    Base,                      // use --format as-is
+}
+```
+
+`Override` is taken first in the dispatcher's match chain (precedence below); `Promote` second. The dispatcher in `run_safetensors_pipeline` / `run_gguf_pipeline` matches on the carried `GgufFormat` and dispatches to the corresponding `quantize_*g256` function.
+
+### Dispatcher precedence in `fn kmap_resolve_mode` (committed)
+
+Explicit ordering after the rewrite:
+
+```
+1. Norms / 1D tensors          → F16
+2. lm_head / output            → IF --lm-head-format != Q8 then Override(fmt)
+                                  ELSE Q8
+3. token_embd / embed_tokens   → Q8 (unchanged; embeddings are out of scope —
+                                  see §"Embeddings are intentionally untouched")
+4. MoE router                  → Q8
+5. MoE expert (mode-gated)     → Promote(--kmap-promote)
+6. Dense (mode-gated)          → Promote(--kmap-promote) per kmap-mode rules
+7. default                     → Base
+```
+
+### 1a. `--kmap-promote <fmt>` — decouples promote target from MQ6
+
+```
+hipfire-quantize --format mq3 --kmap-promote mq4 --kmap-dense --kmap-mode 2 --awq
+```
+
+Default: `mq6` (preserves current behavior byte-for-byte — kmd2 stays kmd2).
+
+**Explicit promote-pair allowlist** (replaces the original plan's vague "bit-width ≥ base" rule per GLM5 §8):
+
+| Base | Allowed `--kmap-promote` targets |
+|---|---|
+| `mq2`, `mq2-lloyd` | `mq3`, `mq3-lloyd`, `mq4`, `mq6` |
+| `mq3`, `mq3-lloyd` | `mq4`, `mq6` |
+| `mq4` | `mq6` |
+| `hfq4` | `hfq6` |
+| `mfp4` | `mfp4` (no-op; no FP6 sibling) |
+| Same value as base | always allowed (no-op promotion; useful for testing) |
+
+Reject every other combination at parse time with a clear error citing this table. Cross-family promotions (e.g. MQ→HFQ, MQ→HFP) are not in the allowlist because the runtime mixed-format dispatch hasn't been validated across families (only same-rotation-family per the `batched_gemm_single_weight` docstring tightened in #257's last commit).
+
+Wiring: `QuantLevel::Promote6` → `QuantLevel::Promote(GgufFormat)`. Every match arm currently matching `Promote6` (there are ~5 sites; ~47 `Promote6` references but most are simple usage) gets the carried format. The dispatcher in the quantize pipeline reads the carried format and dispatches to the right `quantize_*g256`.
+
+### 1b. `--lm-head-format <fmt>` — picks lm_head target
+
+```
+hipfire-quantize --format mq3 --kmap-promote mq4 --lm-head-format mq4 --awq
+```
+
+Default: `q8` (preserves current behavior).
+
+Accepted vocabulary: `q8`, `f16`, `mq4`, `mq6`, `mq3`, `hfq4`, `hfq6`, `mfp4`. **F16 is included** (per GLM5 §9 — useful for small models where lm_head is a negligible fraction of total parameters and zero quality loss is preferred).
+
+**Required code changes that arrive in this PR (not "preserve verbatim" — write fresh)**:
+
+(i) **Tied-embedding refusal**. Mirror the contract from CUDA branch commit `4b0693d6`:
+
+```rust
+let tied_embed = config.get("tie_word_embeddings")
+    .or_else(|| config.get("text_config").and_then(|tc| tc.get("tie_word_embeddings")))
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
+if tied_embed && !matches!(lm_head_format, GgufFormat::Q8 | GgufFormat::F16) {
+    abort("lm_head AWQ-scaling corrupts shared embed_tokens — refuse.");
+}
+```
+
+Documented limitation (GLM5/Gemini §3): the `unwrap_or(false)` default catches the common case (`tie_word_embeddings: true|false` set in config). Models that omit the field but ARE tied silently default to "untied" and can corrupt. The CUDA branch accepts this risk; we inherit it. A pointer-alias scan beyond the config flag is **future hardening, out of scope here**.
+
+(ii) **awq_eligible whitelist extension**. `fn awq_eligible` in master does **not** include `lm_head.weight` / `output.weight` (GLM5 §3, verified at `main.rs::awq_eligible`). Without this fix, `--lm-head-format mq4 --awq` produces an MQ4 lm_head **without** AWQ pre-scaling, which the runtime will read as if it were AWQ-scaled once the CUDA branch's runtime lands — silent corruption. The fix: add `lm_head.weight` and `output.weight` to the F1 suffix set, gated on `--lm-head-format != Q8 && --awq`.
+
+(iii) **UNSAFE runtime gate**. Any non-Q8 non-F16 `--lm-head-format` requires `HIPFIRE_LM_HEAD_AWQ_UNSAFE=1` (env var introduced fresh in this PR; not yet in master). Without the gate set: refuse to quantize. The gate disappears when the CUDA branch's runtime-side AWQ-aware lm_head dispatch lands (their PR drops the gate requirement in lockstep with our env-var removal).
+
+(iv) **CUDA env-var deprecation** (per user instruction). `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ=1` continues to work as a deprecated alias for `--lm-head-format mq4` for one release cycle, with a `eprintln!("deprecation:...")` warning at startup when set. The CUDA branch owner has confirmed deprecation is acceptable; the env var is removed in the next release after merge.
+
+**Quality-uncharacterized warning**: `--lm-head-format mq4` without `--awq` is allowed but emits a startup warning that lm_head quality at sub-Q8 without AWQ is uncharacterized. (GLM5 §9.)
+
+### 1c. Vision encoder — **phased out of this PR**
+
+Per the user instruction and Gemini §2. The vision tower's forward pass calls `gpu.gemm_f16(...)` only (`hipfire-arch-qwen35-vl`); shipping a `--vision-format` flag that produces models the runtime can't load is a silent-corruption trap regardless of UNSAFE gating.
+
+**`--vision-format` lands when the CUDA branch's Phase 3 vision runtime lands**, in the same PR that adds the vision-tower AWQ-aware dispatch. Our hessian-collector / `awq_eligible` infrastructure is forward-compatible; the missing piece is the runtime kernel side.
+
+Tracked in §"Future expansion".
+
+### Tests
+
+Unit (extend `mod tests` near the end of `main.rs`):
+- New `Promote(GgufFormat)` paths for each (base, promote) pair in the allowlist.
+- `Override(GgufFormat)` paths for each accepted `--lm-head-format` value.
+- Promote-pair allowlist rejection: `--format mq6 --kmap-promote mq3` exits non-zero with the canonical error.
+- Tied-embed refusal: `--lm-head-format mq4` on a config with `tie_word_embeddings: true` exits non-zero.
+- UNSAFE gate sequencing: `--lm-head-format mq4 --awq` without `HIPFIRE_LM_HEAD_AWQ_UNSAFE=1` exits non-zero.
+- `awq_eligible("lm_head.weight")` returns true when `--lm-head-format != Q8 && --awq`; false otherwise.
+- CUDA env-var alias: `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ=1` produces equivalent output to `--lm-head-format mq4` + emits the deprecation warning.
+
+End-to-end:
+- For each canonical configuration, quantize a tiny test model, decode via `dump_meta`, confirm per-tensor `quant_type` matches expectations.
+
+**Phase 1 is shippable on its own** for the `--kmap-promote` flag and the F16-lm_head case. Non-Q8 non-F16 lm_head requires Phase 2 (no runtime change needed) AND the CUDA branch's runtime work to drop the UNSAFE gate.
+
+## Phase 2 — runtime gap analysis + closures for MQ3+MQ4
+
+### What MQ3+MQ4 alternating actually needs at runtime
+
+Walking the **8 dispatch clusters** (GLM5 §5 was correct) in `qwen35.rs`, for `--format mq3 --kmap-promote mq4 --kmap-dense --kmap-mode 2` on Qwen3.5-9B/27B:
+
+| Layer / role | weights | Promoted by mode 2? | Fused kernel uniform? | Runtime status |
+|---|---|---|---|---|
+| DN-attn QKVZA | all MQ3 | no | ✅ `gemm_qkvza_hfq3g256_wmma` | works |
+| DN-attn wo | MQ3 | no | ✅ `gemm_hfq3g256_residual_wmma` | works |
+| DN-FFN gate+up | MQ3 + MQ3 | no | ✅ `gemm_gate_up_hfq3g256_wmma` | works |
+| DN-FFN w_down | MQ4 (promoted) | yes | ✅ `gemm_hfq4g256_residual` | works |
+| FA-attn QKV | wq=MQ3, wk=MQ3, **wv=MQ4** | yes (v_proj) | ❌ mixed → fallback | **MQ3 arm needed in `batched_gemm_single_weight`** |
+| FA-attn wo | MQ3 | no | ✅ works | works |
+| FA-FFN gate+up | MQ3 + MQ3 | no | ✅ works | works |
+| FA-FFN w_down | MQ4 (promoted) | yes | ✅ works | works |
+
+**The only runtime gap for the primary target is the MQ3 arm in `batched_gemm_single_weight`.** Same shape as the MQ6 arm: pre-zero Y on the active stream, call `gemm_hfq3g256_residual_wmma`. ~25 LOC.
+
+### Non-WMMA-arch reachability check (GLM5 §6)
+
+`gemm_hfq3g256_residual_wmma` is WMMA-only (gfx11/gfx12). GLM5 §6 raised whether the new MQ3 arm could be reached on non-WMMA arches (gfx906, gfx10).
+
+**Verified path**:
+- `fn is_batchable_la` in `qwen35.rs` excludes `MQ3G256` on non-WMMA arches (the `mq3_uniform_with_wmma` predicate gates strictly on gfx11/12).
+- When `is_batchable_la` returns false for any weight in the model, `forward_prefill_batch_with_pbs` takes the per-token decode fallback at the top of the function. This bypasses `forward_prefill_chunk` and therefore bypasses `batched_gemm_single_weight` entirely.
+- Result: on gfx906/gfx10 with an MQ3+MQ4 model, the model loads, runs via per-token decode (gemv-based), is correct but slow. `batched_gemm_single_weight` is **not reached**.
+
+**Defensive belt-and-suspenders**: the new MQ3 arm in `batched_gemm_single_weight` adds an arch check at entry — if the running arch doesn't have WMMA, return an error explaining that the caller should have routed through per-token decode. Costs nothing if unreachable; loud failure if a future refactor breaks the assumption. ~5 LOC.
+
+### Latent gaps closed in this PR (defense-in-depth)
+
+Two latent #249-class bugs that don't block MQ3+MQ4 today but are reachable through future kmap configurations:
+
+- **DeltaNet QKVZA 4-way (Cluster 1)**: same stride-mismatch class if a future kmap promotes anything in `linear_attn.in_proj_*`. Add `qkvza_same_dtype` gate.
+- **FFN gate+up 2-way (Clusters 3, 5)**: same class if future kmap promotes only one of `mlp.gate_proj` / `mlp.up_proj`. Add `gate_up_same_dtype` gate.
+
+`gate_up_same_dtype` does not exist in the codebase today (GLM5 §4, verified by grep). `qkvza_same_dtype` likewise. Both are net-new code in this PR.
+
+Per GLM5 §11, we add **explicit tests** for these gates in Phase 3's poison battery — synthesize a mixed-dtype layer through a unit test (no model needed) and assert the gate fires and the fallback dispatch runs. Without those tests the gates are bitrot risk.
+
+### Llama-arch port — **mandatory** in this PR (Gemini §6)
+
+`hipfire-runtime/src/llama.rs` has ~30 dispatch sites mirroring `qwen35.rs`. **`--kmap-dense` applies to GGUF/Llama models** (verified at `fn run_gguf_pipeline` in `main.rs` — the kmap gate doesn't exclude llama-arch). A user running `hipfire-quantize --format mq3 --kmap-promote mq4 --kmap-dense --kmap-mode 2` on a Llama GGUF gets a mixed-format model that the llama-runtime would NaN on (same #249 stride mismatch in the fused QKV).
+
+This makes the Llama port mandatory — we can't ship `--kmap-promote` for GGUF without it. ~120 LOC including the `qkv_same_dtype` gate + `batched_gemm_single_weight` (lifted from qwen35.rs as a shared helper, or duplicated; see §"Refactor opportunity" below).
+
+### qwen35-vl
+
+`hipfire-arch-qwen35-vl` reuses the qwen35 layer dispatch for the language tower; the vision tower has its own forward path (using `gpu.gemm_f16` only). For VL models with non-vision kmap, the language tower goes through qwen35.rs's now-patched dispatch. Vision tower is out of scope (deferred to CUDA branch's Phase 3).
+
+### Refactor opportunity (Gemini §5)
+
+Gemini suggested extracting `kmap_resolve` into a `kmap.rs` module before adding flags. **Rejected as scope creep** — the right refactor is to extract `batched_gemm_single_weight` into a crate-level helper that qwen35.rs and llama.rs both consume (avoiding duplication for the mandatory Llama port). That's the actual code-deduplication win for this PR. Note as a Phase 2 sub-task.
+
+### Phase 2 perf impact estimate (GLM5 §15.5)
+
+From #249 analysis (memo on the merged PR): mixed-format fallback adds ~3 launches + 1 memset per FullAttention layer when triggered. On Qwen3.5-9B, 8/32 layers are FA; the fallback fires only when `qkv_same_dtype=false` (i.e. on every prefill of the affected layers).
+
+| Metric | Cost |
+|---|---|
+| Launch overhead | +24 launches/forward ≈ +100µs at 60 tok/s prefill ≈ **0.6% wall** |
+| wv memset + residual-read Y bandwidth | ~1 MB/layer × 8 layers × 256 GB/s = ~30µs ≈ **0.2% wall** |
+| Total prefill slowdown for MQ3+MQ4 model | **~1% on 9B, similar on 27B** |
+| Decode (per-token) | unchanged (uses `weight_gemv_prerotated` per weight) |
+| Uniform-format models | unchanged (byte-exact original fused path) |
+
+For comparison: the MQ4+MQ6 kmd2 model (#249) was measured at ~1-2% slowdown via the same mechanism. MQ3+MQ4 has identical structure (1 fused-kernel skip per FA layer + 1 memset+residual on `wv`), so the ~1% figure transfers.
+
+### Phase 2 sequencing
+
+A. **MQ3 arm in `batched_gemm_single_weight` + arch check** (~30 LOC). Run kmd2 regression + MQ3+MQ4 forward-pass check.
+
+B. **Same-dtype gates on Clusters 1, 3, 5** (~110 LOC) + corresponding **unit tests for each gate firing** (~80 LOC, Phase 3 will cover).
+
+C. **Llama port** (~120 LOC) — **mandatory**. Lifts `qkv_same_dtype` gate + `batched_gemm_single_weight` pattern from qwen35.rs.
+
+D. Vision-encoder runtime — **out of scope** (CUDA Phase 3).
+
+E. lm_head AWQ-aware runtime — **out of scope** (CUDA Phase 3). The UNSAFE gate in Phase 1 enforces.
+
+## Phase 3 — poison testing + validation
+
+### Poison test (new `crates/hipfire-runtime/examples/test_mixed_format_dispatch.rs`)
+
+For each mixed-format combination reachable through the new code:
+1. Allocate scratch buffers (`pbs.fa_q_full_batch`, etc.).
+2. **Initialize all outputs to `f32::NAN`.**
+3. Synthesize small `(m, k, batch)` tensors + weights; run the dispatch.
+4. Download outputs; assert no NaN survives (every output element overwritten).
+
+Cases covered:
+- FA QKV mixed (MQ3+MQ4) → tests the MQ3 arm of `batched_gemm_single_weight`.
+- DN QKVZA mixed (synthetic; doesn't occur in shipping models today) → tests the `qkvza_same_dtype` gate firing.
+- FFN gate+up mixed (synthetic) → tests the `gate_up_same_dtype` gate.
+
+Without the synthetic mixed-DN tests, the new same-dtype gates would have zero test coverage (GLM5 §11).
+
+### Decode-coherence smoke (new `crates/hipfire-runtime/examples/smoke_mq3_mq4.rs`)
+
+Per GLM5 §12 (no integration test today): load the Phase 0-winning MQ3+MQ4 quant, decode 100 tokens from a fixed prompt at greedy temperature, assert all 100 tokens are finite, and verify the output is non-degenerate (unique-token-ratio > 0.15 — same first-128 attractor threshold from `coherence-gate-dflash.sh`). Doesn't replace n=512 eval but catches gross runtime corruption.
+
+### Acceptance criteria
+
+1. `cargo check --workspace --features deltanet` clean.
+2. Phase 0 report published with the per-mode KLD numbers + Pareto-gate decision.
+3. `cargo test -p hipfire-quantize kmap` — unit tests for new `Promote(GgufFormat)`, `Override(GgufFormat)`, promote-pair allowlist rejection, tied-embed refusal, UNSAFE-gate sequencing, `awq_eligible` lm_head paths, CUDA env-var alias deprecation warning.
+4. Poison tests pass (FA QKV mixed + the two synthetic same-dtype gates).
+5. Decode-coherence smoke passes on the Phase 0-winning MQ3+MQ4 quant.
+6. **kmd2 regression check**: `eval_hipfire` on `qwen3.5-9b.mq4-kmd2-q8conv1d` q8 KV n=20 byte-identical to post-#257 baseline (`0.155438 / 2.219963 / 9.2070`). Verified deterministic across runs in #257's eval.
+7. **MQ3+MQ4 27B n=20** with Phase 0-winning mode: finite KLD/NLL/PPL.
+8. Llama-arch QKV gate test — synthesize a mixed-dtype FA QKV on a llama-arch model harness, assert no NaN.
+
+Coherence-gate (`scripts/coherence-gate.sh`) is **not** in this PR's acceptance set; its model matrix is uniform-format and doesn't exercise the new code path. A `qwen3.5-9b.mq3-kmap-mq4` row gets added in a follow-up.
+
+## Risks
+
+- **Phase 0 Pareto gate fails (n=512 KLD > uniform MQ4 + 0.05 OR bpw saving < 0.4)**: ship CLI as plumbing per the outcomes table. Don't recommend the pair as a default.
+- **CUDA branch's runtime AWQ-aware lm_head dispatch doesn't ship within the next quarter**: per user, this is the CUDA branch owner's responsibility post-merge. Our Phase 1 produces files that error out at runtime (or are gated by UNSAFE) until that lands. If timeline slips significantly, escalate.
+- **Llama-arch port introduces subtle behavior changes**: although the same-dtype gate is byte-exact-no-op for uniform models, ~120 LOC of dispatch refactor in a less-touched file is non-trivial. Mitigation: run any existing llama smoke test (we have `smoke_llama_prefill_batch.rs`) before/after to confirm no drift.
+- **AWQ α=0.55 untuned for MQ3**: real risk. Phase 0 measures at default α; if KLD looks borderline, add an α∈{0.4, 0.5, 0.55, 0.6, 0.7} sweep on the winning kmap mode at n=20. Out of scope to do unconditionally.
+- **Tied-embedding default-untied behavior**: a model that omits `tie_word_embeddings` from config but is actually tied corrupts silently with `--lm-head-format mq4 --awq`. Documented limitation; matches CUDA branch's contract. Exhaustive pointer-alias check is future hardening.
+- **No new HIP kernel files**, but ~300 LOC of runtime dispatch wiring needs writing + testing. "No kernel work" is technically correct but misleading (GLM5 §15.4 — addressed by the §"Phase 2 perf impact estimate" + §"Phase 2 sequencing" tables).
+
+## Out of scope (this PR)
+
+- `--vision-format` and vision-tower AWQ — phased out, ships with CUDA branch's Phase 3 vision runtime.
+- **MQ2-Lloyd kernel family + MQ2-Lloyd+MQ3-Lloyd alternating**: future expansion, separate plan (see §"Future expansion" below).
+- AWQ-aware runtime kernel work for lm_head — CUDA branch's `gptq_lm_head_awq.md` §3.2.
+- Three-or-more-level kmap (current model: base + one promoted level).
+- AWQ α-tuning sweep for sub-4-bit (separate, after Phase 0 establishes the α=0.55 baseline).
+- Exhaustive pointer-alias check for `tie_word_embeddings` (future hardening, beyond CUDA branch contract).
+- `kmap.rs` module extraction from `main.rs` (Gemini §5; useful refactor, separate task).
+- Coherence-gate row additions for the new pair (separate task).
+
+## Effort estimate (revised per GLM5 §14)
+
+- Phase 0 (research): ~9 hours GPU + 2 hours analysis. Single overnight batch.
+- Phase 1 (quantizer CLI, `--kmap-promote` + `--lm-head-format`): **~2.5-3 days**, broken down:
+  - `QuantLevel` enum redesign + `Override` variant threading through ~47 match arms: ~1 day
+  - Three CLI flag parsers + promote-pair allowlist validation: ~0.5 day
+  - Tied-embed safety check (written fresh) + UNSAFE gate logic + `awq_eligible` lm_head extension: ~0.5 day
+  - CUDA env-var deprecated-alias + warning emission: ~0.25 day
+  - Unit tests for ~10 CLI combinations + tied-embed-refusal + UNSAFE-gate sequencing: ~0.5 day
+  - CUDA-branch owner coordination (sync on gate naming, deprecation timeline, end-to-end safety contract): ~0.25 day
+- Phase 2 step A (MQ3 arm + arch check + kmd2 regression eval): ~0.75 day.
+- Phase 2 step B (same-dtype gates on 3 clusters + their unit tests): ~1 day.
+- Phase 2 step C (Llama port, **mandatory**): ~1 day for code + ~0.5 day for testing.
+- Phase 3 (poison + decode-coherence smoke + acceptance harness): ~1 day.
+
+**Total: ~5-6 working days end-to-end**, dominated by Phase 1's CLI surface (the three new flags + the QuantLevel dispatch chain rework) and Phase 2C's mandatory Llama port.
+
+## File layout summary
+
+| Path | Action | LOC delta |
+|---|---|---:|
+| `crates/hipfire-quantize/src/main.rs` | `Promote6` → `Promote(GgufFormat)` + new `Override(GgufFormat)`; `--kmap-promote`, `--lm-head-format` parsing; tied-embed + UNSAFE gates; `awq_eligible` lm_head extension; CUDA env-var deprecated-alias | +~250 / -~50 |
+| `crates/hipfire-arch-qwen35/src/qwen35.rs` — `fn batched_gemm_single_weight` | add MQ3 arm + arch check | +~30 |
+| `crates/hipfire-arch-qwen35/src/qwen35.rs` clusters 1, 3, 5 | `qkvza_same_dtype` + `gate_up_same_dtype` gates with fallback dispatch | +~110 |
+| `crates/hipfire-runtime/src/llama.rs` | port `qkv_same_dtype` gate + shared helper for `batched_gemm_single_weight` | +~120 |
+| `crates/hipfire-runtime/examples/test_mixed_format_dispatch.rs` | NEW poison + same-dtype-gate firing tests | +~180 |
+| `crates/hipfire-runtime/examples/smoke_mq3_mq4.rs` | NEW decode-coherence smoke | +~80 |
+| `docs/perf-checkpoints/<date>-mq3-mq4-awq-kmap-sweep.md` | Phase 0 report | +~100 |
+
+**Total: ~770 LOC** — bulk in quantizer CLI + Llama port + tests.
+
+## Embeddings are intentionally untouched
+
+For clarity (per GLM5 §15.1, my own §8 in the previous review): `token_embd.weight` / `embed_tokens.weight` stays force-Q8. Embeddings are a row lookup, not a matmul — AWQ has no x to divide. The shared "rule 2" arm in `kmap_resolve_mode` gets split so the lm_head sub-arm consults `--lm-head-format` while the embed sub-arm stays at Q8 unconditionally. Sub-Q8 embeddings (e.g. K-means codebooks) are a separate compression direction and not part of this plan.
+
+---
+
+## Future expansion — MQ2-Lloyd-base + MQ3-Lloyd-promote alternating
+
+Deferred from this PR; documented here for sequencing. Was the previous primary target before the MQ3+MQ4 pivot.
+
+### Why it's a future target
+
+MQ3+MQ4 (primary) gives a ~0.5 bpw bracket between uniform MQ3 and uniform MQ4. MQ2-Lloyd+MQ3-Lloyd would give a ~1 bpw bracket between uniform MQ2-Lloyd and uniform MQ3-Lloyd — a bigger compression ratio, but at much higher uncertainty (does Lloyd-MQ2 survive at 27B?) and much higher implementation cost (entire WMMA kernel family port).
+
+### What's needed (preserved from earlier plan iterations)
+
+1. **MQ2-Lloyd batched-prefill kernels** — port the MQ3-Lloyd WMMA family. 8 kernel files mirroring `gemm_qkv/qkvza/gate_up/residual_mq3g256_lloyd_wmma{,_mb4}` plus `fused_*` siblings for decode. Differs in two axes: codebook 8→4 entries, bits 3→2. Templatize over `<CODEBOOK_SIZE, BITS_PER_W>` so MQ3-Lloyd codegen stays byte-identical (`.hsaco` md5 check), per the `docs/plans/mq6_gemm.md` templatize approach.
+2. **`is_batchable_la` extension** to accept `DType::MQ2G256Lloyd` on gfx11+ (mirror MQ3-Lloyd's arch list).
+3. **MQ2-Lloyd arms** in all 8 dispatch clusters + `batched_gemm_single_weight`.
+4. **27B Phase 0**: MQ2-Lloyd-uniform-AWQ-GPTQ baseline at 9B + 27B before kernel work. Hard gate: if 27B-MQ2-Lloyd-uniform collapses, abandon MQ2-Lloyd in any form.
+
+Modeled on `docs/plans/mq3-lloyd-wmma-prefill.md`. Estimated ~3-5 working days for kernel work + ~1 day for dispatch wiring + Phase 0 GPU time. Total ~1000 LOC across kernel + dispatch + decode-path siblings.
+
+### Sequencing
+
+After MQ3+MQ4 lands and Phase 0 of the MQ2-Lloyd track confirms 27B viability. Strict superset of the MQ3+MQ4 PR's dispatch work; the same-dtype gates added here apply directly.
+
+---
+
+## Future expansion — `--vision-format` (phased out of primary PR)
+
+When CUDA branch's Phase 3 vision-tower runtime lands:
+1. Add `--vision-format <fmt>` to the CLI surface.
+2. Extend tied-embed-style refusal check to vision-shared tensors (if any modern VL architecture shares vision encoder weights with anything else).
+3. Mirror `HIPFIRE_VISION_AWQ_UNSAFE` gate semantics until they confirm a non-corruption recipe.
+4. Vision-tower hessian collection is already supported on CUDA branch (commit `2e06a649`).
+
+Companion PR; not standalone.
+
+---
+
+## Coordination with `feat/mq-v2-quant-format-cuda`
+
+Our work lands first; their branch merges ours and implements the runtime-side AWQ-aware lm_head + vision dispatch. Touch-points:
+
+| Surface | This PR | CUDA branch (post-merge) | Final state |
+|---|---|---|---|
+| `--lm-head-format <fmt>` CLI | added | inherited | canonical |
+| `HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ` env var | deprecated-alias-with-warning | removed | gone |
+| Tied-embed refusal check | written fresh | reused | canonical |
+| `awq_eligible` lm_head extension | written fresh | reused | canonical |
+| `HIPFIRE_LM_HEAD_AWQ_UNSAFE` gate | introduced | removed when runtime lands | gone after runtime PR |
+| `--vision-format` CLI | **not added** (phased out) | added by them with runtime | canonical |
+| `HIPFIRE_VISION_AWQ_UNSAFE` gate | **not introduced** here | introduced + removed in same PR | n/a from our side |
+| Vision hessian-collector | reuse their suffix list (mirror `gptq_gpu_pkg/names.py` in Rust when we add `--vision-format`) | unchanged | canonical |
+| GPTQ manifest format (`--precomputed-gptq-path`) | unchanged | extended for new formats | canonical |
+
+When CUDA's Phase 3 runtime PR lands:
+1. The `HIPFIRE_LM_HEAD_AWQ_UNSAFE` requirement drops; their PR includes the gate removal.
+2. The default of `--lm-head-format` can flip from `q8` to `mq4` if their n=512 NLL paired-t shows a strict win (per their §1.2 acceptance).
+3. `--vision-format` ships in the same PR.
+
+Notify the CUDA-branch owner once Phase 1 is in flight so we don't duplicate gate-naming.


### PR DESCRIPTION
**Draft.** Phase 1 of the configurable-kmap-pair plan — quantizer CLI surface only. Runtime side ships separately on #290 + #292; this PR is wire-compatible with them and is safe to land in any merge order (see §"Coordination" below).

Plan doc: `docs/plans/configurable-kmap-pair.md` (in this PR).

## Summary

Three independent CLI gaps in the quantizer that the plan closes in lockstep, because they share the same `QuantLevel` dispatch surface:

1. **`--kmap-promote <fmt>`** — decouples the kmap promote target from hardcoded MQ6. `--format mq3 --kmap-promote mq4 --kmap-dense --kmap-mode 2` now produces an MQ3+MQ4 alternating quant (the previously-unreachable primary target of this plan). Default remains MQ6 so kmd2 / existing recipes stay byte-for-byte unchanged.

2. **`--lm-head-format <fmt>`** — picks the lm_head quant level independently of the dense `--format`. Default `q8` preserves current behavior. Accepts `q8`, `f16`, `mq4`, `mq6`, `mq3`, `hfq4`, `hfq6`, `mfp4`.

3. **AWQ-aware lm_head + Promote arms** — `awq_eligible` extended to match `lm_head.weight` / `output.weight` when `--lm-head-format != q8 && --awq` is set. AWQ pre-scaling + sidecar emission wired into the Override arm (lm_head dispatch) for MQ4 + MQ3, and into the Promote arm (MQ4 / MQ3 promote targets) so kmap-promoted layers can AWQ too.

Internal refactor: `QuantLevel::Promote6` → `QuantLevel::Promote(GgufFormat)`, plus a new `QuantLevel::Override(GgufFormat)`. ~47 match-arm sites updated; dispatcher precedence is explicit (norms → lm_head override → embed Q8 → MoE router Q8 → MoE expert promote → dense promote → base).

## Safety gates (forward-compatible with runtime PRs)

- **Tied-embedding refusal** — hardened version of the check from CUDA-branch `dbcb050`: reads `tie_word_embeddings` from top-level config OR `text_config`, **fail-loud** if missing from both (no `unwrap_or(false)`). Verdict matrix: `true` → abort, `false` → proceed, `missing` → abort.
- **`HIPFIRE_LM_HEAD_AWQ_UNSAFE=1`** required for any non-Q8 non-F16 `--lm-head-format`. This gate exists because the runtime AWQ-aware lm_head dispatch (#290 + #292) hasn't merged yet — a `.hfq` produced without the runtime side would be silently corrupt. The gate is dropped in a small follow-up PR after #290 + #292 land.
- **GGUF input + `--lm-head-format`** — refused with clear error. GGUF doesn't carry safetensors-style tied-embed metadata; safety can't be enforced.
- **Promote-pair allowlist** — explicit table (plan §1a). Lloyd ↔ non-Lloyd cross-family rejected at parse time. CLI flags with no value rejected (no silent no-op).
- **MoE expert path honors carried `Promote(<fmt>)`** — earlier draft dispatched on the base format which would have produced wrong-format expert tensors; fixed pre-merge per review.
- **Defensive 1D shape guard** on Override FP4 cases mirrors the Promote arm.
- **`HIPFIRE_QUANTIZE_LM_HEAD_MQ4_AWQ`** kept as a deprecated alias for `--lm-head-format mq4` with a one-release-cycle deprecation warning, per CUDA-branch owner agreement.

## Coordination with #290 / #292

The plan's §"Runtime coordination" subsection spells out the four-step merge order:

1. #290 `fix/mq3-awq-loader` — loader + sidecar attachment + centralized gate.
2. #292 `fix/lm-head-awq-runtime` — AWQ-aware dispatch in `speculative.rs` + DFlash, stacks on #290.
3. **This PR** — introduces `HIPFIRE_LM_HEAD_AWQ_UNSAFE` and the CLI surface.
4. Small follow-up PR drops the gate once #290 + #292 are both on master.

Safe in any landing order: the gate is opt-in by default, so a `.hfq` produced with it set is loadable by old daemons (refuses with a clear error) and by new daemons (works because the runtime now consumes the sidecar).

## What's NOT in this PR (out of scope, tracked in plan)

- `--vision-format` — phased out; ships with CUDA Phase 3 vision-tower runtime.
- MQ3 arm in `batched_gemm_single_weight` (Phase 2 step A).
- Same-dtype gates on Clusters 1, 3, 5 (Phase 2 step B).
- Mandatory Llama-arch port (Phase 2 step C).
- Phase 0b kmap-mode sweep at 27B + Phase 0c n=512 finale — both blocked on incoming CUDA-pipeline 27B quants.

## Test plan

- [x] `cargo check -p hipfire-quantize` clean.
- [x] Six fix-up commits cut against external review (combined Claude + GLM5 + Gemini): tightened Lloyd allowlist (G2), explicit-value requirement on both new flags (G3), GGUF + `--lm-head-format` refused (C1), MoE expert path on carried Promote (G1), AWQ wired in Promote arm + MQ3 lm_head (C4+G5), defensive 1D shape guard + usage banner mentions new flags (C6+C7).
- [ ] Unit tests for the new `Promote(GgufFormat)` / `Override(GgufFormat)` dispatch arms (plan §Tests). **Pending — added as the next commit on this branch.**
- [ ] End-to-end smoke: quantize a tiny test model with `--format mq3 --kmap-promote mq4 --awq --kmap-dense --kmap-mode 2`, decode via `dump_meta`, confirm per-tensor `quant_type` matches plan precedence. **Pending.**
- [ ] Phase 0b sweep (three kmap modes at 27B). **Blocked on incoming CUDA-pipeline quants.**
- [ ] Phase 0c n=512 finale on winning kmap mode. **Blocked on 0b.**

Acceptance criteria 3 (kmap unit tests), 6 (kmd2 regression byte-identical), and 7 (MQ3+MQ4 27B n=20 finite) from the plan need to land before this PR exits draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)