### PR TITLE
feat(multi-gpu): hetero PP=2 prereqs — env-gate mixed arch, per-arch JIT cache, init_layers VRAM bypass

### DIFF
--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -95,7 +95,7 @@ impl Gpus {
         }
         let device_ids = resolve_device_ids(n_devices)?;
         let devices = construct_devices(&device_ids)?;
-        preflight_vram(&devices)?;
+        preflight_vram_with_opts(&devices, /*check_vram_delta=*/ true)?;
         let per_device = uniform_split_counts(n_devices, n_layers);
         Self::from_parts(devices, per_device, n_layers)
     }
@@ -114,7 +114,12 @@ impl Gpus {
         let n_layers: usize = per_device.iter().sum();
         let device_ids = resolve_device_ids(n_devices)?;
         let devices = construct_devices(&device_ids)?;
-        preflight_vram(&devices)?;
+        // init_layers is the documented escape hatch for asymmetric VRAM
+        // splits — the caller has declared the per-device counts, so skip
+        // the VRAM-delta check (which would otherwise reject 32 GB MI50 +
+        // 12 GB 6700 XT pairs out of the box). Arch-mismatch + per-device
+        // bind+free probe still run.
+        preflight_vram_with_opts(&devices, /*check_vram_delta=*/ false)?;
         Self::from_parts(devices, per_device.to_vec(), n_layers)
     }
 
@@ -382,26 +387,44 @@ fn construct_devices(ids: &[i32]) -> HipResult<Vec<Gpu>> {
     Ok(devices)
 }
 
-fn preflight_vram(devices: &[Gpu]) -> HipResult<()> {
+fn preflight_vram_with_opts(devices: &[Gpu], check_vram_delta: bool) -> HipResult<()> {
     if devices.is_empty() {
         return Ok(());
     }
     let arch0 = devices[0].arch.clone();
+    let allow_mixed = std::env::var("HIPFIRE_ALLOW_MIXED_ARCH")
+        .ok()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     let mut frees = Vec::with_capacity(devices.len());
     for d in devices {
         if d.arch != arch0 {
-            return Err(HipError::new(
-                0,
-                &format!(
-                    "preflight_vram: arch mismatch — dev 0 is {arch0}, dev {} is {}. \
-                     Mixed-arch is not supported in v1.",
+            if allow_mixed {
+                eprintln!(
+                    "preflight_vram: mixed-arch detected — dev 0 is {arch0}, dev {} is {}. \
+                     Proceeding because HIPFIRE_ALLOW_MIXED_ARCH=1. \
+                     Per-arch JIT cache will be populated on first run; boundary_copy uses \
+                     hipMemcpyPeer / hipMemcpyPeerAsync which fall through to host-staging \
+                     if peer access is unsupported by the pair (correctness holds either way).",
                     d.device_id, d.arch,
-                ),
-            ));
+                );
+            } else {
+                return Err(HipError::new(
+                    0,
+                    &format!(
+                        "preflight_vram: arch mismatch — dev 0 is {arch0}, dev {} is {}. \
+                         Mixed-arch is not supported by default; set HIPFIRE_ALLOW_MIXED_ARCH=1 to override.",
+                        d.device_id, d.arch,
+                    ),
+                ));
+            }
         }
         d.bind_thread()?;
         let (free, _total) = d.hip.get_vram_info()?;
         frees.push(free);
+    }
+    if !check_vram_delta {
+        return Ok(());
     }
     let max_free = *frees.iter().max().unwrap();
     let min_free = *frees.iter().min().unwrap();

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -100,8 +100,9 @@ impl Gpus {
         Self::from_parts(devices, per_device, n_layers)
     }
 
-    /// Explicit escape hatch for asymmetric VRAM / hand-tuned splits. Same
-    /// pre-flight checks as `init_uniform`. `per_device` length determines
+    /// Explicit escape hatch for asymmetric VRAM / hand-tuned splits.
+    /// Keeps arch-mismatch and per-device bind/free pre-flight checks, but
+    /// skips the uniform VRAM-delta gate. `per_device` length determines
     /// `n_devices`; sum determines `n_layers`.
     pub fn init_layers(per_device: &[usize]) -> HipResult<Self> {
         let n_devices = per_device.len();

--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -90,9 +90,17 @@ impl KernelCompiler {
         // thrashed each other's hash sidecars. $CWD isolation fixes that.
         // End-user / CI can pin the old location back via
         // HIPFIRE_KERNEL_CACHE=/tmp/hipfire_kernels if tmpfs speed matters.
-        let cache_dir = std::env::var_os("HIPFIRE_KERNEL_CACHE")
+        // Per-arch keying matters for hetero (gfx906 + gfx1031 in one process):
+        // without it, both arches would race for the same `{name}.hsaco` path,
+        // surviving correctness via the source+arch hash check but thrashing
+        // recompiles every cross-arch interleaving. Path layout matches the
+        // pre-compiled `kernels/compiled/{arch}/` install dir + the already-
+        // documented `.hipfire_kernels/{arch}/{name}.hsaco` shape in
+        // docs/perf-checkpoints/2026-05-04-gfx906-mmq-junroll.md.
+        let cache_root = std::env::var_os("HIPFIRE_KERNEL_CACHE")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(".hipfire_kernels"));
+        let cache_dir = cache_root.join(arch);
         std::fs::create_dir_all(&cache_dir).map_err(|e| {
             hip_bridge::HipError::new(0, &format!("failed to create cache dir: {e}"))
         })?;
@@ -119,7 +127,8 @@ impl KernelCompiler {
         // (or with stale hash) to avoid churn when both locations agree.
         // `hipfire update` wipes BOTH /tmp and the install dir, so after an
         // update + restart we get a fully-fresh re-seed.
-        let hot_dir = cache_dir.join(arch);
+        // cache_dir is already arch-keyed; the hot dir IS the cache dir.
+        let hot_dir = cache_dir.clone();
         if let Some(ref cold) = precompiled_dir {
             if let Err(e) = seed_hot_from_cold(cold, &hot_dir) {
                 eprintln!("  hot-path seed failed ({e}) — falling back to install dir reads");

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -103,7 +103,7 @@ Categories are best-effort, derived from naming + source location. See the categ
 | `HIPFIRE_HAVE_2_GPU` | MULTI-GPU | "" (set to "1" to enable) | `crates/hipfire-arch-qwen35/tests/pp_parity.rs:159` |
 | `HIPFIRE_HIPCC_EXTRA_FLAGS` | MISC-USER | — | `crates/rdna-compute/src/compiler.rs:298` |
 | `HIPFIRE_HOST_TIMING` | PERF-DIAG | "" (set to "1" to enable) | `crates/hipfire-runtime/examples/dflash_spec_demo.rs:934` |
-| `HIPFIRE_KERNEL_CACHE` | MISC-USER | `.hipfire_kernels` (cwd-relative) | `crates/rdna-compute/src/compiler.rs:89` |
+| `HIPFIRE_KERNEL_CACHE` | MISC-USER | `.hipfire_kernels` (cwd-relative; per-arch subdir) | `crates/rdna-compute/src/compiler.rs:100` |
 | `HIPFIRE_KV_MODE` | KV-CACHE | — | `cli/index.ts:400` |
 | `HIPFIRE_KV_PHYSICAL_CAP` | KV-CACHE | — | `crates/hipfire-runtime/examples/daemon.rs:1211` |
 | `HIPFIRE_LLOYD_FORCE_BASELINE` | KERNEL-SELECTOR | "" (set to "1" to enable) | `crates/rdna-compute/src/kernels.rs:76` |
@@ -333,7 +333,7 @@ Miscellaneous user-facing flags.
 - `HIPFIRE_DETERMINISTIC=1` — byte-exact output mode. Disables non-deterministic optimizations.
 - `HIPFIRE_EXPERIMENTAL_BUDGET_ALERT=1` — gate the `budget_alert_at_tok` / `budget_alert_text` daemon params. Maps to `cfg.experimental_budget_alert`.
 - `HIPFIRE_HIPCC_EXTRA_FLAGS` — extra flags appended to all hipcc invocations during JIT.
-- `HIPFIRE_KERNEL_CACHE` — JIT'd `.hsaco` cache directory. Default `.hipfire_kernels` (cwd-relative). Pin to `/tmp/hipfire_kernels` for tmpfs speed; default isolates parallel worktrees/agents from clobbering each other's blobs.
+- `HIPFIRE_KERNEL_CACHE` — JIT'd `.hsaco` cache root. Default `.hipfire_kernels` (cwd-relative). Blobs land under `<root>/{arch}/` so cross-arch workflows (multiple GPUs in one process, parallel CI matrix arches) don't collide. Pin to `/tmp/hipfire_kernels` for tmpfs speed; default isolates parallel worktrees/agents from clobbering each other's blobs.
 - `HIPFIRE_ALLOW_MQ2=1`, `HIPFIRE_ALLOW_MQ2_LLOYD=1`, `HIPFIRE_ALLOW_MQ3_LLOYD=1` — opt-in research-grade quant formats during quantizer run.
 
 ### `DIAG-DUMP` (8)
@@ -541,7 +541,7 @@ grep -rE 'env::var(_os)?\("HIPFIRE_|process\.env\.HIPFIRE_' \
     | sort -u
 ```
 
-Note the `(_os)?` group — `compiler.rs:89` uses `std::env::var_os("HIPFIRE_KERNEL_CACHE")` rather than the more common `std::env::var(...)`. A regex that only matches `env::var(` will silently miss it; this was caught post-merge by Codex stop-gate review and is the reason this regex now covers both forms.
+Note the `(_os)?` group — `compiler.rs:100` uses `std::env::var_os("HIPFIRE_KERNEL_CACHE")` rather than the more common `std::env::var(...)`. A regex that only matches `env::var(` will silently miss it; this was caught post-merge by Codex stop-gate review and is the reason this regex now covers both forms.
 
 A future pass should ship `scripts/regen-env-vars-doc.sh` that mechanically rebuilds the quick-reference table while preserving the prose category guide.
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -53,6 +53,7 @@ Categories are best-effort, derived from naming + source location. See the categ
 | `HIPFIRE_ADAPTIVE_B_DOWN` | DFLASH-ADAPT | — | `crates/hipfire-runtime/examples/dflash_spec_demo.rs:981` |
 | `HIPFIRE_ADAPTIVE_B_UNSAFE` | DFLASH-ADAPT | "" (set to "1" to enable) | `crates/hipfire-runtime/examples/dflash_spec_demo.rs:444` |
 | `HIPFIRE_ADAPTIVE_B_UP` | DFLASH-ADAPT | — | `crates/hipfire-runtime/examples/dflash_spec_demo.rs:979` |
+| `HIPFIRE_ALLOW_MIXED_ARCH` | MULTI-GPU | "" (set to "1" or "true" to enable) | `crates/hipfire-runtime/src/multi_gpu.rs:395` |
 | `HIPFIRE_ALLOW_MQ2` | MISC-USER | "" (set to "1" to enable) | `crates/hipfire-quantize/src/main.rs:2106` |
 | `HIPFIRE_ALLOW_MQ2_LLOYD` | MISC-USER | "" (set to "1" to enable) | `crates/hipfire-quantize/src/main.rs:2141` |
 | `HIPFIRE_ALLOW_MQ3_LLOYD` | MISC-USER | "" (set to "1" to enable) | `crates/hipfire-quantize/src/main.rs:2126` |
@@ -218,16 +219,17 @@ Hot-path kernel choice levers. **All silent today.** Power users who tune for sp
 - `HIPFIRE_ROCBLAS_ALL_ARCHS`, `HIPFIRE_ROCBLAS_MIN_BATCH`, `HIPFIRE_ROCBLAS_OFF` — rocBLAS dispatch gates.
 - `HIPFIRE_WO_MMQ`, `HIPFIRE_WO_WMMA_VARIANT` — workaround flags for specific arch quirks.
 
-### `MULTI-GPU` (6)
+### `MULTI-GPU` (7)
 
 Pipeline-parallel and multi-device orchestration. Tied to `crates/hipfire-runtime/src/multi_gpu.rs` + Stage 7 of issue #58.
 
+- `HIPFIRE_ALLOW_MIXED_ARCH=1` — opt into mixed-architecture device pairs after the default arch-mismatch guard.
 - `HIPFIRE_DEVICES` — explicit device selection (alternate to `ROCR_VISIBLE_DEVICES`).
 - `HIPFIRE_PP_LAYERS="a,b,..."` — explicit asymmetric layer split (PR #190).
 - `HIPFIRE_PP_PFLASH=1` — opt into experimental PFlash + pp>1 compose (PR #190).
 - `HIPFIRE_HAVE_2_GPU=1` — pp_parity test gate; required for the 2-GPU parity battery.
 - `HIPFIRE_PP_PARITY_MODEL` — model path override for the pp_parity test.
-- `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB` — VRAM-tolerance threshold above which mixed-arch warning fires under `HIPFIRE_ALLOW_MIXED_ARCH=1`.
+- `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB` — free-VRAM delta tolerance for `init_uniform`; `init_layers` skips this gate.
 
 ### `PFLASH` (13)
 

--- a/docs/multi-gpu-bringup-lessons.md
+++ b/docs/multi-gpu-bringup-lessons.md
@@ -1,0 +1,243 @@
+# Multi-GPU bring-up lessons (dev log)
+
+Captures non-obvious gotchas and root-causes from bringing up hetero
+PP=2 across a cross-arch AMD pair (gfx906 MI50 CDNA1 + gfx1031 RX 6700 XT
+RDNA2). Companion to the operational `docs/multi-gpu.md` — that one
+covers what PP gives you and how to deploy it; this one covers what
+broke and why during bring-up.
+
+Audience: anyone wiring up a new multi-GPU configuration in hipfire,
+especially one that mixes architectures or includes a previously
+untested device.
+
+## 1. Per-arch JIT kernel cache
+
+**Lesson:** the runtime JIT cache MUST be per-arch keyed at the cache
+directory level, not just per kernel-source-hash.
+
+**What we found:** before this branch, `compiler.rs` keyed
+pre-compiled blobs under `.hipfire_kernels/{arch}/` (correct) but
+wrote runtime-JIT'd blobs to the **flat** `.hipfire_kernels/*.hsaco`
+root. Single-arch users were unaffected — the source+arch hash check
+on read would force a recompile when the blob was from a different
+arch. But:
+
+- **Cross-arch in one process** (hetero spec-decode prototyping):
+  drafter on arch_A and target on arch_B race for the same flat path.
+  Each `ensure_kernel` for shared kernel names overwrites the other's
+  binary. The hash invalidates the freshly-compiled one on the next
+  read, triggering ping-pong recompiles.
+- **Parallel cross-arch workflows on the same machine** (CI matrix
+  with multiple `--offload-arch` targets, or developer running tests
+  on dev box with two cards): same pathological collisions in the
+  flat layout.
+
+**Fix shape:** `cache_dir = base.join(arch)` at the `KernelCompiler`
+constructor. Reads + writes both land under `.hipfire_kernels/{arch}/`,
+matching the pre-compiled install-blob layout. The hot-path seeding
+helper already knew about per-arch dirs; only the runtime-compile
+writeback was wrong.
+
+**Side effect for existing single-arch users:** stale blobs at the
+flat root get ignored. On first run after the fix they're re-JIT'd
+under `{arch}/` (~10s of warmup). Can be cleaned up with
+`find .hipfire_kernels -maxdepth 1 -type f -delete` if desired.
+
+## 2. `Gpus::init_layers` is the asymmetric-VRAM escape hatch — let it act like one
+
+**Lesson:** when a function's docstring says "explicit escape hatch
+for asymmetric VRAM / hand-tuned splits," the function should not
+re-apply a uniform-VRAM tolerance check.
+
+**What we found:** `init_layers` shares its pre-flight with
+`init_uniform`. That pre-flight enforces a 2 GiB free-VRAM delta
+across devices (`HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB`). Reasonable for
+`init_uniform` (where the caller is implicitly saying "treat both
+cards equally"). Wrong for `init_layers` where the caller has just
+hand-typed `HIPFIRE_PP_LAYERS=24,8` to declare asymmetric intent.
+
+A 32 GB MI50 + 12 GB 6700 XT pair has a 20 GB free-VRAM delta after
+target load — far over the 2 GiB tolerance. The caller already split
+the layers in a way that respects the asymmetry; the gate fires
+anyway and refuses the load.
+
+**Fix shape:** split `preflight_vram` into a `preflight_vram_with_opts(check_vram_delta: bool)`
+so `init_uniform` can request the delta check and `init_layers` can
+skip it. The arch-mismatch and per-device bind/free probe still run
+on both paths.
+
+## 3. `HIPFIRE_ALLOW_MIXED_ARCH=1` was documented but never wired
+
+**Lesson:** when a PRD claims an env var is shipped, audit the actual
+code path before relying on it.
+
+**What we found:** `docs/env-vars.md:230` references `HIPFIRE_ALLOW_MIXED_ARCH`
+as a tunable. `docs/plans/hetero-pflash-dflash.prd:138-148` claims
+the env was wired into the arch-mismatch path. But `preflight_vram`
+hard-errored unconditionally on any arch mismatch — the env-var
+parsing didn't exist.
+
+**Fix shape:** read the env in `preflight_vram_with_opts`, downgrade
+from hard-error to `eprintln!` warning when set. The default
+behavior is preserved (still rejects mismatched arches), but the
+opt-in path actually works now.
+
+## 4. AMD-AMD peer access works across mixed arches (don't assume otherwise)
+
+**Lesson:** test peer access empirically on your specific pair; folklore
+"peer access only works between same-arch cards" is wrong on AMD ROCm
+6.4+ for pairs that share a PCIe root.
+
+**What we found:** gfx906 (CDNA1) + gfx1031 (RDNA2), both on the same
+AMD Starship root complex, support full bidirectional peer access:
+
+- `hipDeviceCanAccessPeer(0, 1) = 1` and reverse.
+- `hipDeviceEnablePeerAccess` succeeds in both directions (returns
+  `hipSuccess`).
+- `hipMemcpyPeer` between them correctness-passes on a 4 MiB
+  round-trip; cross-card peer reads inside a kernel also work
+  (PR #204 leveraged this to have drafter-bound kernels read target's
+  `token_embd` directly).
+
+The constraint is **same PCIe root + AMD-AMD**, not same-arch. eGPU
+enclosures (Thunderbolt / OCuLink) are the configuration where peer
+access typically fails; direct slot-mounted AMD pairs typically don't.
+
+**Practical impact:** the hetero spec-decode work in PR #204 used
+peer-access cross-card memory reads inside drafter-bound kernels
+(target's `token_embd` is target-resident, but the drafter-side
+embedding lookup kernel reads it directly via peer mapping). This
+avoids host-bounce D2H/H2D entirely. Plan for the optimistic path.
+
+## 5. `Gpu::bind_thread()` keeps a thread-local cache; `hip.set_device()` bypasses it
+
+**Lesson:** never call `gpu.hip.set_device(id)` directly when working
+with multiple `Gpu` instances. Always go through `Gpu::bind_thread()`.
+
+**What we found:** `bind_thread()` (dispatch.rs:846) keeps a
+`LAST_BOUND_DEVICE` thread-local and skips a redundant HIP `set_device`
+call when the device is already current. `hip.set_device(id)` calls
+the FFI directly **without updating** that thread-local.
+
+If a code path does `gpu_a.hip.set_device(a.device_id)` followed
+later by `gpu_b.bind_thread()`, the thread-local says "current is a",
+so the bind_thread skips its set_device call — but the HIP runtime
+state is whatever the last raw `set_device` left it as. Kernel
+launches on whichever Gpu thinks it's bound silently target the
+wrong device.
+
+Symptoms we saw: `hipModuleLaunchKernel: invalid device ordinal`
+(error 101) from the first kernel after a multi-Gpu init sequence.
+Investigation initially blamed stream-device binding (we worked
+around it with stream destroy+recreate), but the actual root cause
+was the bind-cache desync. Replacing raw `set_device` calls with
+`bind_thread` removed the workaround entirely.
+
+**Practical guidance:**
+- In application code: always use `gpu.bind_thread()?` to switch
+  device. Treat `hip.set_device` as a low-level primitive that
+  should only be called from inside the `bind_thread` implementation.
+- For multi-Gpu setup sequences (peer-access enable, model load,
+  etc.) explicitly `bind_thread` each Gpu before calling functions
+  that operate on it.
+
+## 6. HIP streams are bound to the device that was current when they were created
+
+**Lesson:** `hipStreamCreate` reads the currently-bound device and
+attaches the new stream to it. Creating a stream while bound to the
+wrong device produces a "stream" that launches kernels onto a
+different device than your application expects.
+
+**What we saw:** during a multi-Gpu spec-decode bring-up, both Gpus
+needed their own `active_stream`. The naive sequence
+`gpu_t.active_stream = Some(gpu_t.hip.stream_create()?); gpu_d.active_stream = Some(gpu_d.hip.stream_create()?);`
+created one stream bound to whatever device happened to be current
+at the moment. Later kernel launches on the "wrong" stream failed
+with the same "invalid device ordinal" error.
+
+**Fix shape:** `bind_thread()` immediately before every
+`stream_create()` so the new stream is attached to its owning Gpu's
+device. The `Gpu::ensure_draft_stream()` helper on this branch does
+this explicitly; copy the pattern for any future secondary streams.
+
+## 7. `hipDeviceEnablePeerAccess` direction matters — bind the source device first
+
+**Lesson:** the peer-access API takes a peer device id but operates
+on the **currently-bound** device. Forgetting to bind first registers
+self→peer instead of source→peer (or vice versa).
+
+**What we saw:** PR #204's PR3 step 2 commit message documents this:
+the prior code called `gpu_target.hip.enable_peer_access(drafter_dev_id)`
+from a thread that was actually bound to the drafter (post-`init_with_device`
+left the drafter bound). This silently registered drafter→drafter peer
+access (a no-op) instead of target→drafter. Errors weren't surfaced —
+just nothing happened, and downstream peer-copy attempts went through
+host-staging fallback.
+
+**Fix shape:** explicit `bind_thread` of the SOURCE device before each
+`enable_peer_access(peer_device_id)` call. Validate the return
+code (don't `let _ = ...` errors). Recipe for enabling bidirectional
+peer access between gpu_a and gpu_b:
+```rust
+gpu_a.bind_thread()?;
+gpu_a.hip.enable_peer_access(gpu_b.device_id)?;
+gpu_b.bind_thread()?;
+gpu_b.hip.enable_peer_access(gpu_a.device_id)?;
+gpu_a.bind_thread()?;  // restore application's "current" device convention
+```
+
+## 8. Long-context spec-decode is verify-bound; AR wins past a cliff
+
+**Lesson:** spec-decode's per-cycle batched verify cost grows with KV
+size; τ (mean acceptance length) tends to collapse at long context;
+combined effect is that pure autoregressive decode beats spec-decode
+past some context-length threshold. The crossover sits at very
+different context lengths for different architectures.
+
+**What we observed:** on 27B-3.6 dflash drafter + 27B-3.6 target at
+short context (~240 tokens), spec-decode delivers τ=8.14 and a
+~10× tok/s gain over pure AR. At 13K context: τ collapses to 1.6,
+verify cycle wall balloons, and AR (3.76 tok/s) beats spec-decode
+(1.85 tok/s solo or 1.65 hetero). PR #204 saw the same proportional
+pattern on faster gfx1100 hardware (45.4 tok/s AR vs 33 tok/s
+hetero dflash at 16K).
+
+**Practical impact:** don't assume spec-decode is strictly faster than
+AR. Bench both at the context lengths your workload actually uses.
+Multi-GPU spec-decode pipelining cannot fix the long-context cliff —
+the overlap saves `min(draft, verify)` which is dominated by the
+small drafter, not the huge verify wall.
+
+## 9. The `Command::terminate()` stack overflow at long contexts
+
+**Lesson:** AMD HIP 6.4 accumulates an internal command-chain when
+many small async memcpys queue without intervening syncs. The chain
+releases recursively, which blows the host thread stack at >~50K
+queued commands.
+
+**Source:** PR #204 commit message for `c0983236` (May 9 2026).
+50K commands ≈ 10K rows × 5 extract layers worth of
+`scatter_hidden_block_to_interleaved` memcpys. The recursive release
+chain (`Command::terminate → ReferenceCountedObject::release →
+Command::releaseResources → terminate`) blows the 8 MB main-thread
+stack on the FIRST kernel launch following the unbounded queueing.
+
+**Fix shape (per PR #204):** periodic `device_synchronize()` inside
+the scatter loop (every 1024 rows) to drain the command chain.
+Trailing drain conditional on `n_rows % CHAIN_DRAIN_INTERVAL != 0`
+so short-prompt cycles don't pay an extra sync.
+
+Not currently a problem on master because `scatter_hidden_block_to_interleaved`
+is only invoked in the spec-decode path where B ≤ 16; long-prompt
+contexts that hit this issue specifically require the cross-card
+hetero scatter pattern PR #204 was prototyping. **If you build
+out any new code path that does N×M cross-card or same-card memcpys
+in a loop without a sync, budget a periodic device_synchronize from
+day one.**
+
+## See also
+
+- `docs/multi-gpu.md` — operational guide (memory budgets, deployment recipes, throughput).
+- `docs/plans/hetero-pflash-dflash.prd` — the hetero PFlash+DFlash architectural plan.
+- `docs/plans/path_d.md` — same-card spec-decode pipelining design (closed without merge after empirical dominated by chain-mode; preserved for future revival).
+- PR #204 (closed) — full hetero spec-decode prototype with the bind_thread pattern, long-context findings, and the pivot to native MTP as the actual perf lever.


### PR DESCRIPTION
## Summary

Three small bug fixes + a multi-GPU dev log, validated by a hetero
PP=2 bring-up across a cross-arch AMD pair (gfx906 MI50 CDNA1 + gfx1031
RX 6700 XT RDNA2). All three fixes are doc-vs-code-reality bugs: the
existing public API and existing documentation already assume these
behaviors. This PR makes the code match.

**290 LOC, single commit, all behind opt-in env vars / function
selection — no default behavior changes.**

## What broke before

Three unrelated paths conspired to make hetero PP=2 unusable on
mixed-arch AMD pairs:

1. **`HIPFIRE_ALLOW_MIXED_ARCH=1` was documented but never wired.**
   `docs/env-vars.md:230` lists it; `docs/plans/hetero-pflash-dflash.prd:138-148`
   claims it was shipped. But `preflight_vram` hard-errored
   unconditionally on any arch mismatch — the env-var read didn't
   exist.

2. **Runtime JIT cache wrote to a flat path.** Pre-compiled blobs
   correctly used `.hipfire_kernels/{arch}/`. Runtime-JIT'd blobs went
   to the flat `.hipfire_kernels/*.hsaco` root. Single-arch users
   weren't affected (source+arch hash check forces recompile on
   mismatch), but anyone running cross-arch in one process — or
   parallel hipfire processes across CI matrix arches — got
   pathological ping-pong recompiles.

3. **`Gpus::init_layers` rejected its own documented use case.** Its
   docstring calls it "the explicit escape hatch for asymmetric
   VRAM / hand-tuned splits." But the shared pre-flight enforced a
   2 GiB free-VRAM delta — a sensible gate for `init_uniform`, wrong
   for `init_layers` where the caller has already declared
   asymmetric intent. A 32 GB MI50 + 12 GB 6700 XT pair was rejected
   despite the operator having hand-typed `HIPFIRE_PP_LAYERS=24,8`.

## The fix

All in one commit (squashed for review readability). 21+/7- LOC in
the env-gate, 22+/5- LOC across the cache and init_layers fixes, plus
~245 LOC of dev log.

| change | scope | risk |
|---|---|---|
| HIPFIRE_ALLOW_MIXED_ARCH env-gate | `multi_gpu.rs::preflight_vram` | opt-in via env, default unchanged |
| Per-arch JIT cache | `compiler.rs::KernelCompiler::new` | stale flat-root blobs ignored, re-JIT on first run (~10s warmup, no correctness) |
| init_layers VRAM bypass | `multi_gpu.rs::preflight_vram_with_opts(check_vram_delta: bool)` | init_uniform passes true (prior behavior); only init_layers path loosens |
| `docs/env-vars.md` update | minor | doc clarifies `HIPFIRE_KERNEL_CACHE` is the cache root with per-arch subdirs |
| `docs/multi-gpu-bringup-lessons.md` | new file | doc-only |

## Migration note for existing users

This PR changes where JIT'd `.hsaco` blobs live on disk:

- **Before:** `.hipfire_kernels/{name}.hsaco` (flat root)
- **After:** `.hipfire_kernels/{arch}/{name}.hsaco`

The change is transparent to running code (per-arch reads + writes
go to the new path). The only user-visible effect is that pre-existing
flat-root blobs become orphaned — they will not be read again and the
runtime won't delete them automatically. On first run after upgrade,
you'll see a one-time JIT recompile pass (~10s warmup, same as a
fresh checkout) which populates the new layout. To reclaim disk:

```bash
find .hipfire_kernels -maxdepth 1 -type f -delete
```

`HIPFIRE_KERNEL_CACHE` users (typically pinning to a tmpfs path) see
the same one-time re-JIT after upgrade.

## Validation

- `cargo check -p hipfire-runtime -p rdna-compute` clean.
- `cargo build --release -p hipfire-runtime --example pp_parity_chatml --example dflash_spec_demo --example daemon` clean.
- At default (env vars unset): byte-for-byte unchanged. `init_uniform`
  still applies the 2 GiB delta gate; `preflight_vram` rejects
  mismatched arches.
- Hetero PP=2 on gfx906 + gfx1031 with `HIPFIRE_ALLOW_MIXED_ARCH=1 HIPFIRE_PP_LAYERS="24,8"`:
  bit-identical first-token output vs solo gfx906 at temp=0 across
  all tested splits (16/16, 24/8, 28/4, 20/12). Decode tok/s within
  2-7% of solo. See `docs/multi-gpu-bringup-lessons.md` for the
  bring-up narrative.
- Post-push smoke (after a system reboot that exercised the cold-cache
  path): solo gfx906 9B mq4 decode 56.8 tok/s; hetero PP=2 24/8 decode
  51.4 tok/s (90% of solo); per-arch cache layout verified
  (`.hipfire_kernels/gfx906/` + `.hipfire_kernels/gfx1031/`, 0 blobs
  at flat root); all four state machines (default / env-only /
  env+uniform / env+asym) behave as designed.

## What's NOT in this PR

This branch builds on a longer hetero spec-decode prototype that we
ran for a few days. Most of that work doesn't belong upstream yet:

- **No hetero spec-decode plumbing.** We prototyped a `drafter_gpu:
  Option<&mut Gpu>` path through `spec_step_dflash` similar to PR #204.
  Empirical finding (matching PR #204's closure rationale): hetero
  dflash at long context (13K+) falls below solo AR on both the
  gfx906/gfx1031 pair we tested AND the gfx1100 hardware PR #204 used.
  Pipelining doesn't fix the underlying issue (verify-dominated cycle
  wall + τ collapse at long context). Holding the dflash plumbing for
  a separate revival when the perf case actually closes (per PR #204's
  recommendation, that's likely native MTP, not more spec-decode
  plumbing).

- **No `bind_thread` vs `set_device` cache-coherence fix.** That fix
  is real and we shipped it, but the symptom only surfaces with two
  `Gpu` instances simultaneously — irrelevant to anything currently on
  master. Documented in the dev log as gotcha #5; ship it when there's
  an upstream caller.

## Dev log

`docs/multi-gpu-bringup-lessons.md` (new) — investigation-focused
companion to the existing operational `docs/multi-gpu.md`. Covers nine
gotchas: per-arch cache rationale, `init_layers` semantics, AMD-AMD
peer access across mixed arches, `bind_thread` vs `set_device` cache
desync, `hipStreamCreate` device-binding gotcha,
`hipDeviceEnablePeerAccess` direction footgun, the long-context
spec-decode cliff, and AMD HIP's recursive command-chain stack
overflow. References PR #204's `Command::terminate()` finding.

## Test plan

- [x] `cargo check --workspace` clean
- [x] Hetero PP=2 AR end-to-end on gfx906 + gfx1031 (bit-identical to
      solo at temp=0, 2-7% slower depending on split)
- [x] Default behavior preserved (init_uniform still gates VRAM delta;
      preflight still rejects mismatched arches without the env)
- [x] Four-state-machine smoke (default-reject, env+uniform-VRAM-gate,
      env+asym-loads, warm hetero matches Phase A baseline)
- [x] Per-arch cache layout verified after cold-cache reboot path
- [ ] Second-reviewer validation on a same-arch PP=2 pair (e.g. 2× RX 7900 XTX)
      — pp-gate.sh battery would be the natural fit
