### PR TITLE
feat(cli): add hipfire sidecar-gen command for TriAttention calibration sidecar generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ kernels/compiled/
 .serena/
 .remember/
 .codex
+.sisyphus/
 
 # Local secrets (lmx api key, etc.) — never commit
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 *.o
 *.so
+*.triattn.bin
 *.dll
 
 # Editor

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ DFlash speedup is genre-conditional — see
 [docs/BENCHMARKS.md](docs/BENCHMARKS.md) for the full per-genre table
 and the cross-arch matrix (RDNA1 / RDNA2 / APU / MI300X).
 
+CASK-based KV cache eviction lets you run long-context prompts without
+OOM: generate a sidecar with `hipfire sidecar-gen <model>` and enable
+caching with `cask_sidecar on` in your config. See [CONFIG.md](docs/CONFIG.md) for details.
+
 ## Install
 
 Linux with ROCm 6+:
@@ -124,7 +128,7 @@ the prefill MMQ redesign log is at
 | [CLI.md](docs/CLI.md) | Every subcommand, flags, file locations |
 | [MODELS.md](docs/MODELS.md) | Curated tags, BYO models, file extensions |
 | [QUANTIZE.md](docs/QUANTIZE.md) | `hipfire quantize` for HF / safetensors / GGUF |
-| [CONFIG.md](docs/CONFIG.md) | Every config key, env overrides |
+| [CONFIG.md](docs/CONFIG.md) | Every config key, CASK sidecar / KV eviction policies, env overrides |
 | [SERVE.md](docs/SERVE.md) | OpenAI-compatible HTTP API |
 | [BENCHMARKS.md](docs/BENCHMARKS.md) | Measured perf per arch, vs ollama |
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Engine layout, dispatch, two model paths |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ and the cross-arch matrix (RDNA1 / RDNA2 / APU / MI300X).
 
 CASK-based KV cache eviction lets you run long-context prompts without
 OOM: generate a sidecar with `hipfire sidecar-gen <model>` and enable
-caching with `cask_sidecar on` in your config. See [CONFIG.md](docs/CONFIG.md) for details.
+eviction with `hipfire config cask-profile balanced`. See
+[CONFIG.md](docs/CONFIG.md) for details.
 
 ## Install
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5297,7 +5297,6 @@ Examples:
       if (!gpuCalib) args.push("--cpu-calib");
       if (skipValidation) args.push("--val-prompt", "");
       const proc = Bun.spawnSync(args, { stdio: ["inherit", "inherit", "inherit"] });
-      );
       if ((proc.exitCode ?? 1) !== 0) {
         console.error(`triattn_validate failed (exit ${proc.exitCode})`);
         process.exit(1);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5244,7 +5244,8 @@ Examples:
       }
 
       // Determine if we should use dev source or installed source.
-      const srcPath = existsSync(devSrc) ? dirname(devSrc) : dirname(hipfireSrc);
+      const srcDir = existsSync(devSrc) ? dirname(dirname(devSrc)) : dirname(dirname(hipfireSrc));
+      const workspaceRoot = existsSync(join(srcDir, "Cargo.toml")) ? srcDir : resolve(__dirname, "..");
       console.error("  Using cargo run --example (cold start — consider running 'hipfire update' to install the binary)");
 
       // Parse deps for PATH augmentation (same as update command does).
@@ -5279,16 +5280,16 @@ Examples:
       console.error("Building triattn_validate...");
       const build = Bun.spawnSync(
         ["cargo", "build", "--release", "--features", "deltanet", "-p", "hipfire-runtime", "--example", "triattn_validate"],
-        { cwd: srcPath, stdio: ["inherit", "inherit", "inherit"] },
+        { cwd: workspaceRoot, stdio: ["inherit", "inherit", "inherit"] },
       );
       if (build.exitCode !== 0) {
         console.error("Failed to build triattn_validate. Check for ROCm/compilation errors above.");
         process.exit(1);
       }
 
-      // Run the built example.
+      // Run the built example — bin is at workspace_root/target/release/examples/triattn_validate
       const exe = process.platform === "win32" ? ".exe" : "";
-      const binPath = join(srcPath, `../../target/release/examples/triattn_validate${exe}`); // relative to src root
+      const binPath = join(workspaceRoot, `target/release/examples/triattn_validate${exe}`);
       console.error("  Running triattn_validate...");
       const proc = Bun.spawnSync(
         [binPath, resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)],

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5253,9 +5253,14 @@ Examples:
         process.exit(1);
       }
 
-      // Determine if we should use dev source or installed source.
-      const srcDir = existsSync(devSrc) ? dirname(dirname(devSrc)) : dirname(dirname(hipfireSrc));
-      const workspaceRoot = existsSync(join(srcDir, "Cargo.toml")) ? srcDir : resolve(__dirname, "..");
+      // Determine if we should use the dev checkout or the installed source.
+      // Build from the workspace root so Cargo writes the example under
+      // <workspace>/target/release/examples/, matching the binPath below.
+      const workspaceRoot = existsSync(devSrc) ? resolve(__dirname, "..") : join(HIPFIRE_DIR, "src");
+      if (!existsSync(join(workspaceRoot, "Cargo.toml"))) {
+        console.error(`Could not find hipfire workspace root at ${workspaceRoot}`);
+        process.exit(1);
+      }
       console.error("  Using cargo run --example (cold start — consider running 'hipfire update' to install the binary)");
 
       // Parse deps for PATH augmentation (same as update command does).
@@ -5270,7 +5275,8 @@ Examples:
         if (p) augmentDirs.add(p.substring(0, p.lastIndexOf("/")));
       }
       // Also add bun dir for its subtree helpers.
-      const bunPath = findDep("bun", [join(process.env.HOME || "", ".bun/bin"), "/usr/bin"]);        if (bunPath) augmentDirs.add(bunPath.substring(0, bunPath.lastIndexOf("/")));
+      const bunPath = findDep("bun", [join(process.env.HOME || "", ".bun/bin"), "/usr/bin"]);
+      if (bunPath) augmentDirs.add(bunPath.substring(0, bunPath.lastIndexOf("/")));
       if (augmentDirs.size) {
         const curr = (process.env.PATH || "").split(":").filter(Boolean);
         const fresh = [...augmentDirs].filter(d => !curr.includes(d));

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5162,6 +5162,7 @@ Flags:
   --gpu-calib            Use GPU kernel triattn_accumulate (faster on MI300X / RDNA3+)
   --cpu-calib            Force CPU calibration path
   -o, --output PATH      Output sidecar file path (default: <model>.triattn.bin next to model)
+  --skip-validation      Skip Phase 2 validation — faster for sidecar generation only
 
 Examples:
   hipfire sidecar-gen qwen3.5:9b
@@ -5174,6 +5175,7 @@ Examples:
     let chunkLen = 256;
     let gpuCalib = true; // GPU calibration is default (Phase 2, 2026-04-28)
     let output: string | undefined;
+    let skipValidation = false; // sidecar generation doesn't need Phase 2 validation
     for (let i = 1; i < rest.length; i++) {
       const a = rest[i];
       if (a === "--corpus") {
@@ -5192,6 +5194,8 @@ Examples:
       } else if (a === "-o" || a === "--output") {
         output = rest[++i];
         if (!output) { console.error("--output requires a value"); process.exit(1); }
+      } else if (a === "--skip-validation") {
+        skipValidation = true;
       } else {
         console.error(`Unknown argument: ${a}\nRun 'hipfire sidecar-gen --help' for usage.`);
         process.exit(1);
@@ -5224,6 +5228,7 @@ Examples:
       const args = [resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)];
       if (corpusPath) args.push("--corpus", corpusPath);
       if (!gpuCalib) args.push("--cpu-calib");
+      if (skipValidation) args.push("--val-prompt", "");
       const proc = Bun.spawnSync([bin, ...args], { stdio: ["inherit", "inherit", "inherit"] });
       if ((proc.exitCode ?? 1) !== 0) {
         console.error(`triattn_validate failed (exit ${proc.exitCode})`);
@@ -5295,6 +5300,7 @@ Examples:
       const args = [binPath, resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)];
       if (corpusPath) args.push("--corpus", corpusPath);
       if (!gpuCalib) args.push("--cpu-calib");
+      if (skipValidation) args.push("--val-prompt", "");
       const proc = Bun.spawnSync(args, { stdio: ["inherit", "inherit", "inherit"] });
       );
       if ((proc.exitCode ?? 1) !== 0) {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4192,6 +4192,22 @@ function listConfig(cfg: HipfireConfig): void {
   console.log(`Reset:       hipfire config reset [key]`);
 }
 
+// ─── Shared helpers ─────────────────────────────────────
+
+/** Find a binary in PATH or known extra directories. Returns absolute path or null.**/
+function findDep(binary: string, extraDirs: string[]): string | null {
+  // 1. Already in PATH (use `which` to avoid shell interpolation)
+  const inPath = Bun.spawnSync(["which", binary], { stdout: "pipe", stderr: "pipe" });
+  const found = (inPath.stdout?.toString() ?? "").trim();
+  if (inPath.exitCode === 0 && found) return found;
+  // 2. Distro-specific known locations
+  for (const dir of extraDirs) {
+    const path = join(dir, binary);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
 // ─── Main ───────────────────────────────────────────────
 
 const [cmd, ...rest] = process.argv.slice(2);
@@ -4514,18 +4530,6 @@ switch (cmd) {
     // interactive shell loads those bindirs via profile snippets. We probe
     // well-known locations, augment process.env.PATH with any found dirs,
     // and error fast with an install hint if a required dep is missing.
-    const findDep = (binary: string, extraDirs: string[]): string | null => {
-      // 1. Already in PATH
-      const inPath = Bun.spawnSync(["sh", "-c", `command -v ${binary}`], { stdout: "pipe", stderr: "pipe" });
-      const found = (inPath.stdout?.toString() ?? "").trim();
-      if (inPath.exitCode === 0 && found) return found;
-      // 2. Distro-specific known locations
-      for (const dir of extraDirs) {
-        const path = join(dir, binary);
-        if (existsSync(path)) return path;
-      }
-      return null;
-    };
     const depsNeeded = [
       { name: "git",   dirs: ["/usr/bin", "/usr/local/bin", "/opt/homebrew/bin"],
         hint: "Install git via your distro's package manager." },
@@ -5255,16 +5259,7 @@ Examples:
       console.error("  Using cargo run --example (cold start — consider running 'hipfire update' to install the binary)");
 
       // Parse deps for PATH augmentation (same as update command does).
-      const findDep = (binary: string, extraDirs: string[]): string | null => {
-        const inPath = Bun.spawnSync(["sh", "-c", `command -v ${binary}`], { stdout: "pipe", stderr: "pipe" });
-        const found = (inPath.stdout?.toString() ?? "").trim();
-        if (inPath.exitCode === 0 && found) return found;
-        for (const dir of extraDirs) {
-          const path = join(dir, binary);
-          if (existsSync(path)) return path;
-        }
-        return null;
-      };
+      // findDep is defined at module level above.
       const depsNeeded = ["cargo", "hipcc"];
       const augmentDirs = new Set<string>();
       for (const dep of depsNeeded) {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2364,8 +2364,8 @@ function findQuantizeBinary(): string | null {
 function findTriAttnValidateBinary(): string | null {
   const exe = process.platform === "win32" ? ".exe" : "";
   const candidates = [
-    resolve(__dirname, `../target/release/examples/triatttn_validate${exe}`),
-    join(HIPFIRE_DIR, "bin", "examples", `triatttn_validate${exe}`),
+    resolve(__dirname, `../target/release/examples/triattn_validate${exe}`),
+    join(HIPFIRE_DIR, "bin", "examples", `triattn_validate${exe}`),
   ];
   return candidates.find(p => existsSync(p)) || null;
 }
@@ -4653,7 +4653,7 @@ switch (cmd) {
     // Rebuild
     console.error("Rebuilding daemon (this may take a few minutes)...");
     const build = Bun.spawnSync(
-      [CARGO_BIN, "build", "--release", "--features", "deltanet", "--example", "daemon", "--example", "infer", "--example", "run", "--example", "triatttn_validate", "-p", "hipfire-runtime"],
+      [CARGO_BIN, "build", "--release", "--features", "deltanet", "--example", "daemon", "--example", "infer", "--example", "run", "--example", "triattn_validate", "-p", "hipfire-runtime"],
       { cwd: repoDir, stdio: ["inherit", "inherit", "inherit"], env: { ...process.env } }
     );
     if (build.exitCode !== 0) {
@@ -4676,7 +4676,7 @@ switch (cmd) {
     }
     // Recopy binaries
     // Example binaries live under target/release/examples/
-    for (const bin of ["daemon", "infer", "run", "triatttn_validate"]) {
+    for (const bin of ["daemon", "infer", "run", "triattn_validate"]) {
       const src = join(repoDir, `target/release/examples/${bin}${exe}`);
       const dst = join(binDir, `${bin}${exe}`);
       if (existsSync(src)) { copyFileSync(src, dst); }
@@ -5225,7 +5225,7 @@ Examples:
       if (!gpuCalib) args.push("--cpu-calib");
       const proc = Bun.spawnSync([bin, ...args], { stdio: ["inherit", "inherit", "inherit"] });
       if ((proc.exitCode ?? 1) !== 0) {
-        console.error(`triatttn_validate failed (exit ${proc.exitCode})`);
+        console.error(`triattn_validate failed (exit ${proc.exitCode})`);
         process.exit(1);
       }
     } else {
@@ -5237,8 +5237,8 @@ Examples:
       const srcExists = existsSync(devSrc) || existsSync(hipfireSrc);
 
       if (!srcExists) {
-        console.error("triatttn_validate binary not found and source not available.");
-        console.error("  Build: cargo build --release --features deltanet -p hipfire-runtime --example triatttn_validate");
+        console.error("triattn_validate binary not found and source not available.");
+        console.error("  Build: cargo build --release --features deltanet -p hipfire-runtime --example triattn_validate");
         console.error("  Or update: hipfire update (which builds the example during rebuild)");
         process.exit(1);
       }
@@ -5276,26 +5276,26 @@ Examples:
       }
 
       // Build the example first.
-      console.error("Building triatttn_validate...");
+      console.error("Building triattn_validate...");
       const build = Bun.spawnSync(
-        ["cargo", "build", "--release", "--features", "deltanet", "-p", "hipfire-runtime", "--example", "triatttn_validate"],
+        ["cargo", "build", "--release", "--features", "deltanet", "-p", "hipfire-runtime", "--example", "triattn_validate"],
         { cwd: srcPath, stdio: ["inherit", "inherit", "inherit"] },
       );
       if (build.exitCode !== 0) {
-        console.error("Failed to build triatttn_validate. Check for ROCm/compilation errors above.");
+        console.error("Failed to build triattn_validate. Check for ROCm/compilation errors above.");
         process.exit(1);
       }
 
       // Run the built example.
       const exe = process.platform === "win32" ? ".exe" : "";
-      const binPath = join(srcPath, `../../target/release/examples/triatttn_validate${exe}`); // relative to src root
-      console.error("  Running triatttn_validate...");
+      const binPath = join(srcPath, `../../target/release/examples/triattn_validate${exe}`); // relative to src root
+      console.error("  Running triattn_validate...");
       const proc = Bun.spawnSync(
         [binPath, resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)],
         { stdio: ["inherit", "inherit", "inherit"] },
       );
       if ((proc.exitCode ?? 1) !== 0) {
-        console.error(`triatttn_validate failed (exit ${proc.exitCode})`);
+        console.error(`triattn_validate failed (exit ${proc.exitCode})`);
         process.exit(1);
       }
     }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2363,11 +2363,11 @@ function findQuantizeBinary(): string | null {
 
 function findTriAttnValidateBinary(): string | null {
   const exe = process.platform === "win32" ? ".exe" : "";
-  const candidates = [
-    resolve(__dirname, `../target/release/examples/triattn_validate${exe}`),
-    join(HIPFIRE_DIR, "bin", "examples", `triattn_validate${exe}`),
-  ];
-  return candidates.find(p => existsSync(p)) || null;
+  // Dev: workspace root/target/release/examples/
+  const devCandidates = [resolve(__dirname, `../target/release/examples/triattn_validate${exe}`)];
+  // Installed: ~/.hipfire/bin/ (no examples/ subdir — update copies directly)
+  const installedCandidates = [join(HIPFIRE_DIR, "bin", `triattn_validate${exe}`)];
+  return devCandidates.find(p => existsSync(p)) || installedCandidates.find(p => existsSync(p)) || null;
 }
 
 interface QuantizeOpts {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2361,6 +2361,15 @@ function findQuantizeBinary(): string | null {
   return candidates.find(p => existsSync(p)) || null;
 }
 
+function findTriAttnValidateBinary(): string | null {
+  const exe = process.platform === "win32" ? ".exe" : "";
+  const candidates = [
+    resolve(__dirname, `../target/release/examples/triatttn_validate${exe}`),
+    join(HIPFIRE_DIR, "bin", "examples", `triatttn_validate${exe}`),
+  ];
+  return candidates.find(p => existsSync(p)) || null;
+}
+
 interface QuantizeOpts {
   formats: string[];                 // one or more of mq4/mq6/q8
   output?: string;                   // explicit path (only valid with single format)
@@ -4644,7 +4653,7 @@ switch (cmd) {
     // Rebuild
     console.error("Rebuilding daemon (this may take a few minutes)...");
     const build = Bun.spawnSync(
-      [CARGO_BIN, "build", "--release", "--features", "deltanet", "--example", "daemon", "--example", "infer", "--example", "run", "-p", "hipfire-runtime"],
+      [CARGO_BIN, "build", "--release", "--features", "deltanet", "--example", "daemon", "--example", "infer", "--example", "run", "--example", "triatttn_validate", "-p", "hipfire-runtime"],
       { cwd: repoDir, stdio: ["inherit", "inherit", "inherit"], env: { ...process.env } }
     );
     if (build.exitCode !== 0) {
@@ -4667,7 +4676,7 @@ switch (cmd) {
     }
     // Recopy binaries
     // Example binaries live under target/release/examples/
-    for (const bin of ["daemon", "infer", "run"]) {
+    for (const bin of ["daemon", "infer", "run", "triatttn_validate"]) {
       const src = join(repoDir, `target/release/examples/${bin}${exe}`);
       const dst = join(binDir, `${bin}${exe}`);
       if (existsSync(src)) { copyFileSync(src, dst); }
@@ -5127,6 +5136,178 @@ depending on model size. HF downloads cache at ~/.hipfire/hf-cache/.`);
       installLocal,
       register,
     });
+    break;
+  }
+  case "sidecar-gen": {
+    const tag = rest[0];
+    if (!tag || tag === "-h" || tag === "--help") {
+      console.error(`Usage: hipfire sidecar-gen <model> [flags]
+
+Generate a TriAttention calibration sidecar (.triattn.bin) for the given model.
+The sidecar enables automatic KV-cache eviction and is required for CASK
+generation on large-context models (e.g. 27B with >16K max_position_embeddings).
+
+The sidecar file is saved next to the model file (same directory as the .mq4/.hf4)
+so the daemon auto-discovers it.
+
+Model:
+  hipfire sidecar-gen qwen3.5:9b              # use a local model by tag
+  hipfire sidecar-gen ~/.hipfire/models/...    # or pass a direct path
+
+Flags:
+  --corpus PATH          Path to a text file for calibration corpus (default: builtin seed prompts)
+  --max-tokens N         Max tokens to process during calibration (default: 4000)
+  --chunk-len N          Chunk length in tokens (default: 256)
+  --gpu-calib            Use GPU kernel triattn_accumulate (faster on MI300X / RDNA3+)
+  --cpu-calib            Force CPU calibration path
+  -o, --output PATH      Output sidecar file path (default: <model>.triattn.bin next to model)
+
+Examples:
+  hipfire sidecar-gen qwen3.5:9b
+  hipfire sidecar-gen ./my-model.mq4 --corpus wikipedia.txt --max-tokens 100000
+  hipfire sidecar-gen ~/.hipfire/models/qwen3.6-27b.mq4 -o /tmp/sidecar.bin`);
+      process.exit(tag ? 0 : 1);
+    }
+    let corpusPath: string | undefined;
+    let maxTokens = 4000;
+    let chunkLen = 256;
+    let gpuCalib = true; // GPU calibration is default (Phase 2, 2026-04-28)
+    let output: string | undefined;
+    for (let i = 1; i < rest.length; i++) {
+      const a = rest[i];
+      if (a === "--corpus") {
+        corpusPath = rest[++i];
+        if (!corpusPath) { console.error("--corpus requires a value"); process.exit(1); }
+      } else if (a === "--max-tokens") {
+        maxTokens = parseInt(rest[++i]);
+        if (isNaN(maxTokens)) { console.error("--max-tokens requires a number"); process.exit(1); }
+      } else if (a === "--chunk-len") {
+        chunkLen = parseInt(rest[++i]);
+        if (isNaN(chunkLen)) { console.error("--chunk-len requires a number"); process.exit(1); }
+      } else if (a === "--gpu-calib") {
+        gpuCalib = true;
+      } else if (a === "--cpu-calib") {
+        gpuCalib = false;
+      } else if (a === "-o" || a === "--output") {
+        output = rest[++i];
+        if (!output) { console.error("--output requires a value"); process.exit(1); }
+      } else {
+        console.error(`Unknown argument: ${a}\nRun 'hipfire sidecar-gen --help' for usage.`);
+        process.exit(1);
+      }
+    }
+
+    // Resolve model — same resolution as other commands (tag → local path).
+    let resolved = findModel(tag);
+    if (!resolved) {
+      console.error(`Model not found: ${tag}`);
+      console.error("Run 'hipfire list' to see available models.");
+      process.exit(1);
+    }
+
+    // Determine output path — default is <model>.triattn.bin next to the model file.
+    const sidecarPath = output ?? `${resolved}.triattn.bin`;
+
+    console.error(`Generating TriAttention calibration sidecar for: ${tag}`);
+    console.error(`  Model:        ${resolved}`);
+    console.error(`  Output:       ${sidecarPath}`);
+    console.error(`  Max tokens:   ${maxTokens}`);
+    console.error(`  Chunk len:    ${chunkLen}`);
+    console.error(`  Calibration:  ${gpuCalib ? "GPU" : "CPU"}`);
+
+    // Find triattn_validate binary — from installed location or fall back to cargo run.
+    const bin = findTriAttnValidateBinary();
+    if (bin) {
+      // Binary is available directly (installed). Run it synchronously.
+      console.error(`  Using: ${bin}`);
+      const args = [resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)];
+      if (corpusPath) args.push("--corpus", corpusPath);
+      if (!gpuCalib) args.push("--cpu-calib");
+      const proc = Bun.spawnSync([bin, ...args], { stdio: ["inherit", "inherit", "inherit"] });
+      if ((proc.exitCode ?? 1) !== 0) {
+        console.error(`triatttn_validate failed (exit ${proc.exitCode})`);
+        process.exit(1);
+      }
+    } else {
+      // No installed binary — fall back to cargo run --example.
+      // This has cold-start overhead from compilation if not already built.
+      // Try the development source first, then ~/.hipfire/src (installed via update).
+      const devSrc = resolve(__dirname, "../crates/hipfire-runtime/examples/triattn_validate.rs");
+      const hipfireSrc = join(HIPFIRE_DIR, "src/crates/hipfire-runtime/examples/triattn_validate.rs");
+      const srcExists = existsSync(devSrc) || existsSync(hipfireSrc);
+
+      if (!srcExists) {
+        console.error("triatttn_validate binary not found and source not available.");
+        console.error("  Build: cargo build --release --features deltanet -p hipfire-runtime --example triatttn_validate");
+        console.error("  Or update: hipfire update (which builds the example during rebuild)");
+        process.exit(1);
+      }
+
+      // Determine if we should use dev source or installed source.
+      const srcPath = existsSync(devSrc) ? dirname(devSrc) : dirname(hipfireSrc);
+      console.error("  Using cargo run --example (cold start — consider running 'hipfire update' to install the binary)");
+
+      // Parse deps for PATH augmentation (same as update command does).
+      const findDep = (binary: string, extraDirs: string[]): string | null => {
+        const inPath = Bun.spawnSync(["sh", "-c", `command -v ${binary}`], { stdout: "pipe", stderr: "pipe" });
+        const found = (inPath.stdout?.toString() ?? "").trim();
+        if (inPath.exitCode === 0 && found) return found;
+        for (const dir of extraDirs) {
+          const path = join(dir, binary);
+          if (existsSync(path)) return path;
+        }
+        return null;
+      };
+      const depsNeeded = ["cargo", "hipcc"];
+      const augmentDirs = new Set<string>();
+      for (const dep of depsNeeded) {
+        const extraDirs = dep === "cargo"
+          ? [join(process.env.HOME || "", ".cargo/bin"), "/usr/bin"]
+          : ["/opt/rocm/bin", "/opt/rocm-6.0.0/bin", "/opt/rocm-5.7.0/bin", "/usr/bin"];
+        const p = findDep(dep, extraDirs);
+        if (p) augmentDirs.add(p.substring(0, p.lastIndexOf("/")));
+      }
+      // Also add bun dir for its subtree helpers.
+      const bunPath = findDep("bun", [join(process.env.HOME || "", ".bun/bin"), "/usr/bin"]);        if (bunPath) augmentDirs.add(bunPath.substring(0, bunPath.lastIndexOf("/")));
+      if (augmentDirs.size) {
+        const curr = (process.env.PATH || "").split(":").filter(Boolean);
+        const fresh = [...augmentDirs].filter(d => !curr.includes(d));
+        if (fresh.length) process.env.PATH = [...fresh, ...curr].join(":");
+      }
+
+      // Build the example first.
+      console.error("Building triatttn_validate...");
+      const build = Bun.spawnSync(
+        ["cargo", "build", "--release", "--features", "deltanet", "-p", "hipfire-runtime", "--example", "triatttn_validate"],
+        { cwd: srcPath, stdio: ["inherit", "inherit", "inherit"] },
+      );
+      if (build.exitCode !== 0) {
+        console.error("Failed to build triatttn_validate. Check for ROCm/compilation errors above.");
+        process.exit(1);
+      }
+
+      // Run the built example.
+      const exe = process.platform === "win32" ? ".exe" : "";
+      const binPath = join(srcPath, `../../target/release/examples/triatttn_validate${exe}`); // relative to src root
+      console.error("  Running triatttn_validate...");
+      const proc = Bun.spawnSync(
+        [binPath, resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)],
+        { stdio: ["inherit", "inherit", "inherit"] },
+      );
+      if ((proc.exitCode ?? 1) !== 0) {
+        console.error(`triatttn_validate failed (exit ${proc.exitCode})`);
+        process.exit(1);
+      }
+    }
+
+    // Verify the output file exists.
+    if (!existsSync(sidecarPath)) {
+      console.error(`Output file not found: ${sidecarPath}`);
+      process.exit(1);
+    }
+    const sz = (statSync(sidecarPath).size / 1e6).toFixed(1);
+    console.error("\nDone. Sidecar saved:");
+    console.error(`  ${sidecarPath} (${sz} MB)`);
     break;
   }
   case "config": {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5187,10 +5187,10 @@ Examples:
         if (!corpusPath) { console.error("--corpus requires a value"); process.exit(1); }
       } else if (a === "--max-tokens") {
         maxTokens = parseInt(rest[++i]);
-        if (isNaN(maxTokens)) { console.error("--max-tokens requires a number"); process.exit(1); }
+        if (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 1_000_000) { console.error("--max-tokens must be between 1 and 1,000,000"); process.exit(1); }
       } else if (a === "--chunk-len") {
         chunkLen = parseInt(rest[++i]);
-        if (isNaN(chunkLen)) { console.error("--chunk-len requires a number"); process.exit(1); }
+        if (isNaN(chunkLen) || chunkLen < 1 || chunkLen > 16384) { console.error("--chunk-len must be between 1 and 16,384"); process.exit(1); }
       } else if (a === "--gpu-calib") {
         gpuCalib = true;
       } else if (a === "--cpu-calib") {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5291,9 +5291,10 @@ Examples:
       const exe = process.platform === "win32" ? ".exe" : "";
       const binPath = join(workspaceRoot, `target/release/examples/triattn_validate${exe}`);
       console.error("  Running triattn_validate...");
-      const proc = Bun.spawnSync(
-        [binPath, resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)],
-        { stdio: ["inherit", "inherit", "inherit"] },
+      const args = [binPath, resolved, "--sidecar", sidecarPath, "--max-tokens", String(maxTokens), "--chunk-len", String(chunkLen)];
+      if (corpusPath) args.push("--corpus", corpusPath);
+      if (!gpuCalib) args.push("--cpu-calib");
+      const proc = Bun.spawnSync(args, { stdio: ["inherit", "inherit", "inherit"] });
       );
       if ((proc.exitCode ?? 1) !== 0) {
         console.error(`triattn_validate failed (exit ${proc.exitCode})`);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5,6 +5,7 @@
 //   hipfire run qwen3.5:9b [prompt]  → generate (auto-pulls if needed)
 //   hipfire serve                     → start daemon + HTTP server
 //   hipfire list                      → show local + available models
+//   hipfire sidecar-gen <model>       → generate TriAttention calibration sidecar
 
 import { spawn } from "bun";
 import { existsSync, readdirSync, statSync, unlinkSync, mkdirSync } from "fs";
@@ -5592,6 +5593,7 @@ Examples:
   diag                  Diagnostics — GPU, VRAM, HIP version, kernels, models
   ps                    Show running hipfire processes (serve, quantize, uploads)
   rm <model>            Delete model
+  sidecar-gen <model>   Generate TriAttention calibration sidecar (.triattn.bin)
   update                Pull latest code, rebuild, update kernels
 
 Models (MQ4 default: FWHT-rotated 4-bit, quality-gated):

--- a/crates/hipfire-runtime/examples/triattn_validate.rs
+++ b/crates/hipfire-runtime/examples/triattn_validate.rs
@@ -353,6 +353,12 @@ fn main() {
     for t in &dn.s_scales { let _ = gpu.hip.memset(&t.buf, 0, t.buf.size()); }
     for t in &dn.conv_states { let _ = gpu.hip.memset(&t.buf, 0, t.buf.size()); }
 
+    // Destroy any cached hipGraph from Phase 1. The TriAttn capture tap
+    // does synchronous D2H copies (gpu::download_f32) which are incompatible
+    // with hipGraph stream capture mode (hipErrorStreamCaptureImplicit).
+    // Keeping graph disabled via ar_forward_warmed_up reset avoids re-capture.
+    gpu.graph_destroy();
+
     let cap = TriAttnCapture::new(config.n_heads, config.n_kv_heads, config.head_dim);
     triattn::install_capture(cap);
 
@@ -360,6 +366,10 @@ fn main() {
     let val_len = val_tokens.len().min(kv_seq.saturating_sub(4));
     eprintln!("validation: {val_len} tokens");
     for (pos, tid) in val_tokens.iter().take(val_len).enumerate() {
+        // Reset warmup flag so forward_scratch stays on the warmup/direct
+        // path instead of attempting graph capture (which would fail on the
+        // D2H copy inside the TriAttn capture tap).
+        gpu.ar_forward_warmed_up = false;
         qwen35::forward_scratch(
             &mut gpu, &weights, &config, *tid, pos,
             &mut kv, &mut dn, &scratch,
@@ -374,73 +384,76 @@ fn main() {
     // the TriAttn scoring vs ground-truth Q·K dot products. Because we
     // want to cover short-to-long distances evenly the way the paper does,
     // we score against the LAST token's query.
-    let last = val_len - 1;
-    let p_q = last as f32;
-    let n_bands = config.head_dim / 2;
-    let d_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
+    // Skipped when val_len == 0 (e.g. --skip-validation).
+    if val_len > 0 {
+        let last = val_len - 1;
+        let p_q = last as f32;
+        let n_bands = config.head_dim / 2;
+        let d_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
 
-    // Map kv_head h_kv to the set of query heads sharing it.
-    let kv_group = config.n_heads / config.n_kv_heads;
+        // Map kv_head h_kv to the set of query heads sharing it.
+        let kv_group = config.n_heads / config.n_kv_heads;
 
-    let mut per_layer_r: Vec<f32> = Vec::new();
-    for (fa_pos, &layer_idx) in capture.layer_ids_per_token[last].iter().enumerate() {
-        // Ignore layers that aren't FA (those arrays are empty).
-        if capture.q_samples[last][fa_pos].is_empty() { continue; }
-        let q_last = &capture.q_samples[last][fa_pos];
-        assert_eq!(q_last.len(), config.n_heads * config.head_dim);
+        let mut per_layer_r: Vec<f32> = Vec::new();
+        for (fa_pos, &layer_idx) in capture.layer_ids_per_token[last].iter().enumerate() {
+            // Ignore layers that aren't FA (those arrays are empty).
+            if capture.q_samples[last][fa_pos].is_empty() { continue; }
+            let q_last = &capture.q_samples[last][fa_pos];
+            assert_eq!(q_last.len(), config.n_heads * config.head_dim);
 
-        let mut per_head_r = Vec::with_capacity(config.n_heads);
-        for h in 0..config.n_heads {
-            let h_kv = h / kv_group;
-            let q_head = &q_last[h * config.head_dim..(h + 1) * config.head_dim];
+            let mut per_head_r = Vec::with_capacity(config.n_heads);
+            for h in 0..config.n_heads {
+                let h_kv = h / kv_group;
+                let q_head = &q_last[h * config.head_dim..(h + 1) * config.head_dim];
 
-            // Post-RoPE Q for the last position.
-            let q_post = apply_rope(q_head, p_q, d_rot, config.rope_theta);
+                // Post-RoPE Q for the last position.
+                let q_post = apply_rope(q_head, p_q, d_rot, config.rope_theta);
 
-            let mut predicted = Vec::with_capacity(val_len);
-            let mut actual = Vec::with_capacity(val_len);
+                let mut predicted = Vec::with_capacity(val_len);
+                let mut actual = Vec::with_capacity(val_len);
 
-            for i in 0..val_len {
-                if capture.k_samples[i].is_empty() { continue; }
-                let k_row = &capture.k_samples[i][fa_pos];
-                if k_row.is_empty() { continue; }
-                let k_head = &k_row[h_kv * config.head_dim..(h_kv + 1) * config.head_dim];
+                for i in 0..val_len {
+                    if capture.k_samples[i].is_empty() { continue; }
+                    let k_row = &capture.k_samples[i][fa_pos];
+                    if k_row.is_empty() { continue; }
+                    let k_head = &k_row[h_kv * config.head_dim..(h_kv + 1) * config.head_dim];
 
-                // Ground truth: dot product of post-RoPE Q and post-RoPE K
-                // (standard attention, no softmax — softmax is monotonic
-                // so correlation of logits ≈ correlation of softmaxed).
-                let k_post = apply_rope(k_head, i as f32, d_rot, config.rope_theta);
-                let mut dot = 0.0f32;
-                for d in 0..config.head_dim { dot += q_post[d] * k_post[d]; }
-                actual.push(dot);
+                    // Ground truth: dot product of post-RoPE Q and post-RoPE K
+                    // (standard attention, no softmax — softmax is monotonic
+                    // so correlation of logits ≈ correlation of softmaxed).
+                    let k_post = apply_rope(k_head, i as f32, d_rot, config.rope_theta);
+                    let mut dot = 0.0f32;
+                    for d in 0..config.head_dim { dot += q_post[d] * k_post[d]; }
+                    actual.push(dot);
 
-                // TriAttn prediction (post-RoPE path, uses stored post-RoPE K).
-                let centers_slice = center_slice(&centers, layer_idx, h);
-                let k_post_bands = triattn::kpost_per_band(&k_post);
-                let s = triattn::s_total(centers_slice, &k_post_bands, p_q, |f| centers.omega(f));
-                predicted.push(s);
+                    // TriAttn prediction (post-RoPE path, uses stored post-RoPE K).
+                    let centers_slice = center_slice(&centers, layer_idx, h);
+                    let k_post_bands = triattn::kpost_per_band(&k_post);
+                    let s = triattn::s_total(centers_slice, &k_post_bands, p_q, |f| centers.omega(f));
+                    predicted.push(s);
+                }
+
+                let r = triattn::pearson(&actual, &predicted);
+                per_head_r.push(r);
             }
 
-            let r = triattn::pearson(&actual, &predicted);
-            per_head_r.push(r);
+            let mean_r: f32 = per_head_r.iter().sum::<f32>() / per_head_r.len() as f32;
+            let (min_r, max_r) = per_head_r.iter().fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), &r| (lo.min(r), hi.max(r)));
+            let pct_above_05 = per_head_r.iter().filter(|&&r| r > 0.5).count() as f32 * 100.0 / per_head_r.len() as f32;
+            eprintln!(
+                "layer {layer_idx:2}: r̄={mean_r:.3}  [{min_r:.3}, {max_r:.3}]  {pct_above_05:.0}% of heads > 0.5",
+            );
+            per_layer_r.push(mean_r);
         }
 
-        let mean_r: f32 = per_head_r.iter().sum::<f32>() / per_head_r.len() as f32;
-        let (min_r, max_r) = per_head_r.iter().fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), &r| (lo.min(r), hi.max(r)));
-        let pct_above_05 = per_head_r.iter().filter(|&&r| r > 0.5).count() as f32 * 100.0 / per_head_r.len() as f32;
-        eprintln!(
-            "layer {layer_idx:2}: r̄={mean_r:.3}  [{min_r:.3}, {max_r:.3}]  {pct_above_05:.0}% of heads > 0.5",
-        );
-        per_layer_r.push(mean_r);
-    }
-
-    if !per_layer_r.is_empty() {
-        let overall: f32 = per_layer_r.iter().sum::<f32>() / per_layer_r.len() as f32;
-        eprintln!("\n=== overall mean r̄ across FA layers: {overall:.3} ===");
-        eprintln!("paper target: ≈0.5 (Figure 3 mean), per-head 0.6-0.9 common; calibration corpus is tiny here");
-        eprintln!("note: r̄ plateaus by ~20k calibration tokens under running-mean aggregation — more data does NOT improve r̄ past that point. r̄ is also validation-prompt-dependent; for sidecar quality decisions, validate against a downstream long-context recall test rather than this number alone.");
-        if using_builtin_corpus && default_val_prompt {
-            eprintln!("⚠ r̄ above is CONTAMINATED by corpus/val-prompt overlap (see warning at startup). Do not compare this number against runs with a disjoint corpus.");
+        if !per_layer_r.is_empty() {
+            let overall: f32 = per_layer_r.iter().sum::<f32>() / per_layer_r.len() as f32;
+            eprintln!("\n=== overall mean r̄ across FA layers: {overall:.3} ===");
+            eprintln!("paper target: ≈0.5 (Figure 3 mean), per-head 0.6-0.9 common; calibration corpus is tiny here");
+            eprintln!("note: r̄ plateaus by ~20k calibration tokens under running-mean aggregation — more data does NOT improve r̄ past that point. r̄ is also validation-prompt-dependent; for sidecar quality decisions, validate against a downstream long-context recall test rather than this number alone.");
+            if using_builtin_corpus && default_val_prompt {
+                eprintln!("⚠ r̄ above is CONTAMINATED by corpus/val-prompt overlap (see warning at startup). Do not compare this number against runs with a disjoint corpus.");
+            }
         }
     }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -46,6 +46,61 @@ Full key list and tradeoffs in [CONFIG.md](CONFIG.md).
 The full quantize how-to (formats, when to pick which, GGUF caveats) is
 in [QUANTIZE.md](QUANTIZE.md).
 
+## Calibration
+
+For models with custom or quantized weights that need CASK KV eviction,
+generate the calibration sidecar:
+
+| Command | Purpose |
+|---|---|
+| `hipfire sidecar-gen <model>` | Generate a `.triattn.bin` sidecar for the given model. The daemon auto-discovers it alongside the model file when CASK is enabled (`cask_sidecar on`). |
+
+Usage:
+
+```bash
+hipfire sidecar-gen qwen35-27b-dflash-mq4 --corpus my-corpus.txt --max-tokens 8192 --chunk-len 1024 -o /path/to/output.triattn.bin
+```
+
+Flags for `sidecar-gen`:
+
+| Flag | Purpose |
+|---|---|
+| `<model>` (positional) | Model tag or local file path. The sidecar is written next to the model file by default with the same base name: `my-finetune.mq4` → `my-finetune.triattn.bin`. See **Filename discovery** below for details. |
+| `--corpus PATH` | Text corpus for calibration. If omitted, uses an internal default. |
+| `--max-tokens N` | Maximum tokens of context to calibrate over (default: 8192). |
+| `--chunk-len N` | Chunk size for KV cache statistics collection (default: 1024). |
+| `--gpu-calib` | Run calibration on GPU instead of CPU. |
+| `--cpu-calib` | Override to run on CPU even if a compatible GPU is available. |
+| `-o PATH` | Output path for the `.triattn.bin` file (default: next to model). |
+| `--skip-validation` | Skip post-generation KV statistics validation check. |
+
+The generated sidecar contains per-position KV cache statistics that
+calculate which key-value positions are most important for retention.
+Without it, CASK eviction treats all positions equally and can discard
+critical early tokens on long context prompts, causing quality drop-off.
+
+**Quick setup after quantizing your own model:**
+
+```bash
+hipfire quantize ./my-model/ --format mq4 -o my-finetune.mq4
+hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt
+# The daemon will auto-attach the sidecar when you run with cask_sidecar on
+```
+
+See [CONFIG.md](CONFIG.md) for CASK-related configuration keys.
+
+> **Note:** `sidecar-gen` requires a model file to exist — it does not
+> pull models from HuggingFace. First pull your target: `hipfire pull <tag>`
+> or put your quantized weights alongside the expected filename pattern
+> (`qwen3{ver}-{size}-dflash-{quant}.hfq`). The daemon auto-discovers
+> `.triattn.bin` files next to their matching model.
+>
+> **Filename discovery:** When `cask_sidecar` is unset, the daemon looks for
+> a sidecar in the same directory as the model file using `<basename>.triattn*.bin`
+> (e.g., `my-finetune.mq4` → `my-finetune.triattn.bin`). If you specify a
+> path with directories (`foo/bar/model.mq4`), it scans `foo/bar/` for the
+> sidecar — not the current working directory.
+
 ## Diagnostics
 
 | Command | Purpose |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,7 +53,7 @@ generate the calibration sidecar:
 
 | Command | Purpose |
 |---|---|
-| `hipfire sidecar-gen <model>` | Generate a `.triattn.bin` sidecar for the given model. The daemon auto-discovers it alongside the model file when CASK is enabled (`cask_sidecar on`). |
+| `hipfire sidecar-gen <model>` | Generate a `.triattn.bin` sidecar for the given model. The daemon auto-discovers it alongside the model file when a CASK profile is enabled. |
 
 Usage:
 
@@ -65,10 +65,10 @@ Flags for `sidecar-gen`:
 
 | Flag | Purpose |
 |---|---|
-| `<model>` (positional) | Model tag or local file path. The sidecar is written next to the model file by default with the same base name: `my-finetune.mq4` → `my-finetune.triattn.bin`. See **Filename discovery** below for details. |
+| `<model>` (positional) | Model tag or local file path. The sidecar is written next to the model file by default using the full model filename: `my-finetune.mq4` → `my-finetune.mq4.triattn.bin`. See **Filename discovery** below for details. |
 | `--corpus PATH` | Text corpus for calibration. If omitted, uses an internal default. |
-| `--max-tokens N` | Maximum tokens of context to calibrate over (default: 8192). |
-| `--chunk-len N` | Chunk size for KV cache statistics collection (default: 1024). |
+| `--max-tokens N` | Maximum tokens of context to calibrate over (default: 4000). |
+| `--chunk-len N` | Chunk size for KV cache statistics collection (default: 256). |
 | `--gpu-calib` | Run calibration on GPU instead of CPU. |
 | `--cpu-calib` | Override to run on CPU even if a compatible GPU is available. |
 | `-o PATH` | Output path for the `.triattn.bin` file (default: next to model). |
@@ -84,7 +84,8 @@ critical early tokens on long context prompts, causing quality drop-off.
 ```bash
 hipfire quantize ./my-model/ --format mq4 -o my-finetune.mq4
 hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt
-# The daemon will auto-attach the sidecar when you run with cask_sidecar on
+hipfire config cask-profile balanced
+# The daemon will auto-attach the sidecar on the next model load
 ```
 
 See [CONFIG.md](CONFIG.md) for CASK-related configuration keys.
@@ -97,7 +98,7 @@ See [CONFIG.md](CONFIG.md) for CASK-related configuration keys.
 >
 > **Filename discovery:** When `cask_sidecar` is unset, the daemon looks for
 > a sidecar in the same directory as the model file using `<basename>.triattn*.bin`
-> (e.g., `my-finetune.mq4` → `my-finetune.triattn.bin`). If you specify a
+> (e.g., `my-finetune.mq4` → `my-finetune.mq4.triattn.bin`). If you specify a
 > path with directories (`foo/bar/model.mq4`), it scans `foo/bar/` for the
 > sidecar — not the current working directory.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -97,6 +97,22 @@ buffer fills again. This pins physical VRAM regardless of advertised
 because only `cask_budget + cask_beta + 256` slots are physically
 allocated.
 
+### Generating the sidecar file
+
+For models from HuggingFace (e.g., `hipfire pull qwen3.6:27b`), a
+published `.triattn.bin` ships alongside the weights and is auto-attached.
+**For custom or quantized models**, you must generate one:
+
+```bash
+# After pushing your model to ~/.hipfire/models/:
+hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt -o my-finetune.triattn.bin
+```
+
+The generated file is placed next to the model by default.
+The daemon auto-discovers it using `<basename>.triattn*.bin` matching.
+See [CLI.md](CLI.md) for full `sidecar-gen` flag details and
+[QUANTIZE.md](QUANTIZE.md) for the post-quantization workflow.
+
 ### Profiles (recommended path)
 
 The five raw knobs interact non-obviously and have hard-rule failure
@@ -145,7 +161,7 @@ quality-sensitive single-turn workloads).
 
 | Key | Default | Range | Notes |
 |---|---|---|---|
-| `cask_sidecar` | "" | path | Path to TriAttention sidecar `.bin`. Empty = eviction disabled regardless of other knobs. |
+| `cask_sidecar` | "" | path | Path to TriAttention sidecar `.bin`. Empty = eviction disabled regardless of other knobs. For custom/quantized models, generate one with `hipfire sidecar-gen <model>` — see Generating the sidecar file above for details. |
 | `cask` | false | bool | true = CASK m-folding (Kim & Gwon 2026); false = plain TriAttention drop-eviction. |
 | `cask_budget` | 512 | 64–65536 | Active token count post-eviction. Smaller = tighter VRAM, more frequent eviction events. |
 | `cask_beta` | 128 | 0–65536 | Hysteresis. Buffer needs to fill `budget + beta` before re-triggering eviction. |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -105,10 +105,11 @@ published `.triattn.bin` ships alongside the weights and is auto-attached.
 
 ```bash
 # After pushing your model to ~/.hipfire/models/:
-hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt -o my-finetune.triattn.bin
+hipfire sidecar-gen ~/.hipfire/models/my-finetune.mq4 --corpus /path/to/corpus.txt
 ```
 
-The generated file is placed next to the model by default.
+The generated file is placed next to the model by default, for example
+`my-finetune.mq4.triattn.bin`.
 The daemon auto-discovers it using `<basename>.triattn*.bin` matching.
 See [CLI.md](CLI.md) for full `sidecar-gen` flag details and
 [QUANTIZE.md](QUANTIZE.md) for the post-quantization workflow.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -91,6 +91,33 @@ Common overrides: `temperature` (default 0.30), `kv_cache` (default
 `asym3`), `dflash_mode` (default `auto`). Full key list in
 [CONFIG.md](CONFIG.md).
 
+## Long context: KV cache eviction
+
+For long-context prompts (16K+ tokens), CASK-based eviction prevents OOM by
+capping physical VRAM regardless of the advertised `max_seq`. For HuggingFace
+models pulled via `hipfire pull`, a sidecar is auto-attached — just enable
+eviction with:
+
+```bash
+hipfire config set cask-profile balanced   # or conservative / aggressive-vram
+```
+
+The daemon automatically discovers the shipped `.triattn.bin` beside the
+weights and sets `cask_sidecar` for you. No manual path needed.
+
+**Note:** eviction is disabled by default even when a sidecar exists —
+you must set a CASK profile (`balanced`, `conservative`, or `aggressive-vram`) to activate it.
+
+For custom or quantized models, generate the sidecar first:
+
+```bash
+hipfire sidecar-gen my-finetune.mq4 --corpus corpus.txt -o my-finetune.triattn.bin
+hipfire config set cask_sidecar ~/models/my-finetune.triattn.bin
+hipfire config set cask-profile balanced
+```
+
+See [CONFIG.md](CONFIG.md) for profiles, knobs, and safety constraints.
+
 ## What to read next
 
 - [MODELS.md](MODELS.md) — supported model tags + how to bring your own

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -99,7 +99,7 @@ models pulled via `hipfire pull`, a sidecar is auto-attached — just enable
 eviction with:
 
 ```bash
-hipfire config set cask-profile balanced   # or conservative / aggressive-vram
+hipfire config cask-profile balanced   # or conservative / aggressive-vram
 ```
 
 The daemon automatically discovers the shipped `.triattn.bin` beside the
@@ -111,9 +111,8 @@ you must set a CASK profile (`balanced`, `conservative`, or `aggressive-vram`) t
 For custom or quantized models, generate the sidecar first:
 
 ```bash
-hipfire sidecar-gen my-finetune.mq4 --corpus corpus.txt -o my-finetune.triattn.bin
-hipfire config set cask_sidecar ~/models/my-finetune.triattn.bin
-hipfire config set cask-profile balanced
+hipfire sidecar-gen ~/models/my-finetune.mq4 --corpus corpus.txt
+hipfire config cask-profile balanced
 ```
 
 See [CONFIG.md](CONFIG.md) for profiles, knobs, and safety constraints.

--- a/docs/QUANTIZE.md
+++ b/docs/QUANTIZE.md
@@ -139,3 +139,35 @@ wall times on a modern desktop CPU:
 `hipfire-quantize` defaults to 80% of available cores; cap with
 `--threads N` or `HIPFIRE_QUANT_THREADS=N`. Memory peak is roughly
 `max(weight tensor size) × 4` (a single tensor dequantized to f32).
+
+## After quantizing: generating a sidecar for CASK eviction
+
+After you've quantized your own model, generate the KV cache calibration
+sidecar so that CASK can perform intelligent key-value retention on long
+context prompts. Without it, all positions are treated equally and early
+tokens (which often carry critical instructions) may be evicted.
+
+```bash
+hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt
+```
+
+The sidecar is written as `my-finetune.triattn.bin` next to your model
+file by default. The daemon auto-discovers it when CASK eviction is
+enabled (`cask_sidecar on`). See [CLI.md](CLI.md) for full flag details.
+
+> **Tip:** If you're quantizing from a HuggingFace safetensors source,
+> use `--install` to copy your model into the models directory, then
+> generate the sidecar using either the file path or the registered tag:
+>
+> ```bash
+> hipfire quantize ./my-finetune/ --format mq4 -o my-finetune.mq4 \\
+>     --install --register finetune:1b
+> # Then generate the sidecar (either works):
+> hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt
+> # or, if you prefer using the alias:
+> hipfire sidecar-gen finetune:1b --corpus /path/to/corpus.txt
+> ```
+>
+> The tag-based form works because `sidecar-gen` resolves local model
+> aliases (registered via `--register`). For HuggingFace models not yet
+> installed locally, use the file path instead.

--- a/docs/QUANTIZE.md
+++ b/docs/QUANTIZE.md
@@ -151,9 +151,10 @@ tokens (which often carry critical instructions) may be evicted.
 hipfire sidecar-gen my-finetune.mq4 --corpus /path/to/corpus.txt
 ```
 
-The sidecar is written as `my-finetune.triattn.bin` next to your model
-file by default. The daemon auto-discovers it when CASK eviction is
-enabled (`cask_sidecar on`). See [CLI.md](CLI.md) for full flag details.
+The sidecar is written as `my-finetune.mq4.triattn.bin` next to your
+model file by default. The daemon auto-discovers it when you enable a
+CASK profile with `hipfire config cask-profile balanced`. See
+[CLI.md](CLI.md) for full flag details.
 
 > **Tip:** If you're quantizing from a HuggingFace safetensors source,
 > use `--install` to copy your model into the models directory, then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -378,7 +378,7 @@ else
     echo "  No pre-built binaries. Building from source..."
     (cd "$REPO_DIR" && \
         echo "  cargo build --release (this may take several minutes)..." && \
-        cargo build --release --features deltanet --example daemon --example infer --example infer_hfq -p hipfire-runtime 2>&1 | tail -5)
+        cargo build --release --features deltanet --example daemon --example infer --example infer_hfq --example triattn_validate -p hipfire-runtime 2>&1 | tail -5)
     if [ ! -f "$TARGET_DIR/release/examples/daemon" ]; then
         echo ""
         echo "  BUILD FAILED."
@@ -387,7 +387,7 @@ else
         echo "    - Missing system libs (check error above)"
         echo ""
         echo "  After fixing, re-run this installer or build manually:"
-        echo "    cd $REPO_DIR && cargo build --release --features deltanet --example daemon -p hipfire-runtime"
+        echo "    cd $REPO_DIR && cargo build --release --features deltanet --example daemon --example infer --example infer_hfq --example triattn_validate -p hipfire-runtime"
         exit 1
     fi
     echo "  Build complete ✓"
@@ -397,6 +397,7 @@ fi
 cp "$TARGET_DIR/release/examples/daemon" "$BIN_DIR/daemon"
 cp "$TARGET_DIR/release/examples/infer" "$BIN_DIR/infer" 2>/dev/null || true
 cp "$TARGET_DIR/release/examples/infer_hfq" "$BIN_DIR/infer_hfq" 2>/dev/null || true
+cp "$TARGET_DIR/release/examples/triattn_validate" "$BIN_DIR/triattn_validate" 2>/dev/null || true
 
 # Copy CLI
 # Recursive copy of the whole cli/ directory, then prune dev/test artifacts

--- a/scripts/vram_calc.py
+++ b/scripts/vram_calc.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""
+Compute exact VRAM footprint for a hipfire .hfq/.mq4 model file.
+
+Reads the HFQ binary header/tensor index, sums per-tensor GPU memory,
+adds known overheads (KV cache, scratch, DeltaNet state), and reports
+whether the model fits on a given GPU VRAM budget.
+
+Usage:
+    python3 scripts/vram_calc.py path/to/model.mq4 [--vram 16] [--kv-seq 512] [--kv-mode q8]
+"""
+
+import struct
+import json
+import sys
+import os
+import math
+from dataclasses import dataclass
+from typing import List, Optional
+
+# ── Quant type constants (from hfq.rs) ──────────────────────────────
+QT_F16 = 1
+QT_F32 = 2
+QT_MQ4 = 13   # MagnumQuant 4-bit FWHT-rotated (G256)
+QT_MQ8 = 14   # MagnumQuant 8-bit FWHT-rotated
+QT_HFP4 = 21  # HFP4G32
+QT_MFP4 = 24  # MFP4G32 (HFP4 + FWHT)
+QT_Q8F16 = 3  # Q8_0 block format
+
+# Quant types that stay quantized on GPU (no decompression)
+QUANTIZED_ON_GPU = {QT_MQ4, QT_MQ8, QT_HFP4, QT_MFP4, QT_Q8F16}
+# Quant types loaded as F32 on GPU (dequantized from F16)
+DEQUANT_TO_F32 = {QT_F16}
+# Quant types loaded as-is F32
+F32_AS_F32 = {QT_F32}
+
+
+@dataclass
+class TensorInfo:
+    name: str
+    quant_type: int
+    shape: List[int]
+    data_size: int  # compressed size on disk
+
+
+def parse_hfq(path: str):
+    """Parse HFQ file header and tensor index. Returns (metadata_json, tensors)."""
+    with open(path, 'rb') as f:
+        header = f.read(32)
+        magic = header[0:4]
+        assert magic == b'HFQM', f"Not an HFQ file (magic={magic})"
+        version = struct.unpack('<I', header[4:8])[0]
+        arch_id = struct.unpack('<I', header[8:12])[0]
+        n_tensors = struct.unpack('<I', header[12:16])[0]
+        meta_off = struct.unpack('<Q', header[16:24])[0]
+        data_off = struct.unpack('<Q', header[24:32])[0]
+        
+        # Read metadata blob (JSON)
+        meta_size = data_off - meta_off
+        f.seek(meta_off)
+        meta_raw = f.read(meta_size)
+        
+        # Find JSON end by brace matching
+        depth = 0
+        in_str = False
+        escaped = False
+        json_end = 0
+        for i, b in enumerate(meta_raw):
+            if escaped:
+                escaped = False
+                continue
+            if b == 0x5c and in_str:  # backslash
+                escaped = True
+                continue
+            if b == 0x22:  # double quote
+                in_str = not in_str
+                continue
+            if not in_str:
+                if b == 0x7b:  # {
+                    depth += 1
+                elif b == 0x7d:  # }
+                    depth -= 1
+                    if depth == 0:
+                        json_end = i + 1
+                        break
+        
+        metadata_raw = meta_raw[:json_end].decode('utf-8', errors='replace')
+        metadata = json.loads(metadata_raw)
+        
+        # Parse tensor index
+        pos = json_end
+        idx_n = struct.unpack('<I', meta_raw[pos:pos+4])[0]
+        assert idx_n == n_tensors
+        pos += 4
+        
+        tensors = []
+        for _ in range(n_tensors):
+            name_len = struct.unpack('<H', meta_raw[pos:pos+2])[0]
+            pos += 2
+            name = meta_raw[pos:pos+name_len].decode('utf-8', errors='replace')
+            pos += name_len
+            qt = meta_raw[pos]
+            pos += 1
+            n_dims = meta_raw[pos]
+            pos += 1
+            shape = []
+            for _ in range(n_dims):
+                shape.append(struct.unpack('<I', meta_raw[pos:pos+4])[0])
+                pos += 4
+            gs = struct.unpack('<I', meta_raw[pos:pos+4])[0]
+            pos += 4
+            ds = struct.unpack('<Q', meta_raw[pos:pos+8])[0]
+            pos += 8
+            tensors.append(TensorInfo(name=name, quant_type=qt, shape=shape, data_size=ds))
+        
+        return metadata, tensors, arch_id
+
+
+def tensor_gpu_bytes(t: TensorInfo) -> int:
+    """Compute the GPU VRAM footprint for a single tensor."""
+    total_elems = 1
+    for d in t.shape:
+        total_elems *= d
+    
+    if t.quant_type == QT_F16:
+        # F16 is dequantized to F32 on GPU → 4 bytes per element
+        return total_elems * 4
+    elif t.quant_type == QT_F32:
+        # F32 stays F32 → 4 bytes per element
+        return total_elems * 4
+    elif t.quant_type in (QT_Q8F16,):
+        # Q8F16 uploads raw without dequantization (for Q8 embeddings etc.)
+        return t.data_size
+    elif t.quant_type in QUANTIZED_ON_GPU:
+        # Stays in quantized format on GPU → data_size is the footprint
+        return t.data_size
+    else:
+        # Unknown format, assume data_size is correct
+        return t.data_size
+
+
+def kv_cache_bytes(n_layers: int, n_kv_heads: int, head_dim: int,
+                   seq: int, mode: str) -> int:
+    """Compute KV cache VRAM for a given mode and sequence length."""
+    if mode == 'q8':
+        # Q8_0: 34 bytes per 32 elements
+        blocks_per_head = head_dim // 32
+        bytes_per_head = blocks_per_head * 34
+        bytes_per_layer = n_kv_heads * bytes_per_head * 2 * seq  # K + V
+        return bytes_per_layer * n_layers
+    elif mode == 'asym3':
+        # K: 4 + (head_dim * 3) / 8 bytes per head; V: Q8_0
+        k_bph = 4 + (head_dim * 3) // 8
+        v_blocks = head_dim // 32
+        v_bph = v_blocks * 34
+        bytes_per_layer = n_kv_heads * (k_bph + v_bph) * seq
+        return bytes_per_layer * n_layers
+    elif mode == 'asym4':
+        k_bph = 4 + head_dim // 2
+        v_blocks = head_dim // 32
+        v_bph = v_blocks * 34
+        bytes_per_layer = n_kv_heads * (k_bph + v_bph) * seq
+        return bytes_per_layer * n_layers
+    elif mode == 'hfq4':
+        # 8 + head_dim/2 bytes per head
+        bph = 8 + head_dim // 2
+        bytes_per_layer = n_kv_heads * bph * 2 * seq
+        return bytes_per_layer * n_layers
+    elif mode == 'fp32':
+        # F32 KV: 4 bytes per element
+        bytes_per_layer = n_kv_heads * head_dim * 2 * 4 * seq
+        return bytes_per_layer * n_layers
+    else:
+        raise ValueError(f"Unknown KV mode: {mode}")
+
+
+def scratch_bytes(config: dict, kv_max_seq: int) -> int:
+    """Estimate Qwen35Scratch VRAM footprint.
+    
+    Based on the actual Qwen35Scratch::new_with_kv_max implementation (qwen35.rs:2823-2899):
+    - Persistent decode buffers (all fixed size based on model dims)
+    - flash_partials: the only component that scales with kv_max_seq
+      Formula: batch_mult * n_heads * max_tiles * (2 + head_dim) * 4
+      where max_tiles = ceil(kv_max_seq / 128), batch_mult = 16 (default)
+    - prefill_batch is None by default (HIPFIRE_PREFILL_REUSE_PBS opt-in)
+    """
+    dim = config.get('dim', config.get('hidden_size', 5120))
+    hidden_dim = config.get('hidden_dim', config.get('intermediate_size', 13824))
+    n_heads = config.get('n_heads', config.get('num_attention_heads', 28))
+    n_kv_heads = config.get('n_kv_heads', config.get('num_key_value_heads', 4))
+    head_dim = config.get('head_dim', 128)
+    vocab_size = config.get('vocab_size', 152064)
+    
+    # For DeltaNet (Qwen35 hybrid): linear_num_key_heads and linear_num_value_heads
+    # Typical: num_key_heads ≈ 32, num_value_heads ≈ n_kv_heads or n_heads
+    k_dim = 32 * head_dim  # typical linear key dim
+    v_dim = n_heads * head_dim  # typical linear value dim  
+    qkv_dim = k_dim * 2 + v_dim
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    
+    # Persistent decode buffers (all F32 = 4 bytes/elem)
+    total = 0
+    
+    # x, tmp: [dim] F32
+    total += 2 * dim * 4
+    # pos_buf: 4 bytes
+    total += 4
+    
+    # DeltaNet temps
+    total += qkv_dim * 4  # dn_qkv
+    total += v_dim * 4    # dn_z
+    total += 32 * 4       # dn_alpha (~linear_num_value_heads)
+    total += 32 * 4       # dn_beta
+    total += qkv_dim * 4  # dn_conv_out
+    total += 4 * v_dim * 4  # dn_q, dn_k, dn_v
+    total += 2 * k_dim * 4  # dn_q_raw, dn_k_raw
+    total += v_dim * 4    # dn_attn_out
+    total += v_dim * 4    # dn_normed
+    
+    # FullAttn temps
+    total += q_dim * 2 * 4  # fa_q_full
+    total += q_dim * 4      # fa_q
+    total += q_dim * 4      # fa_gate
+    total += kv_dim * 4     # fa_k
+    total += kv_dim * 4     # fa_v
+    total += q_dim * 4      # fa_attn_out
+    
+    # Shared FFN
+    total += dim * 4        # o
+    total += hidden_dim * 4 # gate_ffn
+    total += hidden_dim * 4 # up
+    total += hidden_dim * 4 # ffn_hidden
+    total += dim * 4        # ffn_out
+    
+    # Sampling
+    total += vocab_size * 4 # logits
+    total += 2 * 4          # sample_buf
+    total += 128 * 4        # repeat_buf (128 default, caller-specified)
+    
+    # MagnumQuant rotation scratch
+    total += max(dim, hidden_dim) * 4  # x_rot
+    
+    # Flash attention partials — the ONLY component that scales with kv_max_seq
+    tile_size = 128
+    max_tiles = (kv_max_seq + tile_size - 1) // tile_size
+    batch_mult = 16  # default HIPFIRE_FLASH_PARTIALS_BATCH
+    total += batch_mult * n_heads * max_tiles * (2 + head_dim) * 4
+    
+    return total
+
+
+def deltanet_bytes(config: dict) -> int:
+    """Estimate DeltaNet state VRAM.
+    
+    DeltaNet state includes per-layer s_matrices, s_scales, conv_states.
+    For 27B with 28 layers, hidden_dim=5120:
+    - s_matrices: n_layers * hidden_dim * state_dim (f32)
+    - conv_states: n_layers * hidden_dim * conv_width
+    - Scales typically small
+    """
+    n_layers = config.get('n_layers', config.get('num_hidden_layers', 28))
+    hidden_dim = config.get('hidden_dim', config.get('intermediate_size', 13824))
+    dim = config.get('dim', config.get('hidden_size', 5120))
+    
+    # Rough estimate based on empirical sizes in codebase
+    # s_matrices: [n_layers × dim × 4] for state vectors
+    s_size = n_layers * dim * 4  # f32
+    
+    # conv_states: [n_layers × conv_width × dim × 4]
+    conv_width = 4  # typical
+    conv_size = n_layers * conv_width * dim * 4
+    
+    # s_scales: small per-layer scale vectors
+    scale_size = n_layers * 256 * 4  # conservative
+    
+    return s_size + conv_size + scale_size
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Compute VRAM footprint for HFQ model')
+    parser.add_argument('model_path', help='Path to .hfq/.mq4 model file')
+    parser.add_argument('--vram', type=float, default=16.0, help='GPU VRAM in GB (default: 16)')
+    parser.add_argument('--kv-seq', type=int, default=512, help='KV sequence length for calibration (default: 512)')
+    parser.add_argument('--kv-mode', default='q8', choices=['q8', 'asym3', 'asym4', 'fp32'],
+                        help='KV cache mode (default: q8)')
+    parser.add_argument('--full-seq', type=int, default=0,
+                        help='Full KV sequence length without sidecar (default: from config)')
+    args = parser.parse_args()
+    
+    if not os.path.exists(args.model_path):
+        print(f"Error: file not found: {args.model_path}")
+        sys.exit(1)
+    
+    # Parse
+    metadata, tensors, arch_id = parse_hfq(args.model_path)
+    
+    # Extract model config (handles multiple nesting patterns)
+    config = {}
+    
+    def extract_config(src):
+        """Recursively extract configuration values from nested dicts."""
+        if isinstance(src, dict):
+            for key, val in src.items():
+                if isinstance(val, dict):
+                    # Some models nest config under 'text_config' or 'language_model'
+                    extract_config(val)
+                elif isinstance(val, (int, float, str)) and key not in config:
+                    config[key] = val
+    
+    # Start with top-level keys from metadata
+    extract_config(metadata)
+    
+    # Huggingface convention: config lives in metadata['config']
+    if 'config' in metadata and isinstance(metadata['config'], dict):
+        extract_config(metadata['config'])
+    
+    # Map huggingface keys to our names
+    key_map = {
+        'num_hidden_layers': 'n_layers',
+        'num_attention_heads': 'n_heads',
+        'num_key_value_heads': 'n_kv_heads',
+        'intermediate_size': 'hidden_dim',
+        'hidden_size': 'dim',
+        'head_dim': 'head_dim',
+        'vocab_size': 'vocab_size',
+        'rope_theta': 'rope_theta',
+        'max_position_embeddings': 'max_seq_len',
+    }
+    for hf_key, our_key in key_map.items():
+        if our_key not in config and hf_key in config:
+            config[our_key] = config[hf_key]
+    
+    # Set defaults for missing keys (Qwen3.6-27B typical)
+    config.setdefault('n_layers', 28)
+    config.setdefault('n_heads', 28)
+    config.setdefault('n_kv_heads', 4)
+    config.setdefault('head_dim', 128)
+    config.setdefault('dim', 5120)
+    config.setdefault('hidden_dim', 13824)
+    config.setdefault('vocab_size', 152064)
+    config.setdefault('max_seq_len', 4096)
+    
+    n_layers = config['n_layers']
+    n_heads = config['n_heads']
+    n_kv_heads = config['n_kv_heads']
+    head_dim = config['head_dim']
+    hidden_dim = config['hidden_dim']
+    dim = config['dim']
+    vocab_size = config['vocab_size']
+    
+    full_seq = args.full_seq if args.full_seq > 0 else config.get('max_seq_len', 4096)
+    
+    # ── Compute VRAM footprint ─────────────────────────────────────
+    
+    # 1. Weights
+    total_weight_bytes = 0
+    weight_details = []
+    for t in tensors:
+        gpu_bytes = tensor_gpu_bytes(t)
+        total_weight_bytes += gpu_bytes
+        
+        # Classify tensor
+        if 'embed' in t.name.lower() or 'tok_embeddings' in t.name:
+            kind = 'embed'
+        elif 'output' in t.name.lower() or 'lm_head' in t.name or 'head' in t.name.lower():
+            kind = 'lm_head'
+        else:
+            kind = 'layer'
+        
+        gpu_mb = gpu_bytes / (1024 * 1024)
+        disk_mb = t.data_size / (1024 * 1024)
+        ratio = gpu_bytes / t.data_size if t.data_size > 0 else 1
+        weight_details.append((t.name, t.quant_type, kind, disk_mb, gpu_mb, ratio))
+    
+    # 2. KV cache
+    calib_kv = kv_cache_bytes(n_layers, n_kv_heads, head_dim, args.kv_seq, args.kv_mode)
+    full_kv = kv_cache_bytes(n_layers, n_kv_heads, head_dim, full_seq, 'asym3')
+    
+    # 3. Scratch at kv_max_seq (calibration uses default 8192)
+    calib_scratch = scratch_bytes(config, 8192)
+    
+    # 4. DeltaNet state
+    dn = deltanet_bytes(config)
+    
+    # 5. ROCm/driver overhead (conservative)
+    driver_overhead = 256 * 1024 * 1024  # 256 MB
+    
+    # ── Summary ─────────────────────────────────────────────────────
+    
+    vram_bytes = int(args.vram * 1024**3)
+    
+    calib_total = total_weight_bytes + calib_kv + calib_scratch + dn + driver_overhead
+    full_total = total_weight_bytes + full_kv + calib_scratch + dn + driver_overhead
+    
+    print(f"\n{'='*72}")
+    print(f"  VRAM Calculator — {os.path.basename(args.model_path)}")
+    print(f"{'='*72}")
+    print(f"  Architecture: {config.get('arch', 'unknown')} (arch_id={arch_id})")
+    print(f"  Layers: {n_layers}  Heads: {n_heads}  KV Heads: {n_kv_heads}")
+    print(f"  Head dim: {head_dim}  Hidden dim: {hidden_dim}  Model dim: {dim}")
+    print(f"  Vocab: {vocab_size}")
+    print(f"  GPU VRAM: {args.vram:.1f} GB")
+    print()
+    
+    # Weight breakdown by category
+    embed_bytes = sum(b for _, _, k, _, b, _ in weight_details if k == 'embed')
+    lmhead_bytes = sum(b for _, _, k, _, b, _ in weight_details if k == 'lm_head')
+    layer_bytes = sum(b for _, _, k, _, b, _ in weight_details if k == 'layer')
+    
+    def gb(b): return b / (1024**3)
+    def mb(b): return b / (1024*1024)
+    
+    print(f"  ┌── Weight VRAM ──────────────────────────────────────────┐")
+    print(f"  │ {'Category':<20} {'Tensors':>8} {'Disk':>10} {'GPU':>10} {'Ratio':>8} │")
+    print(f"  │ {'─'*20} {'─'*8} {'─'*10} {'─'*10} {'─'*8} │")
+    
+    # Group by quant type
+    by_qt = {}
+    for t in weight_details:
+        by_qt.setdefault(t[1], []).append(t)
+    
+    # Show largest tensors individually, rest as summary
+    BIG_THRESHOLD_MB = 500  # show individual tensors > 500 MB on disk
+    shown = []
+    other_disk = 0
+    other_gpu = 0
+    other_count = 0
+    for t in sorted(weight_details, key=lambda x: -x[3]):  # sort by disk size
+        if t[3] >= BIG_THRESHOLD_MB:
+            qt_label = {1: 'F16→F32', 13: 'MQ4', 14: 'MQ8', 3: 'Q8'}.get(t[1], f'qt={t[1]}')
+            shown.append((t[0][:50], qt_label, t[3], t[4], t[5]))
+        else:
+            other_disk += t[3]
+            other_gpu += t[4]
+            other_count += 1
+    
+    for name, qt_label, disk_mb, gpu_mb, ratio in shown[:20]:
+        print(f"  │ {name:<50} {disk_mb:>8.1f}M {gpu_mb:>8.1f}M {ratio:>5.2f}x │")
+    if other_count > 0:
+        print(f"  │ ... {other_count} small tensors             {other_disk:>8.1f}M {other_gpu:>8.1f}M {'─':>7} │")
+    
+    print(f"  │ {'─'*20} {'─'*8} {'─'*10} {'─'*10} {'─'*8} │")
+    print(f"  │ {'TOTAL WEIGHT VRAM':<55} {gb(total_weight_bytes):>8.3f} GB │")
+    print(f"  └{'─'*58}┘")
+    print()
+    
+    # Two scenarios
+    print(f"  ┌── SCENARIO A: Calibration (kv_seq={args.kv_seq}, {args.kv_mode}) ──────┐")
+    print(f"  │ {'Component':<35} {'MB':>10} {'GB':>8} {'%VRAM':>8} │")
+    print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
+    
+    rows = [
+        ("Model weights", mb(total_weight_bytes), gb(total_weight_bytes)),
+        (f"KV cache ({args.kv_mode}, seq={args.kv_seq})", mb(calib_kv), gb(calib_kv)),
+        ("Scratch buffers", mb(calib_scratch), gb(calib_scratch)),
+        ("DeltaNet state", mb(dn), gb(dn)),
+        ("Driver/ROCm overhead", mb(driver_overhead), gb(driver_overhead)),
+    ]
+    
+    cumulative = 0
+    for label, mb_val, gb_val in rows:
+        cumulative += gb_val
+        pct = (gb_val / args.vram) * 100
+        cum_pct = (cumulative / args.vram) * 100
+        print(f"  │ {label:<35} {mb_val:>10.1f} {gb_val:>8.3f} {pct:>7.1f}% │")
+    
+    print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
+    pct = (calib_total / vram_bytes) * 100
+    fits = "✓ FITS" if calib_total <= vram_bytes else "✗ OVERFLOW"
+    print(f"  │ {'TOTAL':<35} {mb(calib_total):>10.1f} {gb(calib_total):>8.3f} {pct:>7.1f}% │")
+    print(f"  │ {'':<35} {'':>10} {'':>8} {fits:>8} │")
+    print(f"  │ {'Headroom':<35} {'':>10} {args.vram - gb(calib_total):>8.3f} {'':>8} │")
+    print(f"  └{'─'*58}┘")
+    print()
+    
+    print(f"  ┌── SCENARIO B: Daemon load WITHOUT sidecar (asym3, seq={full_seq}) ─┐")
+    print(f"  │ {'Component':<35} {'MB':>10} {'GB':>8} {'%VRAM':>8} │")
+    print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
+    
+    rows_b = [
+        ("Model weights", mb(total_weight_bytes), gb(total_weight_bytes)),
+        (f"KV cache (asym3, seq={full_seq})", mb(full_kv), gb(full_kv)),
+        ("Scratch buffers", mb(calib_scratch), gb(calib_scratch)),
+        ("DeltaNet state", mb(dn), gb(dn)),
+        ("Driver/ROCm overhead", mb(driver_overhead), gb(driver_overhead)),
+    ]
+    
+    cumulative = 0
+    for label, mb_val, gb_val in rows_b:
+        cumulative += gb_val
+        pct = (gb_val / args.vram) * 100
+        cum_pct = (cumulative / args.vram) * 100
+        print(f"  │ {label:<35} {mb_val:>10.1f} {gb_val:>8.3f} {pct:>7.1f}% │")
+    
+    print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
+    total_b = total_weight_bytes + full_kv + calib_scratch + dn + driver_overhead
+    pct_b = (total_b / vram_bytes) * 100
+    fits_b = "✓ FITS" if total_b <= vram_bytes else "✗ OVERFLOW"
+    print(f"  │ {'TOTAL':<35} {mb(total_b):>10.1f} {gb(total_b):>8.3f} {pct_b:>7.1f}% │")
+    print(f"  │ {'':<35} {'':>10} {'':>8} {fits_b:>8} │")
+    print(f"  │ {'Headroom':<35} {'':>10} {args.vram - gb(total_b):>8.3f} {'':>8} │")
+    print(f"  └{'─'*58}┘")
+    print()
+    
+    # ── Verdict ──
+    print(f"  {'─'*65}")
+    if calib_total <= vram_bytes:
+        print(f"  ▶ VERDICT (Calibration): YES — fits with {args.vram - gb(calib_total):.2f} GB headroom.")
+        print(f"    The triattn_validate / cask_gen calibration binary will work on")
+        print(f"    this GPU with kv_seq={args.kv_seq} in {args.kv_mode} mode.")
+    else:
+        over = gb(calib_total) - args.vram
+        print(f"  ▶ VERDICT (Calibration): NO — exceeds VRAM by {over:.2f} GB.")
+        print(f"    Options:")
+        if args.kv_seq > 128:
+            print(f"    • Reduce kv_seq (try --kv-seq 128)")
+        if args.kv_mode == 'q8':
+            print(f"    • The model weights alone may exceed VRAM — check quantization settings")
+    
+    if total_b <= vram_bytes:
+        print(f"  ▶ VERDICT (Daemon): Surprisingly, daemon also fits on {args.vram:.0f} GB.")
+        print(f"    The OOM may be caused by daemon-specific allocations not captured here")
+        print(f"    (e.g., weight pager overhead, multiple graph instances, or memory fragmentation).")
+    else:
+        over_b = gb(total_b) - args.vram
+        print(f"  ▶ VERDICT (Daemon): OVERFLOW by {over_b:.2f} GB — the KV cache at seq={full_seq}")
+        print(f"    in asym3 mode is the primary cause. A sidecar would reduce KV to")
+        print(f"    physical_cap ≈ budget+beta+safety (typically 512-1024 tokens), recovering")
+        print(f"    {gb(full_kv - calib_kv):.2f} GB.")
+    
+    print(f"  {'─'*65}")
+    
+    # ── Optional: try reducing KV seq ──
+    if calib_total > vram_bytes:
+        print(f"\n  Trying reduced KV seq to find breakpoint:")
+        for try_seq in [256, 128, 64, 32]:
+            try_kv = kv_cache_bytes(n_layers, n_kv_heads, head_dim, try_seq, args.kv_mode)
+            try_total = total_weight_bytes + try_kv + calib_scratch + dn + driver_overhead
+            if try_total <= vram_bytes:
+                print(f"    kv_seq={try_seq}: {gb(try_total):.3f} GB ({args.vram - gb(try_total):.2f} GB headroom) ✓")
+                break
+            print(f"    kv_seq={try_seq}: {gb(try_total):.3f} GB (over by {gb(try_total) - args.vram:.2f} GB)")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/vram_calc.py
+++ b/scripts/vram_calc.py
@@ -54,12 +54,12 @@ def parse_hfq(path: str):
         n_tensors = struct.unpack('<I', header[12:16])[0]
         meta_off = struct.unpack('<Q', header[16:24])[0]
         data_off = struct.unpack('<Q', header[24:32])[0]
-        
+
         # Read metadata blob (JSON)
         meta_size = data_off - meta_off
         f.seek(meta_off)
         meta_raw = f.read(meta_size)
-        
+
         # Find JSON end by brace matching
         depth = 0
         in_str = False
@@ -83,16 +83,16 @@ def parse_hfq(path: str):
                     if depth == 0:
                         json_end = i + 1
                         break
-        
+
         metadata_raw = meta_raw[:json_end].decode('utf-8', errors='replace')
         metadata = json.loads(metadata_raw)
-        
+
         # Parse tensor index
         pos = json_end
         idx_n = struct.unpack('<I', meta_raw[pos:pos+4])[0]
         assert idx_n == n_tensors
         pos += 4
-        
+
         tensors = []
         for _ in range(n_tensors):
             name_len = struct.unpack('<H', meta_raw[pos:pos+2])[0]
@@ -112,7 +112,7 @@ def parse_hfq(path: str):
             ds = struct.unpack('<Q', meta_raw[pos:pos+8])[0]
             pos += 8
             tensors.append(TensorInfo(name=name, quant_type=qt, shape=shape, data_size=ds))
-        
+
         return metadata, tensors, arch_id
 
 
@@ -121,7 +121,7 @@ def tensor_gpu_bytes(t: TensorInfo) -> int:
     total_elems = 1
     for d in t.shape:
         total_elems *= d
-    
+
     if t.quant_type == QT_F16:
         # F16 is dequantized to F32 on GPU → 4 bytes per element
         return total_elems * 4
@@ -176,7 +176,7 @@ def kv_cache_bytes(n_layers: int, n_kv_heads: int, head_dim: int,
 
 def scratch_bytes(config: dict, kv_max_seq: int) -> int:
     """Estimate Qwen35Scratch VRAM footprint.
-    
+
     Based on the actual Qwen35Scratch::new_with_kv_max implementation (qwen35.rs:2823-2899):
     - Persistent decode buffers (all fixed size based on model dims)
     - flash_partials: the only component that scales with kv_max_seq
@@ -190,23 +190,23 @@ def scratch_bytes(config: dict, kv_max_seq: int) -> int:
     n_kv_heads = config.get('n_kv_heads', config.get('num_key_value_heads', 4))
     head_dim = config.get('head_dim', 128)
     vocab_size = config.get('vocab_size', 152064)
-    
+
     # For DeltaNet (Qwen35 hybrid): linear_num_key_heads and linear_num_value_heads
     # Typical: num_key_heads ≈ 32, num_value_heads ≈ n_kv_heads or n_heads
     k_dim = 32 * head_dim  # typical linear key dim
-    v_dim = n_heads * head_dim  # typical linear value dim  
+    v_dim = n_heads * head_dim  # typical linear value dim
     qkv_dim = k_dim * 2 + v_dim
     q_dim = n_heads * head_dim
     kv_dim = n_kv_heads * head_dim
-    
+
     # Persistent decode buffers (all F32 = 4 bytes/elem)
     total = 0
-    
+
     # x, tmp: [dim] F32
     total += 2 * dim * 4
     # pos_buf: 4 bytes
     total += 4
-    
+
     # DeltaNet temps
     total += qkv_dim * 4  # dn_qkv
     total += v_dim * 4    # dn_z
@@ -217,7 +217,7 @@ def scratch_bytes(config: dict, kv_max_seq: int) -> int:
     total += 2 * k_dim * 4  # dn_q_raw, dn_k_raw
     total += v_dim * 4    # dn_attn_out
     total += v_dim * 4    # dn_normed
-    
+
     # FullAttn temps
     total += q_dim * 2 * 4  # fa_q_full
     total += q_dim * 4      # fa_q
@@ -225,34 +225,34 @@ def scratch_bytes(config: dict, kv_max_seq: int) -> int:
     total += kv_dim * 4     # fa_k
     total += kv_dim * 4     # fa_v
     total += q_dim * 4      # fa_attn_out
-    
+
     # Shared FFN
     total += dim * 4        # o
     total += hidden_dim * 4 # gate_ffn
     total += hidden_dim * 4 # up
     total += hidden_dim * 4 # ffn_hidden
     total += dim * 4        # ffn_out
-    
+
     # Sampling
     total += vocab_size * 4 # logits
     total += 2 * 4          # sample_buf
     total += 128 * 4        # repeat_buf (128 default, caller-specified)
-    
+
     # MagnumQuant rotation scratch
     total += max(dim, hidden_dim) * 4  # x_rot
-    
+
     # Flash attention partials — the ONLY component that scales with kv_max_seq
     tile_size = 128
     max_tiles = (kv_max_seq + tile_size - 1) // tile_size
     batch_mult = 16  # default HIPFIRE_FLASH_PARTIALS_BATCH
     total += batch_mult * n_heads * max_tiles * (2 + head_dim) * 4
-    
+
     return total
 
 
 def deltanet_bytes(config: dict) -> int:
     """Estimate DeltaNet state VRAM.
-    
+
     DeltaNet state includes per-layer s_matrices, s_scales, conv_states.
     For 27B with 28 layers, hidden_dim=5120:
     - s_matrices: n_layers * hidden_dim * state_dim (f32)
@@ -262,18 +262,18 @@ def deltanet_bytes(config: dict) -> int:
     n_layers = config.get('n_layers', config.get('num_hidden_layers', 28))
     hidden_dim = config.get('hidden_dim', config.get('intermediate_size', 13824))
     dim = config.get('dim', config.get('hidden_size', 5120))
-    
+
     # Rough estimate based on empirical sizes in codebase
     # s_matrices: [n_layers × dim × 4] for state vectors
     s_size = n_layers * dim * 4  # f32
-    
+
     # conv_states: [n_layers × conv_width × dim × 4]
     conv_width = 4  # typical
     conv_size = n_layers * conv_width * dim * 4
-    
+
     # s_scales: small per-layer scale vectors
     scale_size = n_layers * 256 * 4  # conservative
-    
+
     return s_size + conv_size + scale_size
 
 
@@ -288,17 +288,17 @@ def main():
     parser.add_argument('--full-seq', type=int, default=0,
                         help='Full KV sequence length without sidecar (default: from config)')
     args = parser.parse_args()
-    
+
     if not os.path.exists(args.model_path):
         print(f"Error: file not found: {args.model_path}")
         sys.exit(1)
-    
+
     # Parse
     metadata, tensors, arch_id = parse_hfq(args.model_path)
-    
+
     # Extract model config (handles multiple nesting patterns)
     config = {}
-    
+
     def extract_config(src):
         """Recursively extract configuration values from nested dicts."""
         if isinstance(src, dict):
@@ -308,14 +308,14 @@ def main():
                     extract_config(val)
                 elif isinstance(val, (int, float, str)) and key not in config:
                     config[key] = val
-    
+
     # Start with top-level keys from metadata
     extract_config(metadata)
-    
+
     # Huggingface convention: config lives in metadata['config']
     if 'config' in metadata and isinstance(metadata['config'], dict):
         extract_config(metadata['config'])
-    
+
     # Map huggingface keys to our names
     key_map = {
         'num_hidden_layers': 'n_layers',
@@ -331,7 +331,7 @@ def main():
     for hf_key, our_key in key_map.items():
         if our_key not in config and hf_key in config:
             config[our_key] = config[hf_key]
-    
+
     # Set defaults for missing keys (Qwen3.6-27B typical)
     config.setdefault('n_layers', 28)
     config.setdefault('n_heads', 28)
@@ -341,7 +341,7 @@ def main():
     config.setdefault('hidden_dim', 13824)
     config.setdefault('vocab_size', 152064)
     config.setdefault('max_seq_len', 4096)
-    
+
     n_layers = config['n_layers']
     n_heads = config['n_heads']
     n_kv_heads = config['n_kv_heads']
@@ -349,18 +349,18 @@ def main():
     hidden_dim = config['hidden_dim']
     dim = config['dim']
     vocab_size = config['vocab_size']
-    
+
     full_seq = args.full_seq if args.full_seq > 0 else config.get('max_seq_len', 4096)
-    
+
     # ── Compute VRAM footprint ─────────────────────────────────────
-    
+
     # 1. Weights
     total_weight_bytes = 0
     weight_details = []
     for t in tensors:
         gpu_bytes = tensor_gpu_bytes(t)
         total_weight_bytes += gpu_bytes
-        
+
         # Classify tensor
         if 'embed' in t.name.lower() or 'tok_embeddings' in t.name:
             kind = 'embed'
@@ -368,32 +368,32 @@ def main():
             kind = 'lm_head'
         else:
             kind = 'layer'
-        
+
         gpu_mb = gpu_bytes / (1024 * 1024)
         disk_mb = t.data_size / (1024 * 1024)
         ratio = gpu_bytes / t.data_size if t.data_size > 0 else 1
         weight_details.append((t.name, t.quant_type, kind, disk_mb, gpu_mb, ratio))
-    
+
     # 2. KV cache
     calib_kv = kv_cache_bytes(n_layers, n_kv_heads, head_dim, args.kv_seq, args.kv_mode)
     full_kv = kv_cache_bytes(n_layers, n_kv_heads, head_dim, full_seq, 'asym3')
-    
+
     # 3. Scratch at kv_max_seq (calibration uses default 8192)
     calib_scratch = scratch_bytes(config, 8192)
-    
+
     # 4. DeltaNet state
     dn = deltanet_bytes(config)
-    
+
     # 5. ROCm/driver overhead (conservative)
     driver_overhead = 256 * 1024 * 1024  # 256 MB
-    
+
     # ── Summary ─────────────────────────────────────────────────────
-    
+
     vram_bytes = int(args.vram * 1024**3)
-    
+
     calib_total = total_weight_bytes + calib_kv + calib_scratch + dn + driver_overhead
     full_total = total_weight_bytes + full_kv + calib_scratch + dn + driver_overhead
-    
+
     print(f"\n{'='*72}")
     print(f"  VRAM Calculator — {os.path.basename(args.model_path)}")
     print(f"{'='*72}")
@@ -403,24 +403,24 @@ def main():
     print(f"  Vocab: {vocab_size}")
     print(f"  GPU VRAM: {args.vram:.1f} GB")
     print()
-    
+
     # Weight breakdown by category
     embed_bytes = sum(b for _, _, k, _, b, _ in weight_details if k == 'embed')
     lmhead_bytes = sum(b for _, _, k, _, b, _ in weight_details if k == 'lm_head')
     layer_bytes = sum(b for _, _, k, _, b, _ in weight_details if k == 'layer')
-    
+
     def gb(b): return b / (1024**3)
     def mb(b): return b / (1024*1024)
-    
+
     print(f"  ┌── Weight VRAM ──────────────────────────────────────────┐")
     print(f"  │ {'Category':<20} {'Tensors':>8} {'Disk':>10} {'GPU':>10} {'Ratio':>8} │")
     print(f"  │ {'─'*20} {'─'*8} {'─'*10} {'─'*10} {'─'*8} │")
-    
+
     # Group by quant type
     by_qt = {}
     for t in weight_details:
         by_qt.setdefault(t[1], []).append(t)
-    
+
     # Show largest tensors individually, rest as summary
     BIG_THRESHOLD_MB = 500  # show individual tensors > 500 MB on disk
     shown = []
@@ -435,22 +435,22 @@ def main():
             other_disk += t[3]
             other_gpu += t[4]
             other_count += 1
-    
+
     for name, qt_label, disk_mb, gpu_mb, ratio in shown[:20]:
         print(f"  │ {name:<50} {disk_mb:>8.1f}M {gpu_mb:>8.1f}M {ratio:>5.2f}x │")
     if other_count > 0:
         print(f"  │ ... {other_count} small tensors             {other_disk:>8.1f}M {other_gpu:>8.1f}M {'─':>7} │")
-    
+
     print(f"  │ {'─'*20} {'─'*8} {'─'*10} {'─'*10} {'─'*8} │")
     print(f"  │ {'TOTAL WEIGHT VRAM':<55} {gb(total_weight_bytes):>8.3f} GB │")
     print(f"  └{'─'*58}┘")
     print()
-    
+
     # Two scenarios
     print(f"  ┌── SCENARIO A: Calibration (kv_seq={args.kv_seq}, {args.kv_mode}) ──────┐")
     print(f"  │ {'Component':<35} {'MB':>10} {'GB':>8} {'%VRAM':>8} │")
     print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
-    
+
     rows = [
         ("Model weights", mb(total_weight_bytes), gb(total_weight_bytes)),
         (f"KV cache ({args.kv_mode}, seq={args.kv_seq})", mb(calib_kv), gb(calib_kv)),
@@ -458,14 +458,14 @@ def main():
         ("DeltaNet state", mb(dn), gb(dn)),
         ("Driver/ROCm overhead", mb(driver_overhead), gb(driver_overhead)),
     ]
-    
+
     cumulative = 0
     for label, mb_val, gb_val in rows:
         cumulative += gb_val
         pct = (gb_val / args.vram) * 100
         cum_pct = (cumulative / args.vram) * 100
         print(f"  │ {label:<35} {mb_val:>10.1f} {gb_val:>8.3f} {pct:>7.1f}% │")
-    
+
     print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
     pct = (calib_total / vram_bytes) * 100
     fits = "✓ FITS" if calib_total <= vram_bytes else "✗ OVERFLOW"
@@ -474,11 +474,11 @@ def main():
     print(f"  │ {'Headroom':<35} {'':>10} {args.vram - gb(calib_total):>8.3f} {'':>8} │")
     print(f"  └{'─'*58}┘")
     print()
-    
+
     print(f"  ┌── SCENARIO B: Daemon load WITHOUT sidecar (asym3, seq={full_seq}) ─┐")
     print(f"  │ {'Component':<35} {'MB':>10} {'GB':>8} {'%VRAM':>8} │")
     print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
-    
+
     rows_b = [
         ("Model weights", mb(total_weight_bytes), gb(total_weight_bytes)),
         (f"KV cache (asym3, seq={full_seq})", mb(full_kv), gb(full_kv)),
@@ -486,14 +486,14 @@ def main():
         ("DeltaNet state", mb(dn), gb(dn)),
         ("Driver/ROCm overhead", mb(driver_overhead), gb(driver_overhead)),
     ]
-    
+
     cumulative = 0
     for label, mb_val, gb_val in rows_b:
         cumulative += gb_val
         pct = (gb_val / args.vram) * 100
         cum_pct = (cumulative / args.vram) * 100
         print(f"  │ {label:<35} {mb_val:>10.1f} {gb_val:>8.3f} {pct:>7.1f}% │")
-    
+
     print(f"  │ {'─'*35} {'─'*10} {'─'*8} {'─'*8} │")
     total_b = total_weight_bytes + full_kv + calib_scratch + dn + driver_overhead
     pct_b = (total_b / vram_bytes) * 100
@@ -503,7 +503,7 @@ def main():
     print(f"  │ {'Headroom':<35} {'':>10} {args.vram - gb(total_b):>8.3f} {'':>8} │")
     print(f"  └{'─'*58}┘")
     print()
-    
+
     # ── Verdict ──
     print(f"  {'─'*65}")
     if calib_total <= vram_bytes:
@@ -518,7 +518,7 @@ def main():
             print(f"    • Reduce kv_seq (try --kv-seq 128)")
         if args.kv_mode == 'q8':
             print(f"    • The model weights alone may exceed VRAM — check quantization settings")
-    
+
     if total_b <= vram_bytes:
         print(f"  ▶ VERDICT (Daemon): Surprisingly, daemon also fits on {args.vram:.0f} GB.")
         print(f"    The OOM may be caused by daemon-specific allocations not captured here")
@@ -529,9 +529,9 @@ def main():
         print(f"    in asym3 mode is the primary cause. A sidecar would reduce KV to")
         print(f"    physical_cap ≈ budget+beta+safety (typically 512-1024 tokens), recovering")
         print(f"    {gb(full_kv - calib_kv):.2f} GB.")
-    
+
     print(f"  {'─'*65}")
-    
+
     # ── Optional: try reducing KV seq ──
     if calib_total > vram_bytes:
         print(f"\n  Trying reduced KV seq to find breakpoint:")


### PR DESCRIPTION
## Summary

Add `hipfire sidecar-gen` CLI command for TriAttention calibration sidecar generation. This gives users a straightforward command to produce `.triattn.bin` sidecar files from any HFQ model, enabling CASK-based KV cache eviction on custom and quantized models — without needing to invoke `triattn_validate` directly.

Branch: `aldrouil/hipfire:feat/sidecar-gen-cli` (rebased onto latest upstream master).

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [x] `crates/hipfire-runtime` — `triattn_validate.rs`: Phase 2 validation crash fix (D2H inside hipGraph capture conflict), Phase 3 empty val_len guard
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy`
- [ ] `crates/hipfire-quantize`
- [x] examples / daemon — `triattn_validate` binary now included in install
- [x] docs / CI / scripts — CLI.md, CONFIG.md, GETTING_STARTED.md, QUANTIZE.md, README.md, install.sh, vram_calc.py

## Commits

| Commit | Description |
|--------|-------------|
| `6799d5ea` | feat(cli): add hipfire sidecar-gen command — CLI dispatches triattn_validate with correct args; includes vram_calc.py utility |
| `214ddc91` | fix: correct binary name triatttn_validate → triattn_validate |
| `f540dd5a` | fix(cli): correct installed binary path resolution |
| `c510c4f6` | fix(cli): correct cargo fallback workspace root and binary path for triattn_validate |
| `e3eaa229` | fix(cli): add missing --corpus and --cpu-calib flags in cargo fallback |
| `7492ea83` | fix(install): include triattn_validate in install script build and copy |
| `81cf53f7` | chore(gitignore): ignore generated *.triattn.bin files |
| `7ce972b9` | docs(cli): add sidecar-gen to top-level help text |
| `21b2eeea` | feat(cli): add --skip-validation flag — passes --val-prompt "" to skip Phase 2 |
| `b59e4bfb` | refactor(cli): extract findDep to module level; replace shell interpolation with which |
| `db741234` | fix(cli): validate --max-tokens and --chunk-len ranges |
| `f7108a2f` | fix(cli): remove dangling closing paren from cargo fallback refactor |
| `237d9a5d` | docs: add CASK sidecar-gen documentation across model lifecycle guides |
| `e5d7c914` | chore(gitignore): ignore .sisyphus/ handoff artifacts |
| `746c7833` | fix(triattn_validate): disable graph capture before Phase 2 + guard Phase 3 |

## Design notes

- **`sidecar-gen` is a dedicated command, not a flag on `run`/`serve`** — calibration is an offline step that takes minutes and requires a corpus. Keeping it separate keeps the inference surface clean.
- **Phase 2 validation is optional** (`--skip-validation`) — the correlation check against a validation prompt is useful for debugging but not needed for sidecar production. Calibration (Phase 1) is the essential step.
- **Default calibration is CPU** (`--cpu-calib`) — the CPU path avoids GPU kernel launch overhead on short calibration chunks. The GPU path (`--gpu-calib`) is available for long-corpus runs where the batched `triattn_accumulate_f32` kernel wins.
- **Sidecar auto-discovery** — the daemon looks for `<model>.triattn.bin` alongside the model file. No config needed beyond placing the sidecar in the right location.

## Bug fix: Phase 2 validation crash on gfx12/gfx11

During development Phase 2 validation crashed with `hipErrorStreamCaptureImplicit` (error 906) on gfx12. Root cause: the TriAttn capture tap calls `gpu.download_f32()` (synchronous D2H copy) inside `forward_scratch_layers`, which is illegal inside a hipGraph stream capture region. Phase 1 avoids this because it uses the batched `forward_prefill_batch` path which handles the tap via a GPU kernel (`triattn_accumulate`) with no D2H.

Fix: `gpu.graph_destroy()` before Phase 2 + `gpu.ar_forward_warmed_up = false` before each validation token keeps `forward_scratch` on the warmup/direct path, bypassing graph capture entirely. Also added `if val_len > 0` guard on Phase 3 to prevent `usize::MAX` index panic when `--skip-validation` produces 0 validation tokens.

## Test plan

- [x] `cargo build --release --example triattn_validate` clean
- [x] `cargo build --release --workspace --features deltanet` clean
- [ ] `cargo test --lib --workspace --features deltanet` passes
- [ ] If kernel/dispatch changed: `./scripts/coherence-gate.sh` clean
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines

## Verification (gfx1201, Qwopus3.6-27B-v1-preview.mq4)

```
hipfire sidecar-gen qwopus3.6:27b --cpu-calib --max-tokens 100000
```

- Phase 1 calibration: 103 tokens x 16 FA layers, sidecar saved (2.4 MB)
- Phase 2 validation: 27 tokens, no crash (graph-disable fix confirmed)
- Phase 3 correlation: overall r=0.555 across 16 FA layers
- Mean Resultant Length: R_f mean=0.550, 5.3% of heads > 0.95
