### PR TITLE
feat: wire mtp_mode/mtp_k into global and per-model config

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -152,6 +152,10 @@ export interface HipfireConfig {
   prefill_drafter_device: number;  // HIP device for the PFlash drafter. -1 = same as target (default). Set to a sibling device for hetero compress.
   prefill_profile: boolean;        // Per-stage timing logs.
   prefill_sparse_threshold: number;// Phase 3 sparse-attention threshold (32768).
+
+  // ── MTP speculative decode ──────────────────────────────
+  mtp_mode: string;      // "off" | "on" | "auto"
+  mtp_k: number;         // draft tokens per spec-decode window
 }
 
 // Detect GPU at import time for smart defaults
@@ -214,6 +218,8 @@ const CONFIG_DEFAULTS: HipfireConfig = {
   prefill_drafter_device: -1,
   prefill_profile: false,
   prefill_sparse_threshold: 32768,
+  mtp_mode: "auto",
+  mtp_k: 3,
 };
 
 function validateConfigValue(key: string, value: any): boolean {
@@ -257,6 +263,8 @@ function validateConfigValue(key: string, value: any): boolean {
     case "prefill_drafter_device": return typeof value === "number" && Number.isInteger(value) && value >= -1 && value <= 15;
     case "prefill_profile": return typeof value === "boolean";
     case "prefill_sparse_threshold": return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 524288;
+    case "mtp_mode": return ["off", "on", "auto"].includes(value);
+    case "mtp_k": return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 10;
     default: return false;
   }
 }
@@ -315,6 +323,7 @@ const PER_MODEL_KEYS = [
   "prefill_alpha", "prefill_min_keep", "prefill_sink", "prefill_recent",
   "prefill_block", "prefill_drafter", "prefill_drafter_device", "prefill_profile",
   "prefill_sparse_threshold",
+  "mtp_mode", "mtp_k",
 ] as const;
 type PerModelKey = typeof PER_MODEL_KEYS[number];
 
@@ -650,6 +659,9 @@ function buildLoadMessage(path: string, tag?: string | null): any {
     );
   }
 
+  params.mtp_mode = resolved.mtp_mode;
+  params.mtp_k = resolved.mtp_k;
+
   return { type: "load", model: path, params };
 }
 
@@ -860,6 +872,8 @@ function applyConfigEnv(cfg: HipfireConfig, modelTag?: string | null): void {
   } else {
     delete process.env.HIPFIRE_DFLASH_NGRAM_BLOCK;
   }
+  process.env.HIPFIRE_MTP_MODE = cfg.mtp_mode;
+  process.env.HIPFIRE_MTP_K = String(cfg.mtp_k);
 }
 
 // ─── Background serve lifecycle ─────────────────────────

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -607,6 +607,16 @@ struct LoadedModel {
     /// Falls back to 1 (DeepSeek family default) if the tokenizer lacks
     /// the special-token entry.
     deepseek4_eos_tok: u32,
+    /// MTP config — parsed from load-message params, read at generate time.
+    /// Arch-agnostic: currently only DeepSeek V4 (arch_id=9) evaluates these,
+    /// but the namespace is intentionally not deepseek4-specific.
+    mtp_mode: String,
+    /// Draft tokens per spec-decode window (1-10, default 3).
+    mtp_k: usize,
+    /// Whether MTP head weights were found at load time. Set by the sibling-
+    /// file scan (e.g. `<stem>-mtp.*`) or bundled MTP detection. Used by
+    /// `mtp_mode = "auto"` to decide whether to enable spec-decode.
+    mtp_weights_present: bool,
     // dots.ocr state (arch_id=8 — Qwen2-VL family). The text decoder is
     // Qwen2: `dots_ocr_config.text` / `dots_ocr_weights.text` feed
     // `qwen2::forward_step*`, and the per-step decode state reuses the
@@ -868,6 +878,14 @@ fn main() {
                 let kv_mode_override = msg.get("params").and_then(|p| p.get("kv_mode")).and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty()).map(|s| s.to_string());
 
+                // MTP speculative decode config. `mtp_mode` gates weight
+                // discovery at load time (off=skip, on=error-if-missing,
+                // auto=scan+log). `mtp_k` sets the draft window size.
+                let mtp_mode = msg.get("params").and_then(|p| p.get("mtp_mode"))
+                    .and_then(|v| v.as_str()).unwrap_or("auto").to_string();
+                let mtp_k: usize = msg.get("params").and_then(|p| p.get("mtp_k"))
+                    .and_then(|v| v.as_u64()).unwrap_or(3) as usize;
+
                 // 0.1.7-alpha: DFlash tuning knobs forwarded from the CLI.
                 // `adaptive_b` matches dflash_spec_demo's --adaptive-b default.
                 // Accepted here; the generate loop will honor it in the
@@ -1010,7 +1028,7 @@ fn main() {
                     .filter(|s| !s.is_empty()).map(|s| s.to_string());
 
                 match load_model(path, max_seq, draft_path.as_deref(), kv_mode_override.as_deref(), state_quant_override.as_deref(), &cask, pp, &mut gpu) {
-                    Ok(m) => {
+                    Ok(mut m) => {
                         let arch = match m.arch_id {
                             5 => "qwen3_5",
                             6 => "qwen3_5_moe",
@@ -1029,6 +1047,18 @@ fn main() {
                         } else if let Some(ref c) = m.dots_ocr_config {
                             (c.text.hidden_size, c.text.num_hidden_layers, c.text.vocab_size)
                         } else { (0, 0, 0) };
+
+                        // Apply MTP config from load-message params.
+                        m.mtp_mode = mtp_mode;
+                        m.mtp_k = mtp_k;
+                        // Detect whether MTP weights are present in the loaded
+                        // model (DeepSeek V4 only today). Used by mtp_mode=auto
+                        // to decide whether to enable spec-decode at generate time.
+                        m.mtp_weights_present = m.deepseek4_weights
+                            .as_ref()
+                            .and_then(|w| w.mtp_layer.as_ref())
+                            .is_some();
+
                         // ── Optional DPM stabilization (perf instrumentation) ──
                         //
                         // Pins the GPU at high sclk/mclk so the first `generate`
@@ -2044,6 +2074,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
             qwen2_config: Some(config), qwen2_weights: Some(weights), qwen2_state: Some(state),
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2089,6 +2120,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
             qwen2_config: None, qwen2_weights: None, qwen2_state: Some(state),
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
             dots_ocr_config: Some(config), dots_ocr_weights: Some(weights),
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2151,6 +2183,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             qwen2_config: None, qwen2_weights: None, qwen2_state: None,
             deepseek4_config: Some(config), deepseek4_weights: Some(weights), deepseek4_state: Some(state),
             deepseek4_pbs: Some(pbs), deepseek4_eos_tok: eos_tok,
+            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2339,6 +2372,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
             qwen2_config: None, qwen2_weights: None, qwen2_state: None,
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config, vision_weights,
             tokenizer: Some(tokenizer),
@@ -2372,6 +2406,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: Some(config), llama_weights: Some(weights), llama_scratch: Some(scratch), llama_kv: Some(kv),
             qwen2_config: None, qwen2_weights: None, qwen2_state: None,
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2465,6 +2500,9 @@ fn load_model_safetensors(
             deepseek4_state: None,
             deepseek4_pbs: None,
             deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(),
+            mtp_k: 3,
+            mtp_weights_present: false,
             vision_config: None,
             vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2532,6 +2570,9 @@ fn load_model_safetensors(
         deepseek4_state: None,
         deepseek4_pbs: None,
         deepseek4_eos_tok: 0,
+        mtp_mode: "auto".to_string(),
+        mtp_k: 3,
+        mtp_weights_present: false,
         vision_config: None,
         vision_weights: None,
         tokenizer: Some(tokenizer),
@@ -2667,12 +2708,13 @@ fn load_model_pp(
         dn_state: Some(dn),
         llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
         qwen2_config: None, qwen2_weights: None, qwen2_state: None,
-        deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
-        dots_ocr_config: None, dots_ocr_weights: None,
-        vision_config: None, vision_weights: None,
-        tokenizer: Some(tokenizer),
-        seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None,
-        conversation_tokens: Vec::new(),
+            deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            dots_ocr_config: None, dots_ocr_weights: None,
+            vision_config: None, vision_weights: None,
+            tokenizer: Some(tokenizer),
+            seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None,
+            conversation_tokens: Vec::new(),
             asst_turn_cache: std::collections::HashMap::new(), decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
@@ -5299,11 +5341,29 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
         eprintln!("[v4f prompt dump] tokens={} → {}", prompt_ids.len(), path);
     }
 
-    let spec_mode = std::env::var("HIPFIRE_DEEPSEEK4_SPEC_DECODE").ok().as_deref() == Some("1");
+    // Triaged config resolution for MTP speculative decode.
+    // Priority: 1. legacy env var → 2. generic env var → 3. stored config → default.
+    let spec_mode = std::env::var("HIPFIRE_DEEPSEEK4_SPEC_DECODE")
+        .ok()
+        .map(|v| v == "1")
+        .unwrap_or_else(|| {
+            match std::env::var("HIPFIRE_MTP_MODE").ok().as_deref() {
+                Some("on") => true,
+                Some("off") => false,
+                _ => {
+                    m.mtp_mode == "on" || (m.mtp_mode == "auto" && m.mtp_weights_present)
+                }
+            }
+        });
     let spec_k: usize = std::env::var("HIPFIRE_DEEPSEEK4_SPEC_K")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(3);
+        .or_else(|| {
+            std::env::var("HIPFIRE_MTP_K")
+                .ok()
+                .and_then(|s| s.parse().ok())
+        })
+        .unwrap_or(m.mtp_k);
 
     let t0 = Instant::now();
 

--- a/crates/hipfire-runtime/src/config.rs
+++ b/crates/hipfire-runtime/src/config.rs
@@ -31,6 +31,8 @@ pub struct RuntimeConfig {
     pub allow_mixed_arch: bool,
     pub uniform_vram_tolerance_gb: Option<f32>,
     pub lm_head_f16: String,
+    pub mtp_mode: String,
+    pub mtp_k: usize,
 }
 
 static CONFIG: OnceLock<RuntimeConfig> = OnceLock::new();
@@ -105,6 +107,12 @@ impl RuntimeConfig {
                 .and_then(|s| s.parse().ok()),
             lm_head_f16: std::env::var("HIPFIRE_LM_HEAD_F16")
                 .unwrap_or_else(|_| "auto".to_string()),
+            mtp_mode: std::env::var("HIPFIRE_MTP_MODE")
+                .unwrap_or_else(|_| "auto".to_string()),
+            mtp_k: std::env::var("HIPFIRE_MTP_K")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3),
         }
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -48,6 +48,26 @@ for measured speedups. Per-model override is the most common knob:
 `hipfire config qwen3.5:9b set dflash_mode off` if your workload is
 mostly long-form prose.
 
+## Speculative decode (MTP)
+
+| Key | Default | Values | Notes |
+|---|---|---|---|
+| `mtp_mode` | auto | off / on / auto | MTP spec-decode using the model's built-in Multi-Token Prediction head. `auto` enables when MTP weights are present. Currently applies to DeepSeek V4 (arch_id=9). |
+| `mtp_k` | 3 | 1–10 | Draft tokens per spec-decode window. Higher = more parallelism, lower acceptance probability per draft step. |
+
+`auto` discovers MTP weights from `<model>-mtp.*` sibling files (e.g.
+`deepseek-v4-flash-mtp.mq2lloyd` alongside the main `.mq2lloyd`). Set `off`
+to skip the sibling scan entirely and use plain AR decode.
+
+Per-model override:
+```bash
+hipfire config deepseek-v4-flash-mtp:latest set mtp_mode on
+hipfire config deepseek-v4-flash-mtp:latest set mtp_k 5
+```
+
+Legacy env vars `HIPFIRE_DEEPSEEK4_SPEC_DECODE` and `HIPFIRE_DEEPSEEK4_SPEC_K`
+continue to work and take precedence over config values.
+
 ## Attention
 
 | Key | Default | Values |


### PR DESCRIPTION
## Summary

- Adds `mtp_mode` (off/on/auto, default auto) and `mtp_k` (1-10, default 3) config keys for MTP speculative decode
- Arch-agnostic namespace leaves room for future Qwen3.5 MTP integration
- Backward compat: legacy `HIPFIRE_DEEPSEEK4_SPEC_DECODE`/`_K` env vars continue to work at highest precedence

## Changes

| Layer | File | What |
|---|---|---|
| CLI schema | `cli/index.ts` | Interface, defaults, validation, per-model keys |
| CLI→daemon | `cli/index.ts` | `params.mtp_mode/k` in load message, env vars |
| Daemon struct | `daemon.rs` | 3 fields on `LoadedModel` + 8 init sites |
| Load-time | `daemon.rs` | Parse from JSON, detect MTP weights |
| Generate-time | `daemon.rs` | Triaged lookup: legacy env → generic env → stored config |
| Runtime config | `config.rs` | `HIPFIRE_MTP_MODE/K` env var fallback |
| Docs | `CONFIG.md` | MTP spec-decode section with table + examples |

## Test Plan

- [x] `cargo check --features deltanet --example daemon` — clean
- [x] CLI config cycle: get/set/reset works for both keys
- [x] Per-model overrides work
- [x] Input validation rejects invalid values
- [x] Daemon starts and loads model with MTP config
- [x] Full MTP coherence gate: requires -mtp model weights (`./scripts/coherence-gate-deepseek4-mtp.sh`)