### PR TITLE
perf(gfx1151): MQ4-Lloyd K4 prefill kernels (non-mb4 + mb4)

### DIFF
--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -107,6 +107,14 @@ pub const GEMM_QKVZA_MQ4G256_LLOYD_WMMA_MB4_SRC: &str = include_str!("../../../k
 pub const GEMM_QKV_MQ4G256_LLOYD_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq4g256_lloyd_wmma_mb4.hip");
 pub const GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq4g256_lloyd_wmma_mb4.hip");
 
+/// gfx1151 (Strix Halo) K4 variants of the Phase D-B mb4 family.
+/// K4 unroll front-loads 8 nibble-pack reads per inner iteration (vs K2's 4)
+/// to better hide LPDDR5x unified-memory latency on the APU.
+pub const GEMM_MQ4G256_LLOYD_RESIDUAL_WMMA_MB4_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip");
+pub const GEMM_QKVZA_MQ4G256_LLOYD_WMMA_MB4_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq4g256_lloyd_wmma_mb4.gfx1151.hip");
+pub const GEMM_QKV_MQ4G256_LLOYD_WMMA_MB4_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq4g256_lloyd_wmma_mb4.gfx1151.hip");
+pub const GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_MB4_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq4g256_lloyd_wmma_mb4.gfx1151.hip");
+
 /// Returns the MQ4G256Lloyd WMMA residual GEMM kernel source AND module name for
 /// the given arch.
 ///
@@ -144,7 +152,9 @@ pub fn gemm_mq4g256_lloyd_residual_wmma_for_arch(arch: &str) -> (&'static str, &
 /// the kernel's tile shape is gfx11/wave32 specific.
 pub fn gemm_mq4g256_lloyd_residual_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
     match arch {
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_MQ4G256_LLOYD_RESIDUAL_WMMA_MB4_GFX1151_SRC, "gemm_mq4g256_lloyd_residual_wmma_mb4_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_MQ4G256_LLOYD_RESIDUAL_WMMA_MB4_SRC, "gemm_mq4g256_lloyd_residual_wmma_mb4_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA mb4 residual: unsupported arch {arch}. Phase D-A is gfx11-only; \
@@ -206,7 +216,9 @@ pub fn gemm_mq4g256_lloyd_residual_wmma_mb2_for_arch(arch: &str) -> (&'static st
 /// `_mb4` selector (gfx11 only — gfx12 sibling deferred per Phase D plan).
 pub fn gemm_qkvza_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
     match arch {
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_QKVZA_MQ4G256_LLOYD_WMMA_MB4_GFX1151_SRC, "gemm_qkvza_mq4g256_lloyd_wmma_mb4_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_QKVZA_MQ4G256_LLOYD_WMMA_MB4_SRC, "gemm_qkvza_mq4g256_lloyd_wmma_mb4_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA mb4 qkvza: unsupported arch {arch}. Phase D-B is gfx11-only."
@@ -215,7 +227,9 @@ pub fn gemm_qkvza_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, 
 }
 pub fn gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
     match arch {
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_QKV_MQ4G256_LLOYD_WMMA_MB4_GFX1151_SRC, "gemm_qkv_mq4g256_lloyd_wmma_mb4_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_QKV_MQ4G256_LLOYD_WMMA_MB4_SRC, "gemm_qkv_mq4g256_lloyd_wmma_mb4_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA mb4 qkv: unsupported arch {arch}. Phase D-B is gfx11-only."
@@ -224,7 +238,9 @@ pub fn gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'
 }
 pub fn gemm_gate_up_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
     match arch {
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_MB4_GFX1151_SRC, "gemm_gate_up_mq4g256_lloyd_wmma_mb4_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_MB4_SRC, "gemm_gate_up_mq4g256_lloyd_wmma_mb4_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA mb4 gate_up: unsupported arch {arch}. Phase D-B is gfx11-only."

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -93,12 +93,15 @@ pub const GEMM_MQ4G256_LLOYD_RESIDUAL_WMMA_MB2_SRC: &str = include_str!("../../.
 /// MQ4G256Lloyd WMMA fused QKVZA (LA preamble: qkv + z + beta + alpha, 4-way).
 pub const GEMM_QKVZA_MQ4G256_LLOYD_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq4g256_lloyd_wmma.hip");
 pub const GEMM_QKVZA_MQ4G256_LLOYD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq4g256_lloyd_wmma.gfx12.hip");
+pub const GEMM_QKVZA_MQ4G256_LLOYD_WMMA_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_qkvza_mq4g256_lloyd_wmma.gfx1151.hip");
 /// MQ4G256Lloyd WMMA fused QKV (FA preamble: q + k + v, 3-way).
 pub const GEMM_QKV_MQ4G256_LLOYD_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq4g256_lloyd_wmma.hip");
 pub const GEMM_QKV_MQ4G256_LLOYD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq4g256_lloyd_wmma.gfx12.hip");
+pub const GEMM_QKV_MQ4G256_LLOYD_WMMA_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_qkv_mq4g256_lloyd_wmma.gfx1151.hip");
 /// MQ4G256Lloyd WMMA fused gate+up (FFN, 2-way).
 pub const GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq4g256_lloyd_wmma.hip");
 pub const GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq4g256_lloyd_wmma.gfx12.hip");
+pub const GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_GFX1151_SRC: &str = include_str!("../../../kernels/src/gemm_gate_up_mq4g256_lloyd_wmma.gfx1151.hip");
 
 /// Phase D-B: 16×64 output tile per WG (4 batch sub-tiles share A_reg decode).
 /// Same shape as `_wmma`; only the per-WG output fanout and grid differ.
@@ -167,7 +170,9 @@ pub fn gemm_qkvza_mq4g256_lloyd_wmma_for_arch(arch: &str) -> (&'static str, &'st
     match arch {
         "gfx1200" | "gfx1201" =>
             (GEMM_QKVZA_MQ4G256_LLOYD_WMMA_GFX12_SRC, "gemm_qkvza_mq4g256_lloyd_wmma_rdna4"),
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_QKVZA_MQ4G256_LLOYD_WMMA_GFX1151_SRC, "gemm_qkvza_mq4g256_lloyd_wmma_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_QKVZA_MQ4G256_LLOYD_WMMA_SRC, "gemm_qkvza_mq4g256_lloyd_wmma_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA qkvza: unsupported arch {arch}. The is_batchable_la upstream gate \
@@ -180,7 +185,9 @@ pub fn gemm_qkv_mq4g256_lloyd_wmma_for_arch(arch: &str) -> (&'static str, &'stat
     match arch {
         "gfx1200" | "gfx1201" =>
             (GEMM_QKV_MQ4G256_LLOYD_WMMA_GFX12_SRC, "gemm_qkv_mq4g256_lloyd_wmma_rdna4"),
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_QKV_MQ4G256_LLOYD_WMMA_GFX1151_SRC, "gemm_qkv_mq4g256_lloyd_wmma_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_QKV_MQ4G256_LLOYD_WMMA_SRC, "gemm_qkv_mq4g256_lloyd_wmma_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA qkv: unsupported arch {arch}. The is_batchable_la upstream gate \
@@ -193,7 +200,9 @@ pub fn gemm_gate_up_mq4g256_lloyd_wmma_for_arch(arch: &str) -> (&'static str, &'
     match arch {
         "gfx1200" | "gfx1201" =>
             (GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_GFX12_SRC, "gemm_gate_up_mq4g256_lloyd_wmma_rdna4"),
-        "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
+        "gfx1151" =>
+            (GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_GFX1151_SRC, "gemm_gate_up_mq4g256_lloyd_wmma_k4_gfx1151"),
+        "gfx1100" | "gfx1101" | "gfx1102" =>
             (GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_SRC, "gemm_gate_up_mq4g256_lloyd_wmma_rdna3"),
         _ => panic!(
             "MQ4-Lloyd WMMA gate_up: unsupported arch {arch}. The is_batchable_la upstream gate \

--- a/kernels/src/gemm_gate_up_mq4g256_lloyd_wmma.gfx1151.hip
+++ b/kernels/src/gemm_gate_up_mq4g256_lloyd_wmma.gfx1151.hip
@@ -1,0 +1,158 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA fused gate+up GEMM — gfx1151 K4 variant.
+// K4 unroll: front-loads all 8 nibble-pack reads per inner iteration to hide
+// LPDDR5x latency before dependent DQ/LDS lookups.
+// Grid: [ceil((gate_m+up_m)/16), ceil(N/16)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_mq4g256_lloyd_wmma(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate; local_row = safe_row;
+    } else {
+        A = A_up;   local_row = safe_row - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + my_tile_row < N) ? (batch_start + my_tile_row) : 0;
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < gate_m) {
+        load_A = A_gate; load_local_row = load_safe_row;
+    } else {
+        load_A = A_up;   load_local_row = load_safe_row - gate_m;
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const unsigned char* dp = (const unsigned char*)(gp + 32);
+        const int cb_base = my_tile_row * 16;
+        const _Float16* xg = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b_a = *(const half16_t*)(xg + kt * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b_b = *(const half16_t*)(xg + (kt + 1) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b_c = *(const half16_t*)(xg + (kt + 2) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_c, acc);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b_d = *(const half16_t*)(xg + (kt + 3) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_d, acc);
+        }
+        __syncthreads();
+    }
+
+    const int out_col = batch_start + my_tile_row;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < gate_m) {
+                    Y = Y_gate; proj_row = out_row;            out_stride = gate_m;
+                } else {
+                    Y = Y_up;   proj_row = out_row - gate_m;   out_stride = up_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}
+
+#else
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_mq4g256_lloyd_wmma(
+    const char*, const char*, const _Float16*, float*, float*,
+    int, int, int, int) {}
+
+#endif

--- a/kernels/src/gemm_gate_up_mq4g256_lloyd_wmma_mb4.gfx1151.hip
+++ b/kernels/src/gemm_gate_up_mq4g256_lloyd_wmma_mb4.gfx1151.hip
@@ -1,0 +1,200 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA fused gate+up GEMM, 4× batch-tile fanout — gfx1151 K4 variant.
+// K4 unroll: front-loads all 8 nibble-pack reads per inner iteration.
+// See gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip for rationale.
+// Grid: [ceil((gate_m+up_m)/16), ceil(N/64)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_mq4g256_lloyd_wmma_mb4(
+    const char*    __restrict__ A_gate,
+    const char*    __restrict__ A_up,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_gate,
+    float*         __restrict__ Y_up,
+    int gate_m, int up_m,
+    int K, int N
+) {
+    const int total_m = gate_m + up_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < gate_m) {
+        A = A_gate; local_row = safe_row;
+    } else {
+        A = A_up;   local_row = safe_row - gate_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + local_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < gate_m) {
+        load_A = A_gate; load_local_row = load_safe_row;
+    } else {
+        load_A = A_up;   load_local_row = load_safe_row - gate_m;
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const unsigned char* dp = (const unsigned char*)(gp + 32);
+        const int cb_base = my_tile_row * 16;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b0a = *(const half16_t*)(xg_s[0] + kt * 16);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + kt * 16);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + kt * 16);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + kt * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b0b = *(const half16_t*)(xg_s[0] + (kt + 1) * 16);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + (kt + 1) * 16);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + (kt + 1) * 16);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + (kt + 1) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b0c = *(const half16_t*)(xg_s[0] + (kt + 2) * 16);
+            half16_t b1c = *(const half16_t*)(xg_s[1] + (kt + 2) * 16);
+            half16_t b2c = *(const half16_t*)(xg_s[2] + (kt + 2) * 16);
+            half16_t b3c = *(const half16_t*)(xg_s[3] + (kt + 2) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0c, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1c, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2c, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3c, acc[3]);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b0d = *(const half16_t*)(xg_s[0] + (kt + 3) * 16);
+            half16_t b1d = *(const half16_t*)(xg_s[1] + (kt + 3) * 16);
+            half16_t b2d = *(const half16_t*)(xg_s[2] + (kt + 3) * 16);
+            half16_t b3d = *(const half16_t*)(xg_s[3] + (kt + 3) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0d, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1d, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2d, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3d, acc[3]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < gate_m) {
+                        Y = Y_gate; proj_row = out_row;            out_stride = gate_m;
+                    } else {
+                        Y = Y_up;   proj_row = out_row - gate_m;   out_stride = up_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}
+
+#else
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_gate_up_mq4g256_lloyd_wmma_mb4(
+    const char*, const char*, const _Float16*, float*, float*,
+    int, int, int, int) {}
+
+#endif

--- a/kernels/src/gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip
+++ b/kernels/src/gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip
@@ -1,0 +1,182 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA residual GEMM, 4× batch-tile fanout — gfx1151 K4 variant.
+//
+// K4 unroll: 4 K-tiles (64 elements) per inner loop iteration vs the generic
+// kernel's K2 (32 elements). Front-loads all 8 nibble-pack reads before any DQ
+// or WMMA, giving the memory subsystem (LPDDR5x unified on Strix Halo) a wider
+// window to prefetch per-row weight data before it's needed.
+//
+// All other structure identical to gemm_mq4g256_lloyd_residual_wmma_mb4.hip:
+// 16×64 output tile, 4 batch sub-tiles, cooperative codebook LDS load.
+// Bench: benchmarks/results/devlog_20260509_mq4_lloyd_gfx1151_bench.md
+// (K-schedule lever — "cheap to bisect, marginal; needs bench").
+//
+// Grid: [ceil(M/16), ceil(batch/64)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_mq4g256_lloyd_residual_wmma_mb4(
+    const char*    __restrict__ A,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int my_tile_row = tid & 15;
+    const int safe_row = (row_start + my_tile_row < M) ? (row_start + my_tile_row) : (M - 1);
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + safe_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < batch_size) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int safe_load_row = (row_start + load_tile_row < M) ? (row_start + load_tile_row) : (M - 1);
+    const char* load_row_base = A + (long long)safe_load_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const char* dp = gp + 32;
+        const int cb_base = my_tile_row * 16;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        // K4 unroll: 4 tiles per iteration (4 × 8 B = 32 B of nibble data).
+        // All 8 nibble-pack reads are front-loaded to overlap with preceding WMMAs.
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = (const unsigned char*)dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b0a = *(const half16_t*)(xg_s[0] + kt * 16);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + kt * 16);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + kt * 16);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + kt * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b0b = *(const half16_t*)(xg_s[0] + (kt + 1) * 16);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + (kt + 1) * 16);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + (kt + 1) * 16);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + (kt + 1) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b0c = *(const half16_t*)(xg_s[0] + (kt + 2) * 16);
+            half16_t b1c = *(const half16_t*)(xg_s[1] + (kt + 2) * 16);
+            half16_t b2c = *(const half16_t*)(xg_s[2] + (kt + 2) * 16);
+            half16_t b3c = *(const half16_t*)(xg_s[3] + (kt + 2) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0c, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1c, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2c, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3c, acc[3]);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b0d = *(const half16_t*)(xg_s[0] + (kt + 3) * 16);
+            half16_t b1d = *(const half16_t*)(xg_s[1] + (kt + 3) * 16);
+            half16_t b2d = *(const half16_t*)(xg_s[2] + (kt + 3) * 16);
+            half16_t b3d = *(const half16_t*)(xg_s[3] + (kt + 3) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0d, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1d, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2d, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3d, acc[3]);
+        }
+
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < batch_size) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                const int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < M) {
+                    Y[(long long)out_col * M + out_row] += acc[s][j];
+                }
+            }
+        }
+    }
+}
+
+#else
+
+// Stub: this kernel is gfx1151-only. Other archs route through the generic mb4 kernel.
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_mq4g256_lloyd_residual_wmma_mb4(
+    const char*, const _Float16*, float*, int, int, int) {}
+
+#endif

--- a/kernels/src/gemm_qkv_mq4g256_lloyd_wmma.gfx1151.hip
+++ b/kernels/src/gemm_qkv_mq4g256_lloyd_wmma.gfx1151.hip
@@ -1,0 +1,166 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA fused QKV GEMM — gfx1151 K4 variant.
+// K4 unroll: front-loads all 8 nibble-pack reads per inner iteration to hide
+// LPDDR5x latency before dependent DQ/LDS lookups.
+// Grid: [ceil((q_m+k_m+v_m)/16), ceil(N/16)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_mq4g256_lloyd_wmma(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_q,
+    float*         __restrict__ Y_k,
+    float*         __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + my_tile_row < N) ? (batch_start + my_tile_row) : 0;
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < q_m) {
+        load_A = A_q;  load_local_row = load_safe_row;
+    } else if (load_safe_row < q_m + k_m) {
+        load_A = A_k;  load_local_row = load_safe_row - q_m;
+    } else {
+        load_A = A_v;  load_local_row = load_safe_row - q_m - k_m;
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const unsigned char* dp = (const unsigned char*)(gp + 32);
+        const int cb_base = my_tile_row * 16;
+        const _Float16* xg = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b_a = *(const half16_t*)(xg + kt * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b_b = *(const half16_t*)(xg + (kt + 1) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b_c = *(const half16_t*)(xg + (kt + 2) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_c, acc);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b_d = *(const half16_t*)(xg + (kt + 3) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_d, acc);
+        }
+        __syncthreads();
+    }
+
+    const int out_col = batch_start + my_tile_row;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < q_m) {
+                    Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                } else if (out_row < q_m + k_m) {
+                    Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                } else {
+                    Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}
+
+#else
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_mq4g256_lloyd_wmma(
+    const char*, const char*, const char*, const _Float16*,
+    float*, float*, float*, int, int, int, int, int) {}
+
+#endif

--- a/kernels/src/gemm_qkv_mq4g256_lloyd_wmma_mb4.gfx1151.hip
+++ b/kernels/src/gemm_qkv_mq4g256_lloyd_wmma_mb4.gfx1151.hip
@@ -1,0 +1,208 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA fused QKV GEMM, 4× batch-tile fanout — gfx1151 K4 variant.
+// K4 unroll: front-loads all 8 nibble-pack reads per inner iteration.
+// See gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip for rationale.
+// Grid: [ceil((q_m+k_m+v_m)/16), ceil(N/64)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_mq4g256_lloyd_wmma_mb4(
+    const char*    __restrict__ A_q,
+    const char*    __restrict__ A_k,
+    const char*    __restrict__ A_v,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_q,
+    float*         __restrict__ Y_k,
+    float*         __restrict__ Y_v,
+    int q_m, int k_m, int v_m,
+    int K, int N
+) {
+    const int total_m = q_m + k_m + v_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < q_m) {
+        A = A_q;  local_row = safe_row;
+    } else if (safe_row < q_m + k_m) {
+        A = A_k;  local_row = safe_row - q_m;
+    } else {
+        A = A_v;  local_row = safe_row - q_m - k_m;
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + local_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < q_m) {
+        load_A = A_q;  load_local_row = load_safe_row;
+    } else if (load_safe_row < q_m + k_m) {
+        load_A = A_k;  load_local_row = load_safe_row - q_m;
+    } else {
+        load_A = A_v;  load_local_row = load_safe_row - q_m - k_m;
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const unsigned char* dp = (const unsigned char*)(gp + 32);
+        const int cb_base = my_tile_row * 16;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b0a = *(const half16_t*)(xg_s[0] + kt * 16);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + kt * 16);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + kt * 16);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + kt * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b0b = *(const half16_t*)(xg_s[0] + (kt + 1) * 16);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + (kt + 1) * 16);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + (kt + 1) * 16);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + (kt + 1) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b0c = *(const half16_t*)(xg_s[0] + (kt + 2) * 16);
+            half16_t b1c = *(const half16_t*)(xg_s[1] + (kt + 2) * 16);
+            half16_t b2c = *(const half16_t*)(xg_s[2] + (kt + 2) * 16);
+            half16_t b3c = *(const half16_t*)(xg_s[3] + (kt + 2) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0c, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1c, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2c, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3c, acc[3]);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b0d = *(const half16_t*)(xg_s[0] + (kt + 3) * 16);
+            half16_t b1d = *(const half16_t*)(xg_s[1] + (kt + 3) * 16);
+            half16_t b2d = *(const half16_t*)(xg_s[2] + (kt + 3) * 16);
+            half16_t b3d = *(const half16_t*)(xg_s[3] + (kt + 3) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0d, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1d, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2d, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3d, acc[3]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < q_m) {
+                        Y = Y_q;  proj_row = out_row;               out_stride = q_m;
+                    } else if (out_row < q_m + k_m) {
+                        Y = Y_k;  proj_row = out_row - q_m;          out_stride = k_m;
+                    } else {
+                        Y = Y_v;  proj_row = out_row - q_m - k_m;    out_stride = v_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}
+
+#else
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkv_mq4g256_lloyd_wmma_mb4(
+    const char*, const char*, const char*, const _Float16*,
+    float*, float*, float*, int, int, int, int, int) {}
+
+#endif

--- a/kernels/src/gemm_qkvza_mq4g256_lloyd_wmma.gfx1151.hip
+++ b/kernels/src/gemm_qkvza_mq4g256_lloyd_wmma.gfx1151.hip
@@ -1,0 +1,174 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA fused QKVZA GEMM — gfx1151 K4 variant.
+// K4 unroll: front-loads all 8 nibble-pack reads per inner iteration to hide
+// LPDDR5x latency before dependent DQ/LDS lookups.
+// Grid: [ceil((qkv_m+z_m+beta_m+alpha_m)/16), ceil(N/16)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_mq4g256_lloyd_wmma(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + local_row * row_stride;
+
+    const int safe_batch = (batch_start + my_tile_row < N) ? (batch_start + my_tile_row) : 0;
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < qkv_m) {
+        load_A = A_qkv;   load_local_row = load_safe_row;
+    } else if (load_safe_row < qkv_m + z_m) {
+        load_A = A_z;     load_local_row = load_safe_row - qkv_m;
+    } else if (load_safe_row < qkv_m + z_m + beta_m) {
+        load_A = A_beta;  load_local_row = load_safe_row - (qkv_m + z_m);
+    } else {
+        load_A = A_alpha; load_local_row = load_safe_row - (qkv_m + z_m + beta_m);
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const unsigned char* dp = (const unsigned char*)(gp + 32);
+        const int cb_base = my_tile_row * 16;
+        const _Float16* xg = X + (long long)safe_batch * K + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b_a = *(const half16_t*)(xg + kt * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_a, acc);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b_b = *(const half16_t*)(xg + (kt + 1) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_b, acc);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b_c = *(const half16_t*)(xg + (kt + 2) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_c, acc);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b_d = *(const half16_t*)(xg + (kt + 3) * 16);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b_d, acc);
+        }
+        __syncthreads();
+    }
+
+    const int out_col = batch_start + my_tile_row;
+    if (out_col < N) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < total_m) {
+                float* Y;
+                int proj_row;
+                int out_stride;
+                if (out_row < qkv_m) {
+                    Y = Y_qkv;   proj_row = out_row;                          out_stride = qkv_m;
+                } else if (out_row < qkv_m + z_m) {
+                    Y = Y_z;     proj_row = out_row - qkv_m;                  out_stride = z_m;
+                } else if (out_row < qkv_m + z_m + beta_m) {
+                    Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);          out_stride = beta_m;
+                } else {
+                    Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m); out_stride = alpha_m;
+                }
+                Y[(long long)out_col * out_stride + proj_row] = acc[j];
+            }
+        }
+    }
+}
+
+#else
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_mq4g256_lloyd_wmma(
+    const char*, const char*, const char*, const char*, const _Float16*,
+    float*, float*, float*, float*, int, int, int, int, int, int) {}
+
+#endif

--- a/kernels/src/gemm_qkvza_mq4g256_lloyd_wmma_mb4.gfx1151.hip
+++ b/kernels/src/gemm_qkvza_mq4g256_lloyd_wmma_mb4.gfx1151.hip
@@ -1,0 +1,216 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// MQ4-Lloyd WMMA fused QKVZA GEMM, 4× batch-tile fanout — gfx1151 K4 variant.
+// K4 unroll: front-loads all 8 nibble-pack reads per inner iteration.
+// See gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip for rationale.
+// Grid: [ceil((qkv_m+z_m+beta_m+alpha_m)/16), ceil(N/64)]. Block: [32]. LDS: 512 B.
+
+#if defined(__gfx1151__)
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_mq4g256_lloyd_wmma_mb4(
+    const char*    __restrict__ A_qkv,
+    const char*    __restrict__ A_z,
+    const char*    __restrict__ A_beta,
+    const char*    __restrict__ A_alpha,
+    const _Float16* __restrict__ X,
+    float*         __restrict__ Y_qkv,
+    float*         __restrict__ Y_z,
+    float*         __restrict__ Y_beta,
+    float*         __restrict__ Y_alpha,
+    int qkv_m, int z_m, int beta_m, int alpha_m,
+    int K, int N
+) {
+    const int total_m = qkv_m + z_m + beta_m + alpha_m;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 64;
+    const int tid = threadIdx.x;
+
+    if (row_start >= total_m) return;
+    if (batch_start >= N) return;
+
+    const int my_tile_row = tid & 15;
+    const int my_row = row_start + my_tile_row;
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1);
+
+    const char* A;
+    int local_row;
+    if (safe_row < qkv_m) {
+        A = A_qkv;   local_row = safe_row;
+    } else if (safe_row < qkv_m + z_m) {
+        A = A_z;     local_row = safe_row - qkv_m;
+    } else if (safe_row < qkv_m + z_m + beta_m) {
+        A = A_beta;  local_row = safe_row - (qkv_m + z_m);
+    } else {
+        A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m);
+    }
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 160;
+    const char* row_base = A + local_row * row_stride;
+
+    long long safe_batch_s[4];
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int b_idx = batch_start + 16 * s + my_tile_row;
+        safe_batch_s[s] = (b_idx < N) ? (long long)b_idx : 0LL;
+    }
+
+    const int load_tile_row = tid >> 1;
+    const int load_lo       = (tid & 1) * 8;
+    const int load_my_row = row_start + load_tile_row;
+    const int load_safe_row = (load_my_row < total_m) ? load_my_row : (total_m - 1);
+    const char* load_A;
+    int load_local_row;
+    if (load_safe_row < qkv_m) {
+        load_A = A_qkv;   load_local_row = load_safe_row;
+    } else if (load_safe_row < qkv_m + z_m) {
+        load_A = A_z;     load_local_row = load_safe_row - qkv_m;
+    } else if (load_safe_row < qkv_m + z_m + beta_m) {
+        load_A = A_beta;  load_local_row = load_safe_row - (qkv_m + z_m);
+    } else {
+        load_A = A_alpha; load_local_row = load_safe_row - (qkv_m + z_m + beta_m);
+    }
+    const char* load_row_base = load_A + (long long)load_local_row * row_stride;
+
+    __shared__ _Float16 cb_lds[16 * 16];
+
+    float8_t acc[4] = {
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, 0, 0, 0}
+    };
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const __half* cb_h_load = (const __half*)(load_row_base + g * 160);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) {
+            cb_lds[load_tile_row * 16 + load_lo + i] = cb_h_load[load_lo + i];
+        }
+        __syncthreads();
+
+        const char* gp = row_base + g * 160;
+        const unsigned char* dp = (const unsigned char*)(gp + 32);
+        const int cb_base = my_tile_row * 16;
+
+        const _Float16* xg_s[4];
+        #pragma unroll
+        for (int s = 0; s < 4; s++) {
+            xg_s[s] = X + safe_batch_s[s] * (long long)K + g * 256;
+        }
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const unsigned char* dp4 = dp + kt * 8;
+
+            unsigned int pk0a = *(const unsigned int*)dp4;
+            unsigned int pk1a = *(const unsigned int*)(dp4 + 4);
+            unsigned int pk0b = *(const unsigned int*)(dp4 + 8);
+            unsigned int pk1b = *(const unsigned int*)(dp4 + 12);
+            unsigned int pk0c = *(const unsigned int*)(dp4 + 16);
+            unsigned int pk1c = *(const unsigned int*)(dp4 + 20);
+            unsigned int pk0d = *(const unsigned int*)(dp4 + 24);
+            unsigned int pk1d = *(const unsigned int*)(dp4 + 28);
+
+            half16_t a_reg;
+            #define DQ(i, pk, sh) a_reg[i] = cb_lds[cb_base + (((pk) >> (sh)) & 0xFu)]
+
+            // === Tile kt+0 ===
+            DQ(0,  pk0a,  0); DQ(1,  pk0a,  4); DQ(2,  pk0a,  8); DQ(3,  pk0a, 12);
+            DQ(4,  pk0a, 16); DQ(5,  pk0a, 20); DQ(6,  pk0a, 24); DQ(7,  pk0a, 28);
+            DQ(8,  pk1a,  0); DQ(9,  pk1a,  4); DQ(10, pk1a,  8); DQ(11, pk1a, 12);
+            DQ(12, pk1a, 16); DQ(13, pk1a, 20); DQ(14, pk1a, 24); DQ(15, pk1a, 28);
+            half16_t b0a = *(const half16_t*)(xg_s[0] + kt * 16);
+            half16_t b1a = *(const half16_t*)(xg_s[1] + kt * 16);
+            half16_t b2a = *(const half16_t*)(xg_s[2] + kt * 16);
+            half16_t b3a = *(const half16_t*)(xg_s[3] + kt * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0a, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1a, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2a, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3a, acc[3]);
+
+            // === Tile kt+1 ===
+            DQ(0,  pk0b,  0); DQ(1,  pk0b,  4); DQ(2,  pk0b,  8); DQ(3,  pk0b, 12);
+            DQ(4,  pk0b, 16); DQ(5,  pk0b, 20); DQ(6,  pk0b, 24); DQ(7,  pk0b, 28);
+            DQ(8,  pk1b,  0); DQ(9,  pk1b,  4); DQ(10, pk1b,  8); DQ(11, pk1b, 12);
+            DQ(12, pk1b, 16); DQ(13, pk1b, 20); DQ(14, pk1b, 24); DQ(15, pk1b, 28);
+            half16_t b0b = *(const half16_t*)(xg_s[0] + (kt + 1) * 16);
+            half16_t b1b = *(const half16_t*)(xg_s[1] + (kt + 1) * 16);
+            half16_t b2b = *(const half16_t*)(xg_s[2] + (kt + 1) * 16);
+            half16_t b3b = *(const half16_t*)(xg_s[3] + (kt + 1) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0b, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1b, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2b, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3b, acc[3]);
+
+            // === Tile kt+2 ===
+            DQ(0,  pk0c,  0); DQ(1,  pk0c,  4); DQ(2,  pk0c,  8); DQ(3,  pk0c, 12);
+            DQ(4,  pk0c, 16); DQ(5,  pk0c, 20); DQ(6,  pk0c, 24); DQ(7,  pk0c, 28);
+            DQ(8,  pk1c,  0); DQ(9,  pk1c,  4); DQ(10, pk1c,  8); DQ(11, pk1c, 12);
+            DQ(12, pk1c, 16); DQ(13, pk1c, 20); DQ(14, pk1c, 24); DQ(15, pk1c, 28);
+            half16_t b0c = *(const half16_t*)(xg_s[0] + (kt + 2) * 16);
+            half16_t b1c = *(const half16_t*)(xg_s[1] + (kt + 2) * 16);
+            half16_t b2c = *(const half16_t*)(xg_s[2] + (kt + 2) * 16);
+            half16_t b3c = *(const half16_t*)(xg_s[3] + (kt + 2) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0c, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1c, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2c, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3c, acc[3]);
+
+            // === Tile kt+3 ===
+            DQ(0,  pk0d,  0); DQ(1,  pk0d,  4); DQ(2,  pk0d,  8); DQ(3,  pk0d, 12);
+            DQ(4,  pk0d, 16); DQ(5,  pk0d, 20); DQ(6,  pk0d, 24); DQ(7,  pk0d, 28);
+            DQ(8,  pk1d,  0); DQ(9,  pk1d,  4); DQ(10, pk1d,  8); DQ(11, pk1d, 12);
+            DQ(12, pk1d, 16); DQ(13, pk1d, 20); DQ(14, pk1d, 24); DQ(15, pk1d, 28);
+            #undef DQ
+            half16_t b0d = *(const half16_t*)(xg_s[0] + (kt + 3) * 16);
+            half16_t b1d = *(const half16_t*)(xg_s[1] + (kt + 3) * 16);
+            half16_t b2d = *(const half16_t*)(xg_s[2] + (kt + 3) * 16);
+            half16_t b3d = *(const half16_t*)(xg_s[3] + (kt + 3) * 16);
+            acc[0] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b0d, acc[0]);
+            acc[1] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b1d, acc[1]);
+            acc[2] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b2d, acc[2]);
+            acc[3] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_reg, b3d, acc[3]);
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int s = 0; s < 4; s++) {
+        const int out_col = batch_start + 16 * s + (tid & 15);
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                int out_row = row_start + 2 * j + (tid >> 4);
+                if (out_row < total_m) {
+                    float* Y;
+                    int proj_row;
+                    int out_stride;
+                    if (out_row < qkv_m) {
+                        Y = Y_qkv;   proj_row = out_row;                          out_stride = qkv_m;
+                    } else if (out_row < qkv_m + z_m) {
+                        Y = Y_z;     proj_row = out_row - qkv_m;                  out_stride = z_m;
+                    } else if (out_row < qkv_m + z_m + beta_m) {
+                        Y = Y_beta;  proj_row = out_row - (qkv_m + z_m);          out_stride = beta_m;
+                    } else {
+                        Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m); out_stride = alpha_m;
+                    }
+                    Y[(long long)out_col * out_stride + proj_row] = acc[s][j];
+                }
+            }
+        }
+    }
+}
+
+#else
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_qkvza_mq4g256_lloyd_wmma_mb4(
+    const char*, const char*, const char*, const char*, const _Float16*,
+    float*, float*, float*, float*, int, int, int, int, int, int) {}
+
+#endif


### PR DESCRIPTION
## Summary

Adds gfx1151-specific K4-unroll WMMA variants for all seven MQ4-Lloyd prefill kernels (4 mb4, 3 non-mb4). The K4 inner loop front-loads all 8 nibble-pack reads per iteration before any DQ/LDS lookup, hiding LPDDR5x round-trip latency on Strix Halo (gfx1151).

Previous to this PR, gfx1151 fell through to the generic `rdna3` K2 variants for all seven kernels.

## Kernels added

**mb4 path** (batch ≥ 128):
- `gemm_mq4g256_lloyd_residual_wmma_mb4.gfx1151.hip`
- `gemm_gate_up_mq4g256_lloyd_wmma_mb4.gfx1151.hip`
- `gemm_qkv_mq4g256_lloyd_wmma_mb4.gfx1151.hip`
- `gemm_qkvza_mq4g256_lloyd_wmma_mb4.gfx1151.hip`

**non-mb4 path** (batch < 128):
- `gemm_gate_up_mq4g256_lloyd_wmma.gfx1151.hip`
- `gemm_qkv_mq4g256_lloyd_wmma.gfx1151.hip`
- `gemm_qkvza_mq4g256_lloyd_wmma.gfx1151.hip`

`kernels.rs` dispatch functions split gfx1151 from gfx1100/1101/1102 in all seven `_for_arch()` selectors, routing to the new K4 sources under a distinct module name (e.g. `gemm_gate_up_mq4g256_lloyd_wmma_k4_gfx1151`) so the JIT cache never mixes K2 and K4 objects.

## Measured results (qwen3.5-9b.mq4lloyd, gfx1151)

**Non-mb4 prefill (pp32):**
| Kernel | Before | After | Δ |
|---|---|---|---|
| gate_up | 41.4 GiB/s | 47.1 GiB/s | +14% |
| qkvza | 47.1 GiB/s | 58.2 GiB/s | +24% |
| qkv | 74.1 GiB/s | 84.0 GiB/s | +13% |
| **prefill total** | 343 tok/s | 380 tok/s | **+11%** |

**mb4 prefill (pp128+):** +7.1% from the first commit (benchmarked separately, see commit message).

**Gen decode:** unchanged — GEMV path not affected.

**gfx1100/1101/1102:** no change — dispatch still routes to existing rdna3 K2 variants.

## Test plan

- [x] Coherence gate passed (clean run, no hard errors)
- [x] Speed gate passed (gfx1151 baseline not regressed)
- [x] `cargo build --release` clean, no warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)