### PR TITLE
fix(cli): config TUI crashes — missing meta entry for prefill_drafter_device

### DIFF
--- a/cli/config_meta.test.ts
+++ b/cli/config_meta.test.ts
@@ -1,0 +1,33 @@
+// Regression test for the `configTui` crash where a CONFIG_DEFAULTS key was
+// added without a matching `meta` entry, causing `meta[k].label.length` to
+// throw `TypeError: undefined is not an object` on TUI render.
+//
+// Original crash report: `prefill_drafter_device` was added by PR #319 but
+// the TUI's `meta` map wasn't updated. Iterating `Object.keys(CONFIG_DEFAULTS)`
+// then dereferencing `meta[k].label` blew up at startup.
+//
+// We don't import index.ts because of its top-level side effects (see
+// parse_tool_calls.test.ts). Instead, parse the source and assert the
+// invariant: every CONFIG_DEFAULTS key must also exist as a meta key.
+//
+// Run: bun test cli/config_meta.test.ts
+
+import { test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+test("every CONFIG_DEFAULTS key has a matching configTui meta entry", () => {
+  const src = readFileSync(join(import.meta.dir, "index.ts"), "utf-8");
+
+  const defaultsMatch = src.match(/const CONFIG_DEFAULTS[^{]+\{([\s\S]*?)\n\};/);
+  expect(defaultsMatch).not.toBeNull();
+  const cfgKeys = [...defaultsMatch![1].matchAll(/^\s{2}([a-z_]+):/gm)].map(m => m[1]);
+  expect(cfgKeys.length).toBeGreaterThan(0);
+
+  const metaMatch = src.match(/const meta: Record<string, FieldMeta> = \{([\s\S]*?)\n  \};/);
+  expect(metaMatch).not.toBeNull();
+  const metaKeys = [...metaMatch![1].matchAll(/^\s{4}([a-z_]+):\s\{/gm)].map(m => m[1]);
+
+  const missing = cfgKeys.filter(k => !metaKeys.includes(k));
+  expect(missing).toEqual([]);
+});

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3955,6 +3955,11 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       label: "prefill_drafter",
       desc: "Path to PFlash drafter HFQ (e.g. ~/.hipfire/models/qwen3-0.6b.hf4). Tokenizer must match the target's. Empty = disabled.",
     },
+    prefill_drafter_device: {
+      label: "prefill_drafter_device",
+      desc: "HIP device for the PFlash drafter. -1 = same as target (default). Set to a sibling device index for hetero compress.",
+      range: [-1, 15], step: 1,
+    },
     prefill_profile: {
       label: "prefill_profile",
       desc: "Emit per-stage PFlash timing logs (score / select / gather). Off in production.",


### PR DESCRIPTION
## Summary
- `hipfire config` (interactive TUI) crashes at startup with `TypeError: undefined is not an object (evaluating 'meta[k].label')` because `prefill_drafter_device` was added to `CONFIG_DEFAULTS` in #319 (e23f37de, hetero PFlash) but never wired into the TUI's `meta` map.
- Adds the missing `meta.prefill_drafter_device` entry (integer field, range `[-1, 15]` to mirror `validateConfigValue`).
- Adds a Bun-native regression test (`cli/config_meta.test.ts`) that parses `index.ts` and asserts `CONFIG_DEFAULTS keys ⊆ meta keys`, so the next time someone adds a config key they'll find out at PR time, not when a user installs.

Reported by a user immediately after `curl … install.sh | bash` against current master — reproduces with a clean `config.json`. Affects every user who upgrades to current master and runs `hipfire config`.

**Workaround until merge:** the non-TUI paths bypass the broken meta map and still work:
- `hipfire config list`
- `hipfire config set <key> <value>`
- `hipfire config reset [key]`

## Test plan
- [x] `bun test cli/config_meta.test.ts` — passes on fix branch
- [x] Verified the test catches the bug: reverting `cli/index.ts` and re-running the test surfaces `prefill_drafter_device` as the missing key, then passes again after the fix
- [x] `bun build cli/index.ts --target=bun` bundles cleanly
- [ ] Smoke: `hipfire config` opens and renders without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)