### PR TITLE
[codex] Land A3B MTP and DFlash perfmaxx work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,6 +484,64 @@ For dataclass benches:
 - Confirmation that the regression appears across genres (not just one
   prompt that happens to hit a different distribution)
 
+### Pinned Hugging Face bench fixture
+
+For hiptrx dense Qwen3.6-27B AWQ MTP/DFlash perf work, do not identify
+the canonical trunk by local filename. Local filenames drift and lookalike
+AWQ/MQ4 files are not comparable.
+
+The canonical trunk is whichever local artifact byte-matches the current
+Hugging Face `.mq4` artifact:
+
+- HF repo: `schuttdev/hipfire-qwen3.6-27b`
+- HF file: `qwen3.6-27b.mq4`
+- HF repo commit when pinned: `f9b326a657f14cbc400e384ff84a4b9b4b726ba2`
+- File size: `14984158208`
+- SHA-256 / HF `x-linked-etag`:
+  `86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc`
+
+Before reporting dense 3.6 AWQ MTP/DFlash results, verify the candidate
+trunk with `sha256sum` and require the digest above. If Hugging Face has
+published a newer `.mq4`, refresh the HF headers first and pin the new
+`x-linked-etag`/size in the report.
+
+Reports that use a trunk with a different digest are not comparable and
+should be discarded.
+
+### Pinned A3B MoE DFlash fixtures
+
+For hiptrx Qwen3.6-35B-A3B MoE DFlash perf/profiling work, use the
+following command shape and do not substitute other prompts unless the
+user explicitly updates this fixture section:
+
+```bash
+./target/release/examples/dflash_spec_demo \
+  --target /home/kaden/.hipfire/models/qwen3.6-35b-a3b.mq4-awq-mi300x \
+  --draft /home/kaden/.hipfire/models/qwen36-35b-a3b-dflash-mq4.hfq \
+  --prompt-file <allowed-prompt> \
+  --max 256 --temp 0.0 --no-chatml --kv-mode q8 --ctx 4096 \
+  --block-size 6 --no-adaptive-b
+```
+
+Pinned artifacts:
+
+- target md5: `edde51ec1dac0f2bd42cff5ef1cb8944`
+- draft md5: `8254bbe1ffe31edf2b38f3889d6325f1`
+
+The only permitted prompt fixtures for this A3B MoE DFlash thread are:
+
+- `benchmarks/prompts/merge_sort_thinking_off.txt`
+  - md5: `253c7ac50857fe6d0e10fb0d2c5e35c0`
+  - best observed post-MoE tape replay fix: `151.00 tok/s`, tau `2.711`,
+    accept rate `0.5422`, `45` cycles, `168` emitted tokens.
+- `benchmarks/prompts/humaneval_3_below_zero.txt`
+  - md5: `37c5aad9f9efe93b5c47f27256bdf149`
+  - best observed before the MoE tape replay optimization: `127.61 tok/s`,
+    tau `3.714`.
+
+Runs using any other prompt are exploratory only and must not be compared
+against the A3B MoE DFlash perfmaxx line.
+
 ---
 
 ## 6 · Common pitfalls (history of what bit us)

--- a/crates/hipfire-arch-qwen35/src/mtp_head.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_head.rs
@@ -59,14 +59,23 @@
 //! - KV rollback / batched verify: this is a single-token forward, the
 //!   verify-loop equivalent for MTP would be Task 11.
 
-use crate::qwen35::{Qwen35Config, Qwen35Weights};
+use crate::qwen35::Qwen35Weights;
 use hip_bridge::{DeviceBuffer, HipResult};
 use hipfire_runtime::hfq::{HfqFile, HfqTensorInfo};
-use hipfire_runtime::llama::{self, f16_to_f32, weight_gemv, EmbeddingFormat, WeightTensor};
+use hipfire_runtime::llama::{
+    self, f16_to_f32, fused_silu_mul_rotate_mq_batched_for, fused_silu_mul_rotate_mq_for,
+    rotate_x_mq_for, weight_gemv, EmbeddingFormat, WeightTensor,
+};
 use rdna_compute::{DType, Gpu, GpuTensor};
 use std::path::Path;
 
 // ─── Config ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Qwen35MtpFfnKind {
+    Dense,
+    Moe,
+}
 
 /// All dimensions and hyperparams the MTP head needs. Loaded from the
 /// `.mtp` file's metadata JSON; nothing is hardcoded per model size.
@@ -77,6 +86,12 @@ pub struct Qwen35MtpHeadConfig {
     pub n_head_kv: usize,
     pub head_dim: usize,
     pub n_ff: usize,
+    pub ffn_kind: Qwen35MtpFfnKind,
+    pub num_experts: usize,
+    pub num_experts_per_tok: usize,
+    pub moe_intermediate_size: usize,
+    pub shared_expert_intermediate_size: usize,
+    pub norm_topk_prob: bool,
     pub vocab_size: usize,
     pub rope_theta: f32,
     /// Partial-rotary factor; defaults to 0.25 to mirror Qwen3.5 trunk.
@@ -109,6 +124,35 @@ impl Qwen35MtpHeadConfig {
         let n_head_kv = gu("n_head_kv");
         let head_dim = gu("n_embd_head");
         let n_ff = gu("n_ff");
+        let ffn_kind = match meta
+            .get("ffn_kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("dense")
+        {
+            "dense" => Qwen35MtpFfnKind::Dense,
+            "moe" => Qwen35MtpFfnKind::Moe,
+            other => panic!(".mtp metadata has unsupported ffn_kind='{other}'"),
+        };
+        let num_experts = meta
+            .get("num_experts")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let num_experts_per_tok = meta
+            .get("num_experts_per_tok")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let moe_intermediate_size = meta
+            .get("moe_intermediate_size")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let shared_expert_intermediate_size = meta
+            .get("shared_expert_intermediate_size")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let norm_topk_prob = meta
+            .get("norm_topk_prob")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
         let vocab_size = gu("vocab_size");
         // partial_rotary_factor lives nested under config_text_config; fall
         // back to 0.25 (Qwen3.5 default) when absent.
@@ -125,14 +169,59 @@ impl Qwen35MtpHeadConfig {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
         Self {
-            n_embd, n_head, n_head_kv, head_dim, n_ff,
-            vocab_size, rope_theta, n_rot, rms_norm_eps, max_seq,
+            n_embd,
+            n_head,
+            n_head_kv,
+            head_dim,
+            n_ff,
+            ffn_kind,
+            num_experts,
+            num_experts_per_tok,
+            moe_intermediate_size,
+            shared_expert_intermediate_size,
+            norm_topk_prob,
+            vocab_size,
+            rope_theta,
+            n_rot,
+            rms_norm_eps,
+            max_seq,
             tie_word_embeddings,
         }
     }
 }
 
 // ─── Weights ─────────────────────────────────────────────────────────────
+
+pub struct Qwen35MtpDenseFfnWeights {
+    pub gate: WeightTensor, // [n_ff, n_embd]
+    pub up: WeightTensor,   // [n_ff, n_embd]
+    pub down: WeightTensor, // [n_embd, n_ff]
+}
+
+pub struct Qwen35MtpMoeExpertWeights {
+    pub gate_up: WeightTensor, // [2 * moe_intermediate, n_embd]
+    pub down: WeightTensor,    // [n_embd, moe_intermediate]
+}
+
+pub struct Qwen35MtpMoeSharedExpertWeights {
+    pub gate: WeightTensor, // [shared_expert_intermediate, n_embd]
+    pub up: WeightTensor,   // [shared_expert_intermediate, n_embd]
+    pub down: WeightTensor, // [n_embd, shared_expert_intermediate]
+}
+
+pub struct Qwen35MtpMoeFfnWeights {
+    pub router: WeightTensor, // [num_experts, n_embd]
+    pub shared_expert: Qwen35MtpMoeSharedExpertWeights,
+    pub shared_expert_gate: WeightTensor, // [1, n_embd]
+    pub experts: Vec<Qwen35MtpMoeExpertWeights>,
+    pub expert_gate_up_ptrs: GpuTensor,
+    pub expert_down_ptrs: GpuTensor,
+}
+
+pub enum Qwen35MtpFfnWeights {
+    Dense(Qwen35MtpDenseFfnWeights),
+    Moe(Qwen35MtpMoeFfnWeights),
+}
 
 /// All 15 GPU-resident MTP head tensors (+2 optional FastMTP-style
 /// vocab-compression sidecar tensors). Ownership is tied to the head
@@ -147,14 +236,12 @@ pub struct Qwen35MtpHeadWeights {
     pub attn_q_norm: GpuTensor,
     pub attn_k_norm: GpuTensor,
     // 2D weights (MQ4 / Q8)
-    pub eh_proj: WeightTensor,   // [n_embd, 2 * n_embd]
-    pub wq: WeightTensor,        // [2 * head_dim * n_head, n_embd]
-    pub wk: WeightTensor,        // [head_dim * n_head_kv, n_embd]
-    pub wv: WeightTensor,        // [head_dim * n_head_kv, n_embd]
-    pub wo: WeightTensor,        // [n_embd, head_dim * n_head]
-    pub ffn_gate: WeightTensor,  // [n_ff, n_embd]
-    pub ffn_up: WeightTensor,    // [n_ff, n_embd]
-    pub ffn_down: WeightTensor,  // [n_embd, n_ff]
+    pub eh_proj: WeightTensor, // [n_embd, 2 * n_embd]
+    pub wq: WeightTensor,      // [2 * head_dim * n_head, n_embd]
+    pub wk: WeightTensor,      // [head_dim * n_head_kv, n_embd]
+    pub wv: WeightTensor,      // [head_dim * n_head_kv, n_embd]
+    pub wo: WeightTensor,      // [n_embd, head_dim * n_head]
+    pub ffn: Qwen35MtpFfnWeights,
 
     // Optional FastMTP-style vocab-compression sidecar (present iff the
     // .mtp metadata says `has_compressed_lm_head_draft: true`).
@@ -164,12 +251,14 @@ pub struct Qwen35MtpHeadWeights {
     //   Shape [compressed_vocab_size, n_embd]. ~7.7x BW reduction at K=32K
     //   on a 248K-vocab Qwen3.5/3.6.
     // - `lm_head_draft_vocab_map`: host-side u32 array mapping draft idx
-    //   -> full vocab idx. Tiny (32K * 4 = 128KB), kept on CPU because the
-    //   argmax remap is a single scalar lookup per draft step (no benefit
-    //   from GPU residence).
+    //   -> full vocab idx. Kept for host fallback paths and diagnostics.
+    // - `lm_head_draft_vocab_map_gpu`: same map on-device for the greedy
+    //   MTP token-chain path, where draft idx -> full token must happen
+    //   without a per-step D2H sync.
     // - `compressed_vocab_size`: K. Cached for fast access in forward.
     pub lm_head_draft: Option<WeightTensor>,
     pub lm_head_draft_vocab_map: Option<Vec<u32>>,
+    pub lm_head_draft_vocab_map_gpu: Option<GpuTensor>,
     pub compressed_vocab_size: Option<usize>,
 }
 
@@ -187,11 +276,31 @@ impl Qwen35MtpHeadWeights {
         let _ = gpu.free_tensor(self.wk.buf);
         let _ = gpu.free_tensor(self.wv.buf);
         let _ = gpu.free_tensor(self.wo.buf);
-        let _ = gpu.free_tensor(self.ffn_gate.buf);
-        let _ = gpu.free_tensor(self.ffn_up.buf);
-        let _ = gpu.free_tensor(self.ffn_down.buf);
+        match self.ffn {
+            Qwen35MtpFfnWeights::Dense(ffn) => {
+                let _ = gpu.free_tensor(ffn.gate.buf);
+                let _ = gpu.free_tensor(ffn.up.buf);
+                let _ = gpu.free_tensor(ffn.down.buf);
+            }
+            Qwen35MtpFfnWeights::Moe(ffn) => {
+                let _ = gpu.free_tensor(ffn.router.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert_gate.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert.gate.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert.up.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert.down.buf);
+                let _ = gpu.free_tensor(ffn.expert_gate_up_ptrs);
+                let _ = gpu.free_tensor(ffn.expert_down_ptrs);
+                for expert in ffn.experts {
+                    let _ = gpu.free_tensor(expert.gate_up.buf);
+                    let _ = gpu.free_tensor(expert.down.buf);
+                }
+            }
+        }
         if let Some(lm_d) = self.lm_head_draft {
             let _ = gpu.free_tensor(lm_d.buf);
+        }
+        if let Some(vmap) = self.lm_head_draft_vocab_map_gpu {
+            let _ = gpu.free_tensor(vmap);
         }
     }
 }
@@ -203,35 +312,51 @@ impl Qwen35MtpHeadWeights {
 /// `Qwen35Scratch` but sized for the MTP head's single block + LM head.
 pub struct Qwen35MtpHeadScratch {
     // Activation stages
-    pub tok_embd: GpuTensor,    // [n_embd]
-    pub e_norm: GpuTensor,      // [n_embd]
-    pub h_norm: GpuTensor,      // [n_embd]
-    pub concat: GpuTensor,      // [2 * n_embd]
-    pub cur: GpuTensor,         // [n_embd] — primary residual stream
-    pub residual: GpuTensor,    // [n_embd] — saved for inpSA
-    pub tmp: GpuTensor,         // [n_embd] — RMSNorm output scratch
+    pub tok_embd: GpuTensor, // [n_embd]
+    pub e_norm: GpuTensor,   // [n_embd]
+    pub h_norm: GpuTensor,   // [n_embd]
+    pub concat: GpuTensor,   // [2 * n_embd]
+    pub cur: GpuTensor,      // [n_embd] — primary residual stream
+    pub residual: GpuTensor, // [n_embd] — saved for inpSA
+    pub tmp: GpuTensor,      // [n_embd] — RMSNorm output scratch
 
     // Attention sub-block
-    pub q_full: GpuTensor,      // [2 * head_dim * n_head]
-    pub q: GpuTensor,           // [head_dim * n_head]
-    pub gate: GpuTensor,        // [head_dim * n_head]
-    pub k: GpuTensor,           // [head_dim * n_head_kv]
-    pub v: GpuTensor,           // [head_dim * n_head_kv]
-    pub attn_out: GpuTensor,    // [head_dim * n_head]
-    pub o: GpuTensor,           // [n_embd]
+    pub q_full: GpuTensor,   // [2 * head_dim * n_head]
+    pub q: GpuTensor,        // [head_dim * n_head]
+    pub gate: GpuTensor,     // [head_dim * n_head]
+    pub k: GpuTensor,        // [head_dim * n_head_kv]
+    pub v: GpuTensor,        // [head_dim * n_head_kv]
+    pub attn_out: GpuTensor, // [head_dim * n_head]
+    pub o: GpuTensor,        // [n_embd]
 
     // FFN sub-block
-    pub gate_ffn: GpuTensor,    // [n_ff]
-    pub up: GpuTensor,          // [n_ff]
-    pub ffn_hidden: GpuTensor,  // [n_ff]
-    pub ffn_out: GpuTensor,     // [n_embd]
+    pub gate_ffn: GpuTensor,   // [n_ff]
+    pub up: GpuTensor,         // [n_ff]
+    pub ffn_hidden: GpuTensor, // [n_ff]
+    pub ffn_out: GpuTensor,    // [n_embd]
+
+    // MoE FFN scratch, allocated only for ffn_kind=moe.
+    pub moe_router_logits: Option<GpuTensor>, // [num_experts]
+    pub moe_scalar_buf: Option<GpuTensor>,    // [1]
+    pub moe_x_rot: Option<GpuTensor>,         // [n_embd]
+    pub moe_gate_up_buf: Option<GpuTensor>,   // [2 * max(moe_intermediate, shared_intermediate)]
+    pub moe_gate_buf: Option<GpuTensor>,      // [max(moe_intermediate, shared_intermediate)]
+    pub moe_up_buf: Option<GpuTensor>,        // [max(moe_intermediate, shared_intermediate)]
+    pub moe_ffn_hidden: Option<GpuTensor>,    // [max(moe_intermediate, shared_intermediate)]
+    pub moe_ffn_out: Option<GpuTensor>,       // [n_embd]
+    pub moe_gate_batch: Option<GpuTensor>,    // [top_k * moe_intermediate]
+    pub moe_up_batch: Option<GpuTensor>,      // [top_k * moe_intermediate]
+    pub moe_rot_batch: Option<GpuTensor>,     // [top_k * moe_intermediate]
+    pub moe_topk_indices: Option<GpuTensor>,  // [top_k]
+    pub moe_topk_weights: Option<GpuTensor>,  // [top_k]
+    pub moe_down_expanded: Option<GpuTensor>, // [top_k * n_embd]
 
     // Snapshot of the post-FFN, pre-LM-head-norm hidden — caller can
     // capture this and feed back as `prev_hidden` for an n+2 prediction.
-    pub t_mtp_out: GpuTensor,   // [n_embd]
+    pub t_mtp_out: GpuTensor, // [n_embd]
 
     // LM head output
-    pub logits: GpuTensor,      // [vocab_size]
+    pub logits: GpuTensor, // [vocab_size]
 
     // Optional FastMTP-style compressed-logits scratch — sized
     // [compressed_vocab_size] when the head was loaded with a sidecar.
@@ -254,6 +379,10 @@ impl Qwen35MtpHeadScratch {
         let dim = config.n_embd;
         let q_dim = config.head_dim * config.n_head;
         let kv_dim = config.head_dim * config.n_head_kv;
+        let moe_max_inter = config
+            .moe_intermediate_size
+            .max(config.shared_expert_intermediate_size);
+        let alloc_moe = config.ffn_kind == Qwen35MtpFfnKind::Moe;
         Ok(Self {
             tok_embd: gpu.alloc_tensor(&[dim], DType::F32)?,
             e_norm: gpu.alloc_tensor(&[dim], DType::F32)?,
@@ -273,6 +402,85 @@ impl Qwen35MtpHeadScratch {
             up: gpu.alloc_tensor(&[config.n_ff], DType::F32)?,
             ffn_hidden: gpu.alloc_tensor(&[config.n_ff], DType::F32)?,
             ffn_out: gpu.alloc_tensor(&[dim], DType::F32)?,
+            moe_router_logits: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts], DType::F32)?)
+            } else {
+                None
+            },
+            moe_scalar_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[1], DType::F32)?)
+            } else {
+                None
+            },
+            moe_x_rot: if alloc_moe {
+                Some(gpu.alloc_tensor(&[dim], DType::F32)?)
+            } else {
+                None
+            },
+            moe_gate_up_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[2 * moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_gate_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_up_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_ffn_hidden: if alloc_moe {
+                Some(gpu.alloc_tensor(&[moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_ffn_out: if alloc_moe {
+                Some(gpu.alloc_tensor(&[dim], DType::F32)?)
+            } else {
+                None
+            },
+            moe_gate_batch: if alloc_moe {
+                Some(gpu.alloc_tensor(
+                    &[config.num_experts_per_tok * config.moe_intermediate_size],
+                    DType::F32,
+                )?)
+            } else {
+                None
+            },
+            moe_up_batch: if alloc_moe {
+                Some(gpu.alloc_tensor(
+                    &[config.num_experts_per_tok * config.moe_intermediate_size],
+                    DType::F32,
+                )?)
+            } else {
+                None
+            },
+            moe_rot_batch: if alloc_moe {
+                Some(gpu.alloc_tensor(
+                    &[config.num_experts_per_tok * config.moe_intermediate_size],
+                    DType::F32,
+                )?)
+            } else {
+                None
+            },
+            moe_topk_indices: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts_per_tok], DType::F32)?)
+            } else {
+                None
+            },
+            moe_topk_weights: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts_per_tok], DType::F32)?)
+            } else {
+                None
+            },
+            moe_down_expanded: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts_per_tok * dim], DType::F32)?)
+            } else {
+                None
+            },
             t_mtp_out: gpu.alloc_tensor(&[dim], DType::F32)?,
             logits: gpu.alloc_tensor(&[config.vocab_size], DType::F32)?,
             logits_compressed: None,
@@ -296,7 +504,9 @@ impl Qwen35MtpHeadScratch {
     /// Idempotent — a no-op if already allocated to the right size. Call
     /// once after head load when the head reports a compressed_vocab_size.
     pub fn ensure_compressed_logits(
-        &mut self, gpu: &mut Gpu, compressed_vocab_size: usize,
+        &mut self,
+        gpu: &mut Gpu,
+        compressed_vocab_size: usize,
     ) -> HipResult<()> {
         if let Some(existing) = self.logits_compressed.as_ref() {
             if existing.numel() == compressed_vocab_size {
@@ -309,9 +519,7 @@ impl Qwen35MtpHeadScratch {
                 let _ = gpu.free_tensor(old);
             }
         }
-        self.logits_compressed = Some(
-            gpu.alloc_tensor(&[compressed_vocab_size], DType::F32)?,
-        );
+        self.logits_compressed = Some(gpu.alloc_tensor(&[compressed_vocab_size], DType::F32)?);
         Ok(())
     }
 
@@ -334,6 +542,48 @@ impl Qwen35MtpHeadScratch {
         let _ = gpu.free_tensor(self.up);
         let _ = gpu.free_tensor(self.ffn_hidden);
         let _ = gpu.free_tensor(self.ffn_out);
+        if let Some(t) = self.moe_router_logits {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_scalar_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_x_rot {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_gate_up_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_gate_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_up_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_ffn_hidden {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_ffn_out {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_gate_batch {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_up_batch {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_rot_batch {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_topk_indices {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_topk_weights {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_down_expanded {
+            let _ = gpu.free_tensor(t);
+        }
         let _ = gpu.free_tensor(self.t_mtp_out);
         let _ = gpu.free_tensor(self.logits);
         if let Some(lc) = self.logits_compressed {
@@ -425,13 +675,25 @@ impl Qwen35MtpHeadKvCache {
     ) -> HipResult<Self> {
         let inner = match kv_mode {
             MtpKvMode::Q8 => hipfire_runtime::llama::KvCache::new_gpu_q8(
-                gpu, /* n_layers */ 1, config.n_head_kv, config.head_dim, config.max_seq,
+                gpu,
+                /* n_layers */ 1,
+                config.n_head_kv,
+                config.head_dim,
+                config.max_seq,
             )?,
             MtpKvMode::Asym3 => hipfire_runtime::llama::KvCache::new_gpu_asym3(
-                gpu, /* n_layers */ 1, config.n_head_kv, config.head_dim, config.max_seq,
+                gpu,
+                /* n_layers */ 1,
+                config.n_head_kv,
+                config.head_dim,
+                config.max_seq,
             )?,
             MtpKvMode::Fwht4 => hipfire_runtime::llama::KvCache::new_gpu_fwht4(
-                gpu, /* n_layers */ 1, config.n_head_kv, config.head_dim, config.max_seq,
+                gpu,
+                /* n_layers */ 1,
+                config.n_head_kv,
+                config.head_dim,
+                config.max_seq,
             )?,
         };
         Ok(Self {
@@ -452,12 +714,10 @@ impl Qwen35MtpHeadKvCache {
             let v_n = self.inner.v_gpu[layer].numel();
             let zeros_k = vec![0.0f32; k_n];
             let zeros_v = vec![0.0f32; v_n];
-            let kb: &[u8] = unsafe {
-                std::slice::from_raw_parts(zeros_k.as_ptr() as *const u8, k_n * 4)
-            };
-            let vb: &[u8] = unsafe {
-                std::slice::from_raw_parts(zeros_v.as_ptr() as *const u8, v_n * 4)
-            };
+            let kb: &[u8] =
+                unsafe { std::slice::from_raw_parts(zeros_k.as_ptr() as *const u8, k_n * 4) };
+            let vb: &[u8] =
+                unsafe { std::slice::from_raw_parts(zeros_v.as_ptr() as *const u8, v_n * 4) };
             gpu.hip.memcpy_htod(&self.inner.k_gpu[layer].buf, kb)?;
             gpu.hip.memcpy_htod(&self.inner.v_gpu[layer].buf, vb)?;
         }
@@ -551,11 +811,7 @@ pub fn load_mtp_head_bundled(
 ///
 /// `max_seq` bounds the per-position KV cache later allocated by
 /// [`Qwen35MtpHeadKvCache::new`]; pick to match your decode budget.
-pub fn load_mtp_head(
-    path: &Path,
-    gpu: &mut Gpu,
-    max_seq: usize,
-) -> HipResult<Qwen35MtpHead> {
+pub fn load_mtp_head(path: &Path, gpu: &mut Gpu, max_seq: usize) -> HipResult<Qwen35MtpHead> {
     load_mtp_head_at_offset(path, gpu, max_seq, 0)
 }
 
@@ -568,16 +824,22 @@ pub fn load_mtp_head_at_offset(
     max_seq: usize,
     base_offset: u64,
 ) -> HipResult<Qwen35MtpHead> {
-    let hfq = HfqFile::open_at_offset(path, base_offset)
-        .unwrap_or_else(|e| panic!("open .mtp file {} @ offset {base_offset}: {e}", path.display()));
+    let hfq = HfqFile::open_at_offset(path, base_offset).unwrap_or_else(|e| {
+        panic!(
+            "open .mtp file {} @ offset {base_offset}: {e}",
+            path.display()
+        )
+    });
     assert_eq!(
-        hfq.arch_id, 21,
+        hfq.arch_id,
+        21,
         ".mtp file at {} has arch_id={} (expected 21 = QWEN35_MTP_HEAD); \
          is this actually an MTP head extracted by mtp_extract?",
-        path.display(), hfq.arch_id
+        path.display(),
+        hfq.arch_id
     );
-    let meta: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
-        .expect(".mtp metadata JSON parse failed");
+    let meta: serde_json::Value =
+        serde_json::from_str(&hfq.metadata_json).expect(".mtp metadata JSON parse failed");
     let config = Qwen35MtpHeadConfig::from_metadata(&meta, max_seq);
 
     // ── Norms (F32, 1D) ─────────────────────────────────────────────────
@@ -594,67 +856,100 @@ pub fn load_mtp_head_at_offset(
     // τ=2.00 on 27B-3.5 LRU bench. The MTP head trains its `mtp.norm` with
     // the trunk per-layer convention, NOT the trunk final-norm convention.
     let shared_head_norm = load_norm_raw(&hfq, gpu, "shared_head_norm", n_embd)?;
-    let enorm           = load_norm_raw(&hfq, gpu, "enorm",            n_embd)?;
-    let hnorm           = load_norm_raw(&hfq, gpu, "hnorm",            n_embd)?;
-    let attn_norm       = load_norm_raw(&hfq, gpu, "attn_norm",        n_embd)?;
-    let attn_post_norm  = load_norm_raw(&hfq, gpu, "attn_post_norm",   n_embd)?;
-    let attn_q_norm     = load_norm_raw(&hfq, gpu, "attn_q_norm",      head_dim)?;
-    let attn_k_norm     = load_norm_raw(&hfq, gpu, "attn_k_norm",      head_dim)?;
+    let enorm = load_norm_raw(&hfq, gpu, "enorm", n_embd)?;
+    let hnorm = load_norm_raw(&hfq, gpu, "hnorm", n_embd)?;
+    let attn_norm = load_norm_raw(&hfq, gpu, "attn_norm", n_embd)?;
+    let attn_post_norm = load_norm_raw(&hfq, gpu, "attn_post_norm", n_embd)?;
+    let attn_q_norm = load_norm_raw(&hfq, gpu, "attn_q_norm", head_dim)?;
+    let attn_k_norm = load_norm_raw(&hfq, gpu, "attn_k_norm", head_dim)?;
 
     // ── 2D weights ──────────────────────────────────────────────────────
     let q_full_dim = 2 * head_dim * config.n_head;
-    let kv_dim     = head_dim * config.n_head_kv;
-    let q_dim      = head_dim * config.n_head;
+    let kv_dim = head_dim * config.n_head_kv;
+    let q_dim = head_dim * config.n_head;
 
-    let eh_proj  = load_weight_raw(&hfq, gpu, "eh_proj",  n_embd,    2 * n_embd)?;
-    let wq       = load_weight_raw(&hfq, gpu, "wq",       q_full_dim, n_embd)?;
-    let wk       = load_weight_raw(&hfq, gpu, "wk",       kv_dim,    n_embd)?;
-    let wv       = load_weight_raw(&hfq, gpu, "wv",       kv_dim,    n_embd)?;
-    let wo       = load_weight_raw(&hfq, gpu, "wo",       n_embd,    q_dim)?;
-    let ffn_gate = load_weight_raw(&hfq, gpu, "ffn_gate", config.n_ff, n_embd)?;
-    let ffn_up   = load_weight_raw(&hfq, gpu, "ffn_up",   config.n_ff, n_embd)?;
-    let ffn_down = load_weight_raw(&hfq, gpu, "ffn_down", n_embd,      config.n_ff)?;
+    let eh_proj = load_weight_raw(&hfq, gpu, "eh_proj", n_embd, 2 * n_embd)?;
+    let wq = load_weight_raw(&hfq, gpu, "wq", q_full_dim, n_embd)?;
+    let wk = load_weight_raw(&hfq, gpu, "wk", kv_dim, n_embd)?;
+    let wv = load_weight_raw(&hfq, gpu, "wv", kv_dim, n_embd)?;
+    let wo = load_weight_raw(&hfq, gpu, "wo", n_embd, q_dim)?;
+    let ffn = match config.ffn_kind {
+        Qwen35MtpFfnKind::Dense => Qwen35MtpFfnWeights::Dense(Qwen35MtpDenseFfnWeights {
+            gate: load_weight_raw(&hfq, gpu, "ffn_gate", config.n_ff, n_embd)?,
+            up: load_weight_raw(&hfq, gpu, "ffn_up", config.n_ff, n_embd)?,
+            down: load_weight_raw(&hfq, gpu, "ffn_down", n_embd, config.n_ff)?,
+        }),
+        Qwen35MtpFfnKind::Moe => {
+            assert_eq!(
+                config.num_experts_per_tok, 8,
+                "MoE MTP runtime currently supports top_k=8, got {}",
+                config.num_experts_per_tok
+            );
+            Qwen35MtpFfnWeights::Moe(load_mtp_moe_ffn(&hfq, gpu, &config)?)
+        }
+    };
 
     // ── Optional FastMTP-style compressed lm_head_draft + vocab map ────
     let has_compressed = meta
         .get("has_compressed_lm_head_draft")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let (lm_head_draft, lm_head_draft_vocab_map, compressed_vocab_size) =
-        if has_compressed {
-            let cvs = meta
-                .get("compressed_vocab_size")
-                .and_then(|v| v.as_u64())
-                .expect("metadata claims has_compressed_lm_head_draft but lacks compressed_vocab_size")
-                as usize;
-            assert!(cvs > 0, "compressed_vocab_size must be positive");
-            let lm_d = load_weight_raw(&hfq, gpu, "lm_head_draft.weight", cvs, n_embd)?;
-            let (vmap_info, vmap_bytes) = hfq
-                .tensor_data_vec("lm_head_draft.vocab_map")
-                .expect("compressed sidecar missing vocab_map tensor");
-            assert_eq!(
-                vmap_info.shape, vec![cvs as u32],
-                "lm_head_draft.vocab_map shape != [compressed_vocab_size]"
-            );
-            assert_eq!(
-                vmap_bytes.len(), cvs * 4,
-                "lm_head_draft.vocab_map byte count != {} (got {})",
-                cvs * 4, vmap_bytes.len()
-            );
-            let vmap: Vec<u32> = vmap_bytes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect();
-            (Some(lm_d), Some(vmap), Some(cvs))
-        } else {
-            (None, None, None)
-        };
+    let (
+        lm_head_draft,
+        lm_head_draft_vocab_map,
+        lm_head_draft_vocab_map_gpu,
+        compressed_vocab_size,
+    ) = if has_compressed {
+        let cvs = meta
+            .get("compressed_vocab_size")
+            .and_then(|v| v.as_u64())
+            .expect("metadata claims has_compressed_lm_head_draft but lacks compressed_vocab_size")
+            as usize;
+        assert!(cvs > 0, "compressed_vocab_size must be positive");
+        let lm_d = load_weight_raw(&hfq, gpu, "lm_head_draft.weight", cvs, n_embd)?;
+        let (vmap_info, vmap_bytes) = hfq
+            .tensor_data_vec("lm_head_draft.vocab_map")
+            .expect("compressed sidecar missing vocab_map tensor");
+        assert_eq!(
+            vmap_info.shape,
+            vec![cvs as u32],
+            "lm_head_draft.vocab_map shape != [compressed_vocab_size]"
+        );
+        assert_eq!(
+            vmap_bytes.len(),
+            cvs * 4,
+            "lm_head_draft.vocab_map byte count != {} (got {})",
+            cvs * 4,
+            vmap_bytes.len()
+        );
+        let vmap: Vec<u32> = vmap_bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        let vmap_gpu = gpu.upload_raw(&vmap_bytes, &[vmap_bytes.len()])?;
+        (Some(lm_d), Some(vmap), Some(vmap_gpu), Some(cvs))
+    } else {
+        (None, None, None, None)
+    };
 
     let weights = Qwen35MtpHeadWeights {
-        shared_head_norm, enorm, hnorm, attn_norm, attn_post_norm,
-        attn_q_norm, attn_k_norm,
-        eh_proj, wq, wk, wv, wo, ffn_gate, ffn_up, ffn_down,
-        lm_head_draft, lm_head_draft_vocab_map, compressed_vocab_size,
+        shared_head_norm,
+        enorm,
+        hnorm,
+        attn_norm,
+        attn_post_norm,
+        attn_q_norm,
+        attn_k_norm,
+        eh_proj,
+        wq,
+        wk,
+        wv,
+        wo,
+        ffn,
+        lm_head_draft,
+        lm_head_draft_vocab_map,
+        lm_head_draft_vocab_map_gpu,
+        compressed_vocab_size,
     };
 
     Ok(Qwen35MtpHead { config, weights })
@@ -665,7 +960,10 @@ pub fn load_mtp_head_at_offset(
 /// · (1 + weight)`). All `.mtp` norms ship as quant_type=2 (F32) per the
 /// `mtp_extract` packing rule.
 fn load_norm_raw(
-    hfq: &HfqFile, gpu: &mut Gpu, name: &str, expected_n: usize,
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    expected_n: usize,
 ) -> HipResult<GpuTensor> {
     load_norm_raw_with_offset(hfq, gpu, name, expected_n, true)
 }
@@ -676,22 +974,29 @@ fn load_norm_raw(
 /// `mtp.norm.weight` (shared_head_norm) is the equivalent of the trunk's
 /// final norm — should also be RAW. Pass apply_plus_one=false for that one.
 fn load_norm_raw_with_offset(
-    hfq: &HfqFile, gpu: &mut Gpu, name: &str, expected_n: usize, apply_plus_one: bool,
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    expected_n: usize,
+    apply_plus_one: bool,
 ) -> HipResult<GpuTensor> {
     let (info, data) = hfq
         .tensor_data_vec(name)
         .unwrap_or_else(|| panic!(".mtp tensor '{name}' missing"));
     let mut f32_data: Vec<f32> = match info.quant_type {
-        1 => data.chunks_exact(2)
+        1 => data
+            .chunks_exact(2)
             .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
             .collect(),
-        2 => data.chunks_exact(4)
+        2 => data
+            .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
         other => panic!("norm '{name}' has unexpected qt={other} (expected F16 or F32)"),
     };
     assert_eq!(
-        f32_data.len(), expected_n,
+        f32_data.len(),
+        expected_n,
         "norm '{name}': loaded {} elems but expected {expected_n}",
         f32_data.len(),
     );
@@ -706,7 +1011,9 @@ fn load_norm_raw_with_offset(
     // representation). Off-by-one risk is small: the trunk does the same
     // +1 for `shared_expert_intermediate.norm` etc.
     if apply_plus_one {
-        for v in &mut f32_data { *v += 1.0; }
+        for v in &mut f32_data {
+            *v += 1.0;
+        }
     }
     gpu.upload_f32(&f32_data, &[expected_n])
 }
@@ -715,7 +1022,11 @@ fn load_norm_raw_with_offset(
 /// the supported quant types into a [`WeightTensor`]; m and k are passed
 /// in (the mtp container stores shape but we trust caller-supplied dims).
 fn load_weight_raw(
-    hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize,
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
 ) -> HipResult<WeightTensor> {
     let (info, data) = hfq
         .tensor_data_vec(name)
@@ -724,13 +1035,68 @@ fn load_weight_raw(
     weight_tensor_from_raw(gpu, info.quant_type, &data, m, k, name)
 }
 
+fn load_mtp_moe_ffn(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    config: &Qwen35MtpHeadConfig,
+) -> HipResult<Qwen35MtpMoeFfnWeights> {
+    let n_exp = config.num_experts;
+    let dim = config.n_embd;
+    let mi = config.moe_intermediate_size;
+    let smi = config.shared_expert_intermediate_size;
+    assert!(n_exp > 0, "MoE MTP config has num_experts=0");
+    assert!(mi > 0, "MoE MTP config has moe_intermediate_size=0");
+    assert!(
+        smi > 0,
+        "MoE MTP config has shared_expert_intermediate_size=0"
+    );
+
+    let router = load_weight_raw(hfq, gpu, "moe_router", n_exp, dim)?;
+    let shared_expert_gate = load_weight_raw(hfq, gpu, "moe_shared_expert_gate", 1, dim)?;
+    let shared_expert = Qwen35MtpMoeSharedExpertWeights {
+        gate: load_weight_raw(hfq, gpu, "moe_shared_gate", smi, dim)?,
+        up: load_weight_raw(hfq, gpu, "moe_shared_up", smi, dim)?,
+        down: load_weight_raw(hfq, gpu, "moe_shared_down", dim, smi)?,
+    };
+
+    let mut experts = Vec::with_capacity(n_exp);
+    for x in 0..n_exp {
+        let gate_up = load_weight_raw(hfq, gpu, &format!("moe_experts.{x}.gate_up"), 2 * mi, dim)?;
+        let down = load_weight_raw(hfq, gpu, &format!("moe_experts.{x}.down"), dim, mi)?;
+        experts.push(Qwen35MtpMoeExpertWeights { gate_up, down });
+    }
+
+    let mut gu_ptrs: Vec<u64> = Vec::with_capacity(n_exp);
+    let mut dn_ptrs: Vec<u64> = Vec::with_capacity(n_exp);
+    for e in &experts {
+        gu_ptrs.push(e.gate_up.buf.buf.as_ptr() as u64);
+        dn_ptrs.push(e.down.buf.buf.as_ptr() as u64);
+    }
+    let gu_bytes: Vec<u8> = gu_ptrs.iter().flat_map(|p| p.to_ne_bytes()).collect();
+    let dn_bytes: Vec<u8> = dn_ptrs.iter().flat_map(|p| p.to_ne_bytes()).collect();
+    let expert_gate_up_ptrs = gpu.alloc_tensor(&[2 * n_exp], DType::F32)?;
+    let expert_down_ptrs = gpu.alloc_tensor(&[2 * n_exp], DType::F32)?;
+    gpu.hip.memcpy_htod(&expert_gate_up_ptrs.buf, &gu_bytes)?;
+    gpu.hip.memcpy_htod(&expert_down_ptrs.buf, &dn_bytes)?;
+
+    Ok(Qwen35MtpMoeFfnWeights {
+        router,
+        shared_expert,
+        shared_expert_gate,
+        experts,
+        expert_gate_up_ptrs,
+        expert_down_ptrs,
+    })
+}
+
 /// Cross-check the on-disk shape against the caller's expected (m, k).
 /// Catches silent dim mismatches (e.g. tied vocab, head split done wrong).
 fn sanity_check_2d_shape(name: &str, info: &HfqTensorInfo, m: usize, k: usize) {
     if info.shape.len() != 2 {
         panic!(
             ".mtp tensor '{name}': expected 2D shape, got {}D = {:?}",
-            info.shape.len(), info.shape,
+            info.shape.len(),
+            info.shape,
         );
     }
     let on_disk_m = info.shape[0] as usize;
@@ -749,7 +1115,12 @@ fn sanity_check_2d_shape(name: &str, info: &HfqTensorInfo, m: usize, k: usize) {
 /// dispatch table from `qwen35::load_weight_tensor_raw`, restricted to the
 /// quant types `mtp_extract` actually emits (MQ4, Q8_F16=Q8_0, F16, F32).
 fn weight_tensor_from_raw(
-    gpu: &Gpu, quant_type: u8, data: &[u8], m: usize, k: usize, name: &str,
+    gpu: &Gpu,
+    quant_type: u8,
+    data: &[u8],
+    m: usize,
+    k: usize,
+    name: &str,
 ) -> HipResult<WeightTensor> {
     match quant_type {
         13 => {
@@ -759,33 +1130,63 @@ fn weight_tensor_from_raw(
                 ".mtp tensor '{name}' is MQ4G256 with K={k} not divisible by 256"
             );
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::MQ4G256,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         3 => {
             // Q8_F16 (group_size=32, 34 bytes/group) — same byte layout as
             // GGML Q8_0; existing gemv_q8_0 dispatch works directly.
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::Q8_0, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::Q8_0,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         1 => {
             // F16 → dequantize on host, upload as F32 (no GPU-native F16
             // GEMV; the trunk does the same conversion in load_weight_tensor_raw).
-            let f32_data: Vec<f32> = data.chunks_exact(2)
+            let f32_data: Vec<f32> = data
+                .chunks_exact(2)
                 .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
                 .collect();
             let bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
-                    f32_data.as_ptr() as *const u8,
-                    f32_data.len() * 4,
-                )
+                std::slice::from_raw_parts(f32_data.as_ptr() as *const u8, f32_data.len() * 4)
             };
             let buf = gpu.upload_raw(bytes, &[m, k])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::F32,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         2 => {
             // F32 raw.
             let buf = gpu.upload_raw(data, &[m, k])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::F32,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         other => panic!(
             ".mtp tensor '{name}': unsupported quant_type={other} \
@@ -842,13 +1243,25 @@ pub fn mtp_head_forward(
     // `scratch.t_mtp_out` and leaves `scratch.ffn_out` holding the same
     // hidden (alias for the LM-head path).
     mtp_head_forward_block_only(
-        gpu, head, scratch, kv, next_token, prev_hidden, None, pos,
+        gpu,
+        head,
+        scratch,
+        kv,
+        next_token,
+        prev_hidden,
+        None,
+        pos,
         trunk_weights,
     )?;
 
     // Standard single-step lm_head: shared_head_norm + GEMV over t_mtp_out.
     let w = &head.weights;
-    gpu.rmsnorm_f32(&scratch.t_mtp_out, &w.shared_head_norm, &scratch.tmp, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_f32(
+        &scratch.t_mtp_out,
+        &w.shared_head_norm,
+        &scratch.tmp,
+        cfg.rms_norm_eps,
+    )?;
     weight_gemv(gpu, lm_head_weights, &scratch.tmp, &scratch.logits)?;
 
     Ok(())
@@ -882,32 +1295,58 @@ pub fn mtp_head_forward_compressed(
     pos: usize,
     trunk_weights: &Qwen35Weights,
 ) -> HipResult<()> {
-    let cfg = &head.config;
-    let w = &head.weights;
-    let lm_head_draft = w.lm_head_draft.as_ref()
-        .expect("mtp_head_forward_compressed called but head has no lm_head_draft sidecar");
-    let logits_c = scratch.logits_compressed.as_ref()
-        .expect("mtp_head_forward_compressed: scratch.logits_compressed not allocated; \
-                 call Qwen35MtpHeadScratch::ensure_compressed_logits first");
-
-    assert_eq!(
-        lm_head_draft.k, cfg.n_embd,
-        "mtp_head_forward_compressed: lm_head_draft.k={} but n_embd={}",
-        lm_head_draft.k, cfg.n_embd,
-    );
-
     // Block forward — identical to mtp_head_forward; produces t_mtp_out.
     mtp_head_forward_block_only(
-        gpu, head, scratch, kv, next_token, prev_hidden, None, pos,
+        gpu,
+        head,
+        scratch,
+        kv,
+        next_token,
+        prev_hidden,
+        None,
+        pos,
         trunk_weights,
     )?;
 
-    // Compressed lm_head dispatch: shared_head_norm into tmp, then GEMV
-    // against the K-row compressed weight matrix into logits_compressed.
-    gpu.rmsnorm_f32(&scratch.t_mtp_out, &w.shared_head_norm, &scratch.tmp, cfg.rms_norm_eps)?;
-    weight_gemv(gpu, lm_head_draft, &scratch.tmp, logits_c)?;
+    mtp_head_apply_lm_head_draft(gpu, head, scratch)?;
 
     Ok(())
+}
+
+/// Applies the compressed draft LM head to `scratch.t_mtp_out`.
+///
+/// This is the shared tail of the host-mediated compressed path and the
+/// device-token-chain path. Keeping it in one helper prevents those paths from
+/// drifting if the compressed head gains another post-block transform.
+pub fn mtp_head_apply_lm_head_draft(
+    gpu: &mut Gpu,
+    head: &Qwen35MtpHead,
+    scratch: &Qwen35MtpHeadScratch,
+) -> HipResult<()> {
+    let cfg = &head.config;
+    let w = &head.weights;
+    let lm_head_draft = w
+        .lm_head_draft
+        .as_ref()
+        .expect("mtp_head_apply_lm_head_draft called but head has no lm_head_draft sidecar");
+    let logits_c = scratch.logits_compressed.as_ref().expect(
+        "mtp_head_apply_lm_head_draft: scratch.logits_compressed not allocated; \
+                 call Qwen35MtpHeadScratch::ensure_compressed_logits first",
+    );
+
+    assert_eq!(
+        lm_head_draft.k, cfg.n_embd,
+        "mtp_head_apply_lm_head_draft: lm_head_draft.k={} but n_embd={}",
+        lm_head_draft.k, cfg.n_embd,
+    );
+
+    gpu.rmsnorm_f32(
+        &scratch.t_mtp_out,
+        &w.shared_head_norm,
+        &scratch.tmp,
+        cfg.rms_norm_eps,
+    )?;
+    weight_gemv(gpu, lm_head_draft, &scratch.tmp, logits_c)
 }
 
 /// Block-only variant of [`mtp_head_forward`]: runs the NextN concat +
@@ -952,12 +1391,11 @@ pub fn mtp_head_forward_block_only(
     trunk_weights: &Qwen35Weights,
 ) -> HipResult<()> {
     let cfg = &head.config;
-    let w = &head.weights;
     let n_embd = cfg.n_embd;
-    let kv_dim = cfg.head_dim * cfg.n_head_kv;
 
     assert_eq!(
-        prev_hidden.numel(), n_embd,
+        prev_hidden.numel(),
+        n_embd,
         "mtp_head_forward_block_only: prev_hidden has {} elems but expected n_embd={n_embd}",
         prev_hidden.numel(),
     );
@@ -969,7 +1407,61 @@ pub fn mtp_head_forward_block_only(
 
     // Upload position scalar for the RoPE / attention kernels.
     let pos_i32 = pos as i32;
-    gpu.hip.memcpy_htod(&scratch.pos_buf, &pos_i32.to_ne_bytes())?;
+    gpu.hip
+        .memcpy_htod(&scratch.pos_buf, &pos_i32.to_ne_bytes())?;
+
+    mtp_head_forward_block_only_with_pos_buf(
+        gpu,
+        head,
+        scratch,
+        kv,
+        next_token,
+        prev_hidden,
+        next_token_embed,
+        &scratch.pos_buf,
+        pos,
+        pos + 1,
+        trunk_weights,
+    )
+}
+
+/// Graph-capturable variant of [`mtp_head_forward_block_only`].
+///
+/// `pos_buf` must point at an i32 device slot containing `pos`. Captured
+/// proposal graphs pass a stable per-step slot here and update the slot bytes
+/// before each graph launch, avoiding scalar position arguments baked into
+/// captured nodes. `seq_len_hint` controls the attention launch shape and
+/// shared-memory reservation; graph callers pass a tier cap that is >= every
+/// replayed `pos + 1`.
+#[allow(clippy::too_many_arguments)]
+pub fn mtp_head_forward_block_only_with_pos_buf(
+    gpu: &mut Gpu,
+    head: &Qwen35MtpHead,
+    scratch: &Qwen35MtpHeadScratch,
+    kv: &mut Qwen35MtpHeadKvCache,
+    next_token: u32,
+    prev_hidden: &GpuTensor,
+    next_token_embed: Option<&GpuTensor>,
+    pos_buf: &DeviceBuffer,
+    pos: usize,
+    seq_len_hint: usize,
+    trunk_weights: &Qwen35Weights,
+) -> HipResult<()> {
+    let cfg = &head.config;
+    let w = &head.weights;
+    let n_embd = cfg.n_embd;
+
+    assert_eq!(
+        prev_hidden.numel(),
+        n_embd,
+        "mtp_head_forward_block_only_with_pos_buf: prev_hidden has {} elems but expected n_embd={n_embd}",
+        prev_hidden.numel(),
+    );
+    assert!(
+        pos < kv.max_seq,
+        "mtp_head_forward_block_only_with_pos_buf: pos={pos} >= kv.max_seq={}",
+        kv.max_seq,
+    );
 
     // ── 1. Token embedding (table lookup OR caller-supplied override) ────
     let dim_bytes = n_embd * 4;
@@ -982,23 +1474,34 @@ pub fn mtp_head_forward_block_only(
         // Lossy-recursion path: feed the caller's pre-computed activation
         // directly into the e_norm input slot. Aliasing-safe (separate
         // backing buffers — caller passes the previous step's t_mtp_out).
-        gpu.hip.memcpy_dtod_at(&scratch.tok_embd.buf, 0, &embed.buf, 0, dim_bytes)?;
+        gpu.memcpy_dtod_at_auto(&scratch.tok_embd.buf, 0, &embed.buf, 0, dim_bytes)?;
     } else {
         embed_lookup_into(gpu, trunk_weights, &scratch.tok_embd, next_token, n_embd)?;
     }
 
     // ── 2. RMSNorm both inputs to the NextN projection ───────────────────
-    gpu.rmsnorm_f32(&scratch.tok_embd, &w.enorm, &scratch.e_norm, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_f32(
+        &scratch.tok_embd,
+        &w.enorm,
+        &scratch.e_norm,
+        cfg.rms_norm_eps,
+    )?;
     gpu.rmsnorm_f32(prev_hidden, &w.hnorm, &scratch.h_norm, cfg.rms_norm_eps)?;
 
     // ── 3. concat = [e_norm | h_norm], then cur = eh_proj @ concat ───────
-    gpu.hip.memcpy_dtod_at(&scratch.concat.buf, 0, &scratch.e_norm.buf, 0, dim_bytes)?;
-    gpu.hip.memcpy_dtod_at(&scratch.concat.buf, dim_bytes, &scratch.h_norm.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(&scratch.concat.buf, 0, &scratch.e_norm.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(
+        &scratch.concat.buf,
+        dim_bytes,
+        &scratch.h_norm.buf,
+        0,
+        dim_bytes,
+    )?;
     weight_gemv(gpu, &w.eh_proj, &scratch.concat, &scratch.cur)?;
 
     // Save inpSA for the attention residual (cur is about to be norm'd
     // out-of-place into scratch.tmp).
-    gpu.hip.memcpy_dtod_at(&scratch.residual.buf, 0, &scratch.cur.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(&scratch.residual.buf, 0, &scratch.cur.buf, 0, dim_bytes)?;
 
     // ── 4. Pre-attn norm + Q/K/V projections ─────────────────────────────
     gpu.rmsnorm_f32(&scratch.cur, &w.attn_norm, &scratch.tmp, cfg.rms_norm_eps)?;
@@ -1007,23 +1510,43 @@ pub fn mtp_head_forward_block_only(
     // Q (head-major first half) and gate (second half) per-head. Mirror
     // qwen35.rs:2402-2414.
     weight_gemv(gpu, &w.wq, &scratch.tmp, &scratch.q_full)?;
-    gpu.deinterleave_f32(&scratch.q_full, &scratch.q, &scratch.gate, cfg.n_head, cfg.head_dim)?;
+    gpu.deinterleave_f32(
+        &scratch.q_full,
+        &scratch.q,
+        &scratch.gate,
+        cfg.n_head,
+        cfg.head_dim,
+    )?;
     gpu.rmsnorm_batched(
-        &scratch.q, &w.attn_q_norm, &scratch.q,
-        cfg.n_head, cfg.head_dim, cfg.rms_norm_eps,
+        &scratch.q,
+        &w.attn_q_norm,
+        &scratch.q,
+        cfg.n_head,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     weight_gemv(gpu, &w.wk, &scratch.tmp, &scratch.k)?;
     weight_gemv(gpu, &w.wv, &scratch.tmp, &scratch.v)?;
     gpu.rmsnorm_batched(
-        &scratch.k, &w.attn_k_norm, &scratch.k,
-        cfg.n_head_kv, cfg.head_dim, cfg.rms_norm_eps,
+        &scratch.k,
+        &w.attn_k_norm,
+        &scratch.k,
+        cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     // ── 5. RoPE (partial-interleaved, mirrors trunk's full-attn layer) ───
     gpu.rope_partial_interleaved_f32(
-        &scratch.q, &scratch.k, &scratch.pos_buf,
-        cfg.n_head, cfg.n_head_kv, cfg.head_dim, cfg.n_rot, cfg.rope_theta,
+        &scratch.q,
+        &scratch.k,
+        pos_buf,
+        cfg.n_head,
+        cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.n_rot,
+        cfg.rope_theta,
     )?;
 
     // ── 6+7. KV cache write + attention (dispatch on kv.kv_mode) ─────────
@@ -1037,33 +1560,67 @@ pub fn mtp_head_forward_block_only(
     match kv.kv_mode {
         MtpKvMode::Q8 => {
             gpu.kv_cache_write_q8_0(
-                &kv.inner.k_gpu[0], &scratch.k, &scratch.pos_buf,
-                cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.k_gpu[0],
+                &scratch.k,
+                pos_buf,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.kv_cache_write_q8_0(
-                &kv.inner.v_gpu[0], &scratch.v, &scratch.pos_buf,
-                cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.v_gpu[0],
+                &scratch.v,
+                pos_buf,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.attention_q8_0_kv(
-                &scratch.q, &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.attn_out, &scratch.pos_buf, pos + 1,
-                cfg.n_head, cfg.n_head_kv, cfg.head_dim, kv.inner.physical_cap,
+                &scratch.q,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.attn_out,
+                pos_buf,
+                seq_len_hint,
+                cfg.n_head,
+                cfg.n_head_kv,
+                cfg.head_dim,
+                kv.inner.physical_cap,
             )?;
         }
         MtpKvMode::Asym3 => {
-            let ct = kv.inner.givens_cos.as_ref()
+            let ct = kv
+                .inner
+                .givens_cos
+                .as_ref()
                 .expect("MtpKvMode::Asym3 requires kv.inner.givens_cos to be Some");
-            let st = kv.inner.givens_sin.as_ref()
+            let st = kv
+                .inner
+                .givens_sin
+                .as_ref()
                 .expect("MtpKvMode::Asym3 requires kv.inner.givens_sin to be Some");
             gpu.kv_cache_write_asym3_fused(
-                &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.k, &scratch.v, &scratch.pos_buf,
-                ct, st, cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.k,
+                &scratch.v,
+                pos_buf,
+                ct,
+                st,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.attention_flash_asym3(
-                &scratch.q, &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.attn_out, &scratch.pos_buf, ct, st, pos + 1,
-                cfg.n_head, cfg.n_head_kv, cfg.head_dim, kv.inner.physical_cap,
+                &scratch.q,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.attn_out,
+                pos_buf,
+                ct,
+                st,
+                seq_len_hint,
+                cfg.n_head,
+                cfg.n_head_kv,
+                cfg.head_dim,
+                kv.inner.physical_cap,
                 &scratch.flash_partials,
             )?;
         }
@@ -1071,19 +1628,40 @@ pub fn mtp_head_forward_block_only(
             // Fwht uses the asym4-shaped k/v buffers + the cos/sin slots hold
             // signs1/signs2 (128 elements each). FWHT operates on 128-element
             // halves; head_dim=256 processes 2 halves reusing the same signs.
-            let ct = kv.inner.givens_cos.as_ref()
+            let ct = kv
+                .inner
+                .givens_cos
+                .as_ref()
                 .expect("MtpKvMode::Fwht4 requires kv.inner.givens_cos (signs1) to be Some");
-            let st = kv.inner.givens_sin.as_ref()
+            let st = kv
+                .inner
+                .givens_sin
+                .as_ref()
                 .expect("MtpKvMode::Fwht4 requires kv.inner.givens_sin (signs2) to be Some");
             gpu.kv_cache_write_fwht4_fused(
-                &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.k, &scratch.v, &scratch.pos_buf,
-                ct, st, cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.k,
+                &scratch.v,
+                pos_buf,
+                ct,
+                st,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.attention_flash_fwht4(
-                &scratch.q, &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.attn_out, &scratch.pos_buf, ct, st, pos + 1,
-                cfg.n_head, cfg.n_head_kv, cfg.head_dim, kv.inner.physical_cap,
+                &scratch.q,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.attn_out,
+                pos_buf,
+                ct,
+                st,
+                seq_len_hint,
+                cfg.n_head,
+                cfg.n_head_kv,
+                cfg.head_dim,
+                kv.inner.physical_cap,
                 &scratch.flash_partials,
             )?;
         }
@@ -1104,17 +1682,153 @@ pub fn mtp_head_forward_block_only(
     // (post-attention-layernorm in HF lingo = pre-FFN norm here, with the
     // "attn_post_norm" name reflecting its source position in the .mtp
     // metadata file).
-    gpu.rmsnorm_f32(&scratch.o, &w.attn_post_norm, &scratch.tmp, cfg.rms_norm_eps)?;
-    weight_gemv(gpu, &w.ffn_gate, &scratch.tmp, &scratch.gate_ffn)?;
-    weight_gemv(gpu, &w.ffn_up,   &scratch.tmp, &scratch.up)?;
-    gpu.silu_mul_f32(&scratch.gate_ffn, &scratch.up, &scratch.ffn_hidden)?;
-    weight_gemv(gpu, &w.ffn_down, &scratch.ffn_hidden, &scratch.ffn_out)?;
-    gpu.add_inplace_f32(&scratch.ffn_out, &scratch.o)?;
+    gpu.rmsnorm_f32(
+        &scratch.o,
+        &w.attn_post_norm,
+        &scratch.tmp,
+        cfg.rms_norm_eps,
+    )?;
+    match &w.ffn {
+        Qwen35MtpFfnWeights::Dense(ffn) => {
+            weight_gemv(gpu, &ffn.gate, &scratch.tmp, &scratch.gate_ffn)?;
+            weight_gemv(gpu, &ffn.up, &scratch.tmp, &scratch.up)?;
+            gpu.silu_mul_f32(&scratch.gate_ffn, &scratch.up, &scratch.ffn_hidden)?;
+            weight_gemv(gpu, &ffn.down, &scratch.ffn_hidden, &scratch.ffn_out)?;
+            gpu.add_inplace_f32(&scratch.ffn_out, &scratch.o)?;
+        }
+        Qwen35MtpFfnWeights::Moe(ffn) => {
+            gpu.memcpy_dtod_at_auto(&scratch.ffn_out.buf, 0, &scratch.o.buf, 0, dim_bytes)?;
+            mtp_moe_ffn_decode(gpu, ffn, &scratch.tmp, &scratch.ffn_out, cfg, scratch)?;
+        }
+    }
     // scratch.ffn_out now holds the post-FFN, pre-LM-head-norm hidden.
 
     // Snapshot for callers that want to chain into n+2 prediction OR feed
     // into the batched `mtp_head_apply_lm_head_batched` end-of-chain reduce.
-    gpu.hip.memcpy_dtod_at(&scratch.t_mtp_out.buf, 0, &scratch.ffn_out.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(
+        &scratch.t_mtp_out.buf,
+        0,
+        &scratch.ffn_out.buf,
+        0,
+        dim_bytes,
+    )?;
+
+    Ok(())
+}
+
+fn mtp_moe_ffn_decode(
+    gpu: &mut Gpu,
+    ffn: &Qwen35MtpMoeFfnWeights,
+    x_norm: &GpuTensor,
+    x_residual: &GpuTensor,
+    cfg: &Qwen35MtpHeadConfig,
+    scratch: &Qwen35MtpHeadScratch,
+) -> HipResult<()> {
+    let dim = cfg.n_embd;
+    let mi = cfg.moe_intermediate_size;
+    let smi = cfg.shared_expert_intermediate_size;
+    let k_top = cfg.num_experts_per_tok;
+    assert_eq!(k_top, 8, "MoE MTP decode currently expects top_k=8");
+    assert_eq!(ffn.experts.len(), cfg.num_experts);
+
+    let router_logits = scratch
+        .moe_router_logits
+        .as_ref()
+        .expect("MoE MTP scratch not allocated");
+    let scalar_buf = scratch.moe_scalar_buf.as_ref().expect("MoE MTP scratch");
+    let x_rot = scratch.moe_x_rot.as_ref().expect("MoE MTP scratch");
+    let gate_buf = scratch.moe_gate_buf.as_ref().expect("MoE MTP scratch");
+    let up_buf = scratch.moe_up_buf.as_ref().expect("MoE MTP scratch");
+    let ffn_hidden = scratch.moe_ffn_hidden.as_ref().expect("MoE MTP scratch");
+    let ffn_out = scratch.moe_ffn_out.as_ref().expect("MoE MTP scratch");
+    let gate_batch = scratch.moe_gate_batch.as_ref().expect("MoE MTP scratch");
+    let up_batch = scratch.moe_up_batch.as_ref().expect("MoE MTP scratch");
+    let rot_batch = scratch.moe_rot_batch.as_ref().expect("MoE MTP scratch");
+    let topk_indices = scratch.moe_topk_indices.as_ref().expect("MoE MTP scratch");
+    let topk_weights = scratch.moe_topk_weights.as_ref().expect("MoE MTP scratch");
+    let down_expanded = scratch.moe_down_expanded.as_ref().expect("MoE MTP scratch");
+
+    weight_gemv(gpu, &ffn.router, x_norm, router_logits)?;
+    gpu.softmax_f32(router_logits)?;
+    gpu.moe_topk_renorm_k8(
+        router_logits,
+        topk_indices,
+        topk_weights,
+        cfg.num_experts,
+        cfg.norm_topk_prob,
+    )?;
+
+    weight_gemv(gpu, &ffn.shared_expert_gate, x_norm, scalar_buf)?;
+    let shared_gate = gate_buf.sub_offset(0, smi);
+    let shared_up = up_buf.sub_offset(0, smi);
+    weight_gemv(gpu, &ffn.shared_expert.gate, x_norm, &shared_gate)?;
+    weight_gemv(gpu, &ffn.shared_expert.up, x_norm, &shared_up)?;
+    if ffn.shared_expert.down.gpu_dtype == DType::MQ4G256 {
+        gpu.ensure_mq_signs()?;
+        let x_rot_alias = GpuTensor {
+            buf: unsafe { gpu.mq_x_rot.as_ref().unwrap().buf.alias() },
+            shape: vec![gpu.mq_x_rot.as_ref().unwrap().buf.size() / 4],
+            dtype: DType::F32,
+        };
+        fused_silu_mul_rotate_mq_for(
+            gpu,
+            &ffn.shared_expert.down,
+            &shared_gate,
+            &shared_up,
+            &x_rot_alias,
+            smi,
+        )?;
+        gpu.gemv_hfq4g256_residual_sigmoid_scaled_gpu(
+            &ffn.shared_expert.down.buf,
+            &x_rot_alias,
+            x_residual,
+            scalar_buf,
+            ffn.shared_expert.down.m,
+            ffn.shared_expert.down.k,
+        )?;
+    } else {
+        gpu.sigmoid_f32(scalar_buf)?;
+        let shared_hid = ffn_hidden.sub_offset(0, smi);
+        gpu.silu_mul_f32(&shared_gate, &shared_up, &shared_hid)?;
+        weight_gemv(gpu, &ffn.shared_expert.down, &shared_hid, ffn_out)?;
+        gpu.scaled_add_inplace_gpu_scalar_f32(x_residual, ffn_out, scalar_buf)?;
+    }
+
+    let e0 = ffn.experts.first().expect("MoE MTP has no routed experts");
+    assert_eq!(
+        e0.gate_up.gpu_dtype,
+        DType::MQ4G256,
+        "MoE MTP routed gate_up currently requires MQ4G256"
+    );
+    assert_eq!(
+        e0.down.gpu_dtype,
+        DType::MQ4G256,
+        "MoE MTP routed down currently requires MQ4G256"
+    );
+    rotate_x_mq_for(gpu, &e0.gate_up, x_norm, x_rot, dim)?;
+    gpu.gemv_hfq4g256_moe_gate_up_k8_indexed(
+        &ffn.expert_gate_up_ptrs,
+        topk_indices,
+        x_rot,
+        gate_batch,
+        up_batch,
+        2 * mi,
+        e0.gate_up.k,
+    )?;
+    fused_silu_mul_rotate_mq_batched_for(
+        gpu, &e0.down, gate_batch, up_batch, rot_batch, mi, k_top,
+    )?;
+    gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
+        &ffn.expert_down_ptrs,
+        topk_indices,
+        rot_batch,
+        down_expanded,
+        e0.down.m,
+        e0.down.k,
+        k_top,
+        1,
+    )?;
+    gpu.moe_down_combine_k8_batched(down_expanded, topk_weights, x_residual, e0.down.m, k_top, 1)?;
 
     Ok(())
 }
@@ -1158,66 +1872,120 @@ pub fn mtp_head_apply_lm_head_batched(
     assert!(
         t_mtp_outs_stacked.numel() >= n * n_embd,
         "t_mtp_outs_stacked too small: {} < n*n_embd ({})",
-        t_mtp_outs_stacked.numel(), n * n_embd,
+        t_mtp_outs_stacked.numel(),
+        n * n_embd,
     );
     assert!(
         tmp_batched.numel() >= n * n_embd,
         "tmp_batched too small: {} < n*n_embd ({})",
-        tmp_batched.numel(), n * n_embd,
+        tmp_batched.numel(),
+        n * n_embd,
     );
     assert!(
         logits_batched.numel() >= n * vocab,
         "logits_batched too small: {} < n*vocab ({})",
-        logits_batched.numel(), n * vocab,
+        logits_batched.numel(),
+        n * vocab,
     );
 
     // Per-row shared_head_norm.
-    gpu.rmsnorm_batched(t_mtp_outs_stacked, &w.shared_head_norm, tmp_batched,
-                        n, n_embd, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_batched(
+        t_mtp_outs_stacked,
+        &w.shared_head_norm,
+        tmp_batched,
+        n,
+        n_embd,
+        cfg.rms_norm_eps,
+    )?;
 
     // Per-dtype batched LM head dispatch (mirrors mtp_probe.rs:278+).
     let logits_view = logits_batched.sub_offset(0, n * vocab);
     match lm_head_weights.gpu_dtype {
         DType::Q8_0 => {
             gpu.gemm_q8_0_batched(
-                &lm_head_weights.buf, tmp_batched, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                tmp_batched,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &lm_head_weights.buf, tmp_batched, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                tmp_batched,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::MQ4G256 => {
             let rot_view = rot_batched.sub_offset(0, n * lm_head_weights.k);
-            llama::rotate_x_mq_batched_for(gpu, lm_head_weights, tmp_batched, &rot_view, lm_head_weights.k, n)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                lm_head_weights,
+                tmp_batched,
+                &rot_view,
+                lm_head_weights.k,
+                n,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &lm_head_weights.buf, &rot_view, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                &rot_view,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::MQ3G256 => {
             let rot_view = rot_batched.sub_offset(0, n * lm_head_weights.k);
-            llama::rotate_x_mq_batched_for(gpu, lm_head_weights, tmp_batched, &rot_view, lm_head_weights.k, n)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                lm_head_weights,
+                tmp_batched,
+                &rot_view,
+                lm_head_weights.k,
+                n,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &lm_head_weights.buf, &rot_view, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                &rot_view,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &lm_head_weights.buf, tmp_batched, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                tmp_batched,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::MQ6G256 => {
             let rot_view = rot_batched.sub_offset(0, n * lm_head_weights.k);
-            llama::rotate_x_mq_batched_for(gpu, lm_head_weights, tmp_batched, &rot_view, lm_head_weights.k, n)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                lm_head_weights,
+                tmp_batched,
+                &rot_view,
+                lm_head_weights.k,
+                n,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &lm_head_weights.buf, &rot_view, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                &rot_view,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         _ => {
@@ -1243,11 +2011,15 @@ fn embed_lookup_into(
     dim: usize,
 ) -> HipResult<()> {
     match weights.embd_format {
-        EmbeddingFormat::HFQ4G256 => gpu.embedding_lookup_hfq4g256(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::HFQ4G128 => gpu.embedding_lookup_hfq4g128(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::Q8_0     => gpu.embedding_lookup_q8(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::Q4K      => gpu.embedding_lookup_q4k(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::F32      => gpu.embedding_lookup(&weights.token_embd, out, token, dim),
+        EmbeddingFormat::HFQ4G256 => {
+            gpu.embedding_lookup_hfq4g256(&weights.token_embd, out, token, dim)
+        }
+        EmbeddingFormat::HFQ4G128 => {
+            gpu.embedding_lookup_hfq4g128(&weights.token_embd, out, token, dim)
+        }
+        EmbeddingFormat::Q8_0 => gpu.embedding_lookup_q8(&weights.token_embd, out, token, dim),
+        EmbeddingFormat::Q4K => gpu.embedding_lookup_q4k(&weights.token_embd, out, token, dim),
+        EmbeddingFormat::F32 => gpu.embedding_lookup(&weights.token_embd, out, token, dim),
     }
 }
 
@@ -1268,26 +2040,26 @@ pub struct Qwen35MtpHeadBatchedScratch {
     pub q_dim: usize,
     pub kv_dim: usize,
     // Activations
-    pub tok_embd: GpuTensor,    // [max_n × n_embd]
-    pub e_norm: GpuTensor,      // [max_n × n_embd]
-    pub h_norm: GpuTensor,      // [max_n × n_embd]
-    pub concat: GpuTensor,      // [max_n × 2 × n_embd]
-    pub cur: GpuTensor,         // [max_n × n_embd]
-    pub residual: GpuTensor,    // [max_n × n_embd]
-    pub tmp: GpuTensor,         // [max_n × n_embd]
+    pub tok_embd: GpuTensor, // [max_n × n_embd]
+    pub e_norm: GpuTensor,   // [max_n × n_embd]
+    pub h_norm: GpuTensor,   // [max_n × n_embd]
+    pub concat: GpuTensor,   // [max_n × 2 × n_embd]
+    pub cur: GpuTensor,      // [max_n × n_embd]
+    pub residual: GpuTensor, // [max_n × n_embd]
+    pub tmp: GpuTensor,      // [max_n × n_embd]
     // Attention sub-block
-    pub q_full: GpuTensor,      // [max_n × 2 × q_dim]
-    pub q: GpuTensor,           // [max_n × q_dim]
-    pub gate: GpuTensor,        // [max_n × q_dim]
-    pub k: GpuTensor,           // [max_n × kv_dim]
-    pub v: GpuTensor,           // [max_n × kv_dim]
-    pub attn_out: GpuTensor,    // [max_n × q_dim]
-    pub o: GpuTensor,           // [max_n × n_embd]
+    pub q_full: GpuTensor,   // [max_n × 2 × q_dim]
+    pub q: GpuTensor,        // [max_n × q_dim]
+    pub gate: GpuTensor,     // [max_n × q_dim]
+    pub k: GpuTensor,        // [max_n × kv_dim]
+    pub v: GpuTensor,        // [max_n × kv_dim]
+    pub attn_out: GpuTensor, // [max_n × q_dim]
+    pub o: GpuTensor,        // [max_n × n_embd]
     // FFN sub-block
-    pub gate_ffn: GpuTensor,    // [max_n × n_ff]
-    pub up: GpuTensor,          // [max_n × n_ff]
-    pub ffn_hidden: GpuTensor,  // [max_n × n_ff]
-    pub ffn_out: GpuTensor,     // [max_n × n_embd]
+    pub gate_ffn: GpuTensor,   // [max_n × n_ff]
+    pub up: GpuTensor,         // [max_n × n_ff]
+    pub ffn_hidden: GpuTensor, // [max_n × n_ff]
+    pub ffn_out: GpuTensor,    // [max_n × n_embd]
     /// Stacked post-FFN, pre-LM-head-norm hidden — feeds
     /// `mtp_head_apply_lm_head_batched` directly. [max_n × n_embd]
     pub t_mtp_outs: GpuTensor,
@@ -1297,7 +2069,10 @@ pub struct Qwen35MtpHeadBatchedScratch {
 
 impl Qwen35MtpHeadBatchedScratch {
     pub fn new(gpu: &mut Gpu, config: &Qwen35MtpHeadConfig, max_n: usize) -> HipResult<Self> {
-        assert!(max_n >= 1, "Qwen35MtpHeadBatchedScratch: max_n must be >= 1");
+        assert!(
+            max_n >= 1,
+            "Qwen35MtpHeadBatchedScratch: max_n must be >= 1"
+        );
         let dim = config.n_embd;
         let q_dim = config.head_dim * config.n_head;
         let kv_dim = config.head_dim * config.n_head_kv;
@@ -1373,8 +2148,7 @@ fn weight_gemm_batched(
         DType::HFQ4G256 => gpu.gemm_hfq4g256(&w.buf, x_batched, y_batched, w.m, w.k, n),
         DType::MQ4G256 => {
             // MQ4 needs an FWHT-rotated x first (matches trunk lm_head + dflash patterns).
-            let rot = rotated_x_scratch
-                .expect("MQ4 batched gemm requires rotated_x_scratch");
+            let rot = rotated_x_scratch.expect("MQ4 batched gemm requires rotated_x_scratch");
             llama::rotate_x_mq_batched_for(gpu, w, x_batched, rot, w.k, n)?;
             gpu.gemm_hfq4g256(&w.buf, rot, y_batched, w.m, w.k, n)
         }
@@ -1457,23 +2231,29 @@ pub fn mtp_head_forward_block_batched(
 
     assert_eq!(next_tokens.len(), n, "next_tokens.len() != n");
     assert_eq!(positions.len(), n, "positions.len() != n");
-    assert!(n <= scratch.max_n, "n={n} > scratch.max_n={}", scratch.max_n);
-    assert!(prev_hiddens_stacked.numel() >= n * dim,
+    assert!(
+        n <= scratch.max_n,
+        "n={n} > scratch.max_n={}",
+        scratch.max_n
+    );
+    assert!(
+        prev_hiddens_stacked.numel() >= n * dim,
         "prev_hiddens_stacked too small: {} < n*dim ({})",
-        prev_hiddens_stacked.numel(), n * dim);
+        prev_hiddens_stacked.numel(),
+        n * dim
+    );
     for &p in positions {
         assert!(
             (p as usize) < kv.max_seq,
-            "position {p} >= kv.max_seq {}", kv.max_seq,
+            "position {p} >= kv.max_seq {}",
+            kv.max_seq,
         );
     }
 
     // Upload positions (i32 stored in F32-typed buffer; aliasing is fine since
     // the kernels read raw bytes via memcpy_htod into the F32 buffer).
     {
-        let bytes = unsafe {
-            std::slice::from_raw_parts(positions.as_ptr() as *const u8, n * 4)
-        };
+        let bytes = unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, n * 4) };
         gpu.hip.memcpy_htod(&scratch.positions.buf, bytes)?;
     }
 
@@ -1489,20 +2269,31 @@ pub fn mtp_head_forward_block_batched(
     let e_norm_view = scratch.e_norm.sub_offset(0, n * dim);
     let prev_view = prev_hiddens_stacked.sub_offset(0, n * dim);
     let h_norm_view = scratch.h_norm.sub_offset(0, n * dim);
-    gpu.rmsnorm_batched(&tok_embd_view, &w.enorm, &e_norm_view, n, dim, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_batched(
+        &tok_embd_view,
+        &w.enorm,
+        &e_norm_view,
+        n,
+        dim,
+        cfg.rms_norm_eps,
+    )?;
     gpu.rmsnorm_batched(&prev_view, &w.hnorm, &h_norm_view, n, dim, cfg.rms_norm_eps)?;
 
     // ── 3. Build concat = [e_norm | h_norm] per slot ─────────────────────
     // Layout: concat[i] = [e_norm[i, 0..dim], h_norm[i, 0..dim]] (length 2*dim).
     for i in 0..n {
         gpu.hip.memcpy_dtod_at(
-            &scratch.concat.buf, i * 2 * dim_bytes,
-            &scratch.e_norm.buf, i * dim_bytes,
+            &scratch.concat.buf,
+            i * 2 * dim_bytes,
+            &scratch.e_norm.buf,
+            i * dim_bytes,
             dim_bytes,
         )?;
         gpu.hip.memcpy_dtod_at(
-            &scratch.concat.buf, i * 2 * dim_bytes + dim_bytes,
-            &scratch.h_norm.buf, i * dim_bytes,
+            &scratch.concat.buf,
+            i * 2 * dim_bytes + dim_bytes,
+            &scratch.h_norm.buf,
+            i * dim_bytes,
             dim_bytes,
         )?;
     }
@@ -1510,14 +2301,18 @@ pub fn mtp_head_forward_block_batched(
     // cur = eh_proj @ concat (per-slot). w.eh_proj has m=n_embd, k=2*n_embd.
     let concat_view = scratch.concat.sub_offset(0, n * 2 * dim);
     let cur_view = scratch.cur.sub_offset(0, n * dim);
-    weight_gemm_batched(gpu, &w.eh_proj, &concat_view, &cur_view, n, rotated_x_scratch)?;
+    weight_gemm_batched(
+        gpu,
+        &w.eh_proj,
+        &concat_view,
+        &cur_view,
+        n,
+        rotated_x_scratch,
+    )?;
 
     // Save residual (inpSA) for the post-attn add.
-    gpu.hip.memcpy_dtod_at(
-        &scratch.residual.buf, 0,
-        &scratch.cur.buf, 0,
-        n * dim_bytes,
-    )?;
+    gpu.hip
+        .memcpy_dtod_at(&scratch.residual.buf, 0, &scratch.cur.buf, 0, n * dim_bytes)?;
 
     // ── 4. Pre-attn norm + Q/K/V projections ─────────────────────────────
     let tmp_view = scratch.tmp.sub_offset(0, n * dim);
@@ -1530,7 +2325,14 @@ pub fn mtp_head_forward_block_batched(
     // Deinterleave per-head into Q + Gate. Output: [n × n_head × head_dim] each.
     let q_view = scratch.q.sub_offset(0, n * q_dim);
     let gate_view = scratch.gate.sub_offset(0, n * q_dim);
-    gpu.deinterleave_f32_batched(&q_full_view, &q_view, &gate_view, cfg.n_head, cfg.head_dim, n)?;
+    gpu.deinterleave_f32_batched(
+        &q_full_view,
+        &q_view,
+        &gate_view,
+        cfg.n_head,
+        cfg.head_dim,
+        n,
+    )?;
 
     // attn_q_norm: per-head normalization of Q.
     // rmsnorm_batched treats `batch` as "rows of length n", and gates the
@@ -1539,8 +2341,12 @@ pub fn mtp_head_forward_block_batched(
     // `batch = n * n_head`, `n = head_dim`. Same convention as the trunk's
     // per-head q_norm at qwen35.rs.
     gpu.rmsnorm_batched(
-        &q_view, &w.attn_q_norm, &q_view,
-        n * cfg.n_head, cfg.head_dim, cfg.rms_norm_eps,
+        &q_view,
+        &w.attn_q_norm,
+        &q_view,
+        n * cfg.n_head,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     // K, V projections.
@@ -1549,14 +2355,25 @@ pub fn mtp_head_forward_block_batched(
     weight_gemm_batched(gpu, &w.wk, &tmp_view, &k_view, n, rotated_x_scratch)?;
     weight_gemm_batched(gpu, &w.wv, &tmp_view, &v_view, n, rotated_x_scratch)?;
     gpu.rmsnorm_batched(
-        &k_view, &w.attn_k_norm, &k_view,
-        n * cfg.n_head_kv, cfg.head_dim, cfg.rms_norm_eps,
+        &k_view,
+        &w.attn_k_norm,
+        &k_view,
+        n * cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     // ── 5. Batched RoPE on Q + K ─────────────────────────────────────────
     gpu.rope_partial_interleaved_f32_batched(
-        &q_view, &k_view, &scratch.positions,
-        cfg.n_head, cfg.n_head_kv, cfg.head_dim, cfg.n_rot, cfg.rope_theta, n,
+        &q_view,
+        &k_view,
+        &scratch.positions,
+        cfg.n_head,
+        cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.n_rot,
+        cfg.rope_theta,
+        n,
     )?;
 
     // ── 6. v1 simplification: per-slot K/V writes + attention = V
@@ -1577,12 +2394,18 @@ pub fn mtp_head_forward_block_batched(
         let v_row = scratch.v.sub_offset(i * kv_dim, kv_dim);
         let pos_slot = scratch.positions.sub_offset(i, 1);
         gpu.kv_cache_write_q8_0(
-            &kv.inner.k_gpu[0], &k_row, &pos_slot.buf,
-            cfg.n_head_kv, cfg.head_dim,
+            &kv.inner.k_gpu[0],
+            &k_row,
+            &pos_slot.buf,
+            cfg.n_head_kv,
+            cfg.head_dim,
         )?;
         gpu.kv_cache_write_q8_0(
-            &kv.inner.v_gpu[0], &v_row, &pos_slot.buf,
-            cfg.n_head_kv, cfg.head_dim,
+            &kv.inner.v_gpu[0],
+            &v_row,
+            &pos_slot.buf,
+            cfg.n_head_kv,
+            cfg.head_dim,
         )?;
     }
 
@@ -1592,17 +2415,15 @@ pub fn mtp_head_forward_block_batched(
     let attn_out_view = scratch.attn_out.sub_offset(0, n * q_dim);
     if cfg.n_head == cfg.n_head_kv {
         // No GQA expansion: attn_out := V row-by-row.
-        gpu.hip.memcpy_dtod_at(
-            &scratch.attn_out.buf, 0,
-            &scratch.v.buf, 0,
-            n * kv_dim * 4,
-        )?;
+        gpu.hip
+            .memcpy_dtod_at(&scratch.attn_out.buf, 0, &scratch.v.buf, 0, n * kv_dim * 4)?;
     } else {
         let ratio = cfg.n_head / cfg.n_head_kv;
         assert!(
             cfg.n_head % cfg.n_head_kv == 0,
             "n_head ({}) must be divisible by n_head_kv ({})",
-            cfg.n_head, cfg.n_head_kv,
+            cfg.n_head,
+            cfg.n_head_kv,
         );
         // Per-slot per-head expand: attn_out[i, h, d] = V[i, h/ratio, d].
         for i in 0..n {
@@ -1611,8 +2432,10 @@ pub fn mtp_head_forward_block_batched(
                 let src_off = (i * kv_dim + kv_h * cfg.head_dim) * 4;
                 let dst_off = (i * q_dim + h * cfg.head_dim) * 4;
                 gpu.hip.memcpy_dtod_at(
-                    &scratch.attn_out.buf, dst_off,
-                    &scratch.v.buf, src_off,
+                    &scratch.attn_out.buf,
+                    dst_off,
+                    &scratch.v.buf,
+                    src_off,
                     cfg.head_dim * 4,
                 )?;
             }
@@ -1631,22 +2454,52 @@ pub fn mtp_head_forward_block_batched(
     gpu.add_inplace_f32(&o_view, &res_view)?;
 
     // ── 9. POST-attn norm + SwiGLU FFN + residual ────────────────────────
-    gpu.rmsnorm_batched(&o_view, &w.attn_post_norm, &tmp_view, n, dim, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_batched(
+        &o_view,
+        &w.attn_post_norm,
+        &tmp_view,
+        n,
+        dim,
+        cfg.rms_norm_eps,
+    )?;
 
     let gate_ffn_view = scratch.gate_ffn.sub_offset(0, n * cfg.n_ff);
     let up_view = scratch.up.sub_offset(0, n * cfg.n_ff);
     let ffn_hidden_view = scratch.ffn_hidden.sub_offset(0, n * cfg.n_ff);
     let ffn_out_view = scratch.ffn_out.sub_offset(0, n * dim);
-    weight_gemm_batched(gpu, &w.ffn_gate, &tmp_view, &gate_ffn_view, n, rotated_x_scratch)?;
-    weight_gemm_batched(gpu, &w.ffn_up,   &tmp_view, &up_view,       n, rotated_x_scratch)?;
-    gpu.silu_mul_f32(&gate_ffn_view, &up_view, &ffn_hidden_view)?;
-    weight_gemm_batched(gpu, &w.ffn_down, &ffn_hidden_view, &ffn_out_view, n, rotated_x_scratch)?;
-    gpu.add_inplace_f32(&ffn_out_view, &o_view)?;
+    match &w.ffn {
+        Qwen35MtpFfnWeights::Dense(ffn) => {
+            weight_gemm_batched(
+                gpu,
+                &ffn.gate,
+                &tmp_view,
+                &gate_ffn_view,
+                n,
+                rotated_x_scratch,
+            )?;
+            weight_gemm_batched(gpu, &ffn.up, &tmp_view, &up_view, n, rotated_x_scratch)?;
+            gpu.silu_mul_f32(&gate_ffn_view, &up_view, &ffn_hidden_view)?;
+            weight_gemm_batched(
+                gpu,
+                &ffn.down,
+                &ffn_hidden_view,
+                &ffn_out_view,
+                n,
+                rotated_x_scratch,
+            )?;
+            gpu.add_inplace_f32(&ffn_out_view, &o_view)?;
+        }
+        Qwen35MtpFfnWeights::Moe(_) => {
+            panic!("batched MTP head forward does not support MoE FFN yet; use serial MTP");
+        }
+    }
 
     // ── 10. Snapshot post-FFN hidden into t_mtp_outs ─────────────────────
     gpu.hip.memcpy_dtod_at(
-        &scratch.t_mtp_outs.buf, 0,
-        &scratch.ffn_out.buf, 0,
+        &scratch.t_mtp_outs.buf,
+        0,
+        &scratch.ffn_out.buf,
+        0,
         n * dim_bytes,
     )?;
 

--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -30,12 +30,10 @@
 //! Greedy-only (temp=0). No DDTree, no PLD, no rejection sampling — that's
 //! Task 11 territory.
 
-use crate::mtp_head::{
-    self, Qwen35MtpHead, Qwen35MtpHeadKvCache, Qwen35MtpHeadScratch,
-};
+use crate::mtp_head::{self, Qwen35MtpHead, Qwen35MtpHeadKvCache, Qwen35MtpHeadScratch};
 use crate::qwen35::{self, Qwen35Weights};
 use crate::speculative::{DeltaNetSnapshot, GdnTape, ModelSlot};
-use hip_bridge::HipResult;
+use hip_bridge::{Event, Graph, GraphExec, HipResult, Stream};
 use hipfire_runtime::llama;
 use rdna_compute::{DType, Gpu, GpuTensor};
 
@@ -48,19 +46,138 @@ use rdna_compute::{DType, Gpu, GpuTensor};
 #[derive(Copy, Clone, Debug)]
 pub struct MtpSamplingConfig {
     pub temp: f32,
-    pub top_k: usize,     // 0 = disabled (no top-K cutoff)
-    pub top_p: f32,       // 1.0 = disabled (no nucleus cutoff)
-    pub min_p: f32,       // 0.0 = disabled (no min-prob cutoff)
+    pub top_k: usize, // 0 = disabled (no top-K cutoff)
+    pub top_p: f32,   // 1.0 = disabled (no nucleus cutoff)
+    pub min_p: f32,   // 0.0 = disabled (no min-prob cutoff)
 }
 
 impl Default for MtpSamplingConfig {
     fn default() -> Self {
-        Self { temp: 0.0, top_k: 0, top_p: 1.0, min_p: 0.0 }
+        Self {
+            temp: 0.0,
+            top_k: 0,
+            top_p: 1.0,
+            min_p: 0.0,
+        }
     }
 }
 
 impl MtpSamplingConfig {
-    pub fn is_greedy(&self) -> bool { self.temp <= 0.0 }
+    pub fn is_greedy(&self) -> bool {
+        self.temp <= 0.0
+    }
+}
+
+fn mtp_device_token_chain_enabled_from_env() -> bool {
+    // Default on: this path is token-identical in greedy mode and removes the
+    // proposal-loop host data dependency needed for later graph capture.
+    match std::env::var("HIPFIRE_MTP_DEVICE_TOKEN_CHAIN") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    }
+}
+
+fn mtp_snapshot_overlap_enabled_from_env() -> bool {
+    // Default off: current gfx1201 benches show this stream split regresses,
+    // but the hook is useful as an opt-in cross-arch experiment.
+    match std::env::var("HIPFIRE_MTP_SNAPSHOT_OVERLAP") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "on" || v == "yes"
+        }
+        Err(_) => false,
+    }
+}
+
+fn mtp_gpu_greedy_accept_enabled_from_env() -> bool {
+    // Default on for greedy device-token-chain MTP: candidates and verify
+    // argmaxes are already on-device, so the prefix accept + bonus selection
+    // can stay there until a compact two-int result is needed on host.
+    match std::env::var("HIPFIRE_MTP_GPU_ACCEPT") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    }
+}
+
+fn mtp_q8_verify_wmma_enabled_from_env_value(value: Option<&str>) -> bool {
+    match value {
+        None => true,
+        Some(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+    }
+}
+
+fn mtp_q8_verify_wmma_enabled_from_env() -> bool {
+    // Default on for MTP q8 verify: the chunked dispatch only routes to gfx12
+    // WMMA when the arch/shape supports it, otherwise it falls back to scalar.
+    // Prompt-sweep parity is clean; opt out with HIPFIRE_MTP_Q8_VERIFY_WMMA=0.
+    mtp_q8_verify_wmma_enabled_from_env_value(
+        std::env::var("HIPFIRE_MTP_Q8_VERIFY_WMMA")
+            .ok()
+            .as_deref(),
+    )
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MtpProposalGraphPolicy {
+    Off,
+    Auto,
+    On,
+}
+
+fn mtp_proposal_graph_policy_from_env_value(value: Option<&str>) -> MtpProposalGraphPolicy {
+    // Opt-in for now: q8 proposal graph capture is token-identical, but
+    // remains neutral/slightly negative on the canonical gfx1201 A3B K=5
+    // smoke after PR #5/#6 lowered verify cost (2026-05-28: 192.99 tok/s
+    // unset vs 191.44 tok/s graph=on, same output md5).
+    match value {
+        None => MtpProposalGraphPolicy::Off,
+        Some(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "0" | "false" | "off" | "no" => MtpProposalGraphPolicy::Off,
+            "1" | "true" | "on" | "yes" => MtpProposalGraphPolicy::On,
+            "auto" | "" => MtpProposalGraphPolicy::Auto,
+            _ => MtpProposalGraphPolicy::Auto,
+        },
+    }
+}
+
+fn mtp_proposal_graph_policy_from_env() -> MtpProposalGraphPolicy {
+    mtp_proposal_graph_policy_from_env_value(
+        std::env::var("HIPFIRE_MTP_PROPOSAL_GRAPH").ok().as_deref(),
+    )
+}
+
+fn mtp_proposal_graph_eligible_for(
+    policy: MtpProposalGraphPolicy,
+    use_device_token_chain: bool,
+    use_full_vocab: bool,
+    kv_mode: crate::mtp_head::MtpKvMode,
+) -> bool {
+    policy != MtpProposalGraphPolicy::Off
+        && use_device_token_chain
+        && !use_full_vocab
+        && kv_mode == crate::mtp_head::MtpKvMode::Q8
+}
+
+fn mtp_device_token_chain_eligible_for(
+    embd_format: llama::EmbeddingFormat,
+    use_sampling: bool,
+    use_p_min: bool,
+) -> bool {
+    !use_sampling
+        && !use_p_min
+        && matches!(
+            embd_format,
+            llama::EmbeddingFormat::HFQ4G256 | llama::EmbeddingFormat::Q8_0
+        )
 }
 
 /// Reproducible xorshift64* RNG. Cheap, fast, no `rand` dep.
@@ -92,13 +209,12 @@ impl MtpRng {
 /// All arithmetic is host-side f64 for the softmax stability + cumulative
 /// sums, then cast back to f32 for the returned probability. The vocab is
 /// typically 32K (compressed) or 248K (full); a few μs per call.
-pub fn sample_from_logits(
-    logits: &[f32],
-    cfg: &MtpSamplingConfig,
-    rng: &mut MtpRng,
-) -> (u32, f32) {
+pub fn sample_from_logits(logits: &[f32], cfg: &MtpSamplingConfig, rng: &mut MtpRng) -> (u32, f32) {
     assert!(!logits.is_empty(), "sample_from_logits: empty logits row");
-    assert!(cfg.temp > 0.0, "sample_from_logits: temp must be > 0; caller must branch on greedy");
+    assert!(
+        cfg.temp > 0.0,
+        "sample_from_logits: temp must be > 0; caller must branch on greedy"
+    );
 
     // 1. Build (id, scaled_logit) pairs.
     let inv_temp = 1.0 / cfg.temp as f64;
@@ -128,18 +244,25 @@ pub fn sample_from_logits(
             e
         })
         .collect();
-    for p in probs.iter_mut() { *p /= sum_exp; }
+    for p in probs.iter_mut() {
+        *p /= sum_exp;
+    }
 
     // 5. min_p: drop tokens with normalized prob < min_p * top_prob.
     if cfg.min_p > 0.0 {
         let top_p_val = probs[0];
         let thresh = (cfg.min_p as f64) * top_p_val;
-        let cutoff = probs.iter().position(|&p| p < thresh).unwrap_or(probs.len());
+        let cutoff = probs
+            .iter()
+            .position(|&p| p < thresh)
+            .unwrap_or(probs.len());
         pairs.truncate(cutoff.max(1));
         probs.truncate(cutoff.max(1));
         // Renormalize after min_p.
         let s: f64 = probs.iter().sum();
-        for p in probs.iter_mut() { *p /= s; }
+        for p in probs.iter_mut() {
+            *p /= s;
+        }
     }
 
     // 6. top_p (nucleus): cumulative-prob cutoff.
@@ -157,7 +280,9 @@ pub fn sample_from_logits(
         probs.truncate(cutoff);
         // Renormalize after top_p.
         let s: f64 = probs.iter().sum();
-        for p in probs.iter_mut() { *p /= s; }
+        for p in probs.iter_mut() {
+            *p /= s;
+        }
     }
 
     // 7. Multinomial sample.
@@ -191,14 +316,18 @@ pub fn softmax_prob_at_temp(logits: &[f32], idx: usize, temp: f32) -> f32 {
     let mut max_scaled = f64::NEG_INFINITY;
     for &l in logits.iter() {
         let s = l as f64 * inv_t;
-        if s > max_scaled { max_scaled = s; }
+        if s > max_scaled {
+            max_scaled = s;
+        }
     }
     let mut sum_exp = 0.0_f64;
     let mut target_e = 0.0_f64;
     for (i, &l) in logits.iter().enumerate() {
         let e = ((l as f64) * inv_t - max_scaled).exp();
         sum_exp += e;
-        if i == idx { target_e = e; }
+        if i == idx {
+            target_e = e;
+        }
     }
     (target_e / sum_exp) as f32
 }
@@ -233,6 +362,12 @@ pub struct MtpSpecState {
 
     /// Trunk DN snapshot for rollback before replay.
     pub trunk_snap: DeltaNetSnapshot,
+
+    /// Side stream used to overlap `trunk_snap.save_from` with the MTP
+    /// proposal loop. The event orders the side-stream copy after any
+    /// prior-cycle main-stream work that may still be updating DN state.
+    pub trunk_snap_stream: Option<Stream>,
+    pub trunk_snap_start_event: Option<Event>,
 
     /// Persistent batch scratch for the trunk's batched verify forward.
     /// Sized to `max_n + 1` so verify always fits in one chunk.
@@ -272,6 +407,32 @@ pub struct MtpSpecState {
     /// GPU-side argmax destination for the K-step batched argmax over
     /// `mtp_lm_logits`. Shape `[max_n]` i32 stored as F32 slots.
     pub mtp_lm_argmax: GpuTensor,
+
+    /// Greedy device-token chain for compressed-serial MTP. Slot 0 is seeded
+    /// with `last_committed`; step k writes slot k+1 after argmax/remap, and
+    /// step k+1 embeds slot k directly from GPU memory. Shape `[max_n + 1]`
+    /// i32 stored in F32-typed slots.
+    pub mtp_token_chain: GpuTensor,
+
+    /// Single-token embedding scratch used by the device-token-chain path.
+    /// The existing MTP block forward consumes it through its embedding
+    /// override hook, avoiding a larger forward-path refactor.
+    pub mtp_token_embed: GpuTensor,
+
+    /// Per-step absolute MTP positions for proposal-graph replay. Shape
+    /// `[max_n]` i32 stored in F32 slots. The captured graph reads each slot
+    /// by pointer, while the host refreshes the values before every launch.
+    pub mtp_positions: GpuTensor,
+
+    /// Captured q8 compressed proposal graph for the greedy device-token-chain
+    /// path. It belongs to this state because the graph bakes scratch/weight
+    /// pointers into captured kernel nodes.
+    mtp_proposal_graph: Option<Graph>,
+    mtp_proposal_graph_exec: Option<GraphExec>,
+    mtp_proposal_graph_blobs: Vec<Vec<u8>>,
+    mtp_proposal_graph_seq_cap: usize,
+    mtp_proposal_graph_warmed: bool,
+    mtp_proposal_graph_disabled: bool,
 
     /// Optional FastMTP-style compressed batched-logits output, shape
     /// `[max_n * compressed_vocab_size]`. Populated by
@@ -347,9 +508,7 @@ impl MtpSpecState {
         head: &Qwen35MtpHead,
         max_n: usize,
     ) -> HipResult<Self> {
-        Self::new_for_slot_with_kv_mode(
-            gpu, target, head, max_n, crate::mtp_head::MtpKvMode::Q8,
-        )
+        Self::new_for_slot_with_kv_mode(gpu, target, head, max_n, crate::mtp_head::MtpKvMode::Q8)
     }
 
     /// Like [`Self::new_for_slot`] but allocates the MTP head's KV cache in
@@ -385,6 +544,13 @@ impl MtpSpecState {
         let verify_rot = gpu.alloc_tensor(&[(max_n + 1) * dim], DType::F32)?;
         let verify_argmax = gpu.alloc_tensor(&[max_n + 1], DType::F32)?;
         let trunk_snap = DeltaNetSnapshot::new_for(gpu, &target.dn_state)?;
+        // Snapshot overlap resources are construction-time only; set the env
+        // before creating MtpSpecState when comparing the opt-in path.
+        let (trunk_snap_stream, trunk_snap_start_event) = if mtp_snapshot_overlap_enabled_from_env() {
+            (Some(gpu.hip.stream_create()?), Some(gpu.hip.event_create()?))
+        } else {
+            (None, None)
+        };
         let trunk_pbs = qwen35::PrefillBatchScratch::new(gpu, &target.config, max_n + 1)?;
         let trunk_gdn_tape = GdnTape::new_for_config(gpu, &target.config, max_n + 1)?;
         let mtp_scratch = Qwen35MtpHeadScratch::new(gpu, &head.config)?;
@@ -396,6 +562,9 @@ impl MtpSpecState {
         let mtp_lm_rot = gpu.alloc_tensor(&[max_n * dim], DType::F32)?;
         let mtp_lm_logits = gpu.alloc_tensor(&[max_n * vocab], DType::F32)?;
         let mtp_lm_argmax = gpu.alloc_tensor(&[max_n], DType::F32)?;
+        let mtp_token_chain = gpu.alloc_tensor(&[max_n + 1], DType::F32)?;
+        let mtp_token_embed = gpu.alloc_tensor(&[dim], DType::F32)?;
+        let mtp_positions = gpu.alloc_tensor(&[max_n], DType::F32)?;
 
         // Per-step top-2 scratches for p_min early-exit (16 B total, always
         // allocated — only used when state.p_min > 0).
@@ -418,6 +587,8 @@ impl MtpSpecState {
             verify_rot,
             verify_argmax,
             trunk_snap,
+            trunk_snap_stream,
+            trunk_snap_start_event,
             trunk_pbs,
             trunk_gdn_tape,
             mtp_scratch,
@@ -427,6 +598,15 @@ impl MtpSpecState {
             mtp_lm_rot,
             mtp_lm_logits,
             mtp_lm_argmax,
+            mtp_token_chain,
+            mtp_token_embed,
+            mtp_positions,
+            mtp_proposal_graph: None,
+            mtp_proposal_graph_exec: None,
+            mtp_proposal_graph_blobs: Vec::new(),
+            mtp_proposal_graph_seq_cap: 0,
+            mtp_proposal_graph_warmed: false,
+            mtp_proposal_graph_disabled: false,
             mtp_lm_logits_compressed: None,
             mtp_topk_idx,
             mtp_topk_logp,
@@ -450,9 +630,21 @@ impl MtpSpecState {
     /// Reseeds BOTH the host RNG (used for the residual accept rule) and the
     /// on-device RNG (used by `gpu.sample_top_p`).
     pub fn set_sampling(&mut self, cfg: MtpSamplingConfig, seed: u64) {
-        assert!(cfg.temp >= 0.0, "set_sampling: temp must be >= 0.0, got {}", cfg.temp);
-        assert!(cfg.top_p > 0.0 && cfg.top_p <= 1.0, "set_sampling: top_p must be in (0,1], got {}", cfg.top_p);
-        assert!(cfg.min_p >= 0.0 && cfg.min_p <= 1.0, "set_sampling: min_p must be in [0,1], got {}", cfg.min_p);
+        assert!(
+            cfg.temp >= 0.0,
+            "set_sampling: temp must be >= 0.0, got {}",
+            cfg.temp
+        );
+        assert!(
+            cfg.top_p > 0.0 && cfg.top_p <= 1.0,
+            "set_sampling: top_p must be in (0,1], got {}",
+            cfg.top_p
+        );
+        assert!(
+            cfg.min_p >= 0.0 && cfg.min_p <= 1.0,
+            "set_sampling: min_p must be in [0,1], got {}",
+            cfg.min_p
+        );
         self.sampling = cfg;
         self.rng = MtpRng::new(seed);
         // GPU rng uses u32; mix the lower + upper halves so different seeds
@@ -475,9 +667,7 @@ impl MtpSpecState {
     /// compressed batched-lm_head dispatch path. Idempotent — reallocates
     /// only if the existing tensor has the wrong size. Call once after
     /// loading a head with a sidecar (cvs = `head.weights.compressed_vocab_size`).
-    pub fn ensure_compressed_lm_logits(
-        &mut self, gpu: &mut Gpu, cvs: usize,
-    ) -> HipResult<()> {
+    pub fn ensure_compressed_lm_logits(&mut self, gpu: &mut Gpu, cvs: usize) -> HipResult<()> {
         let needed = self.max_n * cvs;
         if let Some(existing) = self.mtp_lm_logits_compressed.as_ref() {
             if existing.numel() == needed {
@@ -487,9 +677,7 @@ impl MtpSpecState {
                 let _ = gpu.free_tensor(old);
             }
         }
-        self.mtp_lm_logits_compressed = Some(
-            gpu.alloc_tensor(&[needed], DType::F32)?,
-        );
+        self.mtp_lm_logits_compressed = Some(gpu.alloc_tensor(&[needed], DType::F32)?);
         Ok(())
     }
 
@@ -503,8 +691,10 @@ impl MtpSpecState {
         dim: usize,
     ) -> HipResult<()> {
         gpu.hip.memcpy_dtod_at(
-            &self.prev_hidden.buf, 0,
-            &target_scratch_tmp.buf, 0,
+            &self.prev_hidden.buf,
+            0,
+            &target_scratch_tmp.buf,
+            0,
             dim * 4,
         )
     }
@@ -521,8 +711,10 @@ impl MtpSpecState {
         dim: usize,
     ) -> HipResult<()> {
         gpu.hip.memcpy_dtod_at(
-            &self.prev_hidden.buf, 0,
-            &self.verify_hidden.buf, row * dim * 4,
+            &self.prev_hidden.buf,
+            0,
+            &self.verify_hidden.buf,
+            row * dim * 4,
             dim * 4,
         )
     }
@@ -538,11 +730,35 @@ impl MtpSpecState {
         let _ = gpu.free_tensor(self.mtp_lm_rot);
         let _ = gpu.free_tensor(self.mtp_lm_logits);
         let _ = gpu.free_tensor(self.mtp_lm_argmax);
+        let _ = gpu.free_tensor(self.mtp_token_chain);
+        let _ = gpu.free_tensor(self.mtp_token_embed);
+        let _ = gpu.free_tensor(self.mtp_positions);
+        if let Some(exec) = self.mtp_proposal_graph_exec {
+            let _ = gpu.hip.graph_exec_destroy(exec);
+        }
+        if let Some(graph) = self.mtp_proposal_graph {
+            let _ = gpu.hip.graph_destroy(graph);
+        }
+        drop(self.mtp_proposal_graph_blobs);
         if let Some(lc) = self.mtp_lm_logits_compressed {
             let _ = gpu.free_tensor(lc);
         }
+        let _ = gpu.free_tensor(self.mtp_topk_idx);
+        let _ = gpu.free_tensor(self.mtp_topk_logp);
+        let _ = gpu.free_tensor(self.mtp_sample_result);
+        let _ = gpu.free_tensor(self.mtp_sample_repeat_buf);
+        let _ = gpu.free_tensor(self.mtp_gather_idx_draft);
+        let _ = gpu.free_tensor(self.mtp_gather_prob_draft);
+        let _ = gpu.free_tensor(self.mtp_gather_idx_verify);
+        let _ = gpu.free_tensor(self.mtp_gather_prob_verify);
         // DeltaNetSnapshot's DeviceBuffers free on drop.
         drop(self.trunk_snap);
+        if let Some(event) = self.trunk_snap_start_event {
+            let _ = gpu.hip.event_destroy(event);
+        }
+        if let Some(stream) = self.trunk_snap_stream {
+            let _ = gpu.hip.stream_destroy(stream);
+        }
         self.trunk_pbs.free_gpu(gpu);
         self.trunk_gdn_tape.free_gpu(gpu);
         self.mtp_scratch.free_gpu(gpu);
@@ -579,6 +795,371 @@ pub struct MtpSpecResult {
     /// only set by [`spec_step_mtp_compressed_serial`]; other spec_step
     /// variants always replay and report `false`.
     pub replay_skipped: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GreedyTrunkSpineAccept {
+    committed: Vec<u32>,
+    accept_count: usize,
+    hit_eos: bool,
+}
+
+fn build_trunk_spine_verify_tokens(last_committed: u32, candidates: &[u32]) -> Vec<u32> {
+    let mut verify_tokens = Vec::with_capacity(candidates.len() + 1);
+    verify_tokens.push(last_committed);
+    verify_tokens.extend_from_slice(candidates);
+    verify_tokens
+}
+
+fn embed_device_token_into(
+    gpu: &mut Gpu,
+    weights: &Qwen35Weights,
+    out: &GpuTensor,
+    token_id: &GpuTensor,
+    dim: usize,
+) -> HipResult<()> {
+    match weights.embd_format {
+        llama::EmbeddingFormat::HFQ4G256 => {
+            gpu.embedding_lookup_hfq4g256_batched(&weights.token_embd, out, token_id, 1, dim)
+        }
+        llama::EmbeddingFormat::Q8_0 => {
+            gpu.embedding_lookup_q8_batched(&weights.token_embd, out, token_id, 1, dim)
+        }
+        other => panic!("device-token MTP chain does not support embedding format {other:?}"),
+    }
+}
+
+fn upload_mtp_proposal_graph_inputs(
+    gpu: &mut Gpu,
+    state: &MtpSpecState,
+    last_committed: u32,
+    cur_pos: usize,
+    max_n: usize,
+) -> HipResult<()> {
+    assert!(
+        cur_pos + max_n <= state.mtp_kv.max_seq,
+        "MTP proposal positions [{}..{}) exceed kv max_seq {}",
+        cur_pos,
+        cur_pos + max_n,
+        state.mtp_kv.max_seq,
+    );
+
+    let seed_token = last_committed as i32;
+    let seed_bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(&seed_token as *const i32 as *const u8, 4) };
+    gpu.hip.memcpy_htod(&state.mtp_token_chain.buf, seed_bytes)?;
+
+    let positions: Vec<i32> = (0..max_n).map(|k| (cur_pos + k) as i32).collect();
+    let pos_bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, max_n * 4) };
+    gpu.hip.memcpy_htod(&state.mtp_positions.buf, pos_bytes)
+}
+
+fn mtp_proposal_graph_seq_cap(cur_pos: usize, max_n: usize, kv_max_seq: usize) -> usize {
+    let needed = cur_pos + max_n;
+    needed.next_power_of_two().max(256).min(kv_max_seq)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_mtp_proposal_graph_body_q8(
+    gpu: &mut Gpu,
+    target: &ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    cur_pos: usize,
+    max_n: usize,
+    dim: usize,
+    cvs: usize,
+    seq_cap: usize,
+) -> HipResult<()> {
+    debug_assert_eq!(state.mtp_kv.kv_mode, crate::mtp_head::MtpKvMode::Q8);
+    let dim_bytes = dim * 4;
+    let logits_c = state
+        .mtp_scratch
+        .logits_compressed
+        .as_ref()
+        .expect("proposal graph requires compressed logits scratch");
+    let vocab_map_gpu = head
+        .weights
+        .lm_head_draft_vocab_map_gpu
+        .as_ref()
+        .expect("proposal graph requires GPU vocab_map");
+    let argmax_view = state.mtp_lm_argmax.sub_offset(0, 1);
+
+    for k in 0..max_n {
+        let token_slot = state.mtp_token_chain.sub_offset(k, 1);
+        embed_device_token_into(gpu, &target.weights, &state.mtp_token_embed, &token_slot, dim)?;
+
+        let pos_slot = state.mtp_positions.sub_offset(k, 1);
+        if k == 0 {
+            mtp_head::mtp_head_forward_block_only_with_pos_buf(
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                0,
+                &state.prev_hidden,
+                Some(&state.mtp_token_embed),
+                &pos_slot.buf,
+                cur_pos + k,
+                seq_cap,
+                &target.weights,
+            )?;
+        } else {
+            let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+            mtp_head::mtp_head_forward_block_only_with_pos_buf(
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                0,
+                &prev_row,
+                Some(&state.mtp_token_embed),
+                &pos_slot.buf,
+                cur_pos + k,
+                seq_cap,
+                &target.weights,
+            )?;
+        }
+        mtp_head::mtp_head_apply_lm_head_draft(gpu, head, &state.mtp_scratch)?;
+        gpu.argmax_token_chain_f32(
+            logits_c,
+            &argmax_view,
+            &state.mtp_token_chain,
+            Some(vocab_map_gpu),
+            cvs,
+            k + 1,
+        )?;
+
+        if k + 1 < max_n {
+            gpu.memcpy_dtod_at_auto(
+                &state.mtp_t_outs.buf,
+                k * dim_bytes,
+                &state.mtp_scratch.t_mtp_out.buf,
+                0,
+                dim_bytes,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn begin_mtp_proposal_graph_capture(gpu: &mut Gpu) -> HipResult<()> {
+    gpu.capture_blobs.clear();
+    gpu.capture_mode = true;
+    let stream = gpu
+        .active_stream
+        .as_ref()
+        .expect("proposal graph capture requires an explicit stream");
+    gpu.hip.stream_begin_capture(stream, 0)
+}
+
+fn end_mtp_proposal_graph_capture(
+    gpu: &mut Gpu,
+) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
+    gpu.capture_mode = false;
+    let stream = gpu.active_stream.as_ref().unwrap();
+    let graph = gpu.hip.stream_end_capture(stream)?;
+    let exec = gpu.hip.graph_instantiate(&graph)?;
+    let blobs = std::mem::take(&mut gpu.capture_blobs);
+    Ok((graph, exec, blobs))
+}
+
+fn abort_mtp_proposal_graph_capture(gpu: &mut Gpu) {
+    if gpu.capture_mode {
+        if let Some(stream) = gpu.active_stream.as_ref() {
+            let _ = gpu.hip.stream_end_capture(stream);
+        }
+        gpu.capture_mode = false;
+    }
+    gpu.capture_blobs.clear();
+}
+
+fn destroy_mtp_proposal_graph(gpu: &mut Gpu, state: &mut MtpSpecState) {
+    if let Some(exec) = state.mtp_proposal_graph_exec.take() {
+        let _ = gpu.hip.graph_exec_destroy(exec);
+    }
+    if let Some(graph) = state.mtp_proposal_graph.take() {
+        let _ = gpu.hip.graph_destroy(graph);
+    }
+    state.mtp_proposal_graph_blobs.clear();
+    state.mtp_proposal_graph_seq_cap = 0;
+}
+
+fn greedy_trunk_spine_accept(
+    candidates: &[u32],
+    argmax_per_pos: &[u32],
+    eos_token_id: u32,
+) -> GreedyTrunkSpineAccept {
+    assert!(
+        argmax_per_pos.len() >= candidates.len() + 1,
+        "greedy_trunk_spine_accept: need at least candidates+1 argmax rows \
+         (got {}, candidates={})",
+        argmax_per_pos.len(),
+        candidates.len(),
+    );
+
+    let mut accept_count = 0usize;
+    let mut hit_eos = false;
+    let mut committed: Vec<u32> = Vec::with_capacity(candidates.len() + 1);
+
+    for (k, &candidate) in candidates.iter().enumerate() {
+        if argmax_per_pos[k] == candidate {
+            committed.push(candidate);
+            accept_count += 1;
+            if candidate == eos_token_id {
+                hit_eos = true;
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    if !hit_eos {
+        let bonus = argmax_per_pos[accept_count];
+        committed.push(bonus);
+        if bonus == eos_token_id {
+            hit_eos = true;
+        }
+    }
+
+    GreedyTrunkSpineAccept {
+        committed,
+        accept_count,
+        hit_eos,
+    }
+}
+
+fn assemble_greedy_accept_from_gpu_result(
+    candidates: &[u32],
+    accept_count: usize,
+    bonus_token_or_no_bonus: i32,
+    eos_token_id: u32,
+) -> GreedyTrunkSpineAccept {
+    assert!(
+        accept_count <= candidates.len(),
+        "gpu greedy accept returned accept_count={} for {} candidates",
+        accept_count,
+        candidates.len()
+    );
+
+    let mut committed: Vec<u32> = Vec::with_capacity(candidates.len() + 1);
+    committed.extend_from_slice(&candidates[..accept_count]);
+
+    let hit_eos = if bonus_token_or_no_bonus < 0 {
+        assert!(
+            accept_count > 0 && candidates[accept_count - 1] == eos_token_id,
+            "gpu greedy accept returned no bonus without an accepted EOS"
+        );
+        true
+    } else {
+        let bonus = bonus_token_or_no_bonus as u32;
+        committed.push(bonus);
+        bonus == eos_token_id
+    };
+
+    GreedyTrunkSpineAccept {
+        committed,
+        accept_count,
+        hit_eos,
+    }
+}
+
+/// DS4-style Qwen MTP prefill fill.
+///
+/// Runs trunk prefill once while capturing post-output-norm hidden for every
+/// prompt token, then runs the MTP block-only path over those same prompt
+/// positions. The MTP layer enters decode with a warm private KV cache instead
+/// of starting at the first generated token.
+#[allow(clippy::too_many_arguments)]
+pub fn prefill_trunk_and_mtp_cache(
+    gpu: &mut Gpu,
+    target: &mut ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    prompt_tokens: &[u32],
+    start_pos: usize,
+) -> HipResult<()> {
+    if prompt_tokens.is_empty() {
+        return Ok(());
+    }
+
+    let dim = target.config.dim;
+    let dim_bytes = dim * 4;
+    let prompt_hidden = gpu.alloc_tensor(&[prompt_tokens.len() * dim], DType::F32)?;
+
+    let result = (|| -> HipResult<()> {
+        qwen35::forward_prefill_batch(
+            gpu,
+            &target.weights,
+            &target.config,
+            prompt_tokens,
+            start_pos,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            None,
+            Some(&prompt_hidden),
+            None,
+            None,
+        )?;
+
+        for (i, &token) in prompt_tokens.iter().enumerate() {
+            let hidden_row = prompt_hidden.sub_offset(i * dim, dim);
+            mtp_head::mtp_head_forward_block_only(
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                token,
+                &hidden_row,
+                None,
+                start_pos + i,
+                &target.weights,
+            )?;
+        }
+
+        let last = prompt_tokens.len() - 1;
+        gpu.hip.memcpy_dtod_at(
+            &state.prev_hidden.buf,
+            0,
+            &prompt_hidden.buf,
+            last * dim_bytes,
+            dim_bytes,
+        )?;
+        Ok(())
+    })();
+
+    let _ = gpu.free_tensor(prompt_hidden);
+    result
+}
+
+/// Explicit DS4-shaped Qwen MTP spec step.
+///
+/// This is the discrete-token trunk spine: serial MTP proposals, one trunk
+/// batched verify, greedy/sampling accept, then rollback/replay only when the
+/// full verify state cannot be kept. It intentionally delegates to the mature
+/// compressed-serial implementation, whose name describes the lm_head storage
+/// mode rather than the spine architecture.
+#[allow(clippy::too_many_arguments)]
+pub fn spec_step_mtp_trunk_spine(
+    gpu: &mut Gpu,
+    target: &mut ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    cur_pos: usize,
+    last_committed: u32,
+    eos_token_id: u32,
+) -> HipResult<MtpSpecResult> {
+    spec_step_mtp_compressed_serial(
+        gpu,
+        target,
+        head,
+        state,
+        cur_pos,
+        last_committed,
+        eos_token_id,
+    )
 }
 
 /// One MTP-only spec-decode cycle (greedy, temp=0).
@@ -703,9 +1284,9 @@ pub fn spec_step_mtp(
                 head,
                 &state.mtp_scratch,
                 &mut state.mtp_kv,
-                0,                  // sentinel: ignored when next_token_embed is Some(_)
-                &prev_row,          // prev_hidden = step k-1's t_mtp_out
-                Some(&prev_row),    // embed override = step k-1's t_mtp_out (lossy)
+                0,               // sentinel: ignored when next_token_embed is Some(_)
+                &prev_row,       // prev_hidden = step k-1's t_mtp_out
+                Some(&prev_row), // embed override = step k-1's t_mtp_out (lossy)
                 cur_pos + k,
                 trunk_weights,
             )?;
@@ -714,8 +1295,10 @@ pub fn spec_step_mtp(
         // next step can read it AND so the end-of-chain batched lm_head
         // can ingest the whole stack.
         gpu.hip.memcpy_dtod_at(
-            &state.mtp_t_outs.buf, k * dim_bytes,
-            &state.mtp_scratch.t_mtp_out.buf, 0,
+            &state.mtp_t_outs.buf,
+            k * dim_bytes,
+            &state.mtp_scratch.t_mtp_out.buf,
+            0,
             dim_bytes,
         )?;
     }
@@ -746,9 +1329,7 @@ pub fn spec_step_mtp(
     let mut argmax_host: Vec<i32> = vec![0; max_n];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_host.as_mut_ptr() as *mut u8, max_n * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, max_n * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &lm_argmax_view.buf)?;
     }
@@ -768,7 +1349,7 @@ pub fn spec_step_mtp(
     // `forward_prefill_batch_with_pbs` writes per-position post-output-norm
     // hidden into `state.verify_hidden` when per_token_hidden_out is Some.
     // Trunk KV cache and dn_state advance by max_n+1 (= verify_tokens.len()).
-    qwen35::forward_prefill_batch_with_pbs(
+    qwen35::forward_prefill_batch_with_pbs_opts(
         gpu,
         trunk_weights,
         &target.config,
@@ -784,6 +1365,7 @@ pub fn spec_step_mtp(
         Some(&state.trunk_pbs),
         None, // mask_override
         None, // max_layer
+        false, // MTP computes all verify logits from verify_hidden below
     )?;
 
     // ── 5. Per-position lm_head + batched argmax ─────────────────────────
@@ -796,43 +1378,101 @@ pub fn spec_step_mtp(
     let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
     match w_out.gpu_dtype {
         DType::Q8_0 => {
-            // gemm_q8_0_batched supports up to 64 rows in one launch.
-            gpu.gemm_q8_0_batched(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
-            )?;
+            if mtp_q8_verify_wmma_enabled_from_env() {
+                gpu.gemm_q8_0_batched_chunked(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            } else {
+                gpu.gemm_q8_0_batched(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ4G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ3G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ6G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         _ => {
@@ -851,9 +1491,7 @@ pub fn spec_step_mtp(
     let mut argmax_host: Vec<i32> = vec![0; n_verify];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_host.as_mut_ptr() as *mut u8, n_verify * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, n_verify * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
     }
@@ -935,7 +1573,10 @@ pub fn spec_step_mtp(
             &mut target.kv_cache,
             &mut target.dn_state,
             &target.scratch,
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )?;
     } else {
         // advance == 1: only the seed (last_committed) is "replayed". This
@@ -1017,19 +1658,29 @@ pub fn spec_step_mtp_compressed(
 
     // Precondition: head must have compressed sidecar loaded + caller must
     // have allocated the compressed batched-logits scratch.
-    let lm_head_draft = head.weights.lm_head_draft.as_ref()
+    let lm_head_draft = head
+        .weights
+        .lm_head_draft
+        .as_ref()
         .expect("spec_step_mtp_compressed requires head loaded with --vocab-sidecar");
-    let vocab_map = head.weights.lm_head_draft_vocab_map.as_ref()
+    let vocab_map = head
+        .weights
+        .lm_head_draft_vocab_map
+        .as_ref()
         .expect("compressed head missing vocab_map");
-    let cvs = head.weights.compressed_vocab_size
+    let cvs = head
+        .weights
+        .compressed_vocab_size
         .expect("compressed head missing compressed_vocab_size");
-    let logits_c_batched = state.mtp_lm_logits_compressed.as_ref()
-        .expect("MtpSpecState::mtp_lm_logits_compressed not allocated; \
-                 call ensure_compressed_lm_logits(gpu, cvs) after head load");
+    let logits_c_batched = state.mtp_lm_logits_compressed.as_ref().expect(
+        "MtpSpecState::mtp_lm_logits_compressed not allocated; \
+                 call ensure_compressed_lm_logits(gpu, cvs) after head load",
+    );
     assert!(
         logits_c_batched.numel() >= max_n * cvs,
         "mtp_lm_logits_compressed too small: {} < max_n*cvs ({})",
-        logits_c_batched.numel(), max_n * cvs,
+        logits_c_batched.numel(),
+        max_n * cvs,
     );
 
     if gpu.active_stream.is_none() {
@@ -1053,24 +1704,35 @@ pub fn spec_step_mtp_compressed(
     for k in 0..max_n {
         if k == 0 {
             mtp_head::mtp_head_forward_block_only(
-                gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                last_committed, &state.prev_hidden, None, cur_pos + k,
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                last_committed,
+                &state.prev_hidden,
+                None,
+                cur_pos + k,
                 trunk_weights,
             )?;
         } else {
             let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
             mtp_head::mtp_head_forward_block_only(
-                gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                0,                  // ignored when next_token_embed = Some
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                0, // ignored when next_token_embed = Some
                 &prev_row,
-                Some(&prev_row),    // lossy embed override
+                Some(&prev_row), // lossy embed override
                 cur_pos + k,
                 trunk_weights,
             )?;
         }
         gpu.hip.memcpy_dtod_at(
-            &state.mtp_t_outs.buf, k * dim_bytes,
-            &state.mtp_scratch.t_mtp_out.buf, 0,
+            &state.mtp_t_outs.buf,
+            k * dim_bytes,
+            &state.mtp_scratch.t_mtp_out.buf,
+            0,
             dim_bytes,
         )?;
     }
@@ -1085,8 +1747,13 @@ pub fn spec_step_mtp_compressed(
     let lm_rot_view = state.mtp_lm_rot.sub_offset(0, max_n * dim);
     let lm_logits_view = logits_c_batched.sub_offset(0, max_n * cvs);
     mtp_head::mtp_head_apply_lm_head_batched(
-        gpu, head, lm_head_draft,
-        &t_outs_view, &lm_tmp_view, &lm_rot_view, &lm_logits_view,
+        gpu,
+        head,
+        lm_head_draft,
+        &t_outs_view,
+        &lm_tmp_view,
+        &lm_rot_view,
+        &lm_logits_view,
         max_n,
     )?;
 
@@ -1096,9 +1763,7 @@ pub fn spec_step_mtp_compressed(
     let mut argmax_host: Vec<i32> = vec![0; max_n];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_host.as_mut_ptr() as *mut u8, max_n * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, max_n * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &lm_argmax_view.buf)?;
     }
@@ -1113,14 +1778,12 @@ pub fn spec_step_mtp_compressed(
     }
 
     // ── 2. Trunk verify on [last_committed, c1, ..., c_max_n] ─────────────
-    let mut verify_tokens: Vec<u32> = Vec::with_capacity(max_n + 1);
-    verify_tokens.push(last_committed);
-    verify_tokens.extend_from_slice(&candidates);
+    let verify_tokens = build_trunk_spine_verify_tokens(last_committed, &candidates);
     let n_verify = verify_tokens.len();
 
     state.trunk_snap.save_from(&target.dn_state, gpu)?;
 
-    qwen35::forward_prefill_batch_with_pbs(
+    qwen35::forward_prefill_batch_with_pbs_opts(
         gpu,
         trunk_weights,
         &target.config,
@@ -1136,6 +1799,7 @@ pub fn spec_step_mtp_compressed(
         Some(&state.trunk_pbs),
         None, // mask_override
         None, // max_layer
+        false, // MTP computes all verify logits from verify_hidden below
     )?;
 
     // ── 3. Trunk batched lm_head over verify positions ─────────────────────
@@ -1143,42 +1807,101 @@ pub fn spec_step_mtp_compressed(
     let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
     match w_out.gpu_dtype {
         DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
-            )?;
+            if mtp_q8_verify_wmma_enabled_from_env() {
+                gpu.gemm_q8_0_batched_chunked(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            } else {
+                gpu.gemm_q8_0_batched(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ4G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ3G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ6G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         _ => {
@@ -1195,9 +1918,7 @@ pub fn spec_step_mtp_compressed(
     let mut argmax_v_host: Vec<i32> = vec![0; n_verify];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_v_host.as_mut_ptr() as *mut u8, n_verify * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_v_host.as_mut_ptr() as *mut u8, n_verify * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
     }
@@ -1246,7 +1967,10 @@ pub fn spec_step_mtp_compressed(
             &mut target.kv_cache,
             &mut target.dn_state,
             &target.scratch,
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )?;
     } else {
         qwen35::forward_scratch(
@@ -1332,20 +2056,44 @@ pub fn spec_step_mtp_compressed_serial(
     let (vocab_map_opt, cvs): (Option<&Vec<u32>>, usize) = if use_full_vocab {
         (None, vocab)
     } else {
-        let _ = head.weights.lm_head_draft.as_ref()
+        let _ = head
+            .weights
+            .lm_head_draft
+            .as_ref()
             .expect("compressed head missing lm_head_draft");
-        let vm = head.weights.lm_head_draft_vocab_map.as_ref()
+        let vm = head
+            .weights
+            .lm_head_draft_vocab_map
+            .as_ref()
             .expect("compressed head missing vocab_map");
-        let c = head.weights.compressed_vocab_size
+        let c = head
+            .weights
+            .compressed_vocab_size
             .expect("compressed head missing compressed_vocab_size");
-        let _ = state.mtp_scratch.logits_compressed.as_ref()
-            .expect("Qwen35MtpHeadScratch::logits_compressed not allocated; \
-                     call mtp_scratch.ensure_compressed_logits(gpu, cvs) after head load");
+        let _ = state.mtp_scratch.logits_compressed.as_ref().expect(
+            "Qwen35MtpHeadScratch::logits_compressed not allocated; \
+                     call mtp_scratch.ensure_compressed_logits(gpu, cvs) after head load",
+        );
         (Some(vm), c)
     };
 
     if gpu.active_stream.is_none() {
         gpu.active_stream = Some(gpu.hip.stream_create()?);
+    }
+    let overlap_trunk_snap = mtp_snapshot_overlap_enabled_from_env()
+        && state.trunk_snap_stream.is_some()
+        && state.trunk_snap_start_event.is_some();
+    if overlap_trunk_snap {
+        let snap_event = state.trunk_snap_start_event.as_ref().unwrap();
+        let snap_stream = state.trunk_snap_stream.as_ref().unwrap();
+        {
+            let active_stream = gpu.active_stream.as_ref().unwrap();
+            gpu.hip.event_record(snap_event, Some(active_stream))?;
+            gpu.hip.stream_wait_event(snap_stream, snap_event)?;
+        }
+        state
+            .trunk_snap
+            .save_from_async_on(&target.dn_state, gpu, snap_stream)?;
     }
 
     let dim_bytes = dim * 4;
@@ -1368,7 +2116,11 @@ pub fn spec_step_mtp_compressed_serial(
     // verify, but we stop spending compute speculating further.
     let p_min = state.p_min;
     let use_p_min = p_min > 0.0;
-    let log_p_min = if use_p_min { p_min.ln() } else { f32::NEG_INFINITY };
+    let log_p_min = if use_p_min {
+        p_min.ln()
+    } else {
+        f32::NEG_INFINITY
+    };
     let mut chain_truncated = false;
 
     // Sampling vs greedy: when sampling.temp > 0, K-chain SAMPLES from each
@@ -1392,16 +2144,122 @@ pub fn spec_step_mtp_compressed_serial(
     // Cached host buffer for per-step draft logits readback (sampling only).
     // Sized to whichever vocab the dispatch path uses (compressed cvs or
     // full 248K vocab). Allocated once outside the loop.
-    let mut draft_logits_host: Vec<f32> = if use_sampling {
+    let draft_logits_host: Vec<f32> = if use_sampling {
         let n = if use_full_vocab { vocab } else { cvs };
         vec![0.0; n]
     } else {
         Vec::new()
     };
+    let use_device_token_chain = mtp_device_token_chain_enabled_from_env()
+        && mtp_device_token_chain_eligible_for(trunk_weights.embd_format, use_sampling, use_p_min);
+    if use_device_token_chain && !use_full_vocab {
+        assert!(
+            head.weights.lm_head_draft_vocab_map_gpu.is_some(),
+            "compressed MTP device-token chain requires GPU vocab_map"
+        );
+    }
+    let proposal_graph_policy = mtp_proposal_graph_policy_from_env();
+    let use_proposal_graph = !state.mtp_proposal_graph_disabled
+        && mtp_proposal_graph_eligible_for(
+            proposal_graph_policy,
+            use_device_token_chain,
+            use_full_vocab,
+            state.mtp_kv.kv_mode,
+        );
+    let proposal_graph_seq_cap = if use_proposal_graph {
+        mtp_proposal_graph_seq_cap(cur_pos, max_n, state.mtp_kv.max_seq)
+    } else {
+        0
+    };
+    if use_proposal_graph
+        && state.mtp_proposal_graph_exec.is_some()
+        && proposal_graph_seq_cap > state.mtp_proposal_graph_seq_cap
+    {
+        destroy_mtp_proposal_graph(gpu, state);
+        state.mtp_proposal_graph_warmed = true;
+    }
+    if use_device_token_chain {
+        if use_proposal_graph {
+            upload_mtp_proposal_graph_inputs(gpu, state, last_committed, cur_pos, max_n)?;
+        } else {
+            let seed_token = last_committed as i32;
+            let seed_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(&seed_token as *const i32 as *const u8, 4) };
+            gpu.hip
+                .memcpy_htod(&state.mtp_token_chain.buf, seed_bytes)?;
+        }
+    }
 
     // ── 1. K serial discrete-token roundtrips ─────────────────────────────
-    for k in 0..max_n {
-        let next_tok = if k == 0 { last_committed } else { candidates[k - 1] };
+    let mut proposal_graph_ran = false;
+    if use_proposal_graph {
+        if let Some(exec) = state.mtp_proposal_graph_exec.as_ref() {
+            let stream = gpu.active_stream.as_ref().unwrap();
+            gpu.hip.graph_launch(exec, stream)?;
+            proposal_graph_ran = true;
+        } else if state.mtp_proposal_graph_warmed {
+            let capture_result: HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> = (|| {
+                begin_mtp_proposal_graph_capture(gpu)?;
+                if let Err(e) =
+                    run_mtp_proposal_graph_body_q8(
+                        gpu,
+                        target,
+                        head,
+                        state,
+                        cur_pos,
+                        max_n,
+                        dim,
+                        cvs,
+                        proposal_graph_seq_cap,
+                    )
+                {
+                    abort_mtp_proposal_graph_capture(gpu);
+                    return Err(e);
+                }
+                end_mtp_proposal_graph_capture(gpu)
+            })();
+            match capture_result {
+                Ok((graph, exec, blobs)) => {
+                    state.mtp_proposal_graph = Some(graph);
+                    state.mtp_proposal_graph_exec = Some(exec);
+                    state.mtp_proposal_graph_blobs = blobs;
+                    state.mtp_proposal_graph_seq_cap = proposal_graph_seq_cap;
+                    let stream = gpu.active_stream.as_ref().unwrap();
+                    gpu.hip
+                        .graph_launch(state.mtp_proposal_graph_exec.as_ref().unwrap(), stream)?;
+                    proposal_graph_ran = true;
+                }
+                Err(e) if proposal_graph_policy == MtpProposalGraphPolicy::On => return Err(e),
+                Err(e) => {
+                    abort_mtp_proposal_graph_capture(gpu);
+                    state.mtp_proposal_graph_disabled = true;
+                    eprintln!(
+                        "[mtp-proposal-graph] disabled after capture failure: {}",
+                        e
+                    );
+                }
+            }
+        } else {
+            state.mtp_proposal_graph_warmed = true;
+        }
+    }
+
+    if !proposal_graph_ran {
+        for k in 0..max_n {
+        let next_tok = if use_device_token_chain {
+            0
+        } else if k == 0 {
+            last_committed
+        } else {
+            candidates[k - 1]
+        };
+        let next_token_embed = if use_device_token_chain {
+            let token_slot = state.mtp_token_chain.sub_offset(k, 1);
+            embed_device_token_into(gpu, trunk_weights, &state.mtp_token_embed, &token_slot, dim)?;
+            Some(&state.mtp_token_embed)
+        } else {
+            None
+        };
 
         // Forward: in compressed mode, mtp_head_forward_compressed runs
         // block_only + rmsnorm + small GEMV against lm_head_draft in one
@@ -1410,14 +2268,28 @@ pub fn spec_step_mtp_compressed_serial(
         if use_full_vocab {
             if k == 0 {
                 mtp_head::mtp_head_forward_block_only(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &state.prev_hidden, None, cur_pos + k, trunk_weights,
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    next_tok,
+                    &state.prev_hidden,
+                    next_token_embed,
+                    cur_pos + k,
+                    trunk_weights,
                 )?;
             } else {
                 let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
                 mtp_head::mtp_head_forward_block_only(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &prev_row, None, cur_pos + k, trunk_weights,
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    next_tok,
+                    &prev_row,
+                    next_token_embed,
+                    cur_pos + k,
+                    trunk_weights,
                 )?;
             }
             // rmsnorm(t_mtp_out, shared_head_norm) → tmp, then trunk lm_head
@@ -1436,17 +2308,57 @@ pub fn spec_step_mtp_compressed_serial(
                 &state.mtp_scratch.tmp,
                 &full_vocab_logits_view,
             )?;
+        } else if use_device_token_chain {
+            if k == 0 {
+                mtp_head::mtp_head_forward_block_only(
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    next_tok,
+                    &state.prev_hidden,
+                    next_token_embed,
+                    cur_pos + k,
+                    trunk_weights,
+                )?;
+            } else {
+                let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                mtp_head::mtp_head_forward_block_only(
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    next_tok,
+                    &prev_row,
+                    next_token_embed,
+                    cur_pos + k,
+                    trunk_weights,
+                )?;
+            }
+            mtp_head::mtp_head_apply_lm_head_draft(gpu, head, &state.mtp_scratch)?;
         } else {
             if k == 0 {
                 mtp_head::mtp_head_forward_compressed(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &state.prev_hidden, cur_pos + k, trunk_weights,
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    next_tok,
+                    &state.prev_hidden,
+                    cur_pos + k,
+                    trunk_weights,
                 )?;
             } else {
                 let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
                 mtp_head::mtp_head_forward_compressed(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &prev_row, cur_pos + k, trunk_weights,
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    next_tok,
+                    &prev_row,
+                    cur_pos + k,
+                    trunk_weights,
                 )?;
             }
         }
@@ -1457,7 +2369,7 @@ pub fn spec_step_mtp_compressed_serial(
         } else {
             state.mtp_scratch.logits_compressed.as_ref().unwrap()
         };
-        let argmax_vocab = cvs;  // = full vocab in full-vocab mode, = compressed vocab in compressed mode
+        let argmax_vocab = cvs; // = full vocab in full-vocab mode, = compressed vocab in compressed mode
 
         let draft_idx: usize;
         if use_sampling {
@@ -1482,17 +2394,19 @@ pub fn spec_step_mtp_compressed_serial(
             )?;
             state.gpu_rng_state = new_rng;
             draft_idx = token_u32 as usize;
-            assert!(draft_idx < argmax_vocab,
-                "draft sample {draft_idx} out of argmax_vocab {argmax_vocab}");
+            assert!(
+                draft_idx < argmax_vocab,
+                "draft sample {draft_idx} out of argmax_vocab {argmax_vocab}"
+            );
 
             // GPU p_draft gather: H2D the sampled token id, run the gather
             // kernel with n_rows=1, D2H 4 B prob. Replaces the host
             // softmax_prob_at_temp call (~600 μs).
             let token_i32: i32 = token_u32 as i32;
-            let idx_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(&token_i32 as *const i32 as *const u8, 4)
-            };
-            gpu.hip.memcpy_htod(&state.mtp_gather_idx_draft.buf, idx_bytes)?;
+            let idx_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(&token_i32 as *const i32 as *const u8, 4) };
+            gpu.hip
+                .memcpy_htod(&state.mtp_gather_idx_draft.buf, idx_bytes)?;
             gpu.softmax_prob_gather_batched_f32(
                 logits_for_argmax,
                 &state.mtp_gather_idx_draft,
@@ -1506,7 +2420,8 @@ pub fn spec_step_mtp_compressed_serial(
                 let bytes: &mut [u8] = unsafe {
                     std::slice::from_raw_parts_mut(p_draft_host.as_mut_ptr() as *mut u8, 4)
                 };
-                gpu.hip.memcpy_dtoh(bytes, &state.mtp_gather_prob_draft.buf)?;
+                gpu.hip
+                    .memcpy_dtoh(bytes, &state.mtp_gather_prob_draft.buf)?;
             }
             draft_probs.push(p_draft_host[0]);
 
@@ -1522,24 +2437,28 @@ pub fn spec_step_mtp_compressed_serial(
         } else if use_p_min {
             // Top-2 with log-softmax probs: 8 B idx + 8 B logp D2H per step.
             gpu.topk_logsumexp_batched_f32(
-                logits_for_argmax, &state.mtp_topk_idx, &state.mtp_topk_logp,
-                argmax_vocab, /* k */ 2, /* b */ 1,
+                logits_for_argmax,
+                &state.mtp_topk_idx,
+                &state.mtp_topk_logp,
+                argmax_vocab,
+                /* k */ 2,
+                /* b */ 1,
             )?;
             let mut idx_host: [i32; 2] = [0, 0];
             let mut logp_host: [f32; 2] = [0.0, 0.0];
             {
-                let idx_bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, 8)
-                };
+                let idx_bytes: &mut [u8] =
+                    unsafe { std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, 8) };
                 gpu.hip.memcpy_dtoh(idx_bytes, &state.mtp_topk_idx.buf)?;
-                let logp_bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(logp_host.as_mut_ptr() as *mut u8, 8)
-                };
+                let logp_bytes: &mut [u8] =
+                    unsafe { std::slice::from_raw_parts_mut(logp_host.as_mut_ptr() as *mut u8, 8) };
                 gpu.hip.memcpy_dtoh(logp_bytes, &state.mtp_topk_logp.buf)?;
             }
             draft_idx = idx_host[0] as usize;
-            assert!(draft_idx < argmax_vocab,
-                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}");
+            assert!(
+                draft_idx < argmax_vocab,
+                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
+            );
             // Compressed: remap via vocab_map. Full-vocab: idx IS the token id.
             let token_id = match vocab_map_opt {
                 Some(vm) => vm[draft_idx],
@@ -1553,20 +2472,34 @@ pub fn spec_step_mtp_compressed_serial(
                 chain_truncated = true;
                 break;
             }
+        } else if use_device_token_chain {
+            let vocab_map_gpu = if use_full_vocab {
+                None
+            } else {
+                head.weights.lm_head_draft_vocab_map_gpu.as_ref()
+            };
+            gpu.argmax_token_chain_f32(
+                logits_for_argmax,
+                &argmax_view,
+                &state.mtp_token_chain,
+                vocab_map_gpu,
+                argmax_vocab,
+                k + 1,
+            )?;
         } else {
             gpu.argmax_f32_batched(logits_for_argmax, &argmax_view, argmax_vocab, 1)?;
             let mut argmax_host: [i32; 1] = [0];
             {
                 let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        argmax_host.as_mut_ptr() as *mut u8, 4,
-                    )
+                    std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, 4)
                 };
                 gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
             }
             draft_idx = argmax_host[0] as usize;
-            assert!(draft_idx < argmax_vocab,
-                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}");
+            assert!(
+                draft_idx < argmax_vocab,
+                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
+            );
             let token_id = match vocab_map_opt {
                 Some(vm) => vm[draft_idx],
                 None => draft_idx as u32,
@@ -1575,14 +2508,34 @@ pub fn spec_step_mtp_compressed_serial(
         }
 
         if k + 1 < max_n {
-            gpu.hip.memcpy_dtod_at(
-                &state.mtp_t_outs.buf, k * dim_bytes,
-                &state.mtp_scratch.t_mtp_out.buf, 0,
+            gpu.memcpy_dtod_at_auto(
+                &state.mtp_t_outs.buf,
+                k * dim_bytes,
+                &state.mtp_scratch.t_mtp_out.buf,
+                0,
                 dim_bytes,
             )?;
         }
+        }
     }
-    let drafts_generated = candidates.len();
+    let drafts_generated = if use_device_token_chain {
+        debug_assert!(
+            !use_sampling && !use_p_min,
+            "device-token chain assumes an untruncated greedy chain"
+        );
+        let candidate_view = state.mtp_token_chain.sub_offset(1, max_n);
+        let mut candidate_host: Vec<i32> = vec![0; max_n];
+        {
+            let bytes: &mut [u8] = unsafe {
+                std::slice::from_raw_parts_mut(candidate_host.as_mut_ptr() as *mut u8, max_n * 4)
+            };
+            gpu.hip.memcpy_dtoh(bytes, &candidate_view.buf)?;
+        }
+        candidates.extend(candidate_host.into_iter().map(|t| t as u32));
+        max_n
+    } else {
+        candidates.len()
+    };
 
     // ── 2. Trunk verify ───────────────────────────────────────────────────
     let mut verify_tokens: Vec<u32> = Vec::with_capacity(max_n + 1);
@@ -1590,7 +2543,12 @@ pub fn spec_step_mtp_compressed_serial(
     verify_tokens.extend_from_slice(&candidates);
     let n_verify = verify_tokens.len();
 
-    state.trunk_snap.save_from(&target.dn_state, gpu)?;
+    if overlap_trunk_snap {
+        gpu.hip
+            .stream_synchronize(state.trunk_snap_stream.as_ref().unwrap())?;
+    } else {
+        state.trunk_snap.save_from(&target.dn_state, gpu)?;
+    }
 
     // GDN-tape capture happens only when the verify takes the batched (PBS)
     // path; otherwise the forward silently drops to a tape-less per-token loop
@@ -1616,54 +2574,124 @@ pub fn spec_step_mtp_compressed_serial(
         None
     };
 
-    qwen35::forward_prefill_batch_with_pbs(
-        gpu, trunk_weights, &target.config, &verify_tokens, cur_pos,
-        &mut target.kv_cache, &mut target.dn_state, &target.scratch,
-        None, Some(&state.verify_hidden), verify_tape, None,
-        Some(&state.trunk_pbs), None, // mask_override
+    qwen35::forward_prefill_batch_with_pbs_opts(
+        gpu,
+        trunk_weights,
+        &target.config,
+        &verify_tokens,
+        cur_pos,
+        &mut target.kv_cache,
+        &mut target.dn_state,
+        &target.scratch,
+        None,
+        Some(&state.verify_hidden),
+        verify_tape,
+        None,
+        Some(&state.trunk_pbs),
+        None, // mask_override
         None, // max_layer
+        false, // MTP computes all verify logits from verify_hidden below
     )?;
 
     let w_out = &trunk_weights.output;
     let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
     match w_out.gpu_dtype {
         DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
-            )?;
+            if mtp_q8_verify_wmma_enabled_from_env() {
+                gpu.gemm_q8_0_batched_chunked(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            } else {
+                gpu.gemm_q8_0_batched(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ4G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ3G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ6G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         _ => {
@@ -1674,19 +2702,6 @@ pub fn spec_step_mtp_compressed_serial(
             }
         }
     }
-
-    let argmax_v = state.verify_argmax.sub_offset(0, n_verify);
-    gpu.argmax_f32_batched(&logits_view, &argmax_v, vocab, n_verify)?;
-    let mut argmax_v_host: Vec<i32> = vec![0; n_verify];
-    {
-        let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_v_host.as_mut_ptr() as *mut u8, n_verify * 4,
-            )
-        };
-        gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
-    }
-    let argmax_per_pos: Vec<u32> = argmax_v_host.into_iter().map(|x| x as u32).collect();
 
     let mut accept_count = 0usize;
     let mut hit_eos = false;
@@ -1723,14 +2738,14 @@ pub fn spec_step_mtp_compressed_serial(
         // dispatch the gather kernel, D2H K probs. Replaces the 6 MB D2H
         // of full verify_logits + K host softmax_prob_at_temp calls.
         let cand_indices: Vec<i32> = candidates[..drafts_generated]
-            .iter().map(|&t| t as i32).collect();
+            .iter()
+            .map(|&t| t as i32)
+            .collect();
         let idx_bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(
-                cand_indices.as_ptr() as *const u8,
-                drafts_generated * 4,
-            )
+            std::slice::from_raw_parts(cand_indices.as_ptr() as *const u8, drafts_generated * 4)
         };
-        gpu.hip.memcpy_htod(&state.mtp_gather_idx_verify.buf, idx_bytes)?;
+        gpu.hip
+            .memcpy_htod(&state.mtp_gather_idx_verify.buf, idx_bytes)?;
         gpu.softmax_prob_gather_batched_f32(
             &logits_view,
             &state.mtp_gather_idx_verify,
@@ -1747,7 +2762,8 @@ pub fn spec_step_mtp_compressed_serial(
                     drafts_generated * 4,
                 )
             };
-            gpu.hip.memcpy_dtoh(bytes, &state.mtp_gather_prob_verify.buf)?;
+            gpu.hip
+                .memcpy_dtoh(bytes, &state.mtp_gather_prob_verify.buf)?;
         }
 
         for k in 0..drafts_generated {
@@ -1791,25 +2807,56 @@ pub fn spec_step_mtp_compressed_serial(
         }
     } else {
         // ── Legacy greedy / argmax-match accept rule ─────────────────────
-        for k in 0..drafts_generated {
-            if argmax_per_pos[k] == candidates[k] {
-                committed.push(candidates[k]);
-                accept_count += 1;
-                if candidates[k] == eos_token_id {
-                    hit_eos = true;
-                    break;
-                }
-            } else {
-                break;
+        let argmax_v = state.verify_argmax.sub_offset(0, n_verify);
+        gpu.argmax_f32_batched(&logits_view, &argmax_v, vocab, n_verify)?;
+
+        let use_gpu_accept =
+            use_device_token_chain && mtp_gpu_greedy_accept_enabled_from_env();
+        let accepted = if use_gpu_accept {
+            let candidate_device = state.mtp_token_chain.sub_offset(1, drafts_generated);
+            let accept_result = state.verify_argmax.sub_offset(0, 2);
+            gpu.greedy_accept_from_argmax_i32(
+                &argmax_v,
+                &candidate_device,
+                &accept_result,
+                drafts_generated,
+                eos_token_id,
+            )?;
+            let mut accept_host: [i32; 2] = [0, 0];
+            {
+                let bytes: &mut [u8] = unsafe {
+                    std::slice::from_raw_parts_mut(accept_host.as_mut_ptr() as *mut u8, 8)
+                };
+                gpu.hip.memcpy_dtoh(bytes, &accept_result.buf)?;
             }
-        }
-        if !hit_eos {
-            let bonus = argmax_per_pos[accept_count];
-            committed.push(bonus);
-            if bonus == eos_token_id {
-                hit_eos = true;
+            assemble_greedy_accept_from_gpu_result(
+                &candidates[..drafts_generated],
+                accept_host[0] as usize,
+                accept_host[1],
+                eos_token_id,
+            )
+        } else {
+            let mut argmax_v_host: Vec<i32> = vec![0; n_verify];
+            {
+                let bytes: &mut [u8] = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        argmax_v_host.as_mut_ptr() as *mut u8,
+                        n_verify * 4,
+                    )
+                };
+                gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
             }
-        }
+            let argmax_per_pos: Vec<u32> =
+                argmax_v_host.into_iter().map(|x| x as u32).collect();
+            greedy_trunk_spine_accept(
+                &candidates[..drafts_generated],
+                &argmax_per_pos,
+                eos_token_id,
+            )
+        };
+        committed = accepted.committed;
+        accept_count = accepted.accept_count;
+        hit_eos = accepted.hit_eos;
     }
 
     let advance = committed.len();
@@ -1841,9 +2888,10 @@ pub fn spec_step_mtp_compressed_serial(
     // conv/GDN recurrence for the accepted prefix. Full trunk forward replay
     // was the dominant non-verify cost in the MTP cycle.
     //
-    // The trunk_snap.save_from() call earlier in the cycle is still made
-    // unconditionally (~1 ms, unavoidable since we don't know advance
-    // until verify completes); only the restore + tape replay are gated.
+    // The trunk_snap save is still made unconditionally (we don't know
+    // advance until verify completes). An opt-in side-stream path can start
+    // it before proposal and wait before verify; only the restore + tape
+    // replay are gated.
     //
     // On EOS we still take the replay branch: even though no further
     // forwards happen, the caller's KV cache must reflect ONLY the
@@ -1871,14 +2919,29 @@ pub fn spec_step_mtp_compressed_serial(
             if advance >= 2 {
                 let replay = &verify_tokens[..advance];
                 qwen35::forward_prefill_batch(
-                    gpu, trunk_weights, &target.config, replay, cur_pos,
-                    &mut target.kv_cache, &mut target.dn_state, &target.scratch,
-                    None, None, None, None,
+                    gpu,
+                    trunk_weights,
+                    &target.config,
+                    replay,
+                    cur_pos,
+                    &mut target.kv_cache,
+                    &mut target.dn_state,
+                    &target.scratch,
+                    None,
+                    None,
+                    None,
+                    None,
                 )?;
             } else {
                 qwen35::forward_scratch(
-                    gpu, trunk_weights, &target.config, verify_tokens[0], cur_pos,
-                    &mut target.kv_cache, &mut target.dn_state, &target.scratch,
+                    gpu,
+                    trunk_weights,
+                    &target.config,
+                    verify_tokens[0],
+                    cur_pos,
+                    &mut target.kv_cache,
+                    &mut target.dn_state,
+                    &target.scratch,
                 )?;
             }
         }
@@ -1893,4 +2956,152 @@ pub fn spec_step_mtp_compressed_serial(
         chain_truncated,
         replay_skipped,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trunk_spine_verify_tokens_are_seed_plus_candidates() {
+        let tokens = build_trunk_spine_verify_tokens(42, &[7, 8, 9]);
+
+        assert_eq!(tokens, vec![42, 7, 8, 9]);
+    }
+
+    #[test]
+    fn trunk_spine_accepts_longest_prefix_then_bonus() {
+        let accepted = greedy_trunk_spine_accept(&[11, 12, 13], &[11, 99, 55, 66], 2);
+
+        assert_eq!(accepted.committed, vec![11, 99]);
+        assert_eq!(accepted.accept_count, 1);
+        assert!(!accepted.hit_eos);
+    }
+
+    #[test]
+    fn trunk_spine_stops_without_bonus_when_accepted_candidate_is_eos() {
+        let accepted = greedy_trunk_spine_accept(&[11, 2, 13], &[11, 2, 55, 66], 2);
+
+        assert_eq!(accepted.committed, vec![11, 2]);
+        assert_eq!(accepted.accept_count, 2);
+        assert!(accepted.hit_eos);
+    }
+
+    #[test]
+    fn gpu_greedy_accept_result_matches_host_accept_semantics() {
+        let mismatch_bonus = assemble_greedy_accept_from_gpu_result(&[11, 12, 13], 1, 99, 2);
+        assert_eq!(mismatch_bonus.committed, vec![11, 99]);
+        assert_eq!(mismatch_bonus.accept_count, 1);
+        assert!(!mismatch_bonus.hit_eos);
+
+        let accepted_eos = assemble_greedy_accept_from_gpu_result(&[11, 2, 13], 2, -1, 2);
+        assert_eq!(accepted_eos.committed, vec![11, 2]);
+        assert_eq!(accepted_eos.accept_count, 2);
+        assert!(accepted_eos.hit_eos);
+
+        let bonus_eos = assemble_greedy_accept_from_gpu_result(&[11, 12, 13], 3, 2, 2);
+        assert_eq!(bonus_eos.committed, vec![11, 12, 13, 2]);
+        assert_eq!(bonus_eos.accept_count, 3);
+        assert!(bonus_eos.hit_eos);
+    }
+
+    #[test]
+    fn device_token_chain_is_greedy_only_and_embedding_gated() {
+        assert!(mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G256,
+            false,
+            false
+        ));
+        assert!(mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::Q8_0,
+            false,
+            false
+        ));
+        assert!(!mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G128,
+            false,
+            false
+        ));
+        assert!(!mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G256,
+            true,
+            false
+        ));
+        assert!(!mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G256,
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn proposal_graph_policy_is_opt_in_and_q8_device_chain_only() {
+        assert!(mtp_q8_verify_wmma_enabled_from_env_value(None));
+        assert!(!mtp_q8_verify_wmma_enabled_from_env_value(Some("0")));
+        assert!(!mtp_q8_verify_wmma_enabled_from_env_value(Some("off")));
+        assert!(mtp_q8_verify_wmma_enabled_from_env_value(Some("1")));
+        assert!(mtp_q8_verify_wmma_enabled_from_env_value(Some("ON")));
+
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(None),
+            MtpProposalGraphPolicy::Off
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("0")),
+            MtpProposalGraphPolicy::Off
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("off")),
+            MtpProposalGraphPolicy::Off
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("1")),
+            MtpProposalGraphPolicy::On
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("ON")),
+            MtpProposalGraphPolicy::On
+        );
+
+        assert!(mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            false,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            true,
+            true,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Asym3,
+        ));
+        assert!(mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::On,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Off,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+
+        assert_eq!(mtp_proposal_graph_seq_cap(27, 5, 4096), 256);
+        assert_eq!(mtp_proposal_graph_seq_cap(260, 5, 4096), 512);
+        assert_eq!(mtp_proposal_graph_seq_cap(3000, 5, 4096), 4096);
+    }
 }

--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -36,6 +36,7 @@ use crate::speculative::{DeltaNetSnapshot, GdnTape, ModelSlot};
 use hip_bridge::{Event, Graph, GraphExec, HipResult, Stream};
 use hipfire_runtime::llama;
 use rdna_compute::{DType, Gpu, GpuTensor};
+use std::time::Instant;
 
 // ─── Sampling primitives (host-side, used by temp>0 spec-decode path) ────
 
@@ -120,9 +121,7 @@ fn mtp_q8_verify_wmma_enabled_from_env() -> bool {
     // WMMA when the arch/shape supports it, otherwise it falls back to scalar.
     // Prompt-sweep parity is clean; opt out with HIPFIRE_MTP_Q8_VERIFY_WMMA=0.
     mtp_q8_verify_wmma_enabled_from_env_value(
-        std::env::var("HIPFIRE_MTP_Q8_VERIFY_WMMA")
-            .ok()
-            .as_deref(),
+        std::env::var("HIPFIRE_MTP_Q8_VERIFY_WMMA").ok().as_deref(),
     )
 }
 
@@ -546,8 +545,12 @@ impl MtpSpecState {
         let trunk_snap = DeltaNetSnapshot::new_for(gpu, &target.dn_state)?;
         // Snapshot overlap resources are construction-time only; set the env
         // before creating MtpSpecState when comparing the opt-in path.
-        let (trunk_snap_stream, trunk_snap_start_event) = if mtp_snapshot_overlap_enabled_from_env() {
-            (Some(gpu.hip.stream_create()?), Some(gpu.hip.event_create()?))
+        let (trunk_snap_stream, trunk_snap_start_event) = if mtp_snapshot_overlap_enabled_from_env()
+        {
+            (
+                Some(gpu.hip.stream_create()?),
+                Some(gpu.hip.event_create()?),
+            )
         } else {
             (None, None)
         };
@@ -847,7 +850,8 @@ fn upload_mtp_proposal_graph_inputs(
     let seed_token = last_committed as i32;
     let seed_bytes: &[u8] =
         unsafe { std::slice::from_raw_parts(&seed_token as *const i32 as *const u8, 4) };
-    gpu.hip.memcpy_htod(&state.mtp_token_chain.buf, seed_bytes)?;
+    gpu.hip
+        .memcpy_htod(&state.mtp_token_chain.buf, seed_bytes)?;
 
     let positions: Vec<i32> = (0..max_n).map(|k| (cur_pos + k) as i32).collect();
     let pos_bytes: &[u8] =
@@ -888,7 +892,13 @@ fn run_mtp_proposal_graph_body_q8(
 
     for k in 0..max_n {
         let token_slot = state.mtp_token_chain.sub_offset(k, 1);
-        embed_device_token_into(gpu, &target.weights, &state.mtp_token_embed, &token_slot, dim)?;
+        embed_device_token_into(
+            gpu,
+            &target.weights,
+            &state.mtp_token_embed,
+            &token_slot,
+            dim,
+        )?;
 
         let pos_slot = state.mtp_positions.sub_offset(k, 1);
         if k == 0 {
@@ -954,9 +964,7 @@ fn begin_mtp_proposal_graph_capture(gpu: &mut Gpu) -> HipResult<()> {
     gpu.hip.stream_begin_capture(stream, 0)
 }
 
-fn end_mtp_proposal_graph_capture(
-    gpu: &mut Gpu,
-) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
+fn end_mtp_proposal_graph_capture(gpu: &mut Gpu) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
     gpu.capture_mode = false;
     let stream = gpu.active_stream.as_ref().unwrap();
     let graph = gpu.hip.stream_end_capture(stream)?;
@@ -1071,6 +1079,12 @@ fn assemble_greedy_accept_from_gpu_result(
 /// prompt token, then runs the MTP block-only path over those same prompt
 /// positions. The MTP layer enters decode with a warm private KV cache instead
 /// of starting at the first generated token.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TrunkSpinePrefillTimings {
+    pub trunk_prefill_secs: f64,
+    pub mtp_prompt_fill_secs: f64,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn prefill_trunk_and_mtp_cache(
     gpu: &mut Gpu,
@@ -1079,16 +1093,17 @@ pub fn prefill_trunk_and_mtp_cache(
     state: &mut MtpSpecState,
     prompt_tokens: &[u32],
     start_pos: usize,
-) -> HipResult<()> {
+) -> HipResult<TrunkSpinePrefillTimings> {
     if prompt_tokens.is_empty() {
-        return Ok(());
+        return Ok(TrunkSpinePrefillTimings::default());
     }
 
     let dim = target.config.dim;
     let dim_bytes = dim * 4;
     let prompt_hidden = gpu.alloc_tensor(&[prompt_tokens.len() * dim], DType::F32)?;
 
-    let result = (|| -> HipResult<()> {
+    let result = (|| -> HipResult<TrunkSpinePrefillTimings> {
+        let t_trunk = Instant::now();
         qwen35::forward_prefill_batch(
             gpu,
             &target.weights,
@@ -1103,7 +1118,9 @@ pub fn prefill_trunk_and_mtp_cache(
             None,
             None,
         )?;
+        let trunk_prefill_secs = t_trunk.elapsed().as_secs_f64();
 
+        let t_mtp_fill = Instant::now();
         for (i, &token) in prompt_tokens.iter().enumerate() {
             let hidden_row = prompt_hidden.sub_offset(i * dim, dim);
             mtp_head::mtp_head_forward_block_only(
@@ -1127,7 +1144,11 @@ pub fn prefill_trunk_and_mtp_cache(
             last * dim_bytes,
             dim_bytes,
         )?;
-        Ok(())
+        let mtp_prompt_fill_secs = t_mtp_fill.elapsed().as_secs_f64();
+        Ok(TrunkSpinePrefillTimings {
+            trunk_prefill_secs,
+            mtp_prompt_fill_secs,
+        })
     })();
 
     let _ = gpu.free_tensor(prompt_hidden);
@@ -1363,8 +1384,8 @@ pub fn spec_step_mtp(
         None, // gdn_tape
         None, // tree_verify
         Some(&state.trunk_pbs),
-        None, // mask_override
-        None, // max_layer
+        None,  // mask_override
+        None,  // max_layer
         false, // MTP computes all verify logits from verify_hidden below
     )?;
 
@@ -1797,8 +1818,8 @@ pub fn spec_step_mtp_compressed(
         None,
         None,
         Some(&state.trunk_pbs),
-        None, // mask_override
-        None, // max_layer
+        None,  // mask_override
+        None,  // max_layer
         false, // MTP computes all verify logits from verify_hidden below
     )?;
 
@@ -2200,19 +2221,17 @@ pub fn spec_step_mtp_compressed_serial(
         } else if state.mtp_proposal_graph_warmed {
             let capture_result: HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> = (|| {
                 begin_mtp_proposal_graph_capture(gpu)?;
-                if let Err(e) =
-                    run_mtp_proposal_graph_body_q8(
-                        gpu,
-                        target,
-                        head,
-                        state,
-                        cur_pos,
-                        max_n,
-                        dim,
-                        cvs,
-                        proposal_graph_seq_cap,
-                    )
-                {
+                if let Err(e) = run_mtp_proposal_graph_body_q8(
+                    gpu,
+                    target,
+                    head,
+                    state,
+                    cur_pos,
+                    max_n,
+                    dim,
+                    cvs,
+                    proposal_graph_seq_cap,
+                ) {
                     abort_mtp_proposal_graph_capture(gpu);
                     return Err(e);
                 }
@@ -2233,10 +2252,7 @@ pub fn spec_step_mtp_compressed_serial(
                 Err(e) => {
                     abort_mtp_proposal_graph_capture(gpu);
                     state.mtp_proposal_graph_disabled = true;
-                    eprintln!(
-                        "[mtp-proposal-graph] disabled after capture failure: {}",
-                        e
-                    );
+                    eprintln!("[mtp-proposal-graph] disabled after capture failure: {}", e);
                 }
             }
         } else {
@@ -2246,276 +2262,284 @@ pub fn spec_step_mtp_compressed_serial(
 
     if !proposal_graph_ran {
         for k in 0..max_n {
-        let next_tok = if use_device_token_chain {
-            0
-        } else if k == 0 {
-            last_committed
-        } else {
-            candidates[k - 1]
-        };
-        let next_token_embed = if use_device_token_chain {
-            let token_slot = state.mtp_token_chain.sub_offset(k, 1);
-            embed_device_token_into(gpu, trunk_weights, &state.mtp_token_embed, &token_slot, dim)?;
-            Some(&state.mtp_token_embed)
-        } else {
-            None
-        };
-
-        // Forward: in compressed mode, mtp_head_forward_compressed runs
-        // block_only + rmsnorm + small GEMV against lm_head_draft in one
-        // call. In full-vocab mode we run block_only here and do the
-        // rmsnorm + trunk-lm_head GEMV manually below.
-        if use_full_vocab {
-            if k == 0 {
-                mtp_head::mtp_head_forward_block_only(
-                    gpu,
-                    head,
-                    &state.mtp_scratch,
-                    &mut state.mtp_kv,
-                    next_tok,
-                    &state.prev_hidden,
-                    next_token_embed,
-                    cur_pos + k,
-                    trunk_weights,
-                )?;
+            let next_tok = if use_device_token_chain {
+                0
+            } else if k == 0 {
+                last_committed
             } else {
-                let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
-                mtp_head::mtp_head_forward_block_only(
-                    gpu,
-                    head,
-                    &state.mtp_scratch,
-                    &mut state.mtp_kv,
-                    next_tok,
-                    &prev_row,
-                    next_token_embed,
-                    cur_pos + k,
-                    trunk_weights,
-                )?;
-            }
-            // rmsnorm(t_mtp_out, shared_head_norm) → tmp, then trunk lm_head
-            // GEMV → full_vocab_logits_view. weight_gemv dispatches the right
-            // kernel (gemv_mq4g256_with_rotate / gemv_q8_0 / etc.) on the
-            // trunk's output dtype.
-            gpu.rmsnorm_f32(
-                &state.mtp_scratch.t_mtp_out,
-                &head.weights.shared_head_norm,
-                &state.mtp_scratch.tmp,
-                head.config.rms_norm_eps,
-            )?;
-            llama::weight_gemv(
-                gpu,
-                &trunk_weights.output,
-                &state.mtp_scratch.tmp,
-                &full_vocab_logits_view,
-            )?;
-        } else if use_device_token_chain {
-            if k == 0 {
-                mtp_head::mtp_head_forward_block_only(
-                    gpu,
-                    head,
-                    &state.mtp_scratch,
-                    &mut state.mtp_kv,
-                    next_tok,
-                    &state.prev_hidden,
-                    next_token_embed,
-                    cur_pos + k,
-                    trunk_weights,
-                )?;
-            } else {
-                let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
-                mtp_head::mtp_head_forward_block_only(
-                    gpu,
-                    head,
-                    &state.mtp_scratch,
-                    &mut state.mtp_kv,
-                    next_tok,
-                    &prev_row,
-                    next_token_embed,
-                    cur_pos + k,
-                    trunk_weights,
-                )?;
-            }
-            mtp_head::mtp_head_apply_lm_head_draft(gpu, head, &state.mtp_scratch)?;
-        } else {
-            if k == 0 {
-                mtp_head::mtp_head_forward_compressed(
-                    gpu,
-                    head,
-                    &state.mtp_scratch,
-                    &mut state.mtp_kv,
-                    next_tok,
-                    &state.prev_hidden,
-                    cur_pos + k,
-                    trunk_weights,
-                )?;
-            } else {
-                let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
-                mtp_head::mtp_head_forward_compressed(
-                    gpu,
-                    head,
-                    &state.mtp_scratch,
-                    &mut state.mtp_kv,
-                    next_tok,
-                    &prev_row,
-                    cur_pos + k,
-                    trunk_weights,
-                )?;
-            }
-        }
-
-        // Pick the logits buffer to argmax over (mode-dependent).
-        let logits_for_argmax: &GpuTensor = if use_full_vocab {
-            &full_vocab_logits_view
-        } else {
-            state.mtp_scratch.logits_compressed.as_ref().unwrap()
-        };
-        let argmax_vocab = cvs; // = full vocab in full-vocab mode, = compressed vocab in compressed mode
-
-        let draft_idx: usize;
-        if use_sampling {
-            // GPU sample_top_p: kernel does the whole top_k(=20) + top_p +
-            // multinomial sample on-device. Returns 8 B (token id + new rng
-            // state). Eliminates the full 1 MB draft logits D2H + host
-            // softmax sample (~600 μs each step → ~3 ms/cycle saved).
-            //
-            // sample_top_p modifies logits in-place ONLY if repeat_penalty > 1
-            // and repeat_window > 0; we pass 1.0/0 so logits are untouched
-            // and the subsequent prob-gather sees the same values.
-            let (token_u32, new_rng) = gpu.sample_top_p(
-                logits_for_argmax,
-                &state.mtp_sample_result,
-                &state.mtp_sample_repeat_buf,
-                argmax_vocab,
-                sampling.temp,
-                sampling.top_p,
-                state.gpu_rng_state,
-                /* repeat_window */ 0,
-                /* repeat_penalty */ 1.0,
-            )?;
-            state.gpu_rng_state = new_rng;
-            draft_idx = token_u32 as usize;
-            assert!(
-                draft_idx < argmax_vocab,
-                "draft sample {draft_idx} out of argmax_vocab {argmax_vocab}"
-            );
-
-            // GPU p_draft gather: H2D the sampled token id, run the gather
-            // kernel with n_rows=1, D2H 4 B prob. Replaces the host
-            // softmax_prob_at_temp call (~600 μs).
-            let token_i32: i32 = token_u32 as i32;
-            let idx_bytes: &[u8] =
-                unsafe { std::slice::from_raw_parts(&token_i32 as *const i32 as *const u8, 4) };
-            gpu.hip
-                .memcpy_htod(&state.mtp_gather_idx_draft.buf, idx_bytes)?;
-            gpu.softmax_prob_gather_batched_f32(
-                logits_for_argmax,
-                &state.mtp_gather_idx_draft,
-                &state.mtp_gather_prob_draft,
-                argmax_vocab,
-                sampling.temp,
-                /* n_rows */ 1,
-            )?;
-            let mut p_draft_host: [f32; 1] = [0.0];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(p_draft_host.as_mut_ptr() as *mut u8, 4)
-                };
-                gpu.hip
-                    .memcpy_dtoh(bytes, &state.mtp_gather_prob_draft.buf)?;
-            }
-            draft_probs.push(p_draft_host[0]);
-
-            let token_id = match vocab_map_opt {
-                Some(vm) => vm[draft_idx],
-                None => draft_idx as u32,
+                candidates[k - 1]
             };
-            candidates.push(token_id);
-            // draft_logits_host is unused on the GPU sampling path; left
-            // allocated for symmetry with the (now-removed) host-sample
-            // fallback. Compiler will elide.
-            let _ = &draft_logits_host;
-        } else if use_p_min {
-            // Top-2 with log-softmax probs: 8 B idx + 8 B logp D2H per step.
-            gpu.topk_logsumexp_batched_f32(
-                logits_for_argmax,
-                &state.mtp_topk_idx,
-                &state.mtp_topk_logp,
-                argmax_vocab,
-                /* k */ 2,
-                /* b */ 1,
-            )?;
-            let mut idx_host: [i32; 2] = [0, 0];
-            let mut logp_host: [f32; 2] = [0.0, 0.0];
-            {
-                let idx_bytes: &mut [u8] =
-                    unsafe { std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, 8) };
-                gpu.hip.memcpy_dtoh(idx_bytes, &state.mtp_topk_idx.buf)?;
-                let logp_bytes: &mut [u8] =
-                    unsafe { std::slice::from_raw_parts_mut(logp_host.as_mut_ptr() as *mut u8, 8) };
-                gpu.hip.memcpy_dtoh(logp_bytes, &state.mtp_topk_logp.buf)?;
-            }
-            draft_idx = idx_host[0] as usize;
-            assert!(
-                draft_idx < argmax_vocab,
-                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
-            );
-            // Compressed: remap via vocab_map. Full-vocab: idx IS the token id.
-            let token_id = match vocab_map_opt {
-                Some(vm) => vm[draft_idx],
-                None => draft_idx as u32,
-            };
-            candidates.push(token_id);
-
-            // Check confidence AFTER pushing — keep this candidate, just
-            // skip future steps if confidence is below threshold.
-            if logp_host[0] < log_p_min {
-                chain_truncated = true;
-                break;
-            }
-        } else if use_device_token_chain {
-            let vocab_map_gpu = if use_full_vocab {
+            let next_token_embed = if use_device_token_chain {
+                let token_slot = state.mtp_token_chain.sub_offset(k, 1);
+                embed_device_token_into(
+                    gpu,
+                    trunk_weights,
+                    &state.mtp_token_embed,
+                    &token_slot,
+                    dim,
+                )?;
+                Some(&state.mtp_token_embed)
+            } else {
                 None
-            } else {
-                head.weights.lm_head_draft_vocab_map_gpu.as_ref()
             };
-            gpu.argmax_token_chain_f32(
-                logits_for_argmax,
-                &argmax_view,
-                &state.mtp_token_chain,
-                vocab_map_gpu,
-                argmax_vocab,
-                k + 1,
-            )?;
-        } else {
-            gpu.argmax_f32_batched(logits_for_argmax, &argmax_view, argmax_vocab, 1)?;
-            let mut argmax_host: [i32; 1] = [0];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, 4)
-                };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
-            }
-            draft_idx = argmax_host[0] as usize;
-            assert!(
-                draft_idx < argmax_vocab,
-                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
-            );
-            let token_id = match vocab_map_opt {
-                Some(vm) => vm[draft_idx],
-                None => draft_idx as u32,
-            };
-            candidates.push(token_id);
-        }
 
-        if k + 1 < max_n {
-            gpu.memcpy_dtod_at_auto(
-                &state.mtp_t_outs.buf,
-                k * dim_bytes,
-                &state.mtp_scratch.t_mtp_out.buf,
-                0,
-                dim_bytes,
-            )?;
-        }
+            // Forward: in compressed mode, mtp_head_forward_compressed runs
+            // block_only + rmsnorm + small GEMV against lm_head_draft in one
+            // call. In full-vocab mode we run block_only here and do the
+            // rmsnorm + trunk-lm_head GEMV manually below.
+            if use_full_vocab {
+                if k == 0 {
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &state.prev_hidden,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                } else {
+                    let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &prev_row,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                }
+                // rmsnorm(t_mtp_out, shared_head_norm) → tmp, then trunk lm_head
+                // GEMV → full_vocab_logits_view. weight_gemv dispatches the right
+                // kernel (gemv_mq4g256_with_rotate / gemv_q8_0 / etc.) on the
+                // trunk's output dtype.
+                gpu.rmsnorm_f32(
+                    &state.mtp_scratch.t_mtp_out,
+                    &head.weights.shared_head_norm,
+                    &state.mtp_scratch.tmp,
+                    head.config.rms_norm_eps,
+                )?;
+                llama::weight_gemv(
+                    gpu,
+                    &trunk_weights.output,
+                    &state.mtp_scratch.tmp,
+                    &full_vocab_logits_view,
+                )?;
+            } else if use_device_token_chain {
+                if k == 0 {
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &state.prev_hidden,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                } else {
+                    let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &prev_row,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                }
+                mtp_head::mtp_head_apply_lm_head_draft(gpu, head, &state.mtp_scratch)?;
+            } else {
+                if k == 0 {
+                    mtp_head::mtp_head_forward_compressed(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &state.prev_hidden,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                } else {
+                    let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                    mtp_head::mtp_head_forward_compressed(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &prev_row,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                }
+            }
+
+            // Pick the logits buffer to argmax over (mode-dependent).
+            let logits_for_argmax: &GpuTensor = if use_full_vocab {
+                &full_vocab_logits_view
+            } else {
+                state.mtp_scratch.logits_compressed.as_ref().unwrap()
+            };
+            let argmax_vocab = cvs; // = full vocab in full-vocab mode, = compressed vocab in compressed mode
+
+            let draft_idx: usize;
+            if use_sampling {
+                // GPU sample_top_p: kernel does the whole top_k(=20) + top_p +
+                // multinomial sample on-device. Returns 8 B (token id + new rng
+                // state). Eliminates the full 1 MB draft logits D2H + host
+                // softmax sample (~600 μs each step → ~3 ms/cycle saved).
+                //
+                // sample_top_p modifies logits in-place ONLY if repeat_penalty > 1
+                // and repeat_window > 0; we pass 1.0/0 so logits are untouched
+                // and the subsequent prob-gather sees the same values.
+                let (token_u32, new_rng) = gpu.sample_top_p(
+                    logits_for_argmax,
+                    &state.mtp_sample_result,
+                    &state.mtp_sample_repeat_buf,
+                    argmax_vocab,
+                    sampling.temp,
+                    sampling.top_p,
+                    state.gpu_rng_state,
+                    /* repeat_window */ 0,
+                    /* repeat_penalty */ 1.0,
+                )?;
+                state.gpu_rng_state = new_rng;
+                draft_idx = token_u32 as usize;
+                assert!(
+                    draft_idx < argmax_vocab,
+                    "draft sample {draft_idx} out of argmax_vocab {argmax_vocab}"
+                );
+
+                // GPU p_draft gather: H2D the sampled token id, run the gather
+                // kernel with n_rows=1, D2H 4 B prob. Replaces the host
+                // softmax_prob_at_temp call (~600 μs).
+                let token_i32: i32 = token_u32 as i32;
+                let idx_bytes: &[u8] =
+                    unsafe { std::slice::from_raw_parts(&token_i32 as *const i32 as *const u8, 4) };
+                gpu.hip
+                    .memcpy_htod(&state.mtp_gather_idx_draft.buf, idx_bytes)?;
+                gpu.softmax_prob_gather_batched_f32(
+                    logits_for_argmax,
+                    &state.mtp_gather_idx_draft,
+                    &state.mtp_gather_prob_draft,
+                    argmax_vocab,
+                    sampling.temp,
+                    /* n_rows */ 1,
+                )?;
+                let mut p_draft_host: [f32; 1] = [0.0];
+                {
+                    let bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(p_draft_host.as_mut_ptr() as *mut u8, 4)
+                    };
+                    gpu.hip
+                        .memcpy_dtoh(bytes, &state.mtp_gather_prob_draft.buf)?;
+                }
+                draft_probs.push(p_draft_host[0]);
+
+                let token_id = match vocab_map_opt {
+                    Some(vm) => vm[draft_idx],
+                    None => draft_idx as u32,
+                };
+                candidates.push(token_id);
+                // draft_logits_host is unused on the GPU sampling path; left
+                // allocated for symmetry with the (now-removed) host-sample
+                // fallback. Compiler will elide.
+                let _ = &draft_logits_host;
+            } else if use_p_min {
+                // Top-2 with log-softmax probs: 8 B idx + 8 B logp D2H per step.
+                gpu.topk_logsumexp_batched_f32(
+                    logits_for_argmax,
+                    &state.mtp_topk_idx,
+                    &state.mtp_topk_logp,
+                    argmax_vocab,
+                    /* k */ 2,
+                    /* b */ 1,
+                )?;
+                let mut idx_host: [i32; 2] = [0, 0];
+                let mut logp_host: [f32; 2] = [0.0, 0.0];
+                {
+                    let idx_bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, 8)
+                    };
+                    gpu.hip.memcpy_dtoh(idx_bytes, &state.mtp_topk_idx.buf)?;
+                    let logp_bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(logp_host.as_mut_ptr() as *mut u8, 8)
+                    };
+                    gpu.hip.memcpy_dtoh(logp_bytes, &state.mtp_topk_logp.buf)?;
+                }
+                draft_idx = idx_host[0] as usize;
+                assert!(
+                    draft_idx < argmax_vocab,
+                    "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
+                );
+                // Compressed: remap via vocab_map. Full-vocab: idx IS the token id.
+                let token_id = match vocab_map_opt {
+                    Some(vm) => vm[draft_idx],
+                    None => draft_idx as u32,
+                };
+                candidates.push(token_id);
+
+                // Check confidence AFTER pushing — keep this candidate, just
+                // skip future steps if confidence is below threshold.
+                if logp_host[0] < log_p_min {
+                    chain_truncated = true;
+                    break;
+                }
+            } else if use_device_token_chain {
+                let vocab_map_gpu = if use_full_vocab {
+                    None
+                } else {
+                    head.weights.lm_head_draft_vocab_map_gpu.as_ref()
+                };
+                gpu.argmax_token_chain_f32(
+                    logits_for_argmax,
+                    &argmax_view,
+                    &state.mtp_token_chain,
+                    vocab_map_gpu,
+                    argmax_vocab,
+                    k + 1,
+                )?;
+            } else {
+                gpu.argmax_f32_batched(logits_for_argmax, &argmax_view, argmax_vocab, 1)?;
+                let mut argmax_host: [i32; 1] = [0];
+                {
+                    let bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, 4)
+                    };
+                    gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
+                }
+                draft_idx = argmax_host[0] as usize;
+                assert!(
+                    draft_idx < argmax_vocab,
+                    "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
+                );
+                let token_id = match vocab_map_opt {
+                    Some(vm) => vm[draft_idx],
+                    None => draft_idx as u32,
+                };
+                candidates.push(token_id);
+            }
+
+            if k + 1 < max_n {
+                gpu.memcpy_dtod_at_auto(
+                    &state.mtp_t_outs.buf,
+                    k * dim_bytes,
+                    &state.mtp_scratch.t_mtp_out.buf,
+                    0,
+                    dim_bytes,
+                )?;
+            }
         }
     }
     let drafts_generated = if use_device_token_chain {
@@ -2588,8 +2612,8 @@ pub fn spec_step_mtp_compressed_serial(
         verify_tape,
         None,
         Some(&state.trunk_pbs),
-        None, // mask_override
-        None, // max_layer
+        None,  // mask_override
+        None,  // max_layer
         false, // MTP computes all verify logits from verify_hidden below
     )?;
 
@@ -2810,8 +2834,7 @@ pub fn spec_step_mtp_compressed_serial(
         let argmax_v = state.verify_argmax.sub_offset(0, n_verify);
         gpu.argmax_f32_batched(&logits_view, &argmax_v, vocab, n_verify)?;
 
-        let use_gpu_accept =
-            use_device_token_chain && mtp_gpu_greedy_accept_enabled_from_env();
+        let use_gpu_accept = use_device_token_chain && mtp_gpu_greedy_accept_enabled_from_env();
         let accepted = if use_gpu_accept {
             let candidate_device = state.mtp_token_chain.sub_offset(1, drafts_generated);
             let accept_result = state.verify_argmax.sub_offset(0, 2);
@@ -2846,8 +2869,7 @@ pub fn spec_step_mtp_compressed_serial(
                 };
                 gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
             }
-            let argmax_per_pos: Vec<u32> =
-                argmax_v_host.into_iter().map(|x| x as u32).collect();
+            let argmax_per_pos: Vec<u32> = argmax_v_host.into_iter().map(|x| x as u32).collect();
             greedy_trunk_spine_accept(
                 &candidates[..drafts_generated],
                 &argmax_per_pos,

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -4791,6 +4791,41 @@ pub fn forward_prefill_batch_single_chunk_captured(
     gdn_tape: Option<&mut crate::speculative::GdnTape>,
     tree_verify: Option<TreeVerifyCtx<'_>>,
 ) -> HipResult<()> {
+    forward_prefill_batch_single_chunk_captured_opts(
+        gpu,
+        weights,
+        config,
+        tokens,
+        start_pos,
+        kv_cache,
+        dn_state,
+        scratch,
+        pbs,
+        hidden_rb,
+        per_token_hidden_out,
+        gdn_tape,
+        tree_verify,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn forward_prefill_batch_single_chunk_captured_opts(
+    gpu: &mut Gpu,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    tokens: &[u32],
+    start_pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch: &Qwen35Scratch,
+    pbs: &PrefillBatchScratch,
+    hidden_rb: Option<&HiddenStateRingBuffer>,
+    per_token_hidden_out: Option<&GpuTensor>,
+    gdn_tape: Option<&mut crate::speculative::GdnTape>,
+    tree_verify: Option<TreeVerifyCtx<'_>>,
+    needs_last_token_logits: bool,
+) -> HipResult<()> {
     let n = tokens.len();
     debug_assert!(n > 0 && n <= pbs.max_batch,
         "single_chunk_captured: n={} but pbs.max_batch={}", n, pbs.max_batch);
@@ -4961,7 +4996,7 @@ pub fn forward_prefill_batch_single_chunk_captured(
         true, // pre_uploaded: caller must have run upload_prefill_batch_inputs
         None, // band: full-stack single-GPU path
         None, // mask_override: captured-prefill caller does not use the MTP probe hook
-        true, // needs_last_token_logits: preserve captured-prefill post-condition
+        needs_last_token_logits,
         None, // max_layer: single-chunk captured path always runs the full stack
     )
 }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -4458,8 +4458,9 @@ pub struct PrefillBatchScratch {
 
     // Path 2 (SGLang-style scatter + grouped-WMMA-GEMM) scratch. All
     // allocated when num_experts > 0; gated at runtime by
-    // HIPFIRE_MOE_GROUPED_GEMM=1. m_total_max = max_batch * k_top +
-    // num_experts * (BLOCK_M - 1) with BLOCK_M=16.
+    // HIPFIRE_MOE_GROUPED_GEMM=1. m_total_max is tile-aligned:
+    // align_up(max_batch * k_top + num_experts * (BLOCK_M - 1), BLOCK_M)
+    // with BLOCK_M=16.
     //
     //   moe_expert_token_counts: [num_experts] i32 (raw → padded)
     //   moe_expert_offsets:      [num_experts + 1] i32 (exclusive prefix)
@@ -4575,7 +4576,11 @@ impl PrefillBatchScratch {
                 Some(gpu.alloc_tensor(&[(config.num_experts + 1) * 4], DType::Raw)?)
             } else { None },
             moe_sorted_slot_index: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
                 Some(gpu.alloc_tensor(&[m_total_max * 4], DType::Raw)?)
             } else { None },
             moe_inverse_perm: if config.num_experts > 0 {
@@ -4583,15 +4588,27 @@ impl PrefillBatchScratch {
                 Some(gpu.alloc_tensor(&[total_slots_max * 4], DType::Raw)?)
             } else { None },
             moe_expert_tile_ids: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
-                Some(gpu.alloc_tensor(&[(m_total_max / 16 + 1) * 4], DType::Raw)?)
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
+                Some(gpu.alloc_tensor(&[(m_total_max / MOE_GROUPED_BLOCK_M) * 4], DType::Raw)?)
             } else { None },
             moe_y_gate_up_grouped: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
                 Some(gpu.alloc_tensor(&[m_total_max * 2 * config.moe_intermediate_size], DType::F32)?)
             } else { None },
             moe_y_down_grouped: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
                 Some(gpu.alloc_tensor(&[m_total_max * config.dim], DType::F32)?)
             } else { None },
             dn_s_tape_q8: if config.linear_num_value_heads > 0 {
@@ -4680,6 +4697,46 @@ impl PrefillBatchScratch {
 /// upper bound (staging that's smaller than a chunk will assert-fail
 /// on prompt seeding of long prompts).
 pub const PREFILL_MAX_BATCH: usize = 256;
+
+const MOE_GROUPED_BLOCK_M: usize = 16;
+
+#[inline]
+fn prefill_should_emit_last_token_logits(
+    has_per_token_hidden_out: bool,
+    needs_last_token_logits: bool,
+) -> bool {
+    !has_per_token_hidden_out || needs_last_token_logits
+}
+
+#[inline]
+fn align_up_usize(x: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (x + align - 1) & !(align - 1)
+}
+
+#[inline]
+fn moe_grouped_m_total_max(max_batch: usize, k_top: usize, n_exp: usize) -> usize {
+    // Every grouped-GEMM tile consumes 16 sorted slots. The scatter kernel
+    // initializes sentinel tile ids up to this bound, so the bound itself must
+    // be tile-aligned; otherwise the final launched tile can read an
+    // uninitialized expert id.
+    align_up_usize(
+        max_batch * k_top + n_exp * (MOE_GROUPED_BLOCK_M - 1),
+        MOE_GROUPED_BLOCK_M,
+    )
+}
+
+#[inline]
+fn moe_grouped_m_total_bound(total_slots: usize, n_exp: usize) -> usize {
+    // Actual grouped rows are sum_e align_up(count_e, BLOCK_M). Only experts
+    // that receive at least one slot can contribute padding, so small verify
+    // batches do not need to launch the full all-experts worst case.
+    let live_expert_bound = total_slots.min(n_exp);
+    align_up_usize(
+        total_slots + live_expert_bound * (MOE_GROUPED_BLOCK_M - 1),
+        MOE_GROUPED_BLOCK_M,
+    )
+}
 
 /// Host-side helper: upload token ids and positions to a `PrefillBatchScratch`
 /// via sync `memcpy_htod`. Call this BEFORE entering a hipGraph capture to
@@ -4904,6 +4961,7 @@ pub fn forward_prefill_batch_single_chunk_captured(
         true, // pre_uploaded: caller must have run upload_prefill_batch_inputs
         None, // band: full-stack single-GPU path
         None, // mask_override: captured-prefill caller does not use the MTP probe hook
+        true, // needs_last_token_logits: preserve captured-prefill post-condition
         None, // max_layer: single-chunk captured path always runs the full stack
     )
 }
@@ -4930,6 +4988,43 @@ pub fn forward_prefill_batch(
     )
 }
 
+pub fn forward_prefill_batch_with_pbs(
+    gpu: &mut Gpu,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    tokens: &[u32],
+    start_pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch: &Qwen35Scratch,
+    hidden_rb: Option<&mut HiddenStateRingBuffer>,
+    per_token_hidden_out: Option<&GpuTensor>,
+    gdn_tape: Option<&mut crate::speculative::GdnTape>,
+    tree_verify: Option<TreeVerifyCtx<'_>>,
+    pbs_in: Option<&PrefillBatchScratch>,
+    mask_override: Option<MaskEmbedOverride<'_>>,
+    max_layer: Option<usize>,
+) -> HipResult<()> {
+    forward_prefill_batch_with_pbs_opts(
+        gpu,
+        weights,
+        config,
+        tokens,
+        start_pos,
+        kv_cache,
+        dn_state,
+        scratch,
+        hidden_rb,
+        per_token_hidden_out,
+        gdn_tape,
+        tree_verify,
+        pbs_in,
+        mask_override,
+        max_layer,
+        true, // preserve legacy post-condition: scratch.logits is last-token logits
+    )
+}
+
 /// Like `forward_prefill_batch`, but accepts a caller-owned `PrefillBatchScratch`
 /// so the ~25 per-cycle tensor allocations can be amortized across many calls.
 ///
@@ -4939,7 +5034,12 @@ pub fn forward_prefill_batch(
 /// up to `pbs.max_batch`. Callers driving DFlash verify should size `pbs`
 /// to the maximum block size they'll ever request (e.g. `block_size` or
 /// `1 + tree_budget`) so everything fits in one chunk.
-pub fn forward_prefill_batch_with_pbs(
+///
+/// `needs_last_token_logits = false` is only for callers that pass
+/// `per_token_hidden_out` and compute their own logits from those hidden rows.
+/// The default wrapper keeps this true to protect existing callers that rely on
+/// `scratch.logits` being populated with the last token's logits.
+pub fn forward_prefill_batch_with_pbs_opts(
     gpu: &mut Gpu,
     weights: &Qwen35Weights,
     config: &Qwen35Config,
@@ -4955,6 +5055,7 @@ pub fn forward_prefill_batch_with_pbs(
     pbs_in: Option<&PrefillBatchScratch>,
     mask_override: Option<MaskEmbedOverride<'_>>,
     max_layer: Option<usize>,
+    needs_last_token_logits: bool,
 ) -> HipResult<()> {
     // Upper bound on the PrefillBatchScratch — large prompts get split
     // into chunks of this size and processed in a loop.
@@ -5176,6 +5277,7 @@ pub fn forward_prefill_batch_with_pbs(
                 false, // pre_uploaded: default path uploads inside
                 None,  // band: full-stack single-GPU path
                 mo_for_chunk,
+                needs_last_token_logits,
                 max_layer,
             )?;
             if let Some(rb) = hidden_rb.as_mut() {
@@ -5401,11 +5503,6 @@ fn paro_batched_admit_enabled_from_env(value: Option<&str>) -> bool {
     value != Some("0")
 }
 
-/// MQ6 admit is gated behind `HIPFIRE_MOE_MQ6_ADMIT=1` because of a
-/// known correctness regression on AWQ A3B (token attractor `!!!!!`)
-/// when the new MQ6 dispatch path is exercised — the 4 new MQ6 kernels
-/// pass synthetic channel tests at FP16 ULP precision but produce
-/// garbage activations in production. Bisection of the offending
 /// Threshold below which batching overhead isn't worth the alloc + per-layer
 /// dispatch — single-token prefill must not take the batched path.
 const MIN_BATCH: usize = 2;
@@ -5433,6 +5530,10 @@ pub fn prefill_batch_pbs_eligible(
     // MoE batched path requires K_TOP=8 (hard-coded in the indexed kernels) and
     // num_experts ≤ 1024 (bound of the batched top-K shared mem).
     let moe_topk_ok = config.num_experts_per_tok == 8 && config.num_experts <= 1024;
+    let admit_mq6 = mq6_batched_admit_enabled_from_env(
+        std::env::var("HIPFIRE_MOE_MQ6_ADMIT").ok().as_deref(),
+        arch,
+    );
     !force_fallback
         && n >= MIN_BATCH
         && dn_state.quant == StateQuant::Q8
@@ -5461,7 +5562,7 @@ pub fn prefill_batch_pbs_eligible(
                     && is_batchable_la(l.w_beta.gpu_dtype, arch)
                     && is_batchable_la(l.w_alpha.gpu_dtype, arch)
                     && is_batchable_la(l.wo.gpu_dtype, arch)
-                    && moe_ffn_batched_admissible(&l.ffn),
+                    && moe_ffn_batched_admissible(&l.ffn, admit_mq6),
             LayerWeights::FullAttnMoe(l) =>
                 moe_topk_ok
                     && moe_router_logits_present
@@ -5469,13 +5570,24 @@ pub fn prefill_batch_pbs_eligible(
                     && is_batchable_la(l.wk.gpu_dtype, arch)
                     && is_batchable_la(l.wv.gpu_dtype, arch)
                     && is_batchable_la(l.wo.gpu_dtype, arch)
-                    && moe_ffn_batched_admissible(&l.ffn),
+                    && moe_ffn_batched_admissible(&l.ffn, admit_mq6),
         })
 }
 
-/// dispatch site is pending. Default-off preserves the pre-fan-out
-/// behavior (AWQ A3B → per-token fallback, coherent at ~53 tok/s).
-fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights) -> bool {
+/// Whether MQ6 MoE FFN projections can enter batched prefill. After the
+/// grouped tile-bound fix, gfx12 defaults to admit because its HFQ6
+/// grouped-WMMA path is present and production-smoked; gfx11 and older stay
+/// default-off because the MQ6 grouped sister is not implemented there and the
+/// indexed fallback still lacks an MQ6 gate_up batched kernel.
+fn mq6_batched_admit_enabled_from_env(value: Option<&str>, arch: &str) -> bool {
+    match value {
+        Some("0") | Some("off") | Some("false") => false,
+        Some("1") | Some("on") | Some("true") => true,
+        _ => arch.starts_with("gfx12"),
+    }
+}
+
+fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights, admit_mq6: bool) -> bool {
     // F32 router/shared_gate admit (PARO checkpoints — router is FP16-dense,
     // expanded to F32 on GPU; shared_expert_gate likewise. See
     // load_fp16_weight_from_source at qwen35.rs:1177). The dispatch arms in
@@ -5506,12 +5618,6 @@ fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights) -> bool {
             return true;
         }
     }
-
-    // MQ6 admit env gate (default off — see comment above)
-    static MQ6_ADMIT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let admit_mq6 = *MQ6_ADMIT.get_or_init(|| {
-        std::env::var("HIPFIRE_MOE_MQ6_ADMIT").as_deref() == Ok("1")
-    });
 
     if admit_mq6 {
         // Per-projection MQ4 OR MQ6 admit.
@@ -5807,9 +5913,9 @@ fn prefill_moe_ffn_body_batched(
     let mut path2_m_total: usize = 0;
     if path2_eligible {
         // Stage 1 scatter pipeline. The scratch buffers are sized for
-        // m_total_max = max_batch * k_top + n_exp * 15; here m_total ≤
-        // n * k_top + n_exp * 15. Block size 16 (the WMMA tile row count).
-        const BLOCK_M: usize = 16;
+        // worst-case max_batch. Runtime launch bounds use the tighter live
+        // slot upper bound below. Block size 16 (the WMMA tile row count).
+        const BLOCK_M: usize = MOE_GROUPED_BLOCK_M;
         let counts = pbs.moe_expert_token_counts.as_ref().expect("path2 scratch");
         let offsets = pbs.moe_expert_offsets.as_ref().expect("path2 scratch");
         let sorted = pbs.moe_sorted_slot_index.as_ref().expect("path2 scratch");
@@ -5817,12 +5923,13 @@ fn prefill_moe_ffn_body_batched(
         let tile_ids = pbs.moe_expert_tile_ids.as_ref().expect("path2 scratch");
         let y_gu_grouped = pbs.moe_y_gate_up_grouped.as_ref().expect("path2 scratch");
         let total_slots = n * k_top;
-        // m_total upper bound — sized in PrefillBatchScratch::new with
-        // max_batch * k_top + n_exp * (BLOCK_M - 1). The scatter fused
-        // kernel pre-fills expert_tile_ids[0..m_total_max/16] with -1;
-        // the grouped GEMM and unscatter early-return on those tiles, so
-        // we can skip the m_total dtoh sync entirely. Saves ~50µs/layer.
-        let m_total_max = n * k_top + n_exp * (BLOCK_M - 1);
+        // m_total upper bound — scratch is sized in PrefillBatchScratch::new
+        // with the all-experts worst case, while this launch only needs slots
+        // plus padding for experts that can be non-empty at this N.
+        // The scatter fused kernel pre-fills every tile id in this aligned
+        // bound with -1; grouped GEMM early-returns on sentinel tiles, so we
+        // can skip the m_total dtoh sync entirely. Saves ~50µs/layer.
+        let m_total_max = moe_grouped_m_total_bound(total_slots, n_exp);
 
         // Fused scatter pipeline: one launch replaces histogram + offsets
         // + permute. Saves 2 launches × ~75µs × MoE layers.
@@ -6137,6 +6244,7 @@ fn forward_prefill_chunk(
     pre_uploaded: bool,
     band: Option<&PrefillBandCtx<'_>>,
     mask_override: Option<MaskEmbedOverride<'_>>,
+    needs_last_token_logits: bool,
     max_layer: Option<usize>,
 ) -> HipResult<()> {
     let n = tokens.len();
@@ -8236,11 +8344,13 @@ fn forward_prefill_chunk(
                 &pbs.x_batch, &weights.output_norm, &dst_view,
                 n, dim, config.norm_eps,
             )?;
-            // Still populate s.logits with the last-token logits for callers
-            // that rely on it (the legacy prefill path's post-condition).
-            let last = n - 1;
-            let last_view = dst.sub_offset((offset_rows + last) * dim, dim);
-            weight_gemv(gpu, &weights.output, &last_view, &s.logits)?;
+            if prefill_should_emit_last_token_logits(true, needs_last_token_logits) {
+                // Still populate s.logits with the last-token logits for
+                // callers that rely on it (the legacy prefill post-condition).
+                let last = n - 1;
+                let last_view = dst.sub_offset((offset_rows + last) * dim, dim);
+                weight_gemv(gpu, &weights.output, &last_view, &s.logits)?;
+            }
         } else {
             // Legacy path: only last-token logits.
             // Use _auto so the D→D copy routes through the active stream
@@ -10990,6 +11100,7 @@ pub fn forward_prefill_batch_multi(
                         false, // pre_uploaded
                         Some(&band_ctx),
                         None, // mask_override: multi-GPU PP path doesn't use the MTP probe hook
+                        true, // needs_last_token_logits: preserve multi-GPU post-condition
                         None, // max_layer: multi-GPU PP path runs full stack
                     )?;
                 }
@@ -11093,5 +11204,51 @@ mod tests {
         assert!(paro_batched_admit_enabled_from_env(Some("1")));
         assert!(paro_batched_admit_enabled_from_env(Some("surprise")));
         assert!(!paro_batched_admit_enabled_from_env(Some("0")));
+    }
+
+    #[test]
+    fn mq6_batched_admit_defaults_to_gfx12_only() {
+        assert!(mq6_batched_admit_enabled_from_env(None, "gfx1201"));
+        assert!(mq6_batched_admit_enabled_from_env(None, "gfx1200"));
+        assert!(!mq6_batched_admit_enabled_from_env(None, "gfx1100"));
+        assert!(!mq6_batched_admit_enabled_from_env(None, "gfx942"));
+        assert!(mq6_batched_admit_enabled_from_env(Some("1"), "gfx1100"));
+        assert!(!mq6_batched_admit_enabled_from_env(Some("0"), "gfx1201"));
+    }
+
+    #[test]
+    fn prefill_last_token_logits_policy_requires_explicit_opt_out() {
+        assert!(prefill_should_emit_last_token_logits(false, true));
+        assert!(prefill_should_emit_last_token_logits(true, true));
+        assert!(prefill_should_emit_last_token_logits(false, false));
+        assert!(!prefill_should_emit_last_token_logits(true, false));
+    }
+
+    #[test]
+    fn moe_grouped_m_total_max_is_tile_aligned() {
+        let small_verify = moe_grouped_m_total_max(3, 8, 256);
+        assert_eq!(small_verify % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(small_verify, 3872);
+
+        let prompt_prefill = moe_grouped_m_total_max(27, 8, 256);
+        assert_eq!(prompt_prefill % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(prompt_prefill, 4064);
+
+        let full_chunk = moe_grouped_m_total_max(256, 8, 256);
+        assert_eq!(full_chunk, 5888);
+    }
+
+    #[test]
+    fn moe_grouped_m_total_bound_is_tight_for_small_batches() {
+        let small_verify = moe_grouped_m_total_bound(24, 256);
+        assert_eq!(small_verify % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(small_verify, 384);
+
+        let prompt_prefill = moe_grouped_m_total_bound(216, 256);
+        assert_eq!(prompt_prefill % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(prompt_prefill, 3456);
+
+        let full_chunk = moe_grouped_m_total_bound(2048, 256);
+        assert_eq!(full_chunk, 5888);
     }
 }

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -16,26 +16,24 @@
 //! on different models sharing the same MQ scratch (which we won't, since
 //! speculative decode serializes draft-generate then target-verify).
 
+use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
+use hip_bridge::{DeviceBuffer, HipResult, Stream};
 use hipfire_runtime::dflash::{self, DflashConfig, DflashScratch, DflashWeights};
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{self, KvCache};
-use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
 use hipfire_runtime::tokenizer::{Tokenizer, TokenizerError};
-use hip_bridge::{DeviceBuffer, HipResult, Stream};
 use rdna_compute::{Gpu, GpuTensor};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 fn dflash_q8_lmhead_wmma_enabled_from_env() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        match std::env::var("HIPFIRE_DFLASH_Q8_LMHEAD_WMMA") {
-            Ok(v) => {
-                let v = v.trim().to_ascii_lowercase();
-                !(v == "0" || v == "false" || v == "off" || v == "no")
-            }
-            Err(_) => true,
+    *ENABLED.get_or_init(|| match std::env::var("HIPFIRE_DFLASH_Q8_LMHEAD_WMMA") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
         }
+        Err(_) => true,
     })
 }
 
@@ -61,6 +59,165 @@ fn dflash_gemm_q8_lmhead(
         chunk_start = chunk_end;
     }
     Ok(())
+}
+
+fn dflash_moe_verify_graph_lmhead_enabled_from_env_value(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        None => true,
+    }
+}
+
+fn dflash_moe_verify_graph_lmhead_eligible(
+    num_experts: usize,
+    want_full_logits: bool,
+    tree_verify_present: bool,
+    env_value: Option<&str>,
+) -> bool {
+    // MoE-only: dense DFlash keeps the old forward-only verify graph. The
+    // extended graph is also greedy-only because sampling needs full logits.
+    num_experts > 0
+        && !want_full_logits
+        && !tree_verify_present
+        && dflash_moe_verify_graph_lmhead_enabled_from_env_value(env_value)
+}
+
+fn dflash_moe_draft_ffn_graph_eligible(
+    num_experts: usize,
+    ctx_slice_present: bool,
+    pld_present: bool,
+    use_temp_sampling: bool,
+    env_value: Option<&str>,
+) -> bool {
+    // The draft FFN graph captures fixed-B per-layer work. Keep it off for
+    // dense, PLD, ctx-slice diagnostics, and sampling until each path is
+    // separately benched/coherence-gated.
+    num_experts > 0
+        && !ctx_slice_present
+        && !pld_present
+        && !use_temp_sampling
+        && dflash_moe_verify_graph_lmhead_enabled_from_env_value(env_value)
+}
+
+fn dflash_batched_lm_head_supported(dtype: rdna_compute::DType) -> bool {
+    matches!(
+        dtype,
+        rdna_compute::DType::Q8_0
+            | rdna_compute::DType::HFQ4G256
+            | rdna_compute::DType::MQ4G256
+            | rdna_compute::DType::MQ3G256
+            | rdna_compute::DType::HFQ6G256
+            | rdna_compute::DType::MQ6G256
+    )
+}
+
+fn dflash_enqueue_verify_lm_head(
+    gpu: &mut Gpu,
+    w_out: &llama::WeightTensor,
+    final_hidden: &GpuTensor,
+    verify_scratch: &VerifyScratch,
+    b: usize,
+    vocab: usize,
+) -> HipResult<()> {
+    let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
+    match w_out.gpu_dtype {
+        rdna_compute::DType::Q8_0 => {
+            dflash_gemm_q8_lmhead(gpu, w_out, final_hidden, &logits_batch, b)?;
+        }
+        rdna_compute::DType::HFQ4G256 => {
+            gpu.gemm_hfq4g256_batched_lmhead(
+                &w_out.buf,
+                final_hidden,
+                &logits_batch,
+                w_out.m,
+                w_out.k,
+                b,
+            )?;
+        }
+        rdna_compute::DType::MQ4G256 => {
+            assert!(
+                b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                "verify_scratch.rot undersized: b*k={} > max_n*hidden_k={}",
+                b * w_out.k,
+                verify_scratch.max_n * verify_scratch.hidden_k
+            );
+            let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+            llama::rotate_x_mq_batched_for(gpu, w_out, final_hidden, &rot, w_out.k, b)?;
+            gpu.gemm_hfq4g256_batched_lmhead(&w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b)?;
+        }
+        rdna_compute::DType::MQ3G256 => {
+            assert!(
+                b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                "verify_scratch.rot undersized for MQ3 lm_head: b*k={} > max_n*hidden_k={}",
+                b * w_out.k,
+                verify_scratch.max_n * verify_scratch.hidden_k
+            );
+            let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+            llama::rotate_x_mq_batched_for(gpu, w_out, final_hidden, &rot, w_out.k, b)?;
+            gpu.gemm_hfq3g256_batched_lmhead(&w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b)?;
+        }
+        rdna_compute::DType::HFQ6G256 => {
+            gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf,
+                final_hidden,
+                &logits_batch,
+                w_out.m,
+                w_out.k,
+                b,
+            )?;
+        }
+        rdna_compute::DType::MQ6G256 => {
+            assert!(
+                b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                "verify_scratch.rot undersized for MQ6 lm_head: b*k={} > max_n*hidden_k={}",
+                b * w_out.k,
+                verify_scratch.max_n * verify_scratch.hidden_k
+            );
+            let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+            llama::rotate_x_mq_batched_for(gpu, w_out, final_hidden, &rot, w_out.k, b)?;
+            gpu.gemm_hfq6g256_batched_lmhead(&w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b)?;
+        }
+        other => {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("DFlash verify graph lm_head unsupported dtype {other:?}"),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn dflash_enqueue_verify_lm_head_argmax(
+    gpu: &mut Gpu,
+    w_out: &llama::WeightTensor,
+    final_hidden: &GpuTensor,
+    verify_scratch: &VerifyScratch,
+    b: usize,
+    vocab: usize,
+) -> HipResult<()> {
+    dflash_enqueue_verify_lm_head(gpu, w_out, final_hidden, verify_scratch, b, vocab)?;
+    let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
+    let argmax_buf = verify_scratch.argmax.sub_offset(0, b);
+    gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, b)
+}
+
+fn dflash_download_verify_argmax(
+    gpu: &Gpu,
+    verify_scratch: &VerifyScratch,
+    b: usize,
+) -> HipResult<Vec<u32>> {
+    let argmax_buf = verify_scratch.argmax.sub_offset(0, b);
+    let mut host_idx = vec![0i32; b];
+    {
+        let bytes: &mut [u8] =
+            unsafe { std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, b * 4) };
+        gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
+    }
+    Ok(host_idx.into_iter().map(|idx| idx as u32).collect())
 }
 
 /// Task #93 Phase B seed-prediction oracle counters.
@@ -163,7 +320,11 @@ pub fn read_ddtree_meta_stats() -> DdtreeMetaStats {
         cycles: c,
         total_nodes: DDTREE_META_TOTAL_NODES.load(Ordering::Relaxed),
         max_nodes: DDTREE_META_MAX_NODES.load(Ordering::Relaxed),
-        min_nodes: if c == 0 { 0 } else { DDTREE_META_MIN_NODES.load(Ordering::Relaxed) },
+        min_nodes: if c == 0 {
+            0
+        } else {
+            DDTREE_META_MIN_NODES.load(Ordering::Relaxed)
+        },
     }
 }
 
@@ -259,7 +420,10 @@ impl ModelSlot {
             hip_bridge::HipError::new(0, &format!("open {} ({}): {}", path.display(), name, e))
         })?;
         let config = qwen35::config_from_hfq(&hfq).ok_or_else(|| {
-            hip_bridge::HipError::new(0, &format!("invalid Qwen3.5 config in {} ({})", path.display(), name))
+            hip_bridge::HipError::new(
+                0,
+                &format!("invalid Qwen3.5 config in {} ({})", path.display(), name),
+            )
         })?;
         let weights = qwen35::load_weights(&mut hfq, &config, gpu)?;
 
@@ -644,12 +808,12 @@ pub struct GdnTape {
     pub alpha_bufs: Vec<GpuTensor>,
     pub beta_bufs: Vec<GpuTensor>,
     /// Replay scratch (shared across layers — serial replay is fine).
-    pub q_raw_scratch: GpuTensor,   // [max_n × k_dim]
-    pub k_raw_scratch: GpuTensor,   // [max_n × k_dim]
-    pub v_scratch: GpuTensor,       // [max_n × v_dim]
-    pub q_scratch: GpuTensor,       // [max_n × v_dim] (post repeat-interleave)
-    pub k_scratch: GpuTensor,       // [max_n × v_dim]
-    pub attn_scratch: GpuTensor,    // [max_n × v_dim]
+    pub q_raw_scratch: GpuTensor, // [max_n × k_dim]
+    pub k_raw_scratch: GpuTensor, // [max_n × k_dim]
+    pub v_scratch: GpuTensor,     // [max_n × v_dim]
+    pub q_scratch: GpuTensor,     // [max_n × v_dim] (post repeat-interleave)
+    pub k_scratch: GpuTensor,     // [max_n × v_dim]
+    pub attn_scratch: GpuTensor,  // [max_n × v_dim]
 }
 
 impl GdnTape {
@@ -692,10 +856,10 @@ impl GdnTape {
             beta_bufs,
             q_raw_scratch: gpu.alloc_tensor(&[max_n * k_dim], rdna_compute::DType::F32)?,
             k_raw_scratch: gpu.alloc_tensor(&[max_n * k_dim], rdna_compute::DType::F32)?,
-            v_scratch:     gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
-            q_scratch:     gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
-            k_scratch:     gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
-            attn_scratch:  gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            v_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            q_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            k_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            attn_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
         })
     }
 
@@ -743,8 +907,7 @@ impl GdnTape {
         dn_state: &mut qwen35::DeltaNetState,
         n_steps: usize,
     ) -> HipResult<()> {
-        let graph_enabled =
-            std::env::var("HIPFIRE_REPLAY_GRAPH").ok().as_deref() == Some("1");
+        let graph_enabled = std::env::var("HIPFIRE_REPLAY_GRAPH").ok().as_deref() == Some("1");
         let can_graph = graph_enabled && gpu.active_stream.is_some();
 
         if can_graph && gpu.replay_has_graph(n_steps) {
@@ -768,9 +931,9 @@ impl GdnTape {
                 gpu.replay_graph_launch(n_steps)?;
                 return Ok(());
             } else {
-                let _ = gpu.hip.stream_end_capture(
-                    gpu.active_stream.as_ref().unwrap(),
-                );
+                let _ = gpu
+                    .hip
+                    .stream_end_capture(gpu.active_stream.as_ref().unwrap());
                 gpu.capture_mode = false;
                 gpu.capture_blobs.clear();
                 return r;
@@ -791,7 +954,10 @@ impl GdnTape {
         dn_state: &mut qwen35::DeltaNetState,
         n_steps: usize,
     ) -> HipResult<()> {
-        assert!(n_steps <= self.max_n, "replay_gdn: n_steps {n_steps} > max_n");
+        assert!(
+            n_steps <= self.max_n,
+            "replay_gdn: n_steps {n_steps} > max_n"
+        );
         let n_v_heads = self.n_v_heads;
         let n_key_heads = self.n_key_heads;
         let hd = self.key_head_dim;
@@ -850,8 +1016,20 @@ impl GdnTape {
                 )?;
             } else {
                 let bytes = n_steps * k_dim * 4;
-                gpu.hip.memcpy_dtod_at(&self.q_scratch.buf, 0, &self.q_raw_scratch.buf, 0, bytes)?;
-                gpu.hip.memcpy_dtod_at(&self.k_scratch.buf, 0, &self.k_raw_scratch.buf, 0, bytes)?;
+                gpu.hip.memcpy_dtod_at(
+                    &self.q_scratch.buf,
+                    0,
+                    &self.q_raw_scratch.buf,
+                    0,
+                    bytes,
+                )?;
+                gpu.hip.memcpy_dtod_at(
+                    &self.k_scratch.buf,
+                    0,
+                    &self.k_raw_scratch.buf,
+                    0,
+                    bytes,
+                )?;
             }
 
             // 4. GDN recurrence — advances S_state.
@@ -903,32 +1081,47 @@ impl GdnTape {
         for layer in 0..self.qkv_bufs.len() {
             // qkv
             gpu.kv_compact_gather(
-                &self.qkv_bufs[layer], gather_scratch, gather_indices_dev,
-                qkv_row_bytes, n_positions,
+                &self.qkv_bufs[layer],
+                gather_scratch,
+                gather_indices_dev,
+                qkv_row_bytes,
+                n_positions,
             )?;
             gpu.hip.memcpy_dtod_at(
-                &self.qkv_bufs[layer].buf, 0,
-                &gather_scratch.buf, 0,
+                &self.qkv_bufs[layer].buf,
+                0,
+                &gather_scratch.buf,
+                0,
                 n_positions * qkv_row_bytes,
             )?;
             // alpha
             gpu.kv_compact_gather(
-                &self.alpha_bufs[layer], gather_scratch, gather_indices_dev,
-                alpha_row_bytes, n_positions,
+                &self.alpha_bufs[layer],
+                gather_scratch,
+                gather_indices_dev,
+                alpha_row_bytes,
+                n_positions,
             )?;
             gpu.hip.memcpy_dtod_at(
-                &self.alpha_bufs[layer].buf, 0,
-                &gather_scratch.buf, 0,
+                &self.alpha_bufs[layer].buf,
+                0,
+                &gather_scratch.buf,
+                0,
                 n_positions * alpha_row_bytes,
             )?;
             // beta
             gpu.kv_compact_gather(
-                &self.beta_bufs[layer], gather_scratch, gather_indices_dev,
-                alpha_row_bytes, n_positions,
+                &self.beta_bufs[layer],
+                gather_scratch,
+                gather_indices_dev,
+                alpha_row_bytes,
+                n_positions,
             )?;
             gpu.hip.memcpy_dtod_at(
-                &self.beta_bufs[layer].buf, 0,
-                &gather_scratch.buf, 0,
+                &self.beta_bufs[layer].buf,
+                0,
+                &gather_scratch.buf,
+                0,
                 n_positions * alpha_row_bytes,
             )?;
         }
@@ -937,11 +1130,7 @@ impl GdnTape {
 }
 
 impl DeltaNetTape {
-    pub fn new_for(
-        gpu: &mut Gpu,
-        state: &DeltaNetState,
-        n_slots: usize,
-    ) -> HipResult<Self> {
+    pub fn new_for(gpu: &mut Gpu, state: &DeltaNetState, n_slots: usize) -> HipResult<Self> {
         let mut slots = Vec::with_capacity(n_slots);
         for _ in 0..n_slots {
             slots.push(DeltaNetSnapshot::new_for(gpu, state)?);
@@ -953,12 +1142,7 @@ impl DeltaNetTape {
         self.slots.len()
     }
 
-    pub fn save_at(
-        &mut self,
-        slot: usize,
-        state: &DeltaNetState,
-        gpu: &mut Gpu,
-    ) -> HipResult<()> {
+    pub fn save_at(&mut self, slot: usize, state: &DeltaNetState, gpu: &mut Gpu) -> HipResult<()> {
         self.slots[slot].save_from(state, gpu)
     }
 
@@ -987,8 +1171,12 @@ impl DeltaNetTape {
 /// `[1, 8, 15, 22, 29]`, matching the hard-coded indices in the HuggingFace
 /// `z-lab/Qwen3.5-9B-DFlash` config.
 pub fn dflash_extract_layer_ids(num_target_layers: usize, num_extract: usize) -> Vec<usize> {
-    if num_extract == 0 { return Vec::new(); }
-    if num_extract == 1 { return vec![1]; }
+    if num_extract == 0 {
+        return Vec::new();
+    }
+    if num_extract == 1 {
+        return vec![1];
+    }
     let start: f32 = 1.0;
     let end: f32 = (num_target_layers as i32 - 3).max(1) as f32;
     let step = (end - start) / (num_extract as f32 - 1.0);
@@ -1074,23 +1262,16 @@ impl DdtreeScratch {
         n_fa_layers: usize,
     ) -> HipResult<Self> {
         let max_n = 1 + max_budget;
-        let attn_bias = gpu.alloc_tensor(
-            &[max_n * max_n],
-            rdna_compute::DType::F32,
-        )?;
-        let parent_indices = gpu.alloc_tensor(
-            &[max_n * 4],
-            rdna_compute::DType::Raw,
-        )?;
+        let attn_bias = gpu.alloc_tensor(&[max_n * max_n], rdna_compute::DType::F32)?;
+        let parent_indices = gpu.alloc_tensor(&[max_n * 4], rdna_compute::DType::Raw)?;
         // Path B per-FA-layer pre-RoPE K capture. Sized once at session
         // init. Empty on n_fa_layers=0 → capture is a no-op even if the
         // env gate is set (slow-path-kill won't have data to consume).
         let mut pre_rope_k: Vec<GpuTensor> = Vec::with_capacity(n_fa_layers);
         for _ in 0..n_fa_layers {
-            pre_rope_k.push(gpu.alloc_tensor(
-                &[max_n * n_kv_heads * head_dim],
-                rdna_compute::DType::F32,
-            )?);
+            pre_rope_k.push(
+                gpu.alloc_tensor(&[max_n * n_kv_heads * head_dim], rdna_compute::DType::F32)?,
+            );
         }
 
         // Widest bytes-per-position across KV quant modes we might run under.
@@ -1102,24 +1283,14 @@ impl DdtreeScratch {
         let widest_k_bpp = q8_bpp.max(asym3_k_bpp).max(asym4_k_bpp).max(asym2_k_bpp);
         let widest_v_bpp = q8_bpp;
 
-        let kv_gather_indices = gpu.alloc_tensor(
-            &[max_n * 4],
-            rdna_compute::DType::Raw,
-        )?;
+        let kv_gather_indices = gpu.alloc_tensor(&[max_n * 4], rdna_compute::DType::Raw)?;
         // Raw byte buffers sized to hold `max_n` full K / V rows.
-        let kv_gather_scratch_k = gpu.alloc_tensor(
-            &[(max_n * widest_k_bpp + 3) / 4],
-            rdna_compute::DType::F32,
-        )?;
-        let kv_gather_scratch_v = gpu.alloc_tensor(
-            &[(max_n * widest_v_bpp + 3) / 4],
-            rdna_compute::DType::F32,
-        )?;
+        let kv_gather_scratch_k =
+            gpu.alloc_tensor(&[(max_n * widest_k_bpp + 3) / 4], rdna_compute::DType::F32)?;
+        let kv_gather_scratch_v =
+            gpu.alloc_tensor(&[(max_n * widest_v_bpp + 3) / 4], rdna_compute::DType::F32)?;
         // Tape rows are F32 projections, so sized in F32 elements directly.
-        let tape_gather_scratch = gpu.alloc_tensor(
-            &[max_n * qkv_dim],
-            rdna_compute::DType::F32,
-        )?;
+        let tape_gather_scratch = gpu.alloc_tensor(&[max_n * qkv_dim], rdna_compute::DType::F32)?;
 
         Ok(Self {
             max_n,
@@ -1269,8 +1440,10 @@ impl HiddenStateRingBuffer {
         let mut layer_bufs = Vec::with_capacity(num_extract);
         let mut staging_bufs = Vec::with_capacity(num_extract);
         for _ in 0..num_extract {
-            layer_bufs.push(gpu.alloc_tensor(&[max_positions * hidden_dim], rdna_compute::DType::F32)?);
-            staging_bufs.push(gpu.alloc_tensor(&[max_batch * hidden_dim], rdna_compute::DType::F32)?);
+            layer_bufs
+                .push(gpu.alloc_tensor(&[max_positions * hidden_dim], rdna_compute::DType::F32)?);
+            staging_bufs
+                .push(gpu.alloc_tensor(&[max_batch * hidden_dim], rdna_compute::DType::F32)?);
         }
         Ok(Self {
             layer_bufs,
@@ -1288,19 +1461,16 @@ impl HiddenStateRingBuffer {
     /// index into `layer_bufs`/`extract_layers` for that layer. Otherwise None.
     #[inline]
     pub fn extract_slot(&self, target_layer_idx: usize) -> Option<usize> {
-        self.extract_layers.iter().position(|&l| l == target_layer_idx)
+        self.extract_layers
+            .iter()
+            .position(|&l| l == target_layer_idx)
     }
 
     /// Copy `x` (shape `[hidden_dim]`) into the ring buffer slot for the given
     /// extraction layer at the CURRENT head position. Call once per extracted
     /// layer per forward pass, then `advance_head()` at the end of the forward
     /// to move to the next slot.
-    pub fn write_at_head(
-        &self,
-        gpu: &mut Gpu,
-        extract_idx: usize,
-        x: &GpuTensor,
-    ) -> HipResult<()> {
+    pub fn write_at_head(&self, gpu: &mut Gpu, extract_idx: usize, x: &GpuTensor) -> HipResult<()> {
         let offset = self.head * self.hidden_dim * 4;
         gpu.hip.memcpy_dtod_at(
             &self.layer_bufs[extract_idx].buf,
@@ -1386,22 +1556,26 @@ impl HiddenStateRingBuffer {
         src: &GpuTensor,
         n: usize,
     ) -> HipResult<()> {
-        debug_assert!(n <= self.max_batch,
-            "write_rows_to_staging: n {} > max_batch {}", n, self.max_batch);
+        debug_assert!(
+            n <= self.max_batch,
+            "write_rows_to_staging: n {} > max_batch {}",
+            n,
+            self.max_batch
+        );
         let row_bytes = self.hidden_dim * 4;
         let bytes = n * row_bytes;
         if let Some(stream) = gpu.active_stream.as_ref() {
             gpu.hip.memcpy_dtod_async_at(
-                &self.staging_bufs[extract_idx].buf, 0,
-                &src.buf, 0,
-                bytes, stream,
+                &self.staging_bufs[extract_idx].buf,
+                0,
+                &src.buf,
+                0,
+                bytes,
+                stream,
             )
         } else {
-            gpu.hip.memcpy_dtod_at(
-                &self.staging_bufs[extract_idx].buf, 0,
-                &src.buf, 0,
-                bytes,
-            )
+            gpu.hip
+                .memcpy_dtod_at(&self.staging_bufs[extract_idx].buf, 0, &src.buf, 0, bytes)
         }
     }
 
@@ -1431,20 +1605,26 @@ impl HiddenStateRingBuffer {
         for ei in 0..self.layer_bufs.len() {
             if head + n <= max_pos {
                 gpu.hip.memcpy_dtod_at(
-                    &self.layer_bufs[ei].buf, head * row_bytes,
-                    &self.staging_bufs[ei].buf, 0,
+                    &self.layer_bufs[ei].buf,
+                    head * row_bytes,
+                    &self.staging_bufs[ei].buf,
+                    0,
                     n * row_bytes,
                 )?;
             } else {
                 let first = max_pos - head;
                 gpu.hip.memcpy_dtod_at(
-                    &self.layer_bufs[ei].buf, head * row_bytes,
-                    &self.staging_bufs[ei].buf, 0,
+                    &self.layer_bufs[ei].buf,
+                    head * row_bytes,
+                    &self.staging_bufs[ei].buf,
+                    0,
                     first * row_bytes,
                 )?;
                 gpu.hip.memcpy_dtod_at(
-                    &self.layer_bufs[ei].buf, 0,
-                    &self.staging_bufs[ei].buf, first * row_bytes,
+                    &self.layer_bufs[ei].buf,
+                    0,
+                    &self.staging_bufs[ei].buf,
+                    first * row_bytes,
                     (n - first) * row_bytes,
                 )?;
             }
@@ -1488,7 +1668,9 @@ fn softmax_temp_into(logits: &[f32], temp: f32, out: &mut Vec<f32>) {
     let mut max = f32::NEG_INFINITY;
     for &v in logits {
         let s = v * inv_t;
-        if s > max { max = s; }
+        if s > max {
+            max = s;
+        }
     }
     let mut sum = 0.0f32;
     for &v in logits {
@@ -1497,7 +1679,9 @@ fn softmax_temp_into(logits: &[f32], temp: f32, out: &mut Vec<f32>) {
         sum += e;
     }
     let inv_sum = 1.0 / sum;
-    for p in out.iter_mut() { *p *= inv_sum; }
+    for p in out.iter_mut() {
+        *p *= inv_sum;
+    }
 }
 
 /// Draw a categorical sample from `probs` given uniform u ∈ [0, 1).
@@ -1506,7 +1690,9 @@ fn sample_categorical(probs: &[f32], u: f32) -> u32 {
     let mut acc = 0.0f32;
     for (i, &p) in probs.iter().enumerate() {
         acc += p;
-        if u < acc { return i as u32; }
+        if u < acc {
+            return i as u32;
+        }
     }
     (probs.len() - 1) as u32
 }
@@ -1519,7 +1705,9 @@ fn sample_residual(p_target: &[f32], p_draft: &[f32], u: f32) -> u32 {
     let mut sum = 0.0f32;
     for i in 0..p_target.len() {
         let d = p_target[i] - p_draft[i];
-        if d > 0.0 { sum += d; }
+        if d > 0.0 {
+            sum += d;
+        }
     }
     if sum <= 0.0 {
         // Degenerate case (p_draft >= p_target everywhere). Should not
@@ -1533,7 +1721,9 @@ fn sample_residual(p_target: &[f32], p_draft: &[f32], u: f32) -> u32 {
         let d = p_target[i] - p_draft[i];
         if d > 0.0 {
             acc += d;
-            if u_scaled < acc { return i as u32; }
+            if u_scaled < acc {
+                return i as u32;
+            }
         }
     }
     (p_target.len() - 1) as u32
@@ -1571,12 +1761,7 @@ impl NgramCache {
     /// Record the triple `(a, b) → c` in the cache.
     #[inline]
     pub fn observe(&mut self, a: u32, b: u32, c: u32) {
-        *self
-            .bigram
-            .entry((a, b))
-            .or_default()
-            .entry(c)
-            .or_insert(0) += 1;
+        *self.bigram.entry((a, b)).or_default().entry(c).or_insert(0) += 1;
     }
 
     /// Predict `c` from last-two `(a, b)` if the max-count next-token
@@ -1632,7 +1817,11 @@ pub struct PldMatcher {
 
 impl Default for PldMatcher {
     fn default() -> Self {
-        Self { ngram_lens: vec![5, 4, 3], max_extract: 8, min_extract: 3 }
+        Self {
+            ngram_lens: vec![5, 4, 3],
+            max_extract: 8,
+            min_extract: 3,
+        }
     }
 }
 
@@ -1710,7 +1899,11 @@ impl PldMatcher {
 
         let (n, tokens) = best?;
         let consensus = firsts.iter().filter(|&&t| t == tokens[0]).count();
-        Some(PldMatch { tokens, n, consensus })
+        Some(PldMatch {
+            tokens,
+            n,
+            consensus,
+        })
     }
 }
 
@@ -1846,9 +2039,7 @@ pub fn spec_step_greedy(
     //   drafted[0] verified by target_logits_at_pos  (logits at pos)
     //   drafted[i] (i >= 1) verified by target_mid_logits[i-1] (logits at pos+i)
     let mut accepted: usize = 0;
-    if !target_logits_at_pos.is_empty()
-        && argmax_u32(&target_logits_at_pos) == drafted[0]
-    {
+    if !target_logits_at_pos.is_empty() && argmax_u32(&target_logits_at_pos) == drafted[0] {
         accepted = 1;
         for i in 1..k {
             if argmax_u32(&target_mid_logits[i - 1]) == drafted[i] {
@@ -1906,6 +2097,10 @@ pub struct DflashVerifyOutput {
     pub logits_per_pos: Vec<f32>,
 }
 
+fn dflash_use_gdn_tape_replay(caller_supplied_tape: bool, verify_populates_tape: bool) -> bool {
+    caller_supplied_tape && verify_populates_tape
+}
+
 /// Run the target on `draft_tokens` (length B) positions starting at
 /// `start_pos`. Advances `target.kv_cache` and `target.dn_state` by B
 /// positions. Writes B hidden-state rows into `hidden_rb` (ring head
@@ -1933,7 +2128,14 @@ pub fn verify_dflash_block(
     verify_scratch: &VerifyScratch,
 ) -> HipResult<DflashVerifyOutput> {
     verify_dflash_block_inner(
-        gpu, target, draft_tokens, start_pos, hidden_rb, gdn_tape, want_full_logits, None,
+        gpu,
+        target,
+        draft_tokens,
+        start_pos,
+        hidden_rb,
+        gdn_tape,
+        want_full_logits,
+        None,
         verify_scratch,
     )
 }
@@ -1962,7 +2164,13 @@ pub fn verify_dflash_block_tree(
     verify_scratch: &VerifyScratch,
 ) -> HipResult<DflashVerifyOutput> {
     verify_dflash_block_inner(
-        gpu, target, draft_tokens, start_pos, hidden_rb, gdn_tape, want_full_logits,
+        gpu,
+        target,
+        draft_tokens,
+        start_pos,
+        hidden_rb,
+        gdn_tape,
+        want_full_logits,
         Some(tree_verify),
         verify_scratch,
     )
@@ -1983,8 +2191,12 @@ fn verify_dflash_block_inner(
     let vocab = target.config.vocab_size;
     let dim = target.config.dim;
 
-    assert!(b <= verify_scratch.max_n,
-        "verify_scratch max_n {} < b {}", verify_scratch.max_n, b);
+    assert!(
+        b <= verify_scratch.max_n,
+        "verify_scratch max_n {} < b {}",
+        verify_scratch.max_n,
+        b
+    );
     assert_eq!(verify_scratch.dim, dim, "verify_scratch dim mismatch");
     assert_eq!(verify_scratch.vocab, vocab, "verify_scratch vocab mismatch");
 
@@ -1992,6 +2204,15 @@ fn verify_dflash_block_inner(
     // the actual current `b` (≤ max_n) so downstream kernels see the right
     // shapes. sub_offset returns a non-owning view; do NOT free these.
     let final_hidden = verify_scratch.final_hidden.sub_offset(0, b * dim);
+    let tree_verify_present = tree_verify.is_some();
+    let moe_lmhead_graph_env = std::env::var("HIPFIRE_DFLASH_MOE_VERIFY_GRAPH_LMHEAD").ok();
+    let moe_lmhead_graph_ok =
+        dflash_moe_verify_graph_lmhead_eligible(
+            target.config.num_experts,
+            want_full_logits,
+            tree_verify_present,
+            moe_lmhead_graph_env.as_deref(),
+        ) && dflash_batched_lm_head_supported(target.weights.output.gpu_dtype);
 
     // Graph-capture path eligibility. The captured forward bakes in:
     //   - N (the batch size) — via kernel grid dims
@@ -2030,8 +2251,9 @@ fn verify_dflash_block_inner(
     // the parent_indices-driven conv1d path. DO NOT ENABLE in production.
     //
     // Gate kept live so the next session can bisect without re-plumbing.
-    let tree_graph_enabled = std::env::var("HIPFIRE_VERIFY_GRAPH_TREE").ok().as_deref() == Some("1");
-    if tree_graph_enabled && tree_verify.is_some() {
+    let tree_graph_enabled =
+        std::env::var("HIPFIRE_VERIFY_GRAPH_TREE").ok().as_deref() == Some("1");
+    if tree_graph_enabled && tree_verify_present {
         static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
         if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
             eprintln!(
@@ -2039,12 +2261,13 @@ fn verify_dflash_block_inner(
             );
         }
     }
-    let tree_ok_for_graph = tree_verify.is_none() || tree_graph_enabled;
+    let tree_ok_for_graph = !tree_verify_present || tree_graph_enabled;
     let verify_graph_ok = std::env::var("HIPFIRE_VERIFY_GRAPH").ok().as_deref() != Some("0")
         && tree_ok_for_graph
         && matches!(
             target.weights.embd_format,
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 | hipfire_runtime::llama::EmbeddingFormat::Q8_0,
+            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256
+                | hipfire_runtime::llama::EmbeddingFormat::Q8_0,
         )
         && verify_scratch.prefill_batch.is_some();
 
@@ -2060,6 +2283,7 @@ fn verify_dflash_block_inner(
     } else {
         None
     };
+    let mut graph_includes_lmhead_argmax = false;
 
     let batch_result = if verify_graph_ok {
         let pbs = verify_scratch.prefill_batch.as_ref().unwrap();
@@ -2072,6 +2296,8 @@ fn verify_dflash_block_inner(
         }
         if gpu.verify_has_graph(b) {
             vg_mode = "replay";
+            graph_includes_lmhead_argmax =
+                moe_lmhead_graph_ok && gpu.verify_graph_has_lmhead_argmax(b);
             // Replay path: kernels read pbs.tokens/pbs.positions/dn_state/
             // kv_cache contents that were freshly updated above + upstream.
             gpu.verify_graph_launch(b)?;
@@ -2101,12 +2327,16 @@ fn verify_dflash_block_inner(
                 false, // DFlash computes all verify logits from final_hidden below
             );
             if r.is_ok() {
-                eprintln!("[verify-graph] warmup for B={} complete — capture next cycle at this B", b);
+                eprintln!(
+                    "[verify-graph] warmup for B={} complete — capture next cycle at this B",
+                    b
+                );
             }
             r
         } else {
             vg_mode = "capture";
             // Capture path: first call at this B after warmup.
+            let capture_lmhead_argmax = moe_lmhead_graph_ok;
             gpu.begin_verify_graph_capture(b)?;
             let r = qwen35::forward_prefill_batch_single_chunk_captured_opts(
                 gpu,
@@ -2124,9 +2354,27 @@ fn verify_dflash_block_inner(
                 tree_verify,
                 false, // DFlash computes all verify logits from final_hidden below
             );
+            let r = if r.is_ok() && capture_lmhead_argmax {
+                r.and_then(|_| {
+                    dflash_enqueue_verify_lm_head_argmax(
+                        gpu,
+                        &target.weights.output,
+                        &final_hidden,
+                        verify_scratch,
+                        b,
+                        vocab,
+                    )
+                })
+            } else {
+                r
+            };
             if r.is_ok() {
                 let blob_count = gpu.capture_blobs.len();
                 gpu.end_verify_graph_capture()?;
+                if capture_lmhead_argmax {
+                    gpu.verify_mark_graph_lmhead_argmax(b);
+                    graph_includes_lmhead_argmax = true;
+                }
                 // Under `hipStreamBeginCapture`, kernels + memcpys on the
                 // captured stream are RECORDED, not executed. final_hidden
                 // and hidden_rb staging are left stale. Launching the graph
@@ -2138,12 +2386,16 @@ fn verify_dflash_block_inner(
                 gpu.verify_graph_launch(b)?;
                 eprintln!(
                     "[verify-graph] captured for B={} with {} blobs (cache size: {})",
-                    b, blob_count, gpu.verify_graph_count(),
+                    b,
+                    blob_count,
+                    gpu.verify_graph_count(),
                 );
             } else {
                 // If capture failed, tear down the partial capture so we fall
                 // back to the direct path next cycle cleanly.
-                let _ = gpu.hip.stream_end_capture(gpu.active_stream.as_ref().unwrap());
+                let _ = gpu
+                    .hip
+                    .stream_end_capture(gpu.active_stream.as_ref().unwrap());
                 gpu.capture_mode = false;
                 gpu.capture_blobs.clear();
             }
@@ -2164,8 +2416,8 @@ fn verify_dflash_block_inner(
             gdn_tape,
             tree_verify,
             verify_scratch.prefill_batch.as_ref(),
-            None, // mask_override: speculative verify path doesn't use the MTP probe hook
-            None, // max_layer: DFlash verify always runs the full stack
+            None,  // mask_override: speculative verify path doesn't use the MTP probe hook
+            None,  // max_layer: DFlash verify always runs the full stack
             false, // DFlash computes all verify logits from final_hidden below
         )
     };
@@ -2202,76 +2454,22 @@ fn verify_dflash_block_inner(
     let mut logits_per_pos: Vec<f32> = Vec::with_capacity(b * vocab);
     let mut argmax_per_pos: Vec<u32> = Vec::with_capacity(b);
 
-    let try_batched = match w_out.gpu_dtype {
-        rdna_compute::DType::Q8_0
-        | rdna_compute::DType::HFQ4G256
-        | rdna_compute::DType::MQ4G256
-        | rdna_compute::DType::MQ3G256
-        | rdna_compute::DType::HFQ6G256
-        | rdna_compute::DType::MQ6G256 => true,
-        _ => false,
-    };
+    let try_batched = dflash_batched_lm_head_supported(w_out.gpu_dtype);
 
-    if try_batched {
+    if graph_includes_lmhead_argmax {
+        debug_assert!(!want_full_logits);
+        // The MoE-only extended verify graph already enqueued lm_head+argmax.
+        // Mirror MTP's graph shape: keep device work captured, then perform
+        // the single small D2H read after graph launch.
+        argmax_per_pos = dflash_download_verify_argmax(gpu, verify_scratch, b)?;
+    } else if try_batched {
         let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
         // Q8_0 routes through the DFlash lm_head helper so the gfx12 WMMA
         // arm can be coherence-gated independently of MTP. Set
         // HIPFIRE_DFLASH_Q8_LMHEAD_WMMA=0 to force the legacy scalar chunks.
         // MQ4/HFQ4/HFQ6/MQ6 kernels have no 64-row cap and take the
         // single-shot path.
-        match w_out.gpu_dtype {
-            rdna_compute::DType::Q8_0 => {
-                dflash_gemm_q8_lmhead(gpu, w_out, &final_hidden, &logits_batch, b)?;
-            }
-            rdna_compute::DType::HFQ4G256 => {
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &final_hidden, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::MQ4G256 => {
-                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized: b*k={} > max_n*hidden_k={}",
-                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
-                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                // AWQ-aware rotation: when `w_out.awq_scale.is_some()` (lm_head
-                // has an AWQ sidecar attached), `_for` dispatches the AWQ
-                // variant that divides x by s before FWHT. Numerically
-                // identical to `rotate_x_mq_batched` when no sidecar exists.
-                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::MQ3G256 => {
-                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ3 lm_head: b*k={} > max_n*hidden_k={}",
-                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
-                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                // AWQ-aware rotation; see the MQ4 arm above for rationale.
-                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
-                gpu.gemm_hfq3g256_batched_lmhead(
-                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::HFQ6G256 => {
-                // Phase A.4: gfx906 dp4a path for HFQ6 lm_head batched.
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &final_hidden, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::MQ6G256 => {
-                // Phase A.4: rotate-then-batched lm_head for MQ6.
-                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ6 lm_head: b*k={} > max_n*hidden_k={}",
-                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
-                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            _ => unreachable!(),
-        }
+        dflash_enqueue_verify_lm_head(gpu, w_out, &final_hidden, verify_scratch, b, vocab)?;
         if want_full_logits {
             // Rejection-sampling path needs full target distribution.
             // Cost: B × vocab × 4 bytes D2H per verify (~15 MB at B=16 × 248K).
@@ -2287,16 +2485,7 @@ fn verify_dflash_block_inner(
             // PCIe D2H per verify on the 4B Q8 lm_head (~3-5 ms/iter).
             let argmax_buf = verify_scratch.argmax.sub_offset(0, b);
             gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, b)?;
-            let mut host_idx = vec![0i32; b];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, b * 4)
-                };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
-            }
-            for &idx in &host_idx {
-                argmax_per_pos.push(idx as u32);
-            }
+            argmax_per_pos = dflash_download_verify_argmax(gpu, verify_scratch, b)?;
         }
         // Greedy path doesn't need `logits_per_pos`; leave empty to avoid
         // the 15 MB D2H. If temp>0 sampling is added later, reinstate the
@@ -2306,7 +2495,10 @@ fn verify_dflash_block_inner(
         for i in 0..b {
             let hidden_row = final_hidden.sub_offset(i * dim, dim);
             llama::weight_gemv(
-                gpu, &target.weights.output, &hidden_row, &target.scratch.logits,
+                gpu,
+                &target.weights.output,
+                &hidden_row,
+                &target.scratch.logits,
             )?;
             let row = gpu.download_f32(&target.scratch.logits)?;
             debug_assert_eq!(row.len(), vocab);
@@ -2319,7 +2511,9 @@ fn verify_dflash_block_inner(
         gpu.hip.device_synchronize()?;
         eprintln!(
             "[vg-time] B={} mode={} elapsed_us={}",
-            b, vg_mode, t0.elapsed().as_micros()
+            b,
+            vg_mode,
+            t0.elapsed().as_micros()
         );
     }
 
@@ -2380,13 +2574,19 @@ pub fn scatter_hidden_block_to_interleaved(
     block_size: usize,
     n_rows: usize,
 ) -> HipResult<()> {
-    assert!(n_rows <= block_size, "scatter: n_rows {n_rows} > block_size {block_size}");
+    assert!(
+        n_rows <= block_size,
+        "scatter: n_rows {n_rows} > block_size {block_size}"
+    );
     let num_extract = hidden_rb.extract_layers.len();
     let hidden = hidden_rb.hidden_dim;
     let max_pos = hidden_rb.max_positions;
     let head = hidden_rb.head;
     let written = hidden_rb.written;
-    assert!(block_size <= written, "scatter: block_size {block_size} > written {written}");
+    assert!(
+        block_size <= written,
+        "scatter: block_size {block_size} > written {written}"
+    );
     let row_bytes = hidden * 4;
     let start_slot = (head + max_pos - block_size) % max_pos;
 
@@ -2423,7 +2623,10 @@ pub fn download_hidden_block(
     // `head` points to where the NEXT write will land. After B advances,
     // the most recent B sit at ring slots (head - B) mod max_pos ..
     // (head - 1) mod max_pos.
-    assert!(b <= written, "verify must have written at least B rows to ring buffer");
+    assert!(
+        b <= written,
+        "verify must have written at least B rows to ring buffer"
+    );
     let head = hidden_rb.head;
     let start_slot = (head + max_pos - b) % max_pos;
     let row_bytes = hidden * 4;
@@ -2445,7 +2648,8 @@ pub fn download_hidden_block(
                     b * row_bytes,
                 )
             };
-            gpu.hip.memcpy_dtoh_at(dst_bytes, src_buf, start_slot * row_bytes)?;
+            gpu.hip
+                .memcpy_dtoh_at(dst_bytes, src_buf, start_slot * row_bytes)?;
         } else {
             // Two-segment ring wrap: tail of buffer, then head.
             let first_rows = max_pos - start_slot;
@@ -2456,10 +2660,14 @@ pub fn download_hidden_block(
                     first_rows * row_bytes,
                 )
             };
-            gpu.hip.memcpy_dtoh_at(dst_first_bytes, src_buf, start_slot * row_bytes)?;
+            gpu.hip
+                .memcpy_dtoh_at(dst_first_bytes, src_buf, start_slot * row_bytes)?;
             let dst_second_bytes: &mut [u8] = unsafe {
                 std::slice::from_raw_parts_mut(
-                    layer_data_flat.as_mut_ptr().add(dst_offset_floats + first_rows * hidden) as *mut u8,
+                    layer_data_flat
+                        .as_mut_ptr()
+                        .add(dst_offset_floats + first_rows * hidden)
+                        as *mut u8,
                     second_rows * row_bytes,
                 )
             };
@@ -2587,9 +2795,8 @@ pub fn spec_step_dflash(
     // use only for diagnostics. When disabled, zero cost beyond a handful
     // of Instant::now() calls.
     static PHASE_ON_ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let phase_on = *PHASE_ON_ENV.get_or_init(|| {
-        std::env::var("HIPFIRE_SPEC_PHASES").ok().as_deref() == Some("1")
-    });
+    let phase_on = *PHASE_ON_ENV
+        .get_or_init(|| std::env::var("HIPFIRE_SPEC_PHASES").ok().as_deref() == Some("1"));
     if phase_on {
         gpu.hip.device_synchronize()?;
     }
@@ -2618,11 +2825,18 @@ pub fn spec_step_dflash(
     // Forces the per-row host download even when RP is off (extra D2H per
     // cycle); off-by-default for that reason.
     static NGRAM_BLOCK_ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let ngram_block_env = *NGRAM_BLOCK_ENV.get_or_init(|| {
-        std::env::var("HIPFIRE_DFLASH_NGRAM_BLOCK").ok().as_deref() == Some("1")
-    });
+    let ngram_block_env = *NGRAM_BLOCK_ENV
+        .get_or_init(|| std::env::var("HIPFIRE_DFLASH_NGRAM_BLOCK").ok().as_deref() == Some("1"));
     let ngram_block_active = !use_temp_sampling && ngram_block_env;
     let host_path_active = rp_active || ngram_block_active;
+    let draft_ffn_graph_env = std::env::var("HIPFIRE_DFLASH_MOE_DRAFT_FFN_GRAPH").ok();
+    let draft_ffn_graph = dflash_moe_draft_ffn_graph_eligible(
+        target.config.num_experts,
+        ctx_slice.is_some(),
+        pld_spine.is_some(),
+        use_temp_sampling,
+        draft_ffn_graph_env.as_deref(),
+    );
 
     if let Some(pld) = pld_spine {
         // PLD spine path: drafted tokens come from context-suffix match.
@@ -2645,264 +2859,313 @@ pub fn spec_step_dflash(
             }
         }
     } else {
-    // ── 2. noise_embedding = target.embed_tokens(block) written directly
-    // into draft_scratch.x on GPU (no host round-trip). Target and draft
-    // share the same Gpu, so the embedding lookup can target the draft's
-    // scratch buffer. Avoids 16 × D2H + one H2D per iter (~1 ms saved).
-    for (i, &tok) in block.iter().enumerate() {
-        let dst = draft_scratch.x.sub_offset(i * h, h);
-        match target.weights.embd_format {
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
-                gpu.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
+        // ── 2. noise_embedding = target.embed_tokens(block) written directly
+        // into draft_scratch.x on GPU (no host round-trip). Target and draft
+        // share the same Gpu, so the embedding lookup can target the draft's
+        // scratch buffer. Avoids 16 × D2H + one H2D per iter (~1 ms saved).
+        for (i, &tok) in block.iter().enumerate() {
+            let dst = draft_scratch.x.sub_offset(i * h, h);
+            match target.weights.embd_format {
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
+                    gpu.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
+                    gpu.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
+                    gpu.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::F32 => {
+                    gpu.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
+                }
+                _ => panic!("dflash: unsupported target embedding format for noise lookup"),
             }
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
-                gpu.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
-                gpu.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::F32 => {
-                gpu.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
-            }
-            _ => panic!("dflash: unsupported target embedding format for noise lookup"),
         }
-    }
 
-    // ── 3. Position arrays + optional context slice ─────────────────────
-    // Q positions: the absolute positions of the block slots,
-    //   [position + compact_offset .. position + B + compact_offset).
-    // K positions by default: absolute positions of all populated target_hidden
-    // rows (potentially non-contiguous after a TriAttention eviction), then
-    // the same block slots.
-    //
-    // Pre-eviction: positions are contiguous [0..position+B), so the
-    // abs_positions vec contains [0..position) and this matches the old
-    // behaviour byte-for-byte.
-    // Post-eviction: abs_positions contains the subset retained by the last
-    // FA layer's top-B mask, paired with the correct pre-eviction absolute
-    // positions so draft RoPE aligns with target.
-    //
-    // If `ctx_slice = Some(N)` is set, restrict the draft's context view to
-    // the last `N` rows of target_hidden_host, with RoPE positions
-    // [position-N..position+B). Eviction-aware abs positions are not tracked
-    // on this diagnostic path — callers using it don't expect FlashCASK.
-    let effective_ctx_len = match ctx_slice {
-        Some(n) => n.min(position),
-        None => draft_scratch.target_hidden_abs_positions.len().min(position),
-    };
-    let ctx_start = position - effective_ctx_len;
-    let co = target.kv_cache.compact_offset as i32;
-    let positions_q: Vec<i32> =
-        ((position as i32 + co)..(position as i32 + b as i32 + co)).collect();
-    let positions_k: Vec<i32> = if ctx_slice.is_some() {
-        // Diagnostic path: keep legacy contiguous layout. abs_positions isn't
-        // tracked here and eviction isn't supported with ctx_slice anyway.
-        (ctx_start as i32..(position + b) as i32).collect()
-    } else {
-        let mut v = Vec::with_capacity(effective_ctx_len + b);
-        let th_abs = &draft_scratch.target_hidden_abs_positions;
-        let start_idx = th_abs.len().saturating_sub(effective_ctx_len);
-        v.extend_from_slice(&th_abs[start_idx..]);
-        for p in 0..b {
-            v.push(position as i32 + p as i32 + co);
-        }
-        v
-    };
-
-    // Slice target_hidden_host to the last effective_ctx_len rows. When
-    // ctx_slice is None, this is a no-op (ctx_start = 0). Row stride is
-    // num_extract × hidden = ne * h.
-    //
-    // Fast path (ctx_slice == None, 2026-04-16): `draft_scratch.target_hidden`
-    // is already populated via D2D scatter at the END of the previous cycle
-    // (or seed_target_hidden_from_prompt for the first cycle). We pass
-    // `target_hidden = None` to draft_forward so it skips the H2D upload
-    // entirely — kills the per-cycle CPU roundtrip.
-    //
-    // ctx_slice=Some(N) still goes through the CPU shadow (target_hidden_host
-    // Vec) because its moving-window semantics don't map onto the append-only
-    // GPU buffer without an extra D2D shuffle. It's a diagnostic path anyway.
-    let (th_arg, _th_offset): (Option<&[f32]>, usize) = if ctx_slice.is_some() {
-        let th_offset = ctx_start * ne * h;
-        (Some(&target_hidden_host[th_offset..]), th_offset)
-    } else {
-        (None, 0)
-    };
-
-    // ── 4. draft_forward ────────────────────────────────────────────────
-    // noise_embedding = None: we wrote embeddings directly into
-    // draft_scratch.x above via D2D (no host round-trip).
-    dflash::draft_forward(
-        gpu,
-        draft_weights,
-        draft_cfg,
-        None,
-        th_arg,
-        &positions_q,
-        &positions_k,
-        b,
-        effective_ctx_len,
-        draft_scratch,
-    )?;
-
-    // ── 5. Apply target.lm_head to draft hidden positions 1..B ──────────
-    // Fast path: a single batched GEMM against target.weights.output over
-    // (B-1) hidden rows at once. Drops lm_head from ~40 ms (B-1 serial
-    // weight_gemv + downloads) to ~8 ms (one batched GEMM + one download)
-    // for MQ4/HFQ4 lm_heads. Falls back to the per-row loop when the
-    // output weight dtype isn't covered by the batched gemm dispatch.
-    //
-    // Temperature-sampling mode (temp > 0): we must DOWNLOAD the full
-    // (B-1, vocab) draft logits, softmax + sample + record p_draft[token]
-    // for later rejection acceptance. The greedy GPU-argmax path is kept
-    // intact for temp == 0 so we don't regress that case.
-    let w_out = &target.weights.output;
-    let use_batched_gemm = matches!(
-        w_out.gpu_dtype,
-        rdna_compute::DType::HFQ4G256
-        | rdna_compute::DType::MQ4G256
-        | rdna_compute::DType::MQ3G256
-        | rdna_compute::DType::HFQ6G256
-        | rdna_compute::DType::MQ6G256,
-    );
-    let use_q8_staged = matches!(w_out.gpu_dtype, rdna_compute::DType::Q8_0);
-    if use_batched_gemm || use_q8_staged {
-        // Unified batched path: one GEMM over B-1 rows, GPU-side argmax,
-        // download just (B-1) × 4 bytes of indices.
+        // ── 3. Position arrays + optional context slice ─────────────────────
+        // Q positions: the absolute positions of the block slots,
+        //   [position + compact_offset .. position + B + compact_offset).
+        // K positions by default: absolute positions of all populated target_hidden
+        // rows (potentially non-contiguous after a TriAttention eviction), then
+        // the same block slots.
         //
-        // Reuses `verify_scratch.logits` and `.rot` — same buffers the target
-        // verify uses. Draft calls this BEFORE verify in the cycle, so
-        // there's no aliasing. The verify call overwrites these buffers
-        // afterward. Avoids 2-3 hipMalloc/Free pairs per cycle.
-        let batch = b - 1;
-        assert!(batch <= verify_scratch.max_n,
-            "verify_scratch max_n {} < draft batch {}", verify_scratch.max_n, batch);
-        let hidden_rows = draft_scratch.x.sub_offset(h, batch * h);
-        let logits_batch = verify_scratch.logits.sub_offset(0, batch * vocab);
+        // Pre-eviction: positions are contiguous [0..position+B), so the
+        // abs_positions vec contains [0..position) and this matches the old
+        // behaviour byte-for-byte.
+        // Post-eviction: abs_positions contains the subset retained by the last
+        // FA layer's top-B mask, paired with the correct pre-eviction absolute
+        // positions so draft RoPE aligns with target.
+        //
+        // If `ctx_slice = Some(N)` is set, restrict the draft's context view to
+        // the last `N` rows of target_hidden_host, with RoPE positions
+        // [position-N..position+B). Eviction-aware abs positions are not tracked
+        // on this diagnostic path — callers using it don't expect FlashCASK.
+        let effective_ctx_len = match ctx_slice {
+            Some(n) => n.min(position),
+            None => draft_scratch
+                .target_hidden_abs_positions
+                .len()
+                .min(position),
+        };
+        let ctx_start = position - effective_ctx_len;
+        let co = target.kv_cache.compact_offset as i32;
+        let positions_q: Vec<i32> =
+            ((position as i32 + co)..(position as i32 + b as i32 + co)).collect();
+        let positions_k: Vec<i32> = if ctx_slice.is_some() {
+            // Diagnostic path: keep legacy contiguous layout. abs_positions isn't
+            // tracked here and eviction isn't supported with ctx_slice anyway.
+            (ctx_start as i32..(position + b) as i32).collect()
+        } else {
+            let mut v = Vec::with_capacity(effective_ctx_len + b);
+            let th_abs = &draft_scratch.target_hidden_abs_positions;
+            let start_idx = th_abs.len().saturating_sub(effective_ctx_len);
+            v.extend_from_slice(&th_abs[start_idx..]);
+            for p in 0..b {
+                v.push(position as i32 + p as i32 + co);
+            }
+            v
+        };
 
-        match w_out.gpu_dtype {
-            rdna_compute::DType::Q8_0 => {
-                dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)?;
-            }
-            rdna_compute::DType::HFQ4G256 => {
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::MQ4G256 => {
-                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for draft lm_head");
-                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                // AWQ-aware rotation; same rationale as the target-verify
-                // arms above.
-                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::MQ3G256 => {
-                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ3 draft lm_head");
-                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq3g256_batched_lmhead(
-                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::HFQ6G256 => {
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::MQ6G256 => {
-                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ6 draft lm_head");
-                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            _ => unreachable!(),
-        }
+        // Slice target_hidden_host to the last effective_ctx_len rows. When
+        // ctx_slice is None, this is a no-op (ctx_start = 0). Row stride is
+        // num_extract × hidden = ne * h.
+        //
+        // Fast path (ctx_slice == None, 2026-04-16): `draft_scratch.target_hidden`
+        // is already populated via D2D scatter at the END of the previous cycle
+        // (or seed_target_hidden_from_prompt for the first cycle). We pass
+        // `target_hidden = None` to draft_forward so it skips the H2D upload
+        // entirely — kills the per-cycle CPU roundtrip.
+        //
+        // ctx_slice=Some(N) still goes through the CPU shadow (target_hidden_host
+        // Vec) because its moving-window semantics don't map onto the append-only
+        // GPU buffer without an extra D2D shuffle. It's a diagnostic path anyway.
+        let (th_arg, _th_offset): (Option<&[f32]>, usize) = if ctx_slice.is_some() {
+            let th_offset = ctx_start * ne * h;
+            (Some(&target_hidden_host[th_offset..]), th_offset)
+        } else {
+            (None, 0)
+        };
 
-        if use_temp_sampling {
-            // Full D2H of (B-1)×vocab logits, CPU softmax+sample.
-            let host_logits = gpu.download_f32(&logits_batch)?;
-            debug_assert_eq!(host_logits.len(), batch * vocab);
-            draft_softmaxes.reserve(batch);
-            for i in 0..batch {
-                let row = &host_logits[i * vocab..(i + 1) * vocab];
-                let mut probs = Vec::with_capacity(vocab);
-                softmax_temp_into(row, temp, &mut probs);
-                let u = xorshift_next_unit(rng_state);
-                let t = sample_categorical(&probs, u);
-                draft_probs_at_drafted.push(probs[t as usize]);
-                drafted.push(t);
-                draft_softmaxes.push(probs);
+        // ── 4. draft_forward ────────────────────────────────────────────────
+        // noise_embedding = None: we wrote embeddings directly into
+        // draft_scratch.x above via D2D (no host round-trip).
+        dflash::draft_forward_opts(
+            gpu,
+            draft_weights,
+            draft_cfg,
+            None,
+            th_arg,
+            &positions_q,
+            &positions_k,
+            b,
+            effective_ctx_len,
+            draft_scratch,
+            draft_ffn_graph,
+        )?;
+
+        // ── 5. Apply target.lm_head to draft hidden positions 1..B ──────────
+        // Fast path: a single batched GEMM against target.weights.output over
+        // (B-1) hidden rows at once. Drops lm_head from ~40 ms (B-1 serial
+        // weight_gemv + downloads) to ~8 ms (one batched GEMM + one download)
+        // for MQ4/HFQ4 lm_heads. Falls back to the per-row loop when the
+        // output weight dtype isn't covered by the batched gemm dispatch.
+        //
+        // Temperature-sampling mode (temp > 0): we must DOWNLOAD the full
+        // (B-1, vocab) draft logits, softmax + sample + record p_draft[token]
+        // for later rejection acceptance. The greedy GPU-argmax path is kept
+        // intact for temp == 0 so we don't regress that case.
+        let w_out = &target.weights.output;
+        let use_batched_gemm = matches!(
+            w_out.gpu_dtype,
+            rdna_compute::DType::HFQ4G256
+                | rdna_compute::DType::MQ4G256
+                | rdna_compute::DType::MQ3G256
+                | rdna_compute::DType::HFQ6G256
+                | rdna_compute::DType::MQ6G256,
+        );
+        let use_q8_staged = matches!(w_out.gpu_dtype, rdna_compute::DType::Q8_0);
+        if use_batched_gemm || use_q8_staged {
+            // Unified batched path: one GEMM over B-1 rows, GPU-side argmax,
+            // download just (B-1) × 4 bytes of indices.
+            //
+            // Reuses `verify_scratch.logits` and `.rot` — same buffers the target
+            // verify uses. Draft calls this BEFORE verify in the cycle, so
+            // there's no aliasing. The verify call overwrites these buffers
+            // afterward. Avoids 2-3 hipMalloc/Free pairs per cycle.
+            let batch = b - 1;
+            assert!(
+                batch <= verify_scratch.max_n,
+                "verify_scratch max_n {} < draft batch {}",
+                verify_scratch.max_n,
+                batch
+            );
+            let hidden_rows = draft_scratch.x.sub_offset(h, batch * h);
+            let logits_batch = verify_scratch.logits.sub_offset(0, batch * vocab);
+
+            match w_out.gpu_dtype {
+                rdna_compute::DType::Q8_0 => {
+                    dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)?;
+                }
+                rdna_compute::DType::HFQ4G256 => {
+                    gpu.gemm_hfq4g256_batched_lmhead(
+                        &w_out.buf,
+                        &hidden_rows,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::MQ4G256 => {
+                    assert!(
+                        batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                        "verify_scratch.rot undersized for draft lm_head"
+                    );
+                    let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                    // AWQ-aware rotation; same rationale as the target-verify
+                    // arms above.
+                    llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
+                    gpu.gemm_hfq4g256_batched_lmhead(
+                        &w_out.buf,
+                        &rotated,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::MQ3G256 => {
+                    assert!(
+                        batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                        "verify_scratch.rot undersized for MQ3 draft lm_head"
+                    );
+                    let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                    llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
+                    gpu.gemm_hfq3g256_batched_lmhead(
+                        &w_out.buf,
+                        &rotated,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::HFQ6G256 => {
+                    gpu.gemm_hfq6g256_batched_lmhead(
+                        &w_out.buf,
+                        &hidden_rows,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::MQ6G256 => {
+                    assert!(
+                        batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                        "verify_scratch.rot undersized for MQ6 draft lm_head"
+                    );
+                    let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                    llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
+                    gpu.gemm_hfq6g256_batched_lmhead(
+                        &w_out.buf,
+                        &rotated,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                _ => unreachable!(),
             }
-        } else if host_path_active {
-            // RP / n-gram-block path: apply per-row penalties before argmax
-            // so draft and target pick from the same reshaped distribution.
-            // Keeps spec-decode aligned (τ doesn't collapse from mismatched
-            // argmaxes — both sides see identical -inf logits on banned toks).
-            let host_logits = gpu.download_f32(&logits_batch)?;
-            debug_assert_eq!(host_logits.len(), batch * vocab);
-            let mut row = vec![0f32; vocab];
-            for i in 0..batch {
-                row.copy_from_slice(&host_logits[i * vocab..(i + 1) * vocab]);
-                if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
+
+            if use_temp_sampling {
+                // Full D2H of (B-1)×vocab logits, CPU softmax+sample.
+                let host_logits = gpu.download_f32(&logits_batch)?;
+                debug_assert_eq!(host_logits.len(), batch * vocab);
+                draft_softmaxes.reserve(batch);
+                for i in 0..batch {
+                    let row = &host_logits[i * vocab..(i + 1) * vocab];
+                    let mut probs = Vec::with_capacity(vocab);
+                    softmax_temp_into(row, temp, &mut probs);
+                    let u = xorshift_next_unit(rng_state);
+                    let t = sample_categorical(&probs, u);
+                    draft_probs_at_drafted.push(probs[t as usize]);
+                    drafted.push(t);
+                    draft_softmaxes.push(probs);
                 }
-                if ngram_block_active {
-                    llama::apply_ngram_block(&mut row, prev_committed);
+            } else if host_path_active {
+                // RP / n-gram-block path: apply per-row penalties before argmax
+                // so draft and target pick from the same reshaped distribution.
+                // Keeps spec-decode aligned (τ doesn't collapse from mismatched
+                // argmaxes — both sides see identical -inf logits on banned toks).
+                let host_logits = gpu.download_f32(&logits_batch)?;
+                debug_assert_eq!(host_logits.len(), batch * vocab);
+                let mut row = vec![0f32; vocab];
+                for i in 0..batch {
+                    row.copy_from_slice(&host_logits[i * vocab..(i + 1) * vocab]);
+                    if rp_active {
+                        llama::apply_repeat_penalty(
+                            &mut row,
+                            prev_committed,
+                            repeat_window,
+                            repeat_penalty,
+                        );
+                    }
+                    if ngram_block_active {
+                        llama::apply_ngram_block(&mut row, prev_committed);
+                    }
+                    drafted.push(argmax_u32(&row));
                 }
-                drafted.push(argmax_u32(&row));
+            } else {
+                // GPU argmax over (B-1) rows — one kernel, small D2H.
+                let argmax_buf = verify_scratch.argmax.sub_offset(0, batch);
+                gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, batch)?;
+                let mut host_idx = vec![0i32; batch];
+                {
+                    let bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, batch * 4)
+                    };
+                    gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
+                }
+                for &idx in &host_idx {
+                    drafted.push(idx as u32);
+                }
             }
         } else {
-            // GPU argmax over (B-1) rows — one kernel, small D2H.
-            let argmax_buf = verify_scratch.argmax.sub_offset(0, batch);
-            gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, batch)?;
-            let mut host_idx = vec![0i32; batch];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, batch * 4)
-                };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
-            }
-            for &idx in &host_idx {
-                drafted.push(idx as u32);
+            // Fallback: per-row weight_gemv loop.
+            for i in 1..b {
+                let hidden_row = draft_scratch.x.sub_offset(i * h, h);
+                llama::weight_gemv(gpu, w_out, &hidden_row, &target.scratch.logits)?;
+                let logits = gpu.download_f32(&target.scratch.logits)?;
+                debug_assert_eq!(logits.len(), vocab);
+                if use_temp_sampling {
+                    let mut probs = Vec::with_capacity(vocab);
+                    softmax_temp_into(&logits, temp, &mut probs);
+                    let u = xorshift_next_unit(rng_state);
+                    let t = sample_categorical(&probs, u);
+                    draft_probs_at_drafted.push(probs[t as usize]);
+                    drafted.push(t);
+                    draft_softmaxes.push(probs);
+                } else if host_path_active {
+                    let mut row = logits.clone();
+                    if rp_active {
+                        llama::apply_repeat_penalty(
+                            &mut row,
+                            prev_committed,
+                            repeat_window,
+                            repeat_penalty,
+                        );
+                    }
+                    if ngram_block_active {
+                        llama::apply_ngram_block(&mut row, prev_committed);
+                    }
+                    drafted.push(argmax_u32(&row));
+                } else {
+                    drafted.push(argmax_u32(&logits));
+                }
             }
         }
-    } else {
-        // Fallback: per-row weight_gemv loop.
-        for i in 1..b {
-            let hidden_row = draft_scratch.x.sub_offset(i * h, h);
-            llama::weight_gemv(gpu, w_out, &hidden_row, &target.scratch.logits)?;
-            let logits = gpu.download_f32(&target.scratch.logits)?;
-            debug_assert_eq!(logits.len(), vocab);
-            if use_temp_sampling {
-                let mut probs = Vec::with_capacity(vocab);
-                softmax_temp_into(&logits, temp, &mut probs);
-                let u = xorshift_next_unit(rng_state);
-                let t = sample_categorical(&probs, u);
-                draft_probs_at_drafted.push(probs[t as usize]);
-                drafted.push(t);
-                draft_softmaxes.push(probs);
-            } else if host_path_active {
-                let mut row = logits.clone();
-                if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
-                }
-                if ngram_block_active {
-                    llama::apply_ngram_block(&mut row, prev_committed);
-                }
-                drafted.push(argmax_u32(&row));
-            } else {
-                drafted.push(argmax_u32(&logits));
-            }
-        }
-    }
     } // close else (DFlash draft path)
 
     for i in 1..b {
@@ -2962,31 +3225,34 @@ pub fn spec_step_dflash(
     // re-running the target.
     target_snap.save_from(&target.dn_state, gpu)?;
     // Mutable variable to allow both verify capture + rollback replay usage.
-    let mut gdn_tape_opt = gdn_tape;
-    // MoE targets can't populate the tape: forward_prefill_batch_with_pbs's
-    // eligibility check rejects MoE (qwen35.rs `DeltaNetMoe|FullAttnMoe => false`),
-    // so verify falls through to the per-token loop which doesn't write the
-    // tape. With Some(tape) downstream `replay_gdn` then runs on zero-init
-    // buffers, corrupting `dn_state.conv_states` and hanging the next cycle.
-    // Force None so the fallback replay path (batched forward on committed
-    // tokens) runs instead — correct at ~3-5 ms/cycle extra vs proper tape
-    // replay. Remove once batched MoE prefill + tape recording lands.
-    let target_has_moe = target.weights.layers.iter().any(|lw| matches!(
-        lw,
-        qwen35::LayerWeights::DeltaNetMoe(_) | qwen35::LayerWeights::FullAttnMoe(_),
-    ));
-    if target_has_moe {
-        gdn_tape_opt = None;
-    }
+    let moe_router_logits_present = verify_scratch
+        .prefill_batch
+        .as_ref()
+        .map(|pbs| pbs.moe_router_logits_batch.is_some())
+        .unwrap_or(true);
+    let verify_populates_tape = qwen35::prefill_batch_pbs_eligible(
+        &target.weights,
+        &target.config,
+        &target.dn_state,
+        b,
+        gpu.arch.as_str(),
+        moe_router_logits_present,
+    );
+    let use_tape_replay = dflash_use_gdn_tape_replay(gdn_tape.is_some(), verify_populates_tape);
+    let mut gdn_tape_opt = if use_tape_replay { gdn_tape } else { None };
 
     if phase_on {
         gpu.hip.device_synchronize()?;
     }
     let t_verify_start = std::time::Instant::now();
     let verify_out = verify_dflash_block(
-        gpu, target, &block, position, hidden_rb,
+        gpu,
+        target,
+        &block,
+        position,
+        hidden_rb,
         gdn_tape_opt.as_deref_mut(),
-        use_temp_sampling || host_path_active,  // full target logits needed for rejection sampling, RP, or n-gram block
+        use_temp_sampling || host_path_active, // full target logits needed for rejection sampling, RP, or n-gram block
         verify_scratch,
     )?;
 
@@ -3023,7 +3289,11 @@ pub fn spec_step_dflash(
         // δ==0 reduces to vanilla SpS. Paper's strongest setting is δ=1.0.
         let use_cactus = cactus_delta > 0.0;
         for i in 0..b - 1 {
-            softmax_temp_into(&tgt_logits[i * vocab..(i + 1) * vocab], temp, &mut target_probs);
+            softmax_temp_into(
+                &tgt_logits[i * vocab..(i + 1) * vocab],
+                temp,
+                &mut target_probs,
+            );
             let t = block[i + 1] as usize;
             let p_d = draft_probs_at_drafted[i].max(f32::MIN_POSITIVE);
             let p_t = target_probs[t];
@@ -3049,7 +3319,9 @@ pub fn spec_step_dflash(
                     let gamma_star = accept_prob;
                     if qn >= 1.0 - 1e-6 {
                         // Degenerate: q is (near) one-hot on t; h is one-hot on t too.
-                        for v in target_probs.iter_mut() { *v = 0.0; }
+                        for v in target_probs.iter_mut() {
+                            *v = 0.0;
+                        }
                         target_probs[t] = 1.0;
                     } else {
                         let scale = (1.0 - gamma_star) / (1.0 - qn);
@@ -3059,9 +3331,7 @@ pub fn spec_step_dflash(
                     }
                 }
                 let u2 = xorshift_next_unit(rng_state);
-                rejected_bonus = Some(sample_residual(
-                    &target_probs, &draft_softmaxes[i], u2,
-                ));
+                rejected_bonus = Some(sample_residual(&target_probs, &draft_softmaxes[i], u2));
                 break;
             }
         }
@@ -3070,7 +3340,11 @@ pub fn spec_step_dflash(
         } else {
             // All accepted: sample from target_softmax at position B-1.
             let i = b - 1;
-            softmax_temp_into(&tgt_logits[i * vocab..(i + 1) * vocab], temp, &mut target_probs);
+            softmax_temp_into(
+                &tgt_logits[i * vocab..(i + 1) * vocab],
+                temp,
+                &mut target_probs,
+            );
             let u = xorshift_next_unit(rng_state);
             sample_categorical(&target_probs, u)
         };
@@ -3087,7 +3361,12 @@ pub fn spec_step_dflash(
             for i in 0..b {
                 row.copy_from_slice(&tgt_logits[i * vocab..(i + 1) * vocab]);
                 if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
+                    llama::apply_repeat_penalty(
+                        &mut row,
+                        prev_committed,
+                        repeat_window,
+                        repeat_penalty,
+                    );
                 }
                 if ngram_block_active {
                     llama::apply_ngram_block(&mut row, prev_committed);
@@ -3274,7 +3553,11 @@ pub fn spec_step_dflash(
     // batched call instead of (accept+1) sequential decodes.
     if let Some(tape) = gdn_tape_opt.as_deref() {
         tape.replay_gdn(
-            gpu, &target.weights, &target.config, &mut target.dn_state, accept_len + 1,
+            gpu,
+            &target.weights,
+            &target.config,
+            &mut target.dn_state,
+            accept_len + 1,
         )?;
     } else {
         let replay_tokens = &committed[..accept_len + 1];
@@ -3287,7 +3570,10 @@ pub fn spec_step_dflash(
             &mut target.kv_cache,
             &mut target.dn_state,
             &target.scratch,
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )?;
     }
     // Target state is now at position + accept_len + 1. KV cache has
@@ -3298,23 +3584,38 @@ pub fn spec_step_dflash(
     if phase_on {
         gpu.hip.device_synchronize()?;
         let t_end = std::time::Instant::now();
-        let us_draft   = t_draft_end.duration_since(t_spec_start).as_micros();
-        let us_ngram   = t_verify_start.duration_since(t_draft_end).as_micros();
-        let us_verify  = t_verify_end.duration_since(t_verify_start).as_micros();
-        let us_accept  = t_accept_end.duration_since(t_verify_end).as_micros();
+        let us_draft = t_draft_end.duration_since(t_spec_start).as_micros();
+        let us_ngram = t_verify_start.duration_since(t_draft_end).as_micros();
+        let us_verify = t_verify_end.duration_since(t_verify_start).as_micros();
+        let us_accept = t_accept_end.duration_since(t_verify_end).as_micros();
         let us_scatter = t_scatter_end.duration_since(t_accept_end).as_micros();
         let us_restore = t_restore_end.duration_since(t_scatter_end).as_micros();
-        let us_replay  = t_end.duration_since(t_restore_end).as_micros();
-        let us_total   = t_end.duration_since(t_spec_start).as_micros();
+        let us_replay = t_end.duration_since(t_restore_end).as_micros();
+        let us_total = t_end.duration_since(t_spec_start).as_micros();
         eprintln!(
             "[phase] B={} accept={} draft={}µs ngram={}µs verify={}µs \
              cmpr={}µs scatter={}µs restore={}µs replay={}µs | total={}µs",
-            b, accept_len, us_draft, us_ngram, us_verify, us_accept,
-            us_scatter, us_restore, us_replay, us_total,
+            b,
+            accept_len,
+            us_draft,
+            us_ngram,
+            us_verify,
+            us_accept,
+            us_scatter,
+            us_restore,
+            us_replay,
+            us_total,
         );
     }
-    let _ = (t_phase, t_draft_end, t_verify_start, t_verify_end,
-             t_accept_end, t_scatter_end, t_restore_end);
+    let _ = (
+        t_phase,
+        t_draft_end,
+        t_verify_start,
+        t_verify_end,
+        t_accept_end,
+        t_scatter_end,
+        t_restore_end,
+    );
 
     Ok(SpecStepResult {
         accepted: accept_len,
@@ -3649,7 +3950,12 @@ fn run_dflash_draft_for_topk_gpu(
     let topk_idx_gpu = gpu.alloc_tensor(&[batch * k], rdna_compute::DType::F32)?;
     let topk_val_gpu = gpu.alloc_tensor(&[batch * k], rdna_compute::DType::F32)?;
     let topk_result = gpu.topk_logsumexp_batched_f32(
-        &logits_batch, &topk_idx_gpu, &topk_val_gpu, vocab, k, batch,
+        &logits_batch,
+        &topk_idx_gpu,
+        &topk_val_gpu,
+        vocab,
+        k,
+        batch,
     );
     let _ = gpu.free_tensor(logits_batch);
     if let Err(e) = topk_result {
@@ -3661,12 +3967,10 @@ fn run_dflash_draft_for_topk_gpu(
     // Step 6: D2H just the top-K outputs (tiny — 8 × 15 × 4 = 480 bytes for k=8).
     let mut idx_host: Vec<i32> = vec![0i32; batch * k];
     let mut val_host: Vec<f32> = vec![0f32; batch * k];
-    let idx_bytes: &mut [u8] = unsafe {
-        std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, batch * k * 4)
-    };
-    let val_bytes: &mut [u8] = unsafe {
-        std::slice::from_raw_parts_mut(val_host.as_mut_ptr() as *mut u8, batch * k * 4)
-    };
+    let idx_bytes: &mut [u8] =
+        unsafe { std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, batch * k * 4) };
+    let val_bytes: &mut [u8] =
+        unsafe { std::slice::from_raw_parts_mut(val_host.as_mut_ptr() as *mut u8, batch * k * 4) };
     gpu.hip.memcpy_dtoh(idx_bytes, &topk_idx_gpu.buf)?;
     gpu.hip.memcpy_dtoh(val_bytes, &topk_val_gpu.buf)?;
     let _ = gpu.free_tensor(topk_idx_gpu);
@@ -3946,8 +4250,11 @@ pub fn spec_step_ddtree(
     // batch-size-equal to DFlash but tokens-correct. Some cross-cycle
     // numerical drift vs baseline is the tradeoff; output should remain
     // a valid target-greedy sequence.
-    let topk1_is_committed_prefix = accept_len > 0 && committed[1..=accept_len].iter().enumerate()
-        .all(|(d, &tok)| tok == top_tokens[d * tree_topk]);
+    let topk1_is_committed_prefix = accept_len > 0
+        && committed[1..=accept_len]
+            .iter()
+            .enumerate()
+            .all(|(d, &tok)| tok == top_tokens[d * tree_topk]);
     let tape_block: Vec<u32> = if topk1_is_committed_prefix || accept_len == 0 {
         // Safe to use full-B top-1 block (byte-exact with DFlash path).
         let mut vb: Vec<u32> = Vec::with_capacity(b);
@@ -4121,8 +4428,15 @@ pub fn spec_step_ddtree_batched(
     if tree.nodes.is_empty() {
         target_snap.save_from(&target.dn_state, gpu)?;
         qwen35::forward_scratch_with_hidden(
-            gpu, &target.weights, &target.config, seed_token, position,
-            &mut target.kv_cache, &mut target.dn_state, &target.scratch, hidden_rb,
+            gpu,
+            &target.weights,
+            &target.config,
+            seed_token,
+            position,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            hidden_rb,
         )?;
         let logits0 = gpu.download_f32(&target.scratch.logits)?;
         let bonus = argmax_u32(&logits0);
@@ -4152,7 +4466,8 @@ pub fn spec_step_ddtree_batched(
     assert!(
         big_n <= scratch.max_n,
         "tree big_n {} exceeds scratch.max_n {} (increase DdtreeScratch size)",
-        big_n, scratch.max_n,
+        big_n,
+        scratch.max_n,
     );
     {
         let mask_bytes = unsafe {
@@ -4179,7 +4494,8 @@ pub fn spec_step_ddtree_batched(
         let parent_bytes = unsafe {
             std::slice::from_raw_parts(parent_host.as_ptr() as *const u8, parent_host.len() * 4)
         };
-        gpu.hip.memcpy_htod(&scratch.parent_indices.buf, parent_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.parent_indices.buf, parent_bytes)?;
     }
 
     // ── 6. Snapshot pre-seed target state ─────────────────────────────────
@@ -4218,7 +4534,9 @@ pub fn spec_step_ddtree_batched(
     // overhead until the slow-path branch is replaced. Keep gated until
     // the eyeball-tested smoke (see PRD trap surface) passes.
     let pre_rope_capture = if std::env::var("HIPFIRE_DDTREE_PATH_B_CAPTURE")
-        .ok().as_deref() == Some("1")
+        .ok()
+        .as_deref()
+        == Some("1")
         && !scratch.pre_rope_k.is_empty()
     {
         Some(scratch.pre_rope_k.as_slice())
@@ -4228,12 +4546,23 @@ pub fn spec_step_ddtree_batched(
     let ctx = qwen35::TreeVerifyCtx {
         positions: &verify_positions,
         attn_bias: &attn_bias_view,
-        parent_indices: if use_tree_la { Some(&parent_view) } else { None },
+        parent_indices: if use_tree_la {
+            Some(&parent_view)
+        } else {
+            None
+        },
         pre_rope_k_capture: pre_rope_capture,
     };
     let t_pre_verify = t_all.elapsed();
     let verify_out = verify_dflash_block_tree(
-        gpu, target, &verify_tokens, position, hidden_rb, Some(gdn_tape), false, ctx,
+        gpu,
+        target,
+        &verify_tokens,
+        position,
+        hidden_rb,
+        Some(gdn_tape),
+        false,
+        ctx,
         verify_scratch,
     )?;
     let posterior = verify_out.argmax_per_pos;
@@ -4280,7 +4609,9 @@ pub fn spec_step_ddtree_batched(
     // at same depth otherwise race and the LAST write wins regardless of
     // which sibling was committed).
     let force_slow = std::env::var("HIPFIRE_DDTREE_FORCE_SLOW").ok().as_deref() == Some("1");
-    let spine_accept = accepted_node_indices.iter().enumerate()
+    let spine_accept = accepted_node_indices
+        .iter()
+        .enumerate()
         .all(|(i, &ni)| ni == i);
     let fast_tape_ok = !force_slow && spine_accept;
     // Per-cycle fast/slow accounting. HIPFIRE_DDTREE_TAPE_DUMP=1 emits a
@@ -4316,8 +4647,11 @@ pub fn spec_step_ddtree_batched(
             accept_len + 1,
         )?;
         hidden_rows_written = big_n;
-    } else if std::env::var("HIPFIRE_DDTREE_PATH_B_CAPTURE").ok().as_deref() == Some("1")
-              && !scratch.pre_rope_k.is_empty()
+    } else if std::env::var("HIPFIRE_DDTREE_PATH_B_CAPTURE")
+        .ok()
+        .as_deref()
+        == Some("1")
+        && !scratch.pre_rope_k.is_empty()
     {
         // Path B slow-path-kill (opt-in, WIP). Replaces the ~40-50 ms full
         // re-verify with a gather + per-commit RoPE + quant-write chain
@@ -4347,7 +4681,8 @@ pub fn spec_step_ddtree_batched(
         let tape_idx_bytes: &[u8] = unsafe {
             std::slice::from_raw_parts(tape_idx_host.as_ptr() as *const u8, n_positions * 4)
         };
-        gpu.hip.memcpy_htod(&scratch.parent_indices.buf, tape_idx_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.parent_indices.buf, tape_idx_bytes)?;
         gdn_tape.gather_accepted(
             gpu,
             &scratch.parent_indices,
@@ -4368,7 +4703,9 @@ pub fn spec_step_ddtree_batched(
         // For V: V doesn't carry a position-dependent rotation, so a
         // pure byte gather (raced slot → committed slot) is correct. Same
         // pattern Path A used.
-        let pbs = verify_scratch.prefill_batch.as_ref()
+        let pbs = verify_scratch
+            .prefill_batch
+            .as_ref()
             .expect("Path B requires VerifyScratch.prefill_batch (set during DdtreeScratch init)");
 
         // Tree-verify K source indices (one per accepted committed slot, in
@@ -4382,19 +4719,24 @@ pub fn spec_step_ddtree_batched(
         };
         // Reuse parent_indices buffer for the K gather indices (it was
         // already used for the tape gather above; re-upload now).
-        gpu.hip.memcpy_htod(&scratch.parent_indices.buf, k_src_idx_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.parent_indices.buf, k_src_idx_bytes)?;
 
         // Committed slot positions for RoPE + KV write: [start_pos+0..start_pos+accept_len].
         let pos_host: Vec<i32> = (0..n_positions).map(|i| (position + i) as i32).collect();
-        let pos_bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(pos_host.as_ptr() as *const u8, n_positions * 4)
-        };
-        gpu.hip.memcpy_htod(&scratch.kv_gather_indices.buf, pos_bytes)?;
+        let pos_bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(pos_host.as_ptr() as *const u8, n_positions * 4) };
+        gpu.hip
+            .memcpy_htod(&scratch.kv_gather_indices.buf, pos_bytes)?;
 
         // Absolute KV slots for V gather: [position+0, position+1+acc[0], ...]
         // (V is the same as Path A: byte gather from raced slots to committed).
         let v_src_abs_host: Vec<i32> = std::iter::once(position as i32)
-            .chain(accepted_node_indices.iter().map(|&i| (position + 1 + i) as i32))
+            .chain(
+                accepted_node_indices
+                    .iter()
+                    .map(|&i| (position + 1 + i) as i32),
+            )
             .collect();
         let v_src_abs_bytes: &[u8] = unsafe {
             std::slice::from_raw_parts(v_src_abs_host.as_ptr() as *const u8, n_positions * 4)
@@ -4402,15 +4744,25 @@ pub fn spec_step_ddtree_batched(
         // Park the V indices in the tape_gather_scratch's first 4×n bytes —
         // tape gather is done; the buffer is free until next cycle. (Avoids
         // adding yet another tiny i32 buffer to DdtreeScratch.)
-        gpu.hip.memcpy_htod(&scratch.tape_gather_scratch.buf, v_src_abs_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.tape_gather_scratch.buf, v_src_abs_bytes)?;
 
         let v_bpp = n_kv_heads * (head_dim / 32) * 34; // Q8 V (all asym* modes use Q8 V)
 
         let n_rot = (target.config.head_dim as f32 * target.config.partial_rotary_factor) as usize;
 
-        for (fa_idx, layer_idx) in target.config.layer_types.iter()
+        for (fa_idx, layer_idx) in target
+            .config
+            .layer_types
+            .iter()
             .enumerate()
-            .filter_map(|(li, lt)| if *lt == qwen35::LayerType::FullAttention { Some(li) } else { None })
+            .filter_map(|(li, lt)| {
+                if *lt == qwen35::LayerType::FullAttention {
+                    Some(li)
+                } else {
+                    None
+                }
+            })
             .enumerate()
         {
             // 1. Gather pre-RoPE K rows by k_src_idx into pbs.fa_k_batch.
@@ -4426,9 +4778,15 @@ pub fn spec_step_ddtree_batched(
             // 2. Apply RoPE in-place to gathered K with committed positions.
             //    Q is throwaway — fa_q_batch is large enough.
             gpu.rope_partial_interleaved_f32_batched(
-                &pbs.fa_q_batch, &pbs.fa_k_batch, &scratch.kv_gather_indices,
-                target.config.n_heads, target.config.n_kv_heads, target.config.head_dim,
-                n_rot, target.config.rope_theta, n_positions,
+                &pbs.fa_q_batch,
+                &pbs.fa_k_batch,
+                &scratch.kv_gather_indices,
+                target.config.n_heads,
+                target.config.n_kv_heads,
+                target.config.head_dim,
+                n_rot,
+                target.config.rope_theta,
+                n_positions,
             )?;
 
             // 3. V gather via the existing kv_compact_gather pattern.
@@ -4436,7 +4794,8 @@ pub fn spec_step_ddtree_batched(
                 &kv.v_gpu[layer_idx],
                 &scratch.kv_gather_scratch_v,
                 &scratch.tape_gather_scratch,
-                v_bpp, n_positions,
+                v_bpp,
+                n_positions,
             )?;
 
             // 4. Quant-write K (rotated, in pbs.fa_k_batch) + V (gathered,
@@ -4457,10 +4816,16 @@ pub fn spec_step_ddtree_batched(
                 // proper gather of the raced-but-correctly-quantized V
                 // values. So the garbage V write is a transient no-op.
                 gpu.kv_cache_write_asym3_batched(
-                    &kv.k_gpu[layer_idx], &kv.v_gpu[layer_idx],
-                    &pbs.fa_k_batch, &pbs.fa_v_batch,
+                    &kv.k_gpu[layer_idx],
+                    &kv.v_gpu[layer_idx],
+                    &pbs.fa_k_batch,
+                    &pbs.fa_v_batch,
                     &scratch.kv_gather_indices,
-                    ct, st, n_kv_heads, head_dim, n_positions,
+                    ct,
+                    st,
+                    n_kv_heads,
+                    head_dim,
+                    n_positions,
                 )?;
                 // V byte-gather: read pre-quantized V from raced slots
                 // [position+0, position+1+acc[0], ...] into a contiguous
@@ -4473,11 +4838,14 @@ pub fn spec_step_ddtree_batched(
                     &kv.v_gpu[layer_idx],
                     &scratch.kv_gather_scratch_v,
                     &scratch.tape_gather_scratch,
-                    v_bpp, n_positions,
+                    v_bpp,
+                    n_positions,
                 )?;
                 gpu.hip.memcpy_dtod_at(
-                    &kv.v_gpu[layer_idx].buf, position * v_bpp,
-                    &scratch.kv_gather_scratch_v.buf, 0,
+                    &kv.v_gpu[layer_idx].buf,
+                    position * v_bpp,
+                    &scratch.kv_gather_scratch_v.buf,
+                    0,
                     n_positions * v_bpp,
                 )?;
             } else {
@@ -4485,8 +4853,10 @@ pub fn spec_step_ddtree_batched(
                 // but with the matching kv_cache_write_*_batched call.
                 // For initial Phase 2 prototype, panic so we notice if a
                 // non-asym3 model accidentally enables Path B.
-                panic!("Path B Phase 2 only supports asym3 KV today (got: q8={} asym4={} asym2={})",
-                    kv.quant_q8, kv.quant_asym4, kv.quant_asym2);
+                panic!(
+                    "Path B Phase 2 only supports asym3 KV today (got: q8={} asym4={} asym2={})",
+                    kv.quant_q8, kv.quant_asym4, kv.quant_asym2
+                );
             }
         }
 
@@ -4508,7 +4878,13 @@ pub fn spec_step_ddtree_batched(
         let tape_block: Vec<u32> = committed[..accept_len + 1].to_vec();
         target_snap.restore_to(&mut target.dn_state, gpu)?;
         let _tape_verify = verify_dflash_block(
-            gpu, target, &tape_block, position, hidden_rb, Some(gdn_tape), false,
+            gpu,
+            target,
+            &tape_block,
+            position,
+            hidden_rb,
+            Some(gdn_tape),
+            false,
             verify_scratch,
         )?;
         target_snap.restore_to(&mut target.dn_state, gpu)?;
@@ -4680,8 +5056,15 @@ pub fn spec_step_ddtree_path_c(
     if main_path.is_empty() {
         target_snap.save_from(&target.dn_state, gpu)?;
         qwen35::forward_scratch_with_hidden(
-            gpu, &target.weights, &target.config, seed_token, position,
-            &mut target.kv_cache, &mut target.dn_state, &target.scratch, hidden_rb,
+            gpu,
+            &target.weights,
+            &target.config,
+            seed_token,
+            position,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            hidden_rb,
         )?;
         let logits0 = gpu.download_f32(&target.scratch.logits)?;
         let bonus = argmax_u32(&logits0);
@@ -4709,7 +5092,13 @@ pub fn spec_step_ddtree_path_c(
     //       phase poisoning — RoPE phases match committed slots exactly.
     //       This is the entire "Step 1" of the PRD's three-step pattern.
     let main_verify_out = verify_dflash_block(
-        gpu, target, &verify_tokens, position, hidden_rb, Some(gdn_tape), false,
+        gpu,
+        target,
+        &verify_tokens,
+        position,
+        hidden_rb,
+        Some(gdn_tape),
+        false,
         verify_scratch,
     )?;
     let main_posterior = main_verify_out.argmax_per_pos;
@@ -4772,7 +5161,10 @@ pub fn spec_step_ddtree_path_c(
         static PATH_C_BRANCH_TOKENS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
     }
     PATH_C_TOTAL.with(|c| c.set(c.get() + 1));
-    let verbose = std::env::var("HIPFIRE_DDTREE_PATH_C_VERBOSE").ok().as_deref() == Some("1");
+    let verbose = std::env::var("HIPFIRE_DDTREE_PATH_C_VERBOSE")
+        .ok()
+        .as_deref()
+        == Some("1");
     let mut diag_phase2 = false;
     let mut diag_fork_sibling = false;
     let mut diag_candidate = false;
@@ -4784,7 +5176,8 @@ pub fn spec_step_ddtree_path_c(
         snaps.main_end_snap.save_from(&target.dn_state, gpu)?;
 
         // Find the unique candidate branch.
-        let branches = hipfire_runtime::ddtree::enumerate_branches(&tree, &main_path, accepted_main);
+        let branches =
+            hipfire_runtime::ddtree::enumerate_branches(&tree, &main_path, accepted_main);
         diag_fork_sibling = branches
             .iter()
             .any(|b| b.fork_depth as usize == accepted_main);
@@ -4835,16 +5228,21 @@ pub fn spec_step_ddtree_path_c(
             } else {
                 tree.nodes[main_path[accepted_main - 1]].token
             };
-            let mut branch_chain_tokens: Vec<u32> =
-                Vec::with_capacity(1 + branch.chain.len());
+            let mut branch_chain_tokens: Vec<u32> = Vec::with_capacity(1 + branch.chain.len());
             branch_chain_tokens.push(parent_tok);
             for &ni in &branch.chain {
                 branch_chain_tokens.push(tree.nodes[ni].token);
             }
             let branch_start_pos = position + accepted_main;
             let branch_verify_out = verify_dflash_block(
-                gpu, target, &branch_chain_tokens, branch_start_pos, hidden_rb,
-                Some(gdn_tape), false, verify_scratch,
+                gpu,
+                target,
+                &branch_chain_tokens,
+                branch_start_pos,
+                hidden_rb,
+                Some(gdn_tape),
+                false,
+                verify_scratch,
             )?;
             let branch_posterior = branch_verify_out.argmax_per_pos;
             debug_assert_eq!(branch_posterior.len(), 1 + branch.chain.len());
@@ -4879,7 +5277,9 @@ pub fn spec_step_ddtree_path_c(
                 // Step 3: drive DN state to "after position + accepted_main +
                 // accepted_branch" via tape replay on the branch tape we
                 // just captured (rows [0..1+accepted_branch]).
-                snaps.parent_pre_snap.restore_to(&mut target.dn_state, gpu)?;
+                snaps
+                    .parent_pre_snap
+                    .restore_to(&mut target.dn_state, gpu)?;
                 gdn_tape.replay_gdn(
                     gpu,
                     &target.weights,
@@ -4922,7 +5322,8 @@ pub fn spec_step_ddtree_path_c(
     }
     committed.push(effective_bonus);
 
-    let mut drafted: Vec<u32> = Vec::with_capacity(1 + main_path.len() + accepted_branch_indices.len());
+    let mut drafted: Vec<u32> =
+        Vec::with_capacity(1 + main_path.len() + accepted_branch_indices.len());
     drafted.push(seed_token);
     for &ni in &main_path {
         drafted.push(tree.nodes[ni].token);
@@ -4955,14 +5356,33 @@ pub fn spec_step_ddtree_path_c(
         let ba = PATH_C_BRANCH_ACCEPTED.with(|c| c.get());
         let bt = PATH_C_BRANCH_TOKENS.with(|c| c.get());
         let mean_branch = if ba > 0 { bt as f32 / ba as f32 } else { 0.0 };
-        let cand_rate = if p2 > 0 { 100.0 * cf as f32 / p2 as f32 } else { 0.0 };
-        let accept_rate = if cf > 0 { 100.0 * ba as f32 / cf as f32 } else { 0.0 };
+        let cand_rate = if p2 > 0 {
+            100.0 * cf as f32 / p2 as f32
+        } else {
+            0.0
+        };
+        let accept_rate = if cf > 0 {
+            100.0 * ba as f32 / cf as f32
+        } else {
+            0.0
+        };
         eprintln!(
             "[path-c] cycle: phase2={} acc_main={} fork_sibling={} candidate={} accept_branch={} \
              | cumul: cycles={} phase2={} fork_sib={} cand={} ({:.1}% of phase2) \
              accept={} ({:.1}% of cand) mean_branch_tok={:.2}",
-            diag_phase2, accepted_main, diag_fork_sibling, diag_candidate, diag_accept_branch,
-            total, p2, fs, cf, cand_rate, ba, accept_rate, mean_branch,
+            diag_phase2,
+            accepted_main,
+            diag_fork_sibling,
+            diag_candidate,
+            diag_accept_branch,
+            total,
+            p2,
+            fs,
+            cf,
+            cand_rate,
+            ba,
+            accept_rate,
+            mean_branch,
         );
     }
 
@@ -5064,7 +5484,8 @@ pub fn apply_eviction_retain_to_draft(
                 host.len() * std::mem::size_of::<f32>(),
             )
         };
-        gpu.hip.memcpy_dtoh(bytes, &draft_scratch.target_hidden.buf)?;
+        gpu.hip
+            .memcpy_dtoh(bytes, &draft_scratch.target_hidden.buf)?;
     }
     let budget = retain_mask.len();
     let mut compacted = Vec::with_capacity(budget * row_floats);
@@ -5081,13 +5502,10 @@ pub fn apply_eviction_retain_to_draft(
         );
     }
     let dst_bytes = budget * row_floats * std::mem::size_of::<f32>();
-    let compacted_bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(
-            compacted.as_ptr() as *const u8,
-            dst_bytes,
-        )
-    };
-    gpu.hip.memcpy_htod(&draft_scratch.target_hidden.buf, compacted_bytes)?;
+    let compacted_bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(compacted.as_ptr() as *const u8, dst_bytes) };
+    gpu.hip
+        .memcpy_htod(&draft_scratch.target_hidden.buf, compacted_bytes)?;
     draft_scratch.target_hidden_abs_positions = new_abs;
     draft_scratch.uploaded_target_hidden_rows = budget;
     // The per-layer k_ctx/v_ctx projection cache is indexed by the
@@ -5095,4 +5513,64 @@ pub fn apply_eviction_retain_to_draft(
     // the next draft_forward. One slow cycle per eviction is fine.
     draft_scratch.invalidate_draft_ctx_cache();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dflash_gdn_tape_replay_uses_actual_verify_eligibility() {
+        assert!(dflash_use_gdn_tape_replay(true, true));
+        assert!(!dflash_use_gdn_tape_replay(false, true));
+        assert!(!dflash_use_gdn_tape_replay(true, false));
+    }
+
+    #[test]
+    fn dflash_extended_verify_graph_is_moe_greedy_only() {
+        assert!(dflash_moe_verify_graph_lmhead_eligible(
+            256, false, false, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            0, false, false, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            256, true, false, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            256, false, true, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            256,
+            false,
+            false,
+            Some("0")
+        ));
+    }
+
+    #[test]
+    fn dflash_draft_ffn_graph_is_moe_plain_dflash_only() {
+        assert!(dflash_moe_draft_ffn_graph_eligible(
+            256, false, false, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            0, false, false, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256, true, false, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256, false, true, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256, false, false, true, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256,
+            false,
+            false,
+            false,
+            Some("0")
+        ));
+    }
 }

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -26,6 +26,43 @@ use rdna_compute::{Gpu, GpuTensor};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+fn dflash_q8_lmhead_wmma_enabled_from_env() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        match std::env::var("HIPFIRE_DFLASH_Q8_LMHEAD_WMMA") {
+            Ok(v) => {
+                let v = v.trim().to_ascii_lowercase();
+                !(v == "0" || v == "false" || v == "off" || v == "no")
+            }
+            Err(_) => true,
+        }
+    })
+}
+
+fn dflash_gemm_q8_lmhead(
+    gpu: &mut Gpu,
+    w_out: &llama::WeightTensor,
+    x: &GpuTensor,
+    y: &GpuTensor,
+    n: usize,
+) -> HipResult<()> {
+    if dflash_q8_lmhead_wmma_enabled_from_env() {
+        return gpu.gemm_q8_0_batched_chunked(&w_out.buf, x, y, w_out.m, w_out.k, n);
+    }
+
+    const Q8_LM_MAX: usize = 64;
+    let mut chunk_start = 0usize;
+    while chunk_start < n {
+        let chunk_end = (chunk_start + Q8_LM_MAX).min(n);
+        let chunk_n = chunk_end - chunk_start;
+        let x_chunk = x.sub_offset(chunk_start * w_out.k, chunk_n * w_out.k);
+        let y_chunk = y.sub_offset(chunk_start * w_out.m, chunk_n * w_out.m);
+        gpu.gemm_q8_0_batched(&w_out.buf, &x_chunk, &y_chunk, w_out.m, w_out.k, chunk_n)?;
+        chunk_start = chunk_end;
+    }
+    Ok(())
+}
+
 /// Task #93 Phase B seed-prediction oracle counters.
 ///
 /// Three proxies, all derived from data the draft already computes (zero
@@ -2157,7 +2194,7 @@ fn verify_dflash_block_inner(
     batch_result?;
 
     // Per-position lm_head. Fast paths in priority order:
-    //   Q8_0      → batched gemm_q8_0_batched (one launch + one D2H).
+    //   Q8_0      → DFlash-scoped Q8 lm_head dispatcher (gfx12 WMMA by default).
     //   MQ4G256   → batched rotate + gemm_hfq4g256 (one launch + one D2H).
     //   HFQ4G256  → batched gemm_hfq4g256 directly.
     //   else      → B sequential weight_gemv calls + B downloads (legacy).
@@ -2177,33 +2214,14 @@ fn verify_dflash_block_inner(
 
     if try_batched {
         let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
-        // Q8_0 gemm_q8_0_batched has a hard MAX_BATCH=64 in the kernel, so
-        // tree-verify blocks exceeding 64 (budget + 1 > 64) need chunking.
-        // MQ4/HFQ4/HFQ6/MQ6 kernels have no such cap — they take the single-shot path.
-        //
-        // INVARIANT: this path MUST stay on `gemm_q8_0_batched` (the substrate),
-        // NOT the Tier 3 `gemm_qkv_q8_0_wmma` family. The substrate matches
-        // `gemv_q8_0`'s single-accumulator reduction order, preserving byte-exact
-        // greedy parity with decode — required for DFlash+Q8 spec-verify to ever
-        // be a valid eval target (see docs/plans/q8-fused-prefill-kernels.md
-        // §Constraints — "greedy-parity invariant"). The WMMA family uses a
-        // hardware-determined reduction order and will not match.
+        // Q8_0 routes through the DFlash lm_head helper so the gfx12 WMMA
+        // arm can be coherence-gated independently of MTP. Set
+        // HIPFIRE_DFLASH_Q8_LMHEAD_WMMA=0 to force the legacy scalar chunks.
+        // MQ4/HFQ4/HFQ6/MQ6 kernels have no 64-row cap and take the
+        // single-shot path.
         match w_out.gpu_dtype {
             rdna_compute::DType::Q8_0 => {
-                const Q8_LM_MAX: usize = 64;
-                let mut chunk_start = 0usize;
-                while chunk_start < b {
-                    let chunk_end = (chunk_start + Q8_LM_MAX).min(b);
-                    let chunk_n = chunk_end - chunk_start;
-                    let x_chunk = final_hidden.sub_offset(chunk_start * dim, chunk_n * dim);
-                    let y_chunk = logits_batch.sub_offset(chunk_start * vocab, chunk_n * vocab);
-                    // DO NOT route this through the Q8 WMMA dispatcher — see
-                    // greedy-parity invariant above.
-                    gpu.gemm_q8_0_batched(
-                        &w_out.buf, &x_chunk, &y_chunk, w_out.m, w_out.k, chunk_n,
-                    )?;
-                    chunk_start = chunk_end;
-                }
+                dflash_gemm_q8_lmhead(gpu, w_out, &final_hidden, &logits_batch, b)?;
             }
             rdna_compute::DType::HFQ4G256 => {
                 gpu.gemm_hfq4g256_batched_lmhead(
@@ -2764,10 +2782,7 @@ pub fn spec_step_dflash(
 
         match w_out.gpu_dtype {
             rdna_compute::DType::Q8_0 => {
-                // INVARIANT: substrate-only (greedy-parity with decode); see the
-                // earlier Q8_0 spec-verify path in this file for the full rationale.
-                // Do not route through the Q8 WMMA dispatcher.
-                gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)?;
+                dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)?;
             }
             rdna_compute::DType::HFQ4G256 => {
                 gpu.gemm_hfq4g256_batched_lmhead(
@@ -3400,7 +3415,7 @@ fn run_dflash_draft_for_logits(
 
     let gemm_result = match w_out.gpu_dtype {
         rdna_compute::DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
+            dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)
         }
         rdna_compute::DType::HFQ4G256 => {
             gpu.gemm_hfq4g256(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
@@ -3565,7 +3580,7 @@ fn run_dflash_draft_for_topk_gpu(
     let w_out = &target.weights.output;
     let gemm_result = match w_out.gpu_dtype {
         rdna_compute::DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
+            dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)
         }
         rdna_compute::DType::HFQ4G256 => {
             gpu.gemm_hfq4g256(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -2047,7 +2047,7 @@ fn verify_dflash_block_inner(
             // hits "hipMalloc not permitted under stream capture" the first
             // time any kernel is compiled inline. One warmup per distinct b.
             gpu.verify_mark_warmup_done(b);
-            let r = qwen35::forward_prefill_batch_single_chunk_captured(
+            let r = qwen35::forward_prefill_batch_single_chunk_captured_opts(
                 gpu,
                 &target.weights,
                 &target.config,
@@ -2061,6 +2061,7 @@ fn verify_dflash_block_inner(
                 Some(&final_hidden),
                 gdn_tape,
                 tree_verify,
+                false, // DFlash computes all verify logits from final_hidden below
             );
             if r.is_ok() {
                 eprintln!("[verify-graph] warmup for B={} complete — capture next cycle at this B", b);
@@ -2070,7 +2071,7 @@ fn verify_dflash_block_inner(
             vg_mode = "capture";
             // Capture path: first call at this B after warmup.
             gpu.begin_verify_graph_capture(b)?;
-            let r = qwen35::forward_prefill_batch_single_chunk_captured(
+            let r = qwen35::forward_prefill_batch_single_chunk_captured_opts(
                 gpu,
                 &target.weights,
                 &target.config,
@@ -2084,6 +2085,7 @@ fn verify_dflash_block_inner(
                 Some(&final_hidden),
                 gdn_tape,
                 tree_verify,
+                false, // DFlash computes all verify logits from final_hidden below
             );
             if r.is_ok() {
                 let blob_count = gpu.capture_blobs.len();
@@ -2111,7 +2113,7 @@ fn verify_dflash_block_inner(
             r
         }
     } else {
-        qwen35::forward_prefill_batch_with_pbs(
+        qwen35::forward_prefill_batch_with_pbs_opts(
             gpu,
             &target.weights,
             &target.config,
@@ -2127,6 +2129,7 @@ fn verify_dflash_block_inner(
             verify_scratch.prefill_batch.as_ref(),
             None, // mask_override: speculative verify path doesn't use the MTP probe hook
             None, // max_layer: DFlash verify always runs the full stack
+            false, // DFlash computes all verify logits from final_hidden below
         )
     };
 

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -21,7 +21,7 @@ use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{self, KvCache};
 use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
 use hipfire_runtime::tokenizer::{Tokenizer, TokenizerError};
-use hip_bridge::{DeviceBuffer, HipResult};
+use hip_bridge::{DeviceBuffer, HipResult, Stream};
 use rdna_compute::{Gpu, GpuTensor};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -521,6 +521,31 @@ impl DeltaNetSnapshot {
         }
         for (dst, src) in self.conv_state_bufs.iter().zip(state.conv_states.iter()) {
             gpu.hip.memcpy_dtod(dst, &src.buf, src.buf.size())?;
+        }
+        Ok(())
+    }
+
+    /// Async copy live state → backup on `stream`.
+    ///
+    /// Caller owns cross-stream ordering. MTP trunk-spine uses this as an
+    /// opt-in experiment to overlap DN snapshot copy with proposal work.
+    pub fn save_from_async_on(
+        &mut self,
+        state: &DeltaNetState,
+        gpu: &Gpu,
+        stream: &Stream,
+    ) -> HipResult<()> {
+        for (dst, src) in self.s_matrix_bufs.iter().zip(state.s_matrices.iter()) {
+            gpu.hip
+                .memcpy_dtod_async_at(dst, 0, &src.buf, 0, src.buf.size(), stream)?;
+        }
+        for (dst, src) in self.s_scale_bufs.iter().zip(state.s_scales.iter()) {
+            gpu.hip
+                .memcpy_dtod_async_at(dst, 0, &src.buf, 0, src.buf.size(), stream)?;
+        }
+        for (dst, src) in self.conv_state_bufs.iter().zip(state.conv_states.iter()) {
+            gpu.hip
+                .memcpy_dtod_async_at(dst, 0, &src.buf, 0, src.buf.size(), stream)?;
         }
         Ok(())
     }

--- a/crates/hipfire-quantize/src/bin/mtp_extract.rs
+++ b/crates/hipfire-quantize/src/bin/mtp_extract.rs
@@ -8,8 +8,10 @@
 //!
 //! Empirical: every released dense Qwen3.5 (0.8B / 2B / 4B / 9B / 27B)
 //! and Qwen3.6-27B exposes the SAME 15 MTP-block tensors in safetensors.
-//! MoE variants (35B-A3B, 122B-A10B, 397B-A17B) inflate this to hundreds
-//! of expert tensors and are out of scope for this binary.
+//! MoE variants replace the dense FFN triple with a router, shared expert,
+//! scalar shared gate, and 3D stacked routed experts. The extractor splits
+//! those expert tensors into per-expert 2D weights so the runtime can reuse
+//! the same indexed MoE decode kernels as A3B trunk inference.
 //!
 //! Output container:
 //!   * arch_id = 21 (QWEN35_MTP_HEAD)
@@ -50,8 +52,8 @@ impl SafetensorsFile {
         let header_len = u64::from_le_bytes(mmap[0..8].try_into().unwrap()) as usize;
         let header_json = std::str::from_utf8(&mmap[8..8 + header_len])
             .expect("safetensors header is not valid utf8");
-        let raw: serde_json::Value = serde_json::from_str(header_json)
-            .expect("safetensors header JSON parse failed");
+        let raw: serde_json::Value =
+            serde_json::from_str(header_json).expect("safetensors header JSON parse failed");
         let mut tensors = HashMap::new();
         if let serde_json::Value::Object(map) = raw {
             for (k, v) in map {
@@ -152,6 +154,26 @@ fn to_f32(data: &[u8], dtype: &str) -> Vec<f32> {
     }
 }
 
+fn dtype_size(dtype: &str) -> usize {
+    match dtype {
+        "F16" | "BF16" => 2,
+        "F32" => 4,
+        other => panic!("unsupported input dtype: {other}"),
+    }
+}
+
+fn to_f32_range(data: &[u8], dtype: &str, elem_start: usize, elem_count: usize) -> Vec<f32> {
+    let elem_size = dtype_size(dtype);
+    let byte_start = elem_start * elem_size;
+    let byte_end = byte_start + elem_count * elem_size;
+    assert!(
+        byte_end <= data.len(),
+        "to_f32_range out of bounds: bytes {byte_start}..{byte_end} > {}",
+        data.len()
+    );
+    to_f32(&data[byte_start..byte_end], dtype)
+}
+
 fn f32_slice_to_f32_bytes(f32_data: &[f32]) -> Vec<u8> {
     let mut out = Vec::with_capacity(f32_data.len() * 4);
     for &v in f32_data {
@@ -193,11 +215,12 @@ fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     let mut state = seed;
     (0..n)
         .map(|_| {
-            state = state
-                .wrapping_mul(1103515245)
-                .wrapping_add(12345)
-                & 0x7fffffff;
-            if (state >> 16) & 1 == 1 { 1.0f32 } else { -1.0f32 }
+            state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
+            if (state >> 16) & 1 == 1 {
+                1.0f32
+            } else {
+                -1.0f32
+            }
         })
         .collect()
 }
@@ -353,22 +376,107 @@ fn write_hfq(
 /// matches the trunk extractor's natural dependency order at consume time).
 const MTP_NAMING_MAP: &[(&str, &str, bool, bool)] = &[
     // Norms (F32, 1D)
-    ("mtp.norm.weight",                              "shared_head_norm", true,  false),
-    ("mtp.pre_fc_norm_embedding.weight",             "enorm",            true,  false),
-    ("mtp.pre_fc_norm_hidden.weight",                "hnorm",            true,  false),
-    ("mtp.layers.0.input_layernorm.weight",          "attn_norm",        true,  false),
-    ("mtp.layers.0.post_attention_layernorm.weight", "attn_post_norm",   true,  false),
-    ("mtp.layers.0.self_attn.q_norm.weight",         "attn_q_norm",      true,  false),
-    ("mtp.layers.0.self_attn.k_norm.weight",         "attn_k_norm",      true,  false),
+    ("mtp.norm.weight", "shared_head_norm", true, false),
+    ("mtp.pre_fc_norm_embedding.weight", "enorm", true, false),
+    ("mtp.pre_fc_norm_hidden.weight", "hnorm", true, false),
+    (
+        "mtp.layers.0.input_layernorm.weight",
+        "attn_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.post_attention_layernorm.weight",
+        "attn_post_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.q_norm.weight",
+        "attn_q_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.k_norm.weight",
+        "attn_k_norm",
+        true,
+        false,
+    ),
     // 2D weights (MQ4 / Q8)
-    ("mtp.fc.weight",                                "eh_proj",          false, true),
-    ("mtp.layers.0.self_attn.q_proj.weight",         "wq",               false, true),
-    ("mtp.layers.0.self_attn.k_proj.weight",         "wk",               false, true),
-    ("mtp.layers.0.self_attn.v_proj.weight",         "wv",               false, true),
-    ("mtp.layers.0.self_attn.o_proj.weight",         "wo",               false, true),
-    ("mtp.layers.0.mlp.gate_proj.weight",            "ffn_gate",         false, true),
-    ("mtp.layers.0.mlp.up_proj.weight",              "ffn_up",           false, true),
-    ("mtp.layers.0.mlp.down_proj.weight",            "ffn_down",         false, true),
+    ("mtp.fc.weight", "eh_proj", false, true),
+    ("mtp.layers.0.self_attn.q_proj.weight", "wq", false, true),
+    ("mtp.layers.0.self_attn.k_proj.weight", "wk", false, true),
+    ("mtp.layers.0.self_attn.v_proj.weight", "wv", false, true),
+    ("mtp.layers.0.self_attn.o_proj.weight", "wo", false, true),
+    ("mtp.layers.0.mlp.gate_proj.weight", "ffn_gate", false, true),
+    ("mtp.layers.0.mlp.up_proj.weight", "ffn_up", false, true),
+    ("mtp.layers.0.mlp.down_proj.weight", "ffn_down", false, true),
+];
+
+const MTP_COMMON_NAMING_MAP: &[(&str, &str, bool, bool)] = &[
+    // Norms (F32, 1D)
+    ("mtp.norm.weight", "shared_head_norm", true, false),
+    ("mtp.pre_fc_norm_embedding.weight", "enorm", true, false),
+    ("mtp.pre_fc_norm_hidden.weight", "hnorm", true, false),
+    (
+        "mtp.layers.0.input_layernorm.weight",
+        "attn_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.post_attention_layernorm.weight",
+        "attn_post_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.q_norm.weight",
+        "attn_q_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.k_norm.weight",
+        "attn_k_norm",
+        true,
+        false,
+    ),
+    // NextN projection + attention weights.
+    ("mtp.fc.weight", "eh_proj", false, true),
+    ("mtp.layers.0.self_attn.q_proj.weight", "wq", false, true),
+    ("mtp.layers.0.self_attn.k_proj.weight", "wk", false, true),
+    ("mtp.layers.0.self_attn.v_proj.weight", "wv", false, true),
+    ("mtp.layers.0.self_attn.o_proj.weight", "wo", false, true),
+];
+
+const MTP_MOE_2D_NAMING_MAP: &[(&str, &str, bool, bool)] = &[
+    ("mtp.layers.0.mlp.gate.weight", "moe_router", false, true),
+    (
+        "mtp.layers.0.mlp.shared_expert_gate.weight",
+        "moe_shared_expert_gate",
+        false,
+        true,
+    ),
+    (
+        "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+        "moe_shared_gate",
+        false,
+        true,
+    ),
+    (
+        "mtp.layers.0.mlp.shared_expert.up_proj.weight",
+        "moe_shared_up",
+        false,
+        true,
+    ),
+    (
+        "mtp.layers.0.mlp.shared_expert.down_proj.weight",
+        "moe_shared_down",
+        false,
+        true,
+    ),
 ];
 
 // ─── Discovery ───────────────────────────────────────────────────────────
@@ -382,6 +490,18 @@ fn find_safetensors(dir: &Path) -> Vec<PathBuf> {
         .collect();
     files.sort();
     files
+}
+
+fn find_tensor<'a>(
+    st_files: &'a [SafetensorsFile],
+    name: &str,
+) -> Option<(&'a TensorMeta, &'a [u8])> {
+    for st in st_files {
+        if let Some((meta, data)) = st.tensor_data(name) {
+            return Some((meta, data));
+        }
+    }
+    None
 }
 
 // ─── CLI ─────────────────────────────────────────────────────────────────
@@ -418,6 +538,106 @@ struct Args {
     /// lm_head, MQ4G256) and a `lm_head_draft.vocab_map` (u32 IDs packed
     /// as f32 bit-cast). Tensor count goes 15 -> 17 when present.
     vocab_sidecar: Option<PathBuf>,
+}
+
+fn quantize_mtp_tensor(
+    hf_name: &str,
+    shape: &[usize],
+    f32_data: &[f32],
+    is_norm: bool,
+    is_2d: bool,
+    quant: QuantChoice,
+    force_q8: bool,
+    signs1: &[f32],
+    signs2: &[f32],
+) -> (QuantType, u32, Vec<u8>, &'static str) {
+    let n_elements: usize = shape.iter().product();
+    assert_eq!(
+        f32_data.len(),
+        n_elements,
+        "tensor {hf_name}: element count mismatch (got {}, expected {n_elements})",
+        f32_data.len()
+    );
+    if is_norm || !is_2d {
+        return (QuantType::F32, 0, f32_slice_to_f32_bytes(f32_data), "F32");
+    }
+
+    let k_dim = *shape.last().expect("2D weight has shape");
+    if force_q8 {
+        let q = quantize_q8f16(f32_data);
+        return (QuantType::Q8F16, 32, q, "Q8_F16");
+    }
+
+    match quant {
+        QuantChoice::Mq4 if k_dim % 256 == 0 && n_elements >= 256 => {
+            let q = quantize_mq4g256(f32_data, signs1, signs2);
+            (QuantType::MQ4G256, 256, q, "MQ4G256")
+        }
+        QuantChoice::Mq4 => {
+            eprintln!("  note: {hf_name} K={k_dim} not 256-aligned — falling back to Q8_F16");
+            let q = quantize_q8f16(f32_data);
+            (QuantType::Q8F16, 32, q, "Q8_F16")
+        }
+        QuantChoice::Q8 => {
+            let q = quantize_q8f16(f32_data);
+            (QuantType::Q8F16, 32, q, "Q8_F16")
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pack_safetensor_2d_or_norm(
+    st_files: &[SafetensorsFile],
+    st_name: &str,
+    hf_name: &str,
+    is_norm: bool,
+    is_2d: bool,
+    quant: QuantChoice,
+    force_q8: bool,
+    signs1: &[f32],
+    signs2: &[f32],
+    verbose: bool,
+) -> (HfqTensor, usize, usize) {
+    let (meta, raw) = find_tensor(st_files, st_name).unwrap_or_else(|| {
+        panic!(
+            "safetensors missing required MTP tensor '{st_name}' \
+             — is this actually a Qwen3.5/3.6 model with MTP head?"
+        )
+    });
+    let f32_data = to_f32(raw, &meta.dtype);
+    let shape_usize = meta.shape.clone();
+    let shape: Vec<u32> = shape_usize.iter().map(|d| *d as u32).collect();
+    let (quant_type, group_size, bytes, label) = quantize_mtp_tensor(
+        hf_name,
+        &shape_usize,
+        &f32_data,
+        is_norm,
+        is_2d,
+        quant,
+        force_q8,
+        signs1,
+        signs2,
+    );
+    if verbose {
+        eprintln!(
+            "  [{label:>7}] {hf_name:>24}  shape={:?}  in={:>10}B  out={:>10}B  \
+             (src={st_name})",
+            shape,
+            raw.len(),
+            bytes.len()
+        );
+    }
+    (
+        HfqTensor {
+            name: hf_name.to_string(),
+            quant_type,
+            shape,
+            group_size,
+            data: bytes,
+        },
+        raw.len(),
+        f32_data.len(),
+    )
 }
 
 fn parse_args() -> Args {
@@ -554,15 +774,21 @@ fn verify_round_trip(path: &Path, expected: &[HfqTensor], verbose: bool) {
         assert_eq!(name, exp.name, "verify: tensor[{i}] name mismatch");
         assert_eq!(qt, exp.quant_type as u8, "verify: tensor[{i}] qt mismatch");
         assert_eq!(shape, exp.shape, "verify: tensor[{i}] shape mismatch");
-        assert_eq!(group_size, exp.group_size, "verify: tensor[{i}] gs mismatch");
-        assert_eq!(data_size, exp.data.len(), "verify: tensor[{i}] data_size mismatch");
+        assert_eq!(
+            group_size, exp.group_size,
+            "verify: tensor[{i}] gs mismatch"
+        );
+        assert_eq!(
+            data_size,
+            exp.data.len(),
+            "verify: tensor[{i}] data_size mismatch"
+        );
 
         // Spot-check first/last byte of data region against the in-memory
         // tensor. This catches misaligned data_offset / forgotten padding.
         if !exp.data.is_empty() {
             assert_eq!(
-                mmap[cumulative],
-                exp.data[0],
+                mmap[cumulative], exp.data[0],
                 "verify: tensor[{i}]={name} first byte mismatch"
             );
             assert_eq!(
@@ -580,9 +806,7 @@ fn verify_round_trip(path: &Path, expected: &[HfqTensor], verbose: bool) {
             );
         }
     }
-    eprintln!(
-        "verify: PASS — {n_tensors} tensors round-trip clean (arch_id={arch_id})"
-    );
+    eprintln!("verify: PASS — {n_tensors} tensors round-trip clean (arch_id={arch_id})");
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────
@@ -613,9 +837,8 @@ fn main() {
             .and_then(|v| v.as_u64())
             .unwrap_or_else(|| panic!("config.json missing {k}"))
     };
-    let get_f64 = |k: &str| -> Option<f64> {
-        tc.get(k).or_else(|| config.get(k)).and_then(|v| v.as_f64())
-    };
+    let get_f64 =
+        |k: &str| -> Option<f64> { tc.get(k).or_else(|| config.get(k)).and_then(|v| v.as_f64()) };
 
     let n_embd = get_u64("hidden_size") as usize;
     let n_layer = get_u64("num_hidden_layers") as usize;
@@ -627,7 +850,37 @@ fn main() {
         .and_then(|v| v.as_u64())
         .map(|v| v as usize)
         .unwrap_or(n_embd / n_head);
-    let n_ff = get_u64("intermediate_size") as usize;
+    let intermediate_size = tc
+        .get("intermediate_size")
+        .or_else(|| config.get("intermediate_size"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize);
+    let num_experts = tc
+        .get("num_experts")
+        .or_else(|| config.get("num_experts"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let num_experts_per_tok = tc
+        .get("num_experts_per_tok")
+        .or_else(|| config.get("num_experts_per_tok"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let moe_intermediate_size = tc
+        .get("moe_intermediate_size")
+        .or_else(|| config.get("moe_intermediate_size"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let shared_expert_intermediate_size = tc
+        .get("shared_expert_intermediate_size")
+        .or_else(|| config.get("shared_expert_intermediate_size"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let norm_topk_prob = tc
+        .get("norm_topk_prob")
+        .or_else(|| config.get("norm_topk_prob"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let n_ff = intermediate_size.unwrap_or(moe_intermediate_size);
     let vocab_size = get_u64("vocab_size") as usize;
     let nextn_predict_layers = tc
         .get("mtp_num_hidden_layers")
@@ -678,6 +931,13 @@ fn main() {
         "  dims   : n_embd={n_embd} n_layer={n_layer} n_head={n_head} n_head_kv={n_head_kv} \
          head_dim={n_embd_head} n_ff={n_ff} vocab={vocab_size}"
     );
+    if num_experts > 0 {
+        eprintln!(
+            "  moe    : experts={num_experts} top_k={num_experts_per_tok} \
+             moe_intermediate={moe_intermediate_size} shared_intermediate={shared_expert_intermediate_size} \
+             norm_topk_prob={norm_topk_prob}"
+        );
+    }
     eprintln!(
         "  rope   : theta={rope_theta} sections={}",
         serde_json::to_string(&rope_sections).unwrap_or("null".into())
@@ -704,98 +964,187 @@ fn main() {
     let signs1 = gen_fwht_signs(42, 256);
     let signs2 = gen_fwht_signs(1042, 256);
 
-    let mut hfq_tensors: Vec<HfqTensor> = Vec::with_capacity(MTP_NAMING_MAP.len());
+    let dense_mtp = find_tensor(&st_files, "mtp.layers.0.mlp.gate_proj.weight").is_some();
+    let moe_mtp = find_tensor(&st_files, "mtp.layers.0.mlp.experts.gate_up_proj").is_some();
+    let ffn_kind = match (dense_mtp, moe_mtp) {
+        (true, _) => "dense",
+        (false, true) => "moe",
+        (false, false) => panic!(
+            "MTP FFN tensors not found: expected dense gate_proj/up_proj/down_proj \
+             or MoE experts.gate_up_proj"
+        ),
+    };
+
+    let estimated_tensors = if ffn_kind == "moe" {
+        MTP_COMMON_NAMING_MAP.len() + MTP_MOE_2D_NAMING_MAP.len() + 2 * num_experts
+    } else {
+        MTP_NAMING_MAP.len()
+    };
+    let mut hfq_tensors: Vec<HfqTensor> = Vec::with_capacity(estimated_tensors);
     let mut total_in_bytes: usize = 0;
     let mut total_out_bytes: usize = 0;
 
-    for (st_name, hf_name, is_norm, is_2d) in MTP_NAMING_MAP {
-        // Locate the tensor across shards.
-        let mut found: Option<(&SafetensorsFile, &TensorMeta, &[u8])> = None;
-        for st in &st_files {
-            if let Some((meta, data)) = st.tensor_data(st_name) {
-                found = Some((st, meta, data));
-                break;
-            }
-        }
-        let (_st, meta, raw) = found.unwrap_or_else(|| {
-            panic!(
-                "safetensors missing required MTP tensor '{st_name}' \
-                 — is this actually a Qwen3.5/3.6 dense model with MTP head?"
-            )
-        });
-
-        let in_bytes = raw.len();
-        total_in_bytes += in_bytes;
-
-        let f32_data = to_f32(raw, &meta.dtype);
-        let n_elements: usize = meta.shape.iter().product();
-        assert_eq!(
-            f32_data.len(),
-            n_elements,
-            "tensor {st_name}: element count mismatch (got {}, expected {n_elements})",
-            f32_data.len()
+    let base_map = if ffn_kind == "moe" {
+        MTP_COMMON_NAMING_MAP
+    } else {
+        MTP_NAMING_MAP
+    };
+    for (st_name, hf_name, is_norm, is_2d) in base_map {
+        let (tensor, in_bytes, _n_elems) = pack_safetensor_2d_or_norm(
+            &st_files,
+            st_name,
+            hf_name,
+            *is_norm,
+            *is_2d,
+            args.quant,
+            false,
+            &signs1,
+            &signs2,
+            args.verbose,
         );
-        let shape: Vec<u32> = meta.shape.iter().map(|d| *d as u32).collect();
-
-        // Quantization decision:
-        //   norms (1D *norm) → F32 (matches CLAUDE.md trunk pattern in
-        //                      `should_quantize`; precision-critical, small).
-        //   2D weights      → MQ4 / Q8 per --quant, with a Q8 fallback when
-        //                      MQ4's K%256==0 alignment is not satisfied.
-        let (quant_type, group_size, bytes, label) = if *is_norm || !*is_2d {
-            (
-                QuantType::F32,
-                0u32,
-                f32_slice_to_f32_bytes(&f32_data),
-                "F32",
-            )
-        } else {
-            // 2D weight. K is the innermost dim per safetensors convention.
-            let k_dim = *shape.last().expect("2D weight has shape") as usize;
-            match args.quant {
-                QuantChoice::Mq4 if k_dim % 256 == 0 && n_elements >= 256 => {
-                    let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
-                    (QuantType::MQ4G256, 256u32, q, "MQ4G256")
-                }
-                QuantChoice::Mq4 => {
-                    eprintln!(
-                        "  note: {hf_name} K={k_dim} not 256-aligned — falling back to Q8_F16"
-                    );
-                    let q = quantize_q8f16(&f32_data);
-                    (QuantType::Q8F16, 32u32, q, "Q8_F16")
-                }
-                QuantChoice::Q8 => {
-                    let q = quantize_q8f16(&f32_data);
-                    (QuantType::Q8F16, 32u32, q, "Q8_F16")
-                }
-            }
-        };
-
-        total_out_bytes += bytes.len();
-
-        if args.verbose {
-            eprintln!(
-                "  [{label:>7}] {hf_name:>18}  shape={:?}  in={:>9}B  out={:>9}B  \
-                 (src={st_name})",
-                shape, in_bytes, bytes.len()
-            );
-        }
-
-        hfq_tensors.push(HfqTensor {
-            name: hf_name.to_string(),
-            quant_type,
-            shape,
-            group_size,
-            data: bytes,
-        });
+        total_in_bytes += in_bytes;
+        total_out_bytes += tensor.data.len();
+        hfq_tensors.push(tensor);
     }
 
-    assert_eq!(
-        hfq_tensors.len(),
-        15,
-        "expected to pack exactly 15 MTP tensors before optional sidecar, got {}",
-        hfq_tensors.len()
-    );
+    if ffn_kind == "moe" {
+        assert!(
+            num_experts > 0,
+            "MoE MTP detected but config num_experts is 0"
+        );
+        assert_eq!(
+            num_experts_per_tok, 8,
+            "current MoE MTP runtime supports top_k=8; config has {num_experts_per_tok}"
+        );
+        assert!(
+            moe_intermediate_size > 0,
+            "MoE MTP requires moe_intermediate_size"
+        );
+        assert!(
+            shared_expert_intermediate_size > 0,
+            "MoE MTP requires shared_expert_intermediate_size"
+        );
+
+        for (st_name, hf_name, is_norm, is_2d) in MTP_MOE_2D_NAMING_MAP {
+            // Match the production A3B loader convention: routers and the
+            // scalar shared-expert gate stay Q8, expert/shared FFNs use the
+            // requested quant format.
+            let force_q8 = *hf_name == "moe_router" || *hf_name == "moe_shared_expert_gate";
+            let (tensor, in_bytes, _n_elems) = pack_safetensor_2d_or_norm(
+                &st_files,
+                st_name,
+                hf_name,
+                *is_norm,
+                *is_2d,
+                args.quant,
+                force_q8,
+                &signs1,
+                &signs2,
+                args.verbose,
+            );
+            total_in_bytes += in_bytes;
+            total_out_bytes += tensor.data.len();
+            hfq_tensors.push(tensor);
+        }
+
+        let (gate_up_meta, gate_up_raw) =
+            find_tensor(&st_files, "mtp.layers.0.mlp.experts.gate_up_proj")
+                .expect("MoE MTP missing experts.gate_up_proj");
+        let (down_meta, down_raw) = find_tensor(&st_files, "mtp.layers.0.mlp.experts.down_proj")
+            .expect("MoE MTP missing experts.down_proj");
+        assert_eq!(
+            gate_up_meta.shape,
+            vec![num_experts, 2 * moe_intermediate_size, n_embd],
+            "experts.gate_up_proj shape mismatch"
+        );
+        assert_eq!(
+            down_meta.shape,
+            vec![num_experts, n_embd, moe_intermediate_size],
+            "experts.down_proj shape mismatch"
+        );
+
+        let gate_up_elems = 2 * moe_intermediate_size * n_embd;
+        let down_elems = n_embd * moe_intermediate_size;
+        total_in_bytes += gate_up_raw.len() + down_raw.len();
+        for expert_idx in 0..num_experts {
+            let f32_data = to_f32_range(
+                gate_up_raw,
+                &gate_up_meta.dtype,
+                expert_idx * gate_up_elems,
+                gate_up_elems,
+            );
+            let hf_name = format!("moe_experts.{expert_idx}.gate_up");
+            let (quant_type, group_size, bytes, label) = quantize_mtp_tensor(
+                &hf_name,
+                &[2 * moe_intermediate_size, n_embd],
+                &f32_data,
+                false,
+                true,
+                args.quant,
+                false,
+                &signs1,
+                &signs2,
+            );
+            if args.verbose && (expert_idx < 4 || expert_idx + 4 >= num_experts) {
+                eprintln!(
+                    "  [{label:>7}] {hf_name:>24}  shape=[{}, {}]  out={:>10}B",
+                    2 * moe_intermediate_size,
+                    n_embd,
+                    bytes.len()
+                );
+            }
+            total_out_bytes += bytes.len();
+            hfq_tensors.push(HfqTensor {
+                name: hf_name,
+                quant_type,
+                shape: vec![(2 * moe_intermediate_size) as u32, n_embd as u32],
+                group_size,
+                data: bytes,
+            });
+        }
+        for expert_idx in 0..num_experts {
+            let f32_data = to_f32_range(
+                down_raw,
+                &down_meta.dtype,
+                expert_idx * down_elems,
+                down_elems,
+            );
+            let hf_name = format!("moe_experts.{expert_idx}.down");
+            let (quant_type, group_size, bytes, label) = quantize_mtp_tensor(
+                &hf_name,
+                &[n_embd, moe_intermediate_size],
+                &f32_data,
+                false,
+                true,
+                args.quant,
+                false,
+                &signs1,
+                &signs2,
+            );
+            if args.verbose && (expert_idx < 4 || expert_idx + 4 >= num_experts) {
+                eprintln!(
+                    "  [{label:>7}] {hf_name:>24}  shape=[{}, {}]  out={:>10}B",
+                    n_embd,
+                    moe_intermediate_size,
+                    bytes.len()
+                );
+            }
+            total_out_bytes += bytes.len();
+            hfq_tensors.push(HfqTensor {
+                name: hf_name,
+                quant_type,
+                shape: vec![n_embd as u32, moe_intermediate_size as u32],
+                group_size,
+                data: bytes,
+            });
+        }
+        if args.verbose && num_experts > 8 {
+            eprintln!(
+                "  ... packed {} routed experts for gate_up and down",
+                num_experts
+            );
+        }
+    }
 
     // ─── Optional FastMTP-style vocab-compression sidecar ─────────────────
     //
@@ -816,8 +1165,8 @@ fn main() {
         eprintln!("  sidecar: {}", sidecar_path.display());
         let sidecar_str = std::fs::read_to_string(sidecar_path)
             .unwrap_or_else(|e| panic!("cannot read sidecar {}: {e}", sidecar_path.display()));
-        let sidecar: serde_json::Value = serde_json::from_str(&sidecar_str)
-            .expect("sidecar JSON parse failed");
+        let sidecar: serde_json::Value =
+            serde_json::from_str(&sidecar_str).expect("sidecar JSON parse failed");
         let draft_to_full: Vec<u32> = sidecar
             .get("draft_to_full")
             .and_then(|v| v.as_array())
@@ -870,7 +1219,10 @@ fn main() {
                 lm_head_candidates
             )
         });
-        eprintln!("  lm_head src: {lm_name} dtype={} shape={:?}", lm_meta.dtype, lm_meta.shape);
+        eprintln!(
+            "  lm_head src: {lm_name} dtype={} shape={:?}",
+            lm_meta.dtype, lm_meta.shape
+        );
         assert_eq!(
             lm_meta.shape.len(),
             2,
@@ -926,7 +1278,9 @@ fn main() {
         total_out_bytes += lm_bytes.len();
         eprintln!(
             "  [{lm_label:>7}] {:>18}  shape=[{k_dim}, {h_dim}]  full_f32={:>10}B  out={:>10}B",
-            "lm_head_draft", lm_in_bytes, lm_bytes.len()
+            "lm_head_draft",
+            lm_in_bytes,
+            lm_bytes.len()
         );
         hfq_tensors.push(HfqTensor {
             name: "lm_head_draft.weight".to_string(),
@@ -958,7 +1312,17 @@ fn main() {
         compressed_vocab_size = Some(k_dim);
     }
 
-    let expected_tensor_count = if compressed_vocab_size.is_some() { 17 } else { 15 };
+    let expected_base_tensor_count = if ffn_kind == "moe" {
+        MTP_COMMON_NAMING_MAP.len() + MTP_MOE_2D_NAMING_MAP.len() + 2 * num_experts
+    } else {
+        MTP_NAMING_MAP.len()
+    };
+    let expected_tensor_count = expected_base_tensor_count
+        + if compressed_vocab_size.is_some() {
+            2
+        } else {
+            0
+        };
     assert_eq!(
         hfq_tensors.len(),
         expected_tensor_count,
@@ -972,9 +1336,7 @@ fn main() {
     let tie_word_embeddings = config
         .get("tie_word_embeddings")
         .and_then(|v| v.as_bool())
-        .or_else(|| {
-            tc.get("tie_word_embeddings").and_then(|v| v.as_bool())
-        })
+        .or_else(|| tc.get("tie_word_embeddings").and_then(|v| v.as_bool()))
         .unwrap_or(true);
 
     let metadata = serde_json::json!({
@@ -988,6 +1350,12 @@ fn main() {
         "n_head_kv": n_head_kv,
         "n_embd_head": n_embd_head,
         "n_ff": n_ff,
+        "ffn_kind": ffn_kind,
+        "num_experts": num_experts,
+        "num_experts_per_tok": num_experts_per_tok,
+        "moe_intermediate_size": moe_intermediate_size,
+        "shared_expert_intermediate_size": shared_expert_intermediate_size,
+        "norm_topk_prob": norm_topk_prob,
         "vocab_size": vocab_size,
         "rope_theta": rope_theta,
         "rope_sections": rope_sections,
@@ -1016,9 +1384,7 @@ fn main() {
     )
     .expect("write_hfq failed");
 
-    let file_size = std::fs::metadata(&args.output)
-        .expect("stat output")
-        .len();
+    let file_size = std::fs::metadata(&args.output).expect("stat output").len();
     eprintln!(
         "wrote {}: {:.2} MiB  ({} tensors, in={:.2} MiB, out={:.2} MiB)",
         args.output.display(),

--- a/crates/hipfire-runtime/examples/mtp_only_demo.rs
+++ b/crates/hipfire-runtime/examples/mtp_only_demo.rs
@@ -421,8 +421,10 @@ fn main() {
         eprintln!("prefilling {} tokens (batched)...", prompt_tokens.len());
     }
     let t_prefill = Instant::now();
+    let mut trunk_prefill_secs: Option<f64> = None;
+    let mut mtp_prompt_fill_secs: Option<f64> = None;
     if trunk_spine {
-        mtp_spec::prefill_trunk_and_mtp_cache(
+        let timings = mtp_spec::prefill_trunk_and_mtp_cache(
             &mut gpu,
             &mut target,
             &head,
@@ -431,6 +433,8 @@ fn main() {
             0,
         )
         .expect("prefill trunk + mtp cache");
+        trunk_prefill_secs = Some(timings.trunk_prefill_secs);
+        mtp_prompt_fill_secs = Some(timings.mtp_prompt_fill_secs);
     } else {
         hipfire_arch_qwen35::qwen35::forward_prefill_batch(
             &mut gpu,
@@ -451,6 +455,13 @@ fn main() {
     let prefill_secs = t_prefill.elapsed().as_secs_f64();
     let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
     eprintln!("prefill: {:.2}s ({:.1} tok/s)", prefill_secs, prefill_tok_s);
+    if let (Some(trunk_secs), Some(mtp_secs)) = (trunk_prefill_secs, mtp_prompt_fill_secs) {
+        let trunk_tok_s = prompt_tokens.len() as f64 / trunk_secs.max(1e-9);
+        eprintln!(
+            "prefill split: trunk={:.3}s ({:.1} tok/s) mtp_prompt_fill={:.3}s total={:.3}s",
+            trunk_secs, trunk_tok_s, mtp_secs, prefill_secs
+        );
+    }
 
     // Snapshot trunk's prev_hidden (post-output-norm at last prefill position).
     if !trunk_spine {
@@ -703,6 +714,12 @@ fn main() {
     println!("tau:                  {:.4}", tau);
     println!("prefill_secs:         {:.3}", prefill_secs);
     println!("prefill_tok_s:        {:.2}", prefill_tok_s);
+    if let (Some(trunk_secs), Some(mtp_secs)) = (trunk_prefill_secs, mtp_prompt_fill_secs) {
+        let trunk_tok_s = prompt_tokens.len() as f64 / trunk_secs.max(1e-9);
+        println!("trunk_prefill_secs:   {:.3}", trunk_secs);
+        println!("trunk_prefill_tok_s:  {:.2}", trunk_tok_s);
+        println!("mtp_prompt_fill_secs: {:.3}", mtp_secs);
+    }
     println!("decode_secs:          {:.3}", decode_secs);
     println!("tok_s:                {:.2}", tok_per_s);
     println!("eos_hit:              {}", if hit_eos { "y" } else { "n" });

--- a/crates/hipfire-runtime/examples/mtp_only_demo.rs
+++ b/crates/hipfire-runtime/examples/mtp_only_demo.rs
@@ -43,6 +43,7 @@ fn main() {
     let mut chatml: bool = true;
     let mut compressed: bool = false;
     let mut compressed_serial: bool = false;
+    let mut trunk_spine: bool = false;
     let mut kv_mode_str: String = String::from("q8");
     let mut p_min: f32 = 0.0;
     // Sampling parameters (Unsloth-recommended for Qwen3.5/3.6 MTP):
@@ -57,34 +58,97 @@ fn main() {
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
-            "--target" => { target_path = Some(args[i + 1].clone()); i += 2; }
-            "--mtp-head" => { mtp_path = Some(args[i + 1].clone()); i += 2; }
-            "--prompt" => { prompt_str = Some(args[i + 1].clone()); i += 2; }
-            "--prompt-file" => { prompt_file = Some(args[i + 1].clone()); i += 2; }
-            "--max" => { max_tokens = args[i + 1].parse().unwrap(); i += 2; }
-            "--ctx" => { ctx_capacity = args[i + 1].parse().unwrap(); i += 2; }
-            "--temp" => { temp = args[i + 1].parse().unwrap(); i += 2; }
-            "--max-n" => { max_n = args[i + 1].parse().unwrap(); i += 2; }
-            "--no-chatml" => { chatml = false; i += 1; }
-            "--chatml" => { chatml = true; i += 1; }
-            "--compressed" => { compressed = true; i += 1; }
-            "--compressed-serial" => { compressed = true; compressed_serial = true; i += 1; }
-            "--kv-mode" => { kv_mode_str = args[i + 1].clone(); i += 2; }
-            "--mtp-p-min" => { p_min = args[i + 1].parse().unwrap(); i += 2; }
-            "--top-p" => { top_p = args[i + 1].parse().unwrap(); i += 2; }
-            "--top-k" => { top_k = args[i + 1].parse().unwrap(); i += 2; }
-            "--min-p" => { min_p = args[i + 1].parse().unwrap(); i += 2; }
-            "--seed" => { seed = args[i + 1].parse().unwrap(); i += 2; }
+            "--target" => {
+                target_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--mtp-head" => {
+                mtp_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--prompt" => {
+                prompt_str = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--prompt-file" => {
+                prompt_file = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--max" => {
+                max_tokens = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--ctx" => {
+                ctx_capacity = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--temp" => {
+                temp = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--max-n" => {
+                max_n = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--no-chatml" => {
+                chatml = false;
+                i += 1;
+            }
+            "--chatml" => {
+                chatml = true;
+                i += 1;
+            }
+            "--compressed" => {
+                compressed = true;
+                i += 1;
+            }
+            "--compressed-serial" => {
+                compressed = true;
+                compressed_serial = true;
+                i += 1;
+            }
+            "--trunk-spine" => {
+                trunk_spine = true;
+                compressed = true;
+                compressed_serial = true;
+                i += 1;
+            }
+            "--kv-mode" => {
+                kv_mode_str = args[i + 1].clone();
+                i += 2;
+            }
+            "--mtp-p-min" => {
+                p_min = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--top-p" => {
+                top_p = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--top-k" => {
+                top_k = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--min-p" => {
+                min_p = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--seed" => {
+                seed = args[i + 1].parse().unwrap();
+                i += 2;
+            }
             "-h" | "--help" => {
                 eprintln!(
                     "Usage: mtp_only_demo --target <trunk.hfq> --mtp-head <head.mtp> \\\n\
                      \t(--prompt \"Hello\" | --prompt-file <path>) \\\n\
                      \t[--max 64] [--ctx 4096] [--temp 0.0] [--max-n 4] \\\n\
-                     \t[--no-chatml] [--compressed]\n\
+                     \t[--no-chatml] [--compressed] [--compressed-serial] [--trunk-spine]\n\
                      \n\
                      --compressed: use FastMTP-style compressed lm_head_draft (K=1 path).\n\
                                    Requires .mtp head built with --vocab-sidecar.\n\
-                                   Forces max_n=1 since the compressed spec is K=1 only."
+                                   Forces max_n=1 since the compressed spec is K=1 only.\n\
+                     --compressed-serial: discrete-token serial MTP spine without prompt MTP fill.\n\
+                     --trunk-spine: DS4-style Qwen spine: prompt MTP fill + discrete-token serial verify."
                 );
                 std::process::exit(0);
             }
@@ -102,7 +166,7 @@ fn main() {
     let target_is_bundle = target_path.ends_with(".mq4-mtp");
     let mtp_path = match (mtp_path, target_is_bundle) {
         (Some(p), _) => Some(p),
-        (None, true) => None,  // resolved from bundle below
+        (None, true) => None, // resolved from bundle below
         (None, false) => {
             eprintln!("--mtp-head required for non-bundle .mq4 target (got '{target_path}')");
             std::process::exit(2);
@@ -129,15 +193,19 @@ fn main() {
         std::process::exit(2);
     }
     if temp > 0.0 && !compressed_serial {
-        eprintln!("error: --temp > 0 is only supported on --compressed-serial path \
-                   (other paths are greedy-only); got temp={temp}");
+        eprintln!(
+            "error: --temp > 0 is only supported on --compressed-serial path \
+                   (other paths are greedy-only); got temp={temp}"
+        );
         std::process::exit(2);
     }
     assert!(max_n >= 1 && max_n <= 8, "--max-n must be in [1,8]");
-    if compressed && max_n > 1 {
-        eprintln!("compressed K={max_n}: chains K block forwards with lossy embedding \
+    if compressed && !compressed_serial && max_n > 1 {
+        eprintln!(
+            "compressed K={max_n}: chains K block forwards with lossy embedding \
                    override (same OOD risk as plain K-step path). Batched compressed \
-                   lm_head over the K outputs amortizes the BW saving across the chain.");
+                   lm_head over the K outputs amortizes the BW saving across the chain."
+        );
     }
 
     let prompt = hipfire_runtime::tokenizer::maybe_normalize_prompt(&prompt_raw).into_owned();
@@ -145,10 +213,16 @@ fn main() {
 
     eprintln!("=== mtp_only_demo ===");
     eprintln!("target:     {target_path}");
-    eprintln!("mtp-head:   {}",
-        mtp_path.as_deref().unwrap_or("<bundled in target .mq4-mtp>"));
+    eprintln!(
+        "mtp-head:   {}",
+        mtp_path
+            .as_deref()
+            .unwrap_or("<bundled in target .mq4-mtp>")
+    );
     eprintln!("prompt md5: {prompt_hash}");
-    eprintln!("max={max_tokens} ctx={ctx_capacity} max_n={max_n} chatml={chatml}");
+    eprintln!(
+        "max={max_tokens} ctx={ctx_capacity} max_n={max_n} chatml={chatml} trunk_spine={trunk_spine}"
+    );
 
     // ── Init GPU + load trunk + load MTP head ──────────────────────────
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
@@ -162,9 +236,8 @@ fn main() {
     slot_cfg.max_seq = ctx_capacity + max_tokens * (max_n + 1) + 16;
     let max_seq_total = slot_cfg.max_seq;
     let t_load = Instant::now();
-    let mut target = ModelSlot::load(
-        &mut gpu, Path::new(&target_path), "target", slot_cfg,
-    ).expect("load target");
+    let mut target = ModelSlot::load(&mut gpu, Path::new(&target_path), "target", slot_cfg)
+        .expect("load target");
     eprintln!("trunk loaded in {:.2}s", t_load.elapsed().as_secs_f64());
 
     // MTP head's max_seq mirrors the trunk's. The head's KV cache is one
@@ -172,16 +245,21 @@ fn main() {
     let t_mtp = Instant::now();
     let head = if let Some(ref mp) = mtp_path {
         // Explicit --mtp-head: standalone .mtp file (legacy path).
-        mtp_head::load_mtp_head(Path::new(mp), &mut gpu, max_seq_total)
-            .expect("load mtp head")
+        mtp_head::load_mtp_head(Path::new(mp), &mut gpu, max_seq_total).expect("load mtp head")
     } else {
         // Bundled .mq4-mtp: load MTP section embedded in target file.
         mtp_head::load_mtp_head_bundled(Path::new(&target_path), &mut gpu, max_seq_total)
             .expect("load bundled mtp head")
-            .expect("target ends in .mq4-mtp but no MTP bundle trailer found; \
-                     was the file produced by mq4_merge_mtp?")
+            .expect(
+                "target ends in .mq4-mtp but no MTP bundle trailer found; \
+                     was the file produced by mq4_merge_mtp?",
+            )
     };
-    let head_source = if mtp_path.is_some() { "standalone .mtp" } else { "bundled .mq4-mtp" };
+    let head_source = if mtp_path.is_some() {
+        "standalone .mtp"
+    } else {
+        "bundled .mq4-mtp"
+    };
     eprintln!("mtp head loaded in {:.2}s ({head_source}) — n_embd={} vocab={} n_rot={} rope_theta={} compressed_lm_head_draft={}",
               t_mtp.elapsed().as_secs_f64(),
               head.config.n_embd, head.config.vocab_size,
@@ -189,9 +267,14 @@ fn main() {
               head.weights.lm_head_draft.is_some());
 
     // Sanity dims
-    assert_eq!(head.config.n_embd, target.config.dim, "trunk/head dim mismatch");
-    assert_eq!(head.config.vocab_size, target.config.vocab_size,
-               "trunk/head vocab mismatch");
+    assert_eq!(
+        head.config.n_embd, target.config.dim,
+        "trunk/head dim mismatch"
+    );
+    assert_eq!(
+        head.config.vocab_size, target.config.vocab_size,
+        "trunk/head vocab mismatch"
+    );
 
     // ── Tokenize prompt ────────────────────────────────────────────────
     let tokenizer: Tokenizer = target.load_tokenizer().expect("trunk tokenizer");
@@ -214,7 +297,10 @@ fn main() {
         chat.extend_from_slice(&asst);
         chat.extend_from_slice(&nl);
         prompt_tokens = chat;
-        eprintln!("chatml wrap: prompt {} tokens after wrap", prompt_tokens.len());
+        eprintln!(
+            "chatml wrap: prompt {} tokens after wrap",
+            prompt_tokens.len()
+        );
     } else {
         eprintln!("prompt: {} tokens (no chatml)", prompt_tokens.len());
     }
@@ -222,21 +308,31 @@ fn main() {
     assert!(
         prompt_tokens.len() + max_tokens * (max_n + 1) + 16 <= max_seq_total,
         "prompt ({}) + max ({}) × (max_n + 1) ({}) won't fit in max_seq {}",
-        prompt_tokens.len(), max_tokens, max_n + 1, max_seq_total,
+        prompt_tokens.len(),
+        max_tokens,
+        max_n + 1,
+        max_seq_total,
     );
 
     // ── Allocate spec state ────────────────────────────────────────────
-    let kv_mode = hipfire_arch_qwen35::mtp_head::MtpKvMode::parse(&kv_mode_str)
-        .unwrap_or_else(|e| { eprintln!("{e}"); std::process::exit(2); });
+    let kv_mode =
+        hipfire_arch_qwen35::mtp_head::MtpKvMode::parse(&kv_mode_str).unwrap_or_else(|e| {
+            eprintln!("{e}");
+            std::process::exit(2);
+        });
     eprintln!("mtp-head kv-mode: {kv_mode:?}");
-    let mut state = MtpSpecState::new_for_slot_with_kv_mode(&mut gpu, &target, &head, max_n, kv_mode)
-        .expect("alloc MtpSpecState");
+    let mut state =
+        MtpSpecState::new_for_slot_with_kv_mode(&mut gpu, &target, &head, max_n, kv_mode)
+            .expect("alloc MtpSpecState");
     if p_min > 0.0 {
-        if !compressed_serial {
-            eprintln!("warning: --mtp-p-min only affects --compressed-serial path; ignored for the other two");
+        if !compressed_serial && !trunk_spine {
+            eprintln!("warning: --mtp-p-min only affects --compressed-serial/--trunk-spine path; ignored for the other two");
         }
         state.set_p_min(p_min);
-        eprintln!("mtp-p-min: {p_min} (early-exit chain at log P(argmax) < {:.4})", p_min.ln());
+        eprintln!(
+            "mtp-p-min: {p_min} (early-exit chain at log P(argmax) < {:.4})",
+            p_min.ln()
+        );
     }
     if temp > 0.0 {
         let cfg = hipfire_arch_qwen35::mtp_spec::MtpSamplingConfig {
@@ -261,22 +357,35 @@ fn main() {
     if compressed {
         match head.weights.compressed_vocab_size {
             Some(cvs) => {
-                state.mtp_scratch
+                state
+                    .mtp_scratch
                     .ensure_compressed_logits(&mut gpu, cvs)
                     .expect("alloc logits_compressed");
-                state.ensure_compressed_lm_logits(&mut gpu, cvs)
+                state
+                    .ensure_compressed_lm_logits(&mut gpu, cvs)
                     .expect("alloc mtp_lm_logits_compressed");
-                eprintln!("compressed: ON (cvs={cvs}, K={max_n}, mode=sidecar)");
+                if trunk_spine {
+                    eprintln!("trunk-spine: ON (sidecar draft lm_head, cvs={cvs}, K={max_n})");
+                } else {
+                    eprintln!("compressed: ON (cvs={cvs}, K={max_n}, mode=sidecar)");
+                }
             }
             None if compressed_serial => {
                 // Full-vocab discrete-token chain via trunk's lm_head.
                 // spec_step_mtp_compressed_serial dispatches against
                 // trunk_weights.output and writes into state.mtp_lm_logits.
-                eprintln!(
-                    "compressed: ON (mode=full-vocab, K={max_n}, vocab={}) — \
-                     trunk lm_head used per-step",
-                    target.config.vocab_size
-                );
+                if trunk_spine {
+                    eprintln!(
+                        "trunk-spine: ON (full-vocab draft lm_head, K={max_n}, vocab={})",
+                        target.config.vocab_size
+                    );
+                } else {
+                    eprintln!(
+                        "compressed: ON (mode=full-vocab, K={max_n}, vocab={}) — \
+                         trunk lm_head used per-step",
+                        target.config.vocab_size
+                    );
+                }
             }
             None => {
                 eprintln!(
@@ -303,43 +412,75 @@ fn main() {
     // on 232-token canonical prompt at 36 tok/s). Batched path runs the
     // same 232 tokens at ~540 tok/s (~0.43s), reclaiming ~6s of bench
     // wall time per run.
-    eprintln!("prefilling {} tokens (batched)...", prompt_tokens.len());
+    if trunk_spine {
+        eprintln!(
+            "prefilling {} tokens (batched trunk + MTP cache fill)...",
+            prompt_tokens.len()
+        );
+    } else {
+        eprintln!("prefilling {} tokens (batched)...", prompt_tokens.len());
+    }
     let t_prefill = Instant::now();
-    hipfire_arch_qwen35::qwen35::forward_prefill_batch(
-        &mut gpu,
-        &target.weights,
-        &target.config,
-        &prompt_tokens,
-        0,
-        &mut target.kv_cache,
-        &mut target.dn_state,
-        &target.scratch,
-        None,  // hidden_rb (not needed — MTP demo doesn't use ring buffer)
-        None,  // per_token_hidden_out (not needed for MTP seed)
-        None,  // gdn_tape
-        None,  // tree_verify
-    ).expect("prefill forward_prefill_batch");
+    if trunk_spine {
+        mtp_spec::prefill_trunk_and_mtp_cache(
+            &mut gpu,
+            &mut target,
+            &head,
+            &mut state,
+            &prompt_tokens,
+            0,
+        )
+        .expect("prefill trunk + mtp cache");
+    } else {
+        hipfire_arch_qwen35::qwen35::forward_prefill_batch(
+            &mut gpu,
+            &target.weights,
+            &target.config,
+            &prompt_tokens,
+            0,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            None, // hidden_rb (not needed — MTP demo doesn't use ring buffer)
+            None, // per_token_hidden_out (not needed for MTP seed)
+            None, // gdn_tape
+            None, // tree_verify
+        )
+        .expect("prefill forward_prefill_batch");
+    }
     let prefill_secs = t_prefill.elapsed().as_secs_f64();
     let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
     eprintln!("prefill: {:.2}s ({:.1} tok/s)", prefill_secs, prefill_tok_s);
 
     // Snapshot trunk's prev_hidden (post-output-norm at last prefill position).
-    state.capture_prev_hidden_from_scratch_tmp(
-        &gpu, &target.scratch.tmp, target.config.dim,
-    ).expect("capture prev_hidden");
+    if !trunk_spine {
+        state
+            .capture_prev_hidden_from_scratch_tmp(&gpu, &target.scratch.tmp, target.config.dim)
+            .expect("capture prev_hidden");
+    }
 
     // Pick the seed_token: argmax of the trunk's logits for the last prefill
     // position. This becomes cycle 0's `last_committed`.
-    let logits0 = gpu.download_f32(&target.scratch.logits)
+    let logits0 = gpu
+        .download_f32(&target.scratch.logits)
         .expect("download seed logits");
     let mut seed_token = 0u32;
     let mut best = f32::NEG_INFINITY;
     for (i, &v) in logits0.iter().enumerate() {
-        if v > best { best = v; seed_token = i as u32; }
+        if v > best {
+            best = v;
+            seed_token = i as u32;
+        }
     }
-    eprintln!("seed token (greedy after prefill): {} ('{}')",
-              seed_token,
-              tokenizer.decode(&[seed_token]).chars().take(16).collect::<String>());
+    eprintln!(
+        "seed token (greedy after prefill): {} ('{}')",
+        seed_token,
+        tokenizer
+            .decode(&[seed_token])
+            .chars()
+            .take(16)
+            .collect::<String>()
+    );
 
     // ── Spec-decode loop ───────────────────────────────────────────────
     //
@@ -355,11 +496,11 @@ fn main() {
     let mut cur_pos = prompt_tokens.len();
 
     let mut cycles = 0usize;
-    let mut accepted_total = 0usize;  // sum of accept_count across cycles
-    let mut bonus_total = 0usize;     // sum of "bonus committed" across cycles
-    let mut truncated_cycles = 0usize;  // cycles where p_min fired early-exit
-    let mut drafts_generated_total = 0usize;  // sum of drafts_generated across cycles
-    let mut replay_skipped_cycles = 0usize;  // full-accept cycles that skipped replay
+    let mut accepted_total = 0usize; // sum of accept_count across cycles
+    let mut bonus_total = 0usize; // sum of "bonus committed" across cycles
+    let mut truncated_cycles = 0usize; // cycles where p_min fired early-exit
+    let mut drafts_generated_total = 0usize; // sum of drafts_generated across cycles
+    let mut replay_skipped_cycles = 0usize; // full-accept cycles that skipped replay
 
     // HIPFIRE_PROFILE=1 + HIPFIRE_PROFILE_CYCLES=N: per-kernel profiling
     // armed after cycle 1 (post-JIT warmup), drained after N more cycles.
@@ -381,28 +522,61 @@ fn main() {
             eprintln!("hit max_seq {}; stopping", max_seq_total);
             break;
         }
-        let result = if compressed_serial {
+        let result = if trunk_spine {
+            mtp_spec::spec_step_mtp_trunk_spine(
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp_trunk_spine")
+        } else if compressed_serial {
             mtp_spec::spec_step_mtp_compressed_serial(
-                &mut gpu, &mut target, &head, &mut state,
-                cur_pos, last_committed, eos_token,
-            ).expect("spec_step_mtp_compressed_serial")
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp_compressed_serial")
         } else if compressed {
             mtp_spec::spec_step_mtp_compressed(
-                &mut gpu, &mut target, &head, &mut state,
-                cur_pos, last_committed, eos_token,
-            ).expect("spec_step_mtp_compressed")
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp_compressed")
         } else {
             mtp_spec::spec_step_mtp(
-                &mut gpu, &mut target, &head, &mut state,
-                cur_pos, last_committed, eos_token,
-            ).expect("spec_step_mtp")
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp")
         };
 
         cycles += 1;
         accepted_total += result.accept_count;
         drafts_generated_total += result.drafts_generated;
-        if result.chain_truncated { truncated_cycles += 1; }
-        if result.replay_skipped { replay_skipped_cycles += 1; }
+        if result.chain_truncated {
+            truncated_cycles += 1;
+        }
+        if result.replay_skipped {
+            replay_skipped_cycles += 1;
+        }
 
         // Arm per-kernel profiler after cycle 1 (post-JIT warmup), drain after
         // profile_cycles_target additional cycles. Print kernel breakdown.
@@ -410,9 +584,7 @@ fn main() {
             rdna_compute::profile::start();
             profile_armed = true;
         }
-        if do_profile && profile_armed && !profile_done
-            && cycles >= 1 + profile_cycles_target
-        {
+        if do_profile && profile_armed && !profile_done && cycles >= 1 + profile_cycles_target {
             profile_done = true;
             if let Some(entries) = rdna_compute::profile::stop() {
                 use std::collections::HashMap;
@@ -425,11 +597,13 @@ fn main() {
                     ent.2 += e.bytes;
                 }
                 let mut kerns: Vec<_> = by_kernel.into_iter().collect();
-                kerns.sort_by(|a, b| b.1.0.partial_cmp(&a.1.0).unwrap());
+                kerns.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap());
                 let total_us: f64 = kerns.iter().map(|(_, (t, _, _))| t).sum();
                 eprintln!(
                     "\n=== PROFILE: {} kernel calls over {} cycles, {:.1}ms total kernel time ===",
-                    entries.len(), measured, total_us / 1000.0,
+                    entries.len(),
+                    measured,
+                    total_us / 1000.0,
                 );
                 eprintln!(
                     "  per-cycle kernel total: {:.2} ms",
@@ -440,7 +614,9 @@ fn main() {
                     "kernel", "calls", "total_ms", "us/call", "%", "MB",
                 );
                 for (kern, (us, n, bytes)) in &kerns {
-                    if *us / total_us < 0.005 { continue; }
+                    if *us / total_us < 0.005 {
+                        continue;
+                    }
                     eprintln!(
                         "  {kern:50} {n:>6} {:>10.2} {:>10.0} {:>6.1}% {:>10.1}",
                         us / 1000.0,
@@ -452,8 +628,9 @@ fn main() {
                 eprintln!("=== /PROFILE ===\n");
             }
         }
-        if !result.hit_eos || (result.committed.last().copied() != Some(eos_token)
-                               && result.accept_count < max_n) {
+        if !result.hit_eos
+            || (result.committed.last().copied() != Some(eos_token) && result.accept_count < max_n)
+        {
             // bonus committed unless we EOS-broke inside the chain. Counts
             // the explicit bonus argmax slot.
             bonus_total += 1;
@@ -509,8 +686,14 @@ fn main() {
         let truncated_pct = 100.0 * truncated_cycles as f64 / cycles.max(1) as f64;
         let avg_drafts = drafts_generated_total as f64 / cycles.max(1) as f64;
         println!("p_min:                {}", p_min);
-        println!("chain_truncated:      {} cycles ({:.1}%)", truncated_cycles, truncated_pct);
-        println!("avg_drafts_per_cycle: {:.3} (of max_n={})", avg_drafts, max_n);
+        println!(
+            "chain_truncated:      {} cycles ({:.1}%)",
+            truncated_cycles, truncated_pct
+        );
+        println!(
+            "avg_drafts_per_cycle: {:.3} (of max_n={})",
+            avg_drafts, max_n
+        );
     }
     println!("committed_total:      {}", total_committed);
     println!("committed_seed:       1");

--- a/crates/hipfire-runtime/examples/test_wmma_residual_gfx12.rs
+++ b/crates/hipfire-runtime/examples/test_wmma_residual_gfx12.rs
@@ -70,11 +70,22 @@ fn main() {
         match run_one(&mut gpu, m, k, n) {
             Ok(()) => {
                 total_pass += 1;
-                eprintln!("  {label:50} OK");
+                eprintln!("  residual {label:41} OK");
             }
             Err(e) => {
                 total_fail += 1;
-                eprintln!("  {label:50} FAIL");
+                eprintln!("  residual {label:41} FAIL");
+                eprintln!("{e}");
+            }
+        }
+        match run_one_lmhead(&mut gpu, m, k, n) {
+            Ok(()) => {
+                total_pass += 1;
+                eprintln!("  lmhead   {label:41} OK");
+            }
+            Err(e) => {
+                total_fail += 1;
+                eprintln!("  lmhead   {label:41} FAIL");
                 eprintln!("{e}");
             }
         }
@@ -85,6 +96,62 @@ fn main() {
     eprintln!("  Failed: {total_fail}");
     if total_fail > 0 {
         std::process::exit(1);
+    }
+}
+
+fn run_one_lmhead(gpu: &mut Gpu, m: usize, k: usize, n: usize) -> Result<(), String> {
+    assert_eq!(m % 16, 0);
+    assert_eq!(k % 256, 0, "K must be multiple of 256 (HFQ4G256 group size)");
+    assert_eq!(n % 16, 0, "N must be multiple of 16 (WMMA batch tile)");
+
+    let a_bytes = build_hfq4g256(m, k, 0xB4);
+    let a = gpu
+        .upload_raw(&a_bytes, &[m, k])
+        .map_err(|e| format!("upload a: {e}"))?;
+
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| {
+            let b = (i / k) as i32;
+            let kk = (i % k) as i32;
+            ((b * 5 + kk * 3) % 37 - 18) as f32 * 0.04
+        })
+        .collect();
+    let x = gpu
+        .upload_f32(&x_f32, &[n, k])
+        .map_err(|e| format!("upload x: {e}"))?;
+
+    let y_zero = vec![0.0f32; n * m];
+    let y_ref = gpu
+        .upload_f32(&y_zero, &[n, m])
+        .map_err(|e| format!("upload y_ref init: {e}"))?;
+    gpu.gemm_hfq4g256_residual_fp16(&a, &x, &y_ref, m, k, n)
+        .map_err(|e| format!("dot2-fp16 residual zero-init: {e}"))?;
+    let ref_y = gpu
+        .download_f32(&y_ref)
+        .map_err(|e| format!("download y_ref: {e}"))?;
+
+    let y_dirty: Vec<f32> = (0..(n * m))
+        .map(|i| ((i * 19) % 29) as f32 * 0.01 + 0.25)
+        .collect();
+    let y_cand = gpu
+        .upload_f32(&y_dirty, &[n, m])
+        .map_err(|e| format!("upload y_cand dirty init: {e}"))?;
+    gpu.gemm_hfq4g256_lmhead_wmma_gfx12(&a, &x, &y_cand, m, k, n)
+        .map_err(|e| format!("wmma_gfx12 lmhead: {e}"))?;
+    let cand_y = gpu
+        .download_f32(&y_cand)
+        .map_err(|e| format!("download y_cand: {e}"))?;
+
+    gpu.free_tensor(a).ok();
+    gpu.free_tensor(x).ok();
+    gpu.free_tensor(y_ref).ok();
+    gpu.free_tensor(y_cand).ok();
+
+    let mut report = String::new();
+    if compare("Y_lmhead", n, m, &cand_y, &ref_y, &mut report) {
+        Ok(())
+    } else {
+        Err(report)
     }
 }
 

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -28,8 +28,9 @@
 
 use crate::hfq::{load_awq_scale, HfqFile};
 use crate::llama::WeightTensor;
-use hip_bridge::HipResult;
+use hip_bridge::{Graph, GraphExec, HipResult};
 use rdna_compute::{DType, Gpu, GpuTensor};
+use std::collections::{HashMap, HashSet};
 
 /// Max rows per call into `gemm_dispatch` for the MQ4/MQ3 (FWHT-rotated)
 /// path. The activation rotation scratch (`DflashScratch.mq_x_rot`) is
@@ -417,6 +418,12 @@ pub struct DflashScratch {
     /// reset rebuilds the full prefix in one shot — same cost as a
     /// pre-cache cycle, but amortized thereafter.
     pub draft_ctx_cached_rows: usize,
+
+    /// Per-layer, per-B graph cache for the fixed-shape FFN tail inside
+    /// `draft_forward_opts`. The attention/context part depends on `ctx_len`;
+    /// this FFN subgraph does not, so it can replay across DFlash cycles.
+    pub draft_ffn_graphs: Vec<HashMap<usize, (Graph, GraphExec, Vec<Vec<u8>>)>>,
+    pub draft_ffn_warmed_up: Vec<HashSet<usize>>,
 }
 
 impl DflashScratch {
@@ -480,9 +487,13 @@ impl DflashScratch {
         // = 128 MB. Trivial vs 24 GB VRAM.
         let mut k_ctx_cached = Vec::with_capacity(cfg.n_layers);
         let mut v_ctx_cached = Vec::with_capacity(cfg.n_layers);
+        let mut draft_ffn_graphs = Vec::with_capacity(cfg.n_layers);
+        let mut draft_ffn_warmed_up = Vec::with_capacity(cfg.n_layers);
         for _ in 0..cfg.n_layers {
             k_ctx_cached.push(gpu.alloc_tensor(&[l * kvd], DType::F32)?);
             v_ctx_cached.push(gpu.alloc_tensor(&[l * kvd], DType::F32)?);
+            draft_ffn_graphs.push(HashMap::new());
+            draft_ffn_warmed_up.push(HashSet::new());
         }
 
         Ok(DflashScratch {
@@ -519,6 +530,8 @@ impl DflashScratch {
             k_ctx_cached,
             v_ctx_cached,
             draft_ctx_cached_rows: 0,
+            draft_ffn_graphs,
+            draft_ffn_warmed_up,
         })
     }
 
@@ -546,6 +559,12 @@ impl DflashScratch {
     }
 
     pub fn free_gpu(self, gpu: &mut Gpu) {
+        for per_layer in self.draft_ffn_graphs {
+            for (_, (graph, exec, _blobs)) in per_layer {
+                let _ = gpu.hip.graph_exec_destroy(exec);
+                let _ = gpu.hip.graph_destroy(graph);
+            }
+        }
         let _ = gpu.free_tensor(self.x);
         let _ = gpu.free_tensor(self.x_norm);
         let _ = gpu.free_tensor(self.q);
@@ -709,6 +728,118 @@ fn gemm_dispatch(
     result
 }
 
+fn begin_draft_ffn_graph_capture(gpu: &mut Gpu) -> HipResult<()> {
+    gpu.capture_blobs.clear();
+    gpu.capture_mode = true;
+    let stream = gpu
+        .active_stream
+        .as_ref()
+        .expect("draft FFN graph capture requires an explicit stream");
+    gpu.hip.stream_begin_capture(stream, 0)
+}
+
+fn end_draft_ffn_graph_capture(
+    gpu: &mut Gpu,
+) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
+    gpu.capture_mode = false;
+    let stream = gpu.active_stream.as_ref().unwrap();
+    let graph = gpu.hip.stream_end_capture(stream)?;
+    let exec = gpu.hip.graph_instantiate(&graph)?;
+    let blobs = std::mem::take(&mut gpu.capture_blobs);
+    Ok((graph, exec, blobs))
+}
+
+fn abort_draft_ffn_graph_capture(gpu: &mut Gpu) {
+    if gpu.capture_mode {
+        if let Some(stream) = gpu.active_stream.as_ref() {
+            let _ = gpu.hip.stream_end_capture(stream);
+        }
+        gpu.capture_mode = false;
+    }
+    gpu.capture_blobs.clear();
+}
+
+fn draft_ffn_layer(
+    gpu: &mut Gpu,
+    layer: &DflashLayerWeights,
+    scratch: &mut DflashScratch,
+    b: usize,
+    h: usize,
+    eps: f32,
+    graph_safe: bool,
+) -> HipResult<()> {
+    if graph_safe {
+        gpu.memcpy_dtod_auto(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+    } else {
+        gpu.hip.memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+    }
+
+    gpu.rmsnorm_batched(
+        &scratch.x,
+        &layer.ffn_norm,
+        &scratch.x_norm,
+        b,
+        h,
+        eps,
+    )?;
+    gemm_dispatch(gpu, &scratch.x_norm, &layer.w_gate, &scratch.gate, b, scratch.mq_x_rot.as_ref())?;
+    gemm_dispatch(gpu, &scratch.x_norm, &layer.w_up,   &scratch.up,   b, scratch.mq_x_rot.as_ref())?;
+    gpu.silu_mul_f32(&scratch.gate, &scratch.up, &scratch.gate_up)?;
+    gemm_dispatch(gpu, &scratch.gate_up, &layer.w_down, &scratch.x, b, scratch.mq_x_rot.as_ref())?;
+    if graph_safe {
+        gpu.add_f32_graph_safe(&scratch.residual_ffn, &scratch.x, &scratch.x)
+    } else {
+        gpu.add_f32(&scratch.residual_ffn, &scratch.x, &scratch.x)
+    }
+}
+
+fn draft_ffn_layer_maybe_graph(
+    gpu: &mut Gpu,
+    layer: &DflashLayerWeights,
+    scratch: &mut DflashScratch,
+    layer_idx: usize,
+    b: usize,
+    h: usize,
+    eps: f32,
+    use_graph: bool,
+) -> HipResult<()> {
+    if !use_graph {
+        return draft_ffn_layer(gpu, layer, scratch, b, h, eps, false);
+    }
+
+    if gpu.active_stream.is_none() {
+        gpu.active_stream = Some(gpu.hip.stream_create()?);
+    }
+
+    if scratch.draft_ffn_graphs[layer_idx].contains_key(&b) {
+        let stream = gpu.active_stream.as_ref().unwrap();
+        let entry = scratch.draft_ffn_graphs[layer_idx]
+            .get(&b)
+            .unwrap_or_else(|| panic!("missing draft FFN graph for layer={layer_idx} b={b}"));
+        return gpu.hip.graph_launch(&entry.1, stream);
+    }
+
+    if !scratch.draft_ffn_warmed_up[layer_idx].contains(&b) {
+        scratch.draft_ffn_warmed_up[layer_idx].insert(b);
+        return draft_ffn_layer(gpu, layer, scratch, b, h, eps, false);
+    }
+
+    begin_draft_ffn_graph_capture(gpu)?;
+    let r = draft_ffn_layer(gpu, layer, scratch, b, h, eps, true);
+    if r.is_ok() {
+        let entry = end_draft_ffn_graph_capture(gpu)?;
+        scratch.draft_ffn_graphs[layer_idx].insert(b, entry);
+        let stream = gpu.active_stream.as_ref().unwrap();
+        let entry = scratch.draft_ffn_graphs[layer_idx]
+            .get(&b)
+            .unwrap_or_else(|| panic!("missing captured draft FFN graph for layer={layer_idx} b={b}"));
+        gpu.hip.graph_launch(&entry.1, stream)
+    } else {
+        abort_draft_ffn_graph_capture(gpu);
+        r
+    }
+}
+
 /// Upload f32 slice into a GPU tensor (bytes via memcpy_htod).
 fn upload_slice_f32(gpu: &Gpu, dst: &GpuTensor, data: &[f32]) -> HipResult<()> {
     let bytes: &[u8] = unsafe {
@@ -766,6 +897,34 @@ pub fn draft_forward(
     block_size: usize,
     ctx_len: usize,
     scratch: &mut DflashScratch,
+) -> HipResult<()> {
+    draft_forward_opts(
+        gpu,
+        weights,
+        cfg,
+        noise_embedding,
+        target_hidden,
+        positions_q,
+        positions_k,
+        block_size,
+        ctx_len,
+        scratch,
+        false,
+    )
+}
+
+pub fn draft_forward_opts(
+    gpu: &mut Gpu,
+    weights: &DflashWeights,
+    cfg: &DflashConfig,
+    noise_embedding: Option<&[f32]>,
+    target_hidden: Option<&[f32]>,
+    positions_q: &[i32],
+    positions_k: &[i32],
+    block_size: usize,
+    ctx_len: usize,
+    scratch: &mut DflashScratch,
+    graph_ffn: bool,
 ) -> HipResult<()> {
     let b = block_size;
     let l = ctx_len;
@@ -1053,15 +1212,21 @@ pub fn draft_forward(
         // x = residual_attn + attn_proj
         gpu.add_f32(&scratch.residual_attn, &scratch.attn_proj, &scratch.x)?;
 
-        // Residual for FFN.
-        gpu.hip.memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
-
-        // ffn_norm.
-        gpu.rmsnorm_batched(&scratch.x, &layer.ffn_norm, &scratch.x_norm, b, h, eps)?;
-
-        // gate = x_norm @ w_gate^T; up = x_norm @ w_up^T
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.w_gate, &scratch.gate, b, scratch.mq_x_rot.as_ref())?;
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.w_up,   &scratch.up,   b, scratch.mq_x_rot.as_ref())?;
+        // Fixed-shape FFN tail. MoE DFlash can optionally capture this as a
+        // per-layer/per-B hipGraph; the attention/context work above is left
+        // direct because `ctx_len` changes every accepted cycle.
+        let graph_ffn_active =
+            graph_ffn && !dbg && !crate::config::get().draft_gemm_dump;
+        draft_ffn_layer_maybe_graph(
+            gpu,
+            layer,
+            scratch,
+            li,
+            b,
+            h,
+            eps,
+            graph_ffn_active,
+        )?;
         // 2026-04-21: tried target's fused gemm_gate_up_hfq4g256 here (shared
         // FP16-X convert + interleaved gate/up GEMMs). Byte-exact A/B neutral
         // on 27B HumanEval (median 76.47 fused vs 76.74 baseline; ±7 % run-to-
@@ -1069,15 +1234,6 @@ pub fn draft_forward(
         // Kept per-weight dispatch for clarity. The real draft perf lever is
         // the ~56 ms of ffn_gemm per cycle (see HIPFIRE_DRAFT_SUBPHASE=1);
         // fusion alone doesn't move that number — kernel engineering does.
-
-        // SiLU(gate) * up → gate_up
-        gpu.silu_mul_f32(&scratch.gate, &scratch.up, &scratch.gate_up)?;
-
-        // x = w_down @ gate_up^T  (output [B, hidden])
-        gemm_dispatch(gpu, &scratch.gate_up, &layer.w_down, &scratch.x, b, scratch.mq_x_rot.as_ref())?;
-
-        // x = residual_ffn + x
-        gpu.add_f32(&scratch.residual_ffn, &scratch.x, &scratch.x)?;
 
         if let Some(t) = t3 {
             gpu.hip.device_synchronize()?;

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -19227,7 +19227,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         // ~26.68% of composition cycle wall in this scalar path).
         let arch = self.arch.as_str();
         let wmma_eligible = batch_size > 1
-            && self.arch_caps.has_wmma_w32()
+            && (self.arch_caps.has_wmma_w32() || self.arch_caps.has_wmma_w32_gfx12())
             && !self.flags.fp16_disabled
             && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -22349,6 +22349,118 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         )
     }
 
+    /// GPU-side single-row argmax that writes directly into an MTP token
+    /// chain. If `vocab_map` is present, the argmax index is treated as a
+    /// compressed-vocab row and remapped to the full-vocab token id before
+    /// storing `token_chain[dst_slot]`.
+    pub fn argmax_token_chain_f32(
+        &mut self,
+        data: &GpuTensor,
+        argmax_out: &GpuTensor,
+        token_chain: &GpuTensor,
+        vocab_map: Option<&GpuTensor>,
+        n: usize,
+        dst_slot: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "argmax_token_chain",
+            kernels::ARGMAX_TOKEN_CHAIN_SRC,
+            "argmax_token_chain_f32",
+        )?;
+
+        let mut dp = data.buf.as_ptr();
+        let mut ap = argmax_out.buf.as_ptr();
+        let mut cp = token_chain.buf.as_ptr();
+        let mut vp = vocab_map
+            .map(|t| t.buf.as_ptr())
+            .unwrap_or(std::ptr::null_mut::<c_void>());
+        let mut nn = n as i32;
+        let mut ds = dst_slot as i32;
+        let mut use_map = i32::from(vocab_map.is_some());
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut dp as *mut _ as *mut c_void,
+            &mut ap as *mut _ as *mut c_void,
+            &mut cp as *mut _ as *mut c_void,
+            &mut vp as *mut _ as *mut c_void,
+            &mut nn as *mut _ as *mut c_void,
+            &mut ds as *mut _ as *mut c_void,
+            &mut use_map as *mut _ as *mut c_void,
+        ];
+
+        let block_size = 256u32;
+        let shared = block_size * 8; // f32 + i32 per thread
+        self.launch_maybe_blob(
+            "argmax_token_chain_f32",
+            [1, 1, 1],
+            [block_size, 1, 1],
+            shared,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(dp);
+                b.push_ptr(ap);
+                b.push_ptr(cp);
+                b.push_ptr(vp);
+                b.push_i32(nn);
+                b.push_i32(ds);
+                b.push_i32(use_map);
+                b
+            },
+        )
+    }
+
+    /// Device-side greedy accept prefix scan over verify argmaxes and MTP
+    /// candidates. `result[0]` is accept_count; `result[1]` is the bonus
+    /// token, or -1 if an accepted candidate was EOS and no bonus is present.
+    pub fn greedy_accept_from_argmax_i32(
+        &mut self,
+        argmax_per_pos: &GpuTensor,
+        candidates: &GpuTensor,
+        result: &GpuTensor,
+        drafts_generated: usize,
+        eos_token_id: u32,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "greedy_accept",
+            kernels::GREEDY_ACCEPT_SRC,
+            "greedy_accept_from_argmax_i32",
+        )?;
+
+        let mut ap = argmax_per_pos.buf.as_ptr();
+        let mut cp = candidates.buf.as_ptr();
+        let mut rp = result.buf.as_ptr();
+        let mut dg = drafts_generated as i32;
+        let mut eos = eos_token_id as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ap as *mut _ as *mut c_void,
+            &mut cp as *mut _ as *mut c_void,
+            &mut rp as *mut _ as *mut c_void,
+            &mut dg as *mut _ as *mut c_void,
+            &mut eos as *mut _ as *mut c_void,
+        ];
+
+        self.launch_maybe_blob(
+            "greedy_accept_from_argmax_i32",
+            [1, 1, 1],
+            [1, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ap);
+                b.push_ptr(cp);
+                b.push_ptr(rp);
+                b.push_i32(dg);
+                b.push_i32(eos);
+                b
+            },
+        )
+    }
+
     /// GPU-side argmax: returns index of max value. Avoids downloading full logits.
     pub fn argmax_f32(&mut self, data: &GpuTensor, n: usize) -> HipResult<u32> {
         self.bind_thread()?;
@@ -25193,7 +25305,6 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel("attention_q8_0_kv", kernels::ATTENTION_Q8_0_KV_SRC, "attention_q8_0_kv")?;
-        let func = &self.functions["attention_q8_0_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
         let mut q_ptr = q.buf.as_ptr(); let mut k_ptr = k_cache.buf.as_ptr();
         let mut v_ptr = v_cache.buf.as_ptr(); let mut out_ptr = out.buf.as_ptr();
@@ -25212,7 +25323,27 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         let shared_mem = ((seq_len_hint + block_size as usize + head_dim) * 4) as u32;
         let bytes = crate::profile::attention_q8_0_kv_bytes(n_heads, n_kv_heads, head_dim, seq_len_hint);
         let timer = crate::profile::begin_timer(&self.hip, "attention", "attention_q8_0_kv", bytes);
-        let result = unsafe { self.hip.launch_kernel(func, [n_heads as u32, 1, 1], [block_size, 1, 1], shared_mem, self.stream_ref(), &mut params) };
+        let result = self.launch_maybe_blob(
+            "attention_q8_0_kv",
+            [n_heads as u32, 1, 1],
+            [block_size, 1, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(q_ptr);
+                b.push_ptr(k_ptr);
+                b.push_ptr(v_ptr);
+                b.push_ptr(out_ptr);
+                b.push_ptr(pos_ptr);
+                b.push_i32(nh);
+                b.push_i32(nkv);
+                b.push_i32(hd);
+                b.push_i32(ms);
+                b.push_f32(sc);
+                b
+            },
+        );
         if let Some(t) = timer { t.finish(&self.hip); }
         result
     }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -409,6 +409,11 @@ pub struct Gpu {
     /// graph_destroy + re-capture every oscillation, which was wiping out the
     /// hipGraph replay gain entirely.
     pub verify_graph_cache: HashMap<usize, (hip_bridge::Graph, hip_bridge::GraphExec, Vec<Vec<u8>>)>,
+    /// Subset of `verify_graph_cache` whose captured region also includes the
+    /// DFlash verify lm_head + argmax tail. Forward-only and extended verify
+    /// graphs share the same per-B cache, so callers need this side metadata
+    /// before deciding whether to enqueue lm_head outside the graph.
+    pub verify_graph_lmhead_argmax: HashSet<usize>,
     /// Set of B values that have completed the once-per-B JIT/scratch warmup.
     /// Capture can safely begin only after warmup — see graph_verify_warmup doc.
     pub verify_warmed_up: HashSet<usize>,
@@ -644,6 +649,7 @@ impl Gpu {
             ar_forward_kernel_dirty: true,
             ar_forward_replay_enabled: false,
             verify_graph_cache: HashMap::new(),
+            verify_graph_lmhead_argmax: HashSet::new(),
             verify_warmed_up: HashSet::new(),
             verify_capturing_b: None,
             replay_graph_cache: HashMap::new(),
@@ -903,6 +909,16 @@ impl Gpu {
         self.verify_graph_cache.contains_key(&b)
     }
 
+    pub fn verify_graph_has_lmhead_argmax(&self, b: usize) -> bool {
+        // bind_thread: skip — pure state query
+        self.verify_graph_lmhead_argmax.contains(&b)
+    }
+
+    pub fn verify_mark_graph_lmhead_argmax(&mut self, b: usize) {
+        // bind_thread: skip — pure state update
+        self.verify_graph_lmhead_argmax.insert(b);
+    }
+
     pub fn verify_needs_warmup(&self, b: usize) -> bool {
         // bind_thread: skip — pure state query
         !self.verify_warmed_up.contains(&b)
@@ -968,6 +984,7 @@ impl Gpu {
             let _ = self.hip.graph_exec_destroy(exec);
             let _ = self.hip.graph_destroy(graph);
         }
+        self.verify_graph_lmhead_argmax.clear();
         self.verify_warmed_up.clear();
         self.verify_capturing_b = None;
     }
@@ -22743,6 +22760,40 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         let block = 256u32;
         let grid = ((n as u32) + block - 1) / block;
         unsafe { self.hip.launch_kernel(func, [grid, 1, 1], [block, 1, 1], 0, None, &mut params) }
+    }
+
+    /// c = a + b (element-wise), graph-capture-safe launch path. Keep the
+    /// legacy `add_f32` path unchanged for non-captured callers; use this in
+    /// subgraphs where stack-backed kernelParams would dangle on replay.
+    pub fn add_f32_graph_safe(&mut self, a: &GpuTensor, b: &GpuTensor, c: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel("add", kernels::ADD_SRC, "add_f32")?;
+
+        let n = a.numel() as i32;
+        let mut a_ptr = a.buf.as_ptr();
+        let mut b_ptr = b.buf.as_ptr();
+        let mut c_ptr = c.buf.as_ptr();
+        let mut n_val = n;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut b_ptr as *mut _ as *mut c_void,
+            &mut c_ptr as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let block = 256u32;
+        let grid = ((n as u32) + block - 1) / block;
+        self.launch_maybe_blob(
+            "add_f32",
+            [grid, 1, 1], [block, 1, 1], 0, &mut params,
+            || {
+                let mut bb = hip_bridge::KernargBlob::new();
+                bb.push_ptr(a_ptr); bb.push_ptr(b_ptr); bb.push_ptr(c_ptr);
+                bb.push_i32(n_val);
+                bb
+            },
+        )
     }
 
     /// a += b (in-place element-wise add)

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -13565,6 +13565,66 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         result
     }
 
+    /// gfx12 lm_head sibling of `gemm_hfq4g256_residual_wmma_gfx12`.
+    /// Uses the same WMMA tile mapping but overwrites Y instead of reading
+    /// and adding to it, so lm_head callers can skip a full-vocab zero-fill.
+    pub fn gemm_hfq4g256_lmhead_wmma_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfq4g256_lmhead_wmma_gfx12",
+            kernels::GEMM_HFQ4G256_LMHEAD_WMMA_GFX12_SRC,
+            "gemm_hfq4g256_lmhead_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_lmhead_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_lmhead_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ4-G256 GEMV with fused residual add: y[row] += A[row] · x.
     /// Same math as `gemv_hfq4g256` but the final write accumulates into `y`
     /// instead of overwriting. Used for wo / w_down projections where the
@@ -19192,6 +19252,8 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// WMMA lm_head fast path for DFlash. Computes y = A @ x at batch>1 via
     /// the residual-WMMA kernel on pre-zeroed y — 8-10× faster than the
     /// scalar `gemm_hfq4g256` on 9B lm_head (batch=16, vocab=248K, k=2560).
+    /// HIPFIRE_LM_HEAD_OVERWRITE=1 opts into a gfx12 overwrite sibling that
+    /// skips the zero-fill; measured as a small win but not enough to default.
     ///
     /// NOT numerically identical to `gemm_hfq4g256`. Uses FP16 tensor cores
     /// with the accumulators in FP32 the residual kernel ships. On the
@@ -19232,17 +19294,22 @@ self.flags.rocblas_min_batch.unwrap_or(4)
             && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
-            match self.active_stream.as_ref() {
-                Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
-                None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
-            }
-            return if arch.starts_with("gfx12") {
-                self.gemm_hfq4g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size)
+            if arch.starts_with("gfx12") && self.flags.lm_head_overwrite {
+                self.gemm_hfq4g256_lmhead_wmma_gfx12(a_raw, x, y, m, k, batch_size)
             } else {
-                self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size)
-            };
+                match self.active_stream.as_ref() {
+                    Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
+                    None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
+                }
+                if arch.starts_with("gfx12") {
+                    self.gemm_hfq4g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size)
+                } else {
+                    self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size)
+                }
+            }
+        } else {
+            self.gemm_hfq4g256(a_raw, x, y, m, k, batch_size)
         }
-        self.gemm_hfq4g256(a_raw, x, y, m, k, batch_size)
     }
 
     /// HFQ6-G256 sister of `gemm_hfq4g256_batched_lmhead`. Phase A.4

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -44,6 +44,7 @@ pub struct FeatureFlags {
     pub fp16_layer_max: Option<usize>,
     pub wo_mmq: bool,
     pub lm_head_wmma_disabled: bool,
+    pub lm_head_overwrite: bool,
 
     // ── MMQ screening ─────────────────────────────────────────────
     pub mmq_screen: bool,
@@ -160,6 +161,7 @@ impl FeatureFlags {
             fp16_layer_max: parse_usize("HIPFIRE_FP16_LAYER_MAX"),
             wo_mmq: std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1"),
             lm_head_wmma_disabled: std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0"),
+            lm_head_overwrite: std::env::var("HIPFIRE_LM_HEAD_OVERWRITE").as_deref() == Ok("1"),
 
             // MMQ screening
             mmq_screen: std::env::var("HIPFIRE_MMQ_SCREEN")
@@ -311,6 +313,7 @@ impl FeatureFlags {
             fp16_layer_max: None,
             wo_mmq: false,
             lm_head_wmma_disabled: false,
+            lm_head_overwrite: false,
             mmq_screen: false,
             mmq_screen_threshold: if is_gfx906 { 0.50 } else { 0.10 },
             mmq_diag_quantize_only: false,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1257,6 +1257,7 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_SRC: &str = include_str!("../../../
 // the residual-GEMM gap on 9B prefill (42% of decode-batch GEMM time was
 // stuck on the dot2 fp16 fallback before this).
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip");
+pub const GEMM_HFQ4G256_LMHEAD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip");
 // Q8_1 MMQ prefill variant — opt-in via HIPFIRE_MMQ=1, gated to RDNA3/3.5.
 // Pre-quantizes activations to Q8_1 + uses i8 WMMA over 128×128 tiles. Targets
 // the Strix Halo prefill gap vs llama.cpp (#60); also wins ~+20% on gfx1100

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2476,6 +2476,14 @@ pub const ARGMAX_SRC: &str = include_str!("../../../kernels/src/argmax.hip");
 /// Used by DFlash verify to collapse the B × [vocab] logit download to B × 4 bytes.
 pub const ARGMAX_BATCHED_SRC: &str = include_str!("../../../kernels/src/argmax_batched.hip");
 
+/// Single-row argmax that writes the selected token into an on-device MTP
+/// token chain, optionally remapping through a compressed-vocab sidecar.
+pub const ARGMAX_TOKEN_CHAIN_SRC: &str = include_str!("../../../kernels/src/argmax_token_chain.hip");
+
+/// Device-side greedy MTP accept prefix scan over verify argmaxes and draft
+/// candidates. Writes compact `[accept_count, bonus_or_minus_one]` result.
+pub const GREEDY_ACCEPT_SRC: &str = include_str!("../../../kernels/src/greedy_accept.hip");
+
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Vision encoder kernels (ViT: GEMM, LayerNorm, GELU, bias-add)

--- a/kernels/src/argmax_token_chain.hip
+++ b/kernels/src/argmax_token_chain.hip
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// Single-row F32 argmax that writes the next MTP token directly into a
+// device-resident token chain. `vocab_map == nullptr` means the argmax index
+// is already the full-vocab token id; otherwise it maps compressed draft-vocab
+// index -> full-vocab token id.
+extern "C" __global__ void argmax_token_chain_f32(
+    const float* __restrict__ data,
+    int* __restrict__ argmax_out,
+    int* __restrict__ token_chain,
+    const unsigned int* __restrict__ vocab_map,
+    int n,
+    int dst_slot,
+    int use_vocab_map
+) {
+    extern __shared__ float s[];
+    int* si = (int*)(s + blockDim.x);
+
+    float lmax = -1e30f;
+    int lidx = 0;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) {
+        float v = data[i];
+        if (v > lmax) {
+            lmax = v;
+            lidx = i;
+        }
+    }
+    s[threadIdx.x] = lmax;
+    si[threadIdx.x] = lidx;
+    __syncthreads();
+
+    for (int sz = blockDim.x / 2; sz > 0; sz >>= 1) {
+        if (threadIdx.x < sz && s[threadIdx.x + sz] > s[threadIdx.x]) {
+            s[threadIdx.x] = s[threadIdx.x + sz];
+            si[threadIdx.x] = si[threadIdx.x + sz];
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+        int idx = si[0];
+        argmax_out[0] = idx;
+        token_chain[dst_slot] = use_vocab_map ? (int)vocab_map[idx] : idx;
+    }
+}

--- a/kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Robin Van Cauter
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 HFQ4-G256 batched lm_head GEMM.
+//
+// Same math and tile mapping as gemm_hfq4g256_residual_wmma_gfx12, but with
+// overwrite semantics (Y = W·X) instead of residual semantics (Y += W·X).
+// DFlash and MTP verify lm_head call sites only need logits, so the residual
+// kernel's pre-zero memset and output read are avoidable work at the largest
+// matrix in the decode cycle.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq4g256_lmhead_wmma_gfx12(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int safe_row   = (row_start   + m_lane < M)          ? (row_start   + m_lane) : (M - 1);
+    const int safe_batch = (batch_start + m_lane < batch_size) ? (batch_start + m_lane) : 0;
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 136;
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 136;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg = x_base + g * 256;
+
+        #define DQ8(pk) \
+            a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int k_off_a = (kt + 0) * 16;
+            const int k_off_b = (kt + 1) * 16;
+            const int k_off_c = (kt + 2) * 16;
+            const int k_off_d = (kt + 3) * 16;
+
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(gp + 8 + k_off_c / 2 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(gp + 8 + k_off_d / 2 + k_grp * 4);
+
+            half8_t b_a = *(const half8_t*)(xg + k_off_a + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(xg + k_off_b + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(xg + k_off_c + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(xg + k_off_d + k_grp * 8);
+
+            half8_t a_reg;
+            DQ8(pka);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            DQ8(pkb);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+        }
+        #undef DQ8
+    }
+
+    const int out_col = batch_start + m_lane;
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] = acc[j];
+        }
+    }
+}

--- a/kernels/src/greedy_accept.hip
+++ b/kernels/src/greedy_accept.hip
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// Greedy speculative-accept prefix scan over device-resident verify argmaxes
+// and MTP candidate tokens.
+//
+// result[0] = number of draft candidates accepted
+// result[1] = bonus token id, or -1 when an accepted candidate was EOS and no
+//             bonus should be committed
+extern "C" __global__ void greedy_accept_from_argmax_i32(
+    const int* __restrict__ argmax_per_pos,
+    const int* __restrict__ candidates,
+    int* __restrict__ result,
+    int drafts_generated,
+    int eos_token_id
+) {
+    if (blockIdx.x != 0 || threadIdx.x != 0) {
+        return;
+    }
+
+    int accept_count = 0;
+    for (int k = 0; k < drafts_generated; ++k) {
+        int candidate = candidates[k];
+        if (argmax_per_pos[k] != candidate) {
+            result[0] = accept_count;
+            result[1] = argmax_per_pos[k];
+            return;
+        }
+
+        ++accept_count;
+        if (candidate == eos_token_id) {
+            result[0] = accept_count;
+            result[1] = -1;
+            return;
+        }
+    }
+
+    result[0] = accept_count;
+    result[1] = argmax_per_pos[drafts_generated];
+}


### PR DESCRIPTION
## Summary

This PR lands the speculative-decode perf work developed across the local branch stack:

- `feat/moe-mtp-a3b`: MoE MTP trunk-spine path, small-N grouped-MoE tile bound fix, device token chain, GPU accept reduction, replay-skip accounting, and Q8 verify-lmhead WMMA routing.
- `feat/moe-dflash-perfmaxx`: DFlash verify-side cleanup, including skipping redundant last-token logits and routing Q8 lmhead verify through gfx12 WMMA.
- `feat/dense-dflash-perfmaxx`: dense/A3B DFlash follow-up routing for HFQ4 lmhead WMMA on gfx12, helper commentary, bench publication notes, and branch-level AGENTS guidance.

## Why

The main goal was to make A3B speculative decode competitive on gfx12 by removing host synchronizations and redundant verify work before considering new kernels. The final validated path is A3B MTP trunk-spine with the calibrated MoE MTP head; DFlash work remains useful as shared infrastructure and as a perf audit trail, but MoE DFlash appears structurally less promising than MoE MTP on the current engine.

## Notable Results

- Published A3B MTP LocalMaxxing run: https://www.localmaxxing.com/runs/cmppmb47l0051pl01lyaup9mc
- Median decode: `259.53 tok/s` on Radeon AI Pro R9700 / gfx12.
- Fixture: Qwen3.6-35B-A3B MQ4-AWQ trunk + MoE MTP head, HumanEval/26 raw prompt.
- Validation run metadata captured in `.codeinsight+research` locally; LocalMaxxing notes include target/head/binary/prompt md5s.

## Implementation Notes

- Fixes the grouped MoE tile bound by aligning runtime and scratch bounds to `MOE_GROUPED_BLOCK_M`, preventing stale/uninitialized expert tile IDs on small verification batches.
- Keeps MQ6/HFQ6 MoE grouped WMMA admission gfx12-scoped; gfx1151 should not inherit that path without a real port and validation.
- Adds a device-resident MTP token chain and GPU-side greedy accept/bonus reduction, reducing per-cycle host sync pressure.
- Adds/gates gfx12 WMMA lmhead verify paths for Q8 and HFQ4-shaped DFlash/MTP verify work.
- Adds `needs_last_token_logits` plumbing so MTP/DFlash verify callers can skip dead scalar logits when they only consume hidden states.

## Validation

Ran before commit:

- `git diff --check`
- `cargo test --features deltanet -p hipfire-arch-qwen35 --lib` — 43 tests passed
- `cargo build --release --features deltanet -p hipfire-runtime --example mtp_only_demo --example dflash_spec_demo`
- pre-commit general coherence gate — no hard errors, report `/tmp/coherence-20260528-150049.md`
- pre-commit DFlash coherence gate — no hard errors, report `/tmp/coherence-dflash-20260528-150118.md`
- pre-commit agentic gate — PASS, report `/tmp/agentic-gate-20260528-150130.md`

## Review Focus

- Check that gfx12-specific dispatch does not accidentally become reachable on gfx11/gfx1151 without a matching kernel.
- Check that the `needs_last_token_logits` default remains safe for non-spec-decode callers.
- Check that the grouped MoE tile bound and sentinel handling are correct for small `K+1` verify batches.
- Check that DFlash/MTP env defaults are appropriately conservative outside validated gfx12 paths.