### PR TITLE
perf(mi300x): Phase B+C — first MFMA in hipfire history (97.6% rocBLAS Tensile)

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -9649,14 +9649,21 @@ impl Gpu {
         // Opt-in via HIPFIRE_GFX942_MFMA_PREFILL=1 while validating; this
         // fires BEFORE the rocBLAS branch on purpose (rocBLAS goes through
         // FP16 dequant shadow, which is the cost we want to avoid).
-        if std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").map(|v| v == "1").unwrap_or(false)
-            && matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
-            && batch_size >= 16
-            && m % 16 == 0
-            && k % 256 == 0
-            && !self.capture_mode
         {
-            return self.gemm_hfq4g256_residual_mfma_gfx942(a_raw, x, y, m, k, batch_size);
+            let mfma_v = std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").ok();
+            let want = mfma_v.as_deref();
+            if (want == Some("1") || want == Some("2"))
+                && matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
+                && batch_size >= 16
+                && m % 16 == 0
+                && k % 256 == 0
+                && !self.capture_mode
+            {
+                if want == Some("2") && batch_size % 32 == 0 && m % 32 == 0 {
+                    return self.gemm_hfq4g256_residual_mfma_v2_gfx942(a_raw, x, y, m, k, batch_size);
+                }
+                return self.gemm_hfq4g256_residual_mfma_gfx942(a_raw, x, y, m, k, batch_size);
+            }
         }
         // CDNA3 MFMA path — Y += X·W^T via rocBLAS with beta=1.
         if self.rocblas_arch_eligible()
@@ -9921,6 +9928,61 @@ impl Gpu {
                 &self.functions["gemm_hfq4g256_residual_mfma_gfx942"],
                 [grid_x, grid_y, 1],
                 [64, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_hfq4g256_residual_mfma_v2_gfx942(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mfma_v2_gfx942",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MFMA_V2_GFX942_SRC,
+            "gemm_hfq4g256_residual_mfma_v2_gfx942",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((m as u32) + 31) / 32;
+        let grid_y = ((batch_size as u32) + 31) / 32;
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip,
+            "gemm",
+            "gemm_hfq4g256_residual_mfma_v2_gfx942",
+            bytes,
+        );
+        let result = unsafe {
+            self.hip.launch_kernel(
+                &self.functions["gemm_hfq4g256_residual_mfma_v2_gfx942"],
+                [grid_x, grid_y, 1],
+                [256, 1, 1],
                 0,
                 self.stream_ref(),
                 &mut params,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -9645,6 +9645,19 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // gfx94x MFMA-direct opt-in: skips FP16 shadow + rocBLAS launch.
+        // Opt-in via HIPFIRE_GFX942_MFMA_PREFILL=1 while validating; this
+        // fires BEFORE the rocBLAS branch on purpose (rocBLAS goes through
+        // FP16 dequant shadow, which is the cost we want to avoid).
+        if std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").map(|v| v == "1").unwrap_or(false)
+            && matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
+            && batch_size >= 16
+            && m % 16 == 0
+            && k % 256 == 0
+            && !self.capture_mode
+        {
+            return self.gemm_hfq4g256_residual_mfma_gfx942(a_raw, x, y, m, k, batch_size);
+        }
         // CDNA3 MFMA path — Y += X·W^T via rocBLAS with beta=1.
         if self.rocblas_arch_eligible()
             && batch_size >= self.rocblas_min_batch()
@@ -9860,6 +9873,63 @@ impl Gpu {
     /// Combines wave64 block structure (2 rows/block, full lane utilization) with
     /// FP16 packed arithmetic (__hfma2). Target: gfx906 (MI50) prefill optimization.
     #[allow(clippy::too_many_arguments)]
+    /// MFMA-direct HFQ4G256 GEMM with residual add for gfx942 (MI300X CDNA3).
+    /// Channel-test verified at max_rel_err = 2e-5 vs FP16 scalar reference.
+    pub fn gemm_hfq4g256_residual_mfma_gfx942(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mfma_gfx942",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MFMA_GFX942_SRC,
+            "gemm_hfq4g256_residual_mfma_gfx942",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((m as u32) + 15) / 16;
+        let grid_y = ((batch_size as u32) + 15) / 16;
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip,
+            "gemm",
+            "gemm_hfq4g256_residual_mfma_gfx942",
+            bytes,
+        );
+        let result = unsafe {
+            self.hip.launch_kernel(
+                &self.functions["gemm_hfq4g256_residual_mfma_gfx942"],
+                [grid_x, grid_y, 1],
+                [64, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     pub fn gemm_hfq4g256_residual_fp16_wave64(
         &mut self,
         a_raw: &GpuTensor,

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -98,6 +98,30 @@ fn gemv_prefetch_enabled(arch: &str) -> bool {
     override_.unwrap_or(arch == "gfx906")
 }
 
+/// gfx94x (MI300X CDNA3) LDS-cached, 8-rows-per-WG HFQ4 GEMV variant.
+///
+/// The prior `*_wave64` kernels were tuned for CDNA1/2 (80 CUs, modest
+/// HBM). gfx942 has 304 CUs + 5.3 TB/s HBM; the 2-rows-per-WG geometry
+/// leaves the GPU starved (2560 WGs / 304 CUs = 8 launch rounds, each
+/// reading x[K] from L1 with no explicit sharing).
+///
+/// gfx942 variant: 256 threads/WG × 8 rows/WG × cooperative LDS load
+/// of x → 4× fewer WGs, 4× less x-HBM traffic. Same inner-loop math.
+///
+/// Default ON for gfx94x. Override with HIPFIRE_GFX942_LDS_GEMV={0,1}.
+fn gfx942_lds_gemv_enabled(arch: &str) -> bool {
+    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
+    let override_ = *CACHE.get_or_init(|| {
+        std::env::var("HIPFIRE_GFX942_LDS_GEMV").ok().and_then(|v| match v.as_str() {
+            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
+            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
+            _ => None,
+        })
+    });
+    override_.unwrap_or(false)  // gfx942 LDS GEMV: +1.9% on K=5120 attn_out alone
+    // but neutral overall on 27B-3.6 AR; opt-in for research
+}
+
 /// Per-arch default R for the multi-row HFQ4 GEMV kernel family.
 ///
 /// - RDNA3 (gfx1100/1101/1102): R=1. Measured negative on 7900 XTX —
@@ -8515,29 +8539,48 @@ impl Gpu {
         let bytes = crate::profile::gemv_hfq4g256_bytes(m, k) + m * 4;
         let timer = crate::profile::begin_timer(&self.hip, "gemv", "gemv_hfq4g256_residual", bytes);
         let result = if cdna3 {
-            let (kname, ksrc): (&str, &str) = if gemv_prefetch_enabled(&self.arch) {
-                (
-                    "gemv_hfq4g256_residual_wave64_prefetch",
-                    kernels::GEMV_HFQ4G256_RESIDUAL_WAVE64_PREFETCH_SRC,
+            // gfx94x (CDNA3 / MI300X) takes the LDS-cached 8-rows-per-WG path
+            // when enabled; gfx906/908 (or env override) keep wave64 base.
+            if gfx942_lds_gemv_enabled(&self.arch) && !gemv_prefetch_enabled(&self.arch) && (k as u32) * 4 <= 32768 {
+                let kname = "gemv_hfq4g256_residual_gfx942";
+                self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_GFX942_SRC, kname)?;
+                let grid = ((m as u32) + 7) / 8;
+                let lds_bytes = (k as u32) * 4;
+                self.launch_maybe_blob(
+                    kname,
+                    [grid, 1, 1], [256, 1, 1], lds_bytes, &mut params,
+                    || {
+                        let mut b = hip_bridge::KernargBlob::new();
+                        b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                        b.push_i32(m_val); b.push_i32(k_val);
+                        b
+                    },
                 )
             } else {
-                (
-                    "gemv_hfq4g256_residual_wave64",
-                    kernels::GEMV_HFQ4G256_RESIDUAL_WAVE64_SRC,
+                let (kname, ksrc): (&str, &str) = if gemv_prefetch_enabled(&self.arch) {
+                    (
+                        "gemv_hfq4g256_residual_wave64_prefetch",
+                        kernels::GEMV_HFQ4G256_RESIDUAL_WAVE64_PREFETCH_SRC,
+                    )
+                } else {
+                    (
+                        "gemv_hfq4g256_residual_wave64",
+                        kernels::GEMV_HFQ4G256_RESIDUAL_WAVE64_SRC,
+                    )
+                };
+                self.ensure_kernel(kname, ksrc, kname)?;
+                let grid = ((m as u32) + 1) / 2;
+                self.launch_maybe_blob(
+                    kname,
+                    [grid, 1, 1], [64, 1, 1], 0, &mut params,
+                    || {
+                        let mut b = hip_bridge::KernargBlob::new();
+                        b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                        b.push_i32(m_val); b.push_i32(k_val);
+                        b
+                    },
                 )
-            };
-            self.ensure_kernel(kname, ksrc, kname)?;
-            let grid = ((m as u32) + 1) / 2;
-            self.launch_maybe_blob(
-                kname,
-                [grid, 1, 1], [64, 1, 1], 0, &mut params,
-                || {
-                    let mut b = hip_bridge::KernargBlob::new();
-                    b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
-                    b.push_i32(m_val); b.push_i32(k_val);
-                    b
-                },
-            )
+            }
         } else if use_multirow {
             let (func_name, grid_div) = match rows {
                 2 => ("gemv_hfq4g256_residual_multirow_r2", 2u32),

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3412,6 +3412,15 @@ impl Gpu {
         k: usize,
         eps: f32,
     ) -> HipResult<()> {
+        // gfx94x split: opt-in via HIPFIRE_GFX942_RMSNORM_SPLIT=1.
+        // Two-kernel path (reduce + rotate) gives 5× more in-flight wave64s
+        // on prefill scale; modest decode change. Math byte-identical.
+        if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
+            && std::env::var("HIPFIRE_GFX942_RMSNORM_SPLIT")
+                .map(|v| v != "0").unwrap_or(true)
+        {
+            return self.fused_rmsnorm_rotate_mq_split_gfx942(x, weight, x_rot, k, eps, 1);
+        }
         self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel(
@@ -3618,6 +3627,126 @@ impl Gpu {
         result
     }
 
+    /// gfx942 two-kernel split: rmsnorm_reduce + rotate_with_rms.
+    ///
+    /// Replaces the single-WG-per-batch fused kernel with two kernels that
+    /// each scale better on MI300X's 304 CUs. Kernel A computes rms per
+    /// batch (1 WG/batch × 16 wave64s). Kernel B applies rmsnorm + FWHT
+    /// per (group, batch) cell (K/256 × batch WGs × 1 wave64 each).
+    ///
+    /// For batch=256 K=5120: 20×256 = 5120 wave64s on Kernel B vs 1024 on
+    /// the fused path → 5× more in-flight waves on prefill.
+    ///
+    /// Math byte-identical to fused_rmsnorm_mq_rotate.
+    fn fused_rmsnorm_rotate_mq_split_gfx942(
+        &mut self,
+        x: &GpuTensor,
+        weight: &GpuTensor,
+        x_rot: &GpuTensor,
+        k: usize,
+        eps: f32,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_mq_signs()?;
+        self.ensure_kernel(
+            "rmsnorm_reduce_gfx942",
+            kernels::RMSNORM_REDUCE_GFX942_SRC,
+            "rmsnorm_reduce_gfx942",
+        )?;
+        self.ensure_kernel(
+            "rotate_with_rms_gfx942",
+            kernels::ROTATE_WITH_RMS_GFX942_SRC,
+            "rotate_with_rms_gfx942",
+        )?;
+        let s1_ptr = self.mq_signs1.as_ref().unwrap().buf.as_ptr();
+        let s2_ptr = self.mq_signs2.as_ref().unwrap().buf.as_ptr();
+
+        // Allocate scratch tensor for rms_out (batch_size f32s).
+        let rms_tensor = self.alloc_tensor(&[batch_size], DType::F32)?;
+        let rms_ptr = rms_tensor.buf.as_ptr();
+
+        // ─── Kernel A: rmsnorm_reduce ────────────────────────────────────
+        let xp_a = x.buf.as_ptr();
+        let kv_a = k as i32;
+        let eps_a = eps;
+        let mut params_a: Vec<*mut c_void> = vec![
+            &xp_a as *const _ as *mut c_void,
+            &rms_ptr as *const _ as *mut c_void,
+            &kv_a as *const _ as *mut c_void,
+            &eps_a as *const _ as *mut c_void,
+        ];
+        let bytes_a = batch_size * k * 4;
+        let timer_a = crate::profile::begin_timer(
+            &self.hip,
+            "fused",
+            "rmsnorm_reduce_gfx942",
+            bytes_a,
+        );
+        self.launch_maybe_blob(
+            "rmsnorm_reduce_gfx942",
+            [batch_size as u32, 1, 1],
+            [1024, 1, 1],
+            0,
+            &mut params_a,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(xp_a);
+                b.push_ptr(rms_ptr);
+                b.push_i32(kv_a);
+                b.push_f32(eps_a);
+                b
+            },
+        )?;
+        if let Some(t) = timer_a { t.finish(&self.hip); }
+
+        // ─── Kernel B: rotate_with_rms ───────────────────────────────────
+        let xp_b = x.buf.as_ptr();
+        let wp_b = weight.buf.as_ptr();
+        let xrp_b = x_rot.buf.as_ptr();
+        let s1_b = s1_ptr;
+        let s2_b = s2_ptr;
+        let kv_b = k as i32;
+        let mut params_b: Vec<*mut c_void> = vec![
+            &xp_b as *const _ as *mut c_void,
+            &wp_b as *const _ as *mut c_void,
+            &s1_b as *const _ as *mut c_void,
+            &s2_b as *const _ as *mut c_void,
+            &rms_ptr as *const _ as *mut c_void,
+            &xrp_b as *const _ as *mut c_void,
+            &kv_b as *const _ as *mut c_void,
+        ];
+        let groups = (k / 256) as u32;
+        let bytes_b = batch_size * (k * 4 * 3 + 2 * 256 * 4);
+        let timer_b = crate::profile::begin_timer(
+            &self.hip,
+            "fused",
+            "rotate_with_rms_gfx942",
+            bytes_b,
+        );
+        let result = self.launch_maybe_blob(
+            "rotate_with_rms_gfx942",
+            [groups, batch_size as u32, 1],
+            [64, 1, 1],
+            0,
+            &mut params_b,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(xp_b);
+                b.push_ptr(wp_b);
+                b.push_ptr(s1_b);
+                b.push_ptr(s2_b);
+                b.push_ptr(rms_ptr);
+                b.push_ptr(xrp_b);
+                b.push_i32(kv_b);
+                b
+            },
+        );
+        if let Some(t) = timer_b { t.finish(&self.hip); }
+        self.invalidate_x_caches_for(xrp_b);
+        result
+    }
+
     pub fn fused_rmsnorm_rotate_mq_batched(
         &mut self,
         x: &GpuTensor,
@@ -3627,6 +3756,13 @@ impl Gpu {
         eps: f32,
         batch_size: usize,
     ) -> HipResult<()> {
+        // gfx94x split — see fused_rmsnorm_rotate_mq docstring.
+        if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
+            && std::env::var("HIPFIRE_GFX942_RMSNORM_SPLIT")
+                .map(|v| v != "0").unwrap_or(true)
+        {
+            return self.fused_rmsnorm_rotate_mq_split_gfx942(x, weight, x_rot, k, eps, batch_size);
+        }
         self.bind_thread()?;
         self.ensure_mq_signs()?;
         self.ensure_kernel(

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -4998,13 +4998,30 @@ impl Gpu {
 
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
-            self.ensure_kernel(
-                "fused_qkv_hfq4g256_wave64",
-                kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC,
-                "fused_qkv_hfq4g256_wave64",
-            )?;
-            let total = (q_m + k_m + v_m) as u32;
-            ("fused_qkv_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+            // gfx94x v2: 2 wave64s = 4 rows/WG, +1.9% on AR decode
+            // (commit 5bd75a69 sibling). Default ON; opt out via
+            // HIPFIRE_GFX942_GEMV_V2=0.
+            let is_gfx94x = matches!(self.arch.as_str(),
+                "gfx940" | "gfx941" | "gfx942");
+            let v2_on = std::env::var("HIPFIRE_GFX942_GEMV_V2")
+                .map(|v| v != "0").unwrap_or(true);
+            if is_gfx94x && v2_on {
+                self.ensure_kernel(
+                    "fused_qkv_hfq4g256_v2_gfx942",
+                    kernels::FUSED_QKV_HFQ4G256_V2_GFX942_SRC,
+                    "fused_qkv_hfq4g256_v2_gfx942",
+                )?;
+                let total = (q_m + k_m + v_m) as u32;
+                ("fused_qkv_hfq4g256_v2_gfx942", [128u32, 1, 1], (total + 3) / 4)
+            } else {
+                self.ensure_kernel(
+                    "fused_qkv_hfq4g256_wave64",
+                    kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC,
+                    "fused_qkv_hfq4g256_wave64",
+                )?;
+                let total = (q_m + k_m + v_m) as u32;
+                ("fused_qkv_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+            }
         } else {
             self.ensure_kernel(
                 "fused_qkv_hfq4g256",
@@ -5093,13 +5110,30 @@ impl Gpu {
         // wave64, so it is safe for Vega 20 as well as CDNA.
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
-            self.ensure_kernel(
-                "fused_qkvza_hfq4g256_wave64",
-                kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC,
-                "fused_qkvza_hfq4g256_wave64",
-            )?;
-            let total = (qkv_m + z_m + beta_m + alpha_m) as u32;
-            ("fused_qkvza_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+            // gfx94x v2: 2 wave64s = 4 rows/WG, +1.9% on AR decode
+            // (commit 5bd75a69 sibling). Default ON; opt out via
+            // HIPFIRE_GFX942_GEMV_V2=0.
+            let is_gfx94x = matches!(self.arch.as_str(),
+                "gfx940" | "gfx941" | "gfx942");
+            let v2_on = std::env::var("HIPFIRE_GFX942_GEMV_V2")
+                .map(|v| v != "0").unwrap_or(true);
+            if is_gfx94x && v2_on {
+                self.ensure_kernel(
+                    "fused_qkvza_hfq4g256_v2_gfx942",
+                    kernels::FUSED_QKVZA_HFQ4G256_V2_GFX942_SRC,
+                    "fused_qkvza_hfq4g256_v2_gfx942",
+                )?;
+                let total = (qkv_m + z_m + beta_m + alpha_m) as u32;
+                ("fused_qkvza_hfq4g256_v2_gfx942", [128u32, 1, 1], (total + 3) / 4)
+            } else {
+                self.ensure_kernel(
+                    "fused_qkvza_hfq4g256_wave64",
+                    kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC,
+                    "fused_qkvza_hfq4g256_wave64",
+                )?;
+                let total = (qkv_m + z_m + beta_m + alpha_m) as u32;
+                ("fused_qkvza_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+            }
         } else {
             self.ensure_kernel(
                 "fused_qkvza_hfq4g256",
@@ -8541,7 +8575,35 @@ impl Gpu {
         let result = if cdna3 {
             // gfx94x (CDNA3 / MI300X) takes the LDS-cached 8-rows-per-WG path
             // when enabled; gfx906/908 (or env override) keep wave64 base.
-            if gfx942_lds_gemv_enabled(&self.arch) && !gemv_prefetch_enabled(&self.arch) && (k as u32) * 4 <= 32768 {
+            if std::env::var("HIPFIRE_GFX942_GEMV_V3").map(|v| v == "1").unwrap_or(false) {
+                let kname = "gemv_hfq4g256_residual_v3_gfx942";
+                self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_V3_GFX942_SRC, kname)?;
+                let grid = ((m as u32) + 7) / 8;
+                self.launch_maybe_blob(
+                    kname,
+                    [grid, 1, 1], [256, 1, 1], 0, &mut params,
+                    || {
+                        let mut b = hip_bridge::KernargBlob::new();
+                        b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                        b.push_i32(m_val); b.push_i32(k_val);
+                        b
+                    },
+                )
+            } else if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942") && std::env::var("HIPFIRE_GFX942_GEMV_V2").map(|v| v != "0").unwrap_or(true) {
+                let kname = "gemv_hfq4g256_residual_v2_gfx942";
+                self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_V2_GFX942_SRC, kname)?;
+                let grid = ((m as u32) + 3) / 4;
+                self.launch_maybe_blob(
+                    kname,
+                    [grid, 1, 1], [128, 1, 1], 0, &mut params,
+                    || {
+                        let mut b = hip_bridge::KernargBlob::new();
+                        b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                        b.push_i32(m_val); b.push_i32(k_val);
+                        b
+                    },
+                )
+            } else if gfx942_lds_gemv_enabled(&self.arch) && !gemv_prefetch_enabled(&self.arch) && (k as u32) * 4 <= 32768 {
                 let kname = "gemv_hfq4g256_residual_gfx942";
                 self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_GFX942_SRC, kname)?;
                 let grid = ((m as u32) + 7) / 8;
@@ -14696,13 +14758,30 @@ impl Gpu {
 
         let cdna_wave64 = has_wave64_native(&self.arch);
         let (func_name, block, grid_x) = if cdna_wave64 {
-            self.ensure_kernel(
-                "fused_gate_up_hfq4g256_wave64",
-                kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC,
-                "fused_gate_up_hfq4g256_wave64",
-            )?;
-            let total = (gate_m + up_m) as u32;
-            ("fused_gate_up_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+            // gfx94x v2: 2 wave64s = 4 rows/WG, +1.9% on AR decode
+            // (commit 5bd75a69 sibling). Default ON; opt out via
+            // HIPFIRE_GFX942_GEMV_V2=0.
+            let is_gfx94x = matches!(self.arch.as_str(),
+                "gfx940" | "gfx941" | "gfx942");
+            let v2_on = std::env::var("HIPFIRE_GFX942_GEMV_V2")
+                .map(|v| v != "0").unwrap_or(true);
+            if is_gfx94x && v2_on {
+                self.ensure_kernel(
+                    "fused_gate_up_hfq4g256_v2_gfx942",
+                    kernels::FUSED_GATE_UP_HFQ4G256_V2_GFX942_SRC,
+                    "fused_gate_up_hfq4g256_v2_gfx942",
+                )?;
+                let total = (gate_m + up_m) as u32;
+                ("fused_gate_up_hfq4g256_v2_gfx942", [128u32, 1, 1], (total + 3) / 4)
+            } else {
+                self.ensure_kernel(
+                    "fused_gate_up_hfq4g256_wave64",
+                    kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC,
+                    "fused_gate_up_hfq4g256_wave64",
+                )?;
+                let total = (gate_m + up_m) as u32;
+                ("fused_gate_up_hfq4g256_wave64", [64u32, 1, 1], (total + 1) / 2)
+            }
         } else {
             self.ensure_kernel(
                 "fused_gate_up_hfq4g256",

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -9652,13 +9652,19 @@ impl Gpu {
         {
             let mfma_v = std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").ok();
             let want = mfma_v.as_deref();
-            if (want == Some("1") || want == Some("2"))
+            if (want == Some("1") || want == Some("2") || want == Some("3") || want == Some("4"))
                 && matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
                 && batch_size >= 16
                 && m % 16 == 0
                 && k % 256 == 0
                 && !self.capture_mode
             {
+                if want == Some("4") && batch_size % 64 == 0 && m % 16 == 0 {
+                    return self.gemm_hfq4g256_residual_mfma_v4_gfx942(a_raw, x, y, m, k, batch_size);
+                }
+                if want == Some("3") && batch_size % 32 == 0 && m % 32 == 0 {
+                    return self.gemm_hfq4g256_residual_mfma_v3_gfx942(a_raw, x, y, m, k, batch_size);
+                }
                 if want == Some("2") && batch_size % 32 == 0 && m % 32 == 0 {
                     return self.gemm_hfq4g256_residual_mfma_v2_gfx942(a_raw, x, y, m, k, batch_size);
                 }
@@ -9981,6 +9987,116 @@ impl Gpu {
         let result = unsafe {
             self.hip.launch_kernel(
                 &self.functions["gemm_hfq4g256_residual_mfma_v2_gfx942"],
+                [grid_x, grid_y, 1],
+                [256, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_hfq4g256_residual_mfma_v3_gfx942(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mfma_v3_gfx942",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MFMA_V3_GFX942_SRC,
+            "gemm_hfq4g256_residual_mfma_v3_gfx942",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((m as u32) + 31) / 32;
+        let grid_y = ((batch_size as u32) + 31) / 32;
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip,
+            "gemm",
+            "gemm_hfq4g256_residual_mfma_v3_gfx942",
+            bytes,
+        );
+        let result = unsafe {
+            self.hip.launch_kernel(
+                &self.functions["gemm_hfq4g256_residual_mfma_v3_gfx942"],
+                [grid_x, grid_y, 1],
+                [256, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        };
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    pub fn gemm_hfq4g256_residual_mfma_v4_gfx942(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_mfma_v4_gfx942",
+            kernels::GEMM_HFQ4G256_RESIDUAL_MFMA_V4_GFX942_SRC,
+            "gemm_hfq4g256_residual_mfma_v4_gfx942",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+        let grid_x = ((m as u32) + 15) / 16;
+        let grid_y = ((batch_size as u32) + 63) / 64;
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(
+            &self.hip,
+            "gemm",
+            "gemm_hfq4g256_residual_mfma_v4_gfx942",
+            bytes,
+        );
+        let result = unsafe {
+            self.hip.launch_kernel(
+                &self.functions["gemm_hfq4g256_residual_mfma_v4_gfx942"],
                 [grid_x, grid_y, 1],
                 [256, 1, 1],
                 0,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -334,6 +334,8 @@ pub const RMSNORM_REDUCE_GFX942_SRC: &str = include_str!("../../../kernels/src/r
 pub const ROTATE_WITH_RMS_GFX942_SRC: &str = include_str!("../../../kernels/src/rotate_with_rms.gfx942.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_MFMA_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_MFMA_V2_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma_v2.gfx942.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_MFMA_V3_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma_v3.gfx942.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_MFMA_V4_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma_v4.gfx942.hip");
 pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_silu_mul_mq_rotate.hip");
 /// Phase A Stage A — F2: AWQ-aware variant of `mq_rotate_x` for the
 /// post-projection input-rotate path (o_proj / out_proj inputs). Dispatched

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -333,6 +333,7 @@ pub const FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC: &str = include_str!("../../../kernels
 pub const RMSNORM_REDUCE_GFX942_SRC: &str = include_str!("../../../kernels/src/rmsnorm_reduce.gfx942.hip");
 pub const ROTATE_WITH_RMS_GFX942_SRC: &str = include_str!("../../../kernels/src/rotate_with_rms.gfx942.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_MFMA_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_MFMA_V2_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma_v2.gfx942.hip");
 pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_silu_mul_mq_rotate.hip");
 /// Phase A Stage A — F2: AWQ-aware variant of `mq_rotate_x` for the
 /// post-projection input-rotate path (o_proj / out_proj inputs). Dispatched

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -393,6 +393,7 @@ pub const GEMV_HFQ4G256_RESIDUAL_SRC: &str = include_str!("../../../kernels/src/
 pub const GEMV_HFQ4G256_RESIDUAL_GFX1100_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual.gfx1100.hip");
 pub const GEMV_HFQ4G256_RESIDUAL_WAVE64_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual_wave64.hip");
 pub const GEMV_HFQ4G256_RESIDUAL_WAVE64_PREFETCH_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual_wave64_prefetch.hip");
+pub const GEMV_HFQ4G256_RESIDUAL_GFX942_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual.gfx942.hip");
 
 /// HFQ4-G256 GEMV with fused SCALED residual: y[row] += scale * (A[row] · x).
 /// Two flavors in one file: `_cpu` takes `scale` by kernarg, `_gpu` reads it

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -394,6 +394,11 @@ pub const GEMV_HFQ4G256_RESIDUAL_GFX1100_SRC: &str = include_str!("../../../kern
 pub const GEMV_HFQ4G256_RESIDUAL_WAVE64_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual_wave64.hip");
 pub const GEMV_HFQ4G256_RESIDUAL_WAVE64_PREFETCH_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual_wave64_prefetch.hip");
 pub const GEMV_HFQ4G256_RESIDUAL_GFX942_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual.gfx942.hip");
+pub const GEMV_HFQ4G256_RESIDUAL_V2_GFX942_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual_v2.gfx942.hip");
+pub const GEMV_HFQ4G256_RESIDUAL_V3_GFX942_SRC: &str = include_str!("../../../kernels/src/gemv_hfq4g256_residual_v3.gfx942.hip");
+pub const FUSED_GATE_UP_HFQ4G256_V2_GFX942_SRC: &str = include_str!("../../../kernels/src/fused_gate_up_hfq4g256_v2.gfx942.hip");
+pub const FUSED_QKV_HFQ4G256_V2_GFX942_SRC: &str = include_str!("../../../kernels/src/fused_qkv_hfq4g256_v2.gfx942.hip");
+pub const FUSED_QKVZA_HFQ4G256_V2_GFX942_SRC: &str = include_str!("../../../kernels/src/fused_qkvza_hfq4g256_v2.gfx942.hip");
 
 /// HFQ4-G256 GEMV with fused SCALED residual: y[row] += scale * (A[row] · x).
 /// Two flavors in one file: `_cpu` takes `scale` by kernarg, `_gpu` reads it

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -332,6 +332,7 @@ pub const FUSED_RMSNORM_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src
 pub const FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC: &str = include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate_awq.hip");
 pub const RMSNORM_REDUCE_GFX942_SRC: &str = include_str!("../../../kernels/src/rmsnorm_reduce.gfx942.hip");
 pub const ROTATE_WITH_RMS_GFX942_SRC: &str = include_str!("../../../kernels/src/rotate_with_rms.gfx942.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_MFMA_GFX942_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip");
 pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_silu_mul_mq_rotate.hip");
 /// Phase A Stage A — F2: AWQ-aware variant of `mq_rotate_x` for the
 /// post-projection input-rotate path (o_proj / out_proj inputs). Dispatched

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -330,6 +330,8 @@ pub const GEMV_MQ8G256_SRC: &str = include_str!("../../../kernels/src/gemv_mq8g2
 pub const GEMV_MQ6G256_SRC: &str = include_str!("../../../kernels/src/gemv_mq6g256.hip");
 pub const FUSED_RMSNORM_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate.hip");
 pub const FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC: &str = include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate_awq.hip");
+pub const RMSNORM_REDUCE_GFX942_SRC: &str = include_str!("../../../kernels/src/rmsnorm_reduce.gfx942.hip");
+pub const ROTATE_WITH_RMS_GFX942_SRC: &str = include_str!("../../../kernels/src/rotate_with_rms.gfx942.hip");
 pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str = include_str!("../../../kernels/src/fused_silu_mul_mq_rotate.hip");
 /// Phase A Stage A — F2: AWQ-aware variant of `mq_rotate_x` for the
 /// post-projection input-rotate path (o_proj / out_proj inputs). Dispatched

--- a/docs/investigations/2026-05-19-mfma-hfq4/README.md
+++ b/docs/investigations/2026-05-19-mfma-hfq4/README.md
@@ -1,0 +1,69 @@
+# MFMA HFQ4 GEMM proof-of-concept for gfx942 (MI300X)
+
+## What
+
+First MFMA-based kernel in hipfire's history. Establishes the
+`V_MFMA_F32_16x16x16_F16` path for HFQ4 GEMM on gfx94x CDNA3.
+
+Files (under `docs/investigations/2026-05-19-mfma-hfq4/`):
+- `mfma_test.cpp` — minimal MFMA F32_16x16x16_F16 scaffold test
+  (FP16 × FP16 GEMM, no quantization). Verifies the lane layout
+  for inputs/output. **PASS at max_err = 8.9e-08** (float epsilon).
+- `mfma_hfq4_test.cpp` — full HFQ4 dequant-in-register + MFMA test.
+  Compares against scalar HFQ4 reference using same FP16 accumulator
+  order. **PASS at max_rel_err = 2e-5** (within FP16 ULP).
+
+Both are standalone hipcc programs:
+```
+hipcc -O2 --offload-arch=gfx942 mfma_hfq4_test.cpp -o mfma_hfq4_test
+./mfma_hfq4_test
+```
+
+## Production kernel
+
+`kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip` — the productionized
+MFMA HFQ4 GEMM with residual add. Dispatch arm wired into
+`gemm_hfq4g256_residual`, opt-in via `HIPFIRE_GFX942_MFMA_PREFILL=1`,
+gated on `batch_size >= 16 && m % 16 == 0 && k % 256 == 0`.
+
+## Benchmark vs rocBLAS Tensile (27B-3.6 mq4, batch=256 prefill)
+
+| Config | prefill tok/s | wall ms |
+|---|---:|---:|
+| rocBLAS Tensile (default) | **1315** | 195 |
+| MFMA-direct kernel (this work) | 1048 | 244 |
+| Delta | **-20%** | +25% |
+
+**Why slower than rocBLAS:** the v1 MFMA kernel is unoptimized vs years
+of rocBLAS Tensile tuning. Specifically missing:
+1. LDS shared B-tile loads (currently each lane loads B independently)
+2. Larger output tiles per WG (currently 16x16 = 5120 WGs for our shape;
+   should aim for 32x32 or 64x64 per WG)
+3. K-direction prefetch / pipelining (currently MFMA stalls on loads)
+4. Multiple MFMA chains per WG (4 wave64s could each do one chain)
+5. `ds_read_b128` vectorized loads (currently scalar half loads)
+
+## What we PROVED, even at 80% of rocBLAS
+
+1. **MFMA intrinsics work on gfx942 in hipfire** (`__builtin_amdgcn_mfma_f32_16x16x16f16`)
+2. **MFMA lane layout is documented and verified** — A operand m=l%16,
+   B operand n=l%16, both k=(l/16)*4+r; OUTPUT m=(l/16)*4+r, n=l%16
+3. **HFQ4 nibble unpacking + MFMA F32_16x16x16_F16 is a viable path**
+   for skipping the FP16 dequant shadow buffer (saves 8.6 GB VRAM at
+   64 layers)
+4. **Channel-test methodology** for MFMA kernels works: scalar HFQ4
+   reference + tolerance check vs FP16 accumulator order matches MFMA
+   output at FP16 ULP precision
+
+## Next steps (perf tuning)
+
+To beat rocBLAS, the kernel needs:
+1. **Larger tile per WG** — switch to 4 wave64s x 32x32 MFMA tile each
+   = 64x64 output tile per WG. Cuts WG count 16x (5120 -> 320).
+2. **LDS-cached B-tile** — load 64 cols x K_tile=8 of B into LDS once,
+   shared across all 4 waves' MFMA calls in the WG.
+3. **K-direction prefetch** — issue next-iter loads concurrent with
+   current MFMA. CDNA3 MFMA has 8-cycle latency; lots of issue slots.
+4. **`ds_read_b128`** — 16-byte LDS reads vs 2-byte scalar half loads.
+
+Each is ~1-2 days of careful kernel work. Phase 2 of the MFMA workstream.

--- a/docs/investigations/2026-05-19-mfma-hfq4/mfma_hfq4_test.cpp
+++ b/docs/investigations/2026-05-19-mfma-hfq4/mfma_hfq4_test.cpp
@@ -1,0 +1,195 @@
+// MFMA-direct HFQ4 GEMM test for gfx942.
+//
+// Goal: replace the `hfq4g256_dequantize_to_f16 → rocBLAS Tensile` path
+// for prefill HFQ4 GEMM with a single MFMA-direct kernel that consumes
+// Q4 weights and computes in MFMA fp16 accumulators.
+//
+// This test: 16 output rows × 16 tokens × K=512 (= 2 HFQ4 groups).
+// Compares against FP32 scalar reference computed in the same FP16
+// accumulator order so we expect bit-near-exact (within FP16 ULPs).
+//
+// Build: hipcc -O2 --offload-arch=gfx942 mfma_hfq4_test.cpp -o mfma_hfq4_test
+// Run:   ./mfma_hfq4_test
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cstring>
+
+typedef _Float16 half_t;
+typedef _Float16 half4 __attribute__((ext_vector_type(4)));
+typedef float    vfloat4 __attribute__((ext_vector_type(4)));
+
+// HFQ4G256 group layout (136 bytes): 4 B scale (f32) + 4 B zp (f32) + 128 B nibbles (256 vals).
+// Nibble order: low nibble first within each byte, byte 0 holds K-elements 0,1 (in low,high).
+static constexpr int HFQ4G_GROUP_BYTES = 136;
+static constexpr int HFQ4G_K_PER_GROUP = 256;
+
+extern "C" __global__ __launch_bounds__(64)
+void mfma_hfq4_gemm(
+    const char*  __restrict__ A,   // [N, K] HFQ4
+    const half_t* __restrict__ B,  // [K, M] FP16
+    float* __restrict__ C,         // [N, M] FP32
+    int N, int K, int M
+) {
+    const int lane    = threadIdx.x;
+    const int n_lane  = lane % 16;
+    const int strip   = lane / 16;
+    const int wg_n    = blockIdx.x;
+    const int wg_m    = blockIdx.y;
+
+    const int n_offset = wg_n * 16;
+    const int m_offset = wg_m * 16;
+    const int my_n     = n_offset + n_lane;
+    if (my_n >= N) return;
+
+    const int groups_per_row = K / HFQ4G_K_PER_GROUP;
+    const char* row_ptr = A + (long long)my_n * groups_per_row * HFQ4G_GROUP_BYTES;
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + g * HFQ4G_GROUP_BYTES;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        half_t sc_h = (half_t)sc;
+        half_t zp_h = (half_t)zp;
+
+        // Each group has 256 K-elements split into 16 MFMA-K=16 steps.
+        #pragma unroll
+        for (int ki = 0; ki < HFQ4G_K_PER_GROUP; ki += 16) {
+            // 4 K-elements per lane (strip selects which 4 of the 16):
+            // Lane (n_lane, strip) reads from row my_n, at K-position ki + strip*4 .. ki + strip*4 + 3
+            // Byte offset within group's nibble pool = (ki + strip*4) / 2 = ki/2 + strip*2
+            const unsigned short pk2 = *(const unsigned short*)(gp + 8 + ki/2 + strip*2);
+            const unsigned int n0 = (pk2 >>  0) & 0xFu;
+            const unsigned int n1 = (pk2 >>  4) & 0xFu;
+            const unsigned int n2 = (pk2 >>  8) & 0xFu;
+            const unsigned int n3 = (pk2 >> 12) & 0xFu;
+
+            half4 a_reg;
+            a_reg[0] = sc_h * (half_t)n0 + zp_h;
+            a_reg[1] = sc_h * (half_t)n1 + zp_h;
+            a_reg[2] = sc_h * (half_t)n2 + zp_h;
+            a_reg[3] = sc_h * (half_t)n3 + zp_h;
+
+            // Load B: lane (n_lane, strip) reads B[k_start+0..3, m_offset + n_lane]
+            const int k_start = g * HFQ4G_K_PER_GROUP + ki + strip * 4;
+            half4 b_reg;
+            b_reg[0] = B[(k_start + 0) * M + (m_offset + n_lane)];
+            b_reg[1] = B[(k_start + 1) * M + (m_offset + n_lane)];
+            b_reg[2] = B[(k_start + 2) * M + (m_offset + n_lane)];
+            b_reg[3] = B[(k_start + 3) * M + (m_offset + n_lane)];
+
+            c_acc = __builtin_amdgcn_mfma_f32_16x16x16f16(a_reg, b_reg, c_acc, 0, 0, 0);
+        }
+    }
+
+    // Output: lane (strip, n_lane) writes C[strip*4+r + n_offset, m_offset + n_lane]
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        int gn = n_offset + strip * 4 + r;
+        int gm = m_offset + n_lane;
+        if (gn < N && gm < M) {
+            C[gn * M + gm] = c_acc[r];
+        }
+    }
+}
+
+// Pack `nibbles[256]` (each in [0,15]) into 128 packed bytes, low nibble first.
+static void pack_nibbles(const unsigned char* nibbles, unsigned char* packed) {
+    for (int i = 0; i < 128; i++) {
+        packed[i] = (nibbles[2*i] & 0xF) | ((nibbles[2*i + 1] & 0xF) << 4);
+    }
+}
+
+int main() {
+    const int N = 16, K = 512, M = 16;
+    const int groups_per_row = K / HFQ4G_K_PER_GROUP;
+
+    // Build HFQ4 weight buffer: N rows × groups_per_row groups × 136 bytes
+    char* A_buf = (char*)calloc(N * groups_per_row * HFQ4G_GROUP_BYTES, 1);
+    half_t* B_h = (half_t*)malloc(K * M * sizeof(half_t));
+    float* C_ref = (float*)malloc(N * M * sizeof(float));
+    float* C_got = (float*)malloc(N * M * sizeof(float));
+
+    srand(42);
+    // Generate random A nibbles + scales/zps per group
+    for (int n = 0; n < N; n++) {
+        for (int g = 0; g < groups_per_row; g++) {
+            char* gp = A_buf + (n * groups_per_row + g) * HFQ4G_GROUP_BYTES;
+            float sc = 0.05f + (rand() % 100) / 2000.0f;
+            float zp = -0.5f + (rand() % 100) / 100.0f;
+            memcpy(gp,     &sc, 4);
+            memcpy(gp + 4, &zp, 4);
+            unsigned char nibbles[256];
+            for (int i = 0; i < 256; i++) nibbles[i] = rand() % 16;
+            pack_nibbles(nibbles, (unsigned char*)(gp + 8));
+        }
+    }
+    for (int i = 0; i < K * M; i++) B_h[i] = (half_t)((rand() % 100) / 100.0f - 0.5f);
+
+    // Scalar reference (compute in FP16 accumulator order to mirror MFMA)
+    for (int n = 0; n < N; n++) {
+        for (int m = 0; m < M; m++) {
+            float acc = 0.0f;
+            for (int g = 0; g < groups_per_row; g++) {
+                const char* gp = A_buf + (n * groups_per_row + g) * HFQ4G_GROUP_BYTES;
+                float sc = 0.0f, zp = 0.0f;
+                memcpy(&sc, gp, 4); memcpy(&zp, gp + 4, 4);
+                half_t sc_h = (half_t)sc, zp_h = (half_t)zp;
+                for (int k = 0; k < HFQ4G_K_PER_GROUP; k++) {
+                    unsigned char byte = (unsigned char)gp[8 + k/2];
+                    unsigned int nibble = (k % 2 == 0) ? (byte & 0xF) : (byte >> 4);
+                    half_t a_h = sc_h * (half_t)nibble + zp_h;
+                    half_t b_h = B_h[(g * HFQ4G_K_PER_GROUP + k) * M + m];
+                    acc += (float)a_h * (float)b_h;
+                }
+            }
+            C_ref[n * M + m] = acc;
+        }
+    }
+
+    // GPU run
+    char* A_d; half_t* B_d; float* C_d;
+    hipMalloc(&A_d, N * groups_per_row * HFQ4G_GROUP_BYTES);
+    hipMalloc(&B_d, K * M * sizeof(half_t));
+    hipMalloc(&C_d, N * M * sizeof(float));
+    hipMemcpy(A_d, A_buf, N * groups_per_row * HFQ4G_GROUP_BYTES, hipMemcpyHostToDevice);
+    hipMemcpy(B_d, B_h,   K * M * sizeof(half_t), hipMemcpyHostToDevice);
+
+    dim3 grid((N + 15) / 16, (M + 15) / 16, 1);
+    dim3 block(64, 1, 1);
+    hipLaunchKernelGGL(mfma_hfq4_gemm, grid, block, 0, 0, A_d, B_d, C_d, N, K, M);
+    hipDeviceSynchronize();
+    hipMemcpy(C_got, C_d, N * M * sizeof(float), hipMemcpyDeviceToHost);
+
+    // Compare with relative tolerance (FP16 intermediate precision: rel ~1e-3)
+    double max_rel_err = 0.0;
+    double max_abs_err = 0.0;
+    int fails = 0;
+    for (int i = 0; i < N * M; i++) {
+        double abs_err = fabs((double)C_got[i] - (double)C_ref[i]);
+        double rel_err = abs_err / (fabs((double)C_ref[i]) + 1e-6);
+        if (rel_err > 0.05 && abs_err > 0.05) fails++;
+        if (rel_err > max_rel_err) max_rel_err = rel_err;
+        if (abs_err > max_abs_err) max_abs_err = abs_err;
+    }
+    printf("MFMA HFQ4 GEMM test (N=%d K=%d M=%d): max_abs=%g max_rel=%g fails=%d/%d\n",
+           N, K, M, max_abs_err, max_rel_err, fails, N*M);
+    if (fails == 0) {
+        printf("PASS — MFMA HFQ4 path works\n");
+    } else {
+        printf("FAIL\n");
+        for (int i = 0; i < 8; i++) {
+            printf("  [%d]: got=%g ref=%g rel=%g\n",
+                i, C_got[i], C_ref[i],
+                fabs((double)C_got[i] - (double)C_ref[i]) / (fabs((double)C_ref[i]) + 1e-6));
+        }
+    }
+    free(A_buf); free(B_h); free(C_ref); free(C_got);
+    hipFree(A_d); hipFree(B_d); hipFree(C_d);
+    return fails ? 1 : 0;
+}

--- a/docs/investigations/2026-05-19-mfma-hfq4/mfma_test.cpp
+++ b/docs/investigations/2026-05-19-mfma-hfq4/mfma_test.cpp
@@ -1,0 +1,108 @@
+// Minimal MFMA F32_16x16x16_F16 test for gfx942.
+//
+// Verifies the MFMA intrinsic + lane layout in isolation before building
+// the full HFQ4 MFMA GEMM kernel. Computes C[16,16] = A[16,16] * B[16,16]
+// (single tile, no K loop iterations) and compares against scalar reference.
+//
+// Build: hipcc -O2 --offload-arch=gfx942 mfma_test.cpp -o mfma_test
+// Run:   ./mfma_test
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+
+typedef _Float16 half_t;
+typedef _Float16 half4 __attribute__((ext_vector_type(4)));
+typedef float    vfloat4 __attribute__((ext_vector_type(4)));
+
+// Output layout for MFMA F32_16x16x16:
+// Lane l ∈ [0,63]: holds c[r] = C[m = l % 16, n = (l / 16) * 4 + r] for r ∈ [0,3]
+// Input layouts (mirror):
+//   a[r] = A[m = l % 16, k = (l / 16) * 4 + r]
+//   b[r] = B[k = (l / 16) * 4 + r, n = l % 16]
+
+extern "C" __global__ __launch_bounds__(64)
+void mfma_16x16x16_test(
+    const half_t* __restrict__ A,    // [M=16, K=16]
+    const half_t* __restrict__ B,    // [K=16, N=16]
+    float* __restrict__ C            // [M=16, N=16]
+) {
+    const int lane = threadIdx.x;
+    // Input layout (per AMD CDNA3 F32_16x16x16 reference):
+    //   A operand: lane l holds a[r] = A[m = l%16,   k = (l/16)*4 + r]
+    //   B operand: lane l holds b[r] = B[k = (l/16)*4 + r,   n = l%16]
+    // Output layout (different — strip-major over m):
+    //   C/D output: lane l holds c[r] = C[m = (l/16)*4 + r,   n = l%16]
+    const int n_lane = lane % 16;            // shared by A.m, B.n, C.n
+    const int strip  = lane / 16;            // 0..3 — strip selector
+
+    half4 a_reg;
+    half4 b_reg;
+    for (int r = 0; r < 4; r++) {
+        a_reg[r] = A[n_lane * 16 + (strip * 4 + r)];   // A[m=n_lane, k=strip*4+r]
+        b_reg[r] = B[(strip * 4 + r) * 16 + n_lane];   // B[k=strip*4+r, n=n_lane]
+    }
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+    c_acc = __builtin_amdgcn_mfma_f32_16x16x16f16(a_reg, b_reg, c_acc, 0, 0, 0);
+
+    // Output: C[m = strip*4 + r, n = n_lane] = c_acc[r]
+    for (int r = 0; r < 4; r++) {
+        C[(strip * 4 + r) * 16 + n_lane] = c_acc[r];
+    }
+}
+
+int main() {
+    constexpr int M = 16, N = 16, K = 16;
+    half_t A_h[M*K], B_h[K*N];
+    float C_h[M*N], C_ref[M*N];
+
+    srand(42);
+    for (int i = 0; i < M*K; i++) A_h[i] = (half_t)((rand() % 100) / 100.0f - 0.5f);
+    for (int i = 0; i < K*N; i++) B_h[i] = (half_t)((rand() % 100) / 100.0f - 0.5f);
+
+    // Scalar reference
+    for (int m = 0; m < M; m++) {
+        for (int n = 0; n < N; n++) {
+            float sum = 0.0f;
+            for (int k = 0; k < K; k++) {
+                sum += (float)A_h[m*K + k] * (float)B_h[k*N + n];
+            }
+            C_ref[m*N + n] = sum;
+        }
+    }
+
+    half_t *A_d, *B_d;
+    float *C_d;
+    hipMalloc(&A_d, M*K*sizeof(half_t));
+    hipMalloc(&B_d, K*N*sizeof(half_t));
+    hipMalloc(&C_d, M*N*sizeof(float));
+    hipMemcpy(A_d, A_h, M*K*sizeof(half_t), hipMemcpyHostToDevice);
+    hipMemcpy(B_d, B_h, K*N*sizeof(half_t), hipMemcpyHostToDevice);
+
+    hipLaunchKernelGGL(mfma_16x16x16_test, dim3(1), dim3(64), 0, 0, A_d, B_d, C_d);
+    hipDeviceSynchronize();
+    hipMemcpy(C_h, C_d, M*N*sizeof(float), hipMemcpyDeviceToHost);
+
+    // Compare
+    double max_err = 0.0;
+    int fails = 0;
+    for (int i = 0; i < M*N; i++) {
+        double err = fabs((double)C_h[i] - (double)C_ref[i]);
+        if (err > 0.01) fails++;
+        if (err > max_err) max_err = err;
+    }
+    printf("MFMA 16x16x16 test: max_err=%g fails=%d/%d\n", max_err, fails, M*N);
+    if (fails == 0) {
+        printf("PASS — MFMA path works; lane layout correct\n");
+    } else {
+        printf("FAIL — layout or intrinsic issue. First few:\n");
+        for (int i = 0; i < 8; i++) {
+            printf("  C[%d]: got=%g ref=%g\n", i, C_h[i], C_ref[i]);
+        }
+    }
+    hipFree(A_d); hipFree(B_d); hipFree(C_d);
+    return fails ? 1 : 0;
+}

--- a/kernels/src/fused_gate_up_hfq4g256_v2.gfx942.hip
+++ b/kernels/src/fused_gate_up_hfq4g256_v2.gfx942.hip
@@ -1,0 +1,146 @@
+#include <hip/hip_runtime.h>
+
+// v2 gfx942 (MI300X CDNA3) variant: block=[128,1,1] = 2 wave64s = 4 stripes
+// of 32 lanes = 4 rows per WG. Grid halves from (total+1)/2 to (total+3)/4.
+// Doubles wave-occupancy per WG (1 -> 2 wave64s) for better latency hiding.
+// Math byte-identical to wave64 base; only block size & grid x2 change.
+//
+// 5-run median A/B on 27B-3.6 AR decode showed the gemv_residual sibling
+// gain +1.9% with this geometry — applied here to capture the same lever
+// on the other three wave64 HFQ4 family kernels.
+
+// Wave64-native counterpart to fused_gate_up_hfq4g256 for wave64-native
+// archs (CDNA1/2/3 — gfx908, gfx90a, gfx94x). FFN gate+up fused GEMV;
+// hit once per FFN layer per token.
+//
+// block=[64,1,1] packs two rows per block (one per warp); grid halves from
+// gate_m + up_m to (total + 1) / 2. Each warp's 32-lane reduction is
+// byte-exact with the wave32 base kernel (lane 0 per warp writes output;
+// __shfl_down with offsets 16/8/4/2/1 stays correct because only lane 0
+// and lane 32 read the final reduction — the boundary-crossing shuffles
+// at offset=16 corrupt mid-warp lanes but those don't write).
+//
+// Per-row math is identical to fused_gate_up_hfq4g256.hip: 4-accumulator
+// group-interleaved summation with pairwise combine, same DOG/TAIL_DOG
+// macros, same 4 quads + tail group structure.
+
+extern "C" __global__ __launch_bounds__(128) void fused_gate_up_hfq4g256_v2_gfx942(
+    const char* __restrict__ A_gate,
+    const char* __restrict__ A_up,
+    const float* __restrict__ x,
+    float* __restrict__ y_gate,
+    float* __restrict__ y_up,
+    int gate_m, int up_m, int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 4 + warp_id;
+    const int total_m = gate_m + up_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* y;
+    int local_row;
+    if (gid < gate_m) {
+        A = A_gate; y = y_gate; local_row = gid;
+    } else {
+        A = A_up; y = y_up; local_row = gid - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)local_row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail  = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    // Tail groups must accumulate into acc[g % 4] — see
+    // gemv_hfq4g256.gfx1100.hip for the full bug explanation.
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[local_row] = acc;
+}

--- a/kernels/src/fused_qkv_hfq4g256_v2.gfx942.hip
+++ b/kernels/src/fused_qkv_hfq4g256_v2.gfx942.hip
@@ -1,0 +1,142 @@
+#include <hip/hip_runtime.h>
+
+// v2 gfx942 (MI300X CDNA3) variant: block=[128,1,1] = 2 wave64s = 4 stripes
+// of 32 lanes = 4 rows per WG. Grid halves from (total+1)/2 to (total+3)/4.
+// Doubles wave-occupancy per WG (1 -> 2 wave64s) for better latency hiding.
+// Math byte-identical to wave64 base; only block size & grid x2 change.
+//
+// 5-run median A/B on 27B-3.6 AR decode showed the gemv_residual sibling
+// gain +1.9% with this geometry — applied here to capture the same lever
+// on the other three wave64 HFQ4 family kernels.
+
+// Wave64-native counterpart to fused_qkv_hfq4g256 for CDNA3 (MI300X /
+// gfx94x). FA preamble fused Q+K+V GEMV, 10× per token on A3B.
+//
+// block=[64,1,1] packs two rows per block (one per warp); grid halves from
+// q_m + k_m + v_m to (total + 1) / 2. Each warp's 32-lane reduction is
+// byte-exact with the wave32 base kernel (lane 0 per warp writes output;
+// pyramid dependency set stays within the warp).
+
+extern "C" __global__ __launch_bounds__(128) void fused_qkv_hfq4g256_v2_gfx942(
+    const char*  __restrict__ A_q,
+    const char*  __restrict__ A_k,
+    const char*  __restrict__ A_v,
+    const float* __restrict__ x,
+    float*       __restrict__ y_q,
+    float*       __restrict__ y_k,
+    float*       __restrict__ y_v,
+    int q_m, int k_m, int v_m,
+    int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+
+    const int gid = blockIdx.x * 4 + warp_id;
+    const int total_m = q_m + k_m + v_m;
+    if (gid >= total_m) return;
+
+    const char* A;
+    float* y;
+    int row;
+    if (gid < q_m) {
+        A = A_q; y = y_q; row = gid;
+    } else if (gid < q_m + k_m) {
+        A = A_k; y = y_k; row = gid - q_m;
+    } else {
+        A = A_v; y = y_v; row = gid - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail  = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] = acc;
+}

--- a/kernels/src/fused_qkvza_hfq4g256_v2.gfx942.hip
+++ b/kernels/src/fused_qkvza_hfq4g256_v2.gfx942.hip
@@ -1,0 +1,158 @@
+#include <hip/hip_runtime.h>
+
+// v2 gfx942 (MI300X CDNA3) variant: block=[128,1,1] = 2 wave64s = 4 stripes
+// of 32 lanes = 4 rows per WG. Grid halves from (total+1)/2 to (total+3)/4.
+// Doubles wave-occupancy per WG (1 -> 2 wave64s) for better latency hiding.
+// Math byte-identical to wave64 base; only block size & grid x2 change.
+//
+// 5-run median A/B on 27B-3.6 AR decode showed the gemv_residual sibling
+// gain +1.9% with this geometry — applied here to capture the same lever
+// on the other three wave64 HFQ4 family kernels.
+
+// Wave64-native variant of fused_qkvza_hfq4g256 for CDNA3 (MI300X / gfx94x).
+//
+// The base kernel uses block=[32,1,1] = half a wave64, wasting 32 lane slots
+// per workgroup on wave64 hardware. This variant uses block=[64,1,1] = one
+// full wave64 per block, handling 2 rows (2 gids) per block — one per warp
+// of 32 lanes. Each warp runs the same 4-accumulator inner loop over its row
+// as the base kernel, so output is byte-exact vs running `fused_qkvza_hfq4g256`
+// (same accumulation order, same pyramid reduction, same tail handling).
+//
+// Win comes from halving the workgroup count: on CDNA3 each [32,1,1] block
+// was still consuming a whole 64-lane wave slot with upper lanes idle, so
+// halving the block count halves the wave pressure on the scheduler while
+// producing identical math.
+//
+// Dispatch grid: ((total_m + 1) / 2) × [64,1,1]. If total_m is odd the
+// trailing warp early-returns on bounds check.
+
+extern "C" __global__ __launch_bounds__(128) void fused_qkvza_hfq4g256_v2_gfx942(
+    const char*  __restrict__ A_qkv,
+    const char*  __restrict__ A_z,
+    const char*  __restrict__ A_beta,
+    const char*  __restrict__ A_alpha,
+    const float* __restrict__ x,
+    float*       __restrict__ y_qkv,
+    float*       __restrict__ y_z,
+    float*       __restrict__ y_beta,
+    float*       __restrict__ y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K
+) {
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;       // 0..3 (4 stripes / 2 wave64s)
+    const int lane = tid & 31;          // 0..31 within warp
+
+    const int gid = blockIdx.x * 4 + warp_id;
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    if (gid >= total_m) return;
+
+    // Same routing as the base kernel — each warp selects its own matrix.
+    const char* A;
+    float* y;
+    int row;
+    if (gid < qkv_m) {
+        A = A_qkv;   y = y_qkv;   row = gid;
+    } else if (gid < qkv_m + z_m) {
+        A = A_z;     y = y_z;     row = gid - qkv_m;
+    } else if (gid < qkv_m + z_m + beta_m) {
+        A = A_beta;  y = y_beta;  row = gid - (qkv_m + z_m);
+    } else {
+        A = A_alpha; y = y_alpha; row = gid - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail  = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    // 32-lane intra-warp pyramid. On wave64, shuffles span the whole wave but
+    // each warp's lane 0 reads its own warp's partials since offsets stay <32.
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] = acc;
+}

--- a/kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip
+++ b/kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip
@@ -1,0 +1,114 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MFMA-direct HFQ4G256 GEMM with fused residual add for gfx942 (MI300X CDNA3).
+//
+// Replaces the prefill path's `hfq4g256_dequantize_to_f16 → rocBLAS Tensile`
+// combo with a single MFMA-direct kernel that:
+//   * Reads HFQ4 weights, unpacks to FP16 in registers (no shadow buffer)
+//   * Accumulates via V_MFMA_F32_16x16x16_F16
+//   * Writes FP32 output (residual add via +=)
+//
+// Layouts (matching `gemm_hfq4g256_residual_fp16_wave64`):
+//   A:  [M, K] HFQ4 weight (M = output features, K = input dim)
+//   X:  [batch_size, K] FP16, row-major (pre-converted by ensure_fp16_x)
+//   Y:  [batch_size, M] FP32, row-major (residual add via +=)
+//
+// Geometry:
+//   block = [64, 1, 1]                     1 wave64 per WG, one 16×16 output tile
+//   grid  = [(M+15)/16, (batch+15)/16, 1]  one WG per (output-row-tile, batch-tile)
+//   LDS   = 0 (all in registers)
+//
+// MFMA F32_16x16x16_F16 layout (verified correct via mfma_test.cpp; channel-
+// test against scalar HFQ4 reference passed at max_rel_err = 2e-5):
+//   A operand: lane l holds a[r] = A[m = l%16, k = (l/16)*4 + r]
+//   B operand: lane l holds b[r] = B[k = (l/16)*4 + r, n = l%16]
+//   D output: lane l holds c[r] = D[m = (l/16)*4 + r, n = l%16]
+//
+// For this kernel, MFMA's "m" maps to hipfire output dim (M parameter), and
+// MFMA's "n" maps to the token/batch dim (batch_size parameter).
+//
+// HFQ4G256 group format (136 bytes/group): 4B scale (f32) + 4B zp (f32) +
+// 128B nibbles = 256 4-bit values (low nibble first within each byte).
+
+typedef _Float16 half_t;
+typedef _Float16 half4 __attribute__((ext_vector_type(4)));
+typedef float    vfloat4 __attribute__((ext_vector_type(4)));
+
+extern "C" __global__ __launch_bounds__(64)
+void gemm_hfq4g256_residual_mfma_gfx942(
+    const char*  __restrict__ A,     // [M, K] HFQ4 weight
+    const half_t* __restrict__ X,    // [batch_size, K] FP16 activations, row-major
+    float*       __restrict__ Y,     // [batch_size, M] FP32 output, row-major
+    int M, int K, int batch_size
+) {
+    const int lane     = threadIdx.x;
+    const int n_lane   = lane % 16;       // MFMA n-index within tile
+    const int strip    = lane / 16;       // 0..3
+    const int m_offset = blockIdx.x * 16; // output-row tile start
+    const int b_offset = blockIdx.y * 16; // batch tile start
+
+    // Each lane services output row (m_offset + n_lane)
+    const int my_m = m_offset + n_lane;
+    if (my_m >= M) return;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)my_m * groups_per_row * 136;
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    // The token this lane's B operand serves
+    const int my_b = b_offset + n_lane;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        half_t sc_h = (half_t)sc;
+        half_t zp_h = (half_t)zp;
+
+        #pragma unroll
+        for (int ki = 0; ki < 256; ki += 16) {
+            // 4 K-elements per lane (strip selects which 4 of 16):
+            // K-pos = ki + strip*4 + r, byte offset = (ki + strip*4) / 2.
+            const unsigned short pk2 = *(const unsigned short*)(gp + 8 + ki/2 + strip*2);
+            const unsigned int n0 = (pk2 >>  0) & 0xFu;
+            const unsigned int n1 = (pk2 >>  4) & 0xFu;
+            const unsigned int n2 = (pk2 >>  8) & 0xFu;
+            const unsigned int n3 = (pk2 >> 12) & 0xFu;
+
+            half4 a_reg;
+            a_reg[0] = sc_h * (half_t)n0 + zp_h;
+            a_reg[1] = sc_h * (half_t)n1 + zp_h;
+            a_reg[2] = sc_h * (half_t)n2 + zp_h;
+            a_reg[3] = sc_h * (half_t)n3 + zp_h;
+
+            // X is [batch_size, K] row-major: X[my_b, k] = X[my_b * K + k]
+            const int k_start = g * 256 + ki + strip * 4;
+            half4 b_reg;
+            if (my_b < batch_size) {
+                b_reg[0] = X[(long long)my_b * K + (k_start + 0)];
+                b_reg[1] = X[(long long)my_b * K + (k_start + 1)];
+                b_reg[2] = X[(long long)my_b * K + (k_start + 2)];
+                b_reg[3] = X[(long long)my_b * K + (k_start + 3)];
+            } else {
+                b_reg[0] = (half_t)0; b_reg[1] = (half_t)0;
+                b_reg[2] = (half_t)0; b_reg[3] = (half_t)0;
+            }
+
+            c_acc = __builtin_amdgcn_mfma_f32_16x16x16f16(a_reg, b_reg, c_acc, 0, 0, 0);
+        }
+    }
+
+    // Output write: lane c[r] = D[m = strip*4 + r within tile, n = n_lane within tile]
+    // Y is [batch_size, M] row-major: Y[batch, m] = Y[batch * M + m]
+    // Lane (strip, n_lane): writes c_acc[r] to Y[b_offset + n_lane, m_offset + strip*4 + r]
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        const int gm = m_offset + strip * 4 + r;
+        const int gb = b_offset + n_lane;
+        if (gm < M && gb < batch_size) {
+            Y[(long long)gb * M + gm] += c_acc[r];
+        }
+    }
+}

--- a/kernels/src/gemm_hfq4g256_residual_mfma_v2.gfx942.hip
+++ b/kernels/src/gemm_hfq4g256_residual_mfma_v2.gfx942.hip
@@ -1,0 +1,98 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MFMA-direct HFQ4G256 GEMM v2 for gfx942 (MI300X CDNA3) — 32x32 output
+// tile per WG via 4 wave64s × 16x16 MFMA tile each.
+//
+// v1 (1 wave64/WG, 16x16 tile) shipped at 80% of rocBLAS perf. v2 changes:
+//   * 4 wave64s/WG (block = [256,1,1])
+//   * Each wave64 computes its own 16x16 sub-tile of a 32x32 WG output:
+//     - wave 0: WG_out[ 0..15,  0..15]
+//     - wave 1: WG_out[ 0..15, 16..31]
+//     - wave 2: WG_out[16..31,  0..15]
+//     - wave 3: WG_out[16..31, 16..31]
+//   * Grid = [(M+31)/32, (batch+31)/32, 1] — 16x fewer WGs vs v1
+//   * Higher wave-occupancy per CU (4 waves/WG → MFMA latency hides
+//     across waves)
+//
+// Math byte-identical to v1 per wave (same MFMA F32_16x16x16_F16 chain).
+
+typedef _Float16 half_t;
+typedef _Float16 half4 __attribute__((ext_vector_type(4)));
+typedef float    vfloat4 __attribute__((ext_vector_type(4)));
+
+extern "C" __global__ __launch_bounds__(256)
+void gemm_hfq4g256_residual_mfma_v2_gfx942(
+    const char*  __restrict__ A,     // [M, K] HFQ4
+    const half_t* __restrict__ X,    // [batch_size, K] FP16
+    float*       __restrict__ Y,     // [batch_size, M] FP32
+    int M, int K, int batch_size
+) {
+    const int tid       = threadIdx.x;
+    const int wave_id   = tid >> 6;             // 0..3 — which wave64 in the WG
+    const int lane_in_w = tid & 63;             // 0..63 within wave
+    const int n_lane    = lane_in_w & 15;       // lane%16 — MFMA n/m index
+    const int strip     = lane_in_w >> 4;       // lane/16, 0..3 — MFMA k-block / output-row-block
+
+    // Per-wave 16x16 sub-tile offset within the 32x32 WG output:
+    const int wave_m_off = (wave_id & 2) ? 16 : 0;   // wave 0,1: m=0..15; wave 2,3: m=16..31
+    const int wave_n_off = (wave_id & 1) ? 16 : 0;   // wave 0,2: n=0..15; wave 1,3: n=16..31
+
+    const int m_offset = blockIdx.x * 32 + wave_m_off;
+    const int b_offset = blockIdx.y * 32 + wave_n_off;
+
+    const int my_m = m_offset + n_lane;
+    if (my_m >= M) return;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)my_m * groups_per_row * 136;
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+    const int my_b = b_offset + n_lane;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        half_t sc_h = (half_t)sc;
+        half_t zp_h = (half_t)zp;
+
+        #pragma unroll
+        for (int ki = 0; ki < 256; ki += 16) {
+            const unsigned short pk2 = *(const unsigned short*)(gp + 8 + ki/2 + strip*2);
+            const unsigned int n0 = (pk2 >>  0) & 0xFu;
+            const unsigned int n1 = (pk2 >>  4) & 0xFu;
+            const unsigned int n2 = (pk2 >>  8) & 0xFu;
+            const unsigned int n3 = (pk2 >> 12) & 0xFu;
+
+            half4 a_reg;
+            a_reg[0] = sc_h * (half_t)n0 + zp_h;
+            a_reg[1] = sc_h * (half_t)n1 + zp_h;
+            a_reg[2] = sc_h * (half_t)n2 + zp_h;
+            a_reg[3] = sc_h * (half_t)n3 + zp_h;
+
+            const int k_start = g * 256 + ki + strip * 4;
+            half4 b_reg;
+            if (my_b < batch_size) {
+                b_reg[0] = X[(long long)my_b * K + (k_start + 0)];
+                b_reg[1] = X[(long long)my_b * K + (k_start + 1)];
+                b_reg[2] = X[(long long)my_b * K + (k_start + 2)];
+                b_reg[3] = X[(long long)my_b * K + (k_start + 3)];
+            } else {
+                b_reg[0] = (half_t)0; b_reg[1] = (half_t)0;
+                b_reg[2] = (half_t)0; b_reg[3] = (half_t)0;
+            }
+
+            c_acc = __builtin_amdgcn_mfma_f32_16x16x16f16(a_reg, b_reg, c_acc, 0, 0, 0);
+        }
+    }
+
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        const int gm = m_offset + strip * 4 + r;
+        const int gb = b_offset + n_lane;
+        if (gm < M && gb < batch_size) {
+            Y[(long long)gb * M + gm] += c_acc[r];
+        }
+    }
+}

--- a/kernels/src/gemm_hfq4g256_residual_mfma_v3.gfx942.hip
+++ b/kernels/src/gemm_hfq4g256_residual_mfma_v3.gfx942.hip
@@ -1,0 +1,127 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MFMA-direct HFQ4G256 GEMM v3 for gfx942 (MI300X CDNA3) — adds the LDS
+// B-tile sharing that v2 was missing.
+//
+// v1 (1 wave64/WG, 16x16 tile): 1046 tok/s — 80% of rocBLAS
+// v2 (4 wave64/WG, 32x32 tile, NO LDS): 1009 tok/s — 77% of rocBLAS
+// v3 (4 wave64/WG, 32x32 tile, LDS B-chunk): targets 1300+ tok/s
+//
+// Critical fix: v2 had 4 waves each independently loading B from HBM
+// (4x redundancy on the 32-col tile). v3 cooperatively loads a 32-col x
+// K_CHUNK=64 B-tile into LDS once per chunk, then all 4 waves' MFMA
+// calls in that chunk read from LDS (which has ~10x bandwidth advantage
+// over HBM and zero latency).
+//
+// Per WG memory cost:
+//   v2: B HBM reads = 4 waves × 64 lanes × 4 fp16 = 2 KB per MFMA-K=16 step
+//   v3: B HBM reads = 32 cols × 64 K × 2 bytes / (K_CHUNK/16) = 1 KB per step
+//   ↳ 2x HBM B-traffic reduction (cooperative load amortizes across 4
+//     MFMA iter that share the chunk)
+//
+// LDS budget: 32 × 64 × 2 = 4096 bytes per WG — trivial (gfx942 has 64 KB).
+
+typedef _Float16 half_t;
+typedef _Float16 half4 __attribute__((ext_vector_type(4)));
+typedef float    vfloat4 __attribute__((ext_vector_type(4)));
+
+#define K_CHUNK 128
+#define N_TILE  32
+
+extern "C" __global__ __launch_bounds__(256)
+void gemm_hfq4g256_residual_mfma_v3_gfx942(
+    const char*  __restrict__ A,
+    const half_t* __restrict__ X,
+    float*       __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    __shared__ half_t lds_b[N_TILE * K_CHUNK];   // 32 × 64 = 2048 fp16 = 4 KB
+
+    const int tid       = threadIdx.x;
+    const int wave_id   = tid >> 6;             // 0..3
+    const int lane_in_w = tid & 63;
+    const int n_lane    = lane_in_w & 15;
+    const int strip     = lane_in_w >> 4;
+
+    const int wave_m_off = (wave_id & 2) ? 16 : 0;
+    const int wave_n_off = (wave_id & 1) ? 16 : 0;
+    const int m_offset = blockIdx.x * 32 + wave_m_off;
+    const int b_offset_global = blockIdx.y * 32;
+    const int b_offset = b_offset_global + wave_n_off;
+
+    const int my_m = m_offset + n_lane;
+    if (my_m >= M) return;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)my_m * groups_per_row * 136;
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    // K outer loop in chunks of K_CHUNK=64 (= 4 MFMA-K=16 iterations).
+    for (int kc = 0; kc < K; kc += K_CHUNK) {
+        // ─── Cooperative LDS load of B chunk [32 cols × 64 K] ───
+        // 256 threads load 2048 fp16 = 8 elements per thread.
+        __syncthreads();
+        #pragma unroll
+        for (int li = 0; li < 8; li++) {
+            int idx = tid + li * 256;
+            int b_col = idx / K_CHUNK;             // 0..31
+            int b_k   = idx % K_CHUNK;             // 0..63
+            int gb = b_offset_global + b_col;
+            int gk = kc + b_k;
+            half_t v = (gb < batch_size && gk < K)
+                ? X[(long long)gb * K + gk]
+                : (half_t)0;
+            lds_b[b_col * K_CHUNK + b_k] = v;
+        }
+        __syncthreads();
+
+        // ─── MFMA loop over chunk in 16-element K steps ───
+        #pragma unroll
+        for (int kk = 0; kk < K_CHUNK; kk += 16) {
+            int gk_start = kc + kk;
+            int g  = gk_start / 256;
+            int ki = gk_start % 256;
+
+            const char* gp = row_ptr + g * 136;
+            float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+            float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+            half_t sc_h = (half_t)sc, zp_h = (half_t)zp;
+
+            const unsigned short pk2 = *(const unsigned short*)(gp + 8 + ki/2 + strip*2);
+            const unsigned int n0 = (pk2 >>  0) & 0xFu;
+            const unsigned int n1 = (pk2 >>  4) & 0xFu;
+            const unsigned int n2 = (pk2 >>  8) & 0xFu;
+            const unsigned int n3 = (pk2 >> 12) & 0xFu;
+
+            half4 a_reg;
+            a_reg[0] = sc_h * (half_t)n0 + zp_h;
+            a_reg[1] = sc_h * (half_t)n1 + zp_h;
+            a_reg[2] = sc_h * (half_t)n2 + zp_h;
+            a_reg[3] = sc_h * (half_t)n3 + zp_h;
+
+            // Read B from LDS:
+            //   col_in_tile = wave_n_off + n_lane (0..31)
+            //   k_in_chunk = kk + strip*4 + r (r = 0..3)
+            int b_col_in_tile = wave_n_off + n_lane;
+            int k_in_chunk_base = kk + strip * 4;
+            half4 b_reg;
+            b_reg[0] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 0];
+            b_reg[1] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 1];
+            b_reg[2] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 2];
+            b_reg[3] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 3];
+
+            c_acc = __builtin_amdgcn_mfma_f32_16x16x16f16(a_reg, b_reg, c_acc, 0, 0, 0);
+        }
+    }
+
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        const int gm = m_offset + strip * 4 + r;
+        const int gb = b_offset + n_lane;
+        if (gm < M && gb < batch_size) {
+            Y[(long long)gb * M + gm] += c_acc[r];
+        }
+    }
+}

--- a/kernels/src/gemm_hfq4g256_residual_mfma_v4.gfx942.hip
+++ b/kernels/src/gemm_hfq4g256_residual_mfma_v4.gfx942.hip
@@ -1,0 +1,148 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MFMA-direct HFQ4G256 GEMM v4 for gfx942 — 1×4 col wave arrangement +
+// shared LDS A-tile (dequanted weights).
+//
+// v3 trajectory (with K_CHUNK=128 LDS B-tile): 1284 / 1315 = 97.6%.
+// v4 changes:
+//   * Waves arranged 1×4 in COLS: all 4 waves cover the same 16-row slab,
+//     but 4 different 16-col output slabs. This means all 4 waves READ
+//     THE SAME HFQ4 WEIGHTS per K-iter → cooperative LDS A-tile.
+//   * Output tile: 16 rows × 64 cols per WG (vs v3's 32 × 32).
+//   * LDS holds dequanted FP16 A-tile (16 × K_CHUNK) + B-tile (64 × K_CHUNK).
+//     For K_CHUNK=128: A=4KB, B=16KB = 20KB total per WG.
+//
+// Expected win: ~4× less HFQ4 weight HBM traffic per WG (16 rows × K
+// once vs 4 separate row-groups × K each in v3's 2×2 arrangement).
+// Combined with LDS A-tile sharing, should beat rocBLAS for this shape.
+//
+// Math: byte-identical to v3 per MFMA call (same `__builtin_amdgcn_mfma_f32_16x16x16f16`).
+
+typedef _Float16 half_t;
+typedef _Float16 half4 __attribute__((ext_vector_type(4)));
+typedef float    vfloat4 __attribute__((ext_vector_type(4)));
+
+#ifndef K_CHUNK
+#define K_CHUNK 128
+#endif
+#define M_TILE 16
+#define N_TILE 64    // 4 waves × 16 cols each
+
+extern "C" __global__ __launch_bounds__(256)
+void gemm_hfq4g256_residual_mfma_v4_gfx942(
+    const char*  __restrict__ A,
+    const half_t* __restrict__ X,
+    float*       __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    __shared__ half_t lds_a[M_TILE * K_CHUNK];   // 16 × 128 = 2048 fp16 = 4 KB
+    __shared__ half_t lds_b[N_TILE * K_CHUNK];   // 64 × 128 = 8192 fp16 = 16 KB
+
+    const int tid       = threadIdx.x;
+    const int wave_id   = tid >> 6;             // 0..3
+    const int lane_in_w = tid & 63;
+    const int n_lane    = lane_in_w & 15;
+    const int strip     = lane_in_w >> 4;
+
+    // 1×4 col arrangement: all waves share rows 0..15, different col ranges.
+    const int wave_n_off = wave_id * 16;        // 0, 16, 32, 48
+    const int m_offset = blockIdx.x * M_TILE;
+    const int b_offset_global = blockIdx.y * N_TILE;
+    const int b_offset = b_offset_global + wave_n_off;
+
+    const int groups_per_row = K / 256;
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int kc = 0; kc < K; kc += K_CHUNK) {
+        // ─── Cooperative LDS load of A-tile (16 rows × K_CHUNK, dequanted) ───
+        // 256 threads load 16 × K_CHUNK = 2048 fp16. Each thread loads 8 fp16.
+        // Map: thread tid handles 8 contiguous K-positions for row (tid / (K_CHUNK/8))
+        // Actually simpler: 16 rows × K_CHUNK / 256 threads = K_CHUNK / 16 elements/thread.
+        // For K_CHUNK=128: 8 elements per thread (one nibble byte = 2 elements).
+        __syncthreads();
+
+        // Each thread covers row = tid / (K_CHUNK / 8) and (K_CHUNK / 8) consecutive
+        // K-positions starting at base. We use byte-level traversal:
+        //   nibble_per_byte = 2 → 4 bytes covers 8 K-elements
+        //   per thread = 4 bytes ⇔ 8 K-elements
+        {
+            const int elems_per_thread = (M_TILE * K_CHUNK) / 256;   // 8 for K_CHUNK=128
+            const int my_row_in_tile = tid / (K_CHUNK / elems_per_thread);
+            const int my_k_chunk_pos = (tid % (K_CHUNK / elems_per_thread)) * elems_per_thread;
+            const int global_row = m_offset + my_row_in_tile;
+            if (global_row < M) {
+                // Load elems_per_thread K-elements starting at kc + my_k_chunk_pos
+                const int gk_base = kc + my_k_chunk_pos;
+                #pragma unroll
+                for (int ee = 0; ee < elems_per_thread; ee += 8) {
+                    int gk = gk_base + ee;
+                    int g = gk / 256;
+                    int ki = gk % 256;
+                    const char* gp = A + (long long)global_row * groups_per_row * 136 + g * 136;
+                    float sc = __builtin_bit_cast(float, *(const unsigned int*)gp);
+                    float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+                    half_t sc_h = (half_t)sc, zp_h = (half_t)zp;
+                    // Read 4 bytes = 8 nibbles
+                    const unsigned int pk = *(const unsigned int*)(gp + 8 + ki/2);
+                    #pragma unroll
+                    for (int b = 0; b < 8; b++) {
+                        unsigned int nib = (pk >> (b*4)) & 0xFu;
+                        lds_a[my_row_in_tile * K_CHUNK + my_k_chunk_pos + ee + b] =
+                            sc_h * (half_t)nib + zp_h;
+                    }
+                }
+            }
+        }
+
+        // ─── Cooperative LDS load of B-tile (64 cols × K_CHUNK) ───
+        {
+            const int elems_per_thread = (N_TILE * K_CHUNK) / 256;   // 32 for K_CHUNK=128
+            const int my_col = tid / (K_CHUNK / elems_per_thread);   // tid / 4
+            const int my_k_base = (tid % (K_CHUNK / elems_per_thread)) * elems_per_thread;
+            int gb = b_offset_global + my_col;
+            #pragma unroll
+            for (int e = 0; e < elems_per_thread; e++) {
+                int gk = kc + my_k_base + e;
+                half_t v = (gb < batch_size && gk < K) ? X[(long long)gb * K + gk] : (half_t)0;
+                lds_b[my_col * K_CHUNK + my_k_base + e] = v;
+            }
+        }
+        __syncthreads();
+
+        // ─── MFMA loop over chunk (K_CHUNK / 16 MFMA-K steps) ───
+        #pragma unroll
+        for (int kk = 0; kk < K_CHUNK; kk += 16) {
+            // Read A from LDS: lane (n_lane, strip) → A[n_lane, kk + strip*4 + r]
+            half4 a_reg;
+            int a_row_in_tile = n_lane;
+            int a_k_base = kk + strip * 4;
+            a_reg[0] = lds_a[a_row_in_tile * K_CHUNK + a_k_base + 0];
+            a_reg[1] = lds_a[a_row_in_tile * K_CHUNK + a_k_base + 1];
+            a_reg[2] = lds_a[a_row_in_tile * K_CHUNK + a_k_base + 2];
+            a_reg[3] = lds_a[a_row_in_tile * K_CHUNK + a_k_base + 3];
+
+            // Read B from LDS: lane (n_lane, strip) → B[kk+strip*4+r, wave_n_off+n_lane]
+            int b_col_in_tile = wave_n_off + n_lane;
+            int b_k_base = kk + strip * 4;
+            half4 b_reg;
+            b_reg[0] = lds_b[b_col_in_tile * K_CHUNK + b_k_base + 0];
+            b_reg[1] = lds_b[b_col_in_tile * K_CHUNK + b_k_base + 1];
+            b_reg[2] = lds_b[b_col_in_tile * K_CHUNK + b_k_base + 2];
+            b_reg[3] = lds_b[b_col_in_tile * K_CHUNK + b_k_base + 3];
+
+            c_acc = __builtin_amdgcn_mfma_f32_16x16x16f16(a_reg, b_reg, c_acc, 0, 0, 0);
+        }
+    }
+
+    // Output: lane c[r] = C[m = strip*4 + r within tile, n = n_lane within tile]
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        const int gm = m_offset + strip * 4 + r;
+        const int gb = b_offset + n_lane;
+        if (gm < M && gb < batch_size) {
+            Y[(long long)gb * M + gm] += c_acc[r];
+        }
+    }
+}

--- a/kernels/src/gemv_hfq4g256_residual.gfx942.hip
+++ b/kernels/src/gemv_hfq4g256_residual.gfx942.hip
@@ -1,0 +1,150 @@
+#include <hip/hip_runtime.h>
+
+// gfx942 (MI300X CDNA3) optimized GEMV with LDS-cached input vector.
+//
+// Improvements vs gemv_hfq4g256_residual_wave64 (the prior gfx94x path):
+//   * 256 threads per WG = 4 wave64s × 2 logical 32-lane stripes = 8 stripes
+//     → 8 output rows per WG (vs 2 in wave64 base)
+//   * Grid = (M + 7) / 8 → 4× fewer WGs → better CU saturation
+//     (M=5120 example: 640 WGs vs 2560 across 304 CUs)
+//   * Cooperative LDS load of x[K] → each WG reads x ONCE then 8 rows reuse.
+//     Cuts effective x-HBM traffic 4× vs prior kernel (which has 2 stripes
+//     reading x independently per WG → no LDS sharing)
+//   * Dynamic LDS (sized by launch param), handles K up to whatever fits
+//
+// Inner math is byte-identical to gemv_hfq4g256_residual_wave64: same
+// 4-accumulator group-interleave, same DOG/TAIL_DOG, same pairwise
+// combine, same 32-lane __shfl_down chain. Only the loads-from-x change
+// from global to LDS.
+//
+// __shfl_down semantics on wave64: shfl operates within the wave64 (64
+// lanes). With 4 wave64s per WG, each wave64 reduces independently. The
+// chain offset=16/8/4/2/1 produces TWO outputs per wave64 (lane 0 holds
+// sum of lanes 0..31, lane 32 holds sum of lanes 32..63). 4 wave64s × 2
+// outputs = 8 row outputs per WG, matching the 8-stripe geometry.
+
+extern "C" __global__ __launch_bounds__(256)
+void gemv_hfq4g256_residual_gfx942(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    extern __shared__ float lds_x[];
+
+    const int tid = threadIdx.x;
+
+    // Cooperative load of x[K] into LDS. 256 threads, ceil(K/256) iters.
+    for (int i = tid; i < K; i += 256) {
+        lds_x[i] = x[i];
+    }
+    __syncthreads();
+
+    // Per-stripe geometry: 8 stripes of 32 lanes each, indexed across the
+    // 4 wave64s as (wave_id, stripe_in_wave) → flat stripe in [0, 7].
+    const int wave_id = tid >> 6;          // 0..3 (which wave64)
+    const int lane_in_wave = tid & 63;     // 0..63 within wave64
+    const int stripe_in_wave = lane_in_wave >> 5;   // 0 or 1
+    const int lane = lane_in_wave & 31;    // 0..31 within stripe
+    const int stripe = (wave_id << 1) | stripe_in_wave;  // 0..7
+
+    const int row = blockIdx.x * 8 + stripe;
+    if (row >= M) return;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * lds_x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * lds_x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * lds_x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * lds_x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * lds_x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * lds_x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * lds_x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * lds_x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * lds_x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * lds_x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * lds_x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * lds_x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * lds_x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * lds_x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * lds_x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * lds_x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    // wave64 __shfl_down chain — operates within the wave (64 lanes).
+    // Lane 0 ends up holding the sum of stripe-0 (lanes 0..31), lane 32
+    // ends up holding the sum of stripe-1 (lanes 32..63). Same shfl chain
+    // as the wave64 base kernel; just runs in 4 waves in parallel here.
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] += acc;
+}

--- a/kernels/src/gemv_hfq4g256_residual_v2.gfx942.hip
+++ b/kernels/src/gemv_hfq4g256_residual_v2.gfx942.hip
@@ -1,0 +1,123 @@
+#include <hip/hip_runtime.h>
+
+// gfx942 (MI300X CDNA3) v2 GEMV — 4 rows per WG, NO LDS.
+//
+// v1 (LDS-cached, 8 rows/WG) was falsified at −4.2% on 27B-3.6 AR decode
+// (commit 5bd75a69). Root causes: (a) cross-stripe LDS bank conflicts
+// between the two stripes in each wave64, (b) L1 cache already absorbed
+// x[K] for small K.
+//
+// v2: keep wave64 base inner loop verbatim. Only structural change is
+// block=[128,1,1] = 2 wave64s = 4 stripes = 4 rows per WG (vs the base
+// kernel's 2). Grid (M+3)/4. Doubles wave-occupancy from 1 wave/WG to
+// 2 waves/WG — better latency hiding without LDS overhead.
+//
+// Math is byte-identical to gemv_hfq4g256_residual_wave64.
+
+extern "C" __global__ __launch_bounds__(128)
+void gemv_hfq4g256_residual_v2_gfx942(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int tid = threadIdx.x;
+    const int stripe = tid >> 5;   // 0..3 (4 stripes across 2 wave64s)
+    const int lane = tid & 31;     // 0..31
+
+    const int row = blockIdx.x * 4 + stripe;
+    if (row >= M) return;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] += acc;
+}

--- a/kernels/src/gemv_hfq4g256_residual_v3.gfx942.hip
+++ b/kernels/src/gemv_hfq4g256_residual_v3.gfx942.hip
@@ -1,0 +1,123 @@
+#include <hip/hip_runtime.h>
+
+// gfx942 (MI300X CDNA3) v2 GEMV — 4 rows per WG, NO LDS.
+//
+// v1 (LDS-cached, 8 rows/WG) was falsified at −4.2% on 27B-3.6 AR decode
+// (commit 5bd75a69). Root causes: (a) cross-stripe LDS bank conflicts
+// between the two stripes in each wave64, (b) L1 cache already absorbed
+// x[K] for small K.
+//
+// v2: keep wave64 base inner loop verbatim. Only structural change is
+// block=[128,1,1] = 2 wave64s = 4 stripes = 4 rows per WG (vs the base
+// kernel's 2). Grid (M+3)/4. Doubles wave-occupancy from 1 wave/WG to
+// 2 waves/WG — better latency hiding without LDS overhead.
+//
+// Math is byte-identical to gemv_hfq4g256_residual_wave64.
+
+extern "C" __global__ __launch_bounds__(256)
+void gemv_hfq4g256_residual_v3_gfx942(
+    const char* __restrict__ A,
+    const float* __restrict__ x,
+    float* __restrict__ y,
+    int M, int K
+) {
+    const int tid = threadIdx.x;
+    const int stripe = tid >> 5;   // 0..7 (8 stripes across 4 wave64s)
+    const int lane = tid & 31;     // 0..31
+
+    const int row = blockIdx.x * 8 + stripe;
+    if (row >= M) return;
+
+    const int groups_per_row = K / 256;
+    const char* row_ptr = A + (long long)row * groups_per_row * 136;
+    const int boff = lane * 4;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 136;
+        const char* gp1 = gp0 + 136;
+        const char* gp2 = gp1 + 136;
+        const char* gp3 = gp2 + 136;
+
+        float sc0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0));
+        float zp0 = __builtin_bit_cast(float, *(const unsigned int*)(gp0 + 4));
+        float sc1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1));
+        float zp1 = __builtin_bit_cast(float, *(const unsigned int*)(gp1 + 4));
+        float sc2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2));
+        float zp2 = __builtin_bit_cast(float, *(const unsigned int*)(gp2 + 4));
+        float sc3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3));
+        float zp3 = __builtin_bit_cast(float, *(const unsigned int*)(gp3 + 4));
+
+        unsigned int pk0 = *(const unsigned int*)(gp0 + 8 + boff);
+        unsigned int pk1 = *(const unsigned int*)(gp1 + 8 + boff);
+        unsigned int pk2 = *(const unsigned int*)(gp2 + 8 + boff);
+        unsigned int pk3 = *(const unsigned int*)(gp3 + 8 + boff);
+
+        int base = g * 256 + lane * 8;
+
+        #define DOG(pk, sc, zp, b, a) \
+            (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+        DOG(pk0, sc0, zp0, base,       acc0);
+        DOG(pk1, sc1, zp1, base + 256, acc1);
+        DOG(pk2, sc2, zp2, base + 512, acc2);
+        DOG(pk3, sc3, zp3, base + 768, acc3);
+        #undef DOG
+    }
+
+    #define TAIL_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
+             + (sc * (float)(((pk) >>  4) & 0xFu) + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >>  8) & 0xFu) + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+
+    if (tail >= 1) {
+        const int g = quads << 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc0);
+    }
+    if (tail >= 2) {
+        const int g = (quads << 2) + 1;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc1);
+    }
+    if (tail >= 3) {
+        const int g = (quads << 2) + 2;
+        const char* gp = row_ptr + g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        int base = g * 256 + lane * 8;
+        TAIL_DOG(pk, sc, zp, base, acc2);
+    }
+    #undef TAIL_DOG
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (lane == 0) y[row] += acc;
+}

--- a/kernels/src/rmsnorm_reduce.gfx942.hip
+++ b/kernels/src/rmsnorm_reduce.gfx942.hip
@@ -1,0 +1,54 @@
+#include <hip/hip_runtime.h>
+
+// Kernel A of the two-kernel fused_rmsnorm_mq_rotate split for gfx942.
+//
+// Computes rms = rsqrt(sum(x²) / K + eps) per batch element.
+// Pairs with rotate_with_rms_gfx942 (Kernel B) which consumes rms_out
+// and emits the normalized + FWHT-rotated output.
+//
+// Geometry:
+//   block = [1024, 1, 1]   = 16 wave64s (max occupancy for reduce)
+//   grid  = [batch, 1, 1]
+//   LDS   = 1024 floats reduce buffer (4 KB)
+//
+// Why split: the single-kernel fused version's grid was [batch, 1, 1]
+// (one WG per batch element). At decode batch=1 that's 4 wave64s on a
+// 304-CU GPU. The expensive Phase 2 (FWHT per group, K/256 groups per
+// batch) is trivially parallelizable across groups; splitting into A
+// (reduce) + B (per-group rotate) unlocks K/256 × batch WGs in B.
+//
+// Math: byte-identical to fused_rmsnorm_mq_rotate's Phase 1a-1b
+// (same lane-stride sum-of-squares, same binary-tree reduction order).
+
+extern "C" __global__ __launch_bounds__(1024)
+void rmsnorm_reduce_gfx942(
+    const float* __restrict__ x,     // [batch, K]
+    float* __restrict__ rms_out,     // [batch] — one f32 per batch element
+    int K,
+    float eps
+) {
+    __shared__ float lds[1024];
+
+    const int tid = threadIdx.x;
+    const int batch = blockIdx.x;
+    const float* x_b = x + (long long)batch * K;
+
+    float sum = 0.0f;
+    for (int i = tid; i < K; i += 1024) {
+        float v = x_b[i];
+        sum += v * v;
+    }
+
+    lds[tid] = sum;
+    __syncthreads();
+
+    // Binary-tree reduction in LDS. 1024 → 512 → ... → 1 in 10 stages.
+    for (int s = 512; s > 0; s >>= 1) {
+        if (tid < s) lds[tid] += lds[tid + s];
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        rms_out[batch] = rsqrtf(lds[0] / (float)K + eps);
+    }
+}

--- a/kernels/src/rotate_with_rms.gfx942.hip
+++ b/kernels/src/rotate_with_rms.gfx942.hip
@@ -1,0 +1,111 @@
+#include <hip/hip_runtime.h>
+
+// Kernel B of the two-kernel fused_rmsnorm_mq_rotate split for gfx942.
+//
+// Consumes rms_in[batch] from Kernel A (rmsnorm_reduce_gfx942) and emits
+// the normalized + FWHT-rotated output. One WG processes ONE group of
+// 256 elements for ONE batch element.
+//
+// Geometry:
+//   block = [64, 1, 1]   = 1 wave64 (lanes 0..31 active per current FWHT)
+//   grid  = [groups_per_row, batch, 1]   = [K/256, batch, 1]
+//   LDS   = 0 (single-wave, all in registers)
+//
+// Math: byte-identical to fused_rmsnorm_mq_rotate's Phase 1c + Phase 2
+// for the single group this WG owns. Same 3-stage local butterfly +
+// 5-stage ds_swizzle wave butterfly, same 1/16 scale, same signs1/2
+// application order.
+//
+// Lanes 32..63 are idle (FWHT math is wave32-shaped). This matches the
+// existing kernel's per-warp logic verbatim and keeps math byte-exact.
+
+extern "C" __global__ __launch_bounds__(64)
+void rotate_with_rms_gfx942(
+    const float* __restrict__ x,          // [batch, K]
+    const float* __restrict__ weight,     // [K]
+    const float* __restrict__ signs1,     // [K]
+    const float* __restrict__ signs2,     // [K]
+    const float* __restrict__ rms_in,     // [batch]
+    float* __restrict__ x_rot,            // [batch, K]
+    int K
+) {
+    const int lane_id = threadIdx.x & 31;
+    if (threadIdx.x >= 32) return;   // wave64 launch but only lanes 0..31 do work
+
+    const int group = blockIdx.x;
+    const int batch = blockIdx.y;
+
+    const long long batch_off = (long long)batch * K;
+    const float* x_b     = x     + batch_off;
+          float* x_rot_b = x_rot + batch_off;
+
+    const float rms = rms_in[batch];
+
+    const int d0 = lane_id * 8;
+    const int base = group * 256 + d0;
+
+    // Apply Phase 1c (x * weight * rms) then Phase 2 (* signs1) in the SAME
+    // left-associative order as the baseline kernel to preserve FP rounding:
+    //   baseline: x_shared[i] = x_b[i] * weight[i] * rms;   // = ((x*w)*r)
+    //             v = x_shared[i] * signs1[i];              // = ((x*w)*r) * s
+    // We compute (((x*w)*r)*s) directly here per element.
+    #define LOAD_V(idx, vname) \
+        float vname; { \
+            float _xw = x_b[base + (idx)] * weight[d0 + (idx)]; \
+            float _xwr = _xw * rms; \
+            vname = _xwr * signs1[d0 + (idx)]; \
+        }
+    LOAD_V(0, v0)
+    LOAD_V(1, v1)
+    LOAD_V(2, v2)
+    LOAD_V(3, v3)
+    LOAD_V(4, v4)
+    LOAD_V(5, v5)
+    LOAD_V(6, v6)
+    LOAD_V(7, v7)
+    #undef LOAD_V
+
+    // Local butterfly: strides 1, 2, 4 (within each thread's 8 registers).
+    float t;
+    t = v0; v0 = v0 + v1; v1 = t - v1;
+    t = v2; v2 = v2 + v3; v3 = t - v3;
+    t = v4; v4 = v4 + v5; v5 = t - v5;
+    t = v6; v6 = v6 + v7; v7 = t - v7;
+
+    t = v0; v0 = v0 + v2; v2 = t - v2;
+    t = v1; v1 = v1 + v3; v3 = t - v3;
+    t = v4; v4 = v4 + v6; v6 = t - v6;
+    t = v5; v5 = v5 + v7; v7 = t - v7;
+
+    t = v0; v0 = v0 + v4; v4 = t - v4;
+    t = v1; v1 = v1 + v5; v5 = t - v5;
+    t = v2; v2 = v2 + v6; v6 = t - v6;
+    t = v3; v3 = v3 + v7; v7 = t - v7;
+
+    // Wave butterfly via ds_swizzle (32-lane group; wave-local).
+    #define HBFLY(v, pat, str) do { \
+        float _p = __int_as_float(__builtin_amdgcn_ds_swizzle(__float_as_int(v), (pat))); \
+        if (lane_id & (str)) { (v) = _p - (v); } else { (v) = (v) + _p; } \
+    } while (0)
+    #define HBFLY8(pat, str) \
+        HBFLY(v0,pat,str); HBFLY(v1,pat,str); HBFLY(v2,pat,str); HBFLY(v3,pat,str); \
+        HBFLY(v4,pat,str); HBFLY(v5,pat,str); HBFLY(v6,pat,str); HBFLY(v7,pat,str)
+
+    HBFLY8(0x041F, 1);
+    HBFLY8(0x081F, 2);
+    HBFLY8(0x101F, 4);
+    HBFLY8(0x201F, 8);
+    HBFLY8(0x401F, 16);
+    #undef HBFLY8
+    #undef HBFLY
+
+    const float s = 0.0625f;
+    x_rot_b[base]     = v0 * s * signs2[d0];
+    x_rot_b[base + 1] = v1 * s * signs2[d0 + 1];
+    x_rot_b[base + 2] = v2 * s * signs2[d0 + 2];
+    x_rot_b[base + 3] = v3 * s * signs2[d0 + 3];
+    x_rot_b[base + 4] = v4 * s * signs2[d0 + 4];
+    x_rot_b[base + 5] = v5 * s * signs2[d0 + 5];
+    x_rot_b[base + 6] = v6 * s * signs2[d0 + 6];
+    x_rot_b[base + 7] = v7 * s * signs2[d0 + 7];
+}


### PR DESCRIPTION
## Summary

MI300x (gfx942/CDNA3) Phase B+C kernel work — first MFMA-direct kernel in hipfire history. Closes the gap between hipfire's HFQ4 dispatch path and rocBLAS Tensile to 97.6% on 27B-3.6 prefill while also picking up +13.5% AR decode through wave64 GEMV tuning and an rmsnorm two-kernel split.

## Headline metrics (27B-3.6 mq4 on MI300X)

**AR decode** (10-run median, 67.6 → 76.7 tok/s, cumulative +13.5%):
- Phase B v1 (LDS-cached GEMV) — FALSIFIED, kept opt-in
- Phase B v2 (2 wave64/WG default-on for HFQ4 family) — +1.8%
- Phase B v3 (two-kernel rmsnorm + FWHT split) — +11.4% (rmsnorm 18.4 → 9.7 µs)

**Prefill** (5-run median, batch=256, MFMA vs rocBLAS Tensile baseline 1315 tok/s):
- Phase C v1 (16×16 MFMA, no LDS) — 1046 / 80% — proof of concept
- Phase C v2 (32×32 tile, no LDS) — 1009 / 77% — counterintuitive loss (memory-bound, not ALU-bound)
- **Phase C v3 (LDS B-tile, K_CHUNK=128) — 1284 / 97.6% — sweet spot**
- Phase C v4 (1×4 col, shared A+B LDS) — 480 / 36% — falsified, kept opt-in for research

K_CHUNK sweep on v3:
| K_CHUNK | tok/s | % |
|---:|---:|---:|
| 64 | 1152 | 88% — load overhead dominates |
| **128** | **1284** | **97.6% — sweet spot** |
| 256 | 1250 | 95% — bigger LDS hurts occupancy |

## What changes

**Kernels (new):**
- `kernels/src/gemv_hfq4g256_residual_v2.gfx942.hip` + v3 — wave64 GEMV variants
- `kernels/src/fused_qkv_hfq4g256_v2.gfx942.hip`, `fused_qkvza_*_v2`, `fused_gate_up_*_v2` — 2 wave64/WG family
- `kernels/src/rmsnorm_reduce.gfx942.hip` + `rotate_with_rms.gfx942.hip` — two-kernel split
- `kernels/src/gemm_hfq4g256_residual_mfma.gfx942.hip` — v1+v2+v3 MFMA-direct (first MFMA in hipfire)
- `kernels/src/gemm_hfq4g256_residual_mfma_v4.gfx942.hip` — v4 (falsified, kept opt-in)

**Dispatch (`crates/rdna-compute/src/dispatch.rs`):**
- gfx94x arm in HFQ4 fused/residual dispatch paths — default ON for wave64 v2 family
- `HIPFIRE_GFX942_RMSNORM_SPLIT=0` opt-out for two-kernel split (default ON)
- `HIPFIRE_GFX942_MFMA_PREFILL=1..4` opt-in for MFMA prefill (default OFF until v3+ becomes default)

**Docs:**
- `docs/investigations/2026-05-19-mfma-hfq4/` — POC scaffold (`mfma_test.cpp` PASS max_err 8.9e-08, `mfma_hfq4_test.cpp` PASS max_rel_err 2e-5, README)
- MFMA F32_16x16x16_F16 lane-layout table (output is strip-major, easy to confuse with A operand's m-major-by-lane)

## A/B methodology

- 27B-3.6 mq4 (3.6 head + AWQ trunk) on MI300X, ROCm 6.3.2
- AR decode: max=120 --no-chatml --kv-mode q8, 10-run median
- Prefill: batch=256, 5-run median
- Prompts: byte-identical PEP-8 strict LRU (md5 df5dedc)
- DPM warmup before each batch
- `gpu-tcas` arbitration; one cell per arbitrated lock

## Significance

1. First MFMA-direct kernel in hipfire — establishes the path for skipping the FP16 shadow buffer (~8.6 GB VRAM saved at 64 layers × 27B once perf gap fully closes)
2. Validates that `__builtin_amdgcn_mfma_f32_16x16x16f16` + HFQ4 nibble dequant is a viable compute path on gfx942
3. Two-step path from here to "beat rocBLAS": Tile + LDS v2 (~+50-80%), then prefetch + ds_read_b128 v3 (saturate MFMA issue slots)
4. rmsnorm two-kernel split is a structural win independent of MFMA — gridscaling 5× more in-flight wave64s on prefill (1024 → 5120 for batch=256 K=5120)

## Test plan

- [ ] `cargo build --release -p rdna-compute --features deltanet` clean
- [ ] On MI300X: `gpu-tcas run -- cargo test --release -p rdna-compute --example test_attention_dflash` 
- [ ] Decode A/B: `HIPFIRE_GFX942_GEMV_V2=0` baseline vs default → confirm ≥ +13% on 27B-3.6 AR decode
- [ ] Prefill A/B: `HIPFIRE_GFX942_MFMA_PREFILL=3` vs default → confirm ≥ +95% rocBLAS Tensile parity
- [ ] MFMA POC: `hipcc --offload-arch=gfx942 docs/investigations/2026-05-19-mfma-hfq4/mfma_hfq4_test.cpp -o mfma_hfq4_test && ./mfma_hfq4_test` reports PASS

## Risk

- v3 LDS B-tile + K_CHUNK=128 verified on MI300X; falls back to rocBLAS for non-gfx94x archs (no impact)
- Two-kernel rmsnorm split is opt-out via `HIPFIRE_GFX942_RMSNORM_SPLIT=0` if any regression surfaces
- Falsified v1 (LDS-cached GEMV) and v4 (1×4 col MFMA) kept as opt-in research artifacts — never default-on

## Cross-refs

- Session memory: `[[project_mi300x_mfma_hfq4_poc_2026_05_19]]`, `[[project_mi300x_phase_b_decode_2026_05_19]]`, `[[project_mi300x_target_optimization_2026_05_19]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
