### PR TITLE
fix(moe): default gfx1151 i8 MMQ MoE OFF (35B-A3B CJK regression)

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -15177,10 +15177,14 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     ) -> HipResult<()> {
         self.bind_thread()?;
         // gfx1151 (Strix Halo iGPU) i8 MMQ port: lift the compute ceiling
-        // from ~71 (FP16 WMMA) to ~140 TFLOPS (i8 WMMA). Opt-out via
-        // HIPFIRE_MOE_GROUPED_I8=0; default ON for gfx1151 only.
+        // from ~71 (FP16 WMMA) to ~140 TFLOPS (i8 WMMA). Opt-in via
+        // HIPFIRE_MOE_GROUPED_I8=1; default OFF for gfx1151 pending fix
+        // for the qwen3.6:35b-a3b CJK-output regression seen against
+        // commit 6cf455dc (kernel produces NRMSE-clean tile output in the
+        // channel test but corrupts the production MoE chain on real
+        // 35B-A3B prompts — model emits Chinese on English code prompts).
         let use_i8_gfx1151 = self.arch_caps.is_gfx1151()
-            && self.flags.moe_grouped_i8.unwrap_or(true);
+            && self.flags.moe_grouped_i8.unwrap_or(false);
         if use_i8_gfx1151 {
             // Optional deeper-pipeline variants (opt-IN, default OFF).
             // Same kernarg layout + scatter contract as the k2 default.


### PR DESCRIPTION
## Summary

The i8 grouped-MMQ MoE path enabled by default on **gfx1151** (Strix Halo) in 6cf455dc produces incoherent output on `qwen3.6:35b-a3b`: the model emits CJK / structural repetition on simple English coding prompts. The standalone NRMSE channel test passes at ~0.4% vs the FP16 reference, so the regression slipped through tile-level validation but breaks the production MoE chain.

This PR flips the default to OFF on gfx1151 only. Power users can still opt in with `HIPFIRE_MOE_GROUPED_I8=1`. The underlying kernel correctness fix is left as separate work — diagnostic infrastructure for it is already in progress on master.

- **One-line change**: `unwrap_or(true)` → `unwrap_or(false)` in `gemm_hfq4g256_moe_grouped_wmma_k2`, gfx1151 branch only.
- **Untouched**: gfx11 dGPU (gfx1100/1101/1102/1103) — different kernel binary, no garbage reports against those archs. gfx12 — already opt-in.

## Reproducer

`scripts/repro-qwen3.6-a3b-garbage.sh` (already in tree). Confirmed on Strix Halo (gfx1151, AMD Ryzen AI MAX+ 395 / Radeon 8060S), `qwen3.6-35b-a3b.mq4`, temp=0.0, max_tokens=96, prompt = `benchmarks/prompts/dirty/dirty_fib.txt`:

**Default (pre-fix, i8 ON):**
```
秵,  2,  2, 2, 2, 2, 2, 2, 2

1. **分析**：
   - **观察**：
     - **观察**：
       - **观察**：
[repro] has_python_signal=0  has_cjk=1  ascii_alpha_ratio=0.000
[repro] VERDICT: garbage (regression present)
```

**With `HIPFIRE_MOE_GROUPED_I8=0` (equivalent to this fix):**
```
<think>
The user wants a Python function to compute the n-th Fibonacci number.
The requirements are:
1. Use memoization to keep recursion fast.
2. Handle base cases n == 0 and n == 1.
...
[repro] has_python_signal=1  has_cjk=0  ascii_alpha_ratio=0.924
[repro] VERDICT: coherent (model works)
```

## Test plan

- [x] Reproduce CJK garbage on master with default env
- [x] Confirm coherent output with `HIPFIRE_MOE_GROUPED_I8=0 HIPFIRE_MOE_GROUPED_I8_K4=0`
- [x] One-line dispatch flip is byte-equivalent to the env=0 case verified above
- [ ] CI green
- [ ] Coherence gate green on at least one gfx1151 model after rebuild

## Why not also disable on gfx11 dGPU?

gfx11 dGPU uses a different kernel binary (`gemm_hfq4g256_moe_grouped_mmq.gfx11_dgpu.hip`) and there are no reports of the same regression against it. The gfx1151 binary is its own per-arch file. Scope is intentionally narrow to the arch with the reported regression.

## Follow-up (not in this PR)

Root-cause the i8 path so the channel test catches the production failure mode — the divergence appears to live in the X-input chain (FP16 cache invalidation around `gated_norm_f32_batched`, per in-progress diagnostic work on master) rather than the WMMA tile itself.