### PR TITLE
refactor(awq): unify sidecar loader (#268 items 2 + 3)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -5,7 +5,7 @@
 //! Qwen3.5 model: hybrid DeltaNet (linear attention) + standard attention.
 //! Feature-gated behind `deltanet`.
 
-use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::hfq::{load_awq_scale, HfqFile};
 use hipfire_runtime::llama::{self, f16_to_f32, EmbeddingFormat, WeightTensor, weight_gemv,
                               weight_gemv_prerotated, fused_rmsnorm_rotate_for_mq,
                               fused_rmsnorm_rotate_mq_batched_for,
@@ -842,52 +842,6 @@ fn load_weight_tensor_raw(gpu: &Gpu, quant_type: u8, data: &[u8], m: usize, k: u
     }
 }
 
-/// Phase A Stage A — AWQ sidecar loader for the Qwen3.5 forward path.
-///
-/// The .hfq quantizer emits `<weight>.awq_scale.weight` (1D F16, length K)
-/// alongside MQ4G256 weights that were AWQ pre-scaled. The dispatcher in
-/// `fused_rmsnorm_rotate_for_mq` / `fused_rmsnorm_rotate_mq_batched_for`
-/// looks at `WeightTensor.awq_scale.is_some()` to pick the AWQ-aware
-/// kernel variant. WITHOUT this loader populating the field, every MQ4
-/// weight ends up with `awq_scale: None`, the dispatcher falls through
-/// to the non-AWQ kernel, and the math `(W·s) · (x/s) = W·x` breaks
-/// because the runtime never divides by `s` — observed KLD blowup
-/// 0.6721 → 13.4893 on 0.8B Qwen3.5 before this landed.
-///
-/// Lookup pattern matches `hipfire_runtime::hfq::load_awq_scale`:
-/// strip trailing `.weight`, append `.awq_scale.weight`. Try both the
-/// `model.language_model.`-prefixed name and the bare name (the qwen35
-/// crate uses prefixed names; older sidecars or tests may use either).
-fn load_awq_scale_for(hfq: &HfqFile, gpu: &Gpu, name: &str, k: usize) -> Option<GpuTensor> {
-    let sidecar_name = match name.strip_suffix(".weight") {
-        Some(stem) => format!("{stem}.awq_scale.weight"),
-        None => format!("{name}.awq_scale.weight"),
-    };
-    let (sc_info, sc_data) = hfq.tensor_data_pread(&sidecar_name)?;
-    // Must be 1D F16, length K. quant_type 1 = F16.
-    if sc_info.quant_type != 1 {
-        eprintln!(
-            "warning: AWQ sidecar {sidecar_name} has quant_type={} (expected 1=F16); skipping",
-            sc_info.quant_type
-        );
-        return None;
-    }
-    if sc_info.shape.len() != 1 || sc_info.shape[0] as usize != k {
-        eprintln!(
-            "warning: AWQ sidecar {sidecar_name} shape mismatch ({:?} vs expected [{}]); skipping",
-            sc_info.shape, k
-        );
-        return None;
-    }
-    // F16 → F32 on host so the kernel takes a plain `const float*`.
-    let f32_data: Vec<f32> = sc_data
-        .chunks_exact(2)
-        .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
-        .collect();
-    let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
-    gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok()
-}
-
 /// TODO(transformer-extraction): cross-arch duplicate of
 /// `hipfire-arch-qwen2::qwen2::load_weight_tensor` — same name-lookup +
 /// pread + AWQ-sidecar pattern, but qwen35 uses the
@@ -915,8 +869,8 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         // the weight bytes have already been uploaded to GPU (owned by
         // `wt.buf`) so the borrow no longer matters.
         if wt.gpu_dtype.supports_awq_sidecar() {
-            wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
-                .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
+            wt.awq_scale = load_awq_scale(hfq, gpu, &full_name, k)
+                .or_else(|| load_awq_scale(hfq, gpu, name, k));
         }
         return Ok(wt);
     }
@@ -927,8 +881,8 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
             .unwrap_or_else(|| panic!("tensor not found: {name} or {full_name}"));
         let mut wt = load_weight_tensor_raw(gpu, info.quant_type, data, m, k)?;
         if wt.gpu_dtype.supports_awq_sidecar() {
-            wt.awq_scale = load_awq_scale_for(hfq, gpu, &full_name, k)
-                .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
+            wt.awq_scale = load_awq_scale(hfq, gpu, &full_name, k)
+                .or_else(|| load_awq_scale(hfq, gpu, name, k));
         }
         Ok(wt)
     }
@@ -1445,13 +1399,13 @@ pub fn load_weights(hfq: &mut HfqFile, config: &Qwen35Config, gpu: &mut Gpu) -> 
     // attaching a sidecar here would have driven the 0.67 → 13.5 KLD
     // corruption documented at `docs/plans/awq_fix_claude.md` because
     // the spec-verify path used the non-AWQ `rotate_x_mq_batched`.
-    // Try each plausible tensor name; `load_awq_scale_for` returns
+    // Try each plausible tensor name; `load_awq_scale` returns
     // None when no sidecar exists, so this is a no-op for current
     // pre-CUDA-pipeline files.
     if output.gpu_dtype.supports_awq_sidecar() {
-        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+        output.awq_scale = load_awq_scale(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
         eprintln!("  lm_head AWQ sidecar: {}",
             if output.awq_scale.is_some() { "attached" } else { "absent (no-op)" });
     }
@@ -1694,9 +1648,9 @@ fn load_output_into(
     // (spec-verify) route through AWQ-aware rotations on
     // `output.awq_scale.is_some()`. No-op on current files.
     if output.gpu_dtype.supports_awq_sidecar() {
-        output.awq_scale = load_awq_scale_for(hfq, gpu, "lm_head.weight", config.dim)
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
-            .or_else(|| load_awq_scale_for(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
+        output.awq_scale = load_awq_scale(hfq, gpu, "lm_head.weight", config.dim)
+            .or_else(|| load_awq_scale(hfq, gpu, "model.language_model.lm_head.weight", config.dim))
+            .or_else(|| load_awq_scale(hfq, gpu, "model.language_model.embed_tokens.weight", config.dim));
         eprintln!("  lm_head AWQ sidecar: {}",
             if output.awq_scale.is_some() { "attached" } else { "absent (no-op)" });
     }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -865,9 +865,11 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, name: &str, m: usize, k: usize) 
         };
         // Phase A Stage A — populate awq_scale when the dtype is on
         // the AWQ allow-list (centralized at `DType::supports_awq_sidecar`).
-        // The pread call invalidates the prior pread_buf borrow, but
-        // the weight bytes have already been uploaded to GPU (owned by
-        // `wt.buf`) so the borrow no longer matters.
+        // `load_awq_scale` reads the sidecar via `tensor_data_vec` (fresh
+        // owned Vec), so it doesn't touch `self.pread_buf` — the prior
+        // pread_buf Ref guard from the weight load above was already
+        // dropped at the end of the `if let` block, and even if it weren't,
+        // the helper wouldn't invalidate it.
         if wt.gpu_dtype.supports_awq_sidecar() {
             wt.awq_scale = load_awq_scale(hfq, gpu, &full_name, k)
                 .or_else(|| load_awq_scale(hfq, gpu, name, k));

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -26,7 +26,7 @@
 //!   equivalent to the reference's cropped draft-KV cache and avoids
 //!   one whole layer of persistence bookkeeping.
 
-use crate::hfq::HfqFile;
+use crate::hfq::{load_awq_scale, HfqFile};
 use crate::llama::WeightTensor;
 use hip_bridge::HipResult;
 use rdna_compute::{DType, Gpu, GpuTensor};
@@ -252,31 +252,8 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
     // `DType::supports_awq_sidecar` allow-list so future widening (MQ6,
     // MQ2, MQ3-Lloyd, MFP4) is a single helper edit. Sidecar absent →
     // `awq_scale` stays None, dispatch path matches the pre-fix behavior.
-    //
-    // Logic is inlined rather than calling out to hfq.rs's closure or
-    // qwen35.rs's `load_awq_scale_for` to avoid pulling in a cross-crate
-    // dependency for what is structurally a third copy of the same load.
-    // Factor-out (one shared `pub fn load_awq_scale_for` in this crate)
-    // is tracked as a follow-up.
     if wt.gpu_dtype.supports_awq_sidecar() {
-        let sidecar_name = match name.strip_suffix(".weight") {
-            Some(stem) => format!("{stem}.awq_scale.weight"),
-            None => format!("{name}.awq_scale.weight"),
-        };
-        if let Some((sc_info, sc_data)) = hfq.tensor_data(&sidecar_name) {
-            if sc_info.quant_type != 1 {
-                eprintln!("warning: AWQ sidecar {sidecar_name} has quant_type={} (expected 1=F16); skipping", sc_info.quant_type);
-            } else if sc_info.shape.len() != 1 || sc_info.shape[0] as usize != k {
-                eprintln!("warning: AWQ sidecar {sidecar_name} shape mismatch ({:?} vs expected [{}]); skipping", sc_info.shape, k);
-            } else {
-                let f32_data: Vec<f32> = sc_data
-                    .chunks_exact(2)
-                    .map(|c| crate::llama::f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
-                    .collect();
-                let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
-                wt.awq_scale = gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok();
-            }
-        }
+        wt.awq_scale = load_awq_scale(hfq, gpu, name, k);
     }
     Ok(wt)
 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -487,51 +487,60 @@ fn load_f16_tensor(hfq: &HfqFile, gpu: &mut Gpu, st_name: &str, shape: &[usize])
     gpu.upload_f32(&f32_data, shape)
 }
 
+/// Load an AWQ scale sidecar tensor from an HFQ file onto GPU.
+///
+/// Phase A Stage A — AWQ sidecar lookup. The quantizer emits per-tensor
+/// sidecars named `<weight_name>.awq_scale.weight` (1D F16, length K)
+/// alongside MQ4-quantized weights. The forward path uses these to apply
+/// `x /= awq_scale` before the rotation kernel, completing the AWQ
+/// math `(W·s) · (x/s) = W·x`. Backward-compatible: when no sidecar
+/// exists (the common case for pre-Stage-A .hfq files), this returns
+/// None and the runtime behaves identically to before.
+///
+/// Naming convention: replace trailing `.weight` with `.awq_scale.weight`.
+/// Matches hipfire-quantize's emit pattern.
+///
+/// Internally uses `tensor_data_vec`, which on Unix routes through pread
+/// + fadvise_dontneed (avoids page cache buildup on unified-memory APUs)
+/// and on non-Unix falls back to mmap. Sidecars are small (K ≤ ~12288
+/// elements, ~48 KB peak), so the owned-Vec copy is negligible.
+pub fn load_awq_scale(hfq: &HfqFile, gpu: &Gpu, weight_name: &str, k: usize) -> Option<GpuTensor> {
+    let sidecar_name = match weight_name.strip_suffix(".weight") {
+        Some(stem) => format!("{stem}.awq_scale.weight"),
+        None => format!("{weight_name}.awq_scale.weight"),
+    };
+    let (sc_info, sc_data) = hfq.tensor_data_vec(&sidecar_name)?;
+    // Must be 1D F16, length K. quant_type 1 = F16 per the existing
+    // load_f16_tensor path.
+    if sc_info.quant_type != 1 {
+        eprintln!(
+            "warning: AWQ sidecar {sidecar_name} has quant_type={} (expected 1=F16); skipping",
+            sc_info.quant_type
+        );
+        return None;
+    }
+    if sc_info.shape.len() != 1 || sc_info.shape[0] as usize != k {
+        eprintln!(
+            "warning: AWQ sidecar {sidecar_name} shape mismatch ({:?} vs expected [{}]); skipping",
+            sc_info.shape, k
+        );
+        return None;
+    }
+    // Convert F16 → F32 on host before upload, so the kernel receives
+    // a `const float*` and doesn't need <hip/hip_fp16.h>. The 2× VRAM
+    // cost vs raw F16 is negligible at these sizes.
+    let f32_data: Vec<f32> = sc_data
+        .chunks_exact(2)
+        .map(|c| crate::llama::f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+        .collect();
+    let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
+    gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok()
+}
+
 /// Load a weight tensor (quantized or F16) onto GPU.
 fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usize) -> HipResult<WeightTensor> {
     let (info, data) = hfq.tensor_data(st_name)
         .unwrap_or_else(|| panic!("tensor not found: {st_name}"));
-
-    // Phase A Stage A — AWQ sidecar lookup. The quantizer emits per-tensor
-    // sidecars named `<weight_name>.awq_scale.weight` (1D F16, length K)
-    // alongside MQ4-quantized weights. The forward path uses these to apply
-    // `x /= awq_scale` before the rotation kernel, completing the AWQ
-    // math `(W·s) · (x/s) = W·x`. Backward-compatible: when no sidecar
-    // exists (the common case for pre-Stage-A .hfq files), `awq_scale`
-    // stays None and the runtime behaves identically to before.
-    //
-    // Naming convention: replace `.weight` with `.awq_scale.weight` so the
-    // sidecar gets stored as an F16 1D tensor that the loader can detect
-    // by name. Matches hipfire-quantize's emit pattern.
-    let load_awq_scale = || -> Option<GpuTensor> {
-        let sidecar_name = match st_name.strip_suffix(".weight") {
-            Some(stem) => format!("{stem}.awq_scale.weight"),
-            None => format!("{st_name}.awq_scale.weight"),
-        };
-        let (sc_info, sc_data) = hfq.tensor_data(&sidecar_name)?;
-        // Must be 1D F16, length K. Quant type 1 = F16 per the existing
-        // load_f16_tensor path (quant_type field documented at line ~31).
-        if sc_info.quant_type != 1 {
-            eprintln!("warning: AWQ sidecar {sidecar_name} has quant_type={} (expected 1=F16); skipping", sc_info.quant_type);
-            return None;
-        }
-        if sc_info.shape.len() != 1 || sc_info.shape[0] != k as u32 {
-            eprintln!("warning: AWQ sidecar {sidecar_name} shape mismatch ({:?} vs expected [{}]); skipping", sc_info.shape, k);
-            return None;
-        }
-        // Convert F16 → F32 on host before upload, so the kernel receives
-        // a `const float*` and doesn't need <hip/hip_fp16.h>. The scale
-        // vector is small (K ≤ ~12288 elements, ~48 KB peak), so the
-        // 2× memory cost on GPU vs raw F16 is negligible.
-        let f32_data: Vec<f32> = sc_data
-            .chunks_exact(2)
-            .map(|c| crate::llama::f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
-            .collect();
-        let f32_bytes: Vec<u8> = f32_data.iter()
-            .flat_map(|&v| v.to_le_bytes())
-            .collect();
-        gpu.upload_raw(&f32_bytes, &[f32_bytes.len()]).ok()
-    };
 
     let mut wt = match info.quant_type {
         0 => { // Q4F16G64
@@ -641,7 +650,7 @@ fn load_weight_tensor(hfq: &HfqFile, gpu: &Gpu, st_name: &str, m: usize, k: usiz
     // so future widening is a single helper edit, not a scattered
     // per-loader hunt. See dispatch.rs for the allow-list rationale.
     if wt.gpu_dtype.supports_awq_sidecar() {
-        wt.awq_scale = load_awq_scale();
+        wt.awq_scale = load_awq_scale(hfq, gpu, st_name, k);
     }
     Ok(wt)
 }


### PR DESCRIPTION
Closes items **2** and **3** of #268.

## Summary

- **Item 3 (unify loader):** Three near-identical copies of the AWQ sidecar load path existed — `hfq.rs::load_weight_tensor` (closure), `qwen35.rs::load_awq_scale_for`, and `dflash.rs::hfq_weight` (inlined block, whose comment self-documented it as "structurally a third copy"). Consolidated into one `pub fn hipfire_runtime::hfq::load_awq_scale`.
- **Item 2 (cast direction):** The shape check at the former `hfq.rs:518` was `sc_info.shape[0] != k as u32` (lossy direction). The new helper is correct by construction: `sc_info.shape[0] as usize != k`. Now matches the already-correct cast at `dflash.rs:269`.

## Implementation notes

The helper reads via `tensor_data_vec`, which on Unix routes through `pread + fadvise_dontneed` (avoids page cache buildup on unified-memory APUs) and on non-Unix falls back to mmap. Same bytes uploaded to GPU; slightly safer load behavior at the two previously mmap-only sites.

Bonus: the qwen35 site previously needed a comment explaining that its second pread call would invalidate the prior `pread_buf` `Ref` guard. The new helper uses `tensor_data_vec` (fresh owned Vec) and never touches `pread_buf`, so that hazard class is gone. Comment refreshed accordingly.

Net **-60 LOC** (125 deletions, 65 insertions, then 5 / 3 for the comment).

## Items still open on #268

- **1.** Defensive F16 zero-clamp on `awq_scale` (kernel- or quantizer-side).
- **4.** MoE router AWQ-whitelist KLD A/B.
- **5.** Reciprocal scale precompute (deferred behind a perf measurement).

## Test plan

- [x] `cargo check --workspace` clean.
- [x] Local pre-commit gates (coherence + speed) ran on both commits.
- [ ] Reviewer eyeball: confirm the `tensor_data_vec` switch is fine for the two formerly mmap-only sites (`hfq.rs`, `dflash.rs`).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)