### PR TITLE
perf(rdna-compute): MMQ cutoff 256→128 on RDNA3+ for HFQ4 prefill (+118% Strix Halo)

### DIFF
--- a/crates/rdna-compute/src/arch_caps.rs
+++ b/crates/rdna-compute/src/arch_caps.rs
@@ -167,7 +167,21 @@ impl ArchCaps {
             Some(false) => false,
             Some(true) => true,
             None => {
-                let arch_min_batch: usize = if self.is_gfx906 { 8 } else { 256 };
+                // gfx906 hits MMQ at very small batches (its dp4a MMQ kernel
+                // beats fp16 wave64 from B≥8). RDNA3+ has a higher fixed cost
+                // for the WMMA-INT8 dispatch (Q8_1 quantize prelude + MMQ tile
+                // setup) but still beats single-warp WMMA from B=128 up —
+                // measured +118% prefill on qwen3.6-27b.mq4 / gfx1151 by
+                // dropping the cutoff from 256 → 128, with byte-identical
+                // greedy decode parity (2026-05-29). RDNA2 keeps 256 for now
+                // (untested at lower cutoffs in this session).
+                let arch_min_batch: usize = if self.is_gfx906 {
+                    8
+                } else if self.is_rdna3 || self.is_rdna4 {
+                    128
+                } else {
+                    256
+                };
                 let min_batch = self.flags.mmq_min_batch.unwrap_or(arch_min_batch);
                 batch_size >= min_batch
             }


### PR DESCRIPTION
## What

Drop `should_use_mmq`'s `arch_min_batch` from **256 → 128** on RDNA3 / RDNA4 in `crates/rdna-compute/src/arch_caps.rs`. RDNA2 keeps 256; gfx906 keeps 8. Single file, +15/-1 lines.

## Why

The multi-warp WMMA-INT8 MMQ kernel (`gemm_hfq4g256_residual_mmq`) beats the single-warp WMMA dispatch from B=128 up on gfx1151. The old 256 cutoff left the partial tail chunk (B<256) of every prefill on the slow single-warp path for `gate_up`, `qkvza`, and `wo` simultaneously (all three gate on `should_use_mmq`). Lowering the cutoff to 128 keeps those tail chunks on the fast multi-warp kernel.

## Measured — qwen3.6-27b.mq4 / gfx1151 / Strix Halo

755-tok prefill, warm, 3 trials:

| min_batch | prefill tps (median) |
|---|---|
| 256 (before) | 101.1 |
| **128 (this PR)** | **219.8  (+118%)** |

The win is broad wherever the prefill batch lands in [128, 256). Coherence-gate embedded prefill figures also move: 0.8b cap +16%, 4b code +10%, 9b reason +8%, 9b tool-call +198% (a 193-tok prompt now rides MMQ instead of falling below 256 onto WMMA).

## Safety

- **Coherence-gate clean** (0.8b cap / 4b code / 9b reason / 9b tool-call — all status OK).
- 4 prompts at temp=0 produced **byte-identical greedy decode** vs the prior cutoff — this only reroutes *which* kernel runs, no numerical change.
- RDNA2 (gfx101x/103x) and gfx906 paths are unchanged.
- Env override preserved: `HIPFIRE_MMQ_MIN_BATCH=<n>`.

Scoped deliberately to just this cutoff change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
