### PR TITLE
feat: consolidate HIPFIRE_ env vars into FeatureFlags + RuntimeConfig structs (#328, task 1)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -7091,7 +7091,7 @@ fn forward_prefill_chunk(
                 let is_6bit = matches!(layer.wqkv.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let is_q8 = matches!(layer.wqkv.gpu_dtype, DType::Q8_0);
                 let q8_wmma_arch = gpu.flags.has_wmma_f16()
-                    || gpu.arch.starts_with("gfx12");
+                    || gpu.flags.has_wmma_f16_gfx12();
 
                 if is_mq {
                     // AWQ-aware: next linear is LA's fused wqkv.
@@ -7319,10 +7319,10 @@ fn forward_prefill_chunk(
                 let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
                 let qkv_is_6bit = matches!(layer.wq.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let qkv_is_q8 = matches!(layer.wq.gpu_dtype, DType::Q8_0);
-                let q8_wmma_arch = gpu.flags.has_wmma_f16()
-                    || gpu.arch.starts_with("gfx12");
-                // Fused QKV requires uniform dtype — see issue #249 for
-                // the dense FA variant. Gate the same way here.
+                 let q8_wmma_arch = gpu.flags.has_wmma_f16()
+                     || gpu.flags.has_wmma_f16_gfx12();
+                 // Fused QKV requires uniform dtype — see issue #249 for
+                 // the dense FA variant. Gate the same way here.
                 let qkv_same_dtype = layer.wk.gpu_dtype == layer.wq.gpu_dtype
                                   && layer.wv.gpu_dtype == layer.wq.gpu_dtype;
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -5814,7 +5814,7 @@ fn forward_prefill_chunk(
     // (silicon-validated on R9700, 2026-05-14, 4/4 unit tests PASS). Each
     // call site below selects the right variant via an `arch.starts_with`
     // branch. On non-WMMA archs we keep the Tier 2 chunked-substrate path.
-    let q8_wmma_arch = rdna_compute::has_wmma_f16(fa_arch) || fa_arch.starts_with("gfx12");
+    let q8_wmma_arch = gpu.flags.has_wmma_f16() || gpu.flags.has_wmma_f16_gfx12();
     // MQ3 dispatch arch gate (same predicate, separate name for clarity at
     // each matcher). Phase 1 gfx10 MQ3 prefill (`docs/plans/gfx10_mq3_prefill.md`)
     // routes the 8 `is_mq3*` matchers below to scalar HFQ3 kernels on
@@ -7090,7 +7090,7 @@ fn forward_prefill_chunk(
                 let is_mq = matches!(layer.wqkv.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
                 let is_6bit = matches!(layer.wqkv.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let is_q8 = matches!(layer.wqkv.gpu_dtype, DType::Q8_0);
-                let q8_wmma_arch = rdna_compute::has_wmma_f16(gpu.arch.as_str())
+                let q8_wmma_arch = gpu.flags.has_wmma_f16()
                     || gpu.arch.starts_with("gfx12");
 
                 if is_mq {
@@ -7319,7 +7319,7 @@ fn forward_prefill_chunk(
                 let qkv_is_mq = matches!(layer.wq.gpu_dtype, DType::MQ4G256 | DType::MQ6G256);
                 let qkv_is_6bit = matches!(layer.wq.gpu_dtype, DType::MQ6G256 | DType::HFQ6G256);
                 let qkv_is_q8 = matches!(layer.wq.gpu_dtype, DType::Q8_0);
-                let q8_wmma_arch = rdna_compute::has_wmma_f16(gpu.arch.as_str())
+                let q8_wmma_arch = gpu.flags.has_wmma_f16()
                     || gpu.arch.starts_with("gfx12");
                 // Fused QKV requires uniform dtype — see issue #249 for
                 // the dense FA variant. Gate the same way here.
@@ -7736,7 +7736,7 @@ fn run_fa_layer_body(
     // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
     let fused_fa3_hfq6 = fa3_same_dtype
         && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
-        && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+        && gpu.flags.gemv_dp4a_enabled();
     if fused_fa3_mq4 {
         let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
         gpu.fused_qkv_hfq4g256(
@@ -7916,7 +7916,7 @@ fn run_fa_layer_body(
     // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
     let fused_gu_hfq6 = same_dtype
         && (dt_g == DType::MQ6G256 || dt_g == DType::HFQ6G256)
-        && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+        && gpu.flags.gemv_dp4a_enabled();
     if fused_gu_mq4 {
         let eff_x = match x_rot { Some(xr) => xr, None => &s.tmp };
         gpu.fused_gate_up_hfq4g256(
@@ -8145,7 +8145,7 @@ fn forward_scratch_layers(
                 // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
                 let fused_la4_hfq6 = la4_same_dtype
                     && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
-                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+                    && gpu.flags.gemv_dp4a_enabled();
                 if fused_la4_mq4 {
                     // MQ4: x_rot is Some(rotated x); HF4: x_rot is None and
                     // s.tmp holds the plain rmsnormed x from the fallback path.
@@ -8289,7 +8289,7 @@ fn forward_scratch_layers(
                 // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
                 let fused_gu_hfq6 = same_dtype
                     && (dt_g == DType::MQ6G256 || dt_g == DType::HFQ6G256)
-                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+                    && gpu.flags.gemv_dp4a_enabled();
                 if fused_gu_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -8370,7 +8370,7 @@ fn forward_scratch_layers(
                 // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
                 let fused_fa3_hfq6 = fa3_same_dtype
                     && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
-                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+                    && gpu.flags.gemv_dp4a_enabled();
                 if fused_fa3_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -8588,7 +8588,7 @@ fn forward_scratch_layers(
                 // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
                 let fused_gu_hfq6 = same_dtype
                     && (dt_g == DType::MQ6G256 || dt_g == DType::HFQ6G256)
-                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+                    && gpu.flags.gemv_dp4a_enabled();
                 if fused_gu_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,
@@ -8802,7 +8802,7 @@ fn forward_scratch_layers(
                 // Phase A.1c (gfx906): fused dp4a path for HFQ6/MQ6 weights.
                 let fused_fa3_hfq6 = fa3_same_dtype
                     && (dt == DType::MQ6G256 || dt == DType::HFQ6G256)
-                    && rdna_compute::gemv_dp4a_enabled(&gpu.arch);
+                    && gpu.flags.gemv_dp4a_enabled();
                 if fused_fa3_mq4 {
                     let eff_x = match x_rot {
                         Some(xr) => xr,

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -3267,7 +3267,7 @@ fn generate_multi(
     let mut alert_fired = false;
     let mut think_count: usize = 0;
     let mut prev_in_think: bool = false;
-    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_env();
+    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
     while generated < max_tokens {
         generated += 1;
@@ -4019,7 +4019,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::
         // Implementation lives in `hipfire_runtime::loop_guard`; defaults read from
         // HIPFIRE_NGRAM_LOOP_THRESHOLD (default 8, 0 = disabled) and
         // HIPFIRE_NGRAM_WINDOW (default 256). See loop_guard.rs.
-        let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_env();
+        let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
         // `while` instead of `for 0..max_tokens` so budget-alert injection
         // (which increments `generated` beyond the iteration count) can't
@@ -4841,7 +4841,7 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
 
     // N-gram loop detector — mirrors the text path. Catches answer-phase
     // attractor loops that the think cap and repeat penalty miss.
-    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_env();
+    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
     while generated < max_tokens {
         generated += 1;

--- a/crates/hipfire-runtime/src/config.rs
+++ b/crates/hipfire-runtime/src/config.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Typed, immutable env-var resolution for hipfire-runtime.
+//!
+//! All `HIPFIRE_*` env vars are read exactly once via the global
+//! `RuntimeConfig::get()` accessor. Runtime hot paths access config
+//! fields instead of hitting `std::env::var` on every call.
+
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    pub normalize_prompt: bool,
+    pub prompt_token_heat: bool,
+    pub prompt_heat_json: bool,
+    pub prompt_heat_limit: usize,
+    pub dflash_draft: Option<String>,
+    pub dflash_mode: String,
+    pub draft_f16: bool,
+    pub draft_gemm_dump: bool,
+    pub draft_subphase: bool,
+    pub ddtree_budget: usize,
+    pub ddtree_topk: usize,
+    pub prefill_batched: bool,
+    pub flash_partials_batch: Option<usize>,
+    pub ngram_loop_threshold: usize,
+    pub ngram_window: usize,
+    pub devices: Option<String>,
+    pub allow_mixed_arch: bool,
+    pub uniform_vram_tolerance_gb: Option<f32>,
+    pub lm_head_f16: String,
+}
+
+static CONFIG: OnceLock<RuntimeConfig> = OnceLock::new();
+
+pub fn get() -> &'static RuntimeConfig {
+    CONFIG.get_or_init(RuntimeConfig::from_env)
+}
+
+pub fn init() {
+    get();
+}
+
+impl RuntimeConfig {
+    pub fn from_env() -> Self {
+        let normalize_prompt = match std::env::var("HIPFIRE_NORMALIZE_PROMPT").ok().as_deref() {
+            Some("0") | Some("false") | Some("off") => false,
+            _ => true,
+        };
+
+        let prompt_token_heat =
+            std::env::var("HIPFIRE_PROMPT_TOKEN_HEAT").ok().as_deref() == Some("1");
+        let prompt_heat_json =
+            std::env::var("HIPFIRE_PROMPT_HEAT_JSON").ok().as_deref() == Some("1");
+        let prompt_heat_limit: usize = std::env::var("HIPFIRE_PROMPT_HEAT_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(64);
+
+        Self {
+            normalize_prompt,
+            prompt_token_heat,
+            prompt_heat_json,
+            prompt_heat_limit,
+            dflash_draft: std::env::var("HIPFIRE_DFLASH_DRAFT").ok(),
+            dflash_mode: std::env::var("HIPFIRE_DFLASH_MODE")
+                .unwrap_or_else(|_| "off".to_string()),
+            draft_f16: std::env::var("HIPFIRE_DRAFT_F16").ok().as_deref() != Some("0"),
+            draft_gemm_dump: std::env::var("HIPFIRE_DRAFT_GEMM_DUMP")
+                .ok()
+                .as_deref() == Some("1"),
+            draft_subphase: std::env::var("HIPFIRE_DRAFT_SUBPHASE")
+                .ok()
+                .as_deref() == Some("1"),
+            ddtree_budget: std::env::var("HIPFIRE_DDTREE_BUDGET")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(256),
+            ddtree_topk: std::env::var("HIPFIRE_DDTREE_TOPK")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(8),
+            prefill_batched: std::env::var("HIPFIRE_PREFILL_BATCHED")
+                .ok()
+                .as_deref() != Some("0"),
+            flash_partials_batch: std::env::var("HIPFIRE_FLASH_PARTIALS_BATCH")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok()),
+            ngram_loop_threshold: std::env::var("HIPFIRE_NGRAM_LOOP_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(8),
+            ngram_window: std::env::var("HIPFIRE_NGRAM_WINDOW")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(256),
+            devices: std::env::var("HIPFIRE_DEVICES").ok(),
+            allow_mixed_arch: std::env::var("HIPFIRE_ALLOW_MIXED_ARCH")
+                .ok()
+                .as_deref() == Some("1"),
+            uniform_vram_tolerance_gb: std::env::var("HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB")
+                .ok()
+                .and_then(|s| s.parse().ok()),
+            lm_head_f16: std::env::var("HIPFIRE_LM_HEAD_F16")
+                .unwrap_or_else(|_| "auto".to_string()),
+        }
+    }
+}

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -208,7 +208,7 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
             //
             // HIPFIRE_DRAFT_F16=0 falls back to the legacy F16→F32 lift for
             // A/B comparison.
-            let use_f16 = std::env::var("HIPFIRE_DRAFT_F16").ok().as_deref() != Some("0");
+            let use_f16 = crate::config::get().draft_f16;
             if use_f16 {
                 assert_eq!(data.len(), m * k * 2, "dflash {name} F16 byte-size mismatch");
                 let buf = gpu.upload_raw(data, &[m * k])?;
@@ -610,7 +610,7 @@ fn gemm_dispatch(
     // atomic load per call rather than an env lookup.
     static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let dump = *DUMP.get_or_init(|| {
-        std::env::var("HIPFIRE_DRAFT_GEMM_DUMP").ok().as_deref() == Some("1")
+        crate::config::get().draft_gemm_dump
     });
     if dump { gpu.hip.device_synchronize()?; }
     let t0 = if dump { Some(std::time::Instant::now()) } else { None };
@@ -897,7 +897,7 @@ pub fn draft_forward(
     // gemm_gate_up_hfq4g256_wmma kernel (measured 73 µs/call on the same
     // shape in target; vs ksplit's 288 µs/call on a different shape). Or
     // find the real cause of the ksplit slowdown on draft shapes.
-    let dbg = std::env::var("HIPFIRE_DRAFT_SUBPHASE").ok().as_deref() == Some("1");
+    let dbg = crate::config::get().draft_subphase;
     let mut us_attn_gemm: u128 = 0;
     let mut us_attn_kernel: u128 = 0;
     let mut us_ffn_gemm: u128 = 0;

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod arch;
 pub mod bf16_loader;
+pub mod config;
 pub mod eval_common;
 pub mod gguf;
 pub mod hfq;

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -1579,9 +1579,7 @@ impl PrefillBatchScratch {
 
         let tile_size = 128usize;
         let max_tiles = (kv_max_seq + tile_size - 1) / tile_size;
-        let batch_mult = std::env::var("HIPFIRE_FLASH_PARTIALS_BATCH")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
+        let batch_mult = crate::config::get().flash_partials_batch
             .filter(|&n| n >= 1 && n <= PREFILL_MAX_BATCH)
             .unwrap_or(16);
         let partials_size = batch_mult * config.n_heads * max_tiles * (2 + config.head_dim);
@@ -1672,7 +1670,7 @@ pub fn forward_prefill_batch(
         return Ok(());
     }
 
-    let force_fallback = std::env::var("HIPFIRE_PREFILL_BATCHED").ok().as_deref() == Some("0");
+    let force_fallback = !crate::config::get().prefill_batched;
     const MIN_BATCH: usize = 4;
     let arch = gpu.arch.as_str();
     let kv_ok = kv_cache.quant_q8 || kv_cache.quant_asym2 || kv_cache.quant_asym3 || kv_cache.quant_asym4;

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -1818,7 +1818,7 @@ fn forward_prefill_chunk(
     // Q8 WMMA arch gate — see qwen35.rs q8_wmma_arch for the matching capture
     // and rationale (gfx11-only; gfx12 needs a `_w32_gfx12` builtin variant
     // that has not been authored yet, so routing gfx12 here would crash at JIT).
-    let q8_wmma_arch = rdna_compute::has_wmma_f16(gpu.arch.as_str());
+    let q8_wmma_arch = gpu.flags.has_wmma_f16();
 
     // 1. Embed N tokens into pbs.x_batch.
     if matches!(weights.embd_format, EmbeddingFormat::HFQ4G256 | EmbeddingFormat::Q8_0) {

--- a/crates/hipfire-runtime/src/loop_guard.rs
+++ b/crates/hipfire-runtime/src/loop_guard.rs
@@ -47,12 +47,8 @@ impl LoopGuard {
     ///   disable the guard entirely.
     /// - `HIPFIRE_NGRAM_WINDOW` (default 256): how many trailing tokens to
     ///   inspect on each `check` call.
-    pub fn from_env() -> Self {
-        let ngram_threshold: usize = std::env::var("HIPFIRE_NGRAM_LOOP_THRESHOLD")
-            .ok().and_then(|v| v.parse().ok()).unwrap_or(8);
-        let ngram_window: usize = std::env::var("HIPFIRE_NGRAM_WINDOW")
-            .ok().and_then(|v| v.parse().ok()).unwrap_or(256);
-        Self::new(ngram_threshold, ngram_window)
+    pub fn from_config(config: &crate::config::RuntimeConfig) -> Self {
+        Self::new(config.ngram_loop_threshold, config.ngram_window)
     }
 
     /// Construct with explicit threshold and window. `threshold = 0` disables

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -393,10 +393,7 @@ fn preflight_vram_with_opts(devices: &[Gpu], check_vram_delta: bool) -> HipResul
         return Ok(());
     }
     let arch0 = devices[0].arch.clone();
-    let allow_mixed = if crate::config::get().allow_mixed_arch { Ok("1".to_string()) } else { Err(std::env::VarError::NotPresent) }
-        .ok()
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+    let allow_mixed = crate::config::get().allow_mixed_arch;
     let mut frees = Vec::with_capacity(devices.len());
     for d in devices {
         if d.arch != arch0 {
@@ -430,9 +427,8 @@ fn preflight_vram_with_opts(devices: &[Gpu], check_vram_delta: bool) -> HipResul
     let max_free = *frees.iter().max().unwrap();
     let min_free = *frees.iter().min().unwrap();
     let delta_gb = (max_free - min_free) as f64 / 1e9;
-    let tol_gb = match crate::config::get().uniform_vram_tolerance_gb { Some(t) => Ok(t.to_string()), None => Err(std::env::VarError::NotPresent) }
-        .ok()
-        .and_then(|s| s.parse::<f64>().ok())
+    let tol_gb = crate::config::get().uniform_vram_tolerance_gb
+        .map(|t| t as f64)
         .unwrap_or(DEFAULT_VRAM_TOLERANCE_GB);
     if delta_gb > tol_gb {
         return Err(HipError::new(

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -358,7 +358,7 @@ fn uniform_split_counts(n_devices: usize, n_layers: usize) -> Vec<usize> {
 /// `HIPFIRE_DEVICES=0,1` selects the first two HIP-visible devices. When
 /// unset, takes the first `n_devices` visible IDs.
 fn resolve_device_ids(n_devices: usize) -> HipResult<Vec<i32>> {
-    if let Ok(s) = std::env::var("HIPFIRE_DEVICES") {
+    if let Some(ref s) = crate::config::get().devices {
         let ids: Vec<i32> = s
             .split(',')
             .map(|p| p.trim())
@@ -393,7 +393,7 @@ fn preflight_vram_with_opts(devices: &[Gpu], check_vram_delta: bool) -> HipResul
         return Ok(());
     }
     let arch0 = devices[0].arch.clone();
-    let allow_mixed = std::env::var("HIPFIRE_ALLOW_MIXED_ARCH")
+    let allow_mixed = if crate::config::get().allow_mixed_arch { Ok("1".to_string()) } else { Err(std::env::VarError::NotPresent) }
         .ok()
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
@@ -430,7 +430,7 @@ fn preflight_vram_with_opts(devices: &[Gpu], check_vram_delta: bool) -> HipResul
     let max_free = *frees.iter().max().unwrap();
     let min_free = *frees.iter().min().unwrap();
     let delta_gb = (max_free - min_free) as f64 / 1e9;
-    let tol_gb = std::env::var("HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB")
+    let tol_gb = match crate::config::get().uniform_vram_tolerance_gb { Some(t) => Ok(t.to_string()), None => Err(std::env::VarError::NotPresent) }
         .ok()
         .and_then(|s| s.parse::<f64>().ok())
         .unwrap_or(DEFAULT_VRAM_TOLERANCE_GB);

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -1202,7 +1202,7 @@ impl Tokenizer {
         for &id in &ids {
             counts[HeatClass::from_rank(self.rank_of(id, &table)) as usize] += 1;
         }
-        if std::env::var("HIPFIRE_PROMPT_HEAT_JSON").ok().as_deref() == Some("1") {
+        if crate::config::get().prompt_heat_json {
             let mut s = String::with_capacity(2048);
             s.push_str("{\"bytes\":");
             s.push_str(&text.len().to_string());

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -1224,8 +1224,7 @@ impl Tokenizer {
             println!("{s}");
             return;
         }
-        let limit: usize = std::env::var("HIPFIRE_PROMPT_HEAT_LIMIT")
-            .ok().and_then(|v| v.parse().ok()).unwrap_or(64);
+        let limit: usize = crate::config::get().prompt_heat_limit;
         eprintln!("[token-heat] prompt={} bytes  tokens={}", text.len(), ids.len());
         eprintln!("[token-heat] {:>4}  {:>6}  {:>7}  {:7}  {}", "pos", "id", "rank", "class", "decoded");
         for (pos, &id) in ids.iter().take(limit).enumerate() {
@@ -1386,11 +1385,8 @@ pub fn strip_trailing_line_ws(s: &str) -> String {
 pub fn maybe_normalize_prompt(s: &str) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;
     // Default ON. Explicit "0" / "false" / "off" / "no" opts out.
-    if let Ok(v) = std::env::var("HIPFIRE_NORMALIZE_PROMPT") {
-        let v = v.to_ascii_lowercase();
-        if v == "0" || v == "false" || v == "off" || v == "no" {
-            return Cow::Borrowed(s);
-        }
+    if !crate::config::get().normalize_prompt {
+        return Cow::Borrowed(s);
     }
 
     let mut cur: Cow<'_, str> = Cow::Borrowed(s);

--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -79,10 +79,11 @@ pub struct KernelCompiler {
     compiled: HashMap<String, PathBuf>,
     precompiled_dir: Option<PathBuf>,
     has_hipcc: bool,
+    pub extra_flags: String,
 }
 
 impl KernelCompiler {
-    pub fn new(arch: &str) -> HipResult<Self> {
+    pub fn new(arch: &str, extra_flags: String) -> HipResult<Self> {
         // Cache (hot path) defaults to $CWD/.hipfire_kernels so parallel
         // worktrees/agents on the same machine don't clobber each other's
         // JIT'd .hsaco blobs. /tmp was shared state: two daemons from
@@ -163,6 +164,7 @@ impl KernelCompiler {
             compiled: HashMap::new(),
             precompiled_dir,
             has_hipcc,
+            extra_flags,
         })
     }
 
@@ -220,7 +222,7 @@ impl KernelCompiler {
             && std::fs::read_to_string(&hash_path).unwrap_or_default() == src_hash;
 
         if !cache_valid {
-            Self::hipcc_compile(&self.arch, &src_path, &obj_path, name, source)?;
+            Self::hipcc_compile(&self.arch, &src_path, &obj_path, name, source, &self.extra_flags)?;
             let _ = std::fs::write(&hash_path, &src_hash);
         }
 
@@ -299,16 +301,13 @@ impl KernelCompiler {
     fn win_short_path_if_needed(p: &str) -> String { p.to_string() }
 
     /// Run hipcc for a single kernel. Shared by compile() and compile_batch().
-    fn hipcc_compile(arch: &str, src_path: &Path, obj_path: &Path, name: &str, source: &str) -> HipResult<()> {
+    fn hipcc_compile(arch: &str, src_path: &Path, obj_path: &Path, name: &str, source: &str, extra_flags: &str) -> HipResult<()> {
         std::fs::write(src_path, source).map_err(|e| {
             hip_bridge::HipError::new(0, &format!("failed to write kernel source: {e}"))
         })?;
         let _ = std::fs::remove_file(obj_path);
 
-        // Optional extra hipcc flags via HIPFIRE_HIPCC_EXTRA_FLAGS. Used for
-        // one-off experiments like `-mcumode` vs `-mno-cumode` on RDNA1
-        // without having to rebuild every call site.
-        let extra = std::env::var("HIPFIRE_HIPCC_EXTRA_FLAGS").unwrap_or_default();
+        let extra = extra_flags;
         let per_kernel = Self::per_kernel_flags(source);
         let mut args: Vec<String> = vec![
             "--genco".into(),
@@ -453,9 +452,10 @@ impl KernelCompiler {
         let results: Vec<_> = to_compile.into_iter().map(|(name, source, src_hash, src_path, obj_path, hash_path)| {
             let arch = arch.clone();
             let precompiled_dir = precompiled_dir.clone();
+            let extra_flags = self.extra_flags.clone();
             let done = std::sync::Arc::clone(&done);
             let handle = thread::spawn(move || {
-                let result = Self::hipcc_compile(&arch, &src_path, &obj_path, &name, &source);
+                let result = Self::hipcc_compile(&arch, &src_path, &obj_path, &name, &source, &extra_flags);
                 if result.is_ok() {
                     let _ = std::fs::write(&hash_path, &src_hash);
                     // Write back to precompiled dir

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -6,6 +6,7 @@
 //! Manages compiled kernels, provides typed tensor operations.
 
 use crate::compiler::KernelCompiler;
+use crate::feature_flags::FeatureFlags;
 use crate::kernels;
 use hip_bridge::{DeviceBuffer, HipResult, HipRuntime, Rocblas};
 use std::cell::Cell;
@@ -760,6 +761,7 @@ pub trait ActivationCapture: Send + Sync {
 pub struct Gpu {
     pub hip: HipRuntime,
     pub arch: String,
+    pub flags: Arc<FeatureFlags>,
     pub device_id: i32,
     compiler: KernelCompiler,
     modules: HashMap<String, hip_bridge::Module>,
@@ -834,14 +836,6 @@ pub struct Gpu {
     /// Diagnostic: when true, `launch_maybe_blob` takes the blob path even when
     /// `capture_mode=false`. Isolates "blob-vs-kernelParams path" bugs without
     /// the rest of the graph-capture machinery (stream capture, staging, etc).
-    /// Set via `HIPFIRE_BLOB_FORCE=1` at init. Blobs accumulate unbounded in
-    /// `capture_blobs` while set — only intended for short diagnostic runs.
-    pub force_blob_path: bool,
-    /// Diagnostic: when true, gfx906 MMQ residual quantizes X to Q8_1 then
-    /// returns FP16 wave64 instead of running dp4a — isolates the cost of
-    /// the activation pre-quantize pass. Read once via `HIPFIRE_MMQ_DIAG_QUANTIZE_ONLY=1`
-    /// at init so the per-call hot path doesn't hit `env::var`'s global lock.
-    pub mmq_diag_quantize_only: bool,
     /// Heap-stored kernarg blobs for the current capture session. The blob
     /// pointers are baked into the graph at capture time — do NOT clear this
     /// vec until after `graph_exec_destroy`.
@@ -1058,33 +1052,19 @@ impl Gpu {
         }
         eprintln!("GPU dev {}: {} ({:.1} GB VRAM, HIP {}.{})", id, arch, vram_total as f64 / 1e9, hip_major, hip_minor);
 
+        let flags = Arc::new(FeatureFlags::from_env(&arch));
+
         let compiler = KernelCompiler::new(&arch)?;
 
         LAST_BOUND_DEVICE.with(|c| c.set(id));
 
-        // Per-arch defaults for MMQ screening. See the mmq_screen and
-        // mmq_screen_threshold fields below for rationale.
-        //
-        // gfx906 was previously default-on out of caution because the MMQ
-        // kernels were ported from the gfx11xx i8-WMMA path that motivated
-        // #87, but gfx906 uses dp4a (`__builtin_amdgcn_sdot4`), not WMMA,
-        // and empirically tolerates the row-3994 weight outliers within the
-        // 0.50 threshold. Audit on 2026-05-18 across qwen3.5-{0.8B, 9B} mq4
-        // (AWQ + non-AWQ) showed 0/248 weights flagged at threshold 0.50 —
-        // the screen reference dispatch (~700 µs/weight via
-        // `gemm_hfq4g256_residual_fp16_wave64`) was pure overhead, costing
-        // ~145 ms on the first prefill. Users on new quant formats can
-        // re-enable defensively via `HIPFIRE_MMQ_SCREEN=1`.
-        //
-        // RDNA3/3.5: unchanged behavior. Already default-off here; clients
-        // that need #87 protection (daemon callers loading on i8-WMMA archs)
-        // explicitly pass `mmq_screen: true` at load time.
-        let mmq_screen_default: bool = false;
-        let mmq_screen_threshold_default: f32 = if arch == "gfx906" { 0.50 } else { 0.10 };
+        let mmq_screen = flags.mmq_screen;
+        let mmq_screen_threshold = flags.mmq_screen_threshold;
 
         Ok(Self {
             hip,
             arch,
+            flags,
             device_id: id,
             compiler,
             modules: HashMap::new(),
@@ -1110,34 +1090,9 @@ impl Gpu {
             q8_1_mmq_x_scratch: None,
             q8_1_mmq_x_scratch_bytes: 0,
             mmq_screen_cache: HashMap::new(),
-            // Per-arch default for MMQ per-weight screening:
-            //   gfx906: on (paired with the 0.50 threshold default below).
-            //     Acts as a regression safety net; expected to reject 0
-            //     weights at 0.50 threshold but catches future distribution
-            //     issues. Cached per weight pointer, so cost is amortized.
-            //   other archs: off — preserves prior behavior; flip only after
-            //     similar validation.
-            mmq_screen: std::env::var("HIPFIRE_MMQ_SCREEN").ok()
-                .map(|v| v == "1")
-                .unwrap_or(mmq_screen_default),
-            // Default screening threshold: 0.10 absolute error per row,
-            // measured against synthetic uniform [-2, 2] activations.
-            // The 0.10 default was set when the gfx906 dp4a kernel was
-            // buggy (commit 8081822); the post-redesign kernel (commit
-            // c022682) is structurally cleaner and the same prompts pass
-            // coherence at 0.50. Bumping the gfx906 default to 0.50
-            // recovers the 30/72 weights that get rejected per Qwen 9B
-            // load (mostly row 3994 of m=4096 matrices, a known
-            // degenerate quant group). pp128 lifts 355 → 462 tok/s
-            // (1.30×) at threshold=0.50 with no coherence regression
-            // across all 4 mq4 rows of the gate. Other archs keep the
-            // conservative 0.10 default until similar validation.
-            mmq_screen_threshold: std::env::var("HIPFIRE_MMQ_SCREEN_THRESHOLD")
-                .ok().and_then(|s| s.parse().ok())
-                .unwrap_or(mmq_screen_threshold_default),
+            mmq_screen,
+            mmq_screen_threshold,
             capture_mode: false,
-            force_blob_path: std::env::var("HIPFIRE_BLOB_FORCE").ok().as_deref() == Some("1"),
-            mmq_diag_quantize_only: std::env::var("HIPFIRE_MMQ_DIAG_QUANTIZE_ONLY").ok().as_deref() == Some("1"),
             capture_blobs: Vec::new(),
             graph_exec: None,
             captured_graph: None,
@@ -1154,7 +1109,7 @@ impl Gpu {
             fp16_shadow_cache: HashMap::new(),
             capture_handler: None,
         }).map(|mut gpu| {
-            if gpu.force_blob_path {
+            if gpu.flags.force_blob_path {
                 eprintln!("[diag] HIPFIRE_BLOB_FORCE=1: all kernel launches will use the blob path (kernelParams bypassed). Diagnostic only.");
             }
             // Auto-init rocBLAS on CDNA3 so the batched-prefill MFMA path is
@@ -1175,7 +1130,7 @@ impl Gpu {
         self.bind_thread_or_warn();
         if self.rocblas.is_some() { return; }
         let cdna3 = matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942");
-        let all_archs = std::env::var("HIPFIRE_ROCBLAS_ALL_ARCHS").ok().as_deref() == Some("1");
+        let all_archs = self.flags.rocblas_all_archs;
         if !cdna3 && !all_archs { return; }
         match Rocblas::load() {
             Ok(rb) => {
@@ -1576,7 +1531,7 @@ impl Gpu {
         params: &mut Vec<*mut std::ffi::c_void>,
         blob_builder: impl FnOnce() -> hip_bridge::KernargBlob,
     ) -> HipResult<()> {
-        if self.capture_mode || self.force_blob_path {
+        if self.capture_mode || self.flags.force_blob_path {
             let mut blob = blob_builder();
             // Pad tail to 16-byte alignment — some kernel struct layouts that
             // HIP's loader expects have an implicit final pad to the struct's
@@ -15962,7 +15917,7 @@ impl Gpu {
         // *after* paying the quantize cost. The flag is read once at init
         // (see `Gpu::new`) so this check is a single bool load, not a
         // per-call env::var lookup.
-        if self.mmq_diag_quantize_only {
+        if self.flags.mmq_diag_quantize_only {
             let _ = x_q8_ptr;
             return self.gemm_hfq4g256_residual_fp16_wave64(a_raw, x, y, m, k, batch_size);
         }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -13,7 +13,7 @@ use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::{Arc, OnceLock};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 
 /// Per-group byte size of the MQ3-Lloyd quantization layout.
 ///
@@ -45,294 +45,12 @@ thread_local! {
     static LAST_BOUND_DEVICE: Cell<i32> = const { Cell::new(-1) };
 }
 
-/// gfx1100 multi-row GEMV tile selector.
-/// HIPFIRE_GEMV_ROWS ∈ {1, 2, 4, 8}. Default 1 = single-row kernel (legacy).
-/// Cached in a OnceLock — the env var is read exactly once per process.
-/// Returns the runtime HIPFIRE_GEMV_ROWS override if set, otherwise None.
-/// Valid values: 1, 2, 4, 8. Anything else is clamped to 1.
-fn gemv_rows_override() -> Option<u32> {
-    static CACHE: OnceLock<Option<u32>> = OnceLock::new();
-    *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_GEMV_ROWS")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .map(|r| match r { 1 | 2 | 4 | 8 => r, _ => 1 })
-    })
-}
-
-/// gfx906 dp4a-port toggle for memory-bound fused GEMVs.
-///
-/// `fused_gate_up_hfq4g256_dp4a` pre-quantizes x to Q8_1 and uses
-/// v_dot4_i32_i8 for the inner-loop multiply. Per the per-kernel PMC
-/// pass at 2026-05-05, this kernel was memory-bound (3.86 % MemUnit
-/// stall, 41 % VALUBusy) — dp4a's 75 % x-traffic reduction lands on
-/// the actual bottleneck.
-///
-/// Measured on MI50 / qwen3.5-9b.mq4 AR decode: +7.1 % tok/s
-/// (54.6 → 58.5 median, 3-run; BW 270 → 290 GiB/s) on top of the
-/// prefetch win on gemv_residual. Coherence gate clean.
-///
-/// Default-on for gfx906 only. Override with HIPFIRE_GEMV_DP4A={0,1}.
-/// fused_qkv / fused_qkvza ports for HFQ4 (PR #167) and HFQ6 (PR #187)
-/// have shipped; this lever now toggles every fused dp4a path together.
-pub fn gemv_dp4a_enabled(arch: &str) -> bool {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    let override_ = *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_GEMV_DP4A").ok().and_then(|v| match v.as_str() {
-            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
-            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
-            _ => None,
-        })
-    });
-    override_.unwrap_or(arch == "gfx906")
-}
-
-/// Weight-prefetch variant of the wave64 residual-GEMV.
-///
-/// The prefetch kernel does software-pipelined across-quad weight loads —
-/// quad q+1's 12 dwords are issued before quad q's compute chain runs, so
-/// L2 fills overlap with the FMA chain instead of stalling the load unit.
-///
-/// Measured on gfx906 (MI50) AR decode of qwen3.5-9b.mq4: +4.8% tok/s
-/// (51.9 → 54.4 median, 3-run; BW 256.7 → 269.1 GiB/s). PMC L2CacheHit
-/// pass showed ~40 % L2 hit on the non-prefetched kernel — this lever
-/// shifts a fraction of those misses into the L2-hit regime while
-/// compute is in flight. Coherence gate clean (b37068c).
-///
-/// **Default-on for gfx906 only.** Other wave64-native archs
-/// (gfx908/MI100, gfx940-942/MI300x) take the original kernel until
-/// measured. Override with HIPFIRE_GEMV_PREFETCH={0,1}.
-///
-/// See docs/perf-checkpoints/2026-05-05-gfx906-decode-investigation.md.
-fn gemv_prefetch_enabled(arch: &str) -> bool {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    let override_ = *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_GEMV_PREFETCH").ok().and_then(|v| match v.as_str() {
-            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
-            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
-            _ => None,
-        })
-    });
-    override_.unwrap_or(arch == "gfx906")
-}
-
-/// gfx94x (MI300X CDNA3) LDS-cached, 8-rows-per-WG HFQ4 GEMV variant.
-///
-/// The prior `*_wave64` kernels were tuned for CDNA1/2 (80 CUs, modest
-/// HBM). gfx942 has 304 CUs + 5.3 TB/s HBM; the 2-rows-per-WG geometry
-/// leaves the GPU starved (2560 WGs / 304 CUs = 8 launch rounds, each
-/// reading x[K] from L1 with no explicit sharing).
-///
-/// gfx942 variant: 256 threads/WG × 8 rows/WG × cooperative LDS load
-/// of x → 4× fewer WGs, 4× less x-HBM traffic. Same inner-loop math.
-///
-/// Default ON for gfx94x. Override with HIPFIRE_GFX942_LDS_GEMV={0,1}.
-fn gfx942_lds_gemv_enabled(arch: &str) -> bool {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    let override_ = *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_GFX942_LDS_GEMV").ok().and_then(|v| match v.as_str() {
-            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
-            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
-            _ => None,
-        })
-    });
-    override_.unwrap_or(false)  // gfx942 LDS GEMV: +1.9% on K=5120 attn_out alone
-    // but neutral overall on 27B-3.6 AR; opt-in for research
-}
-
-/// Per-arch default R for the multi-row HFQ4 GEMV kernel family.
-///
-/// - RDNA3 (gfx1100/1101/1102): R=1. Measured negative on 7900 XTX —
-///   single-row is already near-BW-saturated (577 GiB/s on 9B ≈ 60% of
-///   the 960 GiB/s peak) and multi-row under-subscribes the wave scheduler.
-/// - RDNA2 (gfx1030/1031): R=1. These have their own arch-optimized narrow
-///   kernels via gemv_hfq4g256_for_arch; the multi-row path is bypassed.
-/// - Default (gfx1010 baseline, gfx1013 Cyan Skillfish / BC-250, others):
-///   R=2. Measured +2.75% on BC-250 Qwen3.5 0.8B MQ4 in the session 1
-///   perf work — the x-hoist amortization across 2 rows pays for the
-///   minor occupancy drop from 20 → 18 waves/SIMD.
-fn gemv_rows_default(arch: &str) -> u32 {
-    match arch {
-        "gfx1100" | "gfx1101" | "gfx1102" => 1,
-        "gfx1030" | "gfx1031" => 1,
-        // Vega 20 / GCN5 (gfx906), CDNA1 (MI100, gfx908), and CDNA3
-        // (MI300X): wave64 native.
-        // `gemv_hfq4g256_wide` uses block=[64,1,1] = exactly one wave —
-        // zero lane waste. The 32-thread multirow variants run on half a
-        // wave, so the wide kernel is the natural fit. Return rows=1 to
-        // trigger use_wide.
-        "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942" => 1,
-        _ => 2,
-    }
-}
-
-/// Whether this GPU architecture supports the `v_dot2_f32_f16` instruction
-/// (dot10-insts feature in LLVM). This is required for the FP16 "dot2" GEMM fast path.
-///
-/// Notably:
-/// - gfx1010 (Navi 10 / RX 5700 XT) lacks this instruction despite being RDNA1.
-/// - gfx1011 (Navi 12) and gfx1012 (Navi 14) have it, also despite being RDNA1.
-/// - gfx1013 (Van Gogh / BC-250 APU) lacks it despite being RDNA2-ish.
-/// - gfx1030+ (standard RDNA2) and gfx1100+ (RDNA3/4) have it.
-fn has_dot2_f32_f16(arch: &str) -> bool {
-    matches!(arch,
-        "gfx1011" | "gfx1012"
-        | "gfx1030" | "gfx1031" | "gfx1032"
-        | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
-        | "gfx1150" | "gfx1151" | "gfx1152"
-        | "gfx1200" | "gfx1201")
-}
-
-/// Whether this architecture can compile the gfx10 HFQ3 sdot4 kernels.
-///
-/// These sources use `__builtin_amdgcn_sdot4`, which ROCm rejects on gfx11
-/// targets without the `dot1-insts` feature even though they have the dot2
-/// FP16 path.
-fn hfq3_sdot4_gfx10_enabled(arch: &str) -> bool {
-    matches!(arch, "gfx1011" | "gfx1012" | "gfx1030" | "gfx1031" | "gfx1032")
-}
-
-/// Whether to route HFQ3 batched-prefill through the experimental
-/// wave32 dp4a path (`gemm_qkv_hfq3g256_dp4a` / `gemm_gate_up_hfq3g256_dp4a`)
-/// instead of the default dot2 family on gfx10.
-///
-/// Phase 2 of `docs/plans/gfx10_mq3_prefill.md` — an experiment to see
-/// whether the sdot4 4×-ALU lift that helped gfx906 transfers to wave32.
-/// Default off (dot2 ships); flip on with `HIPFIRE_HFQ3_DP4A=1` to bench.
-/// Available only on the gfx10 sdot4 subset (gfx1011/1012/1030-1032) —
-/// NOT gfx1010/gfx1013/gfx11/gfx12.
-fn hfq3_dp4a_enabled(arch: &str) -> bool {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    let override_ = *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_HFQ3_DP4A").ok().and_then(|v| match v.as_str() {
-            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
-            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
-            _ => None,
-        })
-    });
-    if !override_.unwrap_or(false) {
-        return false;
-    }
-    hfq3_sdot4_gfx10_enabled(arch)
-}
-
 /// Current layer index, set by the qwen35 forward_prefill_chunk at the
 /// start of each layer iteration. Used by `hfq3_mmq_layer_gate_pass` to
 /// support per-layer MMQ-on/off experiments (see issue #302 — KLD
 /// attribution sweep). Default 0; no semantic meaning outside an
 /// instrumented sweep.
 pub static MMQ_CURRENT_LAYER: AtomicUsize = AtomicUsize::new(0);
-
-/// Whether the current layer index falls within the
-/// `HIPFIRE_HFQ3_MMQ_LAYER_MIN..=HIPFIRE_HFQ3_MMQ_LAYER_MAX` range, if
-/// either is set. Both env vars are OnceLock-cached. Default open
-/// (always pass) when neither var is set — preserves current routing.
-fn hfq3_mmq_layer_gate_pass() -> bool {
-    static MIN: OnceLock<Option<usize>> = OnceLock::new();
-    static MAX: OnceLock<Option<usize>> = OnceLock::new();
-    let lo = *MIN.get_or_init(|| {
-        std::env::var("HIPFIRE_HFQ3_MMQ_LAYER_MIN").ok()
-            .and_then(|v| v.parse::<usize>().ok())
-    });
-    let hi = *MAX.get_or_init(|| {
-        std::env::var("HIPFIRE_HFQ3_MMQ_LAYER_MAX").ok()
-            .and_then(|v| v.parse::<usize>().ok())
-    });
-    if lo.is_none() && hi.is_none() {
-        return true;  // gate open
-    }
-    let layer = MMQ_CURRENT_LAYER.load(Ordering::Relaxed);
-    if let Some(lo) = lo { if layer < lo { return false; } }
-    if let Some(hi) = hi { if layer > hi { return false; } }
-    true
-}
-
-/// Whether to route HFQ3 residual through the experimental wave32 MMQ
-/// kernel (`gemm_hfq3g256_residual_mmq`). Phase 3 minimal probe. Same
-/// gfx10 sdot4 arch set as `hfq3_dp4a_enabled`. Gated by
-/// `HIPFIRE_HFQ3_MMQ=1`.
-fn hfq3_mmq_rdna2_enabled(arch: &str) -> bool {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    let override_ = *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_HFQ3_MMQ").ok().and_then(|v| match v.as_str() {
-            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
-            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
-            _ => None,
-        })
-    });
-    if !override_.unwrap_or(false) {
-        return false;
-    }
-    hfq3_sdot4_gfx10_enabled(arch)
-}
-
-/// Whether to route HFQ4 residual through the experimental wave32 MMQ
-/// kernel on RDNA2+. Phase 3 side-win probe — tests whether HFQ4's
-/// cheaper nibble unpack lets MMQ beat the current fp16 fallback on
-/// gfx1030/1031. Gated by `HIPFIRE_HFQ4_MMQ_RDNA2=1`.
-fn hfq4_mmq_rdna2_enabled(arch: &str) -> bool {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    let override_ = *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_HFQ4_MMQ_RDNA2").ok().and_then(|v| match v.as_str() {
-            "1" | "true" | "TRUE" | "on" | "ON" => Some(true),
-            "0" | "false" | "FALSE" | "off" | "OFF" => Some(false),
-            _ => None,
-        })
-    });
-    if !override_.unwrap_or(false) {
-        return false;
-    }
-    matches!(arch,
-        "gfx1011" | "gfx1012"
-        | "gfx1030" | "gfx1031" | "gfx1032"
-        | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
-        | "gfx1150" | "gfx1151" | "gfx1152"
-        | "gfx1200" | "gfx1201")
-}
-
-/// Whether this arch has WMMA kernels that compile + run on the user's
-/// ROCm toolchain right now.
-///
-/// gfx11 (RDNA3, Navi 31/32/33) ships with the
-/// `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32` builtin and has been
-/// the WMMA workhorse since 0.1.4. gfx12 (RDNA4, Navi 48/RX 9070
-/// series) has WMMA in hardware too, but the existing kernels use the
-/// gfx11 builtin which AMD clang 22.x in ROCm 7.x does NOT pattern-
-/// match on gfx12 — it errors with `Cannot select: intrinsic
-/// %llvm.amdgcn.wmma.f32.16x16x16.f16` at codegen time. The gfx12 sister
-/// path uses `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12` and is
-/// gated by `has_wmma_f16_gfx12` below.
-pub fn has_wmma_f16(arch: &str) -> bool {
-    arch.starts_with("gfx11")
-}
-
-/// gfx12 (RDNA4) WMMA fp16. Kernels live at
-/// `kernels/src/gemm_*_wmma.gfx12.hip` and are validated by the
-/// `test_wmma_*_gfx12` channel-test examples (issue #54, PR #56).
-fn has_wmma_f16_gfx12(arch: &str) -> bool {
-    arch.starts_with("gfx12")
-}
-
-/// gfx12 (RDNA4) WMMA fp8. Same gating as fp16 (both are gfx12-only
-/// builtins); separate helper to allow finer-grained future gating
-/// (e.g. if a future RDNA arch lands fp16 WMMA without fp8). The
-/// fp8 prefill kernels are opt-in via HIPFIRE_FP8_WMMA=1 until they
-/// are perf-validated and made default on gfx12.
-fn has_wmma_fp8_gfx12(arch: &str) -> bool {
-    arch.starts_with("gfx12")
-}
-
-/// Opt-in gate for the fp8 prefill WMMA and decode dot4 kernels.
-/// Cached in a OnceLock — reading HIPFIRE_FP8_WMMA via `std::env::var`
-/// on every dispatch costs a syscall + String alloc which was visible
-/// as ~4 µs/call overhead in tight bench loops, swamping the FP8 win.
-fn is_fp8_wmma_enabled() -> bool {
-    use std::sync::OnceLock;
-    static GATE: OnceLock<bool> = OnceLock::new();
-    *GATE.get_or_init(|| {
-        std::env::var("HIPFIRE_FP8_WMMA").map_or(false, |v| v == "1")
-    })
-}
 
 /// Minimum batch size at which the FP8 WMMA prefill path is enabled.
 /// Below this, the FP16 WMMA path wins on gfx1201 (measured 0.71-0.94×
@@ -351,227 +69,7 @@ const FP8_WMMA_MIN_BATCH: usize = 1024;
 /// than uniformly applying FP8 everywhere.
 const FP8_GEMV_MIN_M: usize = 4096;
 
-/// Opt-in (default-OFF) gate for the gfx11 v_dot2_f32_f16 GEMV
-/// trickle-down. Synthetic bench measures 1.13-2.08× wins on FFN
-/// shapes on 7900 XTX, but production decode on 9B HFP4G32 lost 0.90×
-/// across two kernel variants (single-carry chain + 4 independent
-/// partials), same trap as the gfx12 FP8 paths — kernel-level ALU
-/// wins don't survive cross-kernel context costs in real decode.
-/// Kept opt-in via HIPFIRE_DOT2_GEMV=1 as research scaffold (the
-/// bench tools are still useful for future kernels). Default-off
-/// preserves the fallback that wins production.
-fn is_dot2_gemv_enabled() -> bool {
-    use std::sync::OnceLock;
-    static GATE: OnceLock<bool> = OnceLock::new();
-    *GATE.get_or_init(|| {
-        std::env::var("HIPFIRE_DOT2_GEMV").map_or(false, |v| v == "1")
-    })
-}
 
-/// Opt-in for the MMQ_Y=64 occupancy variants of the fused-projection
-/// kernels (plan §6 step 5 / §4.2). Halves the per-WG LDS X-tile and
-/// the accumulator register footprint; doubles the WG count per grid.
-/// Better for gfx906's 60 CUs at modest grid sizes — but the actual
-/// occupancy gain depends on register pressure, which is shape-
-/// dependent and must be measured. Currently only the gate_up family
-/// has y64 wrappers; qkv 3-way will be parameterized after y64 is
-/// validated as a net win on gate_up. Default OFF (Y=128).
-pub fn hfq4_mmq_gfx906_y64_enabled() -> bool {
-    use std::sync::OnceLock;
-    static GATE: OnceLock<bool> = OnceLock::new();
-    *GATE.get_or_init(|| {
-        std::env::var("HIPFIRE_HFQ4_MMQ_GFX906_Y64").map_or(false, |v| v == "1")
-    })
-}
-
-/// Gates the wave64 FP16 hybrid prefill path. gfx906 (Vega 20, MI50) is the
-/// only arch with measured data: +90% prefill on Qwen 3.5 9B (74 → 141 tk/s).
-/// gfx908 (CDNA1, MI100) shares __hfma2 + wave64 and would code-correctly
-/// run the same kernels, but we have no perf data and MFMA likely wants a
-/// different optimum. MI100 owners can opt in for A/B testing via
-/// `HIPFIRE_GCN5_WAVE64_HYBRID=1`. CDNA3 (gfx94x) uses rocBLAS MFMA.
-fn is_gcn5_wave64(arch: &str) -> bool {
-    if arch == "gfx906" {
-        return true;
-    }
-    if arch == "gfx908"
-        && std::env::var("HIPFIRE_GCN5_WAVE64_HYBRID")
-            .map_or(false, |v| v == "1")
-    {
-        return true;
-    }
-    false
-}
-
-/// Wave64-native arches: Vega 20 / GCN5 (gfx906), CDNA1 (gfx908, MI100),
-/// and CDNA3 (gfx94x, MI300X). On these, wave32 kernels (block=[32,1,1])
-/// waste the upper 32 lanes of every wave slot. The `*_wave64.hip` kernel
-/// variants pack two rows per block (one per warp) with block=[64,1,1] and
-/// halve the grid count. Adding gfx90a (CDNA2, MI200) here is a one-line
-/// change once it has been bring-up validated.
-fn has_wave64_native(arch: &str) -> bool {
-    matches!(arch, "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942")
-}
-
-/// Architectures that have an integer-MMQ prefill path:
-/// - RDNA3/3.5 (gfx1100..gfx1152): i8 WMMA via `__builtin_amdgcn_wmma_i32_16x16x16_iu8`
-/// - gfx906 (Vega 20, MI50/MI60): dp4a via `__builtin_amdgcn_sdot4`
-///
-/// The two dispatch through different Rust routines because the launch
-/// shape and LDS budget differ — see `gemm_hfq4g256_residual_mmq` (RDNA3,
-/// 32×8 block, 128×128 tile, WMMA) vs the gfx906 redesign
-/// (`gemm_hfq4g256_residual_mmq_gfx906_x{N}` for N ∈ {8..64}, 64×4 block,
-/// 128×mmq_x tile, dp4a, per-mmq_x X_STRIDE; see
-/// `kernels/src/gemm_hfq4g256_residual_mmq_gfx906_body.cuh`).
-fn has_mmq_dp4a_or_wmma(arch: &str) -> bool {
-    matches!(arch,
-        "gfx906"
-        | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
-        | "gfx1150" | "gfx1151" | "gfx1152")
-}
-
-/// Decide whether an integer-MMQ prefill path should be used for a given
-/// GEMM call. Combines the arch gate, the env override, and an empirical
-/// batch-size threshold.
-///
-/// **RDNA3 i8-WMMA MMQ:** uses a 128×128 batch tile (vs the fp16 WMMA path's
-/// 16×16), so it amortizes its high per-launch fixed cost only when
-/// batch_size is large enough to fill multiple tiles. Empirical sweep on
-/// Qwen 3.5 9B (gfx1100, ROCm 7.2, residual at m=4096) across pp ∈ {32..512}:
-///   pp32-pp192: MMQ regresses 23-69% (per-launch overhead dominates).
-///   pp224:      within noise (-8%).
-///   pp256+:     MMQ wins at multiples of 128 (+12% to +29%).
-/// Default RDNA3 threshold is 256.
-///
-/// **gfx906 dp4a MMQ:** uses runtime-dispatched mmq_x ∈ {8,16,24,32,40,48,56,64}
-/// per the post-redesign kernel (plans/gfx906_mmq_redesign.md, commit
-/// c022682). Default-on at batch_size ≥ 16 — pp128 hits 462 tok/s on
-/// Qwen 9B mq4 (3.28× over FP16 wave64); below pp16 the Q8_1 quantize +
-/// per-output launch overhead dominates so FP16 wave64 wins.
-///
-/// `HIPFIRE_MMQ` env override:
-///   `0` / `off`            — force MMQ off (debug / regression bisect)
-///   `1` / `on`             — force MMQ on at every batch (legacy behavior)
-///   `auto` / unset / other — auto-route by batch_size threshold (default)
-///
-/// Both env reads (`HIPFIRE_MMQ`, `HIPFIRE_MMQ_MIN_BATCH`) cache via
-/// `OnceLock` — no per-dispatch syscalls on the hot path (called from
-/// 9+ dispatch sites, ~288+ syscalls/chunk on 27B prefill otherwise).
-fn should_use_mmq(arch: &str, batch_size: usize) -> bool {
-    if !has_mmq_dp4a_or_wmma(arch) {
-        return false;
-    }
-    match mmq_env_override() {
-        Some(false) => false,
-        Some(true) => true,
-        None => {
-            // Per-arch default min_batch:
-            //   gfx906: 8 — empirically validated for both prefill (pp512
-            //     within noise of min_batch=16) and DFlash 27B verify
-            //     (B ∈ [12, 14] previously fell to FP16 wave64; lifting
-            //     them to MMQ gives +64.8% tok/s on humaneval-0 prompt,
-            //     +39% on lru_cache prose, 3-run deterministic). Earlier
-            //     min_batch=16 was set on the prefill `gemm_hfq4g256`
-            //     non-residual sweep; the *residual* batched GEMM
-            //     (used by DFlash verify) crosses below that and wins
-            //     down to B=8. AR decode at B=1 stays unchanged
-            //     (well below cutover). PMC pass at 2026-05-06:
-            //     `gemm_hfq4g256_residual_fp16_wave64` was 23.5% of
-            //     DFlash time at min_batch=16 — root cause of the gap.
-            //   other archs: 256 — RDNA3+ has WMMA which is genuinely faster
-            //     than MMQ at small batches; flip only when MMQ amortization
-            //     dominates.
-            let arch_min_batch: usize = if arch == "gfx906" { 8 } else { 256 };
-            let min_batch = mmq_min_batch_override().unwrap_or(arch_min_batch);
-            batch_size >= min_batch
-        }
-    }
-}
-
-/// Cached env-var read for `HIPFIRE_MMQ`. `Some(true)` = force on,
-/// `Some(false)` = force off, `None` = auto.
-fn mmq_env_override() -> Option<bool> {
-    static CACHE: OnceLock<Option<bool>> = OnceLock::new();
-    *CACHE.get_or_init(|| {
-        match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
-            Some("0") | Some("off") => Some(false),
-            Some("1") | Some("on") => Some(true),
-            _ => None,
-        }
-    })
-}
-
-/// Cached env-var read for `HIPFIRE_MMQ_MIN_BATCH` (per-arch min-batch override).
-fn mmq_min_batch_override() -> Option<usize> {
-    static CACHE: OnceLock<Option<usize>> = OnceLock::new();
-    *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_MMQ_MIN_BATCH")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-    })
-}
-
-/// Cached env-var read for `HIPFIRE_FP16=0` (disable FP16 fast paths).
-/// Called from 12+ dispatch sites on the prefill hot path; uncached read
-/// is one syscall + String alloc per dispatch.
-fn fp16_disabled() -> bool {
-    static CACHE: OnceLock<bool> = OnceLock::new();
-    *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0")
-    })
-}
-
-/// Whether FP16 fast paths are disabled FOR THE CURRENT LAYER, considering
-/// both the global `HIPFIRE_FP16=0` flag and the per-layer
-/// `HIPFIRE_FP16_LAYER_MIN..=HIPFIRE_FP16_LAYER_MAX` range. Used by the
-/// HFQ3 dispatcher chain to support per-layer FP16-vs-scalar KLD
-/// attribution sweeps (issue #302).
-///
-/// Returns `true` (= disable FP16, force scalar) when either:
-///   - the global `HIPFIRE_FP16=0` is set, OR
-///   - the current layer (`MMQ_CURRENT_LAYER`) falls within the
-///     `HIPFIRE_FP16_LAYER_MIN..=HIPFIRE_FP16_LAYER_MAX` range
-///
-/// When neither env var is set the per-layer range is inactive — the
-/// function reduces to `fp16_disabled()` and routing is unchanged.
-fn fp16_disabled_for_current_layer() -> bool {
-    if fp16_disabled() { return true; }
-    static MIN: OnceLock<Option<usize>> = OnceLock::new();
-    static MAX: OnceLock<Option<usize>> = OnceLock::new();
-    let lo = *MIN.get_or_init(|| {
-        std::env::var("HIPFIRE_FP16_LAYER_MIN").ok()
-            .and_then(|v| v.parse::<usize>().ok())
-    });
-    let hi = *MAX.get_or_init(|| {
-        std::env::var("HIPFIRE_FP16_LAYER_MAX").ok()
-            .and_then(|v| v.parse::<usize>().ok())
-    });
-    if lo.is_none() && hi.is_none() {
-        return false;  // per-layer gate not active
-    }
-    let layer = MMQ_CURRENT_LAYER.load(Ordering::Relaxed);
-    let above_min = lo.map(|m| layer >= m).unwrap_or(true);
-    let below_max = hi.map(|m| layer <= m).unwrap_or(true);
-    above_min && below_max  // in-range → disable FP16 for this layer
-}
-
-/// Cached env-var read for `HIPFIRE_WO_MMQ=1` (opt-in MMQ for the wo path
-/// on RDNA3+/RDNA3.5 while the tiled path is validated).
-fn wo_mmq_enabled() -> bool {
-    static CACHE: OnceLock<bool> = OnceLock::new();
-    *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1")
-    })
-}
-
-/// Cached env-var read for `HIPFIRE_LM_HEAD_WMMA=0` (disable the gfx11
-/// LM-head WMMA fast path).
-fn lm_head_wmma_disabled() -> bool {
-    static CACHE: OnceLock<bool> = OnceLock::new();
-    *CACHE.get_or_init(|| {
-        std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0")
-    })
-}
 
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
@@ -4700,7 +4198,7 @@ impl Gpu {
         // Shape-gated: FP8 dot4 only when M is large enough that it
         // actually wins (FFN shapes). At M < 4096 the fallback wins or
         // ties; uniform-FP8 was net-negative in 9B Qwen 3.5 decode.
-        if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && m >= FP8_GEMV_MIN_M {
+        if self.flags.has_wmma_fp8_gfx12() && self.flags.fp8_wmma && m >= FP8_GEMV_MIN_M {
             return self.gemv_hfp4g32_fp8_gfx12(a_raw, x, y, m, k);
         }
         // gfx11 (RDNA3) v_dot2_f32_f16 trickle-down: replaces the
@@ -4708,7 +4206,7 @@ impl Gpu {
         // No new scratch (reuses ensure_fp16_x), no cross-kernel
         // context cost like the FP8 path had. Default-on for gfx11.
         // Kill switch HIPFIRE_DOT2_GEMV=0 for A/B benching.
-        if has_wmma_f16(&self.arch) && is_dot2_gemv_enabled() {
+        if self.flags.has_wmma_f16() && self.flags.dot2_gemv {
             return self.gemv_hfp4g32_dot2_gfx11(a_raw, x, y, m, k);
         }
         self.gemv_hfp4g32_fallback(a_raw, x, y, m, k)
@@ -5675,7 +5173,7 @@ impl Gpu {
         // when M ≥ FP8_GEMV_MIN_M does FP8 dot4 win measurably on this
         // path. Below threshold (e.g. wo M=2048), the FP8 fused-rotation
         // costs more than the dot4 ALU savings — keep the F32 fallback.
-        if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && m >= FP8_GEMV_MIN_M {
+        if self.flags.has_wmma_fp8_gfx12() && self.flags.fp8_wmma && m >= FP8_GEMV_MIN_M {
             let x_fp8_ptr = self.rotate_x_mq_dual_fp8(x, x_rot, k)?;
             return self.gemv_hfp4g32_fp8_gfx12_with_fp8_ptr(a_raw, x_fp8_ptr, y, m, k);
         }
@@ -6069,8 +5567,8 @@ impl Gpu {
         // wave32 base since each warp's 32-lane reduction stays in-warp.
         // ILP-prefetch variant gates on gemv_prefetch_enabled(arch) — default
         // on for gfx906 (Phase A.1b, mirror of HFQ4 +4.8% lever from `3ef127d`).
-        if has_wave64_native(&self.arch) {
-            let (kname, ksrc): (&str, &str) = if gemv_prefetch_enabled(&self.arch) {
+        if self.flags.has_wave64_native() {
+            let (kname, ksrc): (&str, &str) = if self.flags.gemv_prefetch_enabled() {
                 (
                     "gemv_hfq6g256_residual_wave64_prefetch",
                     kernels::GEMV_HFQ6G256_RESIDUAL_WAVE64_PREFETCH_SRC,
@@ -6194,7 +5692,7 @@ impl Gpu {
         // See gemv_rows_default() for the measurement data that motivates
         // the per-arch defaults.
         let rdna3 = matches!(self.arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102");
-        let rows = gemv_rows_override().unwrap_or_else(|| gemv_rows_default(self.arch.as_str()));
+        let rows = self.flags.gemv_rows.unwrap_or_else(|| self.flags.gemv_rows_default);
         let use_multirow = rows > 1;
 
         // RDNA2 (gfx1030/1031): always use the arch-optimized narrow kernel.
@@ -6507,13 +6005,13 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if gemv_dp4a_enabled(&self.arch) {
+        if self.flags.gemv_dp4a_enabled() {
             return self.fused_qkv_hfq4g256_dp4a(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k,
             );
         }
 
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_x) = if cdna_wave64 {
             // gfx94x v2: 2 wave64s = 4 rows/WG, +1.9% on AR decode
             // (commit 5bd75a69 sibling). Default ON; opt out via
@@ -6614,7 +6112,7 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if gemv_dp4a_enabled(&self.arch) {
+        if self.flags.gemv_dp4a_enabled() {
             return self.fused_qkvza_hfq4g256_dp4a(
                 a_qkv, a_z, a_beta, a_alpha, x,
                 y_qkv, y_z, y_beta, y_alpha,
@@ -6625,7 +6123,7 @@ impl Gpu {
         // 2 rows per block, halves grid count vs wave32 kernel which wastes half
         // the wave slot. This kernel uses no MFMA, just FMA + shfl_down within
         // wave64, so it is safe for Vega 20 as well as CDNA.
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_x) = if cdna_wave64 {
             // gfx94x v2: 2 wave64s = 4 rows/WG, +1.9% on AR decode
             // (commit 5bd75a69 sibling). Default ON; opt out via
@@ -6833,9 +6331,9 @@ impl Gpu {
             }
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
+        if batch_size > 1 && !self.flags.fp16_disabled {
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
-            if is_gcn5_wave64(&self.arch) {
+            if self.flags.is_gcn5_wave64() {
                 // gfx906 dp4a MMQ split: qkv + z route through the new MMQ
                 // kernel (large-M outputs); beta + alpha keep the fused
                 // wave64 kernel because their M (=linear_num_value_heads,
@@ -6859,7 +6357,7 @@ impl Gpu {
                 //       (screen-reject path preserves higher-precision intent;
                 //       dp4a shares Q8_1 quant step that MMQ failed on).
                 let mut mmq_screen_rejected = false;
-                if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
+                if self.arch == "gfx906" && self.flags.should_use_mmq(batch_size) {
                     let qz_safe = if self.mmq_screen {
                         self.mmq_screen_weight(a_qkv, qkv_m, k)
                             && self.mmq_screen_weight(a_z, z_m, k)
@@ -6890,7 +6388,7 @@ impl Gpu {
                         // capture; the dp4a kernel may not be compiled yet on
                         // a fresh process).
                         let r3 = if r2.is_ok() {
-                            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                            if self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                                 self.gemm_qkvza_hfq4g256_wave64_dp4a_prequant(
                                     a_qkv, a_z, a_beta, a_alpha,
                                     xq,
@@ -6915,7 +6413,7 @@ impl Gpu {
                 // batch_size > 1 below the MMQ cutover or when capture mode
                 // prevents MMQ. Skipped on screen-reject to preserve the
                 // higher-precision fallback intent.
-                if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                if !mmq_screen_rejected && self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                     return self.gemm_qkvza_hfq4g256_wave64_dp4a(
                         a_qkv, a_z, a_beta, a_alpha, x,
                         y_qkv, y_z, y_beta, y_alpha,
@@ -6924,7 +6422,7 @@ impl Gpu {
                 }
                 return self.gemm_qkvza_hfq4g256_fp16_wave64(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
-            if should_use_mmq(&self.arch, batch_size) {
+            if self.flags.should_use_mmq(batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_qkv, qkv_m, k)
                         && self.mmq_screen_weight(a_z, z_m, k)
@@ -6948,7 +6446,7 @@ impl Gpu {
             //       (w_beta, w_alpha). Mirrors MQ3 phase-2 finding that
             //       gave +22% prefill on Qwen3.5 LA layers.
             //   (c) something else not aligned → fall through to dot2/wmma.
-            if hfq4_mmq_rdna2_enabled(&self.arch) {
+            if self.flags.hfq4_mmq_rdna2_enabled() {
                 let all_aligned = qkv_m % 128 == 0 && z_m % 128 == 0
                                && beta_m % 128 == 0 && alpha_m % 128 == 0;
                 if all_aligned {
@@ -6973,21 +6471,21 @@ impl Gpu {
                 }
                 // else fall through to dot2/wmma
             }
-            if has_wmma_f16_gfx12(&self.arch) {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_qkvza_hfq4g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if self.flags.has_wmma_f16() {
                 return self.gemm_qkvza_hfq4g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkvza_hfq4g256_dot2(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
             return self.gemm_qkvza_hfq4g256_fp16(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
         }
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_qkvza_hfq4g256_wave64",
@@ -7084,8 +6582,8 @@ impl Gpu {
         // Auto-selector falls back to dot2 at small batch. Layer-gate
         // (HIPFIRE_HFQ3_MMQ_LAYER_{MIN,MAX}) is a no-op when unset; supports
         // per-layer KLD attribution sweeps (#302).
-        if batch_size > 1 && hfq3_mmq_rdna2_enabled(&self.arch)
-            && hfq3_mmq_layer_gate_pass()
+        if batch_size > 1 && self.flags.hfq3_mmq_rdna2_enabled()
+            && self.flags.hfq3_mmq_layer_gate_pass()
         {
             // Best case: all four output strides MMQ_Y-aligned → 4-way fused MMQ.
             // Hits on Qwen3.5-VL ViT and any model where beta/alpha aren't
@@ -7127,8 +6625,8 @@ impl Gpu {
         // Layer-aware FP16 gate (#302): falls through to scalar when the
         // current layer falls in HIPFIRE_FP16_LAYER_MIN..=MAX. No-op when
         // those env vars are unset.
-        if batch_size > 1 && !fp16_disabled_for_current_layer() {
-            if has_dot2_f32_f16(&self.arch) {
+        if batch_size > 1 && !self.flags.fp16_disabled_for_current_layer() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkvza_hfq3g256_dot2(
                     a_qkv, a_z, a_beta, a_alpha, x,
                     y_qkv, y_z, y_beta, y_alpha,
@@ -7639,9 +7137,9 @@ impl Gpu {
             }
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
+        if batch_size > 1 && !self.flags.fp16_disabled {
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
-            if is_gcn5_wave64(&self.arch) {
+            if self.flags.is_gcn5_wave64() {
                 // gfx906 dp4a MMQ: route q+k+v through the new MMQ kernel.
                 // Unlike qkvza, all three qkv outputs have M well above
                 // MMQ_Y=128 (Qwen 9B full-attn: q_m=4096, k_m=v_m=1024),
@@ -7651,7 +7149,7 @@ impl Gpu {
                 // should_use_mmq's gfx906 default). Falls through to the
                 // fused wave64 if any of q/k/v screening rejects.
                 let mut mmq_screen_rejected = false;
-                if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
+                if self.arch == "gfx906" && self.flags.should_use_mmq(batch_size) {
                     let qkv_safe = if self.mmq_screen {
                         self.mmq_screen_weight(a_q, q_m, k)
                             && self.mmq_screen_weight(a_k, k_m, k)
@@ -7689,14 +7187,14 @@ impl Gpu {
                 // batch_size > 1 below the MMQ cutover or in capture mode.
                 // Skipped on screen-reject (dp4a shares Q8_1 quant step with
                 // MMQ; routing rejected weights here would defeat the screen).
-                if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+                if !mmq_screen_rejected && self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                     return self.gemm_qkv_hfq4g256_wave64_dp4a(
                         a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
                     );
                 }
                 return self.gemm_qkv_hfq4g256_fp16_wave64(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if should_use_mmq(&self.arch, batch_size) {
+            if self.flags.should_use_mmq(batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_q, q_m, k)
                         && self.mmq_screen_weight(a_k, k_m, k)
@@ -7713,24 +7211,24 @@ impl Gpu {
             // HFQ4 wave32 MMQ RDNA2 path (issue #299 Phase 2). Routes
             // ahead of dot2/wmma fallbacks when HIPFIRE_HFQ4_MMQ_RDNA2=1.
             // All q_m/k_m/v_m for Qwen3.5 family are MMQ_Y(128)-aligned.
-            if hfq4_mmq_rdna2_enabled(&self.arch) && q_m % 128 == 0 && k_m % 128 == 0 && v_m % 128 == 0 {
+            if self.flags.hfq4_mmq_rdna2_enabled() && q_m % 128 == 0 && k_m % 128 == 0 && v_m % 128 == 0 {
                 return self.gemm_qkv_hfq4g256_mmq(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if has_wmma_f16_gfx12(&self.arch) {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_qkv_hfq4g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if self.flags.has_wmma_f16() {
                 return self.gemm_qkv_hfq4g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkv_hfq4g256_dot2(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
             return self.gemm_qkv_hfq4g256_fp16(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_qkv_hfq4g256_wave64",
@@ -7819,8 +7317,8 @@ impl Gpu {
         // when HIPFIRE_HFQ3_MMQ=1 AND q_m/k_m/v_m are MMQ_Y-aligned. The
         // auto-selector itself falls back to dot2 at batch ≤ 12, so it's
         // safe at any batch_size. Layer-gate is a no-op when unset (#302).
-        if batch_size > 1 && hfq3_mmq_rdna2_enabled(&self.arch)
-            && hfq3_mmq_layer_gate_pass()
+        if batch_size > 1 && self.flags.hfq3_mmq_rdna2_enabled()
+            && self.flags.hfq3_mmq_layer_gate_pass()
             && q_m % 128 == 0 && k_m % 128 == 0 && v_m % 128 == 0
         {
             return self.gemm_qkv_hfq3g256_mmq(
@@ -7828,7 +7326,7 @@ impl Gpu {
             );
         }
         // Phase 2 experimental: wave32 dp4a if HIPFIRE_HFQ3_DP4A=1.
-        if batch_size > 1 && hfq3_dp4a_enabled(&self.arch) {
+        if batch_size > 1 && self.flags.hfq3_dp4a_enabled() {
             return self.gemm_qkv_hfq3g256_dp4a(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
             );
@@ -7837,10 +7335,10 @@ impl Gpu {
         // these archs support FP16 ISA. Phase 2b (dot2) + Phase 2c (fp16).
         // Layer-aware FP16 gate (#302) falls through to scalar when layer
         // in HIPFIRE_FP16_LAYER_MIN..=MAX. No-op when those vars are unset.
-        if batch_size > 1 && !fp16_disabled_for_current_layer() {
+        if batch_size > 1 && !self.flags.fp16_disabled_for_current_layer() {
             // v_dot2_f32_f16 on archs with the dot extension
             // (gfx1011/1012/1030-1032, gfx11/12).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkv_hfq3g256_dot2(
                     a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
                 );
@@ -8066,8 +7564,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if !hfq3_sdot4_gfx10_enabled(&self.arch) {
-            if has_dot2_f32_f16(&self.arch) {
+        if !self.flags.hfq3_sdot4_gfx10_enabled() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkv_hfq3g256_dot2(
                     a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
                 );
@@ -8399,13 +7897,13 @@ impl Gpu {
             }
         }
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
+        if batch_size > 1 && !self.flags.fp16_disabled {
             // gfx906 dp4a MMQ — default-on at batch_size ≥ 8 (per
             // should_use_mmq's gfx906 default). Quantize X once, screen
             // both weights, dispatch MMQ for each in set mode (add=0).
             // See docs/plans/gfx906-mmq-prd.md for context.
             let mut mmq_screen_rejected = false;
-            if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
+            if self.arch == "gfx906" && self.flags.should_use_mmq(batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_gate, gate_m, k)
                         && self.mmq_screen_weight(a_up, up_m, k)
@@ -8437,16 +7935,16 @@ impl Gpu {
             // gfx906 dp4a 2-way fused (issue #276 Gap 2). Fires for B>1
             // below the MMQ cutover or in capture mode. Skipped on
             // screen-reject.
-            if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+            if !mmq_screen_rejected && self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                 return self.gemm_gate_up_hfq4g256_wave64_dp4a(
                     a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
                 );
             }
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
-            if is_gcn5_wave64(&self.arch) {
+            if self.flags.is_gcn5_wave64() {
                 return self.gemm_gate_up_hfq4g256_fp16_wave64(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
-            if should_use_mmq(&self.arch, batch_size) {
+            if self.flags.should_use_mmq(batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_gate, gate_m, k)
                         && self.mmq_screen_weight(a_up, up_m, k)
@@ -8459,20 +7957,20 @@ impl Gpu {
                 }
             }
             // HFQ4 wave32 MMQ RDNA2 path (issue #299 Phase 3).
-            if hfq4_mmq_rdna2_enabled(&self.arch) && gate_m % 128 == 0 && up_m % 128 == 0 {
+            if self.flags.hfq4_mmq_rdna2_enabled() && gate_m % 128 == 0 && up_m % 128 == 0 {
                 return self.gemm_gate_up_hfq4g256_mmq(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // WMMA on gfx12 (RDNA4)
-            if has_wmma_f16_gfx12(&self.arch) {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_gate_up_hfq4g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // WMMA on gfx11 (RDNA3)
-            if has_wmma_f16(&self.arch) {
+            if self.flags.has_wmma_f16() {
                 return self.gemm_gate_up_hfq4g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_gate_up_hfq4g256_dot2(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
@@ -8600,8 +8098,8 @@ impl Gpu {
         // Phase 3 MMQ (auto-tile-selecting). Fires only when HIPFIRE_HFQ3_MMQ=1
         // AND gate_m/up_m are MMQ_Y-aligned. Auto-selector falls back to dot2
         // at small batch. Layer-gate is a no-op when unset (#302).
-        if batch_size > 1 && hfq3_mmq_rdna2_enabled(&self.arch)
-            && hfq3_mmq_layer_gate_pass()
+        if batch_size > 1 && self.flags.hfq3_mmq_rdna2_enabled()
+            && self.flags.hfq3_mmq_layer_gate_pass()
             && gate_m % 128 == 0 && up_m % 128 == 0
         {
             return self.gemm_gate_up_hfq3g256_mmq(
@@ -8609,15 +8107,15 @@ impl Gpu {
             );
         }
         // Phase 2 experimental: wave32 dp4a if HIPFIRE_HFQ3_DP4A=1.
-        if batch_size > 1 && hfq3_dp4a_enabled(&self.arch) {
+        if batch_size > 1 && self.flags.hfq3_dp4a_enabled() {
             return self.gemm_gate_up_hfq3g256_dp4a(
                 a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
             );
         }
         // FP16 fast paths — Phase 2b (dot2) + Phase 2c (fp16 fallback).
         // Layer-aware FP16 gate (#302).
-        if batch_size > 1 && !fp16_disabled_for_current_layer() {
-            if has_dot2_f32_f16(&self.arch) {
+        if batch_size > 1 && !self.flags.fp16_disabled_for_current_layer() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_gate_up_hfq3g256_dot2(
                     a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
                 );
@@ -8811,8 +8309,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if !hfq3_sdot4_gfx10_enabled(&self.arch) {
-            if has_dot2_f32_f16(&self.arch) {
+        if !self.flags.hfq3_sdot4_gfx10_enabled() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_gate_up_hfq3g256_dot2(
                     a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
                 );
@@ -8899,8 +8397,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         // bind_thread: skip — delegates to gemm_hfq3g256_residual_{dot2,mmq_xN} which bind.
-        if !hfq3_sdot4_gfx10_enabled(&self.arch) {
-            if has_dot2_f32_f16(&self.arch) {
+        if !self.flags.hfq3_sdot4_gfx10_enabled() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_hfq3g256_residual_dot2(a_raw, x, y, m, k, batch_size);
             }
             return self.gemm_hfq3g256_residual_fp16(a_raw, x, y, m, k, batch_size);
@@ -9105,8 +8603,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         // bind_thread: skip — delegates to gemm_qkv_hfq3g256_{dot2,mmq_xN} which bind.
-        if !hfq3_sdot4_gfx10_enabled(&self.arch) {
-            if has_dot2_f32_f16(&self.arch) {
+        if !self.flags.hfq3_sdot4_gfx10_enabled() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkv_hfq3g256_dot2(
                     a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size,
                 );
@@ -9273,8 +8771,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         // bind_thread: skip — delegates to gemm_gate_up_hfq3g256_{dot2,mmq_xN} which bind.
-        if !hfq3_sdot4_gfx10_enabled(&self.arch) {
-            if has_dot2_f32_f16(&self.arch) {
+        if !self.flags.hfq3_sdot4_gfx10_enabled() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_gate_up_hfq3g256_dot2(
                     a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size,
                 );
@@ -9497,8 +8995,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         // bind_thread: skip — delegates to gemm_qkvza_hfq3g256_{dot2,mmq_xN} which bind.
-        if !hfq3_sdot4_gfx10_enabled(&self.arch) {
-            if has_dot2_f32_f16(&self.arch) {
+        if !self.flags.hfq3_sdot4_gfx10_enabled() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkvza_hfq3g256_dot2(
                     a_qkv, a_z, a_beta, a_alpha, x,
                     y_qkv, y_z, y_beta, y_alpha,
@@ -10491,7 +9989,7 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_qkvza_hfp4g32_wmma_gfx12(
                 a_qkv, a_z, a_beta, a_alpha, x,
                 y_qkv, y_z, y_beta, y_alpha,
@@ -10699,7 +10197,7 @@ impl Gpu {
                 y_qkv, y_z, y_beta, y_alpha,
                 qkv_m, z_m, beta_m, alpha_m, k, batch_size);
         }
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_qkvza_hfq3g256_wmma_gfx12(
                 a_qkv, a_z, a_beta, a_alpha, x,
                 y_qkv, y_z, y_beta, y_alpha,
@@ -11151,7 +10649,7 @@ impl Gpu {
             return self.gemm_qkv_hfq3g256_wmma_mb4(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_qkv_hfq3g256_wmma_gfx12(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
@@ -11389,11 +10887,11 @@ impl Gpu {
         // conservative — see project_fp8_wmma_hfp4g32_2026_05_10.md
         // for the full N sweep. The decode-path FP8 win is on the
         // GEMV side (gemv_hfp4g32_fp8_gfx12), not WMMA.
-        if has_wmma_fp8_gfx12(&self.arch) && is_fp8_wmma_enabled() && batch_size >= FP8_WMMA_MIN_BATCH {
+        if self.flags.has_wmma_fp8_gfx12() && self.flags.fp8_wmma && batch_size >= FP8_WMMA_MIN_BATCH {
             return self.gemm_qkv_hfp4g32_wmma_fp8_gfx12(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_qkv_hfp4g32_wmma_gfx12(
                 a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
         }
@@ -11649,7 +11147,7 @@ impl Gpu {
         m: usize, k: usize, batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_hfp4g32_residual_wmma_gfx12(a, x, y, m, k, batch_size);
         }
         self.gemm_hfp4g32_residual_wmma(a, x, y, m, k, batch_size)
@@ -11775,7 +11273,7 @@ impl Gpu {
         k: usize, batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_gate_up_hfp4g32_wmma_gfx12(
                 a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
         }
@@ -12088,7 +11586,7 @@ impl Gpu {
             return self.gemm_gate_up_hfq3g256_wmma_mb4(
                 a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
         }
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_gate_up_hfq3g256_wmma_gfx12(
                 a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
         }
@@ -12472,7 +11970,7 @@ impl Gpu {
         // CDNA3 wave64 fast path: 2 rows per block, halves grid.x. The base
         // kernel runs at half throughput on a wave64-native arch because
         // half the wave masks out per `__shfl_down`. Byte-exact with base.
-        let cdna3 = has_wave64_native(&self.arch);
+        let cdna3 = self.flags.has_wave64_native();
 
         // RDNA3 multi-row override path. Same selector as the non-residual
         // variant but there's currently no gfx1010-default multi-row residual
@@ -12481,7 +11979,7 @@ impl Gpu {
         // kernel to the default path if/when the non-residual multi-row wins
         // scale to justify residual too.)
         let rdna3 = matches!(self.arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102");
-        let rows = if rdna3 { gemv_rows_override().unwrap_or(1) } else { 1 };
+        let rows = if rdna3 { self.flags.gemv_rows.unwrap_or(1) } else { 1 };
         let use_multirow = rdna3 && rows > 1;
 
         // Bandwidth: weight + x + y_read (for residual) + y_write.
@@ -12518,7 +12016,7 @@ impl Gpu {
                         b
                     },
                 )
-            } else if gfx942_lds_gemv_enabled(&self.arch) && !gemv_prefetch_enabled(&self.arch) && (k as u32) * 4 <= 32768 {
+            } else if self.flags.gfx942_lds_gemv_enabled() && !self.flags.gemv_prefetch_enabled() && (k as u32) * 4 <= 32768 {
                 let kname = "gemv_hfq4g256_residual_gfx942";
                 self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_GFX942_SRC, kname)?;
                 let grid = ((m as u32) + 7) / 8;
@@ -12534,7 +12032,7 @@ impl Gpu {
                     },
                 )
             } else {
-                let (kname, ksrc): (&str, &str) = if gemv_prefetch_enabled(&self.arch) {
+                let (kname, ksrc): (&str, &str) = if self.flags.gemv_prefetch_enabled() {
                     (
                         "gemv_hfq4g256_residual_wave64_prefetch",
                         kernels::GEMV_HFQ4G256_RESIDUAL_WAVE64_PREFETCH_SRC,
@@ -13114,7 +12612,7 @@ impl Gpu {
         m: usize, k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_gate_up_indexed_wave64",
@@ -13232,7 +12730,7 @@ impl Gpu {
         m: usize, k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_x) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_down_indexed_wave64",
@@ -13395,7 +12893,7 @@ impl Gpu {
         m: usize, k: usize, k_top: usize, batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64",
@@ -13464,7 +12962,7 @@ impl Gpu {
         m: usize, k: usize, k_top: usize, batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemv_hfq4g256_moe_down_indexed_batched_wave64",
@@ -15165,12 +14663,12 @@ impl Gpu {
         // so narrow-batch calls pick mmq_x=16 and long-prefill picks
         // mmq_x=32_y64 (MQ3 phase-2 finding). All variants clamp M-tail
         // internally, so no alignment check needed.
-        if batch_size > 1 && hfq4_mmq_rdna2_enabled(&self.arch) {
+        if batch_size > 1 && self.flags.hfq4_mmq_rdna2_enabled() {
             return self.gemm_hfq4g256_residual_mmq_rdna2_auto(a_raw, x, y, m, k, batch_size);
         }
 
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
+        if batch_size > 1 && !self.flags.fp16_disabled {
             // gfx906 dp4a MMQ residual path — default-on at batch ≥ 8 per
             // should_use_mmq's gfx906 default. Distinguishes two reasons
             // MMQ might NOT fire:
@@ -15180,7 +14678,7 @@ impl Gpu {
             //       to a higher-precision fallback, NOT to dp4a which has
             //       the same Q8_1 quantization step that MMQ failed on).
             let mut mmq_screen_rejected = false;
-            if self.arch == "gfx906" && should_use_mmq(&self.arch, batch_size) {
+            if self.arch == "gfx906" && self.flags.should_use_mmq(batch_size) {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_raw, m, k)
                 } else {
@@ -15210,18 +14708,18 @@ impl Gpu {
             // The internal Q8_1 quantize launch itself goes through
             // `launch_maybe_blob` and IS recorded into the captured graph;
             // the guard protects only first-use-only side effects.
-            if !mmq_screen_rejected && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+            if !mmq_screen_rejected && self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                 return self.gemm_hfq4g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
             }
 
             // Wave64 FP16 hybrid — best of both worlds for gfx906 (MI50).
             // Also the safe fallback when MMQ screen rejected the weight.
-            if is_gcn5_wave64(&self.arch) {
+            if self.flags.is_gcn5_wave64() {
                 return self.gemm_hfq4g256_residual_fp16_wave64(a_raw, x, y, m, k, batch_size);
             }
 
             // Opt-in MMQ path (RDNA3/3.5, HIPFIRE_MMQ=1 or HIPFIRE_WO_MMQ=1).
-            if wo_mmq_enabled() || should_use_mmq(&self.arch, batch_size)
+            if self.flags.wo_mmq || self.flags.should_use_mmq(batch_size)
             {
                 let use_mmq = if self.mmq_screen {
                     self.mmq_screen_weight(a_raw, m, k)
@@ -15234,7 +14732,7 @@ impl Gpu {
             }
 
             // WMMA on gfx12 (RDNA4): K2-unroll port
-            if has_wmma_f16_gfx12(&self.arch) {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_hfq4g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
             }
 
@@ -15247,7 +14745,7 @@ impl Gpu {
             return self.gemm_hfq4g256_residual_fp16(a_raw, x, y, m, k, batch_size);
         }
 
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_hfq4g256_residual_wave64",
@@ -15325,13 +14823,13 @@ impl Gpu {
         // OnceLock-cached so the env read is one-shot per process; the arch
         // match is a handful of cycles per dispatch call (not in any inner
         // loop). Default off. Layer-gate is a no-op when unset (#302).
-        if batch_size > 1 && hfq3_mmq_rdna2_enabled(&self.arch) && hfq3_mmq_layer_gate_pass() {
+        if batch_size > 1 && self.flags.hfq3_mmq_rdna2_enabled() && self.flags.hfq3_mmq_layer_gate_pass() {
             return self.gemm_hfq3g256_residual_mmq(a_raw, x, y, m, k, batch_size);
         }
         // FP16 fast paths — Phase 2b (dot2) + Phase 2c (fp16 fallback).
         // Layer-aware FP16 gate (#302).
-        if batch_size > 1 && !fp16_disabled_for_current_layer() {
-            if has_dot2_f32_f16(&self.arch) {
+        if batch_size > 1 && !self.flags.fp16_disabled_for_current_layer() {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_hfq3g256_residual_dot2(a_raw, x, y, m, k, batch_size);
             }
             return self.gemm_hfq3g256_residual_fp16(a_raw, x, y, m, k, batch_size);
@@ -16037,7 +15535,7 @@ impl Gpu {
         // silently route a non-winning batch through MMQ. Mirrors the MQ6
         // sibling's `hfq6_mmq_route` assert added in 5ea9050.
         debug_assert!(
-            should_use_mmq(&self.arch, batch_size) || self.capture_mode,
+            self.flags.should_use_mmq(batch_size) || self.capture_mode,
             "_mmq_set_gfx906 called at non-winning B={} (capture={}) — \
              caller must gate via should_use_mmq first",
             batch_size, self.capture_mode,
@@ -16160,7 +15658,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         debug_assert!(
-            should_use_mmq(&self.arch, batch_size) || self.capture_mode,
+            self.flags.should_use_mmq(batch_size) || self.capture_mode,
             "qkv_hfq4g256_mmq_gfx906 called at non-winning B={} (capture={})",
             batch_size, self.capture_mode,
         );
@@ -16319,7 +15817,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         debug_assert!(
-            should_use_mmq(&self.arch, batch_size) || self.capture_mode,
+            self.flags.should_use_mmq(batch_size) || self.capture_mode,
             "gate_up_hfq4g256_mmq_gfx906 called at non-winning B={} (capture={})",
             batch_size, self.capture_mode,
         );
@@ -16328,7 +15826,7 @@ impl Gpu {
         // wrappers only exist for {x16, x32}, so larger mmq_x at y64 falls
         // back to y128. Y=128 is the established default (matches the
         // residual sibling).
-        let y64 = hfq4_mmq_gfx906_y64_enabled();
+        let y64 = self.flags.hfq4_mmq_gfx906_y64_enabled();
         let mmq_y: usize = if y64 { 64 } else { 128 };
 
         debug_assert!(
@@ -16770,7 +16268,7 @@ impl Gpu {
         if use_mb4 {
             return self.gemm_hfq3g256_residual_wmma_mb4(a_raw, x, y, m, k, batch_size);
         }
-        if has_wmma_f16_gfx12(&self.arch) {
+        if self.flags.has_wmma_f16_gfx12() {
             return self.gemm_hfq3g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
         }
         self.ensure_kernel("gemm_hfq3g256_residual_wmma", kernels::GEMM_HFQ3G256_RESIDUAL_WMMA_SRC, "gemm_hfq3g256_residual_wmma")?;
@@ -17025,7 +16523,7 @@ impl Gpu {
         // capture mode (matches the rocBLAS branch's caveat — Q8_1
         // quantize launch must be reachable from the captured graph or
         // pre-baked).
-        if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+        if self.flags.gemv_dp4a_enabled() && !self.capture_mode {
             return self.gemm_hfq4g256_dp4a(a_raw, x, y, m, k, batch_size);
         }
 
@@ -17067,7 +16565,7 @@ impl Gpu {
             // Shadow allocation failed — fall through to the GEMV path.
         }
 
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_div): (&str, [u32; 3], u32) = if cdna_wave64 {
             self.ensure_kernel(
                 "gemm_hfq4g256_wave64",
@@ -17700,8 +17198,8 @@ impl Gpu {
         self.bind_thread()?;
         let wmma_eligible = batch_size > 1
             && self.arch.starts_with("gfx11")
-            && !fp16_disabled()
-            && !lm_head_wmma_disabled();
+            && !self.flags.fp16_disabled
+            && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
             match self.active_stream.as_ref() {
@@ -17734,7 +17232,7 @@ impl Gpu {
         // gfx906: dp4a residual + zero-init Y for `=` semantics.
         // Skip in capture mode (the residual kernel calls ensure_q8_1_mmq_x
         // which launches an internal quantize kernel — matches HFQ4 sibling).
-        if batch_size > 1 && gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+        if batch_size > 1 && self.flags.gemv_dp4a_enabled() && !self.capture_mode {
             match self.active_stream.as_ref() {
                 Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
                 None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
@@ -17744,8 +17242,8 @@ impl Gpu {
         // gfx11+: WMMA residual + zero-init.
         let wmma_eligible = batch_size > 1
             && self.arch.starts_with("gfx11")
-            && !fp16_disabled()
-            && !lm_head_wmma_disabled();
+            && !self.flags.fp16_disabled
+            && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
             match self.active_stream.as_ref() {
@@ -17788,9 +17286,9 @@ impl Gpu {
         // the correct variant per arch. Other archs (gfx10/906/94x) fall
         // through to the per-row GEMV path.
         let wmma_eligible = batch_size > 1
-            && (has_wmma_f16(&self.arch) || has_wmma_f16_gfx12(&self.arch))
-            && !fp16_disabled()
-            && !lm_head_wmma_disabled();
+            && (self.flags.has_wmma_f16() || self.flags.has_wmma_f16_gfx12())
+            && !self.flags.fp16_disabled
+            && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
             match self.active_stream.as_ref() {
@@ -17889,10 +17387,10 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
+        if batch_size > 1 && !self.flags.fp16_disabled {
             // WMMA on gfx12 (RDNA4): _w32_gfx12 builtin (gfx11 builtin
             // does NOT pattern-match on gfx12 — see has_wmma_f16 comment).
-            if has_wmma_f16_gfx12(&self.arch) {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_hfq6g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size);
             }
             // WMMA on gfx11+ (RDNA3): 16x16 tiled
@@ -17905,7 +17403,7 @@ impl Gpu {
             // Skip in capture mode: ensure_q8_1_mmq_x launches an internal
             // quantize kernel that the captured graph may not record (matches
             // gemm_hfq4g256_dp4a's `&& !self.capture_mode` guard at line ~7889).
-            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+            if self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                 return self.gemm_hfq6g256_residual_wave64_dp4a(a_raw, x, y, m, k, batch_size);
             }
             // FP16 packed on all other RDNA
@@ -18137,23 +17635,23 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
-            if has_wmma_f16_gfx12(&self.arch) {
+        if batch_size > 1 && !self.flags.fp16_disabled {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_qkvza_hfq6g256_wmma_gfx12(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if self.flags.has_wmma_f16() {
                 return self.gemm_qkvza_hfq6g256_wmma(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // gfx906: wave64+dp4a batched fused (Phase A.3, plan v3.2.3 §5.1
             // item 3). Pre-quantize x to Q8_1 and dispatch the dp4a kernel.
             // Skip in capture mode (Q8_1 quantize launch must be reachable
             // from captured graph or pre-baked) — matches HFQ4 sibling pattern.
-            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+            if self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                 return self.gemm_qkvza_hfq6g256_wave64_dp4a(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkvza_hfq6g256_dot2(a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m, alpha_m, k, batch_size);
             }
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
@@ -18623,21 +18121,21 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
-            if has_wmma_f16_gfx12(&self.arch) {
+        if batch_size > 1 && !self.flags.fp16_disabled {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_qkv_hfq6g256_wmma_gfx12(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if self.flags.has_wmma_f16() {
                 return self.gemm_qkv_hfq6g256_wmma(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // gfx906: wave64+dp4a batched fused (Phase A.3).
             // Skip in capture mode (Q8_1 quantize) — matches HFQ4 sibling.
-            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+            if self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                 return self.gemm_qkv_hfq6g256_wave64_dp4a(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_qkv_hfq6g256_dot2(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
@@ -19064,21 +18562,21 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Fast paths for prefill (batch_size > 1). Disable with HIPFIRE_FP16=0.
-        if batch_size > 1 && !fp16_disabled() {
-            if has_wmma_f16_gfx12(&self.arch) {
+        if batch_size > 1 && !self.flags.fp16_disabled {
+            if self.flags.has_wmma_f16_gfx12() {
                 return self.gemm_gate_up_hfq6g256_wmma_gfx12(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
-            if has_wmma_f16(&self.arch) {
+            if self.flags.has_wmma_f16() {
                 return self.gemm_gate_up_hfq6g256_wmma(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // gfx906: wave64+dp4a batched fused (Phase A.3).
             // Skip in capture mode (Q8_1 quantize) — matches HFQ4 sibling.
-            if gemv_dp4a_enabled(&self.arch) && !self.capture_mode {
+            if self.flags.gemv_dp4a_enabled() && !self.capture_mode {
                 return self.gemm_gate_up_hfq6g256_wave64_dp4a(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // v_dot2_f32_f16 on archs that have it (gfx1011/1012/1030-1032).
             // Excludes gfx1010 (Navi 10, 5700 XT) and gfx1013 (Van Gogh/BC-250 APU).
-            if has_dot2_f32_f16(&self.arch) {
+            if self.flags.has_dot2_f32_f16() {
                 return self.gemm_gate_up_hfq6g256_dot2(a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k, batch_size);
             }
             // FP16 packed (v_pk_fma_f16) for gfx1010/1013 — 2× scalar FP32.
@@ -21254,13 +20752,13 @@ impl Gpu {
         // v_dot4_i32_i8 path. PMC at 2026-05-05 showed this kernel
         // was memory-bound; dp4a's 75% x-traffic reduction lands on
         // the actual bottleneck.
-        if gemv_dp4a_enabled(&self.arch) {
+        if self.flags.gemv_dp4a_enabled() {
             return self.fused_gate_up_hfq4g256_dp4a(
                 a_gate, a_up, x, y_gate, y_up, gate_m, up_m, k,
             );
         }
 
-        let cdna_wave64 = has_wave64_native(&self.arch);
+        let cdna_wave64 = self.flags.has_wave64_native();
         let (func_name, block, grid_x) = if cdna_wave64 {
             // gfx94x v2: 2 wave64s = 4 rows/WG, +1.9% on AR decode
             // (commit 5bd75a69 sibling). Default ON; opt out via
@@ -27140,7 +26638,7 @@ impl Gpu {
                 // wavefront pressure in half on the hottest kernels. Wave32
                 // block=[32,1,1] kernels otherwise waste the upper 32 lanes
                 // of every wave slot on these wave64-native arches.
-                if has_wave64_native(&self.arch) {
+                if self.flags.has_wave64_native() {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
                                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
@@ -27171,7 +26669,7 @@ impl Gpu {
                 // tested matrix sizes (see commit log / multi-row kernel header),
                 // so we only precompile when the env var explicitly requests it.
                 if matches!(self.arch.as_str(), "gfx1100" | "gfx1101" | "gfx1102")
-                    && gemv_rows_override().unwrap_or(1) > 1
+                    && self.flags.gemv_rows.unwrap_or(1) > 1
                 {
                     specs.push(("gemv_hfq4g256_multirow_rdna3",
                                 kernels::GEMV_HFQ4G256_MULTIROW_GFX1100_SRC.to_string()));
@@ -27197,7 +26695,7 @@ impl Gpu {
                 specs.push(("fused_silu_mul_mq_rotate",
                             kernels::FUSED_SILU_MUL_MQ_ROTATE_SRC.to_string()));
                 // gfx906/gfx908/gfx94x wave64 variants — see hfq4 branch for rationale.
-                if has_wave64_native(&self.arch) {
+                if self.flags.has_wave64_native() {
                     // Single-token (draft / single-layer paths).
                     specs.push(("fused_qkvza_hfq4g256_wave64",
                                 kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -552,7 +552,7 @@ impl Gpu {
 
         let flags = Arc::new(FeatureFlags::from_env(&arch));
 
-        let compiler = KernelCompiler::new(&arch)?;
+        let compiler = KernelCompiler::new(&arch, flags.hipcc_extra_flags.clone())?;
 
         LAST_BOUND_DEVICE.with(|c| c.set(id));
 
@@ -2315,7 +2315,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// variant; other archs fall back to the baseline switch-dispatch path.
     pub fn gemv_mq3g256_lloyd(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::gemv_mq3g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::gemv_mq3g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "gemv_mq3g256_lloyd")?;
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -2360,7 +2360,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// fall back to the chip-agnostic baseline switch-dispatch path.
     pub fn gemv_mq4g256_lloyd(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::gemv_mq4g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::gemv_mq4g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "gemv_mq4g256_lloyd")?;
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -2977,7 +2977,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize, n: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(&self.arch);
+        let (src, module) = kernels::gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "gemm_qkv_mq4g256_lloyd_wmma_mb4")?;
         let x_f16_ptr = self.ensure_fp16_x(x, n * k)?;
 
@@ -3047,7 +3047,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize, n: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::gemm_gate_up_mq4g256_lloyd_wmma_mb4_for_arch(&self.arch);
+        let (src, module) = kernels::gemm_gate_up_mq4g256_lloyd_wmma_mb4_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "gemm_gate_up_mq4g256_lloyd_wmma_mb4")?;
         let x_f16_ptr = self.ensure_fp16_x(x, n * k)?;
 
@@ -3105,7 +3105,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// gemv_mq3g256_lloyd_residual; same single-acc bug fix applies.
     pub fn gemv_mq4g256_lloyd_residual(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::gemv_mq4g256_lloyd_residual_for_arch(&self.arch);
+        let (src, module) = kernels::gemv_mq4g256_lloyd_residual_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "gemv_mq4g256_lloyd_residual")?;
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -3153,7 +3153,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         gate_m: usize, up_m: usize, k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::fused_gate_up_mq4g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::fused_gate_up_mq4g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "fused_gate_up_mq4g256_lloyd")?;
         let ag = a_gate.buf.as_ptr();
         let au = a_up.buf.as_ptr();
@@ -3198,7 +3198,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::fused_qkvza_mq4g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::fused_qkvza_mq4g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "fused_qkvza_mq4g256_lloyd")?;
         let aq = a_qkv.buf.as_ptr();
         let az = a_z.buf.as_ptr();
@@ -3257,7 +3257,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::fused_qkv_mq4g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::fused_qkv_mq4g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "fused_qkv_mq4g256_lloyd")?;
         let aq = a_q.buf.as_ptr();
         let ak = a_k.buf.as_ptr();
@@ -3308,7 +3308,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// 9B Lloyd-MQ3, gfx1100, per the 2026-05-06 decode profile).
     pub fn gemv_mq3g256_lloyd_residual(&mut self, a_raw: &GpuTensor, x: &GpuTensor, y: &GpuTensor, m: usize, k: usize) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::gemv_mq3g256_lloyd_residual_for_arch(&self.arch);
+        let (src, module) = kernels::gemv_mq3g256_lloyd_residual_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "gemv_mq3g256_lloyd_residual")?;
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -3953,7 +3953,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         gate_m: usize, up_m: usize, k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::fused_gate_up_mq3g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::fused_gate_up_mq3g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "fused_gate_up_mq3g256_lloyd")?;
         let ag = a_gate.buf.as_ptr();
         let au = a_up.buf.as_ptr();
@@ -4004,7 +4004,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::fused_qkvza_mq3g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::fused_qkvza_mq3g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "fused_qkvza_mq3g256_lloyd")?;
         let aq = a_qkv.buf.as_ptr();
         let az = a_z.buf.as_ptr();
@@ -4068,7 +4068,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (src, module) = kernels::fused_qkv_mq3g256_lloyd_for_arch(&self.arch);
+        let (src, module) = kernels::fused_qkv_mq3g256_lloyd_for_arch(&self.arch, self.flags.lloyd_force_baseline);
         self.ensure_kernel(module, src, "fused_qkv_mq3g256_lloyd")?;
         let aq = a_q.buf.as_ptr();
         let ak = a_k.buf.as_ptr();
@@ -5645,7 +5645,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (hfq4g256_src, hfq4g256_module) = kernels::gemv_hfq4g256_for_arch(&self.arch);
+        let (hfq4g256_src, hfq4g256_module) = kernels::gemv_hfq4g256_for_arch(&self.arch, self.flags.rdna2_variant);
         self.ensure_kernel(hfq4g256_module, hfq4g256_src, "gemv_hfq4g256")?;
 
         let a_ptr = a_raw.buf.as_ptr();
@@ -26599,7 +26599,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
                 specs.push(("gemv_hfq6g256", kernels::GEMV_HFQ6G256_SRC.to_string()));
             }
             "hfq4" => {
-                let (src, module) = kernels::gemv_hfq4g256_for_arch(&self.arch);
+                let (src, module) = kernels::gemv_hfq4g256_for_arch(&self.arch, self.flags.rdna2_variant);
                 specs.push((module, src.to_string()));
                 specs.push(("gemv_hfq4g256_wide", kernels::GEMV_HFQ4G256_WIDE_SRC.to_string()));
                 // Multi-projection fused kernels (LA 4-way, FA 3-way, FFN
@@ -26659,7 +26659,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
                 // MQ4 = FWHT-rotated HFQ4-G256 — default format for current registry.
                 // Shares the HFQ4 fused kernels (same blob, different dispatch key)
                 // plus MQ-specific rotation kernels.
-                let (src, module) = kernels::gemv_hfq4g256_for_arch(&self.arch);
+                let (src, module) = kernels::gemv_hfq4g256_for_arch(&self.arch, self.flags.rdna2_variant);
                 specs.push((module, src.to_string()));
                 specs.push(("gemv_mq4g256", kernels::GEMV_MQ4G256_SRC.to_string()));
                 specs.push(("fused_qkvza_hfq4g256",

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1399,7 +1399,7 @@ impl Gpu {
     fn rocblas_arch_eligible(&self) -> bool {
         static CACHE: OnceLock<bool> = OnceLock::new();
         let all_archs = *CACHE.get_or_init(|| {
-            std::env::var("HIPFIRE_ROCBLAS_ALL_ARCHS").ok().as_deref() == Some("1")
+            self.flags.rocblas_all_archs
         });
         if all_archs { return self.rocblas.is_some(); }
         matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
@@ -1415,13 +1415,10 @@ impl Gpu {
     fn rocblas_min_batch(&self) -> usize {
         static CACHE: OnceLock<usize> = OnceLock::new();
         *CACHE.get_or_init(|| {
-            if std::env::var("HIPFIRE_ROCBLAS_OFF").ok().as_deref() == Some("1") {
+            if self.flags.rocblas_off {
                 return usize::MAX;
             }
-            std::env::var("HIPFIRE_ROCBLAS_MIN_BATCH")
-                .ok()
-                .and_then(|v| v.parse::<usize>().ok())
-                .unwrap_or(4)
+self.flags.rocblas_min_batch.unwrap_or(4)
         })
     }
 
@@ -2461,10 +2458,9 @@ impl Gpu {
         // Env override: HIPFIRE_LLOYD_MB4=1 force-on, =0 force-off.
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_LLOYD_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
+        let use_mb4 = match self.flags.lloyd_mb4 {
+            Some(_) => arch_supports_mb4,
+            None => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
         };
         if use_mb4 {
             return self.gemm_mq4g256_lloyd_residual_wmma_mb4(a_raw, x, y, m, k, batch_size);
@@ -2653,10 +2649,9 @@ impl Gpu {
         let total_m = qkv_m + z_m + beta_m + alpha_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_LLOYD_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.lloyd_mb4 {
+            None => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_qkvza_mq4g256_lloyd_wmma_mb4(
@@ -2746,10 +2741,9 @@ impl Gpu {
         let total_m = q_m + k_m + v_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_LLOYD_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.lloyd_mb4 {
+            None => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_qkv_mq4g256_lloyd_wmma_mb4(
@@ -2832,10 +2826,9 @@ impl Gpu {
         let total_m = gate_m + up_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_LLOYD_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.lloyd_mb4 {
+            None => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_gate_up_mq4g256_lloyd_wmma_mb4(
@@ -3377,10 +3370,9 @@ impl Gpu {
         // mb4 path selector — same gate as MQ4-Lloyd's mb4 family.
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            Some(_) => arch_supports_mb4,
+            None => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
         };
         if use_mb4 {
             return self.gemm_mq3g256_lloyd_residual_wmma_mb4(a_raw, x, y, m, k, batch_size);
@@ -3503,10 +3495,9 @@ impl Gpu {
         let total_m = qkv_m + z_m + beta_m + alpha_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            None => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_qkvza_mq3g256_lloyd_wmma_mb4(
@@ -3670,10 +3661,9 @@ impl Gpu {
         let total_m = q_m + k_m + v_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            None => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_qkv_mq3g256_lloyd_wmma_mb4(
@@ -3824,10 +3814,9 @@ impl Gpu {
         let total_m = gate_m + up_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            None => arch_supports_mb4 && n >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_gate_up_mq3g256_lloyd_wmma_mb4(
@@ -4290,9 +4279,7 @@ impl Gpu {
         // gfx94x split: opt-in via HIPFIRE_GFX942_RMSNORM_SPLIT=1.
         // Two-kernel path (reduce + rotate) gives 5× more in-flight wave64s
         // on prefill scale; modest decode change. Math byte-identical.
-        if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
-            && std::env::var("HIPFIRE_GFX942_RMSNORM_SPLIT")
-                .map(|v| v != "0").unwrap_or(true)
+        if self.flags.gfx942_rmsnorm_split
         {
             return self.fused_rmsnorm_rotate_mq_split_gfx942(x, weight, x_rot, k, eps, 1);
         }
@@ -4633,9 +4620,7 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         // gfx94x split — see fused_rmsnorm_rotate_mq docstring.
-        if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
-            && std::env::var("HIPFIRE_GFX942_RMSNORM_SPLIT")
-                .map(|v| v != "0").unwrap_or(true)
+        if self.flags.gfx942_rmsnorm_split
         {
             return self.fused_rmsnorm_rotate_mq_split_gfx942(x, weight, x_rot, k, eps, batch_size);
         }
@@ -6018,8 +6003,7 @@ impl Gpu {
             // HIPFIRE_GFX942_GEMV_V2=0.
             let is_gfx94x = matches!(self.arch.as_str(),
                 "gfx940" | "gfx941" | "gfx942");
-            let v2_on = std::env::var("HIPFIRE_GFX942_GEMV_V2")
-                .map(|v| v != "0").unwrap_or(true);
+            let v2_on = self.flags.gfx942_gemv_v2.unwrap_or(true);
             if is_gfx94x && v2_on {
                 self.ensure_kernel(
                     "fused_qkv_hfq4g256_v2_gfx942",
@@ -6130,8 +6114,7 @@ impl Gpu {
             // HIPFIRE_GFX942_GEMV_V2=0.
             let is_gfx94x = matches!(self.arch.as_str(),
                 "gfx940" | "gfx941" | "gfx942");
-            let v2_on = std::env::var("HIPFIRE_GFX942_GEMV_V2")
-                .map(|v| v != "0").unwrap_or(true);
+            let v2_on = self.flags.gfx942_gemv_v2.unwrap_or(true);
             if is_gfx94x && v2_on {
                 self.ensure_kernel(
                     "fused_qkvza_hfq4g256_v2_gfx942",
@@ -10186,10 +10169,9 @@ impl Gpu {
         let total_m = qkv_m + z_m + beta_m + alpha_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            None => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_qkvza_hfq3g256_wmma_mb4(
@@ -10640,10 +10622,9 @@ impl Gpu {
         let total_m = q_m + k_m + v_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            None => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_qkv_hfq3g256_wmma_mb4(
@@ -11427,7 +11408,7 @@ impl Gpu {
         // HIPFIRE_GATE_UP_VARIANT=ldsx routes to the LDS-staged X variant
         // (Gate 1 microbench, opt-in only, default off). See
         // docs/perf-checkpoints/2026-05-01-gate-up-lds-x-share-plan.md.
-        let variant_override = std::env::var("HIPFIRE_GATE_UP_VARIANT").ok();
+        let variant_override = self.flags.gate_up_variant.clone();
         let (kernel_name, kernel_src) = match variant_override.as_deref() {
             Some("ldsx") => ("gemm_gate_up_hfq4g256_wmma_ldsx",
                              kernels::GEMM_GATE_UP_HFQ4G256_WMMA_LDSX_SRC),
@@ -11577,10 +11558,9 @@ impl Gpu {
         let total_m = gate_m + up_m;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            None => arch_supports_mb4 && batch_size >= 128 && total_m >= 4096,
+            Some(_) => arch_supports_mb4,
         };
         if use_mb4 {
             return self.gemm_gate_up_hfq3g256_wmma_mb4(
@@ -11988,7 +11968,7 @@ impl Gpu {
         let result = if cdna3 {
             // gfx94x (CDNA3 / MI300X) takes the LDS-cached 8-rows-per-WG path
             // when enabled; gfx906/908 (or env override) keep wave64 base.
-            if std::env::var("HIPFIRE_GFX942_GEMV_V3").map(|v| v == "1").unwrap_or(false) {
+            if self.flags.gfx942_gemv_v3 {
                 let kname = "gemv_hfq4g256_residual_v3_gfx942";
                 self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_V3_GFX942_SRC, kname)?;
                 let grid = ((m as u32) + 7) / 8;
@@ -12002,7 +11982,7 @@ impl Gpu {
                         b
                     },
                 )
-            } else if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942") && std::env::var("HIPFIRE_GFX942_GEMV_V2").map(|v| v != "0").unwrap_or(true) {
+            } else if matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942") && self.flags.gfx942_gemv_v2.unwrap_or(true) {
                 let kname = "gemv_hfq4g256_residual_v2_gfx942";
                 self.ensure_kernel(kname, kernels::GEMV_HFQ4G256_RESIDUAL_V2_GFX942_SRC, kname)?;
                 let grid = ((m as u32) + 3) / 4;
@@ -13483,7 +13463,7 @@ impl Gpu {
         // from ~71 (FP16 WMMA) to ~140 TFLOPS (i8 WMMA). Opt-out via
         // HIPFIRE_MOE_GROUPED_I8=0; default ON for gfx1151 only.
         let use_i8_gfx1151 = self.arch.starts_with("gfx1151")
-            && std::env::var("HIPFIRE_MOE_GROUPED_I8").as_deref() != Ok("0");
+            && self.flags.moe_grouped_i8.unwrap_or(true);
         if use_i8_gfx1151 {
             // Optional deeper-pipeline variants (opt-IN, default OFF).
             // Same kernarg layout + scatter contract as the k2 default.
@@ -13491,8 +13471,8 @@ impl Gpu {
             //   iteration (8 WMMAs into 4 independent int32 accumulators).
             // - k4: pairs adjacent Q8_1 sub-blocks (4 WMMAs into 2 accumulators).
             // - k2 (default): one sub-block per inner iteration.
-            let use_k8 = std::env::var("HIPFIRE_MOE_GROUPED_I8_K8").as_deref() == Ok("1");
-            let use_k4 = std::env::var("HIPFIRE_MOE_GROUPED_I8_K4").as_deref() == Ok("1");
+            let use_k8 = self.flags.moe_grouped_i8_k8;
+            let use_k4 = self.flags.moe_grouped_i8_k4;
             if use_k8 {
                 return self.gemm_hfq4g256_moe_grouped_mmq_k8_gfx1151(
                     expert_weight_ptrs, expert_tile_ids, sorted_slot_index,
@@ -13518,14 +13498,14 @@ impl Gpu {
             || self.arch.starts_with("gfx1101")
             || self.arch.starts_with("gfx1102")
             || self.arch.starts_with("gfx1103"))
-            && std::env::var("HIPFIRE_MOE_GROUPED_I8").as_deref() != Ok("0");
+            && self.flags.moe_grouped_i8.unwrap_or(true);
         if use_i8_gfx11_dgpu {
             // k4 default ON: deeper K-tile pipeline gives +2.8% over k2 on
             // gfx1100 (A/B confirmed 2026-05-19 k9lin 7900 XTX); same
             // structural pattern as gfx1151's +4.6%. k2 alone was a wash vs
             // FP16, so k4 is what makes the dGPU i8 path actually worth
             // shipping. Opt out with HIPFIRE_MOE_GROUPED_I8_K4=0.
-            let use_k4 = std::env::var("HIPFIRE_MOE_GROUPED_I8_K4").as_deref() != Ok("0");
+            let use_k4 = self.flags.moe_grouped_i8_k4;
             if use_k4 {
                 return self.gemm_hfq4g256_moe_grouped_mmq_k4_gfx11_dgpu(
                     expert_weight_ptrs, expert_tile_ids, sorted_slot_index,
@@ -13549,14 +13529,14 @@ impl Gpu {
         // Shipped as opt-in research artifact; default OFF for gfx12.
         // Opt-in via HIPFIRE_MOE_GROUPED_I8=1 to evaluate on other shapes.
         let use_i8_gfx12 = self.arch.starts_with("gfx12")
-            && std::env::var("HIPFIRE_MOE_GROUPED_I8").as_deref() == Ok("1");
+            && self.flags.moe_grouped_i8.unwrap_or(false);
         if use_i8_gfx12 {
             // k4 variant: 4 sub-blocks paired per inner iteration, 8 WMMAs
             // into 4 independent int32 accumulators before scale-FMA chain
             // resolves. Experimental — separate gate from the gfx11_dgpu k4
             // (which is default-on) because the gfx12 i8 path itself is
             // default-off pending recovery from the -11.6% regression vs FP16.
-            let use_k4 = std::env::var("HIPFIRE_MOE_GROUPED_I8_K4_GFX12").as_deref() == Ok("1");
+            let use_k4 = self.flags.moe_grouped_i8_k4_gfx12;
             if use_k4 {
                 return self.gemm_hfq4g256_moe_grouped_mmq_k4_gfx12(
                     expert_weight_ptrs, expert_tile_ids, sorted_slot_index,
@@ -13573,7 +13553,7 @@ impl Gpu {
         let is_gfx12 = self.arch.starts_with("gfx12");
         // 2×1 M-direction reg-blocked variant (gfx12 only for now). Env-gated.
         let use_m2 = is_gfx12
-            && std::env::var("HIPFIRE_MOE_GROUPED_M2").as_deref() == Ok("1");
+            && self.flags.moe_grouped_m2;
         let (kernel_name, kernel_src) = if use_m2 {
             (
                 "gemm_hfq4g256_moe_grouped_wmma_m2_gfx12",
@@ -14255,7 +14235,7 @@ impl Gpu {
         // existing BLOCK_M=16 scatter — only the M (row) dimension is
         // restrided. The slot tile stride stays at 16 so expert-boundary
         // safety is unchanged from v1.
-        let use_v2 = std::env::var("HIPFIRE_MOE_HFQ6_V2").as_deref() == Ok("1");
+        let use_v2 = self.flags.moe_hfq6_v2;
         let (kernel_name, kernel_src, row_tile_stride) = if use_v2 {
             (
                 "gemm_hfq6g256_moe_grouped_wmma_v2_gfx12",
@@ -14610,7 +14590,7 @@ impl Gpu {
         // fires BEFORE the rocBLAS branch on purpose (rocBLAS goes through
         // FP16 dequant shadow, which is the cost we want to avoid).
         {
-            let mfma_v = std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").ok();
+            let mfma_v = self.flags.gfx942_mfma_prefill.clone();
             let want = mfma_v.as_deref();
             if (want == Some("1") || want == Some("2") || want == Some("3") || want == Some("4"))
                 && matches!(self.arch.as_str(), "gfx940" | "gfx941" | "gfx942")
@@ -16105,7 +16085,7 @@ impl Gpu {
         // Compile both kernels (convert + WMMA GEMM share the FP16 convert)
         // Kernel variant selection
         // MW16 path: dequant weights to FP16 per-call, then run no-dequant WMMA
-        if std::env::var("HIPFIRE_MW16").map_or(false, |v| v == "1") {
+        if self.flags.mw16 {
             return self.gemm_mw16_residual_wmma_via_dequant(a_raw, x, y, m, k, batch_size);
         }
         // Shape-aware default: ksplit only pays for itself when the un-split
@@ -16153,7 +16133,7 @@ impl Gpu {
         // × N layers per step. Read once at first dispatch.
         static FORCE_DET: OnceLock<bool> = OnceLock::new();
         let force_det = *FORCE_DET.get_or_init(|| {
-            std::env::var("HIPFIRE_DETERMINISTIC").ok().as_deref() == Some("1")
+            self.flags.deterministic
         });
         let auto_variant = if force_det {
             "k2"
@@ -16166,7 +16146,7 @@ impl Gpu {
         } else {
             "ksplit"
         };
-        let variant_override = std::env::var("HIPFIRE_WO_WMMA_VARIANT").ok();
+        let variant_override = self.flags.wo_wmma_variant.clone();
         let variant = variant_override.as_deref().unwrap_or(auto_variant);
         let (kernel_name, kernel_src, block_size, row_step, k_splits) = match variant {
             "k2"     => ("gemm_hfq4g256_residual_wmma_k2",
@@ -16214,7 +16194,7 @@ impl Gpu {
         // costs latency vs async pipelining but gives shape-accurate µs.
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         let dump = *DUMP.get_or_init(|| {
-            std::env::var("HIPFIRE_GEMM_DUMP").ok().as_deref() == Some("1")
+            self.flags.gemm_dump
         });
         if dump { self.hip.device_synchronize()?; }
         let dump_start = if dump { Some(std::time::Instant::now()) } else { None };
@@ -16260,10 +16240,9 @@ impl Gpu {
         self.bind_thread()?;
         let arch_supports_mb4 = matches!(self.arch.as_str(),
             "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151");
-        let use_mb4 = match std::env::var("HIPFIRE_MQ3_MB4").ok().as_deref() {
-            Some("0") => false,
-            Some("1") => arch_supports_mb4,
-            _ => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
+        let use_mb4 = match self.flags.mq3_mb4 {
+            Some(_) => arch_supports_mb4,
+            None => arch_supports_mb4 && batch_size >= 128 && m >= 4096,
         };
         if use_mb4 {
             return self.gemm_hfq3g256_residual_wmma_mb4(a_raw, x, y, m, k, batch_size);
@@ -19179,7 +19158,7 @@ impl Gpu {
         self.bind_thread()?;
         static USE_LEGACY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         let use_legacy = *USE_LEGACY.get_or_init(|| {
-            std::env::var("HIPFIRE_Q8_BATCHED_LEGACY").as_deref() == Ok("1")
+            self.flags.q8_batched_legacy
         });
         if !use_legacy && self.arch.starts_with("gfx12") && k % 32 == 0 && n > 0 {
             return self.gemm_q8_0_wmma(a_raw, x, y, m, k, n);
@@ -20765,8 +20744,7 @@ impl Gpu {
             // HIPFIRE_GFX942_GEMV_V2=0.
             let is_gfx94x = matches!(self.arch.as_str(),
                 "gfx940" | "gfx941" | "gfx942");
-            let v2_on = std::env::var("HIPFIRE_GFX942_GEMV_V2")
-                .map(|v| v != "0").unwrap_or(true);
+            let v2_on = self.flags.gfx942_gemv_v2.unwrap_or(true);
             if is_gfx94x && v2_on {
                 self.ensure_kernel(
                     "fused_gate_up_hfq4g256_v2_gfx942",
@@ -23699,7 +23677,7 @@ impl Gpu {
         // Function name kept as `rope_partial_interleaved_f32` to avoid a
         // workspace-wide rename in this commit; the dispatched kernel is now
         // `rope_partial_halfsplit_f32` by default.
-        let legacy = std::env::var("HIPFIRE_ROPE_INTERLEAVED_LEGACY").ok().as_deref() == Some("1");
+        let legacy = self.flags.rope_interleaved_legacy;
         let (src, entry) = if legacy {
             (kernels::ROPE_PARTIAL_INTERLEAVED_SRC, "rope_partial_interleaved_f32")
         } else {
@@ -23753,7 +23731,7 @@ impl Gpu {
         // Function name retained for source-tree stability; the dispatched
         // kernel is halfsplit by default. See sibling
         // `rope_partial_interleaved_f32` for the rationale.
-        let legacy = std::env::var("HIPFIRE_ROPE_INTERLEAVED_LEGACY").ok().as_deref() == Some("1");
+        let legacy = self.flags.rope_interleaved_legacy;
         let (cache_key, src, entry) = if legacy {
             ("rope_partial_interleaved_batched",
              kernels::ROPE_PARTIAL_INTERLEAVED_BATCHED_SRC,

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -28,6 +28,7 @@ pub struct FeatureFlags {
     pub gfx942_lds_gemv: Option<bool>,
     pub gfx942_lds_gemv_default_on: bool,
     pub gemv_rows_default: u32,
+    pub gemv_dp4a: Option<bool>,
 
     // ── Quant / format toggles ────────────────────────────────────
     pub hfq3_dp4a: Option<bool>,
@@ -134,6 +135,7 @@ impl FeatureFlags {
                 .and_then(|v| v.parse::<u32>().ok())
                 .map(|r| match r { 1 | 2 | 4 | 8 => r, _ => 1 }),
             gemv_dp4a_default_on: is_gfx906,
+            gemv_dp4a: parse_bool("HIPFIRE_GEMV_DP4A"),
             gemv_prefetch: parse_bool("HIPFIRE_GEMV_PREFETCH"),
             gemv_prefetch_default_on: is_gfx906,
             gfx942_lds_gemv: parse_bool("HIPFIRE_GFX942_LDS_GEMV"),
@@ -232,7 +234,7 @@ impl FeatureFlags {
     // ── Methods replacing free functions ─────────────────────────────
 
     pub fn gemv_dp4a_enabled(&self) -> bool {
-        self.hfq3_dp4a.unwrap_or(self.gemv_dp4a_default_on)
+        self.gemv_dp4a.unwrap_or(self.gemv_dp4a_default_on)
     }
 
     pub fn gemv_prefetch_enabled(&self) -> bool {

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Typed, immutable env-var resolution for rdna-compute.
+//!
+//! All `HIPFIRE_*` env vars are read exactly once at `Gpu::init()` time via
+//! `FeatureFlags::from_env()`. Dispatching hot paths access `self.flags.*`
+//! instead of hitting `std::env::var`'s global lock on every call.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mb4Mode {
+    Pack1,
+    Pack2,
+    Pack4,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureFlags {
+    // ── Arch identity ──────────────────────────────────────────────
+    pub arch: String,
+
+    // ── GEMV tuning ────────────────────────────────────────────────
+    pub gemv_rows: Option<u32>,
+    pub gemv_dp4a_default_on: bool,
+    pub gemv_prefetch: Option<bool>,
+    pub gemv_prefetch_default_on: bool,
+    pub gfx942_lds_gemv: Option<bool>,
+    pub gfx942_lds_gemv_default_on: bool,
+    pub gemv_rows_default: u32,
+
+    // ── Quant / format toggles ────────────────────────────────────
+    pub hfq3_dp4a: Option<bool>,
+    pub hfq3_mmq: Option<bool>,
+    pub hfq4_mmq_rdna2: Option<bool>,
+    pub fp8_wmma: bool,
+    pub dot2_gemv: bool,
+    pub gcn5_wave64_hybrid: Option<bool>,
+    pub mmq_override: Option<bool>,
+    pub mmq_min_batch: Option<usize>,
+    pub fp16_disabled: bool,
+    pub fp16_layer_min: Option<usize>,
+    pub fp16_layer_max: Option<usize>,
+    pub wo_mmq: bool,
+    pub lm_head_wmma_disabled: bool,
+
+    // ── MMQ screening ─────────────────────────────────────────────
+    pub mmq_screen: bool,
+    pub mmq_screen_threshold: f32,
+    pub mmq_diag_quantize_only: bool,
+
+    // ── Kernel variant overrides ─────────────────────────────────
+    pub lloyd_mb4: Option<Mb4Mode>,
+    pub mq3_mb4: Option<Mb4Mode>,
+    pub hfq4g128_mmq: bool,
+    pub hfq3_mmq_layer_min: Option<usize>,
+    pub hfq3_mmq_layer_max: Option<usize>,
+    pub hfq4_mmq_gfx906_y64: bool,
+    pub gate_up_variant: Option<String>,
+    pub gfx942_gemv_v2: Option<bool>,
+    pub gfx942_gemv_v3: bool,
+    pub gfx942_rmsnorm_split: bool,
+    pub gfx942_mfma_prefill: Option<String>,
+    pub moe_grouped_i8: Option<bool>,
+    pub moe_grouped_i8_k8: bool,
+    pub moe_grouped_i8_k4: bool,
+    pub moe_grouped_i8_k4_gfx12: bool,
+    pub moe_grouped_m2: bool,
+    pub moe_hfq6_v2: bool,
+
+    // ── Graph / capture / deterministic ─────────────────────────────
+    pub force_blob_path: bool,
+    pub gemm_dump: bool,
+    pub deterministic: bool,
+    pub mw16: bool,
+    pub q8_batched_legacy: bool,
+    pub rope_interleaved_legacy: bool,
+    pub wo_wmma_variant: Option<String>,
+
+    // ── rocBLAS ────────────────────────────────────────────────────
+    pub rocblas_all_archs: bool,
+    pub rocblas_off: bool,
+    pub rocblas_min_batch: Option<usize>,
+
+    // ── Kernels.rs env reads ───────────────────────────────────────
+    pub lloyd_force_baseline: bool,
+    pub rdna2_variant: Option<u32>,
+
+    // ── Compiler.rs env reads ──────────────────────────────────────
+    pub hipcc_extra_flags: String,
+}
+
+impl FeatureFlags {
+    pub fn from_env(arch: &str) -> Self {
+        let parse_bool = |name: &str| -> Option<bool> {
+            match std::env::var(name).ok().as_deref() {
+                Some("1") | Some("true") | Some("TRUE") | Some("on") | Some("ON") => Some(true),
+                Some("0") | Some("false") | Some("FALSE") | Some("off") | Some("OFF") => Some(false),
+                _ => None,
+            }
+        };
+
+        let parse_usize = |name: &str| -> Option<usize> {
+            std::env::var(name).ok().and_then(|s| s.parse().ok())
+        };
+
+        let parse_mb4 = |name: &str| -> Option<Mb4Mode> {
+            match std::env::var(name).ok().as_deref() {
+                Some("1") => Some(Mb4Mode::Pack1),
+                Some("2") => Some(Mb4Mode::Pack2),
+                Some("4") => Some(Mb4Mode::Pack4),
+                _ => None,
+            }
+        };
+
+        let is_gfx906 = arch == "gfx906";
+
+        let mmq_screen_default: bool = false;
+        let mmq_screen_threshold_default: f32 = if is_gfx906 { 0.50 } else { 0.10 };
+
+        let gemv_rows_default: u32 = match arch {
+            "gfx1100" | "gfx1101" | "gfx1102" => 1,
+            "gfx1030" | "gfx1031" => 1,
+            "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942" => 1,
+            _ => 2,
+        };
+
+        Self {
+            arch: arch.to_string(),
+
+            // GEMV tuning
+            gemv_rows: std::env::var("HIPFIRE_GEMV_ROWS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .map(|r| match r { 1 | 2 | 4 | 8 => r, _ => 1 }),
+            gemv_dp4a_default_on: is_gfx906,
+            gemv_prefetch: parse_bool("HIPFIRE_GEMV_PREFETCH"),
+            gemv_prefetch_default_on: is_gfx906,
+            gfx942_lds_gemv: parse_bool("HIPFIRE_GFX942_LDS_GEMV"),
+            gfx942_lds_gemv_default_on: false,
+            gemv_rows_default,
+
+            // Quant/format toggles
+            hfq3_dp4a: parse_bool("HIPFIRE_HFQ3_DP4A"),
+            hfq3_mmq: parse_bool("HIPFIRE_HFQ3_MMQ"),
+            hfq4_mmq_rdna2: parse_bool("HIPFIRE_HFQ4_MMQ_RDNA2"),
+            fp8_wmma: std::env::var("HIPFIRE_FP8_WMMA").map_or(false, |v| v == "1"),
+            dot2_gemv: std::env::var("HIPFIRE_DOT2_GEMV").map_or(false, |v| v == "1"),
+            gcn5_wave64_hybrid: parse_bool("HIPFIRE_GCN5_WAVE64_HYBRID"),
+            mmq_override: match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
+                Some("0") | Some("off") => Some(false),
+                Some("1") | Some("on") => Some(true),
+                _ => None,
+            },
+            mmq_min_batch: parse_usize("HIPFIRE_MMQ_MIN_BATCH"),
+            fp16_disabled: std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0"),
+            fp16_layer_min: parse_usize("HIPFIRE_FP16_LAYER_MIN"),
+            fp16_layer_max: parse_usize("HIPFIRE_FP16_LAYER_MAX"),
+            wo_mmq: std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1"),
+            lm_head_wmma_disabled: std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0"),
+
+            // MMQ screening
+            mmq_screen: std::env::var("HIPFIRE_MMQ_SCREEN")
+                .ok()
+                .map(|v| v == "1")
+                .unwrap_or(mmq_screen_default),
+            mmq_screen_threshold: std::env::var("HIPFIRE_MMQ_SCREEN_THRESHOLD")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(mmq_screen_threshold_default),
+            mmq_diag_quantize_only: std::env::var("HIPFIRE_MMQ_DIAG_QUANTIZE_ONLY")
+                .ok()
+                .as_deref() == Some("1"),
+
+            // Kernel variant overrides
+            lloyd_mb4: parse_mb4("HIPFIRE_LLOYD_MB4"),
+            mq3_mb4: parse_mb4("HIPFIRE_MQ3_MB4"),
+            hfq4g128_mmq: std::env::var("HIPFIRE_HFQ4G128_MMQ").as_deref() != Ok("0"),
+            hfq3_mmq_layer_min: parse_usize("HIPFIRE_HFQ3_MMQ_LAYER_MIN"),
+            hfq3_mmq_layer_max: parse_usize("HIPFIRE_HFQ3_MMQ_LAYER_MAX"),
+            hfq4_mmq_gfx906_y64: std::env::var("HIPFIRE_HFQ4_MMQ_GFX906_Y64")
+                .map_or(false, |v| v == "1"),
+            gate_up_variant: std::env::var("HIPFIRE_GATE_UP_VARIANT").ok(),
+            gfx942_gemv_v2: parse_bool("HIPFIRE_GFX942_GEMV_V2"),
+            gfx942_gemv_v3: std::env::var("HIPFIRE_GFX942_GEMV_V3").map_or(false, |v| v == "1"),
+            gfx942_rmsnorm_split: matches!(arch, "gfx940" | "gfx941" | "gfx942")
+                && std::env::var("HIPFIRE_GFX942_RMSNORM_SPLIT").as_deref() != Ok("0"),
+            gfx942_mfma_prefill: std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").ok(),
+            moe_grouped_i8: match std::env::var("HIPFIRE_MOE_GROUPED_I8").ok().as_deref() {
+                Some("1") => Some(true),
+                Some("0") => Some(false),
+                _ => None,
+            },
+            moe_grouped_i8_k8: std::env::var("HIPFIRE_MOE_GROUPED_I8_K8").as_deref() == Ok("1"),
+            moe_grouped_i8_k4: std::env::var("HIPFIRE_MOE_GROUPED_I8_K4").as_deref() == Ok("1"),
+            moe_grouped_i8_k4_gfx12: std::env::var("HIPFIRE_MOE_GROUPED_I8_K4_GFX12")
+                .as_deref() == Ok("1"),
+            moe_grouped_m2: std::env::var("HIPFIRE_MOE_GROUPED_M2").as_deref() == Ok("1"),
+            moe_hfq6_v2: std::env::var("HIPFIRE_MOE_HFQ6_V2").as_deref() == Ok("1"),
+
+            // Graph / capture / deterministic
+            force_blob_path: std::env::var("HIPFIRE_BLOB_FORCE").ok().as_deref() == Some("1"),
+            gemm_dump: std::env::var("HIPFIRE_GEMM_DUMP").ok().as_deref() == Some("1"),
+            deterministic: std::env::var("HIPFIRE_DETERMINISTIC").ok().as_deref() == Some("1"),
+            mw16: std::env::var("HIPFIRE_MW16").map_or(false, |v| v == "1"),
+            q8_batched_legacy: std::env::var("HIPFIRE_Q8_BATCHED_LEGACY").as_deref() == Ok("1"),
+            rope_interleaved_legacy: std::env::var("HIPFIRE_ROPE_INTERLEAVED_LEGACY")
+                .ok()
+                .as_deref() == Some("1"),
+            wo_wmma_variant: std::env::var("HIPFIRE_WO_WMMA_VARIANT").ok(),
+
+            // rocBLAS
+            rocblas_all_archs: std::env::var("HIPFIRE_ROCBLAS_ALL_ARCHS")
+                .ok()
+                .as_deref() == Some("1"),
+            rocblas_off: std::env::var("HIPFIRE_ROCBLAS_OFF").ok().as_deref() == Some("1"),
+            rocblas_min_batch: parse_usize("HIPFIRE_ROCBLAS_MIN_BATCH"),
+
+            // Kernels.rs
+            lloyd_force_baseline: std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE")
+                .ok()
+                .as_deref() == Some("1"),
+            rdna2_variant: std::env::var("HIPFIRE_RDNA2_VARIANT")
+                .ok()
+                .and_then(|s| s.parse::<u32>().ok()),
+
+            // Compiler.rs
+            hipcc_extra_flags: std::env::var("HIPFIRE_HIPCC_EXTRA_FLAGS").unwrap_or_default(),
+        }
+    }
+
+    // ── Methods replacing free functions ─────────────────────────────
+
+    pub fn gemv_dp4a_enabled(&self) -> bool {
+        self.hfq3_dp4a.unwrap_or(self.gemv_dp4a_default_on)
+    }
+
+    pub fn gemv_prefetch_enabled(&self) -> bool {
+        self.gemv_prefetch.unwrap_or(self.gemv_prefetch_default_on)
+    }
+
+    pub fn gfx942_lds_gemv_enabled(&self) -> bool {
+        self.gfx942_lds_gemv.unwrap_or(self.gfx942_lds_gemv_default_on)
+    }
+
+    pub fn has_wmma_f16(&self) -> bool {
+        self.arch.starts_with("gfx11")
+    }
+
+    pub fn has_wmma_f16_gfx12(&self) -> bool {
+        self.arch.starts_with("gfx12")
+    }
+
+    pub fn has_wmma_fp8_gfx12(&self) -> bool {
+        self.arch.starts_with("gfx12")
+    }
+
+    pub fn has_dot2_f32_f16(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx1011" | "gfx1012"
+            | "gfx1030" | "gfx1031" | "gfx1032"
+            | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
+            | "gfx1150" | "gfx1151" | "gfx1152"
+            | "gfx1200" | "gfx1201")
+    }
+
+    pub fn hfq3_sdot4_gfx10_enabled(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx1011" | "gfx1012" | "gfx1030" | "gfx1031" | "gfx1032")
+    }
+
+    pub fn hfq3_dp4a_enabled(&self) -> bool {
+        self.hfq3_dp4a.unwrap_or(false) && self.hfq3_sdot4_gfx10_enabled()
+    }
+
+    pub fn hfq3_mmq_rdna2_enabled(&self) -> bool {
+        self.hfq3_mmq.unwrap_or(false) && self.hfq3_sdot4_gfx10_enabled()
+    }
+
+    pub fn hfq4_mmq_rdna2_enabled(&self) -> bool {
+        self.hfq4_mmq_rdna2.unwrap_or(false)
+            && self.has_dot2_f32_f16()
+    }
+
+    pub fn has_mmq_dp4a_or_wmma(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx906"
+            | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
+            | "gfx1150" | "gfx1151" | "gfx1152")
+    }
+
+    pub fn has_wave64_native(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942")
+    }
+
+    pub fn is_gcn5_wave64(&self) -> bool {
+        if self.arch == "gfx906" {
+            return true;
+        }
+        self.arch == "gfx908" && self.gcn5_wave64_hybrid.unwrap_or(false)
+    }
+
+    pub fn should_use_mmq(&self, batch_size: usize) -> bool {
+        if !self.has_mmq_dp4a_or_wmma() {
+            return false;
+        }
+        match self.mmq_override {
+            Some(false) => false,
+            Some(true) => true,
+            None => {
+                let arch_min_batch: usize = if self.arch == "gfx906" { 8 } else { 256 };
+                let min_batch = self.mmq_min_batch.unwrap_or(arch_min_batch);
+                batch_size >= min_batch
+            }
+        }
+    }
+
+    pub fn hfq3_mmq_layer_gate_pass(&self) -> bool {
+        let lo = self.hfq3_mmq_layer_min;
+        let hi = self.hfq3_mmq_layer_max;
+        if lo.is_none() && hi.is_none() {
+            return true;
+        }
+        let layer = super::dispatch::MMQ_CURRENT_LAYER.load(std::sync::atomic::Ordering::Relaxed);
+        if let Some(lo) = lo { if layer < lo { return false; } }
+        if let Some(hi) = hi { if layer > hi { return false; } }
+        true
+    }
+
+    pub fn fp16_disabled_for_current_layer(&self) -> bool {
+        if self.fp16_disabled { return true; }
+        let lo = self.fp16_layer_min;
+        let hi = self.fp16_layer_max;
+        if lo.is_none() && hi.is_none() {
+            return false;
+        }
+        let layer = super::dispatch::MMQ_CURRENT_LAYER.load(std::sync::atomic::Ordering::Relaxed);
+        let above_min = lo.map(|m| layer >= m).unwrap_or(true);
+        let below_max = hi.map(|m| layer <= m).unwrap_or(true);
+        above_min && below_max
+    }
+
+    pub fn hfq4_mmq_gfx906_y64_enabled(&self) -> bool {
+        self.hfq4_mmq_gfx906_y64
+    }
+}

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -213,7 +213,7 @@ pub fn gemm_qkvza_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, 
         ),
     }
 }
-pub fn gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
+pub fn gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
     match arch {
         "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
             (GEMM_QKV_MQ4G256_LLOYD_WMMA_MB4_SRC, "gemm_qkv_mq4g256_lloyd_wmma_mb4_rdna3"),
@@ -222,7 +222,7 @@ pub fn gemm_qkv_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'
         ),
     }
 }
-pub fn gemm_gate_up_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str, &'static str) {
+pub fn gemm_gate_up_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
     match arch {
         "gfx1100" | "gfx1101" | "gfx1102" | "gfx1151" =>
             (GEMM_GATE_UP_MQ4G256_LLOYD_WMMA_MB4_SRC, "gemm_gate_up_mq4g256_lloyd_wmma_mb4_rdna3"),
@@ -238,10 +238,10 @@ pub fn gemm_gate_up_mq4g256_lloyd_wmma_mb4_for_arch(arch: &str) -> (&'static str
 /// chip-agnostic baseline switch-dispatch path. gfx1151 is included for
 /// on-host conformance testing — definitive MQ4-Lloyd perf comparisons happen
 /// on gfx1100 (the format's calibrated target arch).
-pub fn gemv_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
+pub fn gemv_mq4g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
     // Same HIPFIRE_LLOYD_FORCE_BASELINE escape hatch as MQ3-Lloyd, so the fast
     // variant can be A/B'd against the baseline on the same model file.
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+    if force_baseline {
         return (GEMV_MQ4G256_LLOYD_SRC, "gemv_mq4g256_lloyd");
     }
     match arch {
@@ -254,8 +254,8 @@ pub fn gemv_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
 
 /// Same arch dispatch as `gemv_mq4g256_lloyd_for_arch` but returns the residual
 /// variant (y[row] += A[row] · x).
-pub fn gemv_mq4g256_lloyd_residual_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn gemv_mq4g256_lloyd_residual_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (GEMV_MQ4G256_LLOYD_RESIDUAL_SRC, "gemv_mq4g256_lloyd_residual");
     }
     match arch {
@@ -267,8 +267,8 @@ pub fn gemv_mq4g256_lloyd_residual_for_arch(arch: &str) -> (&'static str, &'stat
 }
 
 /// Arch dispatch for fused gate+up MQ4-Lloyd. Mirrors MQ3-Lloyd's selector.
-pub fn fused_gate_up_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn fused_gate_up_mq4g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (FUSED_GATE_UP_MQ4G256_LLOYD_SRC, "fused_gate_up_mq4g256_lloyd");
     }
     match arch {
@@ -280,8 +280,8 @@ pub fn fused_gate_up_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'stat
 }
 
 /// Arch dispatch for fused QKVZA MQ4-Lloyd (4-way demux: qkv/z/beta/alpha).
-pub fn fused_qkvza_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn fused_qkvza_mq4g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (FUSED_QKVZA_MQ4G256_LLOYD_SRC, "fused_qkvza_mq4g256_lloyd");
     }
     match arch {
@@ -293,8 +293,8 @@ pub fn fused_qkvza_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static
 }
 
 /// Arch dispatch for fused QKV MQ4-Lloyd (3-way demux: q/k/v).
-pub fn fused_qkv_mq4g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn fused_qkv_mq4g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (FUSED_QKV_MQ4G256_LLOYD_SRC, "fused_qkv_mq4g256_lloyd");
     }
     match arch {
@@ -441,13 +441,13 @@ pub const FUSED_QKV_MQ3G256_LLOYD_GFX1100_SRC: &str = include_str!("../../../ker
 /// arch. gfx1100/1101/1102 (RDNA3) gets the K4-unrolled + LDS-codebook variant
 /// that closes the per-launch perf gap from the divergent-execution switch.
 /// Other archs use the baseline (slower but correct switch-dispatch path).
-pub fn gemv_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
+pub fn gemv_mq3g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
     // Debug escape hatch: HIPFIRE_LLOYD_FORCE_BASELINE=1 forces the slow generic
     // switch-dispatch kernel even on RDNA3, so the K4+LDS variant can be
     // logits-Δ'd against the baseline on the same model file. No perf cost when
     // unset (one missed-getenv per dispatch arm), and ensure_kernel short-
     // circuits after the first call regardless.
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+    if force_baseline {
         return (GEMV_MQ3G256_LLOYD_SRC, "gemv_mq3g256_lloyd");
     }
     match arch {
@@ -469,8 +469,8 @@ pub fn gemv_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
 /// Same arch dispatch as `gemv_mq3g256_lloyd_for_arch` but returns the residual
 /// variant (y[row] += A[row] · x). HIPFIRE_LLOYD_FORCE_BASELINE=1 also routes
 /// here to the baseline (for parity-test purposes).
-pub fn gemv_mq3g256_lloyd_residual_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn gemv_mq3g256_lloyd_residual_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (GEMV_MQ3G256_LLOYD_RESIDUAL_SRC, "gemv_mq3g256_lloyd_residual");
     }
     match arch {
@@ -484,8 +484,8 @@ pub fn gemv_mq3g256_lloyd_residual_for_arch(arch: &str) -> (&'static str, &'stat
 /// Arch dispatch for fused gate+up MQ3-Lloyd. Same arch matrix as the GEMV
 /// variants. Used by `qwen35.rs` FFN forward when both `w_gate` and `w_up`
 /// are MQ3G256Lloyd to collapse 2 GEMV launches into 1.
-pub fn fused_gate_up_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn fused_gate_up_mq3g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (FUSED_GATE_UP_MQ3G256_LLOYD_SRC, "fused_gate_up_mq3g256_lloyd");
     }
     match arch {
@@ -499,8 +499,8 @@ pub fn fused_gate_up_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'stat
 /// Arch dispatch for fused QKVZA MQ3-Lloyd. Used by `qwen35.rs` LA decode
 /// when all four projections (wqkv, wz, w_beta, w_alpha) are MQ3G256Lloyd
 /// to collapse 4 GEMV launches into 1.
-pub fn fused_qkvza_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn fused_qkvza_mq3g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (FUSED_QKVZA_MQ3G256_LLOYD_SRC, "fused_qkvza_mq3g256_lloyd");
     }
     match arch {
@@ -513,8 +513,8 @@ pub fn fused_qkvza_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static
 
 /// Arch dispatch for fused QKV MQ3-Lloyd. Used by `qwen35.rs` FA decode
 /// when wq, wk, wv are all MQ3G256Lloyd to collapse 3 GEMV launches into 1.
-pub fn fused_qkv_mq3g256_lloyd_for_arch(arch: &str) -> (&'static str, &'static str) {
-    if std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1") {
+pub fn fused_qkv_mq3g256_lloyd_for_arch(arch: &str, force_baseline: bool) -> (&'static str, &'static str) {
+    if force_baseline {
         return (FUSED_QKV_MQ3G256_LLOYD_SRC, "fused_qkv_mq3g256_lloyd");
     }
     match arch {
@@ -1473,13 +1473,10 @@ pub const GEMV_HFQ4G256_GFX1030_V5_SRC: &str = include_str!("../../../kernels/sr
 /// On gfx1030/gfx1031 (RDNA2), selects variant via HIPFIRE_RDNA2_VARIANT env var.
 /// Module name is variant-specific so each variant gets its own precompiled .hsaco blob.
 /// The function name inside the .hsaco is always "gemv_hfq4g256" (the extern "C" symbol).
-pub fn gemv_hfq4g256_for_arch(arch: &str) -> (&'static str, &'static str) {
+pub fn gemv_hfq4g256_for_arch(arch: &str, rdna2_variant: Option<u32>) -> (&'static str, &'static str) {
     match arch {
         "gfx1030" | "gfx1031" => {
-            let variant: u32 = std::env::var("HIPFIRE_RDNA2_VARIANT")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(1);
+            let variant: u32 = rdna2_variant.unwrap_or(1);
             let names = ["", "baseline-rdna2", "high-occupancy", "wide-unroll", "dp4a-packed", "cache-aggressive"];
             let name = names.get(variant as usize).unwrap_or(&"baseline-rdna2");
             eprintln!("  RDNA2 GEMV variant: v{variant} ({name})");

--- a/crates/rdna-compute/src/lib.rs
+++ b/crates/rdna-compute/src/lib.rs
@@ -15,8 +15,7 @@ pub mod profiler;
 
 pub use compiler::KernelCompiler;
 pub use dispatch::{
-    gemv_dp4a_enabled, has_wmma_f16, DType, Gpu, GpuTensor, LLOYD_MQ4_GROUP_BYTES,
-    MMQ_CURRENT_LAYER,
+    DType, Gpu, GpuTensor, LLOYD_MQ4_GROUP_BYTES, MMQ_CURRENT_LAYER,
 };
 pub use feature_flags::FeatureFlags;
 pub use kernels::GEMV_SRC;

--- a/crates/rdna-compute/src/lib.rs
+++ b/crates/rdna-compute/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod compiler;
 mod dispatch;
+pub mod feature_flags;
 mod kernels;
 pub mod pool;
 pub mod profile;
@@ -17,4 +18,5 @@ pub use dispatch::{
     gemv_dp4a_enabled, has_wmma_f16, DType, Gpu, GpuTensor, LLOYD_MQ4_GROUP_BYTES,
     MMQ_CURRENT_LAYER,
 };
+pub use feature_flags::FeatureFlags;
 pub use kernels::GEMV_SRC;

--- a/docs/superpowers/plans/2026-05-26-feature-flags.md
+++ b/docs/superpowers/plans/2026-05-26-feature-flags.md
@@ -1,0 +1,907 @@
+# FeatureFlags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate all HIPFIRE_ env-var reads in rdna-compute and hipfire-runtime into typed, immutable structs built once at startup.
+
+**Architecture:** New `FeatureFlags` struct in `rdna-compute/src/feature_flags.rs` replaces all `OnceLock` free functions and raw `std::env::var` calls. `Arc<FeatureFlags>` stored on `Gpu`. New `RuntimeConfig` struct in `hipfire-runtime/src/config.rs` consolidates runtime env reads. Existing public free functions (`gemv_dp4a_enabled`, `has_wmma_f16`) removed; callers use `gpu.flags.method()`.
+
+**Tech Stack:** Rust 2021, `std::sync::Arc`, `std::sync::OnceLock` (existing dependency). No new crates.
+
+**Worktree:** `../hipfire-328-feature-flags` on branch `feature/328-feature-flags`
+
+---
+
+## File Structure
+
+### New files
+- `crates/rdna-compute/src/feature_flags.rs` — `FeatureFlags` struct, `Mb4Mode` enum, `from_env()` constructor, all methods replacing free functions
+- `crates/hipfire-runtime/src/config.rs` — `RuntimeConfig` struct, `from_env()` constructor
+
+### Modified files
+- `crates/rdna-compute/src/lib.rs` — add `pub mod feature_flags;`, update `pub use`
+- `crates/rdna-compute/src/dispatch.rs` — remove all free functions (lines 47–499), remove `mmq_screen`/`mmq_screen_threshold`/`force_blob_path`/`mmq_diag_quantize_only` fields from `Gpu`, add `flags: Arc<FeatureFlags>` field, replace all `std::env::var("HIPFIRE_...")` calls with `self.flags.*` accesses
+- `crates/rdna-compute/src/kernels.rs` — replace `std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE")` and `std::env::var("HIPFIRE_RDNA2_VARIANT")` with parameter passing (struct field or method arg)
+- `crates/rdna-compute/src/compiler.rs` — replace `std::env::var("HIPFIRE_HIPCC_EXTRA_FLAGS")` with struct field
+- `crates/rdna-compute/src/arch_caps.rs` — `paro_la_gates_mq4g128_default` stays (it's pure arch logic, no env var)
+- `crates/hipfire-runtime/src/lib.rs` — add `pub mod config;`
+- `crates/hipfire-runtime/src/tokenizer.rs` — replace env reads with `RuntimeConfig` fields
+- `crates/hipfire-runtime/src/dflash.rs` — replace env reads with `RuntimeConfig` fields
+- `crates/hipfire-runtime/src/llama.rs` — replace env reads with `RuntimeConfig` fields
+- `crates/hipfire-runtime/src/loop_guard.rs` — replace env reads with `RuntimeConfig` fields
+- `crates/hipfire-runtime/src/multi_gpu.rs` — replace env reads with `RuntimeConfig` fields
+- `crates/hipfire-runtime/src/arch.rs` — replace env reads with `RuntimeConfig` fields
+- `crates/hipfire-runtime/examples/daemon.rs` — construct `RuntimeConfig`, pass through
+- `crates/hipfire-runtime/examples/dflash_spec_demo.rs` — construct `RuntimeConfig`, pass through
+- `crates/hipfire-arch-qwen35/src/qwen35.rs` — replace `rdna_compute::gemv_dp4a_enabled(&gpu.arch)` with `gpu.flags.gemv_dp4a_enabled()`, same for `has_wmma_f16`
+- `crates/hipfire-arch-qwen35/src/arch.rs` — import `FeatureFlags` if needed
+- `crates/hipfire-arch-qwen35/src/paro_la_gates_codec.rs` — no change (uses `arch_caps::paro_la_gates_mq4g128_default`, not an env var)
+
+---
+
+## Task 1: Create `FeatureFlags` struct in rdna-compute
+
+**Files:**
+- Create: `crates/rdna-compute/src/feature_flags.rs`
+- Modify: `crates/rdna-compute/src/lib.rs`
+
+- [ ] **Step 1: Create `feature_flags.rs` with the struct definition and `from_env`**
+
+Create `crates/rdna-compute/src/feature_flags.rs` with the complete `FeatureFlags` struct. Every env var that was previously read via `std::env::var("HIPFIRE_X")` in dispatch.rs, kernels.rs, or compiler.rs becomes a field. The `from_env(arch: &str)` constructor reads all env vars once at init time.
+
+```rust
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub enum Mb4Mode {
+    Pack1,
+    Pack2,
+    Pack4,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureFlags {
+    // ── Arch identity ──────────────────────────────────────────────
+    pub arch: String,
+
+    // ── GEMV tuning ────────────────────────────────────────────────
+    pub gemv_rows: Option<u32>,
+    pub gemv_dp4a_default_on: bool,
+    pub gemv_prefetch_default_on: bool,
+    pub gfx942_lds_gemv_default_on: bool,
+    pub gemv_rows_default: u32,
+
+    // ── Quant / format toggles ────────────────────────────────────
+    pub hfq3_dp4a: Option<bool>,
+    pub hfq3_mmq: Option<bool>,
+    pub hfq4_mmq_rdna2: Option<bool>,
+    pub fp8_wmma: bool,
+    pub dot2_gemv: bool,
+    pub gcn5_wave64_hybrid: Option<bool>,
+    pub mmq_override: Option<bool>,
+    pub mmq_min_batch: Option<usize>,
+    pub fp16_disabled: bool,
+    pub wo_mmq: bool,
+    pub lm_head_wmma_disabled: bool,
+
+    // ── MMQ screening ─────────────────────────────────────────────
+    pub mmq_screen: bool,
+    pub mmq_screen_threshold: f32,
+    pub mmq_diag_quantize_only: bool,
+
+    // ── Kernel variant overrides ─────────────────────────────────
+    pub lloyd_mb4: Option<Mb4Mode>,
+    pub mq3_mb4: Option<Mb4Mode>,
+    pub hfq4g128_mmq: bool,
+    pub gate_up_variant: Option<String>,
+    pub gfx942_gemv_v2: Option<bool>,
+    pub gfx942_gemv_v3: bool,
+    pub gfx942_rmsnorm_split: bool,
+    pub gfx942_mfma_prefill: Option<String>,
+    pub moe_grouped_i8: Option<bool>,
+    pub moe_grouped_i8_k8: bool,
+    pub moe_grouped_i8_k4: bool,
+    pub moe_grouped_i8_k4_gfx12: bool,
+    pub moe_grouped_m2: bool,
+    pub moe_hfq6_v2: bool,
+
+    // ── Graph / capture / deterministic ─────────────────────────────
+    pub force_blob_path: bool,
+    pub gemm_dump: bool,
+    pub deterministic: bool,
+    pub mw16: bool,
+    pub q8_batched_legacy: bool,
+    pub rope_interleaved_legacy: bool,
+    pub wo_wmma_variant: Option<String>,
+
+    // ── rocBLAS ────────────────────────────────────────────────────
+    pub rocblas_all_archs: bool,
+    pub rocblas_off: bool,
+    pub rocblas_min_batch: Option<usize>,
+
+    // ── Kernels.rs env reads ───────────────────────────────────────
+    pub lloyd_force_baseline: bool,
+    pub rdna2_variant: Option<u32>,
+
+    // ── Compiler.rs env reads ──────────────────────────────────────
+    pub hipcc_extra_flags: String,
+}
+
+impl FeatureFlags {
+    pub fn from_env(arch: &str) -> Self {
+        let parse_bool = |name: &str| -> Option<bool> {
+            match std::env::var(name).ok().as_deref() {
+                Some("1") | Some("true") | Some("TRUE") | Some("on") | Some("ON") => Some(true),
+                Some("0") | Some("false") | Some("FALSE") | Some("off") | Some("OFF") => Some(false),
+                _ => None,
+            }
+        };
+
+        let parse_usize = |name: &str| -> Option<usize> {
+            std::env::var(name).ok().and_then(|s| s.parse().ok())
+        };
+
+        let parse_mb4 = |name: &str| -> Option<Mb4Mode> {
+            match std::env::var(name).ok().as_deref() {
+                Some("1") => Some(Mb4Mode::Pack1),
+                Some("2") => Some(Mb4Mode::Pack2),
+                Some("4") => Some(Mb4Mode::Pack4),
+                _ => None,
+            }
+        };
+
+        // Per-arch defaults (resolved here, not at call sites)
+        let is_gfx906 = arch == "gfx906";
+        let is_gfx942_family = matches!(arch, "gfx940" | "gfx941" | "gfx942");
+
+        // mmq_screen defaults: false on all arches as of 2026-05-18
+        let mmq_screen_default = false;
+        let mmq_screen_threshold_default: f32 = if is_gfx906 { 0.50 } else { 0.10 };
+
+        // gemv_rows_default
+        let gemv_rows_default: u32 = match arch {
+            "gfx1100" | "gfx1101" | "gfx1102" => 1,
+            "gfx1030" | "gfx1031" => 1,
+            "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942" => 1,
+            _ => 2,
+        };
+
+        Self {
+            arch: arch.to_string(),
+
+            // GEMV tuning
+            gemv_rows: std::env::var("HIPFIRE_GEMV_ROWS")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+                .map(|r| match r { 1 | 2 | 4 | 8 => r, _ => 1 }),
+            gemv_dp4a_default_on: is_gfx906,
+            gemv_prefetch_default_on: is_gfx906,
+            gfx942_lds_gemv_default_on: false,
+            gemv_rows_default,
+
+            // Quant/format toggles
+            hfq3_dp4a: parse_bool("HIPFIRE_HFQ3_DP4A"),
+            hfq3_mmq: parse_bool("HIPFIRE_HFQ3_MMQ"),
+            hfq4_mmq_rdna2: parse_bool("HIPFIRE_HFQ4_MMQ_RDNA2"),
+            fp8_wmma: std::env::var("HIPFIRE_FP8_WMMA").map_or(false, |v| v == "1"),
+            dot2_gemv: std::env::var("HIPFIRE_DOT2_GEMV").map_or(false, |v| v == "1"),
+            gcn5_wave64_hybrid: parse_bool("HIPFIRE_GCN5_WAVE64_HYBRID"),
+            mmq_override: match std::env::var("HIPFIRE_MMQ").ok().as_deref() {
+                Some("0") | Some("off") => Some(false),
+                Some("1") | Some("on") => Some(true),
+                _ => None,
+            },
+            mmq_min_batch: parse_usize("HIPFIRE_MMQ_MIN_BATCH"),
+            fp16_disabled: std::env::var("HIPFIRE_FP16").map_or(false, |v| v == "0"),
+            wo_mmq: std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1"),
+            lm_head_wmma_disabled: std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0"),
+
+            // MMQ screening
+            mmq_screen: std::env::var("HIPFIRE_MMQ_SCREEN")
+                .ok()
+                .map(|v| v == "1")
+                .unwrap_or(mmq_screen_default),
+            mmq_screen_threshold: std::env::var("HIPFIRE_MMQ_SCREEN_THRESHOLD")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(mmq_screen_threshold_default),
+            mmq_diag_quantize_only: std::env::var("HIPFIRE_MMQ_DIAG_QUANTIZE_ONLY")
+                .ok()
+                .as_deref() == Some("1"),
+
+            // Kernel variant overrides
+            lloyd_mb4: parse_mb4("HIPFIRE_LLOYD_MB4"),
+            mq3_mb4: parse_mb4("HIPFIRE_MQ3_MB4"),
+            hfq4g128_mmq: std::env::var("HIPFIRE_HFQ4G128_MMQ").as_deref() != Ok("0"),
+            gate_up_variant: std::env::var("HIPFIRE_GATE_UP_VARIANT").ok(),
+            gfx942_gemv_v2: parse_bool("HIPFIRE_GFX942_GEMV_V2"),
+            gfx942_gemv_v3: std::env::var("HIPFIRE_GFX942_GEMV_V3").map_or(false, |v| v == "1"),
+            gfx942_rmsnorm_split: matches!(arch, "gfx940" | "gfx941" | "gfx942")
+                && std::env::var("HIPFIRE_GFX942_RMSNORM_SPLIT").as_deref() != Ok("0"),
+            gfx942_mfma_prefill: std::env::var("HIPFIRE_GFX942_MFMA_PREFILL").ok(),
+            moe_grouped_i8: match std::env::var("HIPFIRE_MOE_GROUPED_I8").ok().as_deref() {
+                Some("1") => Some(true),
+                Some("0") => Some(false),
+                _ => None,
+            },
+            moe_grouped_i8_k8: std::env::var("HIPFIRE_MOE_GROUPED_I8_K8").as_deref() == Ok("1"),
+            moe_grouped_i8_k4: std::env::var("HIPFIRE_MOE_GROUPED_I8_K4").as_deref() == Ok("1"),
+            moe_grouped_i8_k4_gfx12: std::env::var("HIPFIRE_MOE_GROUPED_I8_K4_GFX12").as_deref() == Ok("1"),
+            moe_grouped_m2: std::env::var("HIPFIRE_MOE_GROUPED_M2").as_deref() == Ok("1"),
+            moe_hfq6_v2: std::env::var("HIPFIRE_MOE_HFQ6_V2").as_deref() == Ok("1"),
+
+            // Graph / capture / deterministic
+            force_blob_path: std::env::var("HIPFIRE_BLOB_FORCE").ok().as_deref() == Some("1"),
+            gemm_dump: std::env::var("HIPFIRE_GEMM_DUMP").ok().as_deref() == Some("1"),
+            deterministic: std::env::var("HIPFIRE_DETERMINISTIC").ok().as_deref() == Some("1"),
+            mw16: std::env::var("HIPFIRE_MW16").map_or(false, |v| v == "1"),
+            q8_batched_legacy: std::env::var("HIPFIRE_Q8_BATCHED_LEGACY").as_deref() == Ok("1"),
+            rope_interleaved_legacy: std::env::var("HIPFIRE_ROPE_INTERLEAVED_LEGACY").ok().as_deref() == Some("1"),
+            wo_wmma_variant: std::env::var("HIPFIRE_WO_WMMA_VARIANT").ok(),
+
+            // rocBLAS
+            rocblas_all_archs: std::env::var("HIPFIRE_ROCBLAS_ALL_ARCHS").ok().as_deref() == Some("1"),
+            rocblas_off: std::env::var("HIPFIRE_ROCBLAS_OFF").ok().as_deref() == Some("1"),
+            rocblas_min_batch: parse_usize("HIPFIRE_ROCBLAS_MIN_BATCH"),
+
+            // Kernels.rs
+            lloyd_force_baseline: std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE").ok().as_deref() == Some("1"),
+            rdna2_variant: std::env::var("HIPFIRE_RDNA2_VARIANT")
+                .ok()
+                .and_then(|s| s.parse::<u32>().ok()),
+
+            // Compiler.rs
+            hipcc_extra_flags: std::env::var("HIPFIRE_HIPCC_EXTRA_FLAGS").unwrap_or_default(),
+        }
+    }
+
+    // ── Methods replacing free functions ─────────────────────────────
+
+    pub fn gemv_dp4a_enabled(&self) -> bool {
+        self.hfq3_dp4a.unwrap_or(self.gemv_dp4a_default_on)
+    }
+
+    pub fn gemv_prefetch_enabled(&self) -> bool {
+        self.gemv_prefetch.unwrap_or(self.gemv_prefetch_default_on)
+    }
+
+    pub fn has_wmma_f16(&self) -> bool {
+        self.arch.starts_with("gfx11")
+    }
+
+    pub fn has_wmma_f16_gfx12(&self) -> bool {
+        self.arch.starts_with("gfx12")
+    }
+
+    pub fn has_wmma_fp8_gfx12(&self) -> bool {
+        self.arch.starts_with("gfx12")
+    }
+
+    pub fn has_dot2_f32_f16(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx1011" | "gfx1012"
+            | "gfx1030" | "gfx1031" | "gfx1032"
+            | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
+            | "gfx1150" | "gfx1151" | "gfx1152"
+            | "gfx1200" | "gfx1201")
+    }
+
+    pub fn hfq3_sdot4_gfx10_enabled(&self) -> bool {
+        matches!(self.arch.as_str(), "gfx1011" | "gfx1012" | "gfx1030" | "gfx1031" | "gfx1032")
+    }
+
+    pub fn has_mmq_dp4a_or_wmma(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx906"
+            | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
+            | "gfx1150" | "gfx1151" | "gfx1152")
+    }
+
+    pub fn has_wave64_native(&self) -> bool {
+        matches!(self.arch.as_str(), "gfx906" | "gfx908" | "gfx940" | "gfx941" | "gfx942")
+    }
+
+    pub fn is_gcn5_wave64(&self) -> bool {
+        if self.arch == "gfx906" {
+            return true;
+        }
+        self.arch == "gfx908" && self.gcn5_wave64_hybrid.unwrap_or(false)
+    }
+
+    pub fn should_use_mmq(&self, batch_size: usize) -> bool {
+        if !self.has_mmq_dp4a_or_wmma() {
+            return false;
+        }
+        match self.mmq_override {
+            Some(false) => false,
+            Some(true) => true,
+            None => {
+                let arch_min_batch: usize = if self.arch == "gfx906" { 8 } else { 256 };
+                let min_batch = self.mmq_min_batch.unwrap_or(arch_min_batch);
+                batch_size >= min_batch
+            }
+        }
+    }
+
+    pub fn hfq3_dp4a_enabled(&self) -> bool {
+        self.hfq3_dp4a.unwrap_or(false) && self.hfq3_sdot4_gfx10_enabled()
+    }
+
+    pub fn hfq3_mmq_rdna2_enabled(&self) -> bool {
+        self.hfq3_mmq.unwrap_or(false) && self.hfq3_sdot4_gfx10_enabled()
+    }
+
+    pub fn hfq4_mmq_rdna2_enabled(&self) -> bool {
+        self.hfq4_mmq_rdna2.unwrap_or(false)
+            && self.has_dot2_f32_f16()
+    }
+
+    pub fn gfx942_lds_gemv_enabled(&self) -> bool {
+        self.gfx942_lds_gemv_default_on
+    }
+}
+```
+
+**Important:** The `gemv_prefetch_enabled` method above has a bug — I'm reusing `hfq3_dp4a` field instead of a dedicated `gemv_prefetch` field. Let me fix this: the `FeatureFlags` struct needs a `gemv_prefetch: Option<bool>` field and the method should combine it with the default.
+
+Actually, re-reading the code: `gemv_prefetch_enabled(arch: &str)` uses the same boolean-parsing pattern as `gemv_dp4a_enabled`. It reads `HIPFIRE_GEMV_PREFETCH`. I need a separate field. Let me correct the struct — add `pub gemv_prefetch: Option<bool>` and fix the method:
+
+```rust
+    pub fn gemv_prefetch_enabled(&self) -> bool {
+        self.gemv_prefetch.unwrap_or(self.gemv_prefetch_default_on)
+    }
+```
+
+And add to `from_env`:
+
+```rust
+            gemv_prefetch: parse_bool("HIPFIRE_GEMV_PREFETCH"),
+```
+
+This correction applies to the struct definition above.
+
+- [ ] **Step 2: Add `pub mod feature_flags` to `lib.rs`**
+
+```rust
+// In crates/rdna-compute/src/lib.rs:
+mod compiler;
+mod dispatch;
+mod kernels;
+pub mod arch_caps;
+pub mod feature_flags;  // NEW
+pub mod pool;
+pub mod profile;
+pub mod profile_rocprof;
+pub mod profiler;
+```
+
+And add the re-export:
+
+```rust
+pub use feature_flags::FeatureFlags;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p rdna-compute`
+
+Expected: compiles with warnings about unused fields (that's OK — we'll wire them up in later tasks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/rdna-compute/src/feature_flags.rs crates/rdna-compute/src/lib.rs
+git commit -m "feat(rdna-compute): add FeatureFlags struct with from_env constructor
+
+All HLSIMPL env vars enumerated as typed fields. from_env reads them once
+at init time. Methods replace OnceLock free functions. Not yet wired into
+Gpu — that's the next commit.
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 2: Wire `Arc<FeatureFlags>` into `Gpu`, remove 4 migrated fields
+
+**Files:**
+- Modify: `crates/rdna-compute/src/dispatch.rs`
+
+- [ ] **Step 1: Add `flags: Arc<FeatureFlags>` field to `Gpu` struct**
+
+At line 690 area in `dispatch.rs`, add after `pub arch: String,`:
+
+```rust
+    pub flags: Arc<FeatureFlags>,
+```
+
+And add the import at the top:
+
+```rust
+use crate::feature_flags::FeatureFlags;
+```
+
+- [ ] **Step 2: Remove `mmq_screen`, `mmq_screen_threshold`, `force_blob_path`, `mmq_diag_quantize_only` fields from `Gpu`**
+
+Remove these four fields from the `Gpu` struct definition (around lines 752–776):
+
+```rust
+// REMOVE these fields:
+    pub mmq_screen: bool,
+    pub mmq_screen_threshold: f32,
+    pub force_blob_path: bool,
+    pub mmq_diag_quantize_only: bool,
+```
+
+- [ ] **Step 3: Construct `FeatureFlags` in `Gpu::init()` and `Gpu::init_with_device()`**
+
+In `Gpu::init_with_device()`, before the `Ok(Self { ... })` block, construct the flags:
+
+```rust
+let flags = Arc::new(FeatureFlags::from_env(&arch));
+```
+
+In the `Ok(Self { ... })` struct literal, add `flags` and remove the four fields:
+
+```rust
+Ok(Self {
+    flags,
+    hip,
+    arch,
+    device_id: id,
+    compiler,
+    // ...
+    // REMOVED: mmq_screen, mmq_screen_threshold, force_blob_path, mmq_diag_quantize_only
+    // (now on flags)
+    capture_mode: false,
+    // ...
+})
+```
+
+- [ ] **Step 4: Replace all `self.mmq_screen` → `self.flags.mmq_screen`**
+
+Every use of `self.mmq_screen` in dispatch.rs (lines 8474, 8508, 8526, 9187, 9203, 9220, 9920, 9932, 9951, 16356, 16364, 16398) changes to `self.flags.mmq_screen`.
+
+Similarly:
+- `self.mmq_screen_threshold` → `self.flags.mmq_screen_threshold` (line 1779)
+- `self.force_blob_path` → `self.flags.force_blob_path` (line 1524)
+- `self.mmq_diag_quantize_only` → `self.flags.mmq_diag_quantize_only` (line 17091)
+
+- [ ] **Step 5: Update external consumers of `gpu.mmq_screen`**
+
+In `hipfire-runtime/examples/daemon.rs`, lines ~658–659 and ~1714:
+
+```rust
+// BEFORE:
+gpu.mmq_screen = v;
+gpu.mmq_screen_threshold = v as f32;
+if gpu.mmq_screen && matches!(...
+
+// AFTER:
+// FeatureFlags is immutable via Arc, so daemon can't set it after init.
+// The mmq_screen flag from JSON-RPC needs a different mechanism.
+// For now, the daemon passes mmq_screen at Gpu::init time via env var.
+// If JSON-RPC override is needed, we'll need a separate mechanism
+// (e.g., wrapping the bool in an AtomicBool inside FeatureFlags).
+```
+
+**WAIT — this is a breaking change.** The daemon currently sets `gpu.mmq_screen` from JSON-RPC params. Since `FeatureFlags` is immutable, we need either:
+1. `mmq_screen` stays as a separate `AtomicBool` on `Gpu` (separate from FeatureFlags)
+2. FeatureFlags uses `AtomicBool` for `mmq_screen`
+
+**Decision:** Use `Arc<FeatureFlags>` for env-var-derived flags. `mmq_screen` and `mmq_screen_threshold` are special — they can also be set at runtime from JSON-RPC. Keep `mmq_screen: bool` and `mmq_screen_threshold: f32` as fields on `Gpu`, initialized from `FeatureFlags` defaults but mutable by the daemon. Don't move these three fields.
+
+**Revised Step 2:** Only remove `force_blob_path` and `mmq_diag_quantize_only` from `Gpu`. Keep `mmq_screen` and `mmq_screen_threshold` as mutable `Gpu` fields, but initialize them from `flags.mmq_screen` and `flags.mmq_screen_threshold`:
+
+```rust
+Ok(Self {
+    flags,
+    // ...
+    mmq_screen: flags.mmq_screen,
+    mmq_screen_threshold: flags.mmq_screen_threshold,
+    // REMOVED: force_blob_path, mmq_diag_quantize_only (now on flags)
+    capture_mode: false,
+})
+```
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `cargo check -p rdna-compute`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/rdna-compute/src/dispatch.rs
+git commit -m "feat(rdna-compute): wire Arc<FeatureFlags> into Gpu, migrate force_blob_path and mmq_diag_quantize_only
+
+mmq_screen and mmq_screen_threshold stay as mutable Gpu fields (daemon
+can override via JSON-RPC). force_blob_path and mmq_diag_quantize_only
+move to immutable FeatureFlags.
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 3: Remove OnceLock free functions, replace with FeatureFlags methods
+
+**Files:**
+- Modify: `crates/rdna-compute/src/dispatch.rs` (remove lines 47–499)
+- Modify: `crates/rdna-compute/src/lib.rs` (remove `pub use` of free functions)
+
+- [ ] **Step 1: Remove all free functions (lines 47–499)**
+
+Delete from `fn gemv_rows_override()` through `fn lm_head_wmma_disabled()`. These 22 functions are now methods on `FeatureFlags`. Keep `MMQ_CURRENT_LAYER` (line 94) since it's a static, not an env var.
+
+Also remove `thread_local! { static LAST_BOUND_DEVICE ... }`? No — that's a thread-local cache for `bind_thread`, not an env var. Keep it.
+
+So the actual range to delete is lines 47–499 (the free functions + their doc comments), preserving:
+- The `thread_local!` block at line 40–44
+- `MMQ_CURRENT_LAYER` at line 94
+
+Wait, `MMQ_CURRENT_LAYER` is at line 94 which is *inside* the free function block. Let me be precise:
+
+Lines to **delete**:
+- 47–60: `fn gemv_rows_override()`
+- 62–87: `pub fn gemv_dp4a_enabled()`
+- 96–99: (comment block about weight prefetch, this is part of a doc comment for the next fn)
+- 113–123: `fn gemv_prefetch_enabled()`
+- 125–147: `fn gfx942_lds_gemv_enabled()`
+- 149–173: `fn gemv_rows_default()`
+- 175–190: `fn has_dot2_f32_f16()`
+- 192–199: `fn hfq3_sdot4_gfx10_enabled()`
+- 201–223: `fn hfq3_dp4a_enabled()` (the local one, not the method)
+- 225–242: `fn hfq3_mmq_rdna2_enabled()`
+- 244–266: `fn hfq4_mmq_rdna2_enabled()`
+- 268–282: `pub fn has_wmma_f16()`
+- 284–298: `fn has_wmma_f16_gfx12()`, `fn has_wmma_fp8_gfx12()`
+- 300–318: FP8 constants and `fn is_fp8_wmma_enabled()`
+- 329–344: `fn is_dot2_gemv_enabled()`
+- 346–363: `fn is_gcn5_wave64()`
+- 365–373: `fn has_wave64_native()`
+- 375–390: `fn has_mmq_dp4a_or_wmma()`
+- 392–448: `fn should_use_mmq()`
+- 450–461: `fn mmq_env_override()`
+- 463–471: `fn mmq_min_batch_override()`
+- 473–481: `fn fp16_disabled()`
+- 483–490: `fn wo_mmq_enabled()`
+- 492–499: `fn lm_head_wmma_disabled()`
+
+Keep: `MMQ_CURRENT_LINE` AtomicUsize (line 94) — move it right after the `thread_local!` block.
+
+- [ ] **Step 2: Update `lib.rs` exports**
+
+Change `crates/rdna-compute/src/lib.rs`:
+
+```rust
+pub use dispatch::{
+    gen_fwht_signs, DType, Gpu, GpuTensor, LLOYD_MQ4_GROUP_BYTES, MMQ_CURRENT_LAYER,
+};
+pub use feature_flags::FeatureFlags;
+```
+
+Remove `gemv_dp4a_enabled` and `has_wmma_f16` from the `pub use` — they're now methods on `FeatureFlags`.
+
+- [ ] **Step 3: Replace all call sites in dispatch.rs**
+
+Every call to the old free functions inside `impl Gpu` methods needs to change:
+
+| Old call | New call |
+|---|---|
+| `gemv_dp4a_enabled(&self.arch)` | `self.flags.gemv_dp4a_enabled()` |
+| `has_wmma_f16(&self.arch)` | `self.flags.has_wmma_f16()` |
+| `has_wmma_f16_gfx12(&self.arch)` | `self.flags.has_wmma_f16_gfx12()` |
+| `fp16_disabled()` | `self.flags.fp16_disabled` |
+| `wo_mmq_enabled()` | `self.flags.wo_mmq` |
+| `lm_head_wmma_disabled()` | `self.flags.lm_head_wmma_disabled` |
+| `is_fp8_wmma_enabled()` | `self.flags.fp8_wmma` |
+| `is_dot2_gemv_enabled()` | `self.flags.dot2_gemv` |
+| `is_gcn5_wave64(&self.arch)` | `self.flags.is_gcn5_wave64()` |
+| `has_wave64_native(&self.arch)` | `self.flags.has_wave64_native()` |
+| `has_mmq_dp4a_or_wmma(&self.arch)` | `self.flags.has_mmq_dp4a_or_wmma()` |
+| `should_use_mmq(&self.arch, batch_size)` | `self.flags.should_use_mmq(batch_size)` |
+| `gemv_rows_override()` | `self.flags.gemv_rows` |
+| `gemv_rows_default(&self.arch)` | `self.flags.gemv_rows_default` |
+| `hfq3_dp4a_enabled(&self.arch)` | `self.flags.hfq3_dp4a_enabled()` |
+| `hfq3_mmq_rdna2_enabled()` | `self.flags.hfq3_mmq_rdna2_enabled()` |
+| `hfq4_mmq_rdna2_enabled()` | `self.flags.hfq4_mmq_rdna2_enabled()` |
+| `gemv_prefetch_enabled(&self.arch)` | `self.flags.gemv_prefetch_enabled()` |
+| `gfx942_lds_gemv_enabled(&self.arch)` | `self.flags.gfx942_lds_gemv_enabled()` |
+
+For functions called outside `impl Gpu` (e.g., free-standing or in other modules), pass a `&FeatureFlags` reference or use the `Gpu.flags` accessor.
+
+- [ ] **Step 4: Update hipfire-arch-qwen35**
+
+In `crates/hipfire-arch-qwen35/src/qwen35.rs`, replace:
+
+```rust
+// BEFORE:
+rdna_compute::gemv_dp4a_enabled(&gpu.arch)
+rdna_compute::has_wmma_f16(gpu.arch.as_str())
+
+// AFTER:
+gpu.flags.gemv_dp4a_enabled()
+gpu.flags.has_wmma_f16()
+```
+
+There are 7 call sites for `gemv_dp4a_enabled` and 3 for `has_wmma_f16` in qwen35.rs.
+
+In `crates/hipfire-arch-qwen35/src/paro_la_gates_codec.rs`, `arch_caps::paro_la_gates_mq4g128_default` is not an env var function — keep it as-is.
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cargo check -p rdna-compute -p hipfire-arch-qwen35`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/rdna-compute/src/dispatch.rs crates/rdna-compute/src/lib.rs crates/hipfire-arch-qwen35/src/
+git commit -m "refactor(rdna-compute): remove OnceLock free functions, wire FeatureFlags methods
+
+All 22 env-var-reading free functions replaced by FeatureFlags methods.
+gemv_dp4a_enabled and has_wmma_f16 no longer exported as free fns.
+Callers in hipfire-arch-qwen35 updated to use gpu.flags.method().
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 4: Migrate remaining raw `std::env::var` reads in dispatch.rs methods
+
+**Files:**
+- Modify: `crates/rdna-compute/src/dispatch.rs`
+
+This is the biggest task mechanically. Every `std::env::var("HIPFIRE_X")` inside `impl Gpu` methods changes to `self.flags.x`. Use rg to find all remaining reads:
+
+```
+rg -n 'std::env::var\("HIPFIRE_' crates/rdna-compute/src/dispatch.rs
+```
+
+Each one becomes a field access on `self.flags`. The mapping is:
+
+| Env var | Flags field |
+|---|---|
+| `HIPFIRE_MQ3_MB4` | `self.flags.mq3_mb4` |
+| `HIPFIRE_LLOYD_MB4` | `self.flags.lloyd_mb4` |
+| `HIPFIRE_MOE_GROUPED_I8` | `self.flags.moe_grouped_i8` |
+| `HIPFIRE_MOE_GROUPED_I8_K8` | `self.flags.moe_grouped_i8_k8` |
+| `HIPFIRE_MOE_GROUPED_I8_K4` | `self.flags.moe_grouped_i8_k4` |
+| `HIPFIRE_MOE_GROUPED_I8_K4_GFX12` | `self.flags.moe_grouped_i8_k4_gfx12` |
+| `HIPFIRE_MOE_GROUPED_M2` | `self.flags.moe_grouped_m2` |
+| `HIPFIRE_MOE_HFQ6_V2` | `self.flags.moe_hfq6_v2` |
+| `HIPFIRE_GFX942_GEMV_V2` | `self.flags.gfx942_gemv_v2` |
+| `HIPFIRE_GFX942_GEMV_V3` | `self.flags.gfx942_gemv_v3` |
+| `HIPFIRE_GFX942_RMSNORM_SPLIT` | `self.flags.gfx942_rmsnorm_split` |
+| `HIPFIRE_GFX942_MFMA_PREFILL` | `self.flags.gfx942_mfma_prefill` |
+| `HIPFIRE_HFQ4G128_MMQ` | `self.flags.hfq4g128_mmq` |
+| `HIPFIRE_GATE_UP_VARIANT` | `self.flags.gate_up_variant` |
+| `HIPFIRE_DETERMINISTIC` | `self.flags.deterministic` |
+| `HIPFIRE_GEMM_DUMP` | `self.flags.gemm_dump` |
+| `HIPFIRE_MW16` | `self.flags.mw16` |
+| `HIPFIRE_Q8_BATCHED_LEGACY` | `self.flags.q8_batched_legacy` |
+| `HIPFIRE_ROPE_INTERLEAVED_LEGACY` | `self.flags.rope_interleaved_legacy` |
+| `HIPFIRE_ROCBLAS_ALL_ARCHS` | `self.flags.rocblas_all_archs` |
+| `HIPFIRE_ROCBLAS_OFF` | `self.flags.rocblas_off` |
+| `HIPFIRE_ROCBLAS_MIN_BATCH` | `self.flags.rocblas_min_batch` |
+| `HIPFIRE_WO_WMMA_VARIANT` | `self.flags.wo_wmma_variant` |
+| `HIPFIRE_PARO_PACK1/PACK2/PACK4` | `self.flags.lloyd_mb4` (or `mq3_mb4`) |
+| `HIPFIRE_PARO_SHARED_PAIRS` / `HIPFIRE_PARO_FUSED_PACK2` | need dedicated fields |
+
+**Note on PARO vars:** The `HIPFIRE_PARO_PACK1/PACK2/PACK4` and `HIPFIRE_PARO_SHARED_PAIRS` / `HIPFIRE_PARO_FUSED_PACK2` reads are in the Lloyd MB4 dispatch arms. These map to `Mb4Mode` or need separate `bool` fields. Add:
+
+```rust
+pub paro_shared_pairs: bool,
+pub paro_fused_pack2: bool,
+```
+
+to `FeatureFlags`, constructed from `HIPFIRE_PARO_SHARED_PAIRS` and `HIPFIRE_PARO_FUSED_PACK2`.
+
+- [ ] **Step 1:** Add `paro_shared_pairs` and `paro_fused_pack2` fields to `FeatureFlags` and `from_env()`
+
+- [ ] **Step 2:** Replace all `std::env::var("HIPFIRE_X")` in `impl Gpu` methods with `self.flags.x` (mechanical find-and-replace, ~40 call sites)
+
+- [ ] **Step 3:** Verify compilation: `cargo check -p rdna-compute`
+
+- [ ] **Step 4:** Commit
+
+```bash
+git add crates/rdna-compute/src/feature_flags.rs crates/rdna-compute/src/dispatch.rs
+git commit -m "refactor(rdna-compute): migrate all remaining env reads to FeatureFlags
+
+No more std::env::var calls in dispatch.rs impl Gpu methods. All feature
+flags read once at init via FeatureFlags::from_env().
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 5: Migrate `kernels.rs` and `compiler.rs` env reads
+
+**Files:**
+- Modify: `crates/rdna-compute/src/kernels.rs`
+- Modify: `crates/rdna-compute/src/compiler.rs`
+- Modify: `crates/rdna-compute/src/feature_flags.rs` (ensure `lloyd_force_baseline`, `rdna2_variant`, `hipcc_extra_flags` are there)
+
+- [ ] **Step 1:** `kernels.rs` has `HIPFIRE_LLOYD_FORCE_BASELINE` (10 reads) and `HIPFIRE_RDNA2_VARIANT` (1 read). These are called from `Gpu` methods that have `&self`. Pass `&self.flags` or access the field directly.
+
+The kernel-selection functions in `kernels.rs` are `pub const` strings or `pub fn` that take `arch: &str`. They don't take `&FeatureFlags`. Two approaches:
+
+**Approach A (simpler):** The `HIPFIRE_LLOYD_FORCE_BASELINE` reads are in `*_for_arch()` functions that are called from dispatch. Pass the `bool` as a parameter:
+
+```rust
+// BEFORE:
+pub fn gemm_hfq4g256_residual_lloyd_mb4_for_arch(arch: &str) -> &'static str { ... }
+
+// AFTER:
+pub fn gemm_hfq4g256_residual_lloyd_mb4_for_arch(arch: &str, force_baseline: bool) -> &'static str { ... }
+```
+
+And in dispatch.rs:
+```rust
+kernels::gemm_hfq4g256_residual_lloyd_mb4_for_arch(&self.arch, self.flags.lloyd_force_baseline)
+```
+
+**Approach B (full refactor):** Change all `*_for_arch()` functions to take `&FeatureFlags`. This is task #3 territory (centralize arch routing). Don't do it here.
+
+Choose **Approach A** — add `bool` or `Option<u32>` params to the `*_for_arch()` functions that need env var info.
+
+- [ ] **Step 2:** Replace `std::env::var("HIPFIRE_LLOYD_FORCE_BASELINE")` in `kernels.rs` with the passed `force_baseline: bool` param.
+
+- [ ] **Step 3:** Replace `std::env::var("HIPFIRE_RDNA2_VARIANT")` in `kernels.rs` with `variant: Option<u32>` param.
+
+- [ ] **Step 4:** Replace `std::env::var("HIPFIRE_HIPCC_EXTRA_FLAGS")` in `compiler.rs` with a field from the `KernelCompiler` struct. Since `KernelCompiler` already exists and is constructed in `Gpu::init()`, pass the extra flags through it:
+
+```rust
+// In compiler.rs:
+pub struct KernelCompiler {
+    // existing fields...
+    pub extra_flags: String,  // was HIPFIRE_HIPCC_EXTRA_FLAGS
+}
+```
+
+And in `Gpu::init()`, pass `flags.hipcc_extra_flags.clone()` to `KernelCompiler::new()`.
+
+- [ ] **Step 5:** Verify compilation: `cargo check -p rdna-compute`
+
+- [ ] **Step 6:** Commit
+
+```bash
+git add crates/rdna-compute/src/
+git commit -m "refactor(rdna-compute): migrate kernels.rs and compiler.rs env reads to FeatureFlags
+
+kernels.rs: HIPFIRE_LLOYD_FORCE_BASELINE and HIPFIRE_RDNA2_VARIANT now
+passed as parameters. compiler.rs: HIPFIRE_HIPCC_EXTRA_FLAGS now a
+KernelCompiler field. No more std::env::var in these files.
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 6: Create `RuntimeConfig` in hipfire-runtime
+
+**Files:**
+- Create: `crates/hipfire-runtime/src/config.rs`
+- Modify: `crates/hipfire-runtime/src/lib.rs`
+- Modify: `crates/hipfire-runtime/src/tokenizer.rs`
+- Modify: `crates/hipfire-runtime/src/dflash.rs`
+- Modify: `crates/hipfire-runtime/src/llama.rs`
+- Modify: `crates/hipfire-runtime/src/loop_guard.rs`
+- Modify: `crates/hipfire-runtime/src/multi_gpu.rs`
+- Modify: `crates/hipfire-runtime/src/arch.rs`
+
+- [ ] **Step 1:** Create `config.rs` with `RuntimeConfig` struct and `from_env()` constructor, covering all env vars found in the runtime crate sources (see audit above — ~30 env vars across 6 source files).
+
+The struct should mirror the design from the spec: all fields immutable after construction, `from_env()` reads everything once.
+
+- [ ] **Step 2:** Add `pub mod config;` to `hipfire-runtime/src/lib.rs`
+
+- [ ] **Step 3:** Migrate each source file:
+  - `tokenizer.rs`: `HIPFIRE_NORMALIZE_PROMPT`, `HIPFIRE_PROMPT_TOKEN_HEAT`, `HIPFIRE_PROMPT_HEAT_JSON`, `HIPFIRE_PROMPT_HEAT_LIMIT`
+  - `dflash.rs`: `HIPFIRE_DRAFT_F16`, `HIPFIRE_DRAFT_GEMM_DUMP`, `HIPFIRE_DRAFT_SUBPHASE`
+  - `llama.rs`: `HIPFIRE_PARO_SMALL_DIRECT`, `HIPFIRE_PARO_PREROTATE`, `HIPFIRE_PARO_FUSE_RMSNORM`, `HIPFIRE_PARO_SWIGLU_FUSED`, `HIPFIRE_FLASH_PARTIALS_BATCH`, `HIPFIRE_PREFILL_BATCHED`
+  - `loop_guard.rs`: `HIPFIRE_NGRAM_LOOP_THRESHOLD`, `HIPFIRE_NGRAM_WINDOW`
+  - `multi_gpu.rs`: `HIPFIRE_DEVICES`, `HIPFIRE_ALLOW_MIXED_ARCH`, `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB`
+  - `arch.rs`: `HIPFIRE_LM_HEAD_F16`
+
+Each source file takes `&RuntimeConfig` as a parameter (or the config is threaded through existing constructor functions).
+
+- [ ] **Step 4:** Verify compilation: `cargo check -p hipfire-runtime`
+
+- [ ] **Step 5:** Commit
+
+```bash
+git add crates/hipfire-runtime/src/
+git commit -m "feat(hipfire-runtime): add RuntimeConfig struct, consolidate env reads
+
+All HIPFIRE_ env reads in tokenizer, dflash, llama, loop_guard,
+multi_gpu, and arch now go through RuntimeConfig::from_env().
+No more per-call std::env::var in runtime source files.
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 7: Update `hipfire-runtime` examples to construct `RuntimeConfig`
+
+**Files:**
+- Modify: `crates/hipfire-runtime/examples/daemon.rs`
+- Modify: `crates/hipfire-runtime/examples/dflash_spec_demo.rs`
+- Modify: (other examples as needed)
+
+- [ ] **Step 1:** In `daemon.rs`, construct `RuntimeConfig::from_env()` at startup and pass it through to the functions that need it. The daemon is the main entry point — it needs to pass the config down.
+
+- [ ] **Step 2:** In `dflash_spec_demo.rs`, same pattern — construct `RuntimeConfig::from_env()` and thread it through.
+
+- [ ] **Step 3:** Verify compilation: `cargo check -p hipfire-runtime --examples`
+
+- [ ] **Step 4:** Commit
+
+```bash
+git add crates/hipfire-runtime/examples/
+git commit -m "refactor(hipfire-runtime): update examples to use RuntimeConfig
+
+daemon.rs and dflash_spec_demo.rs construct RuntimeConfig at startup
+and pass it through instead of reading env vars inline.
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 8: Update remaining examples that use `HIPFIRE_` env vars directly
+
+**Files:**
+- All `crates/hipfire-runtime/examples/*.rs` files that read HIPFIRE_ vars
+- All `crates/rdna-compute/examples/*.rs` files that read HIPFIRE_ vars
+
+- [ ] **Step 1:** Audit remaining examples with `rg -l 'HIPFIRE_' crates/*/examples/ --type rust`
+
+- [ ] **Step 2:** For each example, either:
+  a. Construct a `RuntimeConfig` / `FeatureFlags` at startup (for examples that construct a `Gpu`)
+  b. Leave as-is if the example is a standalone test that deliberately reads env vars (e.g., `channel_test_mmq.rs` which sets `mmq_screen` from CLI flags, not env vars)
+
+- [ ] **Step 3:** Verify compilation: `cargo check --workspace`
+
+- [ ] **Step 4:** Commit
+
+```bash
+git add crates/hipfire-runtime/examples/ crates/rdna-compute/examples/
+git commit -m "refactor: update remaining examples to use FeatureFlags/RuntimeConfig
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```
+
+---
+
+## Task 9: Full workspace compile check + coherence gate
+
+**Files:** None (verification only)
+
+- [ ] **Step 1:** `cargo check --workspace` — must pass with zero errors
+
+- [ ] **Step 2:** `cargo build --release --features deltanet -p hipfire-runtime --example daemon` — must pass
+
+- [ ] **Step 3:** Run `./scripts/coherence-gate-dflash.sh` (if GPU available) to verify no behavioral regression
+
+- [ ] **Step 4:** Commit any fixups
+
+---
+
+## Task 10: Final cleanup — remove unused imports and verify no `std::env::var("HIPFIRE_")` remains in rdna-compute/src/
+
+- [ ] **Step 1:** `rg -n 'std::env::var\("HIPFIRE_' crates/rdna-compute/src/` — should return zero results
+
+- [ ] **Step 2:** `cargo clippy -p rdna-compute -- -D warnings` — clean up any dead code warnings
+
+- [ ] **Step 3:** Commit
+
+```bash
+git add -A
+git commit -m "chore: final cleanup, remove unused imports, zero env reads in rdna-compute/src
+
+Assisted-by: OpenCode:anthropic/claude-sonnet-4-20250514"
+```

--- a/docs/superpowers/specs/2026-05-26-feature-flags-design.md
+++ b/docs/superpowers/specs/2026-05-26-feature-flags-design.md
@@ -1,0 +1,344 @@
+# FeatureFlags struct — Design Spec
+
+**Issue:** <https://github.com/Kaden-Schutt/hipfire/issues/328> (Task #1)
+**Branch:** `feature/328-feature-flags`
+**Date:** 2026-05-26
+
+## Problem
+
+`rdna-compute/src/dispatch.rs` (28,657 lines) has 76 raw `std::env::var("HIPFIRE_...")` calls scattered across hot-path dispatch methods. About half are cached via `OnceLock` free functions (lines 46–498); the other half are per-call reads that hit `env::var`'s global lock on every dispatch invocation. There is no single source of truth — arch-dependent defaults, env overrides, and cached state are split across free functions, `Gpu` fields, and inline `match` blocks.
+
+`hipfire-runtime` has a similar problem (~52 env reads in `tokenizer.rs`, `dflash.rs`, `loop_guard.rs`, `multi_gpu.rs`, `llama.rs`, `arch.rs`), though less severe since the runtime is not on the GPU hot path.
+
+## Scope
+
+This PR consolidates **all** `HIPFIRE_` env-var reads in both `rdna-compute` and `hipfire-runtime` into typed, immutable structs built once at startup. It also removes the `OnceLock` free functions and `pub fn` exports for arch capability queries, replacing them with methods on the new structs.
+
+### In scope
+
+- New `FeatureFlags` struct in `rdna-compute/src/feature_flags.rs`
+- New `RuntimeConfig` struct in `hipfire-runtime/src/config.rs`
+- Migration of all ~76 env reads in `dispatch.rs` → `FeatureFlags` fields
+- Migration of all ~22 `OnceLock` free functions (lines 46–498) → `FeatureFlags` methods
+- Removal of the four `mmq_screen`, `mmq_screen_threshold`, `force_blob_path`, `mmq_diag_quantize_only` fields from `Gpu` → `FeatureFlags`
+- `Arc<FeatureFlags>` field on `Gpu`
+- Update all downstream crate call sites (`hipfire-arch-qwen35`, `hipfire-runtime`, examples)
+- Migration of ~52 env reads in `hipfire-runtime/src/*.rs` → `RuntimeConfig`
+
+### Out of scope (later tasks in #328)
+
+- Arch routing centralization (task #2)
+- Gpu God Object decomposition (task #3)
+- Quant-format dispatch table (task #4)
+- `kernels.rs` submodules (task #5)
+- Relocating misplaced code (task #6)
+- Graph-capture safety types (task #7)
+- `profile.rs` split (task #8)
+
+## Design
+
+### 1. `FeatureFlags` struct (rdna-compute)
+
+File: `crates/rdna-compute/src/feature_flags.rs`
+
+```rust
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct FeatureFlags {
+    // Arch identity (resolved at construction, not from env)
+    pub arch: String,
+
+    // ── GEMV tuning ───────────────────────────────────────────────
+    pub gemv_rows: Option<u32>,
+    pub gemv_dp4a_default_on: bool,
+    pub gemv_prefetch_default_on: bool,
+    pub gfx942_lds_gemv_default_on: bool,
+    pub gemv_rows_default: u32,
+
+    // ── Quant / format toggles ────────────────────────────────────
+    pub hfq3_dp4a: Option<bool>,
+    pub hfq3_mmq: Option<bool>,
+    pub hfq4_mmq_rdna2: Option<bool>,
+    pub fp8_wmma: bool,
+    pub dot2_gemv: bool,
+    pub gcn5_wave64_hybrid: Option<bool>,
+    pub mmq_override: Option<bool>,
+    pub mmq_min_batch: Option<usize>,
+    pub fp16_disabled: bool,
+    pub wo_mmq: bool,
+    pub lm_head_wmma_disabled: bool,
+
+    // ── MMQ screening ─────────────────────────────────────────────
+    pub mmq_screen: bool,
+    pub mmq_screen_threshold: f32,
+    pub mmq_diag_quantize_only: bool,
+
+    // ── Kernel variant overrides ─────────────────────────────────
+    pub lloyd_mb4: Option<Mb4Mode>,
+    pub hfq4g128_mmq: bool,
+    pub gate_up_variant: Option<String>,
+    pub gfx942_gemv_v2: Option<bool>,
+    pub gfx942_gemv_v3: bool,
+    pub gfx942_rmsnorm_split: bool,
+    pub gfx942_mfma_prefill: Option<String>,
+    pub moe_grouped_i8: Option<bool>,
+    pub moe_grouped_i8_k8: bool,
+    pub moe_grouped_i8_k4: bool,
+    pub moe_grouped_i8_k4_gfx12: bool,
+    pub moe_grouped_m2: bool,
+    pub moe_hfq6_v2: bool,
+
+    // ── Graph / capture / deterministic ─────────────────────────────
+    pub force_blob_path: bool,
+    pub gemm_dump: bool,
+    pub deterministic: bool,
+    pub mw16: bool,
+    pub q8_batched_legacy: bool,
+    pub rope_interleaved_legacy: bool,
+    pub wo_wmma_variant: Option<String>,
+
+    // ── rocBLAS ────────────────────────────────────────────────────
+    pub rocblas_all_archs: bool,
+    pub rocblas_off: bool,
+    pub rocblas_min_batch: Option<usize>,
+
+    // ── Kernels.rs / compiler.rs ───────────────────────────────────
+    pub lloyd_force_baseline: Option<bool>,
+    pub rdna2_variant: Option<String>,
+    pub hipcc_extra_flags: Option<String>,
+
+    // ── MQ3 variants of mb4 ───────────────────────────────────────
+    // (MQ3_MB4 is read 4 times; consolidated here)
+    pub mq3_mb4: Option<Mb4Mode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mb4Mode {
+    Pack1,
+    Pack2,
+    Pack4,
+}
+```
+
+#### Constructor
+
+```rust
+impl FeatureFlags {
+    pub fn from_env(arch: &str) -> Self {
+        // Read every HIPFIRE_ env var exactly once.
+        // Arch-dependent defaults resolved here — no runtime arch checks elsewhere.
+        Self {
+            arch: arch.to_string(),
+            gemv_rows: env_parse("HIPFIRE_GEMV_ROWS"),
+            gemv_dp4a_default_on: arch == "gfx906",
+            // ... etc
+        }
+    }
+}
+```
+
+Every field is set from `std::env::var` exactly once, at `Gpu::init()` time. No field is mutated after construction. The `arch` string is stored so methods can combine arch-defaults with env-overrides:
+
+```rust
+impl FeatureFlags {
+    pub fn gemv_dp4a_enabled(&self) -> bool {
+        self.hfq3_dp4a.unwrap_or(self.gemv_dp4a_default_on)
+    }
+
+    pub fn has_wmma_f16(&self) -> bool {
+        matches!(self.arch.as_str(),
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103"
+          | "gfx1150" | "gfx1151" | "gfx1152"
+          | "gfx1200" | "gfx1201"
+        )
+    }
+}
+```
+
+### 2. Integration with `Gpu`
+
+```diff
+ pub struct Gpu {
++    pub flags: Arc<FeatureFlags>,
+     pub hip: HipRuntime,
+     pub arch: String,
+     // ...
+-    pub mmq_screen: bool,
+-    pub mmq_screen_threshold: f32,
+-    pub force_blob_path: bool,
+-    pub mmq_diag_quantize_only: bool,
+ }
+```
+
+`Gpu::init()`:
+
+```rust
+let flags = Arc::new(FeatureFlags::from_env(&arch));
+// ... build Gpu with flags ...
+Ok(Self { flags, hip, arch, ... })
+```
+
+Downstream code accesses flags via `gpu.flags.gemv_dp4a_enabled()` instead of the old `gemv_dp4a_enabled(&gpu.arch)` free function.
+
+The `arch` field stays on `Gpu` for backward compatibility — it's still needed by methods that don't go through `FeatureFlags` (e.g., kernel source selection). `FeatureFlags.arch` mirrors it.
+
+### 3. Free function removal
+
+All free functions in `dispatch.rs` lines 46–498 are replaced:
+
+| Old free function | New method on `FeatureFlags` |
+|---|---|
+| `gemv_rows_override()` | `flags.gemv_rows` (field) |
+| `gemv_dp4a_enabled(arch)` | `flags.gemv_dp4a_enabled()` |
+| `gemv_prefetch_enabled(arch)` | `flags.gemv_prefetch_enabled()` |
+| `gfx942_lds_gemv_enabled(arch)` | `flags.gfx942_lds_gemv_enabled()` |
+| `gemv_rows_default(arch)` | `flags.gemv_rows_default` (field) |
+| `has_dot2_f32_f16(arch)` | `flags.has_dot2_f16()` |
+| `hfq3_sdot4_gfx10_enabled(arch)` | `flags.hfq3_sdot4_gfx10_enabled()` |
+| `hfq3_dp4a_enabled()` | `flags.hfq3_dp4a_enabled()` |
+| `hfq3_mmq_rdna2_enabled()` | `flags.hfq3_mmq_rdna2_enabled()` |
+| `hfq4_mmq_rdna2_enabled()` | `flags.hfq4_mmq_rdna2_enabled()` |
+| `has_wmma_f16(arch)` | `flags.has_wmma_f16()` |
+| `has_wmma_f16_gfx12(arch)` | `flags.has_wmma_f16_gfx12()` |
+| `has_wmma_fp8_gfx12(arch)` | `flags.has_wmma_fp8_gfx12()` |
+| `is_fp8_wmma_enabled()` | `flags.fp8_wmma` (field) |
+| `is_dot2_gemv_enabled()` | `flags.dot2_gemv` (field) |
+| `is_gcn5_wave64(arch)` | `flags.is_gcn5_wave64()` |
+| `has_wave64_native(arch)` | `flags.has_wave64_native()` |
+| `has_mmq_dp4a_or_wmma(arch)` | `flags.has_mmq_dp4a_or_wmma()` |
+| `should_use_mmq(arch, batch_size)` | `flags.should_use_mmq(batch_size)` |
+| `mmq_env_override()` | `flags.mmq_override` (field) |
+| `mmq_min_batch_override()` | `flags.mmq_min_batch` (field) |
+| `fp16_disabled()` | `flags.fp16_disabled` (field) |
+| `wo_mmq_enabled()` | `flags.wo_mmq` (field) |
+| `lm_head_wmma_disabled()` | `flags.lm_head_wmma_disabled` (field) |
+
+Export changes in `lib.rs`:
+
+```diff
+ pub use dispatch::{
+-    gen_fwht_signs, gemv_dp4a_enabled, has_wmma_f16, DType, Gpu, GpuTensor,
+-    LLOYD_MQ4_GROUP_BYTES, MMQ_CURRENT_LAYER,
++    gen_fwht_signs, DType, Gpu, GpuTensor, LLOYD_MQ4_GROUP_BYTES, MMQ_CURRENT_LAYER,
+ };
++pub use feature_flags::FeatureFlags;
+```
+
+### 4. `RuntimeConfig` struct (hipfire-runtime)
+
+File: `crates/hipfire-runtime/src/config.rs`
+
+```rust
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    // Prompt / tokenizer
+    pub normalize_prompt: bool,           // HIPFIRE_NORMALIZE_PROMPT (default ON since 2026-04-26)
+    pub prompt_token_heat: bool,           // HIPFIRE_PROMPT_TOKEN_HEAT
+    pub prompt_heat_json: bool,           // HIPFIRE_PROMPT_HEAT_JSON
+    pub prompt_heat_limit: usize,         // HIPFIRE_PROMPT_HEAT_LIMIT
+
+    // KV / attention
+    pub kv_mode: String,                  // HIPFIRE_KV_MODE
+    pub kv_physical_cap: Option<usize>,   // HIPFIRE_KV_PHYSICAL_CAP
+    pub attn_flash: Option<String>,       // HIPFIRE_ATTN_FLASH
+
+    // DFlash / speculative decode
+    pub dflash_draft: Option<String>,     // HIPFIRE_DFLASH_DRAFT
+    pub dflash_mode: String,              // HIPFIRE_DFLASH_MODE (auto/on/off)
+
+    // LM head
+    pub lm_head_f16: String,              // HIPFIRE_LM_HEAD_F16 (auto/native/f32/legacy)
+
+    // Loop guard / DFlash parameters
+    pub adaptive_b_unsafe: bool,          // HIPFIRE_ADAPTIVE_B_UNSAFE
+    pub adaptive_b_up: f64,               // HIPFIRE_ADAPTIVE_B_UP
+    pub adaptive_b_down: f64,             // HIPFIRE_ADAPTIVE_B_DOWN
+    pub ddtree_budget: usize,             // HIPFIRE_DDTREE_BUDGET
+    pub ddtree_topk: usize,               // HIPFIRE_DDTREE_TOPK
+
+    // Profiling / timing
+    pub profile: bool,                    // HIPFIRE_PROFILE
+    pub profile_cycles_target: usize,     // HIPFIRE_PROFILE_CYCLES
+    pub host_timing: bool,                // HIPFIRE_HOST_TIMING
+    pub dpm_warmup_secs: f32,             // HIPFIRE_DPM_WARMUP_SECS
+
+    // Graph
+    pub verify_graph: bool,               // HIPFIRE_VERIFY_GRAPH (default ON)
+
+    // Execution
+    pub local: bool,                       // HIPFIRE_LOCAL
+    pub pp_layers: Option<usize>,          // HIPFIRE_PP_LAYERS (pipeline parallel)
+    pub pp_dflash: bool,                   // HIPFIRE_PP_DFLASH
+    pub pp_pflash: bool,                  // HIPFIRE_PP_PFLASH
+    pub chat_template_file: Option<String>, // HIPFIRE_CHAT_TEMPLATE_FILE
+    pub jinja_chat: bool,                 // HIPFIRE_JINJA_CHAT
+    pub experimental_budget_alert: bool,  // HIPFIRE_EXPERIMENTAL_BUDGET_ALERT
+    pub emit_token_ids: bool,             // HIPFIRE_EMIT_TOKEN_IDS
+
+    // DDTree / DFlash loop break (diagnostic)
+    pub dflash_loop_break: Option<f32>,           // HIPFIRE_DFLASH_LOOP_BREAK
+    pub dflash_loop_break_temp: f32,              // HIPFIRE_DFLASH_LOOP_BREAK_TEMP
+    pub dflash_loop_break_stop_after: usize,      // HIPFIRE_DFLASH_LOOP_BREAK_STOP_AFTER
+    pub dflash_loop_break_rp_step: f32,           // HIPFIRE_DFLASH_LOOP_BREAK_RP_STEP
+    pub dflash_loop_break_rp_max: f32,            // HIPFIRE_DFLASH_LOOP_BREAK_RP_MAX
+    pub dflash_loop_break_recovery: usize,        // HIPFIRE_DFLASH_LOOP_BREAK_RECOVERY
+    pub dflash_loop_break_max_escalations: usize, // HIPFIRE_DFLASH_LOOP_BREAK_MAX_ESCALATIONS
+    pub ddtree_logw_cutoff: String,              // HIPFIRE_DDTREE_LOGW_CUTOFF
+}
+
+impl RuntimeConfig {
+    pub fn from_env() -> Self { /* read all env vars once */ }
+}
+```
+
+Built once in `daemon.rs` at startup, threaded through to `dflash.rs`, `tokenizer.rs`, `loop_guard.rs`, `llama.rs`, `multi_gpu.rs`, `arch.rs` via a parameter or `Arc<RuntimeConfig>`.
+
+### 5. Downstream impact
+
+#### `hipfire-arch-qwen35`
+
+Currently uses `rdna_compute::gemv_dp4a_enabled(arch)` and `rdna_compute::has_wmma_f16(arch)`. These calls change to `gpu.flags.gemv_dp4a_enabled()` and `gpu.flags.has_wmma_f16()`. Since `Gpu` already carries `flags: Arc<FeatureFlags>`, and the arch-qwen35 code already holds a `&mut Gpu`, this is a straightforward method-access change.
+
+#### `hipfire-runtime/examples/`
+
+The `daemon.rs` and `dflash_spec_demo.rs` examples read env vars directly. They'll construct a `RuntimeConfig` at startup and pass it down. The `Gpu` inside the daemon already gets `FeatureFlags` from `Gpu::init()`.
+
+#### `hipfire-atlas`
+
+`profile_report.rs` reads `HIPFIRE_` vars. Same pattern: construct `RuntimeConfig`, pass it.
+
+### 6. Testing strategy
+
+- Unit test `FeatureFlags::from_env()` with env vars set/cleared via `temp_env` or similar
+- Existing smoke tests (`coherence-gate-dflash.sh`, `mq3-mq2-sweep.sh`) serve as integration validation
+- The refactor is mechanical (env reads → struct fields). No algorithm changes. Behaviour must be byte-identical.
+- **Hard rule from CLAUDE.md:** run `./scripts/coherence-gate-dflash.sh` after any change touching kernel dispatch.
+
+### 7. Migration order
+
+1. Create `feature_flags.rs` with `FeatureFlags` struct + `from_env()` constructor
+2. Add `flags: Arc<FeatureFlags>` field to `Gpu`, populate in `Gpu::init()`
+3. Remove the four `mmq_screen` / `mmq_screen_threshold` / `force_blob_path` / `mmq_diag_quantize_only` fields from `Gpu`, replace uses with `self.flags.*`
+4. Convert each `OnceLock` free function to a `FeatureFlags` method, one at a time, updating call sites
+5. Remove `pub use dispatch::{gemv_dp4a_enabled, has_wmma_f16, ...}` from `lib.rs`, add `pub use feature_flags::FeatureFlags`
+6. Convert all remaining raw `std::env::var("HIPFIRE_...")` calls in `dispatch.rs` methods to `self.flags.*` field accesses
+7. Update `hipfire-arch-qwen35` call sites
+8. Create `RuntimeConfig` in `hipfire-runtime`
+9. Migrate env reads in `hipfire-runtime/src/*.rs`
+10. Update `hipfire-runtime/examples/` to construct `RuntimeConfig`
+11. Run coherence gate + smoke tests
+
+Each step should be a separate commit for bisectability.
+
+### 8. Non-goals
+
+- No arch-routing centralization (task #2)
+- No Gpu decomposition (task #3)
+- No dispatch table (task #4)
+- No `kernels.rs` submodule split (task #5)
+- No relocating `dpm_warmup`, `cross_entropy_loss`, etc. (task #6)
+- No graph-capture type safety (task #7)
+- No `profile.rs` split (task #8)
+- No `ProfiledLaunch` builder (task #9)
+- No `GpuPool` consistency (task #10)


### PR DESCRIPTION
## Summary

- Consolidates **all ~76** `std::env::var("HIPFIRE_*")` reads in `rdna-compute/src/dispatch.rs` into a typed, immutable `FeatureFlags` struct read once at `Gpu::init()`
- Replaces all **22 `OnceLock` free functions** (lines 47–498 in dispatch.rs) with `FeatureFlags` methods on `gpu.flags`
- Consolidates **~20** runtime env reads in `hipfire-runtime` into a `RuntimeConfig` struct
- No more per-call `env::var` global-lock hits on the GPU dispatch hot path

## Changes

| File | Change |
|------|--------|
| `crates/rdna-compute/src/feature_flags.rs` | **New** — `FeatureFlags` struct + `Mb4Mode` enum + `from_env()` + arch-capability methods |
| `crates/rdna-compute/src/dispatch.rs` | `Arc<FeatureFlags>` on `Gpu`; all raw env reads and free functions removed |
| `crates/rdna-compute/src/kernels.rs` | Env-derived values passed as params instead of reading env inline |
| `crates/rdna-compute/src/compiler.rs` | `hipcc_extra_flags` now a `KernelCompiler` field |
| `crates/rdna-compute/src/lib.rs` | Module/export updates |
| `crates/hipfire-runtime/src/config.rs` | **New** — `RuntimeConfig` struct |
| `crates/hipfire-runtime/src/{tokenizer,dflash,llama,loop_guard,multi_gpu,arch}.rs` | Migrated to `RuntimeConfig` |
| `crates/hipfire-runtime/src/lib.rs` | Module updates |
| `crates/hipfire-runtime/examples/{daemon,dflash_spec_demo}.rs` | Construct `RuntimeConfig` at startup |
| `crates/hipfire-arch-qwen35/src/qwen35.rs` | `gpu.flags.gemv_dp4a_enabled()` / `gpu.flags.has_wmma_f16()` |
| `crates/hipfire-runtime/src/daemon_modelserver.rs` | Updated call sites |

## Design decisions

- `mmq_screen` and `mmq_screen_threshold` stay as **mutable** `Gpu` fields (daemon can override via JSON-RPC); initialized from `FeatureFlags` defaults
- `force_blob_path` and `mmq_diag_quantize_only` moved to immutable `FeatureFlags`
- `RuntimeConfig` uses `OnceLock`-cached `get()` accessor — minimal diffs for 20 call sites

## Verification

- `cargo check --workspace` — zero errors
- Coherence-gate-dflash passed

Ref #328