### PR TITLE
feat(tier1): BF16 MFMA gfx942 + capture-hook foundation for hipfire-native calibration

### DIFF
--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -313,3 +313,26 @@ required-features = []
 [[example]]
 name = "imatrix_collect"
 required-features = []
+
+# ─── Tier 1 calibration binaries (foundation scaffolds, 2026-05-19) ────
+#
+# `collect_imatrix` and `collect_hessian` are the hipfire-native
+# replacements for the Tier 2 wrappers above. Both currently ship as
+# `unimplemented!()` scaffolds — argument parsing + module docs only —
+# so that the workspace compiles cleanly while follow-on subagent
+# tasks build the forward pass, on-GPU activation/Hessian reductions,
+# and the GGUF/HFHS-v1 writers on top.
+#
+# Stdlib only at this stage; no GPU / arch features required for the
+# scaffold itself. When the forward pass lands these bins will pick up
+# `required-features = ["arch-qwen35", "arch-llama"]` (or whichever
+# arches the Tier 1 path supports).
+[[bin]]
+name = "collect_imatrix"
+path = "src/bin/collect_imatrix.rs"
+required-features = []
+
+[[bin]]
+name = "collect_hessian"
+path = "src/bin/collect_hessian.rs"
+required-features = []

--- a/crates/hipfire-runtime/src/bf16_loader.rs
+++ b/crates/hipfire-runtime/src/bf16_loader.rs
@@ -1,0 +1,196 @@
+//! BF16 HuggingFace safetensors model loader scaffold (Tier 1 foundation).
+//!
+//! Stretch deliverable in the 2026-05-19 Tier 1 foundation series. When
+//! complete, this module loads a BF16 HuggingFace model directly into
+//! GPU memory, bypassing the `.hfq` quantized format used by production
+//! inference. The Tier 1 calibration path (`collect_imatrix`,
+//! `collect_hessian` in `src/bin/`) runs its MFMA-direct forward through
+//! the loaded BF16 tensors and feeds activations into the
+//! `ActivationCapture` hook on `Gpu`.
+//!
+//! Status: **scaffold only**. Function signatures, metadata struct, and
+//! safetensors-parse plumbing are sketched; the actual `hipMalloc` +
+//! `hipMemcpy` of weight bytes is left to the follow-on subagent task.
+//!
+//! Why a separate loader (not reuse `hfq.rs`):
+//! - HFQ files contain quantized weights (HFQ4G256 layout, 4-bit packed
+//!   + FP32 scale/zero); calibration needs the FP-precise BF16 source.
+//! - HuggingFace safetensors are the canonical BF16 distribution format
+//!   used by `llama-imatrix` and `collect_hessian.py`. Loading
+//!   safetensors directly removes the GGUF/HFQ-conversion roundtrip
+//!   that adds quantization error to the calibration signal.
+//! - The captured Hessian / Σx² values produced from a BF16 forward
+//!   pass are then used to derive optimal MQ4/MQ3/HFP4 quantization
+//!   parameters — feeding the production .hfq files. So this loader
+//!   sits at the producer end of the quant pipeline, not the consumer
+//!   end.
+//!
+//! Reference doc for the file format:
+//! - safetensors v0.3 spec: https://github.com/huggingface/safetensors
+//! - HF model layout: `<dir>/{config.json, tokenizer.json,
+//!   model.safetensors[.index.json], *.safetensors}` (single-file or
+//!   sharded depending on size).
+
+use hip_bridge::HipResult;
+// `DType` will be threaded through once the scaffold gains a real load
+// path (Phase 2 — see `load_bf16_model` body TODO). For now, only the
+// types referenced in the function signature + struct fields are imported.
+use rdna_compute::{Gpu, GpuTensor};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// A single BF16 weight tensor on the device.
+///
+/// Mirrors the structure of `rdna_compute::GpuTensor` but tagged with
+/// the canonical HuggingFace key so the calibration capture hook can
+/// route activations to the right per-tensor accumulator.
+#[allow(dead_code)]
+pub struct Bf16Tensor {
+    /// Canonical HF safetensors key (e.g.
+    /// `model.layers.0.self_attn.q_proj.weight`). Mirror of the
+    /// `GPTQ_TARGET_SUFFIXES` list in `scripts/collect_hessian.py`
+    /// determines which of these get a Hessian collected.
+    pub name: String,
+    /// Owned device tensor. Always `DType::F16`-tagged for now — the
+    /// rdna-compute layer doesn't have a `BF16` enum arm yet. Phase 2
+    /// adds `DType::BF16` (a 1-line edit in dispatch.rs::DType once we
+    /// have a real BF16 forward path to consume it). For the scaffold,
+    /// we mark the tensor with TODO comments so the downstream wiring
+    /// knows to re-interpret the bytes.
+    ///
+    /// TODO(Phase 2): replace with `DType::BF16` once the dtype enum
+    /// arm lands. The .size() return is still 2 bytes/element — same
+    /// as F16 — so the allocator math is unchanged.
+    pub tensor: GpuTensor,
+    /// Tensor shape as stored on disk (e.g. `[out_features, in_features]`
+    /// for a Linear weight in PyTorch's `[out, in]` row-major convention).
+    pub shape: Vec<usize>,
+}
+
+/// All BF16 weights for a single model, indexed by HF key.
+///
+/// The `TrunkBF16` name follows the rustane convention (separate trunk
+/// vs. expert / head subtensors). For now, MoE expert tensors live in
+/// the same flat map; if memory becomes the bottleneck on large MoEs,
+/// Phase 2 can split into `trunk: HashMap<_>, experts: Vec<HashMap<_>>`.
+#[allow(dead_code)]
+pub struct TrunkBF16 {
+    /// All loaded weight tensors keyed by canonical HF safetensors name.
+    pub tensors: HashMap<String, Bf16Tensor>,
+    /// The model dir we loaded from (for log messages + tokenizer load).
+    pub model_dir: std::path::PathBuf,
+    /// Model architecture id from `config.json["model_type"]`
+    /// (e.g. `qwen3`, `llama`, `mistral`). Drives which arch crate
+    /// the calibration forward pass dispatches into.
+    pub model_type: String,
+    /// Total bytes allocated on device across all tensors (for the
+    /// log line at load time).
+    pub total_bytes: usize,
+}
+
+/// Load a BF16 HuggingFace model directory into GPU memory.
+///
+/// Scaffold — returns `unimplemented!()`. The real implementation will:
+///
+/// 1. Parse `<model_dir>/config.json` to get `model_type` + hidden dim
+///    + layer count.
+/// 2. Parse `<model_dir>/model.safetensors.index.json` (or fallback to
+///    single-file `model.safetensors`) for the tensor → shard map.
+/// 3. For each tensor key:
+///    a. Read the safetensors header to get `dtype`, `shape`,
+///       `data_offsets`.
+///    b. Verify `dtype == "BF16"` (reject FP16/FP32 inputs — quantizer
+///       wants BF16 source-of-truth weights).
+///    c. `gpu.alloc_tensor(&shape, DType::F16 /* TODO: BF16 */)` →
+///       device buffer.
+///    d. `hipMemcpyHtoD` of the raw 2-byte BF16 payload from mmap'd
+///       safetensors → device buffer.
+/// 4. Build the `TrunkBF16` map and return.
+///
+/// The scaffold currently allocates no memory and copies nothing; it
+/// constructs an empty `TrunkBF16` struct so that downstream Phase 2
+/// integration code can compile against the type immediately.
+pub fn load_bf16_model(_gpu: &mut Gpu, model_dir: &Path) -> HipResult<TrunkBF16> {
+    // TODO(Phase 2):
+    //   1. Open <model_dir>/config.json + extract model_type.
+    //   2. Walk safetensors index + read per-tensor headers.
+    //   3. For each BF16 tensor: alloc on GPU + memcpy bytes.
+    //   4. Populate the tensors map.
+    //
+    // For now, return an empty TrunkBF16 so downstream type-checks pass
+    // but a runtime caller sees the scaffold panic.
+    unimplemented!(
+        "load_bf16_model: scaffold only — Phase 2 wires the actual safetensors \
+         parse + device alloc + memcpy. Called with model_dir={}",
+        model_dir.display()
+    );
+}
+
+/// Returns true if a tensor name matches the GPTQ-target whitelist that
+/// `collect_hessian` should accumulate a Hessian for. Mirrors
+/// `scripts/collect_hessian.py::is_gptq_target` so the Tier 1 binary
+/// produces a byte-compatible HFHS-v1 output with the Tier 2 Python
+/// path.
+///
+/// Whitelist (suffixes matched against the last `.`-separated segment):
+///
+///   - Attention input projections: `q_proj`, `k_proj`, `v_proj`,
+///     `qkv_proj`
+///   - Attention output: `o_proj`, `out_proj`
+///   - MLP: `gate_proj`, `up_proj`, `down_proj`, `gate_up_proj`
+///   - Linear-attention (Gated DeltaNet):
+///     `in_proj_qkv`, `in_proj_z`, `in_proj_a`, `in_proj_b`
+///   - MoE router: `gate`
+#[allow(dead_code)]
+pub fn is_gptq_target(name: &str) -> bool {
+    const TARGETS: &[&str] = &[
+        "q_proj", "k_proj", "v_proj", "qkv_proj",
+        "o_proj", "out_proj",
+        "gate_proj", "up_proj", "down_proj", "gate_up_proj",
+        "in_proj_qkv", "in_proj_z", "in_proj_a", "in_proj_b",
+        "gate",
+    ];
+    // Strip a trailing `.weight` (HF safetensors stores Linear weights
+    // as `<module>.weight`; the GPTQ targets are checked on the module
+    // name, not the parameter name).
+    let bare = name.strip_suffix(".weight").unwrap_or(name);
+    let last = bare.rsplit('.').next().unwrap_or(bare);
+    TARGETS.contains(&last)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gptq_target_recognizes_canonical_qwen35_names() {
+        assert!(is_gptq_target("model.layers.0.self_attn.q_proj.weight"));
+        assert!(is_gptq_target("model.layers.0.self_attn.k_proj.weight"));
+        assert!(is_gptq_target("model.layers.0.self_attn.v_proj.weight"));
+        assert!(is_gptq_target("model.layers.0.self_attn.o_proj.weight"));
+        assert!(is_gptq_target("model.layers.0.mlp.gate_proj.weight"));
+        assert!(is_gptq_target("model.layers.0.mlp.up_proj.weight"));
+        assert!(is_gptq_target("model.layers.0.mlp.down_proj.weight"));
+    }
+
+    #[test]
+    fn gptq_target_recognizes_moe_router() {
+        // Qwen3.5-A3B MoE router lives at `model.layers.N.mlp.gate.weight`
+        assert!(is_gptq_target("model.layers.0.mlp.gate.weight"));
+    }
+
+    #[test]
+    fn gptq_target_rejects_norms_and_embed() {
+        assert!(!is_gptq_target("model.embed_tokens.weight"));
+        assert!(!is_gptq_target("model.layers.0.input_layernorm.weight"));
+        assert!(!is_gptq_target("model.norm.weight"));
+        assert!(!is_gptq_target("lm_head.weight"));
+    }
+
+    #[test]
+    fn gptq_target_recognizes_deltanet_projections() {
+        assert!(is_gptq_target("model.layers.0.linear_attn.in_proj_qkv.weight"));
+        assert!(is_gptq_target("model.layers.0.linear_attn.in_proj_z.weight"));
+        assert!(is_gptq_target("model.layers.0.linear_attn.out_proj.weight"));
+    }
+}

--- a/crates/hipfire-runtime/src/bin/collect_hessian.rs
+++ b/crates/hipfire-runtime/src/bin/collect_hessian.rs
@@ -1,0 +1,188 @@
+//! `collect_hessian` — Tier 1 hipfire-native Hessian collector for GPTQ.
+//!
+//! Foundation scaffold for the Hessian-collection binary that replaces
+//! the Tier 2 PyTorch wrapper at `scripts/collect_hessian.py`. When
+//! complete, this binary will:
+//!
+//! 1. Load a BF16 HuggingFace model directly from `<dir>/*.safetensors`
+//!    via `engine::bf16_loader` (Task 4 scaffold in this same series).
+//! 2. Run hipfire's MFMA-direct forward path on the calibration corpus
+//!    through the new BF16 MFMA GEMM kernel
+//!    (`kernels/src/gemm_bf16_mfma.gfx942.hip`).
+//! 3. At each `nn.Linear`-equivalent dispatch site that matches the
+//!    GPTQ target list (mirrors `collect_hessian.py:80-92`), fire the
+//!    `ActivationCapture` hook (Task 3 trait in `rdna-compute::dispatch`)
+//!    to accumulate a per-tensor `H_t = (1/N) * Σ_t x_t · x_t^T`
+//!    outer-product Hessian on-GPU via a dedicated K×K rank-1-update
+//!    kernel (Phase 2, separate task).
+//! 4. Write per-tensor `K×K F32` blocks to a HFHS-v1 binary file
+//!    (Phase 2, separate task; byte-compatible with the existing format
+//!    documented in `scripts/collect_hessian.py:25-43`) so that
+//!    `crates/hipfire-quantize/src/hessian_io.rs` reads it unchanged.
+//!
+//! Target speedup vs Tier 2: 20× (~8h → ~25min for a 27B-class model on
+//! MI300x). The Python path is currently bottlenecked on HF transformers
+//! eager forward + CPU-side `x.T @ x` accumulator with the BF16→FP32
+//! cast + per-token `.cpu()` PCIe transfer in
+//! `scripts/collect_hessian.py:213-222`.
+//!
+//! Tier 1 keeps the outer-product accumulator on-GPU for the full
+//! calibration pass; final HFHS dump is the only host-side step.
+//!
+//! Usage (target CLI):
+//!
+//! ```ignore
+//! cargo run --release -p hipfire-runtime --bin collect_hessian -- \
+//!     --hf-model    <path-to-bf16-hf-model-dir> \
+//!     --corpus      <path-to-corpus.txt-or-hf-dataset-id> \
+//!     --output      <path-to-out.hessian.bin> \
+//!     [--n-sequences 128] [--ctx-len 2048] [--n-passes 1]
+//! ```
+//!
+//! TODO: replace this stdlib-only arg parser with `clap` once the
+//! workspace accepts the dep. Matched the imatrix_collect.rs example
+//! style for now to keep the workspace dep graph clean.
+
+use std::path::PathBuf;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Args {
+    /// HuggingFace BF16 model dir (`*.safetensors` + `config.json`).
+    hf_model: PathBuf,
+    /// Plain-text corpus file OR HuggingFace dataset id
+    /// (e.g. `wikitext-2-raw-v1`). The Tier 2 Python path defaults to
+    /// `wikitext`; we mirror that once corpus-loading lands.
+    corpus: PathBuf,
+    /// Output HFHS-v1 binary path (`*.hessian.bin` by convention).
+    /// Consumed by `crates/hipfire-quantize/src/hessian_io.rs` at
+    /// GPTQ quantize-time.
+    output: PathBuf,
+    /// Number of calibration sequences (GPTQ paper default: 128).
+    n_sequences: usize,
+    /// Tokens per calibration sequence (GPTQ paper default: 2048).
+    ctx_len: usize,
+    /// Number of full passes over the calibration corpus. Default 1.
+    /// Multiple passes are useful for noisy GPTQ convergence on MoE
+    /// models with sparse expert activations.
+    n_passes: usize,
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage:\n  collect_hessian --hf-model <dir> --corpus <file-or-hf-id> --output <bin>\n\
+         \n\
+         Optional flags:\n\
+           --n-sequences <N>     calibration sequences (default: 128)\n\
+           --ctx-len <N>         tokens per calibration sequence (default: 2048)\n\
+           --n-passes <N>        passes over the corpus (default: 1)\n\
+         \n\
+         Tier 1 hipfire-native Hessian collector. See\n\
+         docs/investigations/2026-05-19-tier1-bf16-mfma/ for the foundation POC.\n\
+         Output format: HFHS v1 (see scripts/collect_hessian.py:25-43)."
+    );
+}
+
+fn parse_args() -> Args {
+    let mut hf_model: Option<PathBuf> = None;
+    let mut corpus: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut n_sequences: usize = 128;
+    let mut ctx_len: usize = 2048;
+    let mut n_passes: usize = 1;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--hf-model" => {
+                hf_model = Some(PathBuf::from(&argv[i + 1]));
+                i += 2;
+            }
+            "--corpus" => {
+                corpus = Some(PathBuf::from(&argv[i + 1]));
+                i += 2;
+            }
+            "--output" => {
+                output = Some(PathBuf::from(&argv[i + 1]));
+                i += 2;
+            }
+            "--n-sequences" => {
+                n_sequences = argv[i + 1]
+                    .parse()
+                    .expect("--n-sequences must be a positive integer");
+                i += 2;
+            }
+            "--ctx-len" => {
+                ctx_len = argv[i + 1]
+                    .parse()
+                    .expect("--ctx-len must be a positive integer");
+                i += 2;
+            }
+            "--n-passes" => {
+                n_passes = argv[i + 1]
+                    .parse()
+                    .expect("--n-passes must be a positive integer");
+                i += 2;
+            }
+            "-h" | "--help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("unknown arg: {other}");
+                print_usage();
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let hf_model = hf_model.unwrap_or_else(|| {
+        eprintln!("error: --hf-model is required");
+        print_usage();
+        std::process::exit(1);
+    });
+    let corpus = corpus.unwrap_or_else(|| {
+        eprintln!("error: --corpus is required");
+        print_usage();
+        std::process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("error: --output is required");
+        print_usage();
+        std::process::exit(1);
+    });
+
+    Args {
+        hf_model,
+        corpus,
+        output,
+        n_sequences,
+        ctx_len,
+        n_passes,
+    }
+}
+
+fn main() {
+    let args = parse_args();
+    eprintln!("collect_hessian (Tier 1 — foundation scaffold)");
+    eprintln!("  hf-model:    {}", args.hf_model.display());
+    eprintln!("  corpus:      {}", args.corpus.display());
+    eprintln!("  output:      {}", args.output.display());
+    eprintln!("  n-sequences: {}", args.n_sequences);
+    eprintln!("  ctx-len:     {}", args.ctx_len);
+    eprintln!("  n-passes:    {}", args.n_passes);
+    eprintln!();
+    eprintln!("Implementation pending — this is the Phase 1 scaffold.");
+    eprintln!("Next deliverables (separate subagent tasks):");
+    eprintln!("  - BF16 safetensors loader → device tensors");
+    eprintln!("  - On-GPU K×K outer-product Hessian rank-1-update kernel");
+    eprintln!("  - ActivationCapture wiring at the GPTQ-target dispatch sites");
+    eprintln!("  - HFHS-v1 binary writer (matches scripts/collect_hessian.py)");
+    eprintln!();
+    unimplemented!(
+        "collect_hessian Tier 1 forward pass + outer-product Hessian + HFHS \
+         write not yet implemented. See `scripts/collect_hessian.py` for \
+         the Tier 2 PyTorch fallback."
+    );
+}

--- a/crates/hipfire-runtime/src/bin/collect_imatrix.rs
+++ b/crates/hipfire-runtime/src/bin/collect_imatrix.rs
@@ -1,0 +1,178 @@
+//! `collect_imatrix` — Tier 1 hipfire-native activation-magnitude collector.
+//!
+//! Foundation scaffold for the imatrix-collection binary that replaces
+//! the Tier 2 subprocess wrapper at `examples/imatrix_collect.rs`
+//! (which shells out to `llama-imatrix`). When complete, this binary
+//! will:
+//!
+//! 1. Load a BF16 HuggingFace model directly from `<dir>/*.safetensors`
+//!    via `engine::bf16_loader` (Task 4 scaffold in this same series).
+//! 2. Run hipfire's MFMA-direct forward path on the calibration corpus
+//!    through the new BF16 MFMA GEMM kernel
+//!    (`kernels/src/gemm_bf16_mfma.gfx942.hip`).
+//! 3. At each linear-layer dispatch site, fire the `ActivationCapture`
+//!    hook (Task 3 trait in `rdna-compute::dispatch`) to accumulate
+//!    per-channel `Σ act²` on-GPU via a dedicated reduction kernel
+//!    (Phase 2, separate task).
+//! 4. Write the per-tensor `in_sum2` / `counts` pairs as a GGUF imatrix
+//!    file (Phase 2, separate task) that is byte-compatible with
+//!    `llama-imatrix --output-format gguf` — so existing readers
+//!    (`hipfire-quantize::gguf_input`) work without changes.
+//!
+//! Target speedup vs Tier 2: 20× (~8h → ~25min for a 27B-class model on
+//! MI300x). See `docs/investigations/2026-05-19-tier1-bf16-mfma/README.md`
+//! for the foundation-POC validating the BF16 MFMA GEMM building block.
+//!
+//! Usage (target CLI, mirrors `examples/imatrix_collect.rs` semantics where
+//! possible — the `--hf-model <dir>` arg replaces `--bf16-gguf <file>` since
+//! Tier 1 reads safetensors directly):
+//!
+//! ```ignore
+//! cargo run --release -p hipfire-runtime --bin collect_imatrix -- \
+//!     --hf-model    <path-to-bf16-hf-model-dir> \
+//!     --corpus      <path-to-calibration-corpus.txt> \
+//!     --output      <path-to-output.imatrix.gguf> \
+//!     [--n-ctx 2048] [--n-sequences 128] [--process-output]
+//! ```
+//!
+//! TODO: replace this stdlib-only arg parser with `clap` once the
+//! crate accepts a clap workspace-dep. Matched the imatrix_collect.rs
+//! example style for now to keep the workspace dep graph clean while
+//! the rest of Phase 2 lands.
+
+use std::path::PathBuf;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Args {
+    /// Path to a HuggingFace model directory containing
+    /// `model.safetensors[.index.json]` + `config.json` + `tokenizer.json`.
+    hf_model: PathBuf,
+    /// Plain-text calibration corpus (one document or one file = one
+    /// concatenated sequence; the binary chunks into `n_sequences ×
+    /// n_ctx` tokens internally). Tier 2 used `wikitext-2-raw-v1` by
+    /// default; Tier 1 will mirror that once corpus-loading lands.
+    corpus: PathBuf,
+    /// Output GGUF path (must end in `.imatrix.gguf` by convention).
+    output: PathBuf,
+    /// Tokens per calibration sequence.
+    n_ctx: usize,
+    /// Calibration sequences (matches GPTQ paper's 128-seq scale).
+    n_sequences: usize,
+    /// Also collect data for the `output` / `lm_head` tensor. Mirrors
+    /// llama-imatrix's `--process-output` flag.
+    process_output: bool,
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage:\n  collect_imatrix --hf-model <dir> --corpus <file> --output <gguf>\n\
+         \n\
+         Optional flags:\n\
+           --n-ctx <N>           tokens per calibration sequence (default: 2048)\n\
+           --n-sequences <N>     calibration sequences (default: 128)\n\
+           --process-output      also collect data for lm_head / output tensor\n\
+         \n\
+         Tier 1 hipfire-native imatrix collector. See\n\
+         docs/investigations/2026-05-19-tier1-bf16-mfma/ for the foundation POC."
+    );
+}
+
+fn parse_args() -> Args {
+    let mut hf_model: Option<PathBuf> = None;
+    let mut corpus: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut n_ctx: usize = 2048;
+    let mut n_sequences: usize = 128;
+    let mut process_output = false;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--hf-model" => {
+                hf_model = Some(PathBuf::from(&argv[i + 1]));
+                i += 2;
+            }
+            "--corpus" => {
+                corpus = Some(PathBuf::from(&argv[i + 1]));
+                i += 2;
+            }
+            "--output" => {
+                output = Some(PathBuf::from(&argv[i + 1]));
+                i += 2;
+            }
+            "--n-ctx" => {
+                n_ctx = argv[i + 1].parse().expect("--n-ctx must be a positive integer");
+                i += 2;
+            }
+            "--n-sequences" => {
+                n_sequences = argv[i + 1]
+                    .parse()
+                    .expect("--n-sequences must be a positive integer");
+                i += 2;
+            }
+            "--process-output" => {
+                process_output = true;
+                i += 1;
+            }
+            "-h" | "--help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => {
+                eprintln!("unknown arg: {other}");
+                print_usage();
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let hf_model = hf_model.unwrap_or_else(|| {
+        eprintln!("error: --hf-model is required");
+        print_usage();
+        std::process::exit(1);
+    });
+    let corpus = corpus.unwrap_or_else(|| {
+        eprintln!("error: --corpus is required");
+        print_usage();
+        std::process::exit(1);
+    });
+    let output = output.unwrap_or_else(|| {
+        eprintln!("error: --output is required");
+        print_usage();
+        std::process::exit(1);
+    });
+
+    Args {
+        hf_model,
+        corpus,
+        output,
+        n_ctx,
+        n_sequences,
+        process_output,
+    }
+}
+
+fn main() {
+    let args = parse_args();
+    eprintln!("collect_imatrix (Tier 1 — foundation scaffold)");
+    eprintln!("  hf-model:       {}", args.hf_model.display());
+    eprintln!("  corpus:         {}", args.corpus.display());
+    eprintln!("  output:         {}", args.output.display());
+    eprintln!("  n-ctx:          {}", args.n_ctx);
+    eprintln!("  n-sequences:    {}", args.n_sequences);
+    eprintln!("  process-output: {}", args.process_output);
+    eprintln!();
+    eprintln!("Implementation pending — this is the Phase 1 scaffold.");
+    eprintln!("Next deliverables (separate subagent tasks):");
+    eprintln!("  - BF16 safetensors loader → device tensors");
+    eprintln!("  - On-GPU Σx² reduction kernel + ActivationCapture wiring");
+    eprintln!("  - GGUF imatrix writer (byte-compatible with llama-imatrix)");
+    eprintln!();
+    unimplemented!(
+        "collect_imatrix Tier 1 forward pass + Σx² + GGUF write not yet \
+         implemented. See `examples/imatrix_collect.rs` for the Tier 2 \
+         subprocess fallback."
+    );
+}

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -10,6 +10,7 @@
 //! [`arch::Architecture`] trait.
 
 pub mod arch;
+pub mod bf16_loader;
 pub mod eval_common;
 pub mod gguf;
 pub mod hfq;

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -7,7 +7,7 @@ use hip_bridge::{DeviceBuffer, HipResult, HipRuntime, Rocblas};
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 /// Per-group byte size of the MQ3-Lloyd quantization layout.
 ///
@@ -504,6 +504,55 @@ impl DType {
     }
 }
 
+/// Activation-capture hook for the Tier 1 hipfire-native calibration path.
+///
+/// Foundation scaffold (2026-05-19) — the field on `Gpu` is set by
+/// `collect_imatrix` / `collect_hessian` (see
+/// `crates/hipfire-runtime/src/bin/`) and called from each linear-layer
+/// dispatch site to feed activations into an on-GPU reduction
+/// (per-channel `Σ act²` for imatrix, K×K outer-product for the GPTQ
+/// Hessian).
+///
+/// Phase 1 ships only the trait, the `Gpu::capture_handler` field, and
+/// a default of `None` — so existing call sites are unaffected. Phase 2
+/// threads the `if let Some(h) = &gpu.capture_handler { h.capture(...) }`
+/// call into every fused/unfused GEMM dispatch arm.
+///
+/// `tensor_name` is the canonical hipfire tensor identifier (the same
+/// string the .hfq loader uses, e.g. `model.layers.0.self_attn.q_proj`)
+/// so the reduction kernel can key its on-GPU accumulator dictionary
+/// by name without ambiguity across MoE expert indices.
+///
+/// `input_ptr` / `numel` / `dtype` describe the activation tensor in
+/// HBM at the moment of the linear-layer dispatch. The capture
+/// implementation is responsible for launching its own reduction
+/// kernel on the same stream as the producing GEMM (so ordering is
+/// preserved without an extra `hipDeviceSynchronize`). The hook MUST
+/// NOT free or reallocate the input tensor.
+///
+/// `Send + Sync` lets the same handler be shared across multi-GPU
+/// dispatch threads (one `Gpu` instance per device, all pointing at
+/// the same Arc'd handler that funnels into a per-tensor accumulator).
+pub trait ActivationCapture: Send + Sync {
+    /// Called by linear-layer dispatch arms when calibration is active.
+    ///
+    /// `tensor_name` — canonical .hfq / GGUF tensor name.
+    /// `input_ptr`   — device pointer to the input activation tensor.
+    /// `numel`       — number of elements at `input_ptr` (NOT bytes).
+    /// `dtype`       — element type of the captured activation.
+    /// `shape`       — full activation shape (e.g. `[batch, K]` for the
+    ///                 input of a `[K, M]` linear). Borrowed; do NOT
+    ///                 retain past the call.
+    fn capture(
+        &self,
+        tensor_name: &str,
+        input_ptr: *const c_void,
+        numel: usize,
+        dtype: DType,
+        shape: &[usize],
+    );
+}
+
 /// High-level GPU context. Owns the HIP runtime, compiler, and loaded kernels.
 pub struct Gpu {
     pub hip: HipRuntime,
@@ -668,6 +717,17 @@ pub struct Gpu {
     /// Only populated on CDNA3 when rocBLAS loaded — 4× VRAM blow-up vs MQ4
     /// so consumer cards stay on the wave32/64 hand-rolled GEMV path.
     fp16_shadow_cache: HashMap<usize, GpuTensor>,
+
+    /// Activation-capture hook for the Tier 1 hipfire-native calibration
+    /// path (foundation scaffold 2026-05-19). `None` by default — set by
+    /// `collect_imatrix` / `collect_hessian` binaries when calibration is
+    /// active. Phase 2 threads the `Some(h).capture(...)` call into each
+    /// linear-layer dispatch arm. See `ActivationCapture` trait doc above.
+    ///
+    /// `Arc<dyn>` so the same handler can be shared across multi-GPU
+    /// dispatch threads (one `Gpu` per device, all routing into a single
+    /// per-tensor accumulator).
+    pub capture_handler: Option<Arc<dyn ActivationCapture>>,
 }
 
 impl Gpu {
@@ -887,6 +947,7 @@ impl Gpu {
             replay_capturing_n: None,
             rocblas: None,
             fp16_shadow_cache: HashMap::new(),
+            capture_handler: None,
         }).map(|mut gpu| {
             if gpu.force_blob_path {
                 eprintln!("[diag] HIPFIRE_BLOB_FORCE=1: all kernel launches will use the blob path (kernelParams bypassed). Diagnostic only.");

--- a/docs/investigations/2026-05-19-tier1-bf16-mfma/README.md
+++ b/docs/investigations/2026-05-19-tier1-bf16-mfma/README.md
@@ -1,0 +1,166 @@
+# Tier 1 BF16 MFMA — foundation POC (2026-05-19)
+
+Foundation POC for the **hipfire-native BF16 calibration path** that will
+eventually replace the Tier 2 subprocess wrapper (llama.cpp
+`llama-imatrix` + PyTorch `collect_hessian.py`) with native Rust binaries
+consuming BF16 weights directly through hipfire's MFMA-optimized kernels.
+
+Target speedup: 20× (~8h → ~25min for a Hessian-collection pass on a
+27B-class model).
+
+## Why this exists
+
+The existing imatrix path (`crates/hipfire-runtime/examples/imatrix_collect.rs`)
+shells out to llama.cpp at a pinned commit (`9dcf83552887bb...`) for
+activation-magnitude collection. The Hessian path (`scripts/collect_hessian.py`)
+shells out to PyTorch with HF transformers. Both paths re-implement the
+forward pass outside hipfire:
+
+- `llama-imatrix` runs its own llama.cpp forward (no MFMA on gfx942; no
+  rocBLAS Tensile auto-routing; tokenizer disagrees with hipfire's at
+  ~46% of positions per `docs/plans/issue-113-quant-quality-eval.md:126`).
+- `collect_hessian.py` runs HF transformers eager mode (no MFMA, Python
+  interp overhead, host-side rayon-equivalent rebuilds per `nn.Linear`).
+
+For a 27B model on MI300x both currently bottleneck at single-digit
+tokens/sec wall time on the calibration corpus. hipfire's HFQ4 prefill
+on the same hardware hits 1284 tok/s with the v3 MFMA kernel
+(`feat/mtp-mi300x` commit `496edfbc`, 97.6% of rocBLAS). Routing
+calibration through the same MFMA path closes the gap.
+
+## What this POC validates
+
+The Tier 1 forward pass will consume BF16 weights end-to-end (no
+HFQ4 dequant, no FP16 shadow). This POC verifies:
+
+1. **Intrinsic resolution.** The gfx942 BF16 MFMA intrinsic is
+   `__builtin_amdgcn_mfma_f32_16x16x16bf16_1k` — note the `_1k` suffix.
+   Naively trying `..._bf16` (without `_1k`) or `..._16x16x16_bf16`
+   (extra underscore) both fail compile. The `_1k` is the gfx90a name
+   that gfx942 inherited.
+
+2. **Operand bit-cast.** LLVM models BF16 lane bits as `i16` for the
+   MFMA intrinsic. The wrapper `mfma_bf16(bf16x4, bf16x4) → vfloat4`
+   bit-casts `__bf16x4 → short x4` before the call. The compiler folds
+   the cast away; no data movement.
+
+3. **Lane layout.** Identical to the F16 MFMA F32_16x16x16_F16 layout
+   verified at `docs/investigations/2026-05-19-mfma-hfq4/mfma_test.cpp`:
+
+   ```
+   A:  lane l holds a[r] = A[m = l%16,        k = (l/16)*4 + r]
+   B:  lane l holds b[r] = B[k = (l/16)*4 + r, n = l%16]
+   D:  lane l holds c[r] = D[m = (l/16)*4 + r, n = l%16]   ← strip-major
+   ```
+
+   The strip-major output (different from A's m-major-by-lane input)
+   was the first bug when scaffolding the HFQ4 v1 kernel; same trap here,
+   resolved the same way.
+
+4. **LDS B-tile geometry.** Replicates the v3 sweet-spot from
+   `gemm_hfq4g256_residual_mfma.gfx942.hip` — 256-thread WG (4 wave64),
+   32×32 output tile per WG, cooperative B-tile load to LDS with
+   K_CHUNK=128. The 4-wave arrangement is 2×2 over the output tile
+   (wave_id bit 1 selects m-half, bit 0 selects n-half).
+
+## Files
+
+- `mfma_bf16_test.cpp` — Two-stage POC.
+  - **Stage 1**: single 16×16×16 MFMA tile against an FP32 reference
+    (mirror of the F16 POC). Tight tolerance `max_err < 1e-2` because
+    K=16 → small accumulator-error budget.
+  - **Stage 2**: full LDS-tiled GEMM at M=128 K=128 batch=64 (one
+    outer-K step at K_CHUNK=128 — exercises the LDS cooperative load,
+    inter-wave m/n tiling, output strip-major write). Looser tolerance
+    `max_abs < 1e-1` and `max_rel < 5e-3` since BF16's 7 mantissa bits
+    accumulate ~K × 2^-7 ≈ 1e-2 abs over 128-K dot products.
+- `../../../kernels/src/gemm_bf16_mfma.gfx942.hip` — Production kernel
+  (the file the dispatcher will eventually call).
+
+## Build & run
+
+```bash
+hipcc --offload-arch=gfx942 -O3 mfma_bf16_test.cpp -o mfma_bf16_test
+./mfma_bf16_test
+```
+
+## Status
+
+**Compile-validated locally on ROCm 7.2 / gfx1100 dev host (2026-05-19):**
+
+- `mfma_bf16_test.cpp` compiles to a binary with `__bf16` typing,
+  intrinsic resolution, and lane math typechecking. The host has no
+  CDNA3, so runtime PASS depends on the MI300x droplet rerun.
+- `kernels/src/gemm_bf16_mfma.gfx942.hip` compiles with
+  `hipcc --offload-arch=gfx942 -O3 -c`. Disassembly verifies the
+  emitted instruction is `v_mfma_f32_16x16x16_bf16` (visible in
+  `llvm-objdump -d` of the unbundled gfx942 device object at offset
+  `~0x1DD0` of the kernel).
+
+**Runtime validation pending MI300x droplet rerun** (next session). Expected:
+
+- Stage 1: `max_err < 1e-2`, `fails = 0/256` — exact same shape as the
+  F16 POC's PASS (`max_err = 8.9e-08` at K=16 is the F16 fingerprint;
+  BF16 should be ~3 orders of magnitude wider but still well below the
+  `1e-2` gate).
+- Stage 2: `max_rel_err < 5e-3` on K=128, batch=64. If above, the LDS
+  layout or the 4-wave output offset math has a bug worth bisecting —
+  the v3 HFQ4 channel test got `max_rel_err = 2e-5` so BF16's mantissa
+  loss shouldn't push past 5e-3.
+
+## Theoretical performance ceiling
+
+CDNA3 BF16 MFMA throughput at gfx942 base clock (2.1 GHz, 304 CUs):
+- `v_mfma_f32_16x16x16_bf16` = 16×16×16 = 4096 FMAs per call
+- 8 cycles per call on gfx942 → 512 FMAs/cycle/CU = 1024 FLOPs/cycle/CU
+- 304 CUs × 1024 × 2.1 GHz = **653 TFLOPs/sec BF16 peak**
+
+The 16×16×16 BF16 has the same FMAs/cycle ratio as F16, so the
+prefill-equivalent throughput should be in the same band as the v3 HFQ4
+result (1284 tok/s = 97.6% of rocBLAS BF16 Tensile). The Tier 1 forward
+pass doesn't dequantize, so the per-call cost may even be lower — no
+unpack overhead in the inner loop.
+
+## Comparison to rocBLAS BF16
+
+rocBLAS exposes BF16×BF16→F32 GEMM via `rocblas_gemm_ex` with
+`a/b_type = rocblas_datatype_bf16_r`, `c/d_type = rocblas_datatype_f32_r`,
+`compute_type = rocblas_datatype_f32_r`. The v3 HFQ4 measurement showed
+the LDS B-tile MFMA hit 97.6% of rocBLAS Tensile for HFQ4 → F32. For
+the actual BF16 path, rocBLAS itself is the comparison target — Tier 1
+should land within 5-10% of `rocblas_gemm_ex` for the calibration
+shapes (M ∈ {4096, 5120, 6144}, K ∈ {4096, 5120, 6144}, batch ≈ ctx_len
+= 2048).
+
+## Why a separate kernel (not just rocBLAS)?
+
+Two reasons:
+1. **Capture hooks.** Tier 1 needs to feed activations to the on-GPU
+   Σx²-style and outer-product reductions (Hessian). rocBLAS's
+   `gemm_ex` is opaque — we can't inject a capture hook into the
+   middle. Our kernel can have the capture call site at known offset.
+2. **Custom output handling.** The Hessian / Σx² kernels read each
+   layer's input activations. Tying the GEMM directly to the capture
+   point removes a roundtrip to HBM (the capture hook can be inserted
+   right where the activations are live in registers).
+
+For pure forward-throughput-without-capture, we'd still use rocBLAS;
+the Tier 1 kernel is for the calibration path where the capture hook
+matters.
+
+## What's next (deliberately out of scope here)
+
+- **Phase 2** (separate task): on-GPU Σx² reduction kernel (sums per
+  input channel) — consumed by the AWQ activation-magnitude path.
+- **Phase 2** (separate task): on-GPU outer-product Hessian kernel
+  (K×K rank-1 update per token) — consumed by the GPTQ Cholesky
+  pass. Storage: write back to HBM in K×K FP32 blocks.
+- **Phase 2** (separate task): GGUF imatrix writer in Rust (mirrors
+  `llama.cpp/src/imatrix.cpp::write_to_file` byte-for-byte to keep the
+  produced file consumable by the same `gguf_input.rs` reader).
+- **Phase 3** (separate task): BF16 weight loader from safetensors,
+  attention/MLP forward path wiring through this GEMM, capture-hook
+  threading at every linear-layer dispatch site.
+
+This POC delivers just the GEMM building block. Everything above sits
+on top.

--- a/docs/investigations/2026-05-19-tier1-bf16-mfma/mfma_bf16_test.cpp
+++ b/docs/investigations/2026-05-19-tier1-bf16-mfma/mfma_bf16_test.cpp
@@ -1,0 +1,323 @@
+// BF16 MFMA F32_16x16x16_BF16 test for gfx942 (MI300X CDNA3).
+//
+// Foundation POC for the Tier 1 hipfire-native BF16 calibration path.
+// Verifies the BF16 MFMA intrinsic + lane layout in isolation before
+// validating the full LDS-tiled GEMM kernel.
+//
+// Two stages:
+//   Stage 1: single-tile C[16,16] = A[16,16] * B[16,16] (mirror of the
+//            F16 POC at `docs/investigations/2026-05-19-mfma-hfq4/mfma_test.cpp`).
+//   Stage 2: full kernel C[M,N] = A[M,K] * B[N,K]^T (calls the production
+//            kernel `gemm_bf16_mfma.gfx942.hip`'s shape and layout) at
+//            M=128 K=128 N=64 to exercise LDS B-tile + 4-wave WG geometry.
+//
+// Build: hipcc --offload-arch=gfx942 -O3 mfma_bf16_test.cpp -o mfma_bf16_test
+// Run:   ./mfma_bf16_test
+//
+// Tolerance: BF16 has 7 mantissa bits (vs F16's 10). For a dot product of
+// length K=128 with normal-distribution operands and FP32 accumulator,
+// expect max abs err ~ K * 2^-7 * |operand| ≈ 1e-2. Configured pass gate:
+// max_err < 1e-1 on Stage 2 (relaxed), max_err < 1e-3 on Stage 1 (K=16).
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cstdint>
+
+typedef __bf16 bf16_t;
+typedef __bf16 bf16x4 __attribute__((ext_vector_type(4)));
+typedef short  s16x4  __attribute__((ext_vector_type(4)));
+typedef float  vfloat4 __attribute__((ext_vector_type(4)));
+
+// The CDNA3 BF16 MFMA intrinsic models the BF16 lane bits as i16 — bit_cast
+// is a no-op type pun the compiler folds away. See the kernel header comment
+// in gemm_bf16_mfma.gfx942.hip for why `_1k` is the canonical name on gfx942.
+__device__ static inline vfloat4 mfma_bf16(bf16x4 a, bf16x4 b, vfloat4 c) {
+    s16x4 ai = __builtin_bit_cast(s16x4, a);
+    s16x4 bi = __builtin_bit_cast(s16x4, b);
+    return __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(ai, bi, c, 0, 0, 0);
+}
+
+// ─── Host-side BF16 conversion helpers ────────────────────────────────
+// Round-to-nearest-even FP32 → BF16. hipcc's __bf16 cast is fine but
+// these helpers make the round-trip explicit for the host reference.
+static inline uint16_t f32_to_bf16_bits(float f) {
+    uint32_t u;
+    __builtin_memcpy(&u, &f, sizeof(u));
+    // Handle NaN: preserve sign + signaling bit
+    if ((u & 0x7fffffffu) > 0x7f800000u) {
+        return (uint16_t)((u >> 16) | 0x40u);   // force quiet NaN
+    }
+    // Round-to-nearest-even
+    uint32_t lsb = (u >> 16) & 1u;
+    uint32_t rounding_bias = 0x7fffu + lsb;
+    return (uint16_t)((u + rounding_bias) >> 16);
+}
+
+static inline float bf16_bits_to_f32(uint16_t b) {
+    uint32_t u = ((uint32_t)b) << 16;
+    float f;
+    __builtin_memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+static inline bf16_t f32_to_bf16(float f) {
+    uint16_t bits = f32_to_bf16_bits(f);
+    bf16_t out;
+    __builtin_memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+static inline float bf16_to_f32(bf16_t b) {
+    uint16_t bits;
+    __builtin_memcpy(&bits, &b, sizeof(bits));
+    return bf16_bits_to_f32(bits);
+}
+
+// ─── Stage 1 kernel: single 16×16×16 MFMA tile ────────────────────────
+//
+// Input layout (CDNA3 F32_16x16x16 reference):
+//   A operand: lane l holds a[r] = A[m = l%16,   k = (l/16)*4 + r]
+//   B operand: lane l holds b[r] = B[k = (l/16)*4 + r,   n = l%16]
+// Output layout (strip-major over m, different from A's input layout):
+//   D output: lane l holds c[r] = C[m = (l/16)*4 + r,   n = l%16]
+
+extern "C" __global__ __launch_bounds__(64)
+void mfma_bf16_16x16x16_test(
+    const bf16_t* __restrict__ A,    // [M=16, K=16]
+    const bf16_t* __restrict__ B,    // [K=16, N=16]
+    float* __restrict__ C            // [M=16, N=16]
+) {
+    const int lane = threadIdx.x;
+    const int n_lane = lane % 16;
+    const int strip  = lane / 16;
+
+    bf16x4 a_reg;
+    bf16x4 b_reg;
+    for (int r = 0; r < 4; r++) {
+        a_reg[r] = A[n_lane * 16 + (strip * 4 + r)];   // A[m=n_lane, k=strip*4+r]
+        b_reg[r] = B[(strip * 4 + r) * 16 + n_lane];   // B[k=strip*4+r, n=n_lane]
+    }
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+    c_acc = mfma_bf16(a_reg, b_reg, c_acc);
+
+    for (int r = 0; r < 4; r++) {
+        C[(strip * 4 + r) * 16 + n_lane] = c_acc[r];
+    }
+}
+
+// ─── Stage 2 kernel: LDS-tiled GEMM (production layout copy) ──────────
+// Mirrors `kernels/src/gemm_bf16_mfma.gfx942.hip`. Embedded inline here so
+// the POC is buildable without the kernels/ tree included.
+//
+// Layout: A[M,K] BF16 row-major × B[N,K] BF16 row-major (note B is
+// "[batch, K]") → D[N,M] FP32 row-major.
+
+#define K_CHUNK 128
+#define N_TILE  32
+
+extern "C" __global__ __launch_bounds__(256)
+void gemm_bf16_mfma_gfx942_test(
+    const bf16_t* __restrict__ A,
+    const bf16_t* __restrict__ B,
+    float*        __restrict__ D,
+    int M, int K, int batch_size
+) {
+    __shared__ bf16_t lds_b[N_TILE * K_CHUNK];
+
+    const int tid       = threadIdx.x;
+    const int wave_id   = tid >> 6;
+    const int lane_in_w = tid & 63;
+    const int n_lane    = lane_in_w & 15;
+    const int strip     = lane_in_w >> 4;
+
+    const int wave_m_off = (wave_id & 2) ? 16 : 0;
+    const int wave_n_off = (wave_id & 1) ? 16 : 0;
+    const int m_offset = blockIdx.x * 32 + wave_m_off;
+    const int b_offset_global = blockIdx.y * 32;
+    const int b_offset = b_offset_global + wave_n_off;
+
+    const int my_m = m_offset + n_lane;
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int kc = 0; kc < K; kc += K_CHUNK) {
+        __syncthreads();
+        #pragma unroll
+        for (int li = 0; li < 16; li++) {
+            int idx = tid + li * 256;
+            int b_col = idx / K_CHUNK;
+            int b_k   = idx % K_CHUNK;
+            int gb = b_offset_global + b_col;
+            int gk = kc + b_k;
+            bf16_t v = (gb < batch_size && gk < K)
+                ? B[(long long)gb * K + gk]
+                : (bf16_t)0;
+            lds_b[b_col * K_CHUNK + b_k] = v;
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < K_CHUNK; kk += 16) {
+            int gk_start = kc + kk;
+            int a_k_base = gk_start + strip * 4;
+            bf16x4 a_reg;
+            if (my_m < M) {
+                #pragma unroll
+                for (int r = 0; r < 4; r++) {
+                    int gk = a_k_base + r;
+                    a_reg[r] = (gk < K)
+                        ? A[(long long)my_m * K + gk]
+                        : (bf16_t)0;
+                }
+            } else {
+                a_reg[0] = (bf16_t)0; a_reg[1] = (bf16_t)0;
+                a_reg[2] = (bf16_t)0; a_reg[3] = (bf16_t)0;
+            }
+
+            int b_col_in_tile   = wave_n_off + n_lane;
+            int k_in_chunk_base = kk + strip * 4;
+            bf16x4 b_reg;
+            b_reg[0] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 0];
+            b_reg[1] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 1];
+            b_reg[2] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 2];
+            b_reg[3] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 3];
+
+            c_acc = mfma_bf16(a_reg, b_reg, c_acc);
+        }
+    }
+
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        const int gm = m_offset + strip * 4 + r;
+        const int gb = b_offset + n_lane;
+        if (gm < M && gb < batch_size) {
+            D[(long long)gb * M + gm] = c_acc[r];
+        }
+    }
+}
+
+// ─── Test driver ──────────────────────────────────────────────────────
+
+static int run_stage1() {
+    constexpr int M = 16, N = 16, K = 16;
+    bf16_t A_h[M*K], B_h[K*N];
+    float C_h[M*N], C_ref[M*N];
+
+    srand(42);
+    for (int i = 0; i < M*K; i++) A_h[i] = f32_to_bf16((rand() % 100) / 100.0f - 0.5f);
+    for (int i = 0; i < K*N; i++) B_h[i] = f32_to_bf16((rand() % 100) / 100.0f - 0.5f);
+
+    // FP32 reference (BF16 cast back to FP32 for the multiply, FP32 accumulate)
+    for (int m = 0; m < M; m++) {
+        for (int n = 0; n < N; n++) {
+            float sum = 0.0f;
+            for (int k = 0; k < K; k++) {
+                sum += bf16_to_f32(A_h[m*K + k]) * bf16_to_f32(B_h[k*N + n]);
+            }
+            C_ref[m*N + n] = sum;
+        }
+    }
+
+    bf16_t *A_d, *B_d;
+    float *C_d;
+    hipMalloc(&A_d, M*K*sizeof(bf16_t));
+    hipMalloc(&B_d, K*N*sizeof(bf16_t));
+    hipMalloc(&C_d, M*N*sizeof(float));
+    hipMemcpy(A_d, A_h, M*K*sizeof(bf16_t), hipMemcpyHostToDevice);
+    hipMemcpy(B_d, B_h, K*N*sizeof(bf16_t), hipMemcpyHostToDevice);
+
+    hipLaunchKernelGGL(mfma_bf16_16x16x16_test, dim3(1), dim3(64), 0, 0, A_d, B_d, C_d);
+    hipDeviceSynchronize();
+    hipMemcpy(C_h, C_d, M*N*sizeof(float), hipMemcpyDeviceToHost);
+
+    double max_err = 0.0;
+    int fails = 0;
+    for (int i = 0; i < M*N; i++) {
+        double err = fabs((double)C_h[i] - (double)C_ref[i]);
+        if (err > 1e-2) fails++;
+        if (err > max_err) max_err = err;
+    }
+    printf("Stage 1 (single 16x16x16 BF16 tile): max_err=%.3g fails=%d/%d\n",
+           max_err, fails, M*N);
+
+    hipFree(A_d); hipFree(B_d); hipFree(C_d);
+    return fails;
+}
+
+static int run_stage2() {
+    // Production-shape test: 128x128 weights × 64 batch, K_CHUNK=128 → 1 outer-k step.
+    constexpr int M = 128, K = 128, BATCH = 64;
+    bf16_t *A_h = new bf16_t[M*K];
+    bf16_t *B_h = new bf16_t[BATCH*K];
+    float  *D_h = new float[BATCH*M];
+    float  *D_ref = new float[BATCH*M];
+
+    srand(123);
+    for (int i = 0; i < M*K; i++) A_h[i]    = f32_to_bf16(((rand() % 200) - 100) / 100.0f);
+    for (int i = 0; i < BATCH*K; i++) B_h[i] = f32_to_bf16(((rand() % 200) - 100) / 100.0f);
+
+    // FP32 reference
+    for (int b = 0; b < BATCH; b++) {
+        for (int m = 0; m < M; m++) {
+            float sum = 0.0f;
+            for (int k = 0; k < K; k++) {
+                sum += bf16_to_f32(A_h[m*K + k]) * bf16_to_f32(B_h[b*K + k]);
+            }
+            D_ref[b*M + m] = sum;
+        }
+    }
+
+    bf16_t *A_d, *B_d;
+    float *D_d;
+    hipMalloc(&A_d, M*K*sizeof(bf16_t));
+    hipMalloc(&B_d, BATCH*K*sizeof(bf16_t));
+    hipMalloc(&D_d, BATCH*M*sizeof(float));
+    hipMemcpy(A_d, A_h, M*K*sizeof(bf16_t), hipMemcpyHostToDevice);
+    hipMemcpy(B_d, B_h, BATCH*K*sizeof(bf16_t), hipMemcpyHostToDevice);
+
+    dim3 grid((M + 31) / 32, (BATCH + 31) / 32);
+    dim3 block(256);
+    hipLaunchKernelGGL(gemm_bf16_mfma_gfx942_test, grid, block, 0, 0,
+                       A_d, B_d, D_d, M, K, BATCH);
+    hipDeviceSynchronize();
+    hipMemcpy(D_h, D_d, BATCH*M*sizeof(float), hipMemcpyDeviceToHost);
+
+    double max_err = 0.0;
+    double max_rel_err = 0.0;
+    int fails = 0;
+    int rel_fails = 0;
+    for (int i = 0; i < BATCH*M; i++) {
+        double err = fabs((double)D_h[i] - (double)D_ref[i]);
+        double denom = fmax(fabs((double)D_ref[i]), 1e-3);
+        double rel = err / denom;
+        if (err > 1e-1) fails++;
+        if (rel > 5e-3) rel_fails++;
+        if (err > max_err) max_err = err;
+        if (rel > max_rel_err) max_rel_err = rel;
+    }
+    printf("Stage 2 (LDS-tiled GEMM, M=128 K=128 batch=64): "
+           "max_err=%.3g max_rel_err=%.3g abs_fails=%d/%d rel_fails=%d/%d\n",
+           max_err, max_rel_err, fails, BATCH*M, rel_fails, BATCH*M);
+
+    delete[] A_h; delete[] B_h; delete[] D_h; delete[] D_ref;
+    hipFree(A_d); hipFree(B_d); hipFree(D_d);
+    return fails;
+}
+
+int main() {
+    int s1 = run_stage1();
+    int s2 = run_stage2();
+
+    if (s1 == 0 && s2 == 0) {
+        printf("\nPASS — BF16 MFMA path works; lane layout + LDS tiling correct.\n");
+        printf("       Foundation kernel ready for the Tier 1 calibration forward pass.\n");
+        return 0;
+    } else {
+        printf("\nFAIL — stage1=%d stage2=%d failures.\n", s1, s2);
+        return 1;
+    }
+}

--- a/kernels/src/gemm_bf16_mfma.gfx942.hip
+++ b/kernels/src/gemm_bf16_mfma.gfx942.hip
@@ -1,0 +1,176 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+
+// BF16 × BF16 → FP32 MFMA-direct GEMM for gfx942 (MI300X CDNA3).
+//
+// Foundation kernel for the Tier 1 hipfire-native BF16 calibration path
+// (replaces Tier 2 llama.cpp `llama-imatrix` + PyTorch `collect_hessian.py`
+// subprocess wrappers). Both operands are BF16 in global memory — no
+// dequantization, no FP16 shadow buffer — feeding straight into
+// `__builtin_amdgcn_mfma_f32_16x16x16bf16`.
+//
+// Layout copies the v3 sweet-spot from `gemm_hfq4g256_residual_mfma.gfx942.hip`
+// (commit 496edfbc, 97.6% of rocBLAS Tensile on HFQ4 prefill):
+//
+//   A:  [M, K] BF16, row-major  (M = output features, K = input dim)
+//   B:  [batch_size, K] BF16, row-major (calibration activations / token tiles)
+//   D:  [batch_size, M] FP32, row-major
+//
+// Geometry:
+//   block = [256, 1, 1]                4 wave64/WG, 32×32 output tile per WG
+//   grid  = [(M+31)/32, (batch+31)/32] one WG per (output-row-tile, batch-tile)
+//   LDS   = 32 × K_CHUNK × 2 B         B-tile cooperative load (4 KB at K_CHUNK=128)
+//
+// Intrinsic: `__builtin_amdgcn_mfma_f32_16x16x16bf16_1k`.
+// The `_1k` suffix is the gfx90a/gfx942 inherited name for the 16-K-wide
+// BF16 MFMA (4 BF16 lanes × 16 m-rows × 16 n-cols per call). The operand
+// vector type is `short __attribute__((ext_vector_type(4)))` — clang
+// represents BF16 lane bits as i16 here, so we bit-cast a `__bf16` x4
+// vector into the i16 x4 expected by the intrinsic. No data movement;
+// pure type punning.
+//
+// MFMA F32_16x16x16_BF16 lane layout — identical to the F32_16x16x16_F16
+// variant verified via `docs/investigations/2026-05-19-mfma-hfq4/mfma_test.cpp`
+// (max_err 8.9e-08 on F16; the BF16 intrinsic shares the same lane mapping,
+// only the operand dtype differs):
+//
+//   A operand:  lane l holds a[r] = A[m = l%16,        k = (l/16)*4 + r]
+//   B operand:  lane l holds b[r] = B[k = (l/16)*4 + r, n = l%16]
+//   D output:   lane l holds c[r] = D[m = (l/16)*4 + r, n = l%16]   ← strip-major
+//
+// The output strip-major layout (lane l holds D[m=(l/16)*4+r, n=l%16])
+// differs from the A-operand m-major-by-lane input layout. Easy bug to
+// introduce when swapping intrinsics. The v3 HFQ4 kernel has the same
+// trap and resolves it the same way.
+//
+// Wave-tile arrangement within a WG (4 wave64 → 2×2 wave grid over the
+// 32×32 output tile):
+//
+//   wave_id 0 → output sub-tile (m_off=0,  n_off=0)
+//   wave_id 1 → output sub-tile (m_off=0,  n_off=16)
+//   wave_id 2 → output sub-tile (m_off=16, n_off=0)
+//   wave_id 3 → output sub-tile (m_off=16, n_off=16)
+//
+// All 4 waves cooperatively load one B-chunk [32 cols × K_CHUNK k] into LDS
+// per outer-k step, then each wave's 16×16 MFMA reads B from LDS. v3's
+// HFQ4 measurement showed this LDS B-tile is the lever that closes the
+// gap to rocBLAS — same expectation applies here (B is now actual BF16
+// activations in HBM, the cooperative load amortizes HBM bandwidth across
+// 4 MFMA iterations sharing the chunk).
+
+typedef __bf16 bf16_t;
+typedef __bf16 bf16x4 __attribute__((ext_vector_type(4)));
+typedef short  s16x4  __attribute__((ext_vector_type(4)));
+typedef float  vfloat4 __attribute__((ext_vector_type(4)));
+
+// MFMA F32_16x16x16_BF16 intrinsic — operands are bit-cast __bf16x4 → short x4.
+// LLVM's amdgcn intrinsic models the BF16 lane bits as i16; bit_cast is the
+// no-op punning the compiler folds away.
+__device__ static inline vfloat4 mfma_bf16(bf16x4 a, bf16x4 b, vfloat4 c) {
+    s16x4 ai = __builtin_bit_cast(s16x4, a);
+    s16x4 bi = __builtin_bit_cast(s16x4, b);
+    return __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(ai, bi, c, 0, 0, 0);
+}
+
+#define K_CHUNK 128
+#define N_TILE  32
+
+extern "C" __global__ __launch_bounds__(256)
+void gemm_bf16_mfma_gfx942(
+    const bf16_t* __restrict__ A,    // [M, K] BF16 row-major
+    const bf16_t* __restrict__ B,    // [batch_size, K] BF16 row-major
+    float*        __restrict__ D,    // [batch_size, M] FP32 row-major (overwritten)
+    int M, int K, int batch_size
+) {
+    __shared__ bf16_t lds_b[N_TILE * K_CHUNK];   // 32 × 128 = 4096 bf16 = 8 KB
+
+    const int tid       = threadIdx.x;
+    const int wave_id   = tid >> 6;             // 0..3
+    const int lane_in_w = tid & 63;
+    const int n_lane    = lane_in_w & 15;       // 0..15  (A.m, B.n, D.n within tile)
+    const int strip     = lane_in_w >> 4;       // 0..3   (k-strip / D row-strip)
+
+    const int wave_m_off = (wave_id & 2) ? 16 : 0;
+    const int wave_n_off = (wave_id & 1) ? 16 : 0;
+    const int m_offset = blockIdx.x * 32 + wave_m_off;          // global output-row start
+    const int b_offset_global = blockIdx.y * 32;                // global batch start (per-WG)
+    const int b_offset = b_offset_global + wave_n_off;          // per-wave batch start
+
+    const int my_m = m_offset + n_lane;                         // this lane's output row
+
+    vfloat4 c_acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    // K outer loop in chunks of K_CHUNK (= 8 MFMA-K=16 iterations per chunk).
+    for (int kc = 0; kc < K; kc += K_CHUNK) {
+        // ─── Cooperative LDS load of B chunk [32 cols × K_CHUNK k] ───
+        // 256 threads load 32 × 128 = 4096 bf16 = 16 per thread.
+        __syncthreads();
+        #pragma unroll
+        for (int li = 0; li < 16; li++) {
+            int idx = tid + li * 256;
+            int b_col = idx / K_CHUNK;             // 0..31
+            int b_k   = idx % K_CHUNK;             // 0..K_CHUNK-1
+            int gb = b_offset_global + b_col;
+            int gk = kc + b_k;
+            bf16_t v = (gb < batch_size && gk < K)
+                ? B[(long long)gb * K + gk]
+                : (bf16_t)0;
+            lds_b[b_col * K_CHUNK + b_k] = v;
+        }
+        __syncthreads();
+
+        // ─── MFMA loop over chunk in 16-element K steps ───
+        #pragma unroll
+        for (int kk = 0; kk < K_CHUNK; kk += 16) {
+            int gk_start = kc + kk;
+
+            // A operand: each lane reads 4 contiguous K-elements
+            //   k = gk_start + strip*4 + r for r=0..3
+            // Out-of-bounds rows / k's get zero (clean boundary handling).
+            bf16x4 a_reg;
+            int a_k_base = gk_start + strip * 4;
+            if (my_m < M) {
+                #pragma unroll
+                for (int r = 0; r < 4; r++) {
+                    int gk = a_k_base + r;
+                    a_reg[r] = (gk < K)
+                        ? A[(long long)my_m * K + gk]
+                        : (bf16_t)0;
+                }
+            } else {
+                a_reg[0] = (bf16_t)0; a_reg[1] = (bf16_t)0;
+                a_reg[2] = (bf16_t)0; a_reg[3] = (bf16_t)0;
+            }
+
+            // B operand: read 4 contiguous K-elements from LDS
+            //   col_in_tile = wave_n_off + n_lane  (0..31, this wave's n half)
+            //   k_in_chunk_base = kk + strip*4
+            int b_col_in_tile   = wave_n_off + n_lane;
+            int k_in_chunk_base = kk + strip * 4;
+            bf16x4 b_reg;
+            b_reg[0] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 0];
+            b_reg[1] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 1];
+            b_reg[2] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 2];
+            b_reg[3] = lds_b[b_col_in_tile * K_CHUNK + k_in_chunk_base + 3];
+
+            c_acc = mfma_bf16(a_reg, b_reg, c_acc);
+        }
+    }
+
+    // ─── Output write: strip-major over m ─────────────────────────────
+    // Lane (strip, n_lane) holds c_acc[r] = D[m = m_offset + strip*4 + r,
+    //                                          n = b_offset + n_lane]
+    // D is [batch_size, M] row-major: D[b, m] = D[b * M + m]
+    //
+    // Plain GEMM: overwrite (no residual add). The Tier 1 calibration
+    // path uses this kernel as a forward primitive; the Σx² / outer-
+    // product reductions sit on top and accumulate themselves.
+    #pragma unroll
+    for (int r = 0; r < 4; r++) {
+        const int gm = m_offset + strip * 4 + r;
+        const int gb = b_offset + n_lane;
+        if (gm < M && gb < batch_size) {
+            D[(long long)gb * M + gm] = c_acc[r];
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for **Tier 1 hipfire-native BF16 calibration** — first MFMA-direct BF16 GEMM kernel on gfx942, capture-hook plumbing on `Gpu`, BF16 model loader scaffold, and binary scaffolds for `collect_imatrix` / `collect_hessian`.

Replaces the current Tier 2 subprocess wrappers (`scripts/collect_hessian.py` via PyTorch, `crates/hipfire-runtime/examples/imatrix_collect.rs` via llama.cpp `llama-imatrix`). Target speedup: **20×** (8h → ~25min for a 128-seq × 4-pass Hessian collection on MI300x).

**This PR ships foundation only**, not the full pipeline. The 4 commits unblock the ~7-8 days of follow-on Phase 2 work documented at `docs/plans/imatrix-tier1-hipfire-native.md`.

## Headline metrics

- BF16 MFMA-direct kernel **compiles + disassembles cleanly** on gfx942 with **8× `v_mfma_f32_16x16x16_bf16`** instructions per K-iter unrolled inner loop (offsets `0x1DD0`, `0x21D8`, `0x22C4`, ...)
- 4/4 `bf16_loader::is_gptq_target` whitelist tests pass
- `cargo check --workspace` clean (0 new warnings)
- `cargo test -p hipfire-runtime --lib bf16_loader` PASS
- POC test scaffold compiles to a 30 KB host binary; runtime PASS pending droplet (no MI300x locally)

## What changes

**Kernels (new):**
- `kernels/src/gemm_bf16_mfma.gfx942.hip` (176 lines) — production BF16 MFMA-direct GEMM. Adapts the v3 LDS B-tile sweet-spot from `gemm_hfq4g256_residual_mfma.gfx942.hip` (PR 4 / commit 496edfbc) but with both operands BF16. K_CHUNK=128, 4 wave64/WG, 32×32 output tile.

**Investigation:**
- `docs/investigations/2026-05-19-tier1-bf16-mfma/`
  - `mfma_bf16_test.cpp` (323 lines) — POC test scaffold (compiles with `hipcc --offload-arch=gfx942 -O3`)
  - `README.md` (166 lines) — design, intrinsic-naming gotcha, expected error tolerance, microbench plan

**Binaries (scaffolds with TODOs):**
- `crates/hipfire-runtime/src/bin/collect_imatrix.rs` (178 lines)
- `crates/hipfire-runtime/src/bin/collect_hessian.rs` (188 lines)
- Both compile (`cargo check -p hipfire-runtime`) and `--help` exits 0. Bodies are `unimplemented!()` with TODO comments mapping each section to the corresponding Tier 2 logic to port.

**Dispatch plumbing:**
- `crates/rdna-compute/src/dispatch.rs`:
  - `pub trait ActivationCapture: Send + Sync`
  - `pub capture_handler: Option<Arc<dyn ActivationCapture>>` field on `Gpu`
  - Default `None`; existing call sites unaffected

**Loader scaffold:**
- `crates/hipfire-runtime/src/bf16_loader.rs` (196 lines) — `load_bf16_model()` scaffold that reads HF safetensors metadata and pre-allocates device tensors. Actual weight upload is TODO (Phase 2 — needs `DType::BF16` enum arm which is a 1-line addition).

## Key technical resolution (saves Phase 2 time)

The gfx942 BF16 MFMA intrinsic is named `__builtin_amdgcn_mfma_f32_16x16x16bf16_1k`, **not** the obvious `..._16x16x16_bf16` or `..._bf16`. The `_1k` suffix is the gfx90a-inherited naming convention. LLVM models BF16 lane bits as `i16`; the wrapper bit-casts `__bf16 x4 → short x4` before the intrinsic call — compiler folds the cast away. Documented in the kernel's header comment.

This is the kind of detail that costs real time to discover by trial — having it nailed down in the foundation kernel means Phase 2 BF16 work inherits it directly.

## Future Phase 2 work (NOT in this PR)

Per `docs/plans/imatrix-tier1-hipfire-native.md`:

| Component | Effort | Status |
|---|---:|---|
| GPU-native Σx² reduce kernel | 0.5d | TODO |
| GPU-native Hessian outer-product kernel | 1d | TODO |
| BF16 forward path through trunk (BF16 arm in every dispatch site) | 2-3d | TODO |
| Activation capture hooks threaded through all GEMM call sites | 1d | TODO |
| GGUF imatrix writer (mirror llama.cpp format) | 0.5d | TODO |
| HFHS Hessian writer (mirror trunk format) | 0.5d | TODO |
| Corpus loader + tokenizer driver | 0.5d | TODO |
| BF16 MTP head forward (adapt from `scripts/collect_mtp_imatrix.py`) | 1d | TODO |
| Multi-sequence batching | 2d | TODO |
| Channel test vs PyTorch reference | 1d | TODO |

**Phase 2 total: ~9-10 days remaining** (foundation in this PR removes ~1-2 days from the original 11-day estimate).

## Test plan

- [ ] `cargo check --workspace` clean
- [ ] `cargo build --release -p hipfire-runtime -p rdna-compute` clean
- [ ] `cargo test -p hipfire-runtime --lib bf16_loader` — 4/4 PASS
- [ ] `collect_imatrix --help` + `collect_hessian --help` exit 0
- [ ] On MI300x droplet: `hipcc --offload-arch=gfx942 -O3 docs/investigations/2026-05-19-tier1-bf16-mfma/mfma_bf16_test.cpp -o mfma_bf16_test && ./mfma_bf16_test` reports PASS (max_err < 1e-3)
- [ ] Disassembly verification: `clang-offload-bundler` + `llvm-readelf` shows `v_mfma_f32_16x16x16_bf16` instructions in the unrolled inner-K loop

## Risk

- **Foundation only**: bin scaffolds are `unimplemented!()` — nothing runtime-visible yet
- ActivationCapture trait is optional (`None` default) — existing call sites unaffected
- BF16 MFMA kernel is opt-in via separate dispatch arm (not added yet — that's Phase 2 work)
- POC test runtime PASS pending — only host-compiled, no MI300x in local dev
- No production code paths changed

## Cross-refs

- Companion PR 4 (MI300x B+C): the F16 MFMA v3 layout in `gemm_hfq4g256_residual_mfma.gfx942.hip` is the foundation pattern this kernel adapts for BF16
- `docs/plans/imatrix-tier1-hipfire-native.md` — full gap analysis + effort estimate (filed previously, included in PR 5 / iterate refinements set)
- Session memory: `[[project_mi300x_mfma_hfq4_poc_2026_05_19]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
