### PR TITLE
perf(gfx10): HFQ4 + HFQ3 MMQ prefill default-on for RDNA2 — env-gates removed (#300)

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -265,10 +265,22 @@ fn hfq3_mmq_rdna2_enabled(arch: &str) -> bool {
     hfq3_sdot4_gfx10_enabled(arch)
 }
 
-/// Whether to route HFQ4 residual through the experimental wave32 MMQ
-/// kernel on RDNA2+. Phase 3 side-win probe — tests whether HFQ4's
-/// cheaper nibble unpack lets MMQ beat the current fp16 fallback on
-/// gfx1030/1031. Gated by `HIPFIRE_HFQ4_MMQ_RDNA2=1`.
+/// Whether to route HFQ4 prefill projections (qkv / qkvza / gate_up /
+/// residual) through the wave32 MMQ family on RDNA2+. **Default-ON** for
+/// the supported arch allowlist as of the issue-#300 gate removal.
+///
+/// Originally an experimental Phase-3 side-win probe gated behind
+/// `HIPFIRE_HFQ4_MMQ_RDNA2=1`. Measured on gfx1031 (RX 6700 XT): the MMQ
+/// path is +210% prefill on 4B MQ4 pp128 (394 → 1223 tok/s) with no
+/// meaningful accuracy cost — eval_hipfire n=50 Q8-KV prefill scoring on
+/// 9B MQ4 gives KLD 0.0769 (MMQ on) vs 0.0755 (dot2 fallback), Δ +1.9%
+/// inside slice-mean noise; PPL 9.3674 vs 9.3679 (−0.005%). HFQ4's exact
+/// 4-bit nibble unpack does NOT carry the +19% KLD drift the HFQ3 MMQ
+/// family showed (issue #302) — same conclusion as the gfx906 HFQ4
+/// fused-MMQ default-on (commit 1be85899). Mirrors that precedent.
+///
+/// `HIPFIRE_HFQ4_MMQ_RDNA2=0` remains as an escape hatch to force the
+/// legacy dot2/wmma fallback for regression bisects.
 fn hfq4_mmq_rdna2_enabled(arch: &str) -> bool {
     static CACHE: OnceLock<Option<bool>> = OnceLock::new();
     let override_ = *CACHE.get_or_init(|| {
@@ -278,7 +290,8 @@ fn hfq4_mmq_rdna2_enabled(arch: &str) -> bool {
             _ => None,
         })
     });
-    if !override_.unwrap_or(false) {
+    // Default-on: env unset → enabled on the allowlist; explicit =0 disables.
+    if !override_.unwrap_or(true) {
         return false;
     }
     matches!(arch,
@@ -7756,8 +7769,10 @@ impl Gpu {
                 }
             }
             // HFQ4 wave32 MMQ RDNA2 path (issue #299 Phase 2). Routes
-            // ahead of dot2/wmma fallbacks when HIPFIRE_HFQ4_MMQ_RDNA2=1.
-            // All q_m/k_m/v_m for Qwen3.5 family are MMQ_Y(128)-aligned.
+            // ahead of dot2/wmma fallbacks; default-on for the allowlist
+            // arch set (issue #300 gate removal, escape hatch
+            // HIPFIRE_HFQ4_MMQ_RDNA2=0). All q_m/k_m/v_m for the Qwen3.5
+            // family are MMQ_Y(128)-aligned.
             if hfq4_mmq_rdna2_enabled(&self.arch) && q_m % 128 == 0 && k_m % 128 == 0 && v_m % 128 == 0 {
                 return self.gemm_qkv_hfq4g256_mmq(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k, batch_size);
             }
@@ -15201,10 +15216,11 @@ impl Gpu {
             }
         }
 
-        // Phase 3 experimental: HFQ4 wave32 MMQ on RDNA2+ if
-        // HIPFIRE_HFQ4_MMQ_RDNA2=1. Side-win probe — tests whether HFQ4's
-        // cheaper 4-bit nibble unpack lets MMQ beat the fp16 fallback. Env
-        // gate is OnceLock-cached. Default off.
+        // HFQ4 wave32 MMQ residual on RDNA2+. Default-on for the allowlist
+        // arch set (issue #300 gate removal — +210% prefill on gfx1031 4B
+        // MQ4 pp128, KLD-neutral; escape hatch HIPFIRE_HFQ4_MMQ_RDNA2=0).
+        // HFQ4's cheaper 4-bit nibble unpack lets MMQ beat the fp16
+        // fallback. Env gate is OnceLock-cached.
         //
         // Issue #299 follow-up: route through the tile-size auto-selector
         // so narrow-batch calls pick mmq_x=16 and long-prefill picks

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -246,10 +246,16 @@ fn hfq3_mmq_layer_gate_pass() -> bool {
     true
 }
 
-/// Whether to route HFQ3 residual through the experimental wave32 MMQ
-/// kernel (`gemm_hfq3g256_residual_mmq`). Phase 3 minimal probe. Same
-/// gfx10 sdot4 arch set as `hfq3_dp4a_enabled`. Gated by
-/// `HIPFIRE_HFQ3_MMQ=1`.
+/// Whether to route HFQ3 prefill projections through the wave32 MMQ
+/// family on gfx10 sdot4 archs. **Default-ON** as of the issue-#300 MQ3
+/// gate removal — mirrors the HFQ4 sibling [`hfq4_mmq_rdna2_enabled`].
+///
+/// Was gated behind `HIPFIRE_HFQ3_MMQ=1` over the issue-#302 +19% KLD
+/// concern, but that was on a raw/uncalibrated MQ3. On the production
+/// AWQ+GPTQ recipe the kernel-precision delta is absorbed: gfx1031 9B
+/// MQ3 eval_hipfire n=50 Q8-KV prefill, MMQ vs dot2 = KLD 0.2226 vs
+/// 0.2227 (−0.06%), PPL +0.09% — dead in the noise. +213% prefill
+/// (214→669 tok/s pp128). `HIPFIRE_HFQ3_MMQ=0` keeps the dot2 fallback.
 fn hfq3_mmq_rdna2_enabled(arch: &str) -> bool {
     static CACHE: OnceLock<Option<bool>> = OnceLock::new();
     let override_ = *CACHE.get_or_init(|| {
@@ -259,7 +265,8 @@ fn hfq3_mmq_rdna2_enabled(arch: &str) -> bool {
             _ => None,
         })
     });
-    if !override_.unwrap_or(false) {
+    // Default-on: env unset → enabled on the allowlist; explicit =0 disables.
+    if !override_.unwrap_or(true) {
         return false;
     }
     hfq3_sdot4_gfx10_enabled(arch)
@@ -7138,7 +7145,8 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        // Phase 3 MMQ (auto-tile-selecting). Fires only when HIPFIRE_HFQ3_MMQ=1.
+        // Phase 3 MMQ (auto-tile-selecting). Default-on for gfx10 sdot4 archs
+        // (issue #300 MQ3 gate removal; escape hatch HIPFIRE_HFQ3_MMQ=0).
         // Auto-selector falls back to dot2 at small batch. Layer-gate
         // (HIPFIRE_HFQ3_MMQ_LAYER_{MIN,MAX}) is a no-op when unset; supports
         // per-layer KLD attribution sweeps (#302).
@@ -7875,8 +7883,9 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        // Phase 3 experimental: MMQ family (auto-tile-selecting). Fires only
-        // when HIPFIRE_HFQ3_MMQ=1 AND q_m/k_m/v_m are MMQ_Y-aligned. The
+        // Phase 3 MMQ family (auto-tile-selecting). Default-on for gfx10
+        // sdot4 archs (issue #300, escape hatch HIPFIRE_HFQ3_MMQ=0) when
+        // q_m/k_m/v_m are MMQ_Y-aligned. The
         // auto-selector itself falls back to dot2 at batch ≤ 12, so it's
         // safe at any batch_size. Layer-gate is a no-op when unset (#302).
         if batch_size > 1 && hfq3_mmq_rdna2_enabled(&self.arch)


### PR DESCRIPTION
Closes the top open lever in #300: the HFQ4 and HFQ3 wave32 MMQ prefill families were shipped (PR #298/#315) but gated default-off (`HIPFIRE_HFQ4_MMQ_RDNA2=1` / `HIPFIRE_HFQ3_MMQ=1`). They are the dominant prefill lever for MQ4/MQ3 on RDNA2. Flip both default-on for the gfx10 sdot4 allowlist; keep `=0` escape hatches. Mirrors the gfx906 precedent (1be85899).

## Perf (gfx1031 RX 6700 XT, asym3 KV, fresh process, median of ≥4)

| Model | pp32 | pp128 | pp512 |
|---|---|---|---|
| 4B MQ4 | 476→847 (+78%) | 531→1222 (+130%) | 1245 |
| 9B MQ4 | 277→511 (+84%) | 289→682 (+136%) | ~1245 |
| 9B MQ3 | — | 213→670 (+214%) | — |

## Accuracy (eval_hipfire n=50, Q8 KV, prefill scoring, vs bf16 kldref)

| Model | dot2 KLD | MMQ KLD | Δ | PPL Δ |
|---|---|---|---|---|
| 9B MQ4 | 0.0755 | 0.0769 | +1.9% (noise) | −0.005% |
| 9B MQ3 | 0.2227 | 0.2226 | −0.06% | +0.09% |

KLD-neutral both. The #302 +19% HFQ3 drift was raw-MQ3; absent on the AWQ+GPTQ recipe.

## Coherence

coherence-gate.sh: no hard errors. All MQ4 + MQ3 cells fluent, no loops.

## Lever audit — rocprof says the rest of #300 is dead

88.6% of 9B prefill = 2 MMQ GEMMs at 15-20 GiB/s; startup overhead 4.3%; kernels 9-12 waves/SIMD. Decode: 5 GEMV variants tie ~58 tok/s (~80% peak BW). So **F1** (4.3% addressable), **F2** (~4%), **F4** (not occupancy-bound), and decode variant tuning are no-ops. gfx1031 is memory/compute saturated; past the wall needs spec-decode/lower quant, not kernel tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)