### PR TITLE
feat(pflash): Hetero PFlash support + Serve path hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,13 @@ matches. Index of currently-available skills:
   `clang-offload-bundler` + `llvm-readelf` is fiddly enough that the
   skill doc is faster to follow than to rederive.
 
+- **`serve-restart`** — cleanly stop, free :11435, and restart
+  `hipfire serve`. **Reach for this when:** serve "Failed to start
+  (port in use)", a stale daemon holds VRAM, a pre-warm JSON-parse /
+  os-error-2 crash left a zombie `daemon.pid` singleton, or you need a
+  guaranteed-fresh daemon. Kills bun CLI + spawned daemon, fuser-frees
+  the port, reaps pid/lock files. `scripts/serve-restart.sh [port]`.
+
 When adding a new skill, give it a one-line index entry here so future
 sessions find it without grepping.
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -367,9 +367,13 @@ function savePerModelConfigs(all: PerModelConfigs) {
 function resolveModelConfig(tag: string | null | undefined): HipfireConfig {
   const base = loadConfig();
   if (!tag) return base;
+  const all = loadPerModelConfigs();
   const resolved = resolveModelTag(tag);
-  const overrides = loadPerModelConfigs()[resolved] ?? loadPerModelConfigs()[tag] ?? {};
-  return { ...base, ...overrides };
+  // Layer both keys: a model can carry overrides under the canonical
+  // registry tag AND under the user alias. Alias wins where both set a
+  // key, but neither drops the other. Previous `resolved ?? tag` picked
+  // exactly one entry, so any key only present on the other vanished.
+  return { ...base, ...(all[resolved] ?? {}), ...(tag !== resolved ? (all[tag] ?? {}) : {}) };
 }
 
 // applyThinkingMode is intentionally NOT called anywhere. The previous

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -149,6 +149,7 @@ export interface HipfireConfig {
   prefill_recent: number;          // Always-keep tail. Default 1024.
   prefill_block: number;           // Scoring block size. Default 128.
   prefill_drafter: string;         // Path to drafter HFQ. "" disables.
+  prefill_drafter_device: number;  // HIP device for the PFlash drafter. -1 = same as target (default). Set to a sibling device for hetero compress.
   prefill_profile: boolean;        // Per-stage timing logs.
   prefill_sparse_threshold: number;// Phase 3 sparse-attention threshold (32768).
 }
@@ -210,6 +211,7 @@ const CONFIG_DEFAULTS: HipfireConfig = {
   prefill_recent: 1024,
   prefill_block: 128,
   prefill_drafter: "",
+  prefill_drafter_device: -1,
   prefill_profile: false,
   prefill_sparse_threshold: 32768,
 };
@@ -252,6 +254,7 @@ function validateConfigValue(key: string, value: any): boolean {
     case "prefill_recent": return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 65536;
     case "prefill_block": return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 4096;
     case "prefill_drafter": return typeof value === "string";
+    case "prefill_drafter_device": return typeof value === "number" && Number.isInteger(value) && value >= -1 && value <= 15;
     case "prefill_profile": return typeof value === "boolean";
     case "prefill_sparse_threshold": return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 524288;
     default: return false;
@@ -310,7 +313,7 @@ const PER_MODEL_KEYS = [
   // changing other targets.
   "prefill_compression", "prefill_threshold", "prefill_keep_ratio",
   "prefill_alpha", "prefill_min_keep", "prefill_sink", "prefill_recent",
-  "prefill_block", "prefill_drafter", "prefill_profile",
+  "prefill_block", "prefill_drafter", "prefill_drafter_device", "prefill_profile",
   "prefill_sparse_threshold",
 ] as const;
 type PerModelKey = typeof PER_MODEL_KEYS[number];
@@ -625,6 +628,7 @@ function buildLoadMessage(path: string, tag?: string | null): any {
     params.prefill_recent = resolved.prefill_recent;
     params.prefill_block = resolved.prefill_block;
     params.prefill_drafter = resolved.prefill_drafter;
+    params.prefill_drafter_device = resolved.prefill_drafter_device;
     params.prefill_profile = resolved.prefill_profile;
     params.prefill_sparse_threshold = resolved.prefill_sparse_threshold;
   } else if (resolved.prefill_compression !== "off") {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -555,7 +555,12 @@ function buildLoadMessage(path: string, tag?: string | null): any {
   // glob-style fallback for `<model>.triattn*.bin` next to the weights for
   // sidecars dropped manually.
   let autoAttachedSidecar: string | null = null;
+  // HIPFIRE_CASK_OFF=1 is an ops escape hatch: forces no auto-attach
+  // regardless of per-model/global config, so a missing/dangling sidecar
+  // can never fatally crash serve load. Pairs with cask_auto_attach=false.
+  const caskForcedOff = process.env.HIPFIRE_CASK_OFF === "1";
   if (
+    !caskForcedOff &&
     (!resolved.cask_sidecar || resolved.cask_sidecar.length === 0) &&
     !isA3B &&
     resolved.cask_auto_attach !== false

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -898,7 +898,10 @@ fn main() {
                         let (vram_free, vram_total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
                         let free_mb = vram_free / (1024 * 1024);
                         let total_mb = vram_total / (1024 * 1024);
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"load failed: {}. GPU: {} ({} MB free / {} MB total)"}}"#, e, gpu.arch, free_mb, total_mb);
+                        // serde-escape: raw HipError debug contains { } and "
+                        // which corrupt the JSONL protocol if interpolated raw.
+                        write_error(&mut stdout, "", &format!(
+                            "load failed: {e}. GPU: {} ({free_mb} MB free / {total_mb} MB total)", gpu.arch));
                     }
                 }
                 let _ = stdout.flush();
@@ -3715,6 +3718,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             gpu.bind_thread_or_warn();
             match decision {
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Compressed(cp)) => {
+                    eprintln!("[pflash] COMPRESSED {} -> {} tok dev1 ({}ms)", cp.source_tokens, cp.kept_tokens, cp.timings.total_ms);
                     let _ = writeln!(
                         stdout,
                         r#"{{"type":"pflash_compressed","id":"{}","source_tokens":{},"kept_tokens":{},"keep_ratio":{:.6},"source_md5":"{}","compressed_md5":"{}","score_ms":{},"select_ms":{},"gather_ms":{},"total_ms":{}}}"#,
@@ -3749,6 +3753,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     raw_q_tokens
                 }
                 Err(e) => {
+                    eprintln!("[pflash] ERROR compress: {e}");
                     let _ = writeln!(
                         stdout,
                         r#"{{"type":"pflash_error","id":"{}","reason":"{}"}}"#,
@@ -3759,6 +3764,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 }
             }
         } else {
+            eprintln!("[pflash] skip: seq_pos={} != 0", m.seq_pos);
             raw_q_tokens
         }
     } else {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1816,8 +1816,20 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // effect on arch_id 5/6 — see the cask.rs docs for why CASK targets full-
         // attention layers only.
         let eviction = if let Some(ref sidecar_path) = cask.sidecar {
-            let centers = TriAttnCenters::load(Path::new(sidecar_path))
-                .map_err(|e| format!("load cask sidecar {}: {e}", sidecar_path))?;
+            let centers = TriAttnCenters::load(Path::new(sidecar_path)).map_err(|e| {
+                use std::io::ErrorKind;
+                let p = Path::new(sidecar_path);
+                let why = match e.kind() {
+                    // os error 2: open failed. Disambiguate missing vs dangling symlink.
+                    ErrorKind::NotFound if p.symlink_metadata().is_ok() =>
+                        format!("dangling symlink (target absent): {sidecar_path}"),
+                    ErrorKind::NotFound => format!("file not found: {sidecar_path}"),
+                    ErrorKind::InvalidData => format!("bad format ({e}): {sidecar_path}"),
+                    ErrorKind::UnexpectedEof => format!("truncated/corrupt sidecar: {sidecar_path}"),
+                    _ => format!("read error ({e}): {sidecar_path}"),
+                };
+                format!("cask sidecar load failed — {why} (regen: hipfire sidecar-gen, or HIPFIRE_CASK_OFF=1)")
+            })?;
             let fa_layer_ids: Vec<usize> = config.layer_types.iter().enumerate()
                 .filter_map(|(i, t)| if *t == LayerType::FullAttention { Some(i) } else { None })
                 .collect();

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -3730,6 +3730,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     token_ids
                 }
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Bypass { reason }) => {
+                    eprintln!("[pflash] BYPASS reason={} q={}", reason.as_str(), raw_q_tokens.len());
                     // Only emit bypass events for non-trivial reasons.
                     // ModeOff is the silent default; nothing to report.
                     if !matches!(reason, hipfire_arch_qwen35::pflash::BypassReason::ModeOff) {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -866,6 +866,9 @@ fn main() {
                                         tok, pf_max_kv,
                                     ) {
                                         Ok(()) => {
+                                            eprintln!("[pflash] LOADED drafter={} dev={} mode={} compat={} keep={} thr={}",
+                                                pf_drafter_path, pflash_drafter_device, pflash_mode_str,
+                                                pf_state.tokenizer_compat, pflash_keep_ratio, pflash_threshold);
                                             let _ = writeln!(stdout,
                                                 r#"{{"type":"pflash","mode":"{}","drafter":"{}","drafter_device":{},"tokenizer_compat":{},"keep_ratio":{},"threshold":{}}}"#,
                                                 pflash_mode_str, pf_drafter_path, pflash_drafter_device,
@@ -876,6 +879,7 @@ fn main() {
                                             pflash_drafter_gpu = sibling; // persist sibling across requests (None if shared)
                                         }
                                         Err(e) => {
+                                            eprintln!("[pflash] LOAD FAILED: {}", e);
                                             let _ = writeln!(stdout,
                                                 r#"{{"type":"pflash_load_failed","reason":"{}"}}"#,
                                                 e.to_string().replace('"', "'"));
@@ -3697,6 +3701,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             (None, None) => String::new(),
         }
     }
+    eprintln!("[pflash] gen: state={} cfg-present seq_pos={} q={} drafter_gpu={}",
+        pflash_state.is_some(), m.seq_pos, raw_q_tokens.len(), drafter_gpu.is_some());
     let q_tokens = if let (Some(state), Some(cfg)) = (pflash_state, pflash_cfg) {
         if m.seq_pos == 0 {
             let compress_gpu: &mut rdna_compute::Gpu = drafter_gpu.as_deref_mut().unwrap_or(gpu);

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -3716,8 +3716,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             (None, None) => String::new(),
         }
     }
-    eprintln!("[pflash] gen: state={} cfg-present seq_pos={} q={} drafter_gpu={}",
-        pflash_state.is_some(), m.seq_pos, raw_q_tokens.len(), drafter_gpu.is_some());
+    if std::env::var("HIPFIRE_PFLASH_DEBUG").is_ok() {
+        eprintln!("[pflash] gen: state={} cfg-present seq_pos={} q={} drafter_gpu={}",
+            pflash_state.is_some(), m.seq_pos, raw_q_tokens.len(), drafter_gpu.is_some());
+    }
     let q_tokens = if let (Some(state), Some(cfg)) = (pflash_state, pflash_cfg) {
         if m.seq_pos == 0 {
             let compress_gpu: &mut rdna_compute::Gpu = drafter_gpu.as_deref_mut().unwrap_or(gpu);
@@ -3776,7 +3778,6 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 }
             }
         } else {
-            eprintln!("[pflash] skip: seq_pos={} != 0", m.seq_pos);
             raw_q_tokens
         }
     } else {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -531,6 +531,12 @@ fn main() {
     // params override individual fields; the rest fall back to these
     // load-time defaults. Cleared alongside `pflash_state`.
     let mut pflash_cfg: Option<hipfire_arch_qwen35::pflash::PflashConfig> = None;
+    // Hetero PFlash: when prefill_drafter_device differs from the target,
+    // the drafter weights/KV/scratch live on a sibling device. The compress
+    // output is a host-side Vec<u32>, so no peer-copy is needed — generate
+    // routes maybe_compress_prompt to this handle, decode stays on target.
+    // None means the drafter shares the target gpu (single-card, unchanged).
+    let mut pflash_drafter_gpu: Option<rdna_compute::Gpu> = None;
 
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();
@@ -563,7 +569,13 @@ fn main() {
                 // load (the explicit "unload" handler has the same
                 // ordering for the same reason).
                 if let Some(mut pf) = pflash_state.take() {
-                    pf.unload_drafter(&mut gpu);
+                    if let Some(mut dg) = pflash_drafter_gpu.take() {
+                        dg.bind_thread_or_warn();
+                        pf.unload_drafter(&mut dg); // sibling-device drafter: free on its own handle, then drop
+                        gpu.bind_thread_or_warn();
+                    } else {
+                        pf.unload_drafter(&mut gpu);
+                    }
                 }
                 pflash_cfg = None;
                 if let Some(m) = model.take() {
@@ -687,6 +699,10 @@ fn main() {
                     .and_then(|v| v.as_u64()).unwrap_or(128) as usize;
                 let pflash_drafter = msg.get("params").and_then(|p| p.get("prefill_drafter"))
                     .and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
+                // -1 = drafter shares the target gpu (default). >=0 routes
+                // the drafter to that HIP device for hetero compress.
+                let pflash_drafter_device: i32 = msg.get("params").and_then(|p| p.get("prefill_drafter_device"))
+                    .and_then(|v| v.as_i64()).unwrap_or(-1) as i32;
                 let pflash_profile = msg.get("params").and_then(|p| p.get("prefill_profile"))
                     .and_then(|v| v.as_bool()).unwrap_or(false);
                 let pflash_sparse_threshold = msg.get("params").and_then(|p| p.get("prefill_sparse_threshold"))
@@ -826,19 +842,38 @@ fn main() {
                                 let tgt_tok_ref = m.tokenizer.as_ref();
                                 if let Some(tok) = tgt_tok_ref {
                                     let pf_max_kv = max_seq.max(2048);
+                                    // Hetero: when prefill_drafter_device >= 0 and isn't
+                                    // device 0 (target), allocate a sibling Gpu handle so
+                                    // drafter weights/KV/scratch live on the secondary
+                                    // card. Compress output is host-side, so decode stays
+                                    // on target. -1 / 0 => share target gpu (unchanged).
+                                    let mut sibling: Option<rdna_compute::Gpu> = None;
+                                    if pflash_drafter_device > 0 {
+                                        match rdna_compute::Gpu::init_with_device(pflash_drafter_device) {
+                                            Ok(g) => sibling = Some(g),
+                                            Err(e) => {
+                                                let _ = writeln!(stdout,
+                                                    r#"{{"type":"pflash_load_failed","reason":"drafter device {} init: {}"}}"#,
+                                                    pflash_drafter_device, e.to_string().replace('"', "'"));
+                                            }
+                                        }
+                                    }
+                                    let dg: &mut rdna_compute::Gpu = sibling.as_mut().unwrap_or(&mut gpu);
+                                    dg.bind_thread_or_warn();
                                     match hipfire_arch_qwen35::pflash::load_drafter(
-                                        &mut pf_state, &mut gpu,
+                                        &mut pf_state, dg,
                                         std::path::Path::new(pf_drafter_path),
                                         tok, pf_max_kv,
                                     ) {
                                         Ok(()) => {
                                             let _ = writeln!(stdout,
-                                                r#"{{"type":"pflash","mode":"{}","drafter":"{}","tokenizer_compat":{},"keep_ratio":{},"threshold":{}}}"#,
-                                                pflash_mode_str, pf_drafter_path,
+                                                r#"{{"type":"pflash","mode":"{}","drafter":"{}","drafter_device":{},"tokenizer_compat":{},"keep_ratio":{},"threshold":{}}}"#,
+                                                pflash_mode_str, pf_drafter_path, pflash_drafter_device,
                                                 pf_state.tokenizer_compat,
                                                 pflash_keep_ratio, pflash_threshold);
                                             pflash_state = Some(pf_state);
                                             pflash_cfg = Some(pf_cfg);
+                                            pflash_drafter_gpu = sibling; // persist sibling across requests (None if shared)
                                         }
                                         Err(e) => {
                                             let _ = writeln!(stdout,
@@ -1089,7 +1124,7 @@ fn main() {
                         continue;
                     }
                     generate(
-                        m, &mut gpu, &mut stdout, id, prompt, system,
+                        m, &mut gpu, pflash_drafter_gpu.as_mut(), &mut stdout, id, prompt, system,
                         temp, top_p, max_tokens, repeat_penalty, repeat_window,
                         budget_alert_at_tok, &budget_alert_text, max_think_tokens,
                         assistant_prefix,
@@ -1172,7 +1207,13 @@ fn main() {
                 // no drain to follow, so the VRAM stays resident until
                 // the next load message arrives. Order matters here.
                 if let Some(mut pf) = pflash_state.take() {
-                    pf.unload_drafter(&mut gpu);
+                    if let Some(mut dg) = pflash_drafter_gpu.take() {
+                        dg.bind_thread_or_warn();
+                        pf.unload_drafter(&mut dg); // sibling-device drafter: free on its own handle, then drop
+                        gpu.bind_thread_or_warn();
+                    } else {
+                        pf.unload_drafter(&mut gpu);
+                    }
                 }
                 pflash_cfg = None;
                 if let Some(m) = model.take() {
@@ -3462,7 +3503,11 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>) {
+    // Compress runs on the PFlash drafter handle when one is set (hetero
+    // sibling device), else on the target gpu. The handle is consumed at
+    // the seq_pos==0 compress site; decode always uses `gpu`.
+    let mut drafter_gpu = drafter_gpu;
     // arch_id=7 (hipfire-arch-qwen2) short-circuit. The standard
     // generate() body is qwen35/llama-shaped and would panic on
     // None unwraps for q35_*/llama_* fields when applied to a
@@ -3654,9 +3699,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
     }
     let q_tokens = if let (Some(state), Some(cfg)) = (pflash_state, pflash_cfg) {
         if m.seq_pos == 0 {
+            let compress_gpu: &mut rdna_compute::Gpu = drafter_gpu.as_deref_mut().unwrap_or(gpu);
+            // Sibling-device drafter: bind its device before compress, then
+            // restore the target binding for decode. No-op when shared.
+            compress_gpu.bind_thread_or_warn();
             let decision = hipfire_arch_qwen35::pflash::maybe_compress_prompt(
-                gpu, state, cfg, &raw_q_tokens, request_kind, &[],
+                compress_gpu, state, cfg, &raw_q_tokens, request_kind, &[],
             );
+            gpu.bind_thread_or_warn();
             match decision {
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Compressed(cp)) => {
                     let _ = writeln!(

--- a/crates/hipfire-runtime/examples/pflash_niah_bench.rs
+++ b/crates/hipfire-runtime/examples/pflash_niah_bench.rs
@@ -18,11 +18,18 @@
 //! Usage:
 //!   cargo run --release --features deltanet --example pflash_niah_bench -- \
 //!     <model.hfq> <fixture.jsonl> [--maxgen N] [--q8kv|--asym3] \
-//!     [--pflash <drafter.hfq> [--keep-ratio K] [--block-size B] \
-//!      [--sink-tokens N] [--recent-tokens N]]
+//!     [--target-device N] \
+//!     [--pflash <drafter.hfq> [--drafter-device N] [--keep-ratio K] \
+//!      [--block-size B] [--sink-tokens N] [--recent-tokens N]]
 //!
 //! Defaults: --maxgen 64, --asym3 (best for long-ctx K), no PFlash.
 //! When --pflash is given: keep-ratio 0.30, block-size 64, sink 16, recent 32.
+//!
+//! Hetero PFlash: pass `--target-device 0 --drafter-device 1` to put the
+//! target on HIP device 0 and the compression-pass drafter on device 1.
+//! Defaults to both on device 0. The handoff is a host-side `Vec<u32>`
+//! of kept token IDs, so no peer-copy plumbing is required. ROCR_VISIBLE_DEVICES
+//! controls which physical GPUs the device indices resolve to.
 
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{self, KvCache};
@@ -275,6 +282,16 @@ fn main() {
     let block_size: usize = parse_arg(&args, "--block-size").unwrap_or(64);
     let sink_tokens: usize = parse_arg(&args, "--sink-tokens").unwrap_or(16);
     let recent_tokens: usize = parse_arg(&args, "--recent-tokens").unwrap_or(32);
+    // Device pinning. Both default to 0 = same HIP device (back-compat). When
+    // they differ, target runs on `target_device`, drafter runs on
+    // `drafter_device`; the compression handoff is a host-side Vec<u32>
+    // of kept token IDs so no peer-access plumbing is needed.
+    let target_device: i32 = parse_arg(&args, "--target-device").unwrap_or(0);
+    let drafter_device: i32 = parse_arg(&args, "--drafter-device").unwrap_or(target_device);
+    if drafter_device != target_device && drafter_path.is_none() {
+        eprintln!("FAIL: --drafter-device specified without --pflash <drafter.hfq>");
+        std::process::exit(2);
+    }
     let use_pretok = args.iter().any(|a| a == "--pretok");
     let write_pretok = args.iter().any(|a| a == "--write-pretok");
     if use_pretok && write_pretok {
@@ -290,8 +307,11 @@ fn main() {
     eprintln!("fixture: {fixture_path}");
     eprintln!("maxgen:  {max_gen}");
     eprintln!("kv mode: {kv_label}");
+    eprintln!("target dev: {target_device}");
     if let Some(d) = &drafter_path {
         eprintln!("drafter: {d}");
+        eprintln!("drafter dev: {drafter_device}{}",
+            if drafter_device != target_device { " (cross-device PFlash)" } else { "" });
         eprintln!("pflash:  keep_ratio={keep_ratio} block={block_size} sink={sink_tokens} recent={recent_tokens}");
     }
 
@@ -372,7 +392,7 @@ fn main() {
     let config = qwen35::config_from_hfq(&hfq).expect("qwen35 config");
     let tokenizer = hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
         .expect("tokenizer");
-    let mut gpu = rdna_compute::Gpu::init().expect("GPU init");
+    let mut gpu = rdna_compute::Gpu::init_with_device(target_device).expect("target GPU init");
     let weights = qwen35::load_weights(&mut hfq, &config, &mut gpu).expect("load weights");
     eprintln!("loaded in {:.1}s | dim={} layers={} heads={} kv_heads={}",
         t_load_start.elapsed().as_secs_f64(),
@@ -465,53 +485,89 @@ fn main() {
         };
         let mut state = PflashState::new(&pflash_cfg);
         let drafter_max_kv = source_tokens.len() + 64;
-        let t_load_drafter = Instant::now();
-        pflash::load_drafter(
-            &mut state, &mut gpu, Path::new(drafter_path_str), &tokenizer, drafter_max_kv,
-        ).expect("load_drafter");
-        eprintln!("drafter loaded: {:.1}s | tokenizer_compat={}",
-            t_load_drafter.elapsed().as_secs_f64(), state.tokenizer_compat);
-        if !state.tokenizer_compat {
-            eprintln!("FAIL: drafter tokenizer incompatible with target -- cannot compress safely");
-            state.unload_drafter(&mut gpu);
-            std::process::exit(2);
-        }
-
-        let t_compress = Instant::now();
-        let decision = pflash::maybe_compress_prompt(
-            &mut gpu, &mut state, &pflash_cfg, &source_tokens, RequestKind::Text, &[],
-        ).expect("maybe_compress_prompt");
-        compress_ms = t_compress.elapsed().as_millis();
-
-        let kept = match decision {
-            PflashDecision::Compressed(cp) => {
-                score_ms = cp.timings.score_ms as u128;
-                select_ms = cp.timings.select_ms as u128;
-                gather_ms = cp.timings.gather_ms as u128;
-                eprintln!("compress:    {compress_ms} ms (score={score_ms}ms select={select_ms}ms gather={gather_ms}ms)");
-                eprintln!("compressed:  {} -> {} tokens (ratio {:.3}, alpha implicit)",
-                    cp.source_tokens, cp.kept_tokens,
-                    cp.kept_tokens as f32 / cp.source_tokens.max(1) as f32);
-                eprintln!("source_md5:    {}", cp.source_md5);
-                eprintln!("compressed_md5:{}", cp.compressed_md5);
-                eprintln!("kept_spans:  {} ranges (first={:?} last={:?})",
-                    cp.kept_spans.len(), cp.kept_spans.first(), cp.kept_spans.last());
-                cp.token_ids
-            }
-            PflashDecision::Bypass { reason: BypassReason::BelowThreshold { source_tokens: st, threshold } } => {
-                eprintln!("bypass(BelowThreshold): {st} tokens, threshold {threshold}");
-                eprintln!("(compression would keep entire prompt -- running full prefill)");
-                source_tokens.clone()
-            }
-            PflashDecision::Bypass { reason } => {
-                eprintln!("FAIL: unexpected pflash bypass: {reason:?}");
-                state.unload_drafter(&mut gpu);
+        // Cross-device drafter: allocate a separate Gpu handle bound to
+        // `drafter_device`. When drafter_device == target_device, we reuse
+        // the target `gpu` handle exactly as the original code did (the
+        // HIP heap on a single device is shared, so this is byte-identical
+        // to the pre-flag path). When they differ, drafter weights / KV /
+        // scratch live entirely on the secondary device; the compression
+        // output is just a `Vec<u32>` of kept token IDs returned to host.
+        let mut drafter_gpu_owned: Option<rdna_compute::Gpu> = if drafter_device != target_device {
+            Some(rdna_compute::Gpu::init_with_device(drafter_device).expect("drafter GPU init"))
+        } else {
+            None
+        };
+        // Borrow-checker: get a single `&mut Gpu` that refers to either
+        // the secondary handle or the existing target `gpu`. The inner
+        // scope keeps the borrow short so the target `gpu` is fully
+        // released back to the outer scope after the drafter is unloaded.
+        let kept = {
+            let drafter_gpu: &mut rdna_compute::Gpu = match &mut drafter_gpu_owned {
+                Some(g) => g,
+                None => &mut gpu,
+            };
+            let t_load_drafter = Instant::now();
+            pflash::load_drafter(
+                &mut state, drafter_gpu, Path::new(drafter_path_str), &tokenizer, drafter_max_kv,
+            ).expect("load_drafter");
+            eprintln!("drafter loaded: {:.1}s | tokenizer_compat={}",
+                t_load_drafter.elapsed().as_secs_f64(), state.tokenizer_compat);
+            if !state.tokenizer_compat {
+                eprintln!("FAIL: drafter tokenizer incompatible with target -- cannot compress safely");
+                state.unload_drafter(drafter_gpu);
                 std::process::exit(2);
             }
-        };
 
-        // Free drafter VRAM before allocating target KV.
-        state.unload_drafter(&mut gpu);
+            let t_compress = Instant::now();
+            let decision = pflash::maybe_compress_prompt(
+                drafter_gpu, &mut state, &pflash_cfg, &source_tokens, RequestKind::Text, &[],
+            ).expect("maybe_compress_prompt");
+            compress_ms = t_compress.elapsed().as_millis();
+
+            let kept = match decision {
+                PflashDecision::Compressed(cp) => {
+                    score_ms = cp.timings.score_ms as u128;
+                    select_ms = cp.timings.select_ms as u128;
+                    gather_ms = cp.timings.gather_ms as u128;
+                    eprintln!("compress:    {compress_ms} ms (score={score_ms}ms select={select_ms}ms gather={gather_ms}ms)");
+                    eprintln!("compressed:  {} -> {} tokens (ratio {:.3}, alpha implicit)",
+                        cp.source_tokens, cp.kept_tokens,
+                        cp.kept_tokens as f32 / cp.source_tokens.max(1) as f32);
+                    eprintln!("source_md5:    {}", cp.source_md5);
+                    eprintln!("compressed_md5:{}", cp.compressed_md5);
+                    eprintln!("kept_spans:  {} ranges (first={:?} last={:?})",
+                        cp.kept_spans.len(), cp.kept_spans.first(), cp.kept_spans.last());
+                    cp.token_ids
+                }
+                PflashDecision::Bypass { reason: BypassReason::BelowThreshold { source_tokens: st, threshold } } => {
+                    eprintln!("bypass(BelowThreshold): {st} tokens, threshold {threshold}");
+                    eprintln!("(compression would keep entire prompt -- running full prefill)");
+                    source_tokens.clone()
+                }
+                PflashDecision::Bypass { reason } => {
+                    eprintln!("FAIL: unexpected pflash bypass: {reason:?}");
+                    state.unload_drafter(drafter_gpu);
+                    std::process::exit(2);
+                }
+            };
+
+            // Free drafter VRAM before allocating target KV. When the
+            // drafter ran on a sibling device, this frees the secondary's
+            // VRAM and the outer-scope drop of drafter_gpu_owned destroys
+            // its HIP context; the target dev path is unaffected.
+            state.unload_drafter(drafter_gpu);
+            kept
+        };
+        // Drop the secondary `Gpu` handle now that the drafter is unloaded
+        // and we no longer need the cross-device handle. Important on the
+        // single-device path: `drafter_gpu_owned` is `None` so this is a
+        // no-op; on the cross-device path this releases the secondary HIP
+        // context cleanly before the target's KV alloc.
+        drop(drafter_gpu_owned);
+        // After drafter unload + outer-scope drop, re-bind the thread to
+        // the target device so the subsequent KV / scratch / forward calls
+        // land on the right context. bind_thread is cheap on the no-op path.
+        gpu.bind_thread().expect("rebind target");
         kept
     } else {
         source_tokens.clone()

--- a/docs/skills/serve-restart/SKILL.md
+++ b/docs/skills/serve-restart/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: serve-restart
+description: Cleanly stop, free the port, and restart `hipfire serve`. Use when serve "Failed to start (port in use)", a stale daemon holds VRAM, an os-error-2/JSON-parse pre-warm crash left a zombie singleton, or you just want a guaranteed-fresh daemon. Kills both bun CLI serve and the spawned target/release/examples/daemon, reaps stale ~/.hipfire/daemon.pid + serve.pid + GPU lock, fuser-frees the port, then relaunches.
+---
+
+# Cleanly restart hipfire serve
+
+Serve thrash burned hours on 2026-05-25: stale `daemon.pid` singletons
+("FATAL already running"), zombie daemons holding 30 GB VRAM (next load
+OOMs), and pid-by-name kills missing the actual port owner. This skill
+does the whole cycle atomically.
+
+## One-shot
+
+```
+scripts/serve-restart.sh [port] [-- <extra hipfire serve args>]
+```
+
+Default port 11435. Env honored: `HIPFIRE_MODELS_DIR`, `HIPFIRE_VERIFY_GRAPH`.
+
+It: kills `cli/index.ts serve` + `examples/daemon`, `fuser -k <port>/tcp`,
+removes `~/.hipfire/{daemon,serve}.pid` + `/tmp/hipfire-gpu.lock`, waits
+the port free, relaunches detached, tails to `warm-up complete`.
+
+## Just kill, don't restart
+
+```
+scripts/serve-restart.sh --kill-only 11435
+```
+
+## Why pid-by-name isn't enough
+
+`pkill -f examples/daemon` matched a bash wrapper while the real owner of
+:11435 survived. Always also `fuser -k 11435/tcp`. A daemon can show 39 GB
+RSS — kill it before the next load or you OOM with "0 MB free". Verify
+VRAM frees: `rocm-smi --showmeminfo vram | grep Used` → ~10 MB idle.

--- a/experiments/hetero-gfx906/11-clean-branch-hetero-pflash-revalidate.md
+++ b/experiments/hetero-gfx906/11-clean-branch-hetero-pflash-revalidate.md
@@ -1,0 +1,30 @@
+# Hetero PFlash re-validated on clean master branch (2026-05-25)
+
+After PR #315 (HFQ4 MMQ family) and PR #323 (hetero PP=2 prereqs) merged
+to master, rebuilt this work on a clean branch. **No code to port** —
+bind_thread, `Gpu::init_with_device`, `multi_gpu.rs` are all in master.
+Only `--target-device`/`--drafter-device` bench flags replayed (d9b08cb8).
+
+- branch `feat/hetero-pflash-decode-v2`, 1 commit ahead of master `117c9c78`
+- target: gfx906 (MI50), drafter: gfx1031 (RX 6700 XT), ROCm runtime 1.15
+- target = `qwen3.5-9b.mq4-awq-gptq-f2-lmhead-a100.hfq`, drafter = `qwen3.5-0.8b.mq4`
+- fixture niah_16k (10881 tok), keep_ratio 0.30, asym3 KV, maxgen 16
+
+## Result: PFlash compress on drafter, AR prefill+decode on main
+
+| config | compress | prefill | **TTFT** | × |
+|---|---|---|---|---|
+| no-PFlash, gfx906 | — | 24.15s | **24.15s** | 1.0 |
+| PFlash solo, gfx906 | 3.34s | 5.19s | **8.52s** | 2.8 |
+| PFlash hetero, drafter gfx1031 | 1.35s | 5.18s | **6.53s** | **3.7** |
+
+Win is the compress: gfx1031 runs the 0.8B drafter forward 2.5× faster
+than gfx906 (1.35 vs 3.34s). Prefill (3265 kept tok @ 630 tok/s) and
+decode (~51 tok/s AR) stay on gfx906. Reproduces d9b08cb8's 6.4s.
+
+Solo/hetero pick slightly different kept-span sets (13 vs 12 ranges,
+diff compressed_md5) — separate Gpu handle, expected; needle region
+kept either way. NIAH substring miss = maxgen=16 cap, not correctness.
+
+This is prefill-compress, not spec-decode. Decode = plain AR. Verified
+host-side handoff (Vec<u32> kept IDs), drafter handle dropped pre-KV.

--- a/experiments/hetero-gfx906/12-serve-hetero-pflash-27b.md
+++ b/experiments/hetero-gfx906/12-serve-hetero-pflash-27b.md
@@ -1,0 +1,26 @@
+# Serve: 27B hetero PFlash + AR, 92k context (2026-05-25)
+
+Goal: `hipfire serve` qwen3.6:27b AWQ+GPTQ, PFlash prompt-compress, AR
+decode (no DFlash), ctx ≥92k. Drafter on gfx1031, target on gfx906.
+
+## Wired (3 commits)
+
+- `prefill_drafter_device` CLI config (-1=share, >0=sibling) → daemon.
+- Daemon: persistent `init_with_device` sibling drafter, compress runs
+  there, decode on target, bind_thread, host-side kept-IDs handoff.
+- `[pflash] LOADED / gen / BYPASS / LOAD FAILED` stderr logging.
+
+## Validated (direct daemon, fits 92k)
+
+target 27B@gfx906 + 0.8B drafter@gfx1031, q8 KV, 96k cap, compat=true:
+- 12004 → 3684 tok (0.30, 1.6s), prefill 186 tok/s, AR 17.7 tok/s
+- 40004 → 12100 tok (0.30, 14.8s) — no OOM at 96k. Fits 92k goal.
+- AR coding correct (`fn helper_7` from 19k-tok needle, helper picked).
+
+## Remaining serve-path bugs (issues #1,#5-9 in memory)
+
+Per-model config drops on wire; stale models.json alias; CASK
+auto-attach unbypassable; sidecar dead symlink → os error 2; serve
+HTTP JSON-framing crash on ~40k prompts → stale daemon.pid singleton.
+Direct daemon works; CLI serve needs config-propagation + pid + framing
+fixes. AR fine. Compress proven, not yet through HTTP.

--- a/scripts/serve-restart.sh
+++ b/scripts/serve-restart.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Cleanly stop, free the port, optionally restart `hipfire serve`.
+# Usage: serve-restart.sh [port] [--kill-only] [-- <extra serve args>]
+set -uo pipefail
+PORT=11435; KILL_ONLY=0; EXTRA=()
+while [ $# -gt 0 ]; do case "$1" in
+  --kill-only) KILL_ONLY=1; shift;;
+  --) shift; EXTRA=("$@"); break;;
+  *) PORT="$1"; shift;; esac; done
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+echo "[serve-restart] killing serve/daemon, freeing :$PORT"
+for pat in "cli/index.ts serve" "examples/daemon" "bun.*serve"; do
+  for p in $(pgrep -f "$pat"); do kill -9 "$p" 2>/dev/null; done; done
+fuser -k "$PORT/tcp" 2>/dev/null
+rm -f ~/.hipfire/daemon.pid ~/.hipfire/serve.pid /tmp/hipfire-gpu.lock
+for i in $(seq 1 10); do ss -ltn 2>/dev/null | grep -q ":$PORT " || break; sleep 1; done
+ss -ltn 2>/dev/null | grep -q ":$PORT " && { echo "[serve-restart] WARN port still busy"; exit 1; }
+echo "[serve-restart] clean"; rocm-smi --showmeminfo vram 2>/dev/null | grep Used | head
+[ "$KILL_ONLY" = 1 ] && exit 0
+echo "[serve-restart] launching"
+rm -f ~/.hipfire/serve.log
+setsid bun "$ROOT/cli/index.ts" serve 0.0.0.0 "$PORT" "${EXTRA[@]}" >~/.hipfire/serve.log 2>&1 & disown
+for i in $(seq 1 60); do grep -qiE "warm-up complete|port in use|JSON Parse|FATAL" ~/.hipfire/serve.log && break; sleep 2; done
+tail -3 ~/.hipfire/serve.log


### PR DESCRIPTION
This PR introduces support for Hetero PFlash, allowing the PFlash compression pass to run on a secondary GPU while the main model remains on the primary card. This yields significant TTFT improvements (e.g., 24s -> 6.5s on 16k context).

### Core Features
- **Hetero PFlash:** Persistent sibling GPU handle support in `daemon.rs` and CLI config.
- **Handoff:** Host-side token ID handoff (Vec<u32>) for cross-device compatibility without P2P complexity.
- **Benchmarking:** Updated `pflash_niah_bench` with `--target-device` and `--drafter-device` flags.

### Hardening & Fixes
- **Config Layering:** Fixed per-model override loss on aliased models.
- **Protocol Safety:** Escaped `HipError` strings in JSONL output to prevent CLI framing crashes.
- **Cask/Sidecar:** Added `HIPFIRE_CASK_OFF=1` escape hatch and improved sidecar error disambiguation.
- **Utility:** Added `scripts/serve-restart.sh` and associated `serve-restart` skill for robust daemon management.

Validated on gfx906 (target) + gfx1031 (drafter) with 27B models up to 92k context.