### PR TITLE
MiniMax-M2.7 support (arch_id 10): 229B MoE, 5 quant tiers, runs e2e on RDNA3.5 + CDNA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hipfire-arch-minimax"
+version = "0.2.0"
+dependencies = [
+ "hip-bridge",
+ "hipfire-runtime",
+ "rdna-compute",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hipfire-arch-qwen2"
 version = "0.2.0"
 dependencies = [
@@ -252,6 +263,7 @@ dependencies = [
  "hipfire-arch-deepseek4",
  "hipfire-arch-dots-ocr",
  "hipfire-arch-llama",
+ "hipfire-arch-minimax",
  "hipfire-arch-qwen2",
  "hipfire-arch-qwen35",
  "hipfire-arch-qwen35-vl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/hipfire-arch-qwen35-vl",
     "crates/hipfire-arch-llama",
     "crates/hipfire-arch-deepseek4",
+    "crates/hipfire-arch-minimax",
     "crates/hipfire-arch-toy",
     "crates/hipfire-arch-qwen2",
     "crates/hipfire-arch-dots-ocr",

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -6699,9 +6699,12 @@ fn ffn_batched(
             _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
         } && (2 * im) % 64 == 0
           && hidden % 256 == 0;
-        // MMQ-style index-pack preload (#356, default ON for 4w; opt out via =0).
+        // MMQ-style index-pack preload (#356). Reverted to OPT-IN: the preload
+        // hoisted only 8 of 16 weight packs, decoding half the MQ2 weights wrong
+        // → long-context attractor on DS4 mq2lloyd (root-caused by @nwoolmer on
+        // gfx1151; the corrected kernel measured flat, so no reason to default it).
         let use_mmqload = use_lloyd_4w && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() != Ok("0");
+            .as_deref() == Ok("1");
         // Barrier-free nosync variant (#356, opt in via =1).
         let use_nosync = use_mmqload && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
             .as_deref() == Ok("1");
@@ -6887,8 +6890,9 @@ fn ffn_batched(
             _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
         } && hidden % 64 == 0
           && im % 256 == 0;
+        // Opt-in (see use_mmqload above — same #356 long-context attractor).
         let use_mmqload_down = use_lloyd_4w_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() != Ok("0");
+            .as_deref() == Ok("1");
         let use_nosync_down = use_mmqload_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
             .as_deref() == Ok("1");
         // n32_env / cnd_env / eightw_env reused from the gate_up block above.

--- a/crates/hipfire-arch-minimax/Cargo.toml
+++ b/crates/hipfire-arch-minimax/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+[package]
+name = "hipfire-arch-minimax"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "MiniMax-M2 architecture (Mixtral-style MoE: GQA + per-layer QK-norm + partial rotate_half RoPE + sigmoid+bias 256-expert MoE) for hipfire"
+
+[features]
+default = ["deltanet"]
+# partial rotate_half RoPE (rope_partial_interleaved_f32) is deltanet-gated,
+# matching hipfire-arch-qwen35.
+deltanet = ["hipfire-runtime/deltanet", "rdna-compute/deltanet"]
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+hip-bridge = { path = "../hip-bridge" }
+rdna-compute = { path = "../rdna-compute" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/hipfire-arch-minimax/examples/dump_minimax_hidden_states.rs
+++ b/crates/hipfire-arch-minimax/examples/dump_minimax_hidden_states.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Dump per-layer hidden states from the MiniMax-M2 forward for offline
+//! comparison against the HF transformers oracle (arch bring-up validation).
+//!
+//! Reads chunk tokens from an HFKLDR ref, runs `decode_step_capture` per
+//! position with all layers captured, and writes a single HFHS binary of
+//! post-layer (pre-final-norm) hidden states — byte-format-compatible with
+//! `scripts/dump_hf_hidden_states.py` + `scripts/compare_hidden_states.py`.
+//!
+//! Usage:
+//!   dump_minimax_hidden_states --model <hfq> --ref <kldref> --out <hfhs> [--chunk N]
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_arch_minimax::forward::decode_step_capture;
+    use hipfire_arch_minimax::minimax::{MiniMaxConfig, MiniMaxState, MiniMaxWeights};
+    use hipfire_runtime::hfq::HfqFile;
+    use std::fs::File;
+    use std::io::{BufReader, BufWriter, Read, Write};
+    use std::path::PathBuf;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model: Option<PathBuf> = None;
+    let mut ref_path: Option<PathBuf> = None;
+    let mut out_path: Option<PathBuf> = None;
+    let mut chunk: usize = 0;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model" => { model = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--ref" => { ref_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--out" => { out_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--chunk" => { chunk = argv[i + 1].parse().expect("--chunk"); i += 2; }
+            other => { eprintln!("unknown arg: {other}"); std::process::exit(1); }
+        }
+    }
+    let model = model.expect("--model required");
+    let ref_path = ref_path.expect("--ref required");
+    let out_path = out_path.expect("--out required");
+
+    // ---- read tokens from HFKLDR ref ----
+    let mut ref_in = BufReader::new(File::open(&ref_path).expect("open ref"));
+    let mut magic = [0u8; 8];
+    ref_in.read_exact(&mut magic).expect("magic");
+    assert_eq!(&magic, b"HFKLDR\0\0", "bad ref magic");
+    let mut hdr = [0u8; 24];
+    ref_in.read_exact(&mut hdr).expect("hdr");
+    let n_ctx = u32::from_le_bytes(hdr[4..8].try_into().unwrap()) as usize;
+    let n_chunk = u32::from_le_bytes(hdr[12..16].try_into().unwrap()) as usize;
+    assert!(chunk < n_chunk, "chunk {chunk} >= n_chunk {n_chunk}");
+    let skip = chunk * n_ctx * 4;
+    if skip > 0 {
+        let mut s = vec![0u8; skip];
+        ref_in.read_exact(&mut s).expect("skip");
+    }
+    let mut tb = vec![0u8; n_ctx * 4];
+    ref_in.read_exact(&mut tb).expect("tokens");
+    let tokens: Vec<u32> = tb.chunks_exact(4).map(|b| u32::from_le_bytes(b.try_into().unwrap())).collect();
+    eprintln!("read {} tokens from chunk {}", tokens.len(), chunk);
+
+    // ---- load model ----
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(&model).expect("open model");
+    let cfg = MiniMaxConfig::from_hfq(&hfq).expect("config");
+    eprintln!(
+        "arch=minimax hidden={} layers={} heads={}/{} head_dim={} experts={}/{} rot={}",
+        cfg.hidden_size, cfg.num_hidden_layers, cfg.num_attention_heads,
+        cfg.num_key_value_heads, cfg.head_dim, cfg.num_local_experts,
+        cfg.num_experts_per_tok, cfg.rotary_dim
+    );
+    let weights = MiniMaxWeights::load(&mut hfq, &cfg, &mut gpu).expect("weights");
+    let mut state = MiniMaxState::new_with_max_seq(&mut gpu, &cfg, n_ctx + 16).expect("state");
+
+    // ---- per-token forward with per-layer capture ----
+    let mut capture: Vec<Vec<f32>> = vec![Vec::with_capacity(n_ctx * cfg.hidden_size); cfg.num_hidden_layers];
+    let t0 = std::time::Instant::now();
+    for (pos, &tok) in tokens.iter().enumerate() {
+        decode_step_capture(&cfg, &weights, &mut state, &mut gpu, tok, pos as u32, &mut capture)
+            .expect("decode_step_capture");
+    }
+    eprintln!("forward complete in {:.2}s", t0.elapsed().as_secs_f64());
+
+    // ---- write HFHS ----
+    if let Some(parent) = out_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let mut out = BufWriter::new(File::create(&out_path).expect("create out"));
+    out.write_all(b"HFHS\0\0\0\0").unwrap();
+    out.write_all(&(cfg.num_hidden_layers as u32).to_le_bytes()).unwrap();
+    out.write_all(&(n_ctx as u32).to_le_bytes()).unwrap();
+    out.write_all(&(cfg.hidden_size as u32).to_le_bytes()).unwrap();
+    out.write_all(&0u32.to_le_bytes()).unwrap();
+    for (l, buf) in capture.iter().enumerate() {
+        assert_eq!(buf.len(), n_ctx * cfg.hidden_size, "layer {l} size");
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 4) };
+        out.write_all(bytes).unwrap();
+        let rms = (buf.iter().map(|&v| (v as f64) * (v as f64)).sum::<f64>() / buf.len() as f64).sqrt();
+        eprintln!("  layer {l}: rms={rms:.4}");
+    }
+    out.flush().unwrap();
+    eprintln!("wrote {}", out_path.display());
+}

--- a/crates/hipfire-arch-minimax/examples/infer_minimax.rs
+++ b/crates/hipfire-arch-minimax/examples/infer_minimax.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Minimal MiniMax-M2 greedy inference — real-model e2e coherence check.
+//! Loads an HFQ, runs prefill + greedy decode via `decode_step`, prints text.
+//!
+//! Usage: infer_minimax --model <hfq> [--prompt <text>] [--max N]
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_arch_minimax::forward::decode_step;
+    use hipfire_arch_minimax::minimax::{MiniMaxConfig, MiniMaxState, MiniMaxWeights};
+    use hipfire_runtime::hfq::HfqFile;
+    use hipfire_runtime::tokenizer::Tokenizer;
+    use std::path::PathBuf;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model: Option<PathBuf> = None;
+    let mut prompt = "The capital of France is".to_string();
+    let mut max: usize = 64;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model" => { model = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--prompt" => { prompt = argv[i + 1].clone(); i += 2; }
+            "--max" => { max = argv[i + 1].parse().expect("--max"); i += 2; }
+            other => { eprintln!("unknown arg {other}"); std::process::exit(1); }
+        }
+    }
+    let model = model.expect("--model required");
+
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(&model).expect("open model");
+    let cfg = MiniMaxConfig::from_hfq(&hfq).expect("config");
+    eprintln!(
+        "minimax hidden={} layers={} experts={}/{} vocab={}",
+        cfg.hidden_size, cfg.num_hidden_layers, cfg.num_local_experts,
+        cfg.num_experts_per_tok, cfg.vocab_size
+    );
+    let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
+    let t_load = std::time::Instant::now();
+    let weights = MiniMaxWeights::load(&mut hfq, &cfg, &mut gpu).expect("weights");
+    eprintln!("loaded weights in {:.1}s", t_load.elapsed().as_secs_f64());
+
+    let prompt_ids = tok.encode(&prompt);
+    eprintln!("prompt {:?} → {} tokens", prompt, prompt_ids.len());
+    let max_seq = prompt_ids.len() + max + 16;
+    let mut state = MiniMaxState::new_with_max_seq(&mut gpu, &cfg, max_seq).expect("state");
+
+    let argmax = |v: &[f32]| -> u32 {
+        let mut bi = 0u32;
+        let mut bv = f32::NEG_INFINITY;
+        for (i, &x) in v.iter().enumerate() {
+            if x > bv { bv = x; bi = i as u32; }
+        }
+        bi
+    };
+
+    // Prefill (per-token; correctness-first).
+    let t0 = std::time::Instant::now();
+    let mut logits = Vec::new();
+    for (pos, &t) in prompt_ids.iter().enumerate() {
+        logits = decode_step(&cfg, &weights, &mut state, &mut gpu, t, pos as u32).expect("prefill");
+    }
+    eprintln!("prefill {} tok in {:.2}s", prompt_ids.len(), t0.elapsed().as_secs_f64());
+
+    // Greedy decode.
+    let mut gen = Vec::new();
+    let mut pos = prompt_ids.len();
+    let t1 = std::time::Instant::now();
+    for _ in 0..max {
+        let next = argmax(&logits);
+        gen.push(next);
+        // common MiniMax/Qwen EOS ids; stop early if hit
+        if matches!(next, 200020 | 151643 | 151645 | 2) { break; }
+        logits = decode_step(&cfg, &weights, &mut state, &mut gpu, next, pos as u32).expect("decode");
+        pos += 1;
+    }
+    let dt = t1.elapsed().as_secs_f64();
+    eprintln!("decoded {} tok in {:.2}s ({:.1} tok/s)", gen.len(), dt, gen.len() as f64 / dt);
+    println!("=== PROMPT ===\n{prompt}\n=== GENERATION ===\n{}", tok.decode(&gen));
+    eprintln!("token ids: {:?}", &gen[..gen.len().min(40)]);
+}

--- a/crates/hipfire-arch-minimax/src/arch.rs
+++ b/crates/hipfire-arch-minimax/src/arch.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! `Architecture` trait impl for MiniMax-M2 (arch_id = 10).
+//!
+//! Thin marker + delegation, mirroring `hipfire-arch-deepseek4`'s
+//! `arch.rs`. The forward pass is NOT on the trait — it lives as free
+//! functions in `crate::forward` (hot-path static dispatch), called
+//! directly by the daemon's `arch_id == 10` generate branch.
+
+use crate::minimax::{MiniMaxConfig, MiniMaxState, MiniMaxWeights};
+use hipfire_runtime::arch::Architecture;
+use hipfire_runtime::hfq::HfqFile;
+use rdna_compute::Gpu;
+
+/// Zero-sized type marker for MiniMax-M2. Trait dispatch uses the type.
+pub struct MiniMaxM2;
+
+impl Architecture for MiniMaxM2 {
+    type Weights = MiniMaxWeights;
+    type State = MiniMaxState;
+    type Config = MiniMaxConfig;
+
+    /// Canonical family marker. Reserved in docs/architecture-ids.md
+    /// (next free after DeepSeek V4 = 9).
+    fn arch_id() -> u32 {
+        10
+    }
+
+    fn name() -> &'static str {
+        "minimax"
+    }
+
+    fn config_from_hfq(hfq: &HfqFile) -> Result<Self::Config, String> {
+        MiniMaxConfig::from_hfq(hfq)
+    }
+
+    fn load_weights(
+        hfq: &mut HfqFile,
+        cfg: &Self::Config,
+        gpu: &mut Gpu,
+    ) -> Result<Self::Weights, String> {
+        MiniMaxWeights::load(hfq, cfg, gpu)
+    }
+
+    fn new_state(gpu: &mut Gpu, cfg: &Self::Config) -> Result<Self::State, String> {
+        MiniMaxState::new(gpu, cfg)
+    }
+
+    // Optional overrides left at the ChatML defaults for the scaffold.
+    // MiniMax-M2 ships its own chat template; revisit prompt_frame /
+    // eos_filter overrides once tokenizer wiring lands.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimax_arch_id_and_name() {
+        assert_eq!(MiniMaxM2::arch_id(), 10);
+        assert_eq!(MiniMaxM2::name(), "minimax");
+    }
+}

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -17,14 +17,25 @@
 //! — exactly qwen35's / deepseek4's MoE path. Routing uses `sigmoid_f32` +
 //! `deepseek4_moe_topk_bias_aware_f32` with route_scale = 1.0 (MiniMax-M2
 //! applies no routed-scaling factor).
+//!
+//! Decode has two entry points: `decode_step` (eager, used for prefill +
+//! warmup) and `decode_step_with_graph` (hipGraph capture/replay of the
+//! 62-layer body + lm_head, recovering the ~9% per-token launch-latency gap on
+//! gfx11/gfx12 — see the gfx1151 perfmaxx characterization). Both share
+//! `decode_step_body`; the only per-token-varying GPU input is the device
+//! position scalar (`pos_buf`), staged from the heap-stable `state.pos_host`
+//! so the captured memcpy re-reads it on each replay. The embedding lookup is
+//! kept OUTSIDE the captured region (token_id is baked into its kernarg).
 
 use crate::minimax::{MiniMaxConfig, MiniMaxState, MiniMaxWeights};
 use hipfire_runtime::llama::{
-    fused_silu_mul_rotate_mq_batched_for, rotate_x_mq_for, weight_gemv, weight_gemv_residual,
+    fused_silu_mul_rotate_mq_batched_for, rotate_x_mq_batched_for, rotate_x_mq_for, weight_gemv,
+    weight_gemv_residual,
 };
-use rdna_compute::{DType, Gpu};
+use rdna_compute::{DType, Gpu, GpuTensor};
 
-/// Decode one token; returns the full logits vector.
+/// Decode one token (eager); returns the full logits vector. Used for prefill,
+/// the warm pass, and as the `HIPFIRE_MINIMAX_GRAPH=0` fallback.
 pub fn decode_step(
     cfg: &MiniMaxConfig,
     weights: &MiniMaxWeights,
@@ -33,7 +44,9 @@ pub fn decode_step(
     token_id: u32,
     position: u32,
 ) -> Result<Vec<f32>, String> {
-    decode_step_inner(cfg, weights, state, gpu, token_id, position, None)?;
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, cfg.hidden_size)
+        .map_err(|e| format!("minimax: embed lookup: {e:?}"))?;
+    decode_step_body(cfg, weights, state, gpu, position, None)?;
     gpu.download_f32(&state.logits)
         .map_err(|e| format!("minimax: download logits: {e:?}"))
 }
@@ -41,7 +54,8 @@ pub fn decode_step(
 /// Decode one token, appending each layer's post-residual hidden state
 /// (pre final-norm) to `capture[layer]` — used by the oracle dumper. Set
 /// `HIPFIRE_MINIMAX_CAPTURE_POSTATTN` to capture the post-attention residual
-/// (pre-MoE) instead, for attention-vs-MoE divergence localization.
+/// (pre-MoE) instead, for attention-vs-MoE divergence localization. Eager
+/// only (the per-layer D2H downloads are incompatible with graph capture).
 pub fn decode_step_capture(
     cfg: &MiniMaxConfig,
     weights: &MiniMaxWeights,
@@ -51,15 +65,126 @@ pub fn decode_step_capture(
     position: u32,
     capture: &mut [Vec<f32>],
 ) -> Result<(), String> {
-    decode_step_inner(cfg, weights, state, gpu, token_id, position, Some(capture))
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, cfg.hidden_size)
+        .map_err(|e| format!("minimax: embed lookup: {e:?}"))?;
+    decode_step_body(cfg, weights, state, gpu, position, Some(capture))
 }
 
-fn decode_step_inner(
+/// Decode one token via hipGraph capture/replay. **Opt-in, default OFF**
+/// (`HIPFIRE_MINIMAX_GRAPH=1` to enable). The 62-layer body + lm_head are
+/// captured once and replayed per token.
+///
+/// Output is byte-for-byte identical to eager `decode_step` (validated over 96
+/// greedy tokens). But the perf payoff is marginal: on gfx1151 (Strix Halo —
+/// the only arch MiniMax's 86 GB footprint fits) it measured **+1.0%**
+/// (27.68 → 27.95 tok/s, tight variance), NOT the ~9% the inter-kernel-gap
+/// analysis predicted. Root cause: the 9.7% decode launch/idle gap is GPU
+/// command-processor inter-kernel dispatch latency, not host-launch overhead —
+/// the host thread already runs ahead of the 90%-busy iGPU, so removing the
+/// host launch API cost (all hipGraph does) recovers ~nothing. This matches the
+/// DeepSeek-V4 "hipGraph dead on gfx1151 decode" finding. Kept as a validated
+/// opt-in (may help on a faster CP, e.g. a gfx12 dGPU, if MiniMax ever fits one).
+///
+/// Capture-safety invariants (mirrors the proven DeepSeek-V4 path):
+///   - token_id is per-token → embedding runs OUTSIDE the capture.
+///   - position is per-token → staged via `state.pos_host` (stable `Box`); the
+///     captured `memcpy_htod_auto` re-reads it on every replay.
+///   - attention launch geometry is sized for `state.max_seq` (constant), not
+///     the live `seq_len`, so the baked grid/shared-mem stays valid as the KV
+///     length grows (the kernel reads the true length from `pos_buf[0]+1`).
+pub fn decode_step_with_graph(
     cfg: &MiniMaxConfig,
     weights: &MiniMaxWeights,
     state: &mut MiniMaxState,
     gpu: &mut Gpu,
     token_id: u32,
+    position: u32,
+) -> Result<Vec<f32>, String> {
+    use std::sync::OnceLock;
+    static GRAPH_ENV: OnceLock<Option<bool>> = OnceLock::new();
+    let env_override = *GRAPH_ENV.get_or_init(|| {
+        match std::env::var("HIPFIRE_MINIMAX_GRAPH").ok().as_deref() {
+            Some("1") => Some(true),
+            Some("0") => Some(false),
+            _ => None,
+        }
+    });
+    // Default OFF — measured only +1.0% on gfx1151 (the sole arch MiniMax fits);
+    // the decode gap is GPU-CP dispatch latency, not host-launch overhead, so
+    // hipGraph recovers ~nothing here. Opt in with HIPFIRE_MINIMAX_GRAPH=1.
+    let graph_on = env_override.unwrap_or(false);
+    if !graph_on {
+        return decode_step(cfg, weights, state, gpu, token_id, position);
+    }
+
+    // Warmup: first decode after a fresh load runs eager (JITs kernels + settles
+    // DPM) and drops any stale graph from a previously-loaded model so the next
+    // call captures fresh for THIS model's weight pointers.
+    if !state.ar_warmed_up {
+        state.ar_warmed_up = true;
+        gpu.graph_exec = None;
+        return decode_step(cfg, weights, state, gpu, token_id, position);
+    }
+
+    // Capture + replay both need an explicit (non-null) stream.
+    if gpu.active_stream.is_none() {
+        let s = gpu
+            .hip
+            .stream_create()
+            .map_err(|e| format!("minimax graph: stream_create: {e:?}"))?;
+        gpu.active_stream = Some(s);
+    }
+
+    // Embedding lookup OUTSIDE the captured region — token_id is baked into the
+    // embedding kernarg. Runs on the active stream, ordered before the captured
+    // body that reads `state.h`.
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, cfg.hidden_size)
+        .map_err(|e| format!("minimax graph: embed lookup: {e:?}"))?;
+
+    if gpu.graph_exec.is_none() {
+        // ── Capture phase ──────────────────────────────────────────────
+        // decode_step_body stages pos_host → pos_buf via memcpy_htod_auto
+        // INSIDE the capture, so the recorded memcpy node re-reads pos_host
+        // on each replay.
+        gpu.begin_graph_capture()
+            .map_err(|e| format!("minimax begin_graph_capture: {e:?}"))?;
+        decode_step_body(cfg, weights, state, gpu, position, None)?;
+        gpu.end_graph_capture()
+            .map_err(|e| format!("minimax end_graph_capture: {e:?}"))?;
+        // Captured kernels were RECORDED, not run — launch once so this token's
+        // logits actually get produced.
+        gpu.graph_launch()
+            .map_err(|e| format!("minimax graph_launch (capture): {e:?}"))?;
+        eprintln!(
+            "[MiniMax hipGraph] captured decode forward — {} kernarg blobs retained",
+            gpu.capture_blobs.len()
+        );
+    } else {
+        // ── Replay phase ───────────────────────────────────────────────
+        // Host-only update of the stable position source; the captured memcpy
+        // re-reads it and propagates to pos_buf (read by rope / kv-write /
+        // attention).
+        state.pos_host[0] = position as i32;
+        gpu.graph_launch()
+            .map_err(|e| format!("minimax graph_launch (replay): {e:?}"))?;
+    }
+    state.n_tokens = position as usize + 1;
+
+    // Logits download is outside the captured region (sync dtoh completes after
+    // the captured kernels, which the device observes on the active stream).
+    gpu.download_f32(&state.logits)
+        .map_err(|e| format!("minimax graph: download logits: {e:?}"))
+}
+
+/// The capturable core: stage the device position scalar, run the 62-layer
+/// attention+MoE pipeline, then final-norm + lm_head. Does NOT do the embedding
+/// lookup (the caller stages `state.h`). Under graph capture, `capture` is
+/// `None` (no D2H); the oracle dumper passes `Some(..)` and runs eager only.
+fn decode_step_body(
+    cfg: &MiniMaxConfig,
+    weights: &MiniMaxWeights,
+    state: &mut MiniMaxState,
+    gpu: &mut Gpu,
     position: u32,
     mut capture: Option<&mut [Vec<f32>]>,
 ) -> Result<(), String> {
@@ -73,14 +198,16 @@ fn decode_step_inner(
     let seq_len = position as usize + 1;
     let capture_postattn = std::env::var_os("HIPFIRE_MINIMAX_CAPTURE_POSTATTN").is_some();
 
-    // Device position scalar (i32) for rope / kv-write / attention.
-    gpu.hip
-        .memcpy_htod(&state.pos_buf, &(position as i32).to_ne_bytes())
-        .map_err(|e| format!("minimax: htod pos: {e:?}"))?;
-
-    // Embedding lookup → residual stream h.
-    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, hidden)
-        .map_err(|e| format!("minimax: embed lookup: {e:?}"))?;
+    // Device position scalar (i32) for rope / kv-write / attention. Staged from
+    // the heap-stable `state.pos_host` so the captured memcpy re-reads it on
+    // replay (memcpy_htod_auto → async on the capture stream when capturing).
+    state.pos_host[0] = position as i32;
+    {
+        let pos_bytes =
+            unsafe { std::slice::from_raw_parts(state.pos_host.as_ptr() as *const u8, 4) };
+        gpu.memcpy_htod_auto(&state.pos_buf, pos_bytes)
+            .map_err(|e| format!("minimax: htod pos: {e:?}"))?;
+    }
 
     for (l, layer) in weights.layers.iter().enumerate() {
         // ── Attention block (Q8 projections → plain input) ──────────────────
@@ -110,7 +237,10 @@ fn decode_step_inner(
         )
         .map_err(|e| format!("minimax L{l}: rope: {e:?}"))?;
 
-        // KV cache write (Q8) + GQA attention.
+        // KV cache write (Q8) + GQA attention. The attention kernel reads the
+        // live KV length from `pos_buf[0]+1`; we pass `state.max_seq` as the
+        // geometry hint (NOT `seq_len`) so the captured launch grid / shared-mem
+        // is sized for the max and stays valid as the cache grows on replay.
         gpu.kv_cache_write_q8_0(&state.kv.k_gpu[l], &state.fa_k, &state.pos_buf,
             cfg.num_key_value_heads, cfg.head_dim)
             .map_err(|e| format!("minimax L{l}: kv write k: {e:?}"))?;
@@ -119,7 +249,7 @@ fn decode_step_inner(
             .map_err(|e| format!("minimax L{l}: kv write v: {e:?}"))?;
         gpu.attention_q8_0_kv(
             &state.fa_q, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &state.fa_attn_out,
-            &state.pos_buf, seq_len, cfg.num_attention_heads, cfg.num_key_value_heads,
+            &state.pos_buf, state.max_seq, cfg.num_attention_heads, cfg.num_key_value_heads,
             cfg.head_dim, state.kv.physical_cap,
         )
         .map_err(|e| format!("minimax L{l}: attention: {e:?}"))?;
@@ -249,4 +379,248 @@ fn decode_step_inner(
     weight_gemv(gpu, &weights.lm_head, &state.final_norm_buf, &state.logits)
         .map_err(|e| format!("minimax: lm_head: {e}"))?;
     Ok(())
+}
+
+/// True iff every layer's expert gate_up + down dtypes have batched kernels, so
+/// `forward_batch` won't `Err` partway through a pass. Pre-check this before
+/// enabling batched prefill: unsupported tiers (MQ3-Lloyd, HFQ6-gate_up) then
+/// cleanly take the sequential path instead of corrupting state on a mid-layer
+/// `Err`. Mirrors the dtype match arms in `forward_batch`.
+pub fn forward_batch_supported(weights: &MiniMaxWeights) -> bool {
+    weights.layers.iter().all(|layer| {
+        let gate_up_ok = matches!(
+            layer.experts[0].gate_up.gpu_dtype,
+            DType::MQ4G256 | DType::HFQ4G256 | DType::MQ2G256Lloyd
+        );
+        let down_ok = matches!(
+            layer.experts[0].down.gpu_dtype,
+            DType::MQ4G256 | DType::HFQ4G256 | DType::MQ6G256 | DType::HFQ6G256 | DType::MQ2G256Lloyd
+        );
+        gate_up_ok && down_ok
+    })
+}
+
+/// Batched forward over `B` tokens in ONE pass — the spec-decode VERIFY forward
+/// and fast-prefill keystone. Fills the KV cache for all B positions and returns
+/// the LAST token's logits. Reads each weight matrix ONCE for all B tokens
+/// (bandwidth-amortized — verifying B tokens costs ~1× the 6.2 GB/token weight
+/// read, not B×), which is the basis of the 2-5× spec-decode / fast-TTFT win.
+///
+/// `tokens`: B token ids. `start_pos`: absolute position of `tokens[0]` (the KV
+/// cache must already hold positions `[0, start_pos)`). `B` must be 1..=64
+/// (`gemm_q8_0_batched` kernel cap); the caller chunks longer prompts.
+///
+/// Batched twin of `decode_step_body`: every op uses its batched kernel variant
+/// (audited present in rdna-compute), dense Q8 projections go through
+/// `gemm_q8_0_batched` directly (the `weight_gemm` helper falls back to per-row
+/// GEMV for Q8). Per-row causal masking + the growing KV length are handled
+/// inside `attention_q8_0_kv_batched` via the `positions[B]` array.
+///
+/// Supported expert dtypes (batched kernels that exist today): gate_up ∈
+/// {HFQ4/MQ4, MQ2-Lloyd}; down ∈ {HFQ4/MQ4, HFQ6, MQ2-Lloyd}. HFQ6-gate_up and
+/// MQ3-Lloyd have no batched kernel yet → Err (caller falls back to sequential).
+#[allow(clippy::too_many_arguments)]
+pub fn forward_batch(
+    cfg: &MiniMaxConfig,
+    weights: &MiniMaxWeights,
+    state: &mut MiniMaxState,
+    gpu: &mut Gpu,
+    tokens: &[u32],
+    start_pos: usize,
+) -> Result<Vec<f32>, String> {
+    let b = tokens.len();
+    if b == 0 {
+        return Err("minimax forward_batch: empty token slice".to_string());
+    }
+    if b > 64 {
+        return Err(format!("minimax forward_batch: B={b} exceeds kernel cap 64"));
+    }
+    let hidden = cfg.hidden_size;
+    let q_dim = cfg.q_dim();
+    let kv_dim = cfg.kv_dim();
+    let inter = cfg.intermediate_size;
+    let n_exp = cfg.num_local_experts;
+    let k_top = cfg.num_experts_per_tok;
+    let eps = cfg.rms_norm_eps;
+    let max_ctx = start_pos + b; // largest seq_len across the B rows (geometry)
+    let max_seq = state.kv.physical_cap; // KV cache stride
+
+    // ── Batched scratch (allocated per call; prefill/verify is not the hot
+    //    per-kernel inner loop, and this keeps MiniMaxState unchanged). ──
+    let alloc = |g: &mut Gpu, n: usize, label: &str| -> Result<GpuTensor, String> {
+        g.alloc_tensor(&[n], DType::F32)
+            .map_err(|e| format!("forward_batch alloc {label}: {e:?}"))
+    };
+    let x = alloc(gpu, b * hidden, "x")?;
+    let tmp = alloc(gpu, b * hidden, "tmp")?;
+    let fq = alloc(gpu, b * q_dim, "fq")?;
+    let fk = alloc(gpu, b * kv_dim, "fk")?;
+    let fv = alloc(gpu, b * kv_dim, "fv")?;
+    let attn_out = alloc(gpu, b * q_dim, "attn_out")?;
+    let o = alloc(gpu, b * hidden, "o")?;
+    let ffn_tmp = alloc(gpu, b * hidden, "ffn_tmp")?;
+    let ffn_x_rot = alloc(gpu, b * hidden, "ffn_x_rot")?;
+    let router_logits = alloc(gpu, b * n_exp, "router_logits")?;
+    let topk_idx = alloc(gpu, b * k_top, "topk_idx")?;
+    let topk_w = alloc(gpu, b * k_top, "topk_w")?;
+    let gate = alloc(gpu, b * k_top * inter, "gate")?;
+    let up = alloc(gpu, b * k_top * inter, "up")?;
+    let rot = alloc(gpu, b * k_top * inter, "rot")?;
+    let down_exp = alloc(gpu, b * k_top * hidden, "down_exp")?;
+
+    // positions [B] i32 (stored in an f32-sized buffer; kernels read it as i32).
+    let pos_data: Vec<i32> = (0..b).map(|i| (start_pos + i) as i32).collect();
+    let pos_bytes: Vec<u8> = pos_data.iter().flat_map(|p| p.to_ne_bytes()).collect();
+    let pos_array = alloc(gpu, b, "pos_array")?;
+    gpu.hip
+        .memcpy_htod(&pos_array.buf, &pos_bytes)
+        .map_err(|e| format!("forward_batch htod pos: {e:?}"))?;
+
+    // Embedding: per-token lookup into x[B, hidden] (token_id is a scalar arg).
+    {
+        let x_single = alloc(gpu, hidden, "x_single")?;
+        for (i, &tok) in tokens.iter().enumerate() {
+            gpu.embedding_lookup_q8(&weights.embed, &x_single, tok, hidden)
+                .map_err(|e| format!("forward_batch embed lookup: {e:?}"))?;
+            gpu.hip
+                .memcpy_dtod_at(&x.buf, i * hidden * 4, &x_single.buf, 0, hidden * 4)
+                .map_err(|e| format!("forward_batch embed copy: {e:?}"))?;
+        }
+        gpu.free_tensor(x_single).ok();
+    }
+
+    for (l, layer) in weights.layers.iter().enumerate() {
+        // ── Attention (batched, per-row causal via positions) ──────────────
+        gpu.rmsnorm_batched(&x, &layer.attn_norm, &tmp, b, hidden, eps)
+            .map_err(|e| format!("minimax L{l} batch attn rmsnorm: {e:?}"))?;
+        gpu.gemm_q8_0_batched(&layer.wq.buf, &tmp, &fq, q_dim, hidden, b)
+            .map_err(|e| format!("minimax L{l} batch q_proj: {e:?}"))?;
+        gpu.gemm_q8_0_batched(&layer.wk.buf, &tmp, &fk, kv_dim, hidden, b)
+            .map_err(|e| format!("minimax L{l} batch k_proj: {e:?}"))?;
+        gpu.gemm_q8_0_batched(&layer.wv.buf, &tmp, &fv, kv_dim, hidden, b)
+            .map_err(|e| format!("minimax L{l} batch v_proj: {e:?}"))?;
+        if cfg.use_qk_norm {
+            // Per-row RMSNorm over the full flat q/k vector (MiniMax convention).
+            gpu.rmsnorm_batched(&fq, &layer.q_norm, &fq, b, q_dim, eps)
+                .map_err(|e| format!("minimax L{l} batch q_norm: {e:?}"))?;
+            gpu.rmsnorm_batched(&fk, &layer.k_norm, &fk, b, kv_dim, eps)
+                .map_err(|e| format!("minimax L{l} batch k_norm: {e:?}"))?;
+        }
+        gpu.rope_partial_interleaved_f32_batched(
+            &fq, &fk, &pos_array,
+            cfg.num_attention_heads, cfg.num_key_value_heads, cfg.head_dim,
+            cfg.rotary_dim, cfg.rope_theta, b,
+        )
+        .map_err(|e| format!("minimax L{l} batch rope: {e:?}"))?;
+        gpu.kv_cache_write_q8_0_batched(
+            &state.kv.k_gpu[l], &fk, &pos_array, cfg.num_key_value_heads, cfg.head_dim, b,
+        )
+        .map_err(|e| format!("minimax L{l} batch kv write k: {e:?}"))?;
+        gpu.kv_cache_write_q8_0_batched(
+            &state.kv.v_gpu[l], &fv, &pos_array, cfg.num_key_value_heads, cfg.head_dim, b,
+        )
+        .map_err(|e| format!("minimax L{l} batch kv write v: {e:?}"))?;
+        gpu.attention_q8_0_kv_batched(
+            &fq, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &attn_out, &pos_array,
+            cfg.num_attention_heads, cfg.num_key_value_heads, cfg.head_dim,
+            max_seq, max_ctx, b,
+        )
+        .map_err(|e| format!("minimax L{l} batch attention: {e:?}"))?;
+        gpu.gemm_q8_0_batched(&layer.wo.buf, &attn_out, &o, hidden, q_dim, b)
+            .map_err(|e| format!("minimax L{l} batch o_proj: {e:?}"))?;
+        gpu.add_inplace_f32(&x, &o)
+            .map_err(|e| format!("minimax L{l} batch o residual: {e:?}"))?;
+
+        // ── MoE (batched; no shared expert) ────────────────────────────────
+        gpu.rmsnorm_batched(&x, &layer.ffn_norm, &ffn_tmp, b, hidden, eps)
+            .map_err(|e| format!("minimax L{l} batch ffn rmsnorm: {e:?}"))?;
+        // AWQ-aware FWHT rotate (gate_up may carry an AWQ activation scale —
+        // MQ2-Lloyd+AWQ); the raw rotate_x_mq_batched would drop it.
+        rotate_x_mq_batched_for(gpu, &layer.experts[0].gate_up, &ffn_tmp, &ffn_x_rot, hidden, b)
+            .map_err(|e| format!("minimax L{l} batch ffn rotate: {e}"))?;
+        gpu.gemm_q8_0_batched(&layer.router.buf, &ffn_tmp, &router_logits, n_exp, hidden, b)
+            .map_err(|e| format!("minimax L{l} batch router: {e:?}"))?;
+        gpu.sigmoid_f32(&router_logits)
+            .map_err(|e| format!("minimax L{l} batch sigmoid: {e:?}"))?;
+        gpu.deepseek4_moe_topk_bias_aware_batched_f32(
+            &router_logits, &layer.routing_bias, &topk_idx, &topk_w,
+            n_exp as i32, k_top as i32, 1.0, b as i32,
+        )
+        .map_err(|e| format!("minimax L{l} batch topk: {e:?}"))?;
+
+        let edt = layer.experts[0].gate_up.gpu_dtype;
+        match edt {
+            DType::MQ4G256 | DType::HFQ4G256 => gpu
+                .gemv_hfq4g256_moe_gate_up_k8_indexed_batched(
+                    &layer.expert_gate_up_ptrs, &topk_idx, &ffn_x_rot,
+                    &gate, &up, 2 * inter, hidden, k_top, b)
+                .map_err(|e| format!("minimax L{l} batch gate_up hfq4: {e:?}"))?,
+            DType::MQ2G256Lloyd => gpu
+                .deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed_batched_k4(
+                    &layer.expert_gate_up_ptrs, &topk_idx, &ffn_x_rot,
+                    &gate, &up, 2 * inter, hidden, k_top, b)
+                .map_err(|e| format!("minimax L{l} batch gate_up mq2l: {e:?}"))?,
+            other => {
+                return Err(format!(
+                    "minimax L{l} forward_batch: gate_up dtype {other:?} has no batched kernel yet"
+                ))
+            }
+        }
+
+        // AWQ-aware silu·mul·rotate (down weight; b*k_top expert streams).
+        fused_silu_mul_rotate_mq_batched_for(
+            gpu, &layer.experts[0].down, &gate, &up, &rot, inter, b * k_top,
+        )
+        .map_err(|e| format!("minimax L{l} batch silu_mul_rotate: {e}"))?;
+
+        let ddt = layer.experts[0].down.gpu_dtype;
+        match ddt {
+            DType::MQ4G256 | DType::HFQ4G256 => {
+                gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
+                    &layer.expert_down_ptrs, &topk_idx, &rot, &down_exp, hidden, inter, k_top, b)
+                    .map_err(|e| format!("minimax L{l} batch down hfq4: {e:?}"))?;
+                gpu.moe_down_combine_k8_batched(&down_exp, &topk_w, &x, hidden, k_top, b)
+                    .map_err(|e| format!("minimax L{l} batch combine: {e:?}"))?;
+            }
+            DType::MQ6G256 | DType::HFQ6G256 => {
+                gpu.gemv_hfq6g256_moe_down_k8_indexed_batched_expanded(
+                    &layer.expert_down_ptrs, &topk_idx, &rot, &down_exp, hidden, inter, k_top, b)
+                    .map_err(|e| format!("minimax L{l} batch down hfq6: {e:?}"))?;
+                gpu.moe_down_combine_k8_batched(&down_exp, &topk_w, &x, hidden, k_top, b)
+                    .map_err(|e| format!("minimax L{l} batch combine: {e:?}"))?;
+            }
+            DType::MQ2G256Lloyd => gpu
+                .deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed_batched_k4(
+                    &layer.expert_down_ptrs, &topk_idx, &topk_w, &rot, &x, hidden, inter, k_top, b)
+                .map_err(|e| format!("minimax L{l} batch down mq2l: {e:?}"))?,
+            other => {
+                return Err(format!(
+                    "minimax L{l} forward_batch: down dtype {other:?} has no batched kernel yet"
+                ))
+            }
+        }
+    }
+    state.n_tokens = start_pos + b;
+
+    // ── Final RMSNorm + lm_head on the LAST row only (verify/prefill need the
+    //    last position's logits; per-position logits = a future all-rows head). ──
+    let x_last = alloc(gpu, hidden, "x_last")?;
+    gpu.hip
+        .memcpy_dtod_at(&x_last.buf, 0, &x.buf, (b - 1) * hidden * 4, hidden * 4)
+        .map_err(|e| format!("forward_batch last copy: {e:?}"))?;
+    gpu.rmsnorm_f32(&x_last, &weights.final_norm, &state.final_norm_buf, eps)
+        .map_err(|e| format!("minimax batch final rmsnorm: {e:?}"))?;
+    weight_gemv(gpu, &weights.lm_head, &state.final_norm_buf, &state.logits)
+        .map_err(|e| format!("minimax batch lm_head: {e}"))?;
+    let logits = gpu
+        .download_f32(&state.logits)
+        .map_err(|e| format!("forward_batch download logits: {e:?}"))?;
+
+    for t in [
+        x, tmp, fq, fk, fv, attn_out, o, ffn_tmp, ffn_x_rot, router_logits, topk_idx, topk_w,
+        gate, up, rot, down_exp, pos_array, x_last,
+    ] {
+        gpu.free_tensor(t).ok();
+    }
+    Ok(logits)
 }

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! MiniMax-M2 forward pass (free functions — hot-path static dispatch,
+//! NOT trait methods; called by the daemon's `arch_id == 10` branch).
+//!
+//! SCAFFOLD: signatures + the planned per-layer pipeline are sketched
+//! here as the bring-up contract; bodies are filled component-by-
+//! component and validated against the PyTorch oracle (cosine≈1 per
+//! layer) before the real-weight path is enabled.
+//!
+//! Planned decode/prefill pipeline per layer (verified vs modeling_minimax_m2.py):
+//!   1. h_norm = rmsnorm(h, input_layernorm)                  [rmsnorm_f32 / _batched]
+//!   2. q = q_proj·h_norm ; k = k_proj·h_norm ; v = v_proj·h_norm   [gemv_auto*]
+//!   3. if use_qk_norm: q = rmsnorm(q_flat, q_norm); k = rmsnorm(k_flat, k_norm)
+//!        (per-LAYER, over the flat [n_heads*head_dim]/[n_kv*head_dim] vector)
+//!   4. reshape to heads; partial RoPE first `rotary_dim` dims     [rope_partial_interleaved_f32]
+//!   5. write KV cache; GQA attention                            [attention_flash_gqa / attention_q8_0_kv_batched]
+//!   6. attn_out = o_proj·attn ; h += attn_out
+//!   7. h_norm2 = rmsnorm(h, post_attention_layernorm)
+//!   8. router_logits = gate·h_norm2 ; scores = sigmoid(router_logits)   [sigmoid_f32]
+//!   9. top-8 via scores + e_score_correction_bias ; gather sigmoid ; normalize
+//!        [deepseek4 moe_topk_bias_aware_f32 / _batched]
+//!  10. scatter → grouped SwiGLU experts (gate=w1, up=w3, down=w2) → combine
+//!        [moe_scatter_fused_k8, gemm_hfq4g256_moe_grouped_wmma_k2, silu·mul,
+//!         moe_down_combine_grouped_k8]   (NO shared expert)
+//!  11. h += moe_out
+//! Final: rmsnorm(h, norm) → lm_head [gemv_auto] → logits.
+
+// Bring-up bodies land next; the crate compiles as a registered arch
+// (arch_id=10) with config parsing + stub weights/state in the meantime.

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -2,31 +2,236 @@
 // Copyright (c) 2026 Kaden Schutt
 // hipfire — see LICENSE and NOTICE in the project root.
 
-//! MiniMax-M2 forward pass (free functions — hot-path static dispatch,
-//! NOT trait methods; called by the daemon's `arch_id == 10` branch).
+//! MiniMax-M2 forward pass (free functions — hot-path static dispatch).
 //!
-//! SCAFFOLD: signatures + the planned per-layer pipeline are sketched
-//! here as the bring-up contract; bodies are filled component-by-
-//! component and validated against the PyTorch oracle (cosine≈1 per
-//! layer) before the real-weight path is enabled.
+//! Per-layer pipeline (validated vs the HF `MiniMaxM2` modeling oracle to
+//! cosine 0.9996):
+//!   h += o_proj · attn( qk_norm(q/k/v_proj(rmsnorm(h))) + partial-RoPE )   [GQA, Q8 KV]
+//!   h += combine( experts( sigmoid+bias top-8 route( rmsnorm(h) ) ) )       [MoE]
+//! then logits = lm_head( rmsnorm(h) ).
 //!
-//! Planned decode/prefill pipeline per layer (verified vs modeling_minimax_m2.py):
-//!   1. h_norm = rmsnorm(h, input_layernorm)                  [rmsnorm_f32 / _batched]
-//!   2. q = q_proj·h_norm ; k = k_proj·h_norm ; v = v_proj·h_norm   [gemv_auto*]
-//!   3. if use_qk_norm: q = rmsnorm(q_flat, q_norm); k = rmsnorm(k_flat, k_norm)
-//!        (per-LAYER, over the flat [n_heads*head_dim]/[n_kv*head_dim] vector)
-//!   4. reshape to heads; partial RoPE first `rotary_dim` dims     [rope_partial_interleaved_f32]
-//!   5. write KV cache; GQA attention                            [attention_flash_gqa / attention_q8_0_kv_batched]
-//!   6. attn_out = o_proj·attn ; h += attn_out
-//!   7. h_norm2 = rmsnorm(h, post_attention_layernorm)
-//!   8. router_logits = gate·h_norm2 ; scores = sigmoid(router_logits)   [sigmoid_f32]
-//!   9. top-8 via scores + e_score_correction_bias ; gather sigmoid ; normalize
-//!        [deepseek4 moe_topk_bias_aware_f32 / _batched]
-//!  10. scatter → grouped SwiGLU experts (gate=w1, up=w3, down=w2) → combine
-//!        [moe_scatter_fused_k8, gemm_hfq4g256_moe_grouped_wmma_k2, silu·mul,
-//!         moe_down_combine_grouped_k8]   (NO shared expert)
-//!  11. h += moe_out
-//! Final: rmsnorm(h, norm) → lm_head [gemv_auto] → logits.
+//! Attention weights are Q8 (plain input). The router is Q8 (plain). Routed
+//! experts are FWHT-pre-rotated (MQ4G256 / MQ2G256Lloyd / MQ6G256): the input
+//! is rotated (`rotate_x_mq_for`) and the silu output rotated
+//! (`fused_silu_mul_rotate_mq_batched_for`) before the indexed-MoE GEMV kernels
+//! — exactly qwen35's / deepseek4's MoE path. Routing uses `sigmoid_f32` +
+//! `deepseek4_moe_topk_bias_aware_f32` with route_scale = 1.0 (MiniMax-M2
+//! applies no routed-scaling factor).
 
-// Bring-up bodies land next; the crate compiles as a registered arch
-// (arch_id=10) with config parsing + stub weights/state in the meantime.
+use crate::minimax::{MiniMaxConfig, MiniMaxState, MiniMaxWeights};
+use hipfire_runtime::llama::{
+    fused_silu_mul_rotate_mq_batched_for, rotate_x_mq_for, weight_gemv, weight_gemv_residual,
+};
+use rdna_compute::{DType, Gpu};
+
+/// Decode one token; returns the full logits vector.
+pub fn decode_step(
+    cfg: &MiniMaxConfig,
+    weights: &MiniMaxWeights,
+    state: &mut MiniMaxState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+) -> Result<Vec<f32>, String> {
+    decode_step_inner(cfg, weights, state, gpu, token_id, position, None)?;
+    gpu.download_f32(&state.logits)
+        .map_err(|e| format!("minimax: download logits: {e:?}"))
+}
+
+/// Decode one token, appending each layer's post-residual hidden state
+/// (pre final-norm) to `capture[layer]` — used by the oracle dumper. Set
+/// `HIPFIRE_MINIMAX_CAPTURE_POSTATTN` to capture the post-attention residual
+/// (pre-MoE) instead, for attention-vs-MoE divergence localization.
+pub fn decode_step_capture(
+    cfg: &MiniMaxConfig,
+    weights: &MiniMaxWeights,
+    state: &mut MiniMaxState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+    capture: &mut [Vec<f32>],
+) -> Result<(), String> {
+    decode_step_inner(cfg, weights, state, gpu, token_id, position, Some(capture))
+}
+
+fn decode_step_inner(
+    cfg: &MiniMaxConfig,
+    weights: &MiniMaxWeights,
+    state: &mut MiniMaxState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+    mut capture: Option<&mut [Vec<f32>]>,
+) -> Result<(), String> {
+    let hidden = cfg.hidden_size;
+    let q_dim = cfg.q_dim();
+    let kv_dim = cfg.kv_dim();
+    let inter = cfg.intermediate_size;
+    let n_exp = cfg.num_local_experts;
+    let k_top = cfg.num_experts_per_tok;
+    let eps = cfg.rms_norm_eps;
+    let seq_len = position as usize + 1;
+    let capture_postattn = std::env::var_os("HIPFIRE_MINIMAX_CAPTURE_POSTATTN").is_some();
+
+    // Device position scalar (i32) for rope / kv-write / attention.
+    gpu.hip
+        .memcpy_htod(&state.pos_buf, &(position as i32).to_ne_bytes())
+        .map_err(|e| format!("minimax: htod pos: {e:?}"))?;
+
+    // Embedding lookup → residual stream h.
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, hidden)
+        .map_err(|e| format!("minimax: embed lookup: {e:?}"))?;
+
+    for (l, layer) in weights.layers.iter().enumerate() {
+        // ── Attention block (Q8 projections → plain input) ──────────────────
+        gpu.rmsnorm_f32(&state.h, &layer.attn_norm, &state.tmp, eps)
+            .map_err(|e| format!("minimax L{l}: attn rmsnorm: {e:?}"))?;
+        weight_gemv(gpu, &layer.wq, &state.tmp, &state.fa_q)
+            .map_err(|e| format!("minimax L{l}: q_proj: {e}"))?;
+        weight_gemv(gpu, &layer.wk, &state.tmp, &state.fa_k)
+            .map_err(|e| format!("minimax L{l}: k_proj: {e}"))?;
+        weight_gemv(gpu, &layer.wv, &state.tmp, &state.fa_v)
+            .map_err(|e| format!("minimax L{l}: v_proj: {e}"))?;
+
+        // Per-LAYER QK-norm: RMSNorm over the whole flat q[q_dim]/k[kv_dim]
+        // vector (batch=1), BEFORE head reshape.
+        if cfg.use_qk_norm {
+            gpu.rmsnorm_batched(&state.fa_q, &layer.q_norm, &state.fa_q, 1, q_dim, eps)
+                .map_err(|e| format!("minimax L{l}: q_norm: {e:?}"))?;
+            gpu.rmsnorm_batched(&state.fa_k, &layer.k_norm, &state.fa_k, 1, kv_dim, eps)
+                .map_err(|e| format!("minimax L{l}: k_norm: {e:?}"))?;
+        }
+
+        // Partial rotate_half RoPE on the first `rotary_dim` of each head.
+        gpu.rope_partial_interleaved_f32(
+            &state.fa_q, &state.fa_k, &state.pos_buf,
+            cfg.num_attention_heads, cfg.num_key_value_heads, cfg.head_dim,
+            cfg.rotary_dim, cfg.rope_theta,
+        )
+        .map_err(|e| format!("minimax L{l}: rope: {e:?}"))?;
+
+        // KV cache write (Q8) + GQA attention.
+        gpu.kv_cache_write_q8_0(&state.kv.k_gpu[l], &state.fa_k, &state.pos_buf,
+            cfg.num_key_value_heads, cfg.head_dim)
+            .map_err(|e| format!("minimax L{l}: kv write k: {e:?}"))?;
+        gpu.kv_cache_write_q8_0(&state.kv.v_gpu[l], &state.fa_v, &state.pos_buf,
+            cfg.num_key_value_heads, cfg.head_dim)
+            .map_err(|e| format!("minimax L{l}: kv write v: {e:?}"))?;
+        gpu.attention_q8_0_kv(
+            &state.fa_q, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &state.fa_attn_out,
+            &state.pos_buf, seq_len, cfg.num_attention_heads, cfg.num_key_value_heads,
+            cfg.head_dim, state.kv.physical_cap,
+        )
+        .map_err(|e| format!("minimax L{l}: attention: {e:?}"))?;
+
+        // o_proj + residual: h += W_o · attn_out.
+        weight_gemv_residual(gpu, &layer.wo, &state.fa_attn_out, &state.h)
+            .map_err(|e| format!("minimax L{l}: o_proj: {e}"))?;
+
+        if capture_postattn {
+            if let Some(cap) = capture.as_deref_mut() {
+                let h = gpu.download_f32(&state.h)
+                    .map_err(|e| format!("minimax L{l}: postattn capture: {e:?}"))?;
+                cap[l].extend_from_slice(&h);
+            }
+        }
+
+        // ── MoE block (no shared expert) ────────────────────────────────────
+        // ffn_tmp = rmsnorm(h) (plain, feeds the Q8 router); ffn_x_rot =
+        // FWHT(ffn_tmp) (feeds the FWHT-pre-rotated experts).
+        gpu.rmsnorm_f32(&state.h, &layer.ffn_norm, &state.ffn_tmp, eps)
+            .map_err(|e| format!("minimax L{l}: ffn rmsnorm: {e:?}"))?;
+        rotate_x_mq_for(gpu, &layer.experts[0].gate_up, &state.ffn_tmp, &state.ffn_x_rot, hidden)
+            .map_err(|e| format!("minimax L{l}: ffn rotate: {e:?}"))?;
+
+        // Router: sigmoid(logits) + bias-aware top-k (gather unbiased + normalize;
+        // route_scale = 1.0 — MiniMax-M2 applies no routed-scaling factor).
+        weight_gemv(gpu, &layer.router, &state.ffn_tmp, &state.router_logits)
+            .map_err(|e| format!("minimax L{l}: router: {e}"))?;
+        gpu.sigmoid_f32(&state.router_logits)
+            .map_err(|e| format!("minimax L{l}: sigmoid: {e:?}"))?;
+        gpu.deepseek4_moe_topk_bias_aware_f32(
+            &state.router_logits, &layer.routing_bias, &state.topk_indices,
+            &state.topk_weights, n_exp as i32, k_top as i32, 1.0,
+        )
+        .map_err(|e| format!("minimax L{l}: topk: {e:?}"))?;
+
+        // Routed experts: gate_up (rotated input) → silu·mul·rotate → down → combine.
+        // Dispatch the indexed-MoE GEMV by expert dtype. MQ4/MQ6/MQ2-Lloyd are
+        // FWHT-pre-rotated (byte-compatible with the matching hfq/lloyd kernels
+        // given rotated input). The hfq4/hfq6 family uses a separate down +
+        // `moe_down_combine`; the MQ2-Lloyd down is residual-scaled (fuses the
+        // weighted combine into the down GEMV, accumulating into h directly).
+        let edt = layer.experts[0].gate_up.gpu_dtype;
+        match edt {
+            DType::MQ4G256 | DType::HFQ4G256 => gpu
+                .gemv_hfq4g256_moe_gate_up_k8_indexed(
+                    &layer.expert_gate_up_ptrs, &state.topk_indices, &state.ffn_x_rot,
+                    &state.gate_batch, &state.up_batch, 2 * inter, hidden)
+                .map_err(|e| format!("minimax L{l}: gate_up hfq4: {e:?}"))?,
+            DType::MQ6G256 | DType::HFQ6G256 => gpu
+                .gemv_hfq6g256_moe_gate_up_k8_indexed(
+                    &layer.expert_gate_up_ptrs, &state.topk_indices, &state.ffn_x_rot,
+                    &state.gate_batch, &state.up_batch, 2 * inter, hidden)
+                .map_err(|e| format!("minimax L{l}: gate_up hfq6: {e:?}"))?,
+            DType::MQ2G256Lloyd => gpu
+                .deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed(
+                    &layer.expert_gate_up_ptrs, &state.topk_indices, &state.ffn_x_rot,
+                    &state.gate_batch, &state.up_batch, 2 * inter, hidden, k_top)
+                .map_err(|e| format!("minimax L{l}: gate_up mq2l: {e:?}"))?,
+            other => return Err(format!("minimax L{l}: unsupported expert dtype {other:?}")),
+        }
+
+        fused_silu_mul_rotate_mq_batched_for(
+            gpu, &layer.experts[0].down, &state.gate_batch, &state.up_batch,
+            &state.rot_batch, inter, k_top,
+        )
+        .map_err(|e| format!("minimax L{l}: silu_mul_rotate: {e:?}"))?;
+
+        match edt {
+            DType::MQ4G256 | DType::HFQ4G256 => {
+                gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
+                    &layer.expert_down_ptrs, &state.topk_indices, &state.rot_batch,
+                    &state.down_expanded, hidden, inter, k_top, 1)
+                    .map_err(|e| format!("minimax L{l}: down hfq4: {e:?}"))?;
+                gpu.moe_down_combine_k8_batched(
+                    &state.down_expanded, &state.topk_weights, &state.h, hidden, k_top, 1)
+                    .map_err(|e| format!("minimax L{l}: combine: {e:?}"))?;
+            }
+            DType::MQ6G256 | DType::HFQ6G256 => {
+                gpu.gemv_hfq6g256_moe_down_k8_indexed_batched_expanded(
+                    &layer.expert_down_ptrs, &state.topk_indices, &state.rot_batch,
+                    &state.down_expanded, hidden, inter, k_top, 1)
+                    .map_err(|e| format!("minimax L{l}: down hfq6: {e:?}"))?;
+                gpu.moe_down_combine_k8_batched(
+                    &state.down_expanded, &state.topk_weights, &state.h, hidden, k_top, 1)
+                    .map_err(|e| format!("minimax L{l}: combine: {e:?}"))?;
+            }
+            DType::MQ2G256Lloyd => {
+                // Fused down + weighted residual accumulate (no separate combine).
+                gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed(
+                    &layer.expert_down_ptrs, &state.topk_indices, &state.topk_weights,
+                    &state.rot_batch, &state.h, hidden, inter, k_top)
+                    .map_err(|e| format!("minimax L{l}: down mq2l: {e:?}"))?;
+            }
+            other => return Err(format!("minimax L{l}: unsupported expert dtype {other:?}")),
+        }
+
+        // Capture post-layer residual (pre final-norm) for the oracle compare.
+        if !capture_postattn {
+            if let Some(cap) = capture.as_deref_mut() {
+                let h = gpu.download_f32(&state.h)
+                    .map_err(|e| format!("minimax L{l}: capture download: {e:?}"))?;
+                cap[l].extend_from_slice(&h);
+            }
+        }
+    }
+    state.n_tokens = seq_len;
+
+    // Final RMSNorm + lm_head (Q8 → plain).
+    gpu.rmsnorm_f32(&state.h, &weights.final_norm, &state.final_norm_buf, eps)
+        .map_err(|e| format!("minimax: final rmsnorm: {e:?}"))?;
+    weight_gemv(gpu, &weights.lm_head, &state.final_norm_buf, &state.logits)
+        .map_err(|e| format!("minimax: lm_head: {e}"))?;
+    Ok(())
+}

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -193,7 +193,10 @@ fn decode_step_inner(
         )
         .map_err(|e| format!("minimax L{l}: silu_mul_rotate: {e:?}"))?;
 
-        match edt {
+        // Down dispatches on the DOWN proj's own dtype (may differ from gate_up:
+        // e.g. gate_up=mq2-lloyd + down=mq4, since down carries ~24x the energy).
+        let ddt = layer.experts[0].down.gpu_dtype;
+        match ddt {
             DType::MQ4G256 | DType::HFQ4G256 => {
                 gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
                     &layer.expert_down_ptrs, &state.topk_indices, &state.rot_batch,

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -179,6 +179,11 @@ fn decode_step_inner(
                     &layer.expert_gate_up_ptrs, &state.topk_indices, &state.ffn_x_rot,
                     &state.gate_batch, &state.up_batch, 2 * inter, hidden, k_top)
                 .map_err(|e| format!("minimax L{l}: gate_up mq2l: {e:?}"))?,
+            DType::MQ3G256Lloyd => gpu
+                .deepseek4_gemv_mq3g256_lloyd_moe_gate_up_indexed(
+                    &layer.expert_gate_up_ptrs, &state.topk_indices, &state.ffn_x_rot,
+                    &state.gate_batch, &state.up_batch, 2 * inter, hidden, k_top)
+                .map_err(|e| format!("minimax L{l}: gate_up mq3l: {e:?}"))?,
             other => return Err(format!("minimax L{l}: unsupported expert dtype {other:?}")),
         }
 
@@ -213,6 +218,13 @@ fn decode_step_inner(
                     &layer.expert_down_ptrs, &state.topk_indices, &state.topk_weights,
                     &state.rot_batch, &state.h, hidden, inter, k_top)
                     .map_err(|e| format!("minimax L{l}: down mq2l: {e:?}"))?;
+            }
+            DType::MQ3G256Lloyd => {
+                // Fused down + weighted residual accumulate (no separate combine).
+                gpu.deepseek4_gemv_mq3g256_lloyd_moe_down_residual_scaled_indexed(
+                    &layer.expert_down_ptrs, &state.topk_indices, &state.topk_weights,
+                    &state.rot_batch, &state.h, hidden, inter, k_top)
+                    .map_err(|e| format!("minimax L{l}: down mq3l: {e:?}"))?;
             }
             other => return Err(format!("minimax L{l}: unsupported expert dtype {other:?}")),
         }

--- a/crates/hipfire-arch-minimax/src/lib.rs
+++ b/crates/hipfire-arch-minimax/src/lib.rs
@@ -25,4 +25,6 @@ pub mod forward;
 pub mod minimax;
 
 pub use arch::MiniMaxM2;
-pub use minimax::{MiniMaxConfig, MiniMaxLayerWeights, MiniMaxState, MiniMaxWeights};
+pub use minimax::{
+    MiniMaxConfig, MiniMaxExpertWeights, MiniMaxLayerWeights, MiniMaxState, MiniMaxWeights,
+};

--- a/crates/hipfire-arch-minimax/src/lib.rs
+++ b/crates/hipfire-arch-minimax/src/lib.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! hipfire-arch-minimax: MiniMax-M2 (Mixtral-style MoE) for hipfire.
+//!
+//! Architecture (verified against `modeling_minimax_m2.py`): a textbook
+//! pre-norm transformer, every one of `num_hidden_layers` blocks being
+//!   `h += attn(input_layernorm(h)); h += moe(post_attention_layernorm(h))`
+//! where:
+//!   - attention = GQA (no bias) + **per-layer QK-norm** (RMSNorm on the
+//!     flat q[`n_heads*head_dim`] / k[`n_kv*head_dim`] BEFORE head reshape)
+//!     + **partial rotate_half RoPE** (first `rotary_dim` of `head_dim`).
+//!   - moe = `sigmoid(router_logits) + e_score_correction_bias` top-k
+//!     selection, gather-sigmoid-weights + normalize (DeepSeek-V3 style),
+//!     SwiGLU experts, NO shared expert.
+//!
+//! arch_id = 10 (see docs/architecture-ids.md). Maps onto hipfire's
+//! existing kernels with NO new kernels: qwen35 GQA + `rope_partial_*`,
+//! deepseek4 `moe_topk_bias_aware` routing, the grouped-MQ4 MoE GEMM +
+//! `moe_scatter/unscatter/down_combine_k8` family.
+
+pub mod arch;
+pub mod forward;
+pub mod minimax;
+
+pub use arch::MiniMaxM2;
+pub use minimax::{MiniMaxConfig, MiniMaxLayerWeights, MiniMaxState, MiniMaxWeights};

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -165,6 +165,20 @@ fn load_norm(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: &[usize]) -> Resul
         .map_err(|e| format!("minimax: upload norm {name}: {e:?}"))
 }
 
+/// Load a MiniMax AWQ shared-scale sidecar (1D F16, length k) → F32 GpuTensor.
+fn load_mm_awq_scale(hfq: &HfqFile, gpu: &mut Gpu, name: &str, k: usize) -> Option<GpuTensor> {
+    let (qt, data) = read_tensor(hfq, name).ok()?;
+    if qt != 1 { return None; } // 1 = F16
+    if data.len() != k * 2 {
+        eprintln!("minimax AWQ sidecar {name}: {} bytes != {} (k*2); skipping", data.len(), k * 2);
+        return None;
+    }
+    let f32_data: Vec<f32> = data.chunks_exact(2)
+        .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]]))).collect();
+    let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
+    gpu.upload_raw(&f32_bytes, &[f32_data.len()]).ok()
+}
+
 /// Load a quantized 2D weight → WeightTensor, tagging gpu_dtype from quant_type.
 fn load_wt(
     hfq: &HfqFile,
@@ -284,11 +298,22 @@ impl MiniMaxWeights {
                 let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
                 let mut gate_up_bytes = w1;
                 gate_up_bytes.extend_from_slice(&w3);
-                let gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * inter, hidden)
+                let mut gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * inter, hidden)
                     .map_err(|e2| format!("minimax: fuse gate_up L{l}E{e}: {e2}"))?;
                 let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
-                let down = wt_from_raw(gpu, qt2, &w2, hidden, inter)
+                let mut down = wt_from_raw(gpu, qt2, &w2, hidden, inter)
                     .map_err(|e2| format!("minimax: down L{l}E{e}: {e2}"))?;
+                if e == 0 {
+                    gate_up.awq_scale = load_mm_awq_scale(
+                        hfq, gpu, &format!("{p}.block_sparse_moe.awq_scale_gate_up.weight"), hidden);
+                    if std::env::var_os("HIPFIRE_MINIMAX_ENABLE_DOWN_AWQ").is_some() { // down-AWQ harmful (shared s_down bad approx); opt-in
+                        down.awq_scale = load_mm_awq_scale(
+                            hfq, gpu, &format!("{p}.block_sparse_moe.awq_scale_down.weight"), inter);
+                    }
+                    if gate_up.awq_scale.is_some() {
+                        eprintln!("minimax: AWQ scales attached at L{l} (expert-0 representative)");
+                    }
+                }
                 experts.push(MiniMaxExpertWeights { gate_up, down });
             }
 

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -408,8 +408,19 @@ impl MiniMaxWeights {
 pub struct MiniMaxState {
     pub kv: KvCache,
     pub pos_buf: hip_bridge::DeviceBuffer, // device i32 position scalar
+    /// Stable host source for the device position scalar. The hipGraph decode
+    /// path captures a `memcpy_htod_auto` from these bytes; the captured node
+    /// re-reads this heap-stable `Box` on every replay (see
+    /// `decode_step_with_graph`). Updated host-side before each `graph_launch`.
+    pub pos_host: Box<[i32]>,
     pub max_seq: usize,
     pub n_tokens: usize,
+    /// hipGraph warmup gate: the first decode after a fresh load runs eager
+    /// (no capture) to JIT-compile kernels + settle DPM, then the next call
+    /// captures. Survives turn resets (the graph stays valid for the same
+    /// model — only weight pointers + device buffers are baked, and those are
+    /// stable across turns).
+    pub ar_warmed_up: bool,
 
     // attention scratch
     pub tmp: GpuTensor,    // [hidden] rmsnorm(h)
@@ -493,8 +504,10 @@ impl MiniMaxState {
         Ok(MiniMaxState {
             kv,
             pos_buf,
+            pos_host: vec![0i32; 1].into_boxed_slice(),
             max_seq,
             n_tokens: 0,
+            ar_warmed_up: false,
             tmp: alloc(gpu, hidden, "tmp")?,
             x_rot: alloc(gpu, hidden, "x_rot")?,
             fa_q: alloc(gpu, q_dim, "fa_q")?,

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! MiniMax-M2 config / weights / state.
+//!
+//! Config is parsed from the HFQ `metadata_json` envelope
+//! (`{"architecture":..., "config":{...HF config...}, "tokenizer":...}`),
+//! same as deepseek4/qwen35. Weights/State are SCAFFOLD STUBS for now —
+//! the real loader (mirroring `deepseek4::arch` upload helpers + 256
+//! routed experts) and the KV/MoE scratch land with the forward bring-up.
+
+use hipfire_runtime::hfq::HfqFile;
+use rdna_compute::{Gpu, GpuTensor};
+use serde::Deserialize;
+
+/// Typed MiniMax-M2 shape constants.
+#[derive(Clone, Debug)]
+pub struct MiniMaxConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    /// Expert (MoE) FFN intermediate size (HF `intermediate_size`).
+    pub intermediate_size: usize,
+    pub num_local_experts: usize,
+    pub num_experts_per_tok: usize,
+    /// Rotated-dim count for partial RoPE (`rotary_dim`, < head_dim).
+    pub rotary_dim: usize,
+    pub rope_theta: f32,
+    pub rms_norm_eps: f32,
+    pub max_position_embeddings: usize,
+    /// Per-layer QK-norm on the flat q/k projection (RMSNorm pre-reshape).
+    pub use_qk_norm: bool,
+    /// Router uses `e_score_correction_bias` for top-k selection.
+    pub use_routing_bias: bool,
+    /// Router score activation; MiniMax-M2 = "sigmoid".
+    pub scoring_func: String,
+    /// MTP draft modules (spec-decode; 0 for the base forward).
+    pub num_mtp_modules: usize,
+}
+
+/// Raw deserialize of the inner HF `config` object. `#[serde(default)]`
+/// on the kwarg-style fields so missing keys fall back to MiniMax-M2
+/// defaults rather than erroring.
+#[derive(Deserialize)]
+struct RawMiniMaxConfig {
+    vocab_size: usize,
+    hidden_size: usize,
+    num_hidden_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    #[serde(default)]
+    head_dim: Option<usize>,
+    intermediate_size: usize,
+    num_local_experts: usize,
+    num_experts_per_tok: usize,
+    #[serde(default = "default_rotary_dim")]
+    rotary_dim: usize,
+    #[serde(default = "default_rope_theta")]
+    rope_theta: f32,
+    #[serde(default = "default_eps")]
+    rms_norm_eps: f32,
+    #[serde(default = "default_max_pos")]
+    max_position_embeddings: usize,
+    #[serde(default)]
+    use_qk_norm: bool,
+    #[serde(default)]
+    use_routing_bias: bool,
+    #[serde(default = "default_scoring")]
+    scoring_func: String,
+    #[serde(default)]
+    num_mtp_modules: usize,
+}
+
+fn default_rotary_dim() -> usize {
+    64
+}
+fn default_rope_theta() -> f32 {
+    5_000_000.0
+}
+fn default_eps() -> f32 {
+    1e-6
+}
+fn default_max_pos() -> usize {
+    196_608
+}
+fn default_scoring() -> String {
+    "sigmoid".to_string()
+}
+
+impl MiniMaxConfig {
+    pub fn from_hfq(hfq: &HfqFile) -> Result<Self, String> {
+        let wrapper: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
+            .map_err(|e| format!("minimax: metadata_json not valid JSON: {e}"))?;
+        let inner = wrapper
+            .get("config")
+            .ok_or_else(|| "minimax: metadata_json missing `config` wrapper".to_string())?;
+        let raw: RawMiniMaxConfig = serde_json::from_value(inner.clone())
+            .map_err(|e| format!("minimax: parsing inner config failed: {e}"))?;
+        let head_dim = raw
+            .head_dim
+            .unwrap_or(raw.hidden_size / raw.num_attention_heads);
+        Ok(MiniMaxConfig {
+            vocab_size: raw.vocab_size,
+            hidden_size: raw.hidden_size,
+            num_hidden_layers: raw.num_hidden_layers,
+            num_attention_heads: raw.num_attention_heads,
+            num_key_value_heads: raw.num_key_value_heads,
+            head_dim,
+            intermediate_size: raw.intermediate_size,
+            num_local_experts: raw.num_local_experts,
+            num_experts_per_tok: raw.num_experts_per_tok,
+            rotary_dim: raw.rotary_dim,
+            rope_theta: raw.rope_theta,
+            rms_norm_eps: raw.rms_norm_eps,
+            max_position_embeddings: raw.max_position_embeddings,
+            use_qk_norm: raw.use_qk_norm,
+            use_routing_bias: raw.use_routing_bias,
+            scoring_func: raw.scoring_func,
+            num_mtp_modules: raw.num_mtp_modules,
+        })
+    }
+
+    /// Heads-per-KV-group (GQA repeat factor).
+    pub fn num_key_value_groups(&self) -> usize {
+        self.num_attention_heads / self.num_key_value_heads
+    }
+}
+
+/// Per-layer GPU-resident weights. `Option<GpuTensor>` slots so the
+/// host-walk / progressive-upload paths can populate incrementally
+/// (mirrors `DeepseekV4LayerWeights`). The routed-expert blobs +
+/// pointer tables are added with the real loader.
+#[derive(Default)]
+pub struct MiniMaxLayerWeights {
+    pub input_norm: Option<GpuTensor>,
+    pub post_attn_norm: Option<GpuTensor>,
+    /// Flat per-layer QK-norm weights: q_norm [n_heads*head_dim],
+    /// k_norm [n_kv*head_dim].
+    pub q_norm: Option<GpuTensor>,
+    pub k_norm: Option<GpuTensor>,
+    pub q_proj: Option<GpuTensor>,
+    pub k_proj: Option<GpuTensor>,
+    pub v_proj: Option<GpuTensor>,
+    pub o_proj: Option<GpuTensor>,
+    /// MoE router gate [n_experts, hidden] + e_score_correction_bias [n_experts].
+    pub gate: Option<GpuTensor>,
+    pub e_score_bias: Option<GpuTensor>,
+    // routed experts (gate/up/down blobs + ptr tables) — filled by the
+    // real loader, stubbed here.
+}
+
+/// Model weights. SCAFFOLD: slots present, real upload TODO (P3 wiring).
+pub struct MiniMaxWeights {
+    pub embed: Option<GpuTensor>,
+    pub layers: Vec<MiniMaxLayerWeights>,
+    pub final_norm: Option<GpuTensor>,
+    pub lm_head: Option<GpuTensor>,
+}
+
+impl MiniMaxWeights {
+    /// SCAFFOLD STUB — allocates empty per-layer slots so the crate
+    /// compiles and the daemon can be wired. The real loader mirrors
+    /// `deepseek4::arch::{upload_quant_or_f16, upload_layer_routed_experts}`
+    /// (per-layer attn/norm/router + 256 routed SwiGLU experts) and is
+    /// implemented during forward bring-up.
+    pub fn load(_hfq: &mut HfqFile, cfg: &MiniMaxConfig, _gpu: &mut Gpu) -> Result<Self, String> {
+        let layers = (0..cfg.num_hidden_layers)
+            .map(|_| MiniMaxLayerWeights::default())
+            .collect();
+        Ok(MiniMaxWeights {
+            embed: None,
+            layers,
+            final_norm: None,
+            lm_head: None,
+        })
+    }
+}
+
+/// Per-decode GPU scratch (KV cache, attention workspace, MoE workspace).
+/// SCAFFOLD: tracks position only; buffers allocated during bring-up.
+pub struct MiniMaxState {
+    pub n_tokens: usize,
+}
+
+impl MiniMaxState {
+    /// SCAFFOLD STUB. Real allocation (GQA KV cache sized by
+    /// num_key_value_heads*head_dim*max_seq, attention scratch, MoE
+    /// scatter/expert workspace) lands with the forward.
+    pub fn new(_gpu: &mut Gpu, _cfg: &MiniMaxConfig) -> Result<Self, String> {
+        Ok(MiniMaxState { n_tokens: 0 })
+    }
+}

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -290,42 +290,77 @@ impl MiniMaxWeights {
             let routing_bias =
                 load_norm(hfq, gpu, &format!("{p}.block_sparse_moe.e_score_correction_bias"), &[n_exp])?;
 
-            // Routed experts: byte-fuse w1‖w3 → gate_up [2*inter, hidden]; w2 → down.
-            let mut experts = Vec::with_capacity(n_exp);
+            // Routed experts: pack ALL experts of this layer into ONE gate_up
+            // blob + ONE down blob (deepseek4 `upload_layer_routed_experts`
+            // pattern). The old code did a separate `upload_raw`/hipMalloc per
+            // expert per projection — 2*n_exp tiny allocs/layer, ~31.7k total,
+            // each rounded up to HIP's allocation granularity. That fragmentation
+            // wasted ~20GB of VRAM, inflating mq2-lloyd's 86GB file to a ~114GB
+            // resident footprint that OOM'd gfx1151's 96GB carveout. The
+            // `*_indexed` GEMV kernels index experts by device pointer, so one
+            // packed blob + a base+e*stride pointer table is byte- and
+            // result-identical to the per-expert layout (validated against the
+            // tiny oracle: gfx1151 cosine unchanged).
+            let mut gu_combined: Vec<u8> = Vec::new();
+            let mut dn_combined: Vec<u8> = Vec::new();
+            let mut gu_stride = 0usize;
+            let mut dn_stride = 0usize;
+            let mut qt_gu = 0u8;
+            let mut qt_dn = 0u8;
             for e in 0..n_exp {
                 let ep = format!("{p}.block_sparse_moe.experts.{e}");
                 let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                 let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
-                let mut gate_up_bytes = w1;
-                gate_up_bytes.extend_from_slice(&w3);
-                let mut gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * inter, hidden)
-                    .map_err(|e2| format!("minimax: fuse gate_up L{l}E{e}: {e2}"))?;
                 let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
-                let mut down = wt_from_raw(gpu, qt2, &w2, hidden, inter)
-                    .map_err(|e2| format!("minimax: down L{l}E{e}: {e2}"))?;
+                let gu_len = w1.len() + w3.len();
                 if e == 0 {
-                    gate_up.awq_scale = load_mm_awq_scale(
-                        hfq, gpu, &format!("{p}.block_sparse_moe.awq_scale_gate_up.weight"), hidden);
-                    if std::env::var_os("HIPFIRE_MINIMAX_ENABLE_DOWN_AWQ").is_some() { // down-AWQ harmful (shared s_down bad approx); opt-in
-                        down.awq_scale = load_mm_awq_scale(
-                            hfq, gpu, &format!("{p}.block_sparse_moe.awq_scale_down.weight"), inter);
-                    }
-                    if gate_up.awq_scale.is_some() {
-                        eprintln!("minimax: AWQ scales attached at L{l} (expert-0 representative)");
-                    }
+                    gu_stride = gu_len;
+                    dn_stride = w2.len();
+                    qt_gu = qt1;
+                    qt_dn = qt2;
+                    gu_combined.reserve(gu_len * n_exp);
+                    dn_combined.reserve(w2.len() * n_exp);
+                } else if gu_len != gu_stride || w2.len() != dn_stride {
+                    return Err(format!(
+                        "minimax L{l}E{e}: non-uniform expert stride (gate_up {gu_len}/{gu_stride}, down {}/{dn_stride}); packed layout requires equal-size experts",
+                        w2.len()
+                    ));
                 }
-                experts.push(MiniMaxExpertWeights { gate_up, down });
+                gu_combined.extend_from_slice(&w1);
+                gu_combined.extend_from_slice(&w3);
+                dn_combined.extend_from_slice(&w2);
             }
+            // One allocation per projection. The representative `WeightTensor`'s
+            // buffer IS the packed blob; its m/k describe a SINGLE expert's shape
+            // (the forward's rotate_x_mq / silu_mul_rotate / dtype dispatch read
+            // those + the AWQ scale, never the buffer's full extent — per-expert
+            // data is reached through the pointer table below).
+            let mut gate_up = wt_from_raw(gpu, qt_gu, &gu_combined, 2 * inter, hidden)
+                .map_err(|e2| format!("minimax: pack gate_up L{l}: {e2}"))?;
+            let mut down = wt_from_raw(gpu, qt_dn, &dn_combined, hidden, inter)
+                .map_err(|e2| format!("minimax: pack down L{l}: {e2}"))?;
+            drop(gu_combined);
+            drop(dn_combined);
+            gate_up.awq_scale = load_mm_awq_scale(
+                hfq, gpu, &format!("{p}.block_sparse_moe.awq_scale_gate_up.weight"), hidden);
+            if std::env::var_os("HIPFIRE_MINIMAX_ENABLE_DOWN_AWQ").is_some() { // down-AWQ harmful (shared s_down bad approx); opt-in
+                down.awq_scale = load_mm_awq_scale(
+                    hfq, gpu, &format!("{p}.block_sparse_moe.awq_scale_down.weight"), inter);
+            }
+            if gate_up.awq_scale.is_some() {
+                eprintln!("minimax: AWQ scales attached at L{l} (shared per-layer)");
+            }
+            let gu_base = gate_up.buf.buf.as_ptr() as u64;
+            let dn_base = down.buf.buf.as_ptr() as u64;
+            let experts = vec![MiniMaxExpertWeights { gate_up, down }];
 
-            // Device pointer tables: n_exp u64 device addresses, stored as
-            // [2*n_exp] F32 (8 bytes/ptr). Kernel casts base to `u64*`.
-            let gu_bytes: Vec<u8> = experts
-                .iter()
-                .flat_map(|e| (e.gate_up.buf.buf.as_ptr() as u64).to_ne_bytes())
+            // Device pointer tables: n_exp u64 device addresses INTO the packed
+            // blobs (base + e*stride), stored as [2*n_exp] F32 (8 bytes/ptr).
+            let gu_bytes: Vec<u8> = (0..n_exp)
+                .flat_map(|e| (gu_base + (e * gu_stride) as u64).to_ne_bytes())
                 .collect();
-            let dn_bytes: Vec<u8> = experts
-                .iter()
-                .flat_map(|e| (e.down.buf.buf.as_ptr() as u64).to_ne_bytes())
+            let dn_bytes: Vec<u8> = (0..n_exp)
+                .flat_map(|e| (dn_base + (e * dn_stride) as u64).to_ne_bytes())
                 .collect();
             let expert_gate_up_ptrs = gpu
                 .alloc_tensor(&[2 * n_exp], DType::F32)

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -4,15 +4,18 @@
 
 //! MiniMax-M2 config / weights / state.
 //!
-//! Config is parsed from the HFQ `metadata_json` envelope
-//! (`{"architecture":..., "config":{...HF config...}, "tokenizer":...}`),
-//! same as deepseek4/qwen35. Weights/State are SCAFFOLD STUBS for now —
-//! the real loader (mirroring `deepseek4::arch` upload helpers + 256
-//! routed experts) and the KV/MoE scratch land with the forward bring-up.
+//! Config parses from the HFQ `metadata_json` envelope. Weights/State mirror
+//! the qwen35 GQA+MoE infrastructure (shared `WeightTensor`, `KvCache`, and the
+//! `gemv_hfq4g256_moe_*` indexed-expert kernels) rather than deepseek4's MLA.
+//! Expert weights ship pre-split (w1/w2/w3) in the HFQ; the loader byte-fuses
+//! w1‖w3 into the per-expert `gate_up` blob the indexed GEMV kernels expect.
 
 use hipfire_runtime::hfq::HfqFile;
-use rdna_compute::{Gpu, GpuTensor};
+use hipfire_runtime::llama::{f16_to_f32, KvCache, WeightTensor};
+use rdna_compute::{DType, Gpu, GpuTensor};
 use serde::Deserialize;
+
+// ───────────────────────────── Config ─────────────────────────────
 
 /// Typed MiniMax-M2 shape constants.
 #[derive(Clone, Debug)]
@@ -38,13 +41,10 @@ pub struct MiniMaxConfig {
     pub use_routing_bias: bool,
     /// Router score activation; MiniMax-M2 = "sigmoid".
     pub scoring_func: String,
-    /// MTP draft modules (spec-decode; 0 for the base forward).
+    /// MTP draft modules (spec-decode; 0 for the base forward / this ckpt).
     pub num_mtp_modules: usize,
 }
 
-/// Raw deserialize of the inner HF `config` object. `#[serde(default)]`
-/// on the kwarg-style fields so missing keys fall back to MiniMax-M2
-/// defaults rather than erroring.
 #[derive(Deserialize)]
 struct RawMiniMaxConfig {
     vocab_size: usize,
@@ -124,73 +124,341 @@ impl MiniMaxConfig {
         })
     }
 
-    /// Heads-per-KV-group (GQA repeat factor).
-    pub fn num_key_value_groups(&self) -> usize {
-        self.num_attention_heads / self.num_key_value_heads
+    /// q projection output width (n_heads * head_dim).
+    pub fn q_dim(&self) -> usize {
+        self.num_attention_heads * self.head_dim
+    }
+    /// k/v projection output width (n_kv_heads * head_dim).
+    pub fn kv_dim(&self) -> usize {
+        self.num_key_value_heads * self.head_dim
     }
 }
 
-/// Per-layer GPU-resident weights. `Option<GpuTensor>` slots so the
-/// host-walk / progressive-upload paths can populate incrementally
-/// (mirrors `DeepseekV4LayerWeights`). The routed-expert blobs +
-/// pointer tables are added with the real loader.
-#[derive(Default)]
-pub struct MiniMaxLayerWeights {
-    pub input_norm: Option<GpuTensor>,
-    pub post_attn_norm: Option<GpuTensor>,
-    /// Flat per-layer QK-norm weights: q_norm [n_heads*head_dim],
-    /// k_norm [n_kv*head_dim].
-    pub q_norm: Option<GpuTensor>,
-    pub k_norm: Option<GpuTensor>,
-    pub q_proj: Option<GpuTensor>,
-    pub k_proj: Option<GpuTensor>,
-    pub v_proj: Option<GpuTensor>,
-    pub o_proj: Option<GpuTensor>,
-    /// MoE router gate [n_experts, hidden] + e_score_correction_bias [n_experts].
-    pub gate: Option<GpuTensor>,
-    pub e_score_bias: Option<GpuTensor>,
-    // routed experts (gate/up/down blobs + ptr tables) — filled by the
-    // real loader, stubbed here.
+// ───────────────────────── HFQ load helpers ─────────────────────────
+// Replicated from the qwen35 loader (those are crate-private). MiniMax HFQ
+// files carry RAW HF tensor names, so we look them up by exact name.
+
+fn read_tensor(hfq: &HfqFile, name: &str) -> Result<(u8, Vec<u8>), String> {
+    let (info, data) = hfq
+        .tensor_data_vec(name)
+        .ok_or_else(|| format!("minimax: tensor not found in HFQ: {name}"))?;
+    Ok((info.quant_type, data))
 }
 
-/// Model weights. SCAFFOLD: slots present, real upload TODO (P3 wiring).
+/// Load a 1D norm vector (F16/F32) → F32 GpuTensor. MiniMax-M2 uses STANDARD
+/// RMSNorm (`weight * x_normed`, no +1.0 offset — verified against
+/// MiniMaxM2RMSNorm), so no offset is baked in.
+fn load_norm(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: &[usize]) -> Result<GpuTensor, String> {
+    let (qt, data) = read_tensor(hfq, name)?;
+    let f32_data: Vec<f32> = match qt {
+        1 => data
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        2 => data
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+        _ => return Err(format!("minimax: expected F16/F32 norm for {name}, got qt={qt}")),
+    };
+    gpu.upload_f32(&f32_data, shape)
+        .map_err(|e| format!("minimax: upload norm {name}: {e:?}"))
+}
+
+/// Load a quantized 2D weight → WeightTensor, tagging gpu_dtype from quant_type.
+fn load_wt(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+) -> Result<WeightTensor, String> {
+    let (qt, data) = read_tensor(hfq, name)?;
+    wt_from_raw(gpu, qt, &data, m, k).map_err(|e| format!("minimax: load_wt {name}: {e}"))
+}
+
+/// quant_type → DType mapping (subset used by MiniMax HFQ files; mirrors
+/// qwen35::load_weight_tensor_raw). Uploads raw bytes and tags the dtype.
+fn wt_from_raw(gpu: &mut Gpu, qt: u8, data: &[u8], m: usize, k: usize) -> Result<WeightTensor, String> {
+    let dtype = match qt {
+        3 => DType::Q8_0,
+        6 => DType::HFQ4G256,
+        8 => DType::HFQ6G256,
+        13 => DType::MQ4G256,
+        15 => DType::MQ6G256,
+        17 => DType::MQ3G256,
+        18 => DType::MQ2G256,
+        19 => DType::MQ2G256Lloyd,
+        20 => DType::MQ3G256Lloyd,
+        30 => DType::MQ4G256Lloyd,
+        1 => DType::F16,
+        other => return Err(format!("unsupported quant_type {other}")),
+    };
+    let buf = gpu
+        .upload_raw(data, &[data.len()])
+        .map_err(|e| format!("upload_raw: {e:?}"))?;
+    Ok(WeightTensor {
+        buf,
+        gpu_dtype: dtype,
+        m,
+        k,
+        row_stride: 0,
+        paro: None,
+        awq_scale: None,
+    })
+}
+
+// ──────────────────────────── Weights ────────────────────────────
+
+/// Per-layer GPU-resident weights.
+pub struct MiniMaxLayerWeights {
+    pub attn_norm: GpuTensor,  // input_layernorm
+    pub ffn_norm: GpuTensor,   // post_attention_layernorm
+    pub q_norm: GpuTensor,     // [n_heads*head_dim]
+    pub k_norm: GpuTensor,     // [n_kv*head_dim]
+    pub wq: WeightTensor,
+    pub wk: WeightTensor,
+    pub wv: WeightTensor,
+    pub wo: WeightTensor,
+    pub router: WeightTensor,        // block_sparse_moe.gate.weight [n_exp, hidden]
+    pub routing_bias: GpuTensor,     // e_score_correction_bias [n_exp] F32
+    pub experts: Vec<MiniMaxExpertWeights>,
+    pub expert_gate_up_ptrs: GpuTensor, // [2*n_exp] F32 = n_exp u64 device ptrs
+    pub expert_down_ptrs: GpuTensor,
+}
+
+pub struct MiniMaxExpertWeights {
+    /// Fused gate(w1)‖up(w3): [2*intermediate, hidden] MQ4G256.
+    pub gate_up: WeightTensor,
+    /// Down (w2): [hidden, intermediate] MQ4G256.
+    pub down: WeightTensor,
+}
+
 pub struct MiniMaxWeights {
-    pub embed: Option<GpuTensor>,
+    pub embed: GpuTensor,     // model.embed_tokens.weight (Q8 raw, for embedding_lookup_q8)
+    pub final_norm: GpuTensor, // model.norm.weight
+    pub lm_head: WeightTensor, // lm_head.weight
     pub layers: Vec<MiniMaxLayerWeights>,
-    pub final_norm: Option<GpuTensor>,
-    pub lm_head: Option<GpuTensor>,
 }
 
 impl MiniMaxWeights {
-    /// SCAFFOLD STUB — allocates empty per-layer slots so the crate
-    /// compiles and the daemon can be wired. The real loader mirrors
-    /// `deepseek4::arch::{upload_quant_or_f16, upload_layer_routed_experts}`
-    /// (per-layer attn/norm/router + 256 routed SwiGLU experts) and is
-    /// implemented during forward bring-up.
-    pub fn load(_hfq: &mut HfqFile, cfg: &MiniMaxConfig, _gpu: &mut Gpu) -> Result<Self, String> {
-        let layers = (0..cfg.num_hidden_layers)
-            .map(|_| MiniMaxLayerWeights::default())
-            .collect();
+    pub fn load(hfq: &mut HfqFile, cfg: &MiniMaxConfig, gpu: &mut Gpu) -> Result<Self, String> {
+        let hidden = cfg.hidden_size;
+        let q_dim = cfg.q_dim();
+        let kv_dim = cfg.kv_dim();
+        let inter = cfg.intermediate_size;
+        let n_exp = cfg.num_local_experts;
+
+        // Globals.
+        let (_qt, embed_bytes) = read_tensor(hfq, "model.embed_tokens.weight")?;
+        let embed = gpu
+            .upload_raw(&embed_bytes, &[embed_bytes.len()])
+            .map_err(|e| format!("minimax: upload embed: {e:?}"))?;
+        let final_norm = load_norm(hfq, gpu, "model.norm.weight", &[hidden])?;
+        let lm_head = load_wt(hfq, gpu, "lm_head.weight", cfg.vocab_size, hidden)?;
+
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for l in 0..cfg.num_hidden_layers {
+            let p = format!("model.layers.{l}");
+            let attn_norm = load_norm(hfq, gpu, &format!("{p}.input_layernorm.weight"), &[hidden])?;
+            let ffn_norm =
+                load_norm(hfq, gpu, &format!("{p}.post_attention_layernorm.weight"), &[hidden])?;
+            let q_norm = load_norm(hfq, gpu, &format!("{p}.self_attn.q_norm.weight"), &[q_dim])?;
+            let k_norm = load_norm(hfq, gpu, &format!("{p}.self_attn.k_norm.weight"), &[kv_dim])?;
+            let wq = load_wt(hfq, gpu, &format!("{p}.self_attn.q_proj.weight"), q_dim, hidden)?;
+            let wk = load_wt(hfq, gpu, &format!("{p}.self_attn.k_proj.weight"), kv_dim, hidden)?;
+            let wv = load_wt(hfq, gpu, &format!("{p}.self_attn.v_proj.weight"), kv_dim, hidden)?;
+            let wo = load_wt(hfq, gpu, &format!("{p}.self_attn.o_proj.weight"), hidden, q_dim)?;
+
+            let router =
+                load_wt(hfq, gpu, &format!("{p}.block_sparse_moe.gate.weight"), n_exp, hidden)?;
+            // e_score_correction_bias: [n_exp] F16 → F32 (kept F16 in HFQ).
+            let routing_bias =
+                load_norm(hfq, gpu, &format!("{p}.block_sparse_moe.e_score_correction_bias"), &[n_exp])?;
+
+            // Routed experts: byte-fuse w1‖w3 → gate_up [2*inter, hidden]; w2 → down.
+            let mut experts = Vec::with_capacity(n_exp);
+            for e in 0..n_exp {
+                let ep = format!("{p}.block_sparse_moe.experts.{e}");
+                let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
+                let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
+                let mut gate_up_bytes = w1;
+                gate_up_bytes.extend_from_slice(&w3);
+                let gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * inter, hidden)
+                    .map_err(|e2| format!("minimax: fuse gate_up L{l}E{e}: {e2}"))?;
+                let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
+                let down = wt_from_raw(gpu, qt2, &w2, hidden, inter)
+                    .map_err(|e2| format!("minimax: down L{l}E{e}: {e2}"))?;
+                experts.push(MiniMaxExpertWeights { gate_up, down });
+            }
+
+            // Device pointer tables: n_exp u64 device addresses, stored as
+            // [2*n_exp] F32 (8 bytes/ptr). Kernel casts base to `u64*`.
+            let gu_bytes: Vec<u8> = experts
+                .iter()
+                .flat_map(|e| (e.gate_up.buf.buf.as_ptr() as u64).to_ne_bytes())
+                .collect();
+            let dn_bytes: Vec<u8> = experts
+                .iter()
+                .flat_map(|e| (e.down.buf.buf.as_ptr() as u64).to_ne_bytes())
+                .collect();
+            let expert_gate_up_ptrs = gpu
+                .alloc_tensor(&[2 * n_exp], DType::F32)
+                .map_err(|e| format!("minimax: alloc gu_ptrs: {e:?}"))?;
+            let expert_down_ptrs = gpu
+                .alloc_tensor(&[2 * n_exp], DType::F32)
+                .map_err(|e| format!("minimax: alloc dn_ptrs: {e:?}"))?;
+            gpu.hip
+                .memcpy_htod(&expert_gate_up_ptrs.buf, &gu_bytes)
+                .map_err(|e| format!("minimax: htod gu_ptrs: {e:?}"))?;
+            gpu.hip
+                .memcpy_htod(&expert_down_ptrs.buf, &dn_bytes)
+                .map_err(|e| format!("minimax: htod dn_ptrs: {e:?}"))?;
+
+            layers.push(MiniMaxLayerWeights {
+                attn_norm,
+                ffn_norm,
+                q_norm,
+                k_norm,
+                wq,
+                wk,
+                wv,
+                wo,
+                router,
+                routing_bias,
+                experts,
+                expert_gate_up_ptrs,
+                expert_down_ptrs,
+            });
+        }
+
         Ok(MiniMaxWeights {
-            embed: None,
+            embed,
+            final_norm,
+            lm_head,
             layers,
-            final_norm: None,
-            lm_head: None,
         })
     }
 }
 
-/// Per-decode GPU scratch (KV cache, attention workspace, MoE workspace).
-/// SCAFFOLD: tracks position only; buffers allocated during bring-up.
+// ──────────────────────────── State ────────────────────────────
+
+/// Per-decode GPU scratch + KV cache. Buffers are eager-allocated (the model
+/// is dense in its per-token working set); the KV cache is Q8.
 pub struct MiniMaxState {
+    pub kv: KvCache,
+    pub pos_buf: hip_bridge::DeviceBuffer, // device i32 position scalar
+    pub max_seq: usize,
     pub n_tokens: usize,
+
+    // attention scratch
+    pub tmp: GpuTensor,    // [hidden] rmsnorm(h)
+    pub x_rot: GpuTensor,  // [hidden] FWHT scratch (unused for Q8 attn)
+    pub fa_q: GpuTensor,   // [q_dim]
+    pub fa_k: GpuTensor,   // [kv_dim]
+    pub fa_v: GpuTensor,   // [kv_dim]
+    pub fa_attn_out: GpuTensor, // [q_dim]
+    pub flash_partials: GpuTensor,
+
+    // residual + embedding
+    pub h: GpuTensor, // [hidden] residual stream
+
+    // moe scratch
+    pub ffn_tmp: GpuTensor,    // [hidden] rmsnorm(h)
+    pub ffn_x_rot: GpuTensor,  // [hidden] FWHT(rmsnorm(h)) for MQ4 experts
+    pub router_logits: GpuTensor, // [n_exp]
+    pub topk_indices: GpuTensor,  // [k] i32-in-F32
+    pub topk_weights: GpuTensor,  // [k]
+    pub gate_batch: GpuTensor,    // [k*inter]
+    pub up_batch: GpuTensor,      // [k*inter]
+    pub rot_batch: GpuTensor,     // [k*inter]
+    pub down_expanded: GpuTensor, // [k*hidden]
+
+    // head
+    pub final_norm_buf: GpuTensor, // [hidden]
+    pub final_rot: GpuTensor,      // [hidden]
+    pub logits: GpuTensor,         // [vocab]
 }
 
 impl MiniMaxState {
-    /// SCAFFOLD STUB. Real allocation (GQA KV cache sized by
-    /// num_key_value_heads*head_dim*max_seq, attention scratch, MoE
-    /// scatter/expert workspace) lands with the forward.
-    pub fn new(_gpu: &mut Gpu, _cfg: &MiniMaxConfig) -> Result<Self, String> {
-        Ok(MiniMaxState { n_tokens: 0 })
+    pub fn new(gpu: &mut Gpu, cfg: &MiniMaxConfig) -> Result<Self, String> {
+        // Cap the KV cache so the real 204800-ctx config doesn't OOM; callers
+        // that need a specific window use `new_with_max_seq`.
+        let max_seq = cfg.max_position_embeddings.min(8192);
+        Self::new_with_max_seq(gpu, cfg, max_seq)
+    }
+
+    pub fn new_with_max_seq(
+        gpu: &mut Gpu,
+        cfg: &MiniMaxConfig,
+        max_seq: usize,
+    ) -> Result<Self, String> {
+        let hidden = cfg.hidden_size;
+        let q_dim = cfg.q_dim();
+        let kv_dim = cfg.kv_dim();
+        let inter = cfg.intermediate_size;
+        let n_exp = cfg.num_local_experts;
+        let k = cfg.num_experts_per_tok;
+
+        // FWHT sign LUT must exist before any rotate_x_mq / fused rotate kernel.
+        gpu.ensure_mq_signs()
+            .map_err(|e| format!("minimax: ensure_mq_signs: {e:?}"))?;
+
+        let kv = KvCache::new_gpu_q8(
+            gpu,
+            cfg.num_hidden_layers,
+            cfg.num_key_value_heads,
+            cfg.head_dim,
+            max_seq,
+        )
+        .map_err(|e| format!("minimax: kv cache: {e:?}"))?;
+        let pos_buf = gpu
+            .hip
+            .malloc(4)
+            .map_err(|e| format!("minimax: pos_buf malloc: {e:?}"))?;
+
+        let alloc = |g: &mut Gpu, n: usize, label: &str| -> Result<GpuTensor, String> {
+            g.alloc_tensor(&[n], DType::F32)
+                .map_err(|e| format!("minimax: alloc {label}: {e:?}"))
+        };
+        // Flash-attn partials: [n_heads * max_tiles * (2+head_dim)]; max_tiles
+        // bounded by ceil(max_seq/tile). Use a generous tile bound of 64.
+        let max_tiles = (max_seq / 256).max(1) + 1;
+        let flash_partials = alloc(
+            gpu,
+            cfg.num_attention_heads * max_tiles * (2 + cfg.head_dim),
+            "flash_partials",
+        )?;
+
+        Ok(MiniMaxState {
+            kv,
+            pos_buf,
+            max_seq,
+            n_tokens: 0,
+            tmp: alloc(gpu, hidden, "tmp")?,
+            x_rot: alloc(gpu, hidden, "x_rot")?,
+            fa_q: alloc(gpu, q_dim, "fa_q")?,
+            fa_k: alloc(gpu, kv_dim, "fa_k")?,
+            fa_v: alloc(gpu, kv_dim, "fa_v")?,
+            fa_attn_out: alloc(gpu, q_dim, "fa_attn_out")?,
+            flash_partials,
+            h: alloc(gpu, hidden, "h")?,
+            ffn_tmp: alloc(gpu, hidden, "ffn_tmp")?,
+            ffn_x_rot: alloc(gpu, hidden, "ffn_x_rot")?,
+            router_logits: alloc(gpu, n_exp, "router_logits")?,
+            topk_indices: alloc(gpu, k, "topk_indices")?,
+            topk_weights: alloc(gpu, k, "topk_weights")?,
+            gate_batch: alloc(gpu, k * inter, "gate_batch")?,
+            up_batch: alloc(gpu, k * inter, "up_batch")?,
+            rot_batch: alloc(gpu, k * inter, "rot_batch")?,
+            down_expanded: alloc(gpu, k * hidden, "down_expanded")?,
+            final_norm_buf: alloc(gpu, hidden, "final_norm_buf")?,
+            final_rot: alloc(gpu, hidden, "final_rot")?,
+            logits: alloc(gpu, cfg.vocab_size, "logits")?,
+        })
+    }
+
+    pub fn reset(&mut self) {
+        self.n_tokens = 0;
     }
 }

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3052,7 +3052,10 @@ struct TensorSpill {
 
 impl TensorSpill {
     fn new(dir: &Path) -> std::io::Result<Self> {
-        let path = dir.join(".hipfire_quant_spill.tmp");
+        // PID-unique so concurrent quantize runs in the same output dir don't
+        // share a spill path (a sibling run's Drop would otherwise delete this
+        // run's spill file → write_hfq NotFound panic).
+        let path = dir.join(format!(".hipfire_quant_spill.{}.tmp", std::process::id()));
         let file = std::io::BufWriter::with_capacity(
             4 * 1024 * 1024,
             File::create(&path)?,
@@ -3526,8 +3529,20 @@ fn load_imatrix(path: &Path) -> HashMap<String, Vec<f32>> {
         skipped_moe,
     );
     if total_entries == 0 {
-        eprintln!("error: imatrix file contains no usable .in_sum2 entries");
-        std::process::exit(1);
+        if skipped_moe > 0 {
+            // MoE-only imatrix (e.g. MiniMax routed experts): no 1D dense
+            // entries for the legacy dense-AWQ table, but the file IS valid.
+            // The MiniMax AWQ-on-experts path reads the raw imatrix GGUF
+            // (imatrix_gguf) directly, so an empty dense table is harmless —
+            // dense tensors just fall back to non-imatrix quantization.
+            eprintln!(
+                "imatrix: 0 dense entries, {skipped_moe} MoE multi-matrix entries — \
+                 dense table empty (MoE-only imatrix; expert AWQ uses the raw GGUF)"
+            );
+        } else {
+            eprintln!("error: imatrix file contains no usable .in_sum2 entries");
+            std::process::exit(1);
+        }
     }
     map
 }
@@ -3585,6 +3600,62 @@ fn imatrix_weights_for(safetensors_name: &str) -> Option<&'static [f32]> {
 ///
 /// Cost: O(K). For 9B Qwen3.5 ~32 calls × ~4096 elements = ~131K ops total
 /// across the whole quantize. Negligible.
+/// Parse the layer index N from a MiniMax expert tensor name
+/// `…layers.N.block_sparse_moe.experts.E.wX.weight`.
+fn minimax_layer_index(name: &str) -> Option<usize> {
+    let after = name.split(".layers.").nth(1)?;
+    after.split('.').next()?.parse::<usize>().ok()
+}
+
+/// True if layer `l` falls in the comma-separated range list held in env `var`
+/// (e.g. "12-45,50,55-60"; inclusive ranges or bare singles). Unset/empty →
+/// false. Drives per-layer mixed-precision expert promotion for MiniMax.
+fn minimax_layer_in_env_set(var: &str, l: usize) -> bool {
+    let spec = match std::env::var(var) { Ok(v) => v, Err(_) => return false };
+    for tok in spec.split(',') {
+        let tok = tok.trim();
+        if tok.is_empty() { continue; }
+        if let Some((a, b)) = tok.split_once('-') {
+            if let (Ok(a), Ok(b)) = (a.trim().parse::<usize>(), b.trim().parse::<usize>()) {
+                if l >= a.min(b) && l <= a.max(b) { return true; }
+            }
+        } else if let Ok(n) = tok.parse::<usize>() {
+            if l == n { return true; }
+        }
+    }
+    false
+}
+
+/// Shared-per-layer AWQ scales for MiniMax routed experts from an imatrix GGUF.
+/// Aggregates per-expert activation energy (in_sum2) across ALL experts of
+/// layer `n` into one shared per-input-channel scale: gate(w1)/up(w3) share the
+/// MoE-input channels (s_gate_up, len hidden); down(w2) uses the intermediate
+/// channels (s_down, len inter). The forward applies these via experts[0], so
+/// one scale per layer is exactly what the runtime consumes. None if absent.
+fn minimax_layer_awq_scales(
+    gguf: &gguf_input::GgufFile, n: usize, alpha: f32,
+) -> Option<(Vec<f32>, Vec<f32>)> {
+    let agg = |kind: &str| -> Option<Vec<f32>> {
+        let nm = format!("blk.{n}.ffn_{kind}_exps.weight.in_sum2");
+        let t = gguf.tensors.iter().find(|t| t.name == nm)?;
+        if t.shape.len() != 2 { return None; }
+        let k = t.shape[0]; let n_exp = t.shape[1];
+        let flat: Vec<f32> = gguf.tensor_data(t).chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+        if flat.len() != k * n_exp { return None; }
+        let mut a = vec![0.0f32; k];
+        for e in 0..n_exp { let off = e * k; for j in 0..k { a[j] += flat[off + j]; } }
+        Some(a)
+    };
+    let g = agg("gate")?;
+    let gu: Vec<f32> = match agg("up") {
+        Some(u) if u.len() == g.len() => g.iter().zip(&u).map(|(a, b)| a + b).collect(),
+        _ => g.clone(),
+    };
+    let d = agg("down")?;
+    Some((compute_awq_scales(&gu, alpha), compute_awq_scales(&d, alpha)))
+}
+
 fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
     let k = in_sum2.len();
     debug_assert!(k > 0, "empty imatrix vector");
@@ -5164,6 +5235,9 @@ fn main() {
         eprintln!("  [filter] --include-prefix {p:?} — only tensors with this prefix will be ingested");
     }
     let mut skipped_params = 0u64;
+    // MiniMax AWQ: shared-per-layer expert scales, cached + sidecars emitted once.
+    let mut mm_awq_cache: std::collections::HashMap<usize, Option<(Vec<f32>, Vec<f32>)>> = std::collections::HashMap::new();
+    let mut mm_awq_emitted: std::collections::HashSet<usize> = std::collections::HashSet::new();
     for (name, file_idx) in &all_tensors {
         // --include-prefix filter (highest priority — runs before mtp/vision skips).
         if let Some(ref p) = include_prefix {
@@ -5375,10 +5449,44 @@ fn main() {
             && name.ends_with(".weight")
             && meta.shape.len() == 2
         {
-            let f32_data = tensor_to_f32_with_optional_fp8_scale(
+            let mut f32_data = tensor_to_f32_with_optional_fp8_scale(
                 name, raw_data, meta, &fp8_scale_for, &st_files);
             let k = meta.shape[1];
+            let m = meta.shape[0];
             if k % 256 == 0 {
+                // AWQ shared-per-layer pre-scaling of the routed experts (--awq +
+                // --imatrix). w1/w3 use s_gate_up (MoE-input channels), w2 uses
+                // s_down (intermediate channels). Math W·s @ x/s = W·x is exact;
+                // the forward divides the activation by experts[0]'s scale.
+                if awq_enabled {
+                    if let (Some(layer_n), Some(gg)) = (minimax_layer_index(name), imatrix_gguf.as_ref()) {
+                        let alpha = AWQ_ALPHA.get().copied().unwrap_or(0.55);
+                        let entry = mm_awq_cache.entry(layer_n)
+                            .or_insert_with(|| minimax_layer_awq_scales(gg, layer_n, alpha));
+                        if let Some((s_gu, s_dn)) = entry.as_ref() {
+                            let scale = if name.ends_with(".w2.weight") { s_dn } else { s_gu };
+                            if scale.len() == k {
+                                awq_pre_scale_weights(&mut f32_data, m, k, scale);
+                            } else {
+                                eprintln!("  minimax AWQ L{layer_n}: scale len {} != k {} ({name}); skipped", scale.len(), k);
+                            }
+                            if mm_awq_emitted.insert(layer_n) {
+                                let p = name.split(".block_sparse_moe.").next().unwrap();
+                                hfq_tensors.push(HfqTensor {
+                                    name: format!("{p}.block_sparse_moe.awq_scale_gate_up.weight"),
+                                    quant_type: QuantType::F16, shape: vec![s_gu.len() as u32],
+                                    group_size: 0, data: awq_scales_to_f16_bytes(s_gu), spilled_len: 0,
+                                });
+                                hfq_tensors.push(HfqTensor {
+                                    name: format!("{p}.block_sparse_moe.awq_scale_down.weight"),
+                                    quant_type: QuantType::F16, shape: vec![s_dn.len() as u32],
+                                    group_size: 0, data: awq_scales_to_f16_bytes(s_dn), spilled_len: 0,
+                                });
+                                eprintln!("  AWQ-MM: emitted shared expert scales for L{layer_n}");
+                            }
+                        }
+                    }
+                }
                 let signs1 = gen_fwht_signs(42, 256);
                 let signs2 = gen_fwht_signs(1042, 256);
                 // Expert format by --format: mq2-lloyd (MQ2G256Lloyd, hipx sub-4-bit
@@ -5386,7 +5494,22 @@ fn main() {
                 // HIPFIRE_MINIMAX_EXPERT_MQ6), else mq4 (MQ4G256, default + validated).
                 let mm_mq6 = use_mq6g256 || std::env::var_os("HIPFIRE_MINIMAX_EXPERT_MQ6").is_some();
                 let mm_mq2l = use_mq2g256_lloyd || std::env::var_os("HIPFIRE_MINIMAX_EXPERT_MQ2L").is_some();
-                let (q, qt, label) = if mm_mq2l {
+                let mm_mq3l = use_mq3g256_lloyd || std::env::var_os("HIPFIRE_MINIMAX_EXPERT_MQ3L").is_some();
+                // Per-layer mixed-precision promotion. HIPFIRE_MINIMAX_PROMOTE_MQ4 /
+                // _MQ6 hold comma-separated layer ranges ("12-45,50") whose experts are
+                // forced UP to MQ4 / MQ6 regardless of the base --format. The forward
+                // dispatches expert dtype per-layer (experts[0].gpu_dtype), so the model
+                // carries an MQ2-Lloyd base with MQ4 on the quant-sensitive middle layers.
+                let mm_layer = minimax_layer_index(name);
+                let promote_mq6 = mm_layer.map_or(false, |l| minimax_layer_in_env_set("HIPFIRE_MINIMAX_PROMOTE_MQ6", l));
+                let promote_mq4 = mm_layer.map_or(false, |l| minimax_layer_in_env_set("HIPFIRE_MINIMAX_PROMOTE_MQ4", l));
+                let (q, qt, label) = if promote_mq6 {
+                    (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6-PROMO")
+                } else if promote_mq4 {
+                    (quantize_mq4g256(&f32_data, &signs1, &signs2), QuantType::MQ4G256, "MQ4-PROMO")
+                } else if mm_mq3l {
+                    (quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2), QuantType::MQ3G256Lloyd, "MQ3L-MM")
+                } else if mm_mq2l {
                     (quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2), QuantType::MQ2G256Lloyd, "MQ2L-MM")
                 } else if mm_mq6 {
                     (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6-MM")

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5463,12 +5463,17 @@ fn main() {
                         let alpha = AWQ_ALPHA.get().copied().unwrap_or(0.55);
                         let entry = mm_awq_cache.entry(layer_n)
                             .or_insert_with(|| minimax_layer_awq_scales(gg, layer_n, alpha));
-                        if let Some((s_gu, s_dn)) = entry.as_ref() {
-                            let scale = if name.ends_with(".w2.weight") { s_dn } else { s_gu };
-                            if scale.len() == k {
-                                awq_pre_scale_weights(&mut f32_data, m, k, scale);
-                            } else {
-                                eprintln!("  minimax AWQ L{layer_n}: scale len {} != k {} ({name}); skipped", scale.len(), k);
+                        if let Some((s_gu, _s_dn)) = entry.as_ref() {
+                            // gate/up-AWQ ONLY: down-AWQ (shared s_down) is harmful for MoE
+                            // (per-expert down-input saliency differs), AND the loader divides
+                            // only the gate_up input — so pre-scaling w2 would leave an
+                            // uncancelled scale. Leave w2 unscaled; emit only the gate_up sidecar.
+                            if !name.ends_with(".w2.weight") {
+                                if s_gu.len() == k {
+                                    awq_pre_scale_weights(&mut f32_data, m, k, s_gu);
+                                } else {
+                                    eprintln!("  minimax AWQ L{layer_n}: s_gu len {} != k {} ({name}); skipped", s_gu.len(), k);
+                                }
                             }
                             if mm_awq_emitted.insert(layer_n) {
                                 let p = name.split(".block_sparse_moe.").next().unwrap();
@@ -5477,12 +5482,7 @@ fn main() {
                                     quant_type: QuantType::F16, shape: vec![s_gu.len() as u32],
                                     group_size: 0, data: awq_scales_to_f16_bytes(s_gu), spilled_len: 0,
                                 });
-                                hfq_tensors.push(HfqTensor {
-                                    name: format!("{p}.block_sparse_moe.awq_scale_down.weight"),
-                                    quant_type: QuantType::F16, shape: vec![s_dn.len() as u32],
-                                    group_size: 0, data: awq_scales_to_f16_bytes(s_dn), spilled_len: 0,
-                                });
-                                eprintln!("  AWQ-MM: emitted shared expert scales for L{layer_n}");
+                                eprintln!("  AWQ-MM: emitted gate_up scale for L{layer_n}");
                             }
                         }
                     }
@@ -5503,7 +5503,22 @@ fn main() {
                 let mm_layer = minimax_layer_index(name);
                 let promote_mq6 = mm_layer.map_or(false, |l| minimax_layer_in_env_set("HIPFIRE_MINIMAX_PROMOTE_MQ6", l));
                 let promote_mq4 = mm_layer.map_or(false, |l| minimax_layer_in_env_set("HIPFIRE_MINIMAX_PROMOTE_MQ4", l));
-                let (q, qt, label) = if promote_mq6 {
+                // Per-projection promotion: the down proj (w2) sees ~24x the
+                // activation magnitude of gate/up (the SwiGLU intermediate), so its
+                // 2-bit error dominates the block output. HIPFIRE_MINIMAX_DOWN_FORMAT=
+                // {mq6,mq4,mq3-lloyd} promotes ONLY w2, keeping w1/w3 at the base.
+                // The forward dispatches down on its own dtype, so they can differ.
+                let down_fmt = if name.ends_with(".w2.weight") {
+                    std::env::var("HIPFIRE_MINIMAX_DOWN_FORMAT").ok()
+                } else { None };
+                let (q, qt, label) = if let Some(df) = down_fmt.as_deref() {
+                    match df {
+                        "mq6" => (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6-DN"),
+                        "mq4" => (quantize_mq4g256(&f32_data, &signs1, &signs2), QuantType::MQ4G256, "MQ4-DN"),
+                        "mq3-lloyd" => (quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2), QuantType::MQ3G256Lloyd, "MQ3L-DN"),
+                        _ => (quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2), QuantType::MQ2G256Lloyd, "MQ2L-DN"),
+                    }
+                } else if promote_mq6 {
                     (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6-PROMO")
                 } else if promote_mq4 {
                     (quantize_mq4g256(&f32_data, &signs1, &signs2), QuantType::MQ4G256, "MQ4-PROMO")

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -4860,6 +4860,11 @@ fn main() {
         // path yet; tensor names ship in DeepSeek V4's native shape (split w1/w2/w3,
         // per-expert) and are translated when the forward bring-up lands.
         "deepseek_v4" => 9,
+        // MiniMax-M2 (Mixtral-style MoE): GQA + per-layer QK-norm + partial
+        // rotate_half RoPE; 256 routed experts top-8 sigmoid+e_score_bias, no
+        // shared expert; FP8 E4M3 + F32 weight_scale_inv block-128 storage;
+        // split per-expert w1/w3/w2 (like deepseek_v4). Crate hipfire-arch-minimax.
+        "minimax_m2" => 10,
         other => { eprintln!("Warning: unknown architecture '{other}', treating as llama"); 0 }
     };
     // --arch-id <u32> overrides the auto-detected id. Use when the

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5046,13 +5046,38 @@ fn main() {
 
     // Read tokenizer_config.json (has chat_template)
     let tokenizer_config_path = input_dir.join("tokenizer_config.json");
-    let tokenizer_config: Option<serde_json::Value> = if tokenizer_config_path.exists() {
+    let mut tokenizer_config: Option<serde_json::Value> = if tokenizer_config_path.exists() {
         std::fs::read_to_string(&tokenizer_config_path)
             .ok()
             .and_then(|s| serde_json::from_str(&s).ok())
     } else {
         None
     };
+
+    // Fallback: many recent models (MiniMax-M2, newer Qwen/Gemma) ship the Jinja
+    // chat template as a separate `chat_template.jinja` rather than inside
+    // tokenizer_config.json. The daemon reads `tokenizer_config.chat_template`
+    // from the embedded HFQ metadata (see resolve_chat_template / hfq.chat_template),
+    // so fold the sidecar in when tokenizer_config has no usable template —
+    // otherwise serve runs raw with no chat formatting.
+    {
+        let has_tpl = tokenizer_config
+            .as_ref()
+            .and_then(|v| v.get("chat_template"))
+            .and_then(|t| t.as_str())
+            .map(|t| !t.trim().is_empty())
+            .unwrap_or(false);
+        let jinja_path = input_dir.join("chat_template.jinja");
+        if !has_tpl && jinja_path.exists() {
+            if let Ok(tpl) = std::fs::read_to_string(&jinja_path) {
+                let obj = tokenizer_config.get_or_insert_with(|| serde_json::json!({}));
+                if let Some(map) = obj.as_object_mut() {
+                    map.insert("chat_template".into(), serde_json::Value::String(tpl));
+                    eprintln!("  chat_template: folded chat_template.jinja into tokenizer_config metadata");
+                }
+            }
+        }
+    }
 
     // Read generation_config.json. HF stores some sampler-side defaults
     // here (eos_token_id, pad_token_id, bos_token_id, do_sample, etc.)

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -2276,6 +2276,94 @@ fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
     output
 }
 
+/// Ternary "MQ1.58" probe: K=3 Lloyd-placed codebook packed into the MQ2-Lloyd
+/// container (slot 3 = duplicate of slot 2, never indexed) so it runs on the
+/// existing MQ2G256Lloyd kernel with NO new kernel. Measures sub-2-bit
+/// *information* (3 levels = log2(3) ≈ 1.58 bit) coherence; storage stays
+/// 72 B/group (true 1.58-bpw packing — 5 ternary/byte — is a mechanical
+/// follow-up once coherence is established). Gated by HIPFIRE_LLOYD_K3=1 on the
+/// `--format mq2lloyd` path. Output DType = MQ2G256Lloyd (kernel-agnostic to K).
+fn quantize_mq2g256_lloyd_k3(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+    use rayon::prelude::*;
+    let group_size = 256;
+    let block_bytes = 72;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+    output
+        .par_chunks_mut(block_bytes)
+        .enumerate()
+        .for_each(|(b, out_chunk)| {
+            let start = b * group_size;
+            let end = (start + group_size).min(n);
+            let actual_len = end - start;
+            let mut group = [0.0f32; 256];
+            group[..actual_len].copy_from_slice(&f32_data[start..end]);
+            cpu_fwht_256(&mut group, signs1, signs2);
+
+            let mut sorted: [f32; 256] = group;
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let percentile = |frac: f32| -> f32 {
+                let idx = ((frac * 255.0).round() as usize).min(255);
+                sorted[idx]
+            };
+            // 3 centroids: ~1/6, 1/2, 5/6 percentiles.
+            let mut cb: [f32; 3] = [percentile(0.167), percentile(0.5), percentile(0.833)];
+            let range = sorted[255] - sorted[0];
+            let mut indices = [0u8; 256];
+            if range > 0.0 {
+                let max_iter = 8;
+                let mut prev = [0u8; 256];
+                for it in 0..max_iter {
+                    let mut sums = [0.0f64; 3];
+                    let mut counts = [0u32; 3];
+                    let mut changed = 0u32;
+                    for i in 0..256 {
+                        let w = group[i];
+                        let mut best = 0usize;
+                        let mut best_d = (w - cb[0]).abs();
+                        for k in 1..3 {
+                            let d = (w - cb[k]).abs();
+                            if d < best_d { best_d = d; best = k; }
+                        }
+                        if it == 0 || prev[i] != best as u8 { changed += 1; }
+                        prev[i] = best as u8;
+                        indices[i] = best as u8;
+                        sums[best] += w as f64;
+                        counts[best] += 1;
+                    }
+                    if it > 0 && changed == 0 { break; }
+                    for k in 0..3 {
+                        if counts[k] > 0 { cb[k] = (sums[k] / counts[k] as f64) as f32; }
+                    }
+                }
+            }
+            // Sort the 3 centroids ascending; remap indices.
+            let mut order: [usize; 3] = [0, 1, 2];
+            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            let mut sorted_cb = [0.0f32; 3];
+            let mut inv: [u8; 3] = [0; 3];
+            for new_idx in 0..3 {
+                sorted_cb[new_idx] = cb[order[new_idx]];
+                inv[order[new_idx]] = new_idx as u8;
+            }
+            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            // Header: slots 0..2 = the 3 centroids; slot 3 = dup of slot 2 (never indexed).
+            let header = [sorted_cb[0], sorted_cb[1], sorted_cb[2], sorted_cb[2]];
+            for k in 0..4 {
+                let bits = f32_to_fp16_bits(header[k]);
+                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k + 1] = (bits >> 8) as u8;
+            }
+            for i in 0..64 {
+                let mut byte_val = 0u8;
+                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                out_chunk[8 + i] = byte_val;
+            }
+        });
+    output
+}
+
 /// Inverse FWHT for MQ-family dequantization (sibling of cpu_fwht_256).
 fn cpu_inv_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
     assert!(x.len() == 256);
@@ -3409,6 +3497,16 @@ fn load_imatrix(path: &Path) -> HashMap<String, Vec<f32>> {
 ///     tensor wasn't exercised by the calibration corpus).
 fn imatrix_weights_for(safetensors_name: &str) -> Option<&'static [f32]> {
     let im = IMATRIX.get()?;
+    // `load_imatrix` keys the map by the imatrix FILE's tensor names (`.in_sum2`
+    // stripped). hipfire's `collect_imatrix` emits *safetensors* names
+    // (`model.language_model.layers.N.linear_attn.in_proj_qkv.weight`), so try the
+    // direct safetensors name FIRST — this was the AWQ no-op: the map is
+    // safetensors-keyed but we only tried the GGML-converted name, which always
+    // missed (and 27B-3.6 hybrid linear_attn names don't round-trip anyway).
+    // Fall back to the GGML name for llama.cpp-style (blk.*) imatrices.
+    if let Some(v) = im.get(safetensors_name) {
+        return Some(v.as_slice());
+    }
     let ggml_name = safetensors_to_ggml_name(safetensors_name)?;
     im.get(&ggml_name).map(|v| v.as_slice())
 }
@@ -3459,7 +3557,17 @@ fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
     let mut log_s_raw = Vec::with_capacity(k);
     let mut sum_log: f64 = 0.0;
     for &v in in_sum2 {
-        let v_clamped = (v as f64).max(1e-12);
+        // Floor dead channels to 1e-12 (NaN also maps here: f64::max returns the
+        // non-NaN arg) AND cap non-finite / pathologically-large values to a
+        // finite ceiling. An inf in_sum2 — f32 overflow during imatrix
+        // collection, which the 27B tier1 imatrix actually contains — would
+        // otherwise make this tensor's `mean_log = inf`, and then `l - mean_log`
+        // = inf - inf = NaN for the inf channel. That NaN survives the output
+        // clamp below (f32::clamp propagates NaN), poisoning the F16 sidecar and
+        // NaN'ing the whole forward (37747 such values measured pre-fix).
+        // Capping the input keeps mean_log finite; the output clamp then bounds
+        // the final scale. 1e30 is well inside f64 range (ln ≈ 69).
+        let v_clamped = (v as f64).max(1e-12).min(1e30);
         let log_s = half_alpha * v_clamped.ln();   // log(v^(alpha/2)) = (alpha/2) * log(v)
         log_s_raw.push(log_s);
         sum_log += log_s;
@@ -3468,8 +3576,26 @@ fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
 
     // Step 3: subtract mean in log space, then exp back. After this,
     // geo_mean(s) = exp(0) = 1.0 exactly (within floating-point precision).
+    //
+    // Step 4 (CRITICAL — f16 safety): clamp to an f16-representable,
+    // non-exploding range. The geo-mean is 1.0 by construction, so the bulk
+    // of channels sit near 1; only pathological outliers reach the rails —
+    // dead channels floored to 1e-12, or hot channels with huge activation
+    // sums. Without this, exp() overflows to f32 inf and/or the F16 sidecar
+    // under/overflows, and the inference-time `x / awq_scale` divide produces
+    // inf → NaN. (Verified via dump_awq_scales on the 27B tier1 imatrix:
+    // 49293 scales underflowed to 0.0 and 37747 stored as inf/NaN pre-clamp,
+    // which NaN'd the whole forward — KLD 0.0 / PPL NaN on gfx11.)
+    //
+    // The SAME clamped vector is used for both the weight pre-scale (W*s) and
+    // the emitted sidecar (x/s at inference), so the cancellation stays exact;
+    // clamping only limits how aggressively pathological channels redistribute
+    // quant difficulty. Real AWQ scales live in ~[0.2, 5]; [1e-2, 1e2] keeps
+    // all genuine signal while removing the representability blow-ups.
+    const AWQ_SCALE_MIN: f32 = 1e-2;
+    const AWQ_SCALE_MAX: f32 = 1e2;
     log_s_raw.into_iter()
-        .map(|l| ((l - mean_log).exp()) as f32)
+        .map(|l| ((l - mean_log).exp() as f32).clamp(AWQ_SCALE_MIN, AWQ_SCALE_MAX))
         .collect()
 }
 
@@ -5845,7 +5971,24 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                    // AWQ × MQ3-Lloyd composition (MQ3G256Lloyd is forward-path-ready +
+                    // now in supports_awq_sidecar). Pre-scale by imatrix, then Lloyd-fit.
+                    let q = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            quantize_mq3g256_lloyd(&scaled, &signs1, &signs2)
+                        } else {
+                            quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
+                        }
+                    } else {
+                        quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
                 } else {
                     let q = quantize_hfq3g128(&f32_data);
@@ -5856,7 +5999,27 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                    // AWQ × MQ2-Lloyd (MQ2G256Lloyd is in supports_awq_sidecar): pre-scale
+                    // by imatrix first, then Lloyd-fit (K=4, or K=3-ternary under the flag).
+                    let awq_scaled: Option<Vec<f32>> = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            Some(scaled)
+                        } else { None }
+                    } else { None };
+                    let data: &[f32] = awq_scaled.as_deref().unwrap_or(&f32_data);
+                    // HIPFIRE_LLOYD_K3=1 → ternary "MQ1.58" (3-level codebook, reuses kernel).
+                    let q = if std::env::var("HIPFIRE_LLOYD_K3").ok().as_deref() == Some("1") {
+                        quantize_mq2g256_lloyd_k3(data, &signs1, &signs2)
+                    } else {
+                        quantize_mq2g256_lloyd(data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
                 } else {
                     // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
@@ -5868,7 +6031,27 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                    // AWQ pre-scaling for MQ3 base body (mirrors the MQ4 base arm).
+                    // MQ3G256 is on DType::supports_awq_sidecar, so the runtime applies
+                    // the inverse divide via rotate_x_mq. Without this, `--format mq3
+                    // --awq` was a silent no-op on body tensors (md5(mq3-awq)==md5(mq3)).
+                    // awq_eligible gates to tensors whose runtime path has the inverse.
+                    let q = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            quantize_mq3g256(&scaled, &signs1, &signs2)
+                        } else {
+                            quantize_mq3g256(&f32_data, &signs1, &signs2)
+                        }
+                    } else {
+                        quantize_mq3g256(&f32_data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ3G256, 256u32, "MQ3G256")
                 } else {
                     // Fallback to HFQ3-G128 for non-256-aligned (no rotation)
@@ -5880,7 +6063,25 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                    // AWQ × plain MQ2 (MQ2G256 now in supports_awq_sidecar). Pre-scale by
+                    // imatrix, then quantize. (Plain MQ2 collapses uncalibrated; AWQ is the
+                    // test of whether activation-aware scaling rescues uniform 2-bit.)
+                    let q = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            quantize_mq2g256(&scaled, &signs1, &signs2)
+                        } else {
+                            quantize_mq2g256(&f32_data, &signs1, &signs2)
+                        }
+                    } else {
+                        quantize_mq2g256(&f32_data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ2G256, 256u32, "MQ2G256")
                 } else {
                     // Fallback to HFQ2-G128 for non-256-aligned (no rotation)

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -315,11 +315,14 @@ fn tensor_to_f32_with_optional_fp8_scale(
         let (smeta, sbytes) = st_files[*sfi]
             .tensor_data(sname)
             .unwrap_or_else(|| panic!("FP8 scale tensor missing: {sname}"));
-        assert_eq!(smeta.dtype, "F8_E8M0",
-            "expected F8_E8M0 scale for {name}, got {}", smeta.dtype);
-        return dequantize_e4m3_ue8m0_to_f32(
-            raw_data, &meta.shape, sbytes, &smeta.shape,
-        );
+        if smeta.dtype == "F8_E8M0" {
+            return dequantize_e4m3_ue8m0_to_f32(raw_data, &meta.shape, sbytes, &smeta.shape);
+        } else if smeta.dtype == "F32" {
+            // MiniMax-M2: e4m3 + F32 block-[128,128] weight_scale_inv (multiply).
+            return dequantize_e4m3_f32scale_to_f32(raw_data, &meta.shape, sbytes, &smeta.shape);
+        } else {
+            panic!("expected F8_E8M0 or F32 scale for {name}, got {}", smeta.dtype);
+        }
     }
     if meta.dtype == "I8" {
         panic!("tensor {name} has dtype I8 but no .scale sibling registered \
@@ -438,6 +441,46 @@ fn dequantize_e4m3_ue8m0_to_f32(
                     let c = sc_j * block_cols + dj;
                     let b = weight_bytes[r * cols + c];
                     out[r * cols + c] = e4m3_to_f32(b) * scale;
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Dequantize FP8 E4M3 weights paired with an F32 block-[128,128]
+/// `weight_scale_inv` (MiniMax-M2 / DeepSeek-V3 fp8 block quant). Dequant is
+/// MULTIPLY: `out = e4m3_to_f32(b) * scale` (the stored scale ≈ amax/448 per
+/// block, verified ~5e-4 on the real checkpoint). Scale tile is [rows/sr, cols/sc]
+/// = [128, 128] on MiniMax.
+fn dequantize_e4m3_f32scale_to_f32(
+    weight_bytes: &[u8],
+    weight_shape: &[usize],
+    scale_bytes: &[u8],
+    scale_shape: &[usize],
+) -> Vec<f32> {
+    assert_eq!(weight_shape.len(), 2, "expected 2D weight, got {:?}", weight_shape);
+    assert_eq!(scale_shape.len(), 2, "expected 2D scale, got {:?}", scale_shape);
+    let (rows, cols) = (weight_shape[0], weight_shape[1]);
+    let (sr, sc) = (scale_shape[0], scale_shape[1]);
+    assert_eq!(weight_bytes.len(), rows * cols, "weight byte count mismatch");
+    assert_eq!(scale_bytes.len(), sr * sc * 4, "f32 scale byte count mismatch");
+    assert!(rows % sr == 0 && cols % sc == 0,
+            "scale shape {:?} doesn't tile weight shape {:?}", scale_shape, weight_shape);
+    let block_rows = rows / sr;
+    let block_cols = cols / sc;
+    let mut out = vec![0.0f32; rows * cols];
+    for sr_i in 0..sr {
+        for sc_j in 0..sc {
+            let so = (sr_i * sc + sc_j) * 4;
+            let scale = f32::from_le_bytes([
+                scale_bytes[so], scale_bytes[so + 1], scale_bytes[so + 2], scale_bytes[so + 3],
+            ]);
+            for di in 0..block_rows {
+                let r = sr_i * block_rows + di;
+                for dj in 0..block_cols {
+                    let c = sc_j * block_cols + dj;
+                    out[r * cols + c] = e4m3_to_f32(weight_bytes[r * cols + c]) * scale;
                 }
             }
         }
@@ -3692,6 +3735,10 @@ fn awq_eligible(name: &str) -> bool {
         // correctness. `router.weight` would be a non-HF naming an
         // arch might choose; kept for safety.
         || name.ends_with("mlp.gate.weight")
+        // MiniMax-M2 MoE router (block_sparse_moe.gate.weight). Same intent
+        // as mlp.gate.weight: q8_router (set for is_minimax via is_moe_like)
+        // keeps the router at Q8 so HFQ4 noise can't flip top-k selection.
+        || name.ends_with("block_sparse_moe.gate.weight")
         || name.ends_with("router.weight");
     if f1_only { return f1_match; }
     let f2_match =
@@ -4888,7 +4935,13 @@ fn main() {
     // the standard 2D quant path; the routing fan-out into top-k experts
     // happens at forward time, not quant time.
     let is_deepseek4 = arch_id == 9;
-    let is_moe_like = is_moe || is_deepseek4;
+    // MiniMax-M2 (arch_id=10): MoE like DeepSeek V4, ships per-expert pre-split
+    // 2D tensors (`...block_sparse_moe.experts.E.{w1,w2,w3}.weight`). Quantized
+    // as HFQ4G256 (the only 4-bit format with a complete indexed-MoE GEMV
+    // kernel family). Raw HF tensor names are written verbatim (no rename);
+    // the hipfire loader looks them up.
+    let is_minimax = arch_id == 10;
+    let is_moe_like = is_moe || is_deepseek4 || is_minimax;
     // Q8 router: always on for MoE-class models.
     let q8_router = is_moe_like || q8_router_flag;
     if is_moe {
@@ -4896,6 +4949,9 @@ fn main() {
     }
     if is_deepseek4 {
         eprintln!("  DeepSeek V4 detected — per-expert tensors ship pre-split; quantizing each as 2D weight.");
+    }
+    if is_minimax {
+        eprintln!("  MiniMax-M2 detected — per-expert tensors ship pre-split; quantizing each as HFQ4G256 2D weight.");
     }
 
     // Extract layer count for K-map edge-layer promotion.
@@ -4976,6 +5032,13 @@ fn main() {
     let mut fp8_scale_for: HashMap<String, (usize, String)> = HashMap::new();
     for (fi, st) in st_files.iter().enumerate() {
         for name in st.tensor_names() {
+            // MiniMax-M2 FP8: `<w>.weight` (e4m3) + `<w>.weight_scale_inv` (F32
+            // block-[128,128] scale). Strip the longer suffix FIRST.
+            if let Some(stem) = name.strip_suffix(".weight_scale_inv") {
+                let w_name = format!("{stem}.weight");
+                fp8_scale_for.insert(w_name, (fi, name.to_string()));
+                continue;
+            }
             if let Some(stem) = name.strip_suffix(".scale") {
                 // Sibling weight name (drop `.scale`, add `.weight`).
                 let w_name = format!("{stem}.weight");
@@ -5275,6 +5338,79 @@ fn main() {
                 continue;
             }
             // Fall through to standard path for non-MQ2 formats.
+        }
+
+        // ── MiniMax-M2 router: keep Q8 ─────────────────────────────────────────
+        // The MoE router (`block_sparse_moe.gate.weight`) is precision-sensitive
+        // (4-bit noise flips top-k on borderline tokens) but must NOT be F16:
+        // weight_gemv's F16 arm dispatches gemm_f16_batched_lmhead, which is a
+        // WMMA lm-head kernel that produces garbage for the router's tiny m
+        // (=n_exp). Q8 (gemv_q8_0) is well-behaved at any m and ~0.4% noise.
+        if is_minimax && name.ends_with("block_sparse_moe.gate.weight") {
+            let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
+            let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                name, raw_data, meta, &fp8_scale_for, &st_files);
+            let q = quantize_q8f16(&f32_data);
+            eprintln!("  {:>8}: {} {:?} (router Q8)", "Q8-MM", name, meta.shape);
+            hfq_tensors.push(HfqTensor {
+                name: name.to_string(),
+                quant_type: QuantType::Q8F16,
+                shape, group_size: 32, data: q, spilled_len: 0,
+            });
+            st_files[*file_idx].drop_tensor_pages(name);
+            continue;
+        }
+
+        // ── MiniMax-M2 per-expert pre-split path ───────────────────────────────
+        // Experts ship as 2D `...block_sparse_moe.experts.E.{w1,w2,w3}.weight`
+        // (F32 in the tiny oracle; FP8 e4m3 + F32 weight_scale_inv in the 229B
+        // ckpt — handled transparently by tensor_to_f32_with_optional_fp8_scale).
+        // Quantize each as MQ4G256 (FWHT-pre-rotated 4-bit): byte-compatible with
+        // the gemv_hfq4g256_moe_* indexed kernels — passing FWHT-rotated input to
+        // those kernels is mathematically equivalent to gemv_mq4g256 (the exact
+        // path qwen35's MoE uses). This IS the user-facing "mq4" format. Names
+        // are written verbatim; the loader fuses w1||w3 into the gate_up blob.
+        if is_minimax
+            && name.contains(".block_sparse_moe.experts.")
+            && name.ends_with(".weight")
+            && meta.shape.len() == 2
+        {
+            let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                name, raw_data, meta, &fp8_scale_for, &st_files);
+            let k = meta.shape[1];
+            if k % 256 == 0 {
+                let signs1 = gen_fwht_signs(42, 256);
+                let signs2 = gen_fwht_signs(1042, 256);
+                // Expert format by --format: mq2-lloyd (MQ2G256Lloyd, hipx sub-4-bit
+                // target — has deepseek4 indexed-MoE kernels), mq6 (oracle check /
+                // HIPFIRE_MINIMAX_EXPERT_MQ6), else mq4 (MQ4G256, default + validated).
+                let mm_mq6 = use_mq6g256 || std::env::var_os("HIPFIRE_MINIMAX_EXPERT_MQ6").is_some();
+                let mm_mq2l = use_mq2g256_lloyd || std::env::var_os("HIPFIRE_MINIMAX_EXPERT_MQ2L").is_some();
+                let (q, qt, label) = if mm_mq2l {
+                    (quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2), QuantType::MQ2G256Lloyd, "MQ2L-MM")
+                } else if mm_mq6 {
+                    (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6-MM")
+                } else {
+                    (quantize_mq4g256(&f32_data, &signs1, &signs2), QuantType::MQ4G256, "MQ4-MM")
+                };
+                let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
+                eprintln!("  {label:>8}: {} {:?} ({:.1} KB → {:.1} KB)",
+                    name, meta.shape,
+                    raw_data.len() as f64 / 1024.0, q.len() as f64 / 1024.0);
+                hfq_tensors.push(HfqTensor {
+                    name: name.to_string(),
+                    quant_type: qt,
+                    shape, group_size: 256, data: q, spilled_len: 0,
+                });
+                quantized_params += (meta.shape[0] * meta.shape[1]) as u64;
+                st_files[*file_idx].drop_tensor_pages(name);
+                if let Some(ref mut s) = spill {
+                    maybe_spill(&mut hfq_tensors, s, 2 * 1024 * 1024 * 1024);
+                }
+                continue;
+            }
+            // k not %256 → fall through to standard path (real MiniMax inter=1536,
+            // hidden=3072 are both %256, so this only guards degenerate tinies).
         }
 
         if is_moe

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -40,13 +40,14 @@ description = "Inference orchestrator for RDNA GPUs"
 # block below) which serves both as documentation of which features
 # each example needs and as the gate for downstream library consumers
 # who attempt to build examples through their own build script.
-default = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-dots-ocr", "deltanet"]
+default = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-minimax", "arch-dots-ocr", "deltanet"]
 deltanet = ["rdna-compute/deltanet"]
 arch-qwen35 = []
 arch-qwen35-vl = []
 arch-llama = []
 arch-qwen2 = []
 arch-deepseek4 = []
+arch-minimax = []
 arch-dots-ocr = []
 
 [dependencies]
@@ -96,6 +97,7 @@ hipfire-arch-qwen35-vl = { path = "../hipfire-arch-qwen35-vl" }
 hipfire-arch-llama = { path = "../hipfire-arch-llama" }
 hipfire-arch-qwen2 = { path = "../hipfire-arch-qwen2" }
 hipfire-arch-deepseek4 = { path = "../hipfire-arch-deepseek4" }
+hipfire-arch-minimax = { path = "../hipfire-arch-minimax" }
 hipfire-arch-dots-ocr = { path = "../hipfire-arch-dots-ocr" }
 hipfire-detect = { path = "../hipfire-detect" }
 hipfire-atlas = { path = "../hipfire-atlas" }
@@ -111,7 +113,7 @@ hipfire-atlas = { path = "../hipfire-atlas" }
 
 [[example]]
 name = "daemon"
-required-features = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-dots-ocr"]
+required-features = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-minimax", "arch-dots-ocr"]
 
 [[example]]
 name = "hfq_split"

--- a/crates/hipfire-runtime/examples/bench_gemv_q8_shapes.rs
+++ b/crates/hipfire-runtime/examples/bench_gemv_q8_shapes.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Self-contained Q8_0 GEMV bandwidth microbench at MiniMax-M2.7 decode shapes.
+//! No model/GGUF dependency — synthetic random Q8_0 data. Measures achieved
+//! GB/s per dense-projection shape so we know how close gemv_q8_0 already is to
+//! the gfx1151 memory roofline (decides whether the multirow ILP lever has room).
+//!
+//! Run on hipx with HIP_VISIBLE_DEVICES=1 (gfx1151).
+
+fn make_q8(m: usize, k: usize) -> Vec<u8> {
+    // Q8_0 block = 2-byte f16 scale + 32 int8 = 34 bytes / 32 weights.
+    let nblk = m * (k / 32);
+    let mut buf = vec![0u8; nblk * 34];
+    // scale = 1.0 in f16 = 0x3C00; qvals = deterministic sawtooth (data-independent timing).
+    for blk in 0..nblk {
+        let o = blk * 34;
+        buf[o] = 0x00;
+        buf[o + 1] = 0x3C;
+        for i in 0..32 {
+            buf[o + 2 + i] = ((blk + i) % 17) as u8;
+        }
+    }
+    buf
+}
+
+fn bench_shape(gpu: &mut rdna_compute::Gpu, name: &str, m: usize, k: usize, roofline: f64) {
+    let x: Vec<f32> = (0..k).map(|i| ((i % 7) as f32 - 3.0) * 0.01).collect();
+    let d_x = gpu.upload_f32(&x, &[k]).unwrap();
+    let d_y = gpu.zeros(&[m], rdna_compute::DType::F32).unwrap();
+    let bytes = (m * (k / 32) * 34 + k * 4) as f64;
+    let shape_bytes = m * (k / 32) * 34;
+
+    // WARM: one buffer reused (cache-resident if it fits MALL) — the naive/inflated number.
+    let q8 = make_q8(m, k);
+    let d_q8 = gpu.upload_raw(&q8, &[q8.len()]).unwrap();
+    let n_warm = 50;
+    let n_iter = 300;
+    for _ in 0..n_warm {
+        gpu.gemv_q8_0(&d_q8, &d_x, &d_y, m, k).unwrap();
+    }
+    let start = gpu.hip.event_create().unwrap();
+    let stop = gpu.hip.event_create().unwrap();
+    gpu.hip.event_record(&start, None).unwrap();
+    for _ in 0..n_iter {
+        gpu.gemv_q8_0(&d_q8, &d_x, &d_y, m, k).unwrap();
+    }
+    gpu.hip.event_record(&stop, None).unwrap();
+    gpu.hip.event_synchronize(&stop).unwrap();
+    let ms_w = gpu.hip.event_elapsed_ms(&start, &stop).unwrap();
+    let us_w = ms_w * 1000.0 / n_iter as f32;
+    let bw_w = bytes * n_iter as f64 / (ms_w as f64 / 1000.0) / 1e9;
+
+    // COLD: cycle through enough distinct buffers (>~160MB total) that any one is
+    // evicted from MALL before it's revisited → measures real per-token DRAM cost.
+    let n_slots = (((192 * 1024 * 1024) / shape_bytes.max(1)) + 1).max(4);
+    let slots: Vec<_> = (0..n_slots)
+        .map(|s| {
+            // perturb each slot's bytes so they're distinct allocations
+            let mut q = make_q8(m, k);
+            q[0] = (s & 0xff) as u8;
+            gpu.upload_raw(&q, &[q.len()]).unwrap()
+        })
+        .collect();
+    for i in 0..n_warm {
+        gpu.gemv_q8_0(&slots[i % n_slots], &d_x, &d_y, m, k).unwrap();
+    }
+    gpu.hip.event_record(&start, None).unwrap();
+    for i in 0..n_iter {
+        gpu.gemv_q8_0(&slots[i % n_slots], &d_x, &d_y, m, k).unwrap();
+    }
+    gpu.hip.event_record(&stop, None).unwrap();
+    gpu.hip.event_synchronize(&stop).unwrap();
+    let ms_c = gpu.hip.event_elapsed_ms(&start, &stop).unwrap();
+    let us_c = ms_c * 1000.0 / n_iter as f32;
+    let bw_c = bytes * n_iter as f64 / (ms_c as f64 / 1000.0) / 1e9;
+    let pct_c = bw_c / roofline * 100.0;
+
+    eprintln!(
+        "{:<10} M={:>6} K={:>5} | warm {:>7.1}us {:>6.1}GB/s | COLD {:>7.1}us {:>6.1}GB/s {:>5.1}%roof ({} slots)",
+        name, m, k, us_w, bw_w, us_c, bw_c, pct_c, n_slots
+    );
+}
+
+fn main() {
+    let mut gpu = rdna_compute::Gpu::init().expect("GPU init");
+    eprintln!("arch = {}", gpu.arch);
+    // Roofline probe first: a huge-M shape is maximally BW-bound (tons of blocks),
+    // so its GB/s ~ practical read roofline for this access pattern. Use it to
+    // normalize the others.
+    eprintln!("\n--- roofline probe (huge M, K=3072) ---");
+    // measure raw, roofline=1 so pct prints as the GB/s number itself
+    bench_shape(&mut gpu, "roof", 65536, 3072, 1.0);
+    eprintln!("(read the 'GB/s' above as the practical roofline; re-run mentally)\n");
+
+    // Use a conservative 256 GB/s LPDDR5x theoretical as the % denominator.
+    let roof = 256.0;
+    eprintln!("--- MiniMax-M2.7 decode dense-Q8 shapes (% of {:.0} GB/s theoretical) ---", roof);
+    bench_shape(&mut gpu, "q_proj", 6144, 3072, roof);
+    bench_shape(&mut gpu, "k_proj", 1024, 3072, roof);
+    bench_shape(&mut gpu, "v_proj", 1024, 3072, roof);
+    bench_shape(&mut gpu, "o_proj", 3072, 6144, roof);
+    bench_shape(&mut gpu, "router", 256, 3072, roof);
+    bench_shape(&mut gpu, "lm_head", 200064, 3072, roof);
+}

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -28,6 +28,7 @@ use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama;
 use hipfire_runtime::multi_gpu::Gpus;
 use hipfire_arch_deepseek4 as deepseek4;
+use hipfire_arch_minimax as minimax;
 use hipfire_arch_llama::Llama;
 use hipfire_arch_qwen2::qwen2;
 use hipfire_arch_dots_ocr::dots_ocr;
@@ -607,6 +608,17 @@ struct LoadedModel {
     /// Falls back to 1 (DeepSeek family default) if the tokenizer lacks
     /// the special-token entry.
     deepseek4_eos_tok: u32,
+    // MiniMax-M2 state (arch_id=10 — hipfire-arch-minimax). Mixtral-style
+    // MoE: GQA + per-layer QK-norm + partial RoPE + sigmoid-bias top-k
+    // routing, no shared expert. KV cache lives inside MiniMaxState; no
+    // separate field. NO PrefillBatchScratch — prefill is the per-token
+    // `decode_step` loop. None on every other arch path.
+    minimax_config: Option<hipfire_arch_minimax::MiniMaxConfig>,
+    minimax_weights: Option<hipfire_arch_minimax::MiniMaxWeights>,
+    minimax_state: Option<hipfire_arch_minimax::MiniMaxState>,
+    /// Cached EOS token id resolved at load time. Falls back to 1 if the
+    /// tokenizer lacks the special-token entry.
+    minimax_eos_tok: u32,
     // dots.ocr state (arch_id=8 — Qwen2-VL family). The text decoder is
     // Qwen2: `dots_ocr_config.text` / `dots_ocr_weights.text` feed
     // `qwen2::forward_step*`, and the per-step decode state reuses the
@@ -1017,6 +1029,7 @@ fn main() {
                             7 => "qwen2",
                             8 => "dots-ocr",
                             9 => "deepseek4",
+                            10 => "minimax_m2",
                             _ => "qwen3",
                         };
                         let vl = m.vision_config.is_some() || m.dots_ocr_config.is_some();
@@ -1028,6 +1041,8 @@ fn main() {
                             (c.hidden_size, c.num_hidden_layers, c.vocab_size)
                         } else if let Some(ref c) = m.dots_ocr_config {
                             (c.text.hidden_size, c.text.num_hidden_layers, c.text.vocab_size)
+                        } else if let Some(ref c) = m.minimax_config {
+                            (c.hidden_size, c.num_hidden_layers, c.vocab_size)
                         } else { (0, 0, 0) };
                         // ── Optional DPM stabilization (perf instrumentation) ──
                         //
@@ -1241,7 +1256,12 @@ fn main() {
                 // model. Pick arch-shaped defaults so a vanilla
                 // `/v1/chat/completions` POST (no sampling fields) works on
                 // both. Explicit per-request values still override either.
-                let (default_temp, default_top_p) = if m.arch_id == 9 {
+                let (default_temp, default_top_p) = if m.arch_id == 9 || m.arch_id == 10 {
+                    // DeepSeek V4 (9) + MiniMax-M2 (10): quantized instruct
+                    // MoE models that fall into block-level attractors under
+                    // pure greedy. Default to the HF-recommended sampling
+                    // (temp=1.0, top_p=1.0); explicit per-request values
+                    // still override.
                     (1.0_f64, 1.0_f64)
                 } else {
                     (0.3_f64, 0.8_f64)
@@ -1511,6 +1531,10 @@ fn main() {
                         // rather than jumping straight back to replay.
                         gpu.invalidate_graph_state();
                     }
+                    // arch_id=10 (MiniMax-M2): clear KV cursor between turns.
+                    // No captured hipGraph on this path, so no graph
+                    // invalidation needed.
+                    if let Some(ref mut s) = m.minimax_state { s.reset(); }
                     let _ = writeln!(stdout, r#"{{"type":"reset","seq_pos":0}}"#);
                 } else {
                     let _ = writeln!(stdout, r#"{{"type":"error","message":"no model loaded"}}"#);
@@ -1558,6 +1582,7 @@ fn main() {
                     6 => "qwen3_5_moe",
                     7 => "qwen2",
                     9 => "deepseek4",
+                    10 => "minimax_m2",
                     _ => "qwen3",
                 }).unwrap_or("none");
                 // Count pre-compiled kernels
@@ -1634,6 +1659,9 @@ fn main() {
                 // and the per-step scratch share `Qwen2State`. Reset its position
                 // cursor here so bench_prefill measures cold prefill.
                 if let Some(ref mut s) = m.qwen2_state { s.reset(); }
+                // MiniMax-M2 (arch_id=10): same — KV cache + scratch share
+                // MiniMaxState; reset its cursor for a cold prefill bench.
+                if let Some(ref mut s) = m.minimax_state { s.reset(); }
 
                 // Flush any residual GPU work so it doesn't bleed into the
                 // measured interval, then time forward_prefill_batch + a
@@ -1676,6 +1704,24 @@ fn main() {
                     let mut ok = true;
                     for (i, &tok) in synthetic.iter().enumerate() {
                         if deepseek4::forward::decode_step(
+                            config, weights, state, &mut gpu, tok, i as u32,
+                        ).is_err() {
+                            ok = false;
+                            break;
+                        }
+                    }
+                    ok
+                } else if m.arch_id == 10 {
+                    // MiniMax-M2 warm-pass: per-token decode_step over the
+                    // synthetic prompt. Saturates the GQA + QK-norm + RoPE +
+                    // MoE kernel set before any user-facing generate. This
+                    // IS the production prefill shape (no batched kernel).
+                    let config = m.minimax_config.as_ref().unwrap();
+                    let weights = m.minimax_weights.as_ref().unwrap();
+                    let state = m.minimax_state.as_mut().unwrap();
+                    let mut ok = true;
+                    for (i, &tok) in synthetic.iter().enumerate() {
+                        if minimax::forward::decode_step(
                             config, weights, state, &mut gpu, tok, i as u32,
                         ).is_err() {
                             ok = false;
@@ -2044,6 +2090,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
             qwen2_config: Some(config), qwen2_weights: Some(weights), qwen2_state: Some(state),
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2089,6 +2136,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
             qwen2_config: None, qwen2_weights: None, qwen2_state: Some(state),
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             dots_ocr_config: Some(config), dots_ocr_weights: Some(weights),
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2151,6 +2199,69 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             qwen2_config: None, qwen2_weights: None, qwen2_state: None,
             deepseek4_config: Some(config), deepseek4_weights: Some(weights), deepseek4_state: Some(state),
             deepseek4_pbs: Some(pbs), deepseek4_eos_tok: eos_tok,
+            minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
+            dots_ocr_config: None, dots_ocr_weights: None,
+            vision_config: None, vision_weights: None,
+            tokenizer: Some(tokenizer),
+            seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None,
+            conversation_tokens: Vec::new(),
+            asst_turn_cache: std::collections::HashMap::new(), decoded_vocab: None,
+            model_path: path.to_string(),
+            dflash: None,
+            chat_template,
+        });
+    }
+
+    if hfq.arch_id == 10 {
+        // MiniMax-M2 (hipfire-arch-minimax). Standalone bring-up — no
+        // eviction, no DFlash drafter, no PFlash, no VL, no spec-decode.
+        // The Architecture trait gives us config + weights + state in three
+        // calls; prefill + decode both go through the per-token
+        // `minimax::forward::decode_step` in the generate hot path. There
+        // is NO PrefillBatchScratch (no batched prefill kernel).
+        if draft_path.is_some() {
+            return Err("DFlash not supported on arch_id=10 (MiniMax-M2). \
+                       Reload without a draft.".to_string());
+        }
+        if cask.sidecar.is_some() {
+            return Err("CASK eviction not supported on arch_id=10 (MiniMax-M2). \
+                       Reload without --cask-sidecar.".to_string());
+        }
+        if pp > 1 {
+            return Err("pipeline-parallel (pp>1) not supported on arch_id=10 (MiniMax-M2).".to_string());
+        }
+        let _ = kv_mode;
+        let _ = state_quant_override;
+        use hipfire_runtime::arch::Architecture;
+        let config = <minimax::MiniMaxM2 as Architecture>::config_from_hfq(&hfq)?;
+        let weights = <minimax::MiniMaxM2 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
+        // Size the KV cache to the requested window (the trait's new_state
+        // caps at 8192; honour the caller's max_seq when it's larger/smaller).
+        let state = minimax::MiniMaxState::new_with_max_seq(gpu, &config, max_seq)
+            .map_err(|e| format!("minimax: MiniMaxState::new_with_max_seq failed: {e}"))?;
+        // Resolve EOS via the tokenizer. MiniMax-M2 uses the standard
+        // ChatML-ish `<|im_end|>`; fall back to common alternates, then 1.
+        let eos_tok: u32 = {
+            let try_one = |s: &str| -> Option<u32> {
+                let ids = tokenizer.encode(s);
+                if ids.len() == 1 { Some(ids[0]) } else { None }
+            };
+            try_one("<|im_end|>")
+                .or_else(|| try_one("</s>"))
+                .or_else(|| try_one("<|endoftext|>"))
+                .unwrap_or(1)
+        };
+        let chat_template = resolve_chat_template(&hfq, path);
+        return Ok(LoadedModel {
+            arch_id: hfq.arch_id,
+            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
+            q35_config: None, q35_weights: None, q35_scratch: None,
+            kv_cache: None, dn_state: None,
+            llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
+            qwen2_config: None, qwen2_weights: None, qwen2_state: None,
+            deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            minimax_config: Some(config), minimax_weights: Some(weights), minimax_state: Some(state),
+            minimax_eos_tok: eos_tok,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2339,6 +2450,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
             qwen2_config: None, qwen2_weights: None, qwen2_state: None,
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config, vision_weights,
             tokenizer: Some(tokenizer),
@@ -2372,6 +2484,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             llama_config: Some(config), llama_weights: Some(weights), llama_scratch: Some(scratch), llama_kv: Some(kv),
             qwen2_config: None, qwen2_weights: None, qwen2_state: None,
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+            minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2465,6 +2578,10 @@ fn load_model_safetensors(
             deepseek4_state: None,
             deepseek4_pbs: None,
             deepseek4_eos_tok: 0,
+            minimax_config: None,
+            minimax_weights: None,
+            minimax_state: None,
+            minimax_eos_tok: 0,
             vision_config: None,
             vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2532,6 +2649,10 @@ fn load_model_safetensors(
         deepseek4_state: None,
         deepseek4_pbs: None,
         deepseek4_eos_tok: 0,
+        minimax_config: None,
+        minimax_weights: None,
+        minimax_state: None,
+        minimax_eos_tok: 0,
         vision_config: None,
         vision_weights: None,
         tokenizer: Some(tokenizer),
@@ -2668,6 +2789,7 @@ fn load_model_pp(
         llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
         qwen2_config: None, qwen2_weights: None, qwen2_state: None,
         deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+        minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
         dots_ocr_config: None, dots_ocr_weights: None,
         vision_config: None, vision_weights: None,
         tokenizer: Some(tokenizer),
@@ -2781,6 +2903,13 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     // eviction.
     if let Some(s) = m.deepseek4_state { s.free_gpu(gpu); }
     if let Some(pbs) = m.deepseek4_pbs { pbs.free_gpu(gpu); }
+    // MiniMax-M2 (arch_id=10): MiniMaxState / MiniMaxWeights expose no
+    // free_gpu in the scaffold, so they drop here without returning their
+    // device tensors to the pool. KNOWN LEAK on load/unload churn — there
+    // is no eviction wired for arch_id=10 yet, so the model stays resident
+    // for the daemon's lifetime in the bring-up scope. Add free_gpu to the
+    // minimax crate + explicit frees here when eviction lands.
+    let _ = (&m.minimax_state, &m.minimax_weights);
     // Weights are the bulk of VRAM (~80%). Free them too so idle eviction
     // actually returns VRAM to the system, not just the cache.
     if let Some(w) = m.q35_weights { w.free_gpu(gpu); }
@@ -4038,6 +4167,22 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         generate_deepseek4(
             m, gpu, stdout, id, prompt, system_prompt,
             temp, top_p, max_tokens, think_mode, tools, messages_history,
+        );
+        return;
+    }
+    if m.arch_id == 10 {
+        // arch_id=10 (MiniMax-M2). Minimal AR bring-up — same shape as the
+        // qwen2 / deepseek4 short-circuits above. PFlash / DFlash / VL /
+        // multi-GPU / sampler-budget / grammar / tools-execution all bypass.
+        // We honour `system_prompt`, `temp`, `top_p`, and (via JinjaChatFrame)
+        // `messages_history` + `tools` rendering; spec-decode / MTP / grammar
+        // are out of scope for the scaffold.
+        let _ = (budget_alert_at_tok, budget_alert_text, assistant_prefix,
+                 pflash_state, pflash_cfg, repeat_penalty, repeat_window,
+                 think_mode);
+        generate_minimax(
+            m, gpu, stdout, id, prompt, system_prompt,
+            temp, top_p, max_tokens, max_think_tokens, tools, messages_history,
         );
         return;
     }
@@ -6133,6 +6278,246 @@ fn generate_qwen2(
     let decode_ms = decode_t0.elapsed().as_millis().max(1);
     let total_ms = t0.elapsed().as_millis().max(1);
     let tok_s = if generated_count > 0 && decode_ms > 0 {
+        (generated_count as f64 * 1000.0) / decode_ms as f64
+    } else {
+        0.0
+    };
+    let _ = writeln!(
+        stdout,
+        r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.2},"prefill_ms":{},"total_ms":{}}}"#,
+        id, generated_count, tok_s, prefill_ms, total_ms,
+    );
+    let _ = stdout.flush();
+}
+
+/// MiniMax-M2 (arch_id=10) generate path — minimal AR bring-up.
+///
+/// Mirrors `generate_qwen2`'s shape (prefill = per-token loop, decode =
+/// per-token loop, JSONL `token` / `done` events) with two differences:
+///
+///   1. Prompt build goes through `JinjaChatFrame` when `HIPFIRE_JINJA_CHAT=1`
+///      and the model carries a chat_template (so MiniMax-M2's own ChatML-ish
+///      template + `tools` / `messages` reach the upstream Jinja branches),
+///      falling back to the hand-rolled `ChatFrame::Plain` scaffold otherwise.
+///   2. `minimax::forward::decode_step` returns the full logits `Vec<f32>`
+///      (the state does NOT stash a greedy next-token), so sampling runs
+///      host-side via `deepseek4::sampling::sample_token` on that vector.
+///
+/// Out of scope for the scaffold (and intentionally NOT wired): spec-decode,
+/// MTP, grammar-constrained decoding, tool-call parsing/execution, repeat
+/// penalty, multi-GPU, eviction/prefix-cache. Correctness first.
+#[allow(clippy::too_many_arguments)]
+fn generate_minimax(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    temp: f32,
+    top_p: f32,
+    max_tokens: usize,
+    max_think_tokens: usize,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+) {
+    if m.tokenizer.is_none() {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"tokenizer not loaded"}}"#, id);
+        let _ = stdout.flush();
+        return;
+    }
+    if m.minimax_config.is_none() {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"minimax_config missing on arch_id=10 generate"}}"#, id);
+        let _ = stdout.flush();
+        return;
+    }
+
+    // ── Prompt build (same two-path branch as the qwen35 AR path) ──
+    let prompt_ids: Vec<u32> = {
+        let tokenizer = m.tokenizer.as_ref().unwrap();
+        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
+        let try_jinja = jinja_enabled && m.chat_template.is_some();
+        if try_jinja {
+            let template = m.chat_template.as_ref().unwrap();
+            let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+                tokenizer,
+                template,
+                system: system_prompt,
+                user: prompt,
+                enable_thinking: max_think_tokens != 1,
+                bos_token: None,
+            };
+            let render_result = if tools.is_some() || messages_history.is_some() {
+                let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;
+                let messages_slice: &[hipfire_runtime::prompt_frame::Message] = match messages_history {
+                    Some(h) => h,
+                    None => {
+                        let mut v = Vec::new();
+                        if let Some(sys) = system_prompt {
+                            v.push(hipfire_runtime::prompt_frame::Message {
+                                role: hipfire_runtime::prompt_frame::Role::System,
+                                content: sys.to_string(),
+                                tool_calls: Vec::new(),
+                                tool_call_id: None,
+                            });
+                        }
+                        v.push(hipfire_runtime::prompt_frame::Message {
+                            role: hipfire_runtime::prompt_frame::Role::User,
+                            content: prompt.to_string(),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                        synthesized = v;
+                        &synthesized
+                    }
+                };
+                frame.render_messages(messages_slice, tools, None)
+            } else {
+                frame.render()
+            };
+            match render_result {
+                Ok(rendered) => tokenizer.encode(&rendered),
+                Err(e) => {
+                    eprintln!("[daemon] jinja render failed in minimax path ({e}) — falling back to Plain");
+                    hipfire_runtime::prompt_frame::ChatFrame {
+                        tokenizer,
+                        system: system_prompt,
+                        user: prompt,
+                        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                        raw: false,
+                    }
+                    .build()
+                }
+            }
+        } else {
+            hipfire_runtime::prompt_frame::ChatFrame {
+                tokenizer,
+                system: system_prompt,
+                user: prompt,
+                assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                raw: false,
+            }
+            .build()
+        }
+    };
+
+    if prompt_ids.is_empty() {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"empty prompt after tokenize"}}"#, id);
+        let _ = stdout.flush();
+        return;
+    }
+
+    let eos_tok = m.minimax_eos_tok;
+
+    // Capacity guard. No eviction on arch_id=10 — reset the KV cursor when
+    // the requested run would overflow the budget. (max_seq + n_tokens live
+    // on the state.)
+    let overflow = {
+        let state = m.minimax_state.as_ref().unwrap();
+        state.n_tokens + prompt_ids.len() + max_tokens > state.max_seq
+    };
+    if overflow {
+        let (n, cap) = {
+            let state = m.minimax_state.as_ref().unwrap();
+            (state.n_tokens, state.max_seq)
+        };
+        eprintln!(
+            "[daemon] arch_id=10 context full ({n}/{cap}) — resetting MiniMaxState",
+        );
+        m.minimax_state.as_mut().unwrap().reset();
+        m.seq_pos = 0;
+        m.conversation_tokens.clear();
+    }
+
+    let t0 = Instant::now();
+
+    // ── Prefill: decode_step per prompt token. Disjoint field borrows of
+    // `m` (config / weights / state) let us also push to
+    // `m.conversation_tokens` in the same scope (same pattern as
+    // generate_qwen2). The LAST decode_step's logits are the predictions
+    // for the first generated token. ──
+    let mut last_logits: Vec<f32> = Vec::new();
+    {
+        let cfg = m.minimax_config.as_ref().unwrap();
+        let weights = m.minimax_weights.as_ref().unwrap();
+        let state = m.minimax_state.as_mut().unwrap();
+        let mut position = state.n_tokens as u32;
+        for &tok in &prompt_ids {
+            match minimax::forward::decode_step(cfg, weights, state, gpu, tok, position) {
+                Ok(logits) => last_logits = logits,
+                Err(e) => {
+                    emit_error_with_id(stdout, id, format!("minimax prefill failed: {e:?}"));
+                    return;
+                }
+            }
+            position += 1;
+        }
+    }
+    for &tok in &prompt_ids {
+        m.conversation_tokens.push(tok);
+    }
+    let prefill_ms = t0.elapsed().as_millis();
+
+    // ── Decode loop. Sample host-side from the running logits vector.
+    // `temp <= 0` makes sample_token greedy; otherwise top_p nucleus.
+    // Seed the PRNG from wall-clock nanos so successive same-prompt runs
+    // don't lock-step (greedy is still deterministic). ──
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9E3779B97F4A7C15);
+    let mut rng = deepseek4::sampling::Xorshift::new(seed);
+
+    let mut generated_count: usize = 0;
+    let decode_t0 = Instant::now();
+    loop {
+        if generated_count >= max_tokens {
+            break;
+        }
+        // Sample next token from the most recent logits.
+        let next_tok = deepseek4::sampling::sample_token(&last_logits, temp, 0, top_p, &mut rng);
+        if next_tok == eos_tok {
+            break;
+        }
+
+        // Emit the text fragment. Build through serde_json so a user-supplied
+        // `id` or arbitrary-UTF-8 fragment can't corrupt the JSONL line.
+        let frag = {
+            let tokenizer = m.tokenizer.as_ref().unwrap();
+            tokenizer.decode(&[next_tok])
+        };
+        let envelope = serde_json::json!({
+            "type": "token",
+            "id": id,
+            "text": frag,
+        });
+        let _ = writeln!(stdout, "{}", envelope);
+        let _ = stdout.flush();
+        m.conversation_tokens.push(next_tok);
+        generated_count += 1;
+
+        // Advance one step on the freshly sampled token.
+        let step = {
+            let cfg = m.minimax_config.as_ref().unwrap();
+            let weights = m.minimax_weights.as_ref().unwrap();
+            let state = m.minimax_state.as_mut().unwrap();
+            let position = state.n_tokens as u32;
+            minimax::forward::decode_step(cfg, weights, state, gpu, next_tok, position)
+        };
+        match step {
+            Ok(logits) => last_logits = logits,
+            Err(e) => {
+                emit_error_with_id(stdout, id, format!("minimax decode failed: {e:?}"));
+                return;
+            }
+        }
+    }
+
+    m.seq_pos = m.minimax_state.as_ref().unwrap().n_tokens;
+
+    let decode_ms = decode_t0.elapsed().as_millis().max(1);
+    let total_ms = t0.elapsed().as_millis().max(1);
+    let tok_s = if generated_count > 0 {
         (generated_count as f64 * 1000.0) / decode_ms as f64
     } else {
         0.0

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1863,7 +1863,11 @@ fn resolve_chat_template(
     }
 
     // 3. HFQ-embedded.
-    hfq.chat_template()
+    let tpl = hfq.chat_template();
+    if tpl.is_some() {
+        eprintln!("[chat_template] using HFQ-embedded tokenizer_config.chat_template");
+    }
+    tpl
 }
 
 fn parse_state_quant(mode: Option<&str>) -> Result<hipfire_arch_qwen35::qwen35::StateQuant, String> {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -6522,16 +6522,40 @@ fn generate_minimax(
         let cfg = m.minimax_config.as_ref().unwrap();
         let weights = m.minimax_weights.as_ref().unwrap();
         let state = m.minimax_state.as_mut().unwrap();
-        let mut position = state.n_tokens as u32;
-        for &tok in &prompt_ids {
-            match minimax::forward::decode_step(cfg, weights, state, gpu, tok, position) {
-                Ok(logits) => last_logits = logits,
-                Err(e) => {
-                    emit_error_with_id(stdout, id, format!("minimax prefill failed: {e:?}"));
-                    return;
+        // Batched prefill: process the prompt in chunks of <=64 tokens through
+        // the batched verify forward (one weight read per chunk vs one
+        // decode_step per token) → much lower TTFT. Validated byte-identical to
+        // the sequential path (cosine 1.0). DEFAULT ON when every layer's expert
+        // dtypes have batched kernels; the pre-check routes unsupported tiers
+        // (MQ3-Lloyd etc.) to the sequential path to avoid a mid-pass error.
+        // Force off with HIPFIRE_MINIMAX_BATCH_PREFILL=0.
+        let batch_prefill = std::env::var_os("HIPFIRE_MINIMAX_BATCH_PREFILL")
+            .map_or(true, |v| v != "0")
+            && minimax::forward::forward_batch_supported(weights);
+        if batch_prefill && !prompt_ids.is_empty() {
+            let mut pos = state.n_tokens;
+            for chunk in prompt_ids.chunks(64) {
+                match minimax::forward::forward_batch(cfg, weights, state, gpu, chunk, pos) {
+                    Ok(logits) => last_logits = logits,
+                    Err(e) => {
+                        emit_error_with_id(stdout, id, format!("minimax batch prefill failed: {e:?}"));
+                        return;
+                    }
                 }
+                pos += chunk.len();
             }
-            position += 1;
+        } else {
+            let mut position = state.n_tokens as u32;
+            for &tok in &prompt_ids {
+                match minimax::forward::decode_step(cfg, weights, state, gpu, tok, position) {
+                    Ok(logits) => last_logits = logits,
+                    Err(e) => {
+                        emit_error_with_id(stdout, id, format!("minimax prefill failed: {e:?}"));
+                        return;
+                    }
+                }
+                position += 1;
+            }
         }
     }
     for &tok in &prompt_ids {
@@ -6602,7 +6626,9 @@ fn generate_minimax(
             let weights = m.minimax_weights.as_ref().unwrap();
             let state = m.minimax_state.as_mut().unwrap();
             let position = state.n_tokens as u32;
-            minimax::forward::decode_step(cfg, weights, state, gpu, next_tok, position)
+            // hipGraph decode (gfx11/gfx12 default; HIPFIRE_MINIMAX_GRAPH=0 to
+            // force eager). First call warms up eager, then captures + replays.
+            minimax::forward::decode_step_with_graph(cfg, weights, state, gpu, next_tok, position)
         };
         match step {
             Ok(logits) => last_logits = logits,

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2243,14 +2243,22 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // caps at 8192; honour the caller's max_seq when it's larger/smaller).
         let state = minimax::MiniMaxState::new_with_max_seq(gpu, &config, max_seq)
             .map_err(|e| format!("minimax: MiniMaxState::new_with_max_seq failed: {e}"))?;
-        // Resolve EOS via the tokenizer. MiniMax-M2 uses the standard
-        // ChatML-ish `<|im_end|>`; fall back to common alternates, then 1.
+        // Resolve EOS via the tokenizer. MiniMax-M2 does NOT use ChatML —
+        // its end-of-turn marker is the added token `[e~[` (id 200020 in the
+        // 200k vocab; tokenizer_config.json eos_token = `[e~[`,
+        // generation_config.json eos_token_id = 200020). The earlier ChatML
+        // probes (`<|im_end|>` etc.) are absent from this vocab and silently
+        // fell back to token 1, so generate_minimax never hit EOS: every turn
+        // ran to max_tokens and the model spammed `[e~[` trying to end the
+        // turn. Probe the real marker first; keep the ChatML fallbacks for
+        // safety on any future tokenizer variant.
         let eos_tok: u32 = {
             let try_one = |s: &str| -> Option<u32> {
                 let ids = tokenizer.encode(s);
                 if ids.len() == 1 { Some(ids[0]) } else { None }
             };
-            try_one("<|im_end|>")
+            try_one("[e~[")
+                .or_else(|| try_one("<|im_end|>"))
                 .or_else(|| try_one("</s>"))
                 .or_else(|| try_one("<|endoftext|>"))
                 .unwrap_or(1)
@@ -6337,6 +6345,11 @@ fn generate_minimax(
     }
 
     // ── Prompt build (same two-path branch as the qwen35 AR path) ──
+    // `primed_think` records whether the rendered prompt actually ended with
+    // the MiniMax `<think>` generation-primer, so we only re-emit the opener
+    // (below) when the model truly begins inside the reasoning block. A jinja
+    // render failure that falls back to the Plain frame leaves it false.
+    let mut primed_think = false;
     let prompt_ids: Vec<u32> = {
         let tokenizer = m.tokenizer.as_ref().unwrap();
         let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
@@ -6380,7 +6393,10 @@ fn generate_minimax(
                 frame.render()
             };
             match render_result {
-                Ok(rendered) => tokenizer.encode(&rendered),
+                Ok(rendered) => {
+                    primed_think = rendered.trim_end().ends_with("<think>");
+                    tokenizer.encode(&rendered)
+                }
                 Err(e) => {
                     eprintln!("[daemon] jinja render failed in minimax path ({e}) — falling back to Plain");
                     hipfire_runtime::prompt_frame::ChatFrame {
@@ -6461,6 +6477,25 @@ fn generate_minimax(
         m.conversation_tokens.push(tok);
     }
     let prefill_ms = t0.elapsed().as_millis();
+
+    // MiniMax-M2's chat template unconditionally primes the assistant turn
+    // with `<think>\n` (chat_template.jinja generation-prompt block), so the
+    // model's GENERATED tokens begin *inside* the reasoning block and it only
+    // ever emits the closing `</think>`. Every downstream `<think>` consumer —
+    // the serve reasoning_content/content split, the run/chat-path stripper,
+    // and the history `stripThinkingInline` — keys on a LEADING `<think>` and
+    // so never engages, leaking the chain-of-thought into `message.content`.
+    // The primer is already in the KV from prefill; re-emit it into the token
+    // stream (display-only, not pushed to state) so the assistant message is a
+    // well-formed `<think>...</think>...` block for every consumer.
+    if primed_think {
+        let _ = writeln!(
+            stdout,
+            "{}",
+            serde_json::json!({"type": "token", "id": id, "text": "<think>\n"}),
+        );
+        let _ = stdout.flush();
+    }
 
     // ── Decode loop. Sample host-side from the running logits vector.
     // `temp <= 0` makes sample_token greedy; otherwise top_p nucleus.

--- a/crates/hipfire-runtime/examples/debug_minimax_batch.rs
+++ b/crates/hipfire-runtime/examples/debug_minimax_batch.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Pinpoint forward_batch correctness: compare forward_batch (B tokens, one
+//! pass) last-token logits to the matching sequential decode_step logits.
+//! B=1 isolating a per-call/layout bug from a multi-row batching bug.
+
+use hipfire_arch_minimax as minimax;
+use hipfire_runtime::arch::Architecture;
+use hipfire_runtime::hfq::HfqFile;
+use std::path::Path;
+
+fn argmax(v: &[f32]) -> usize {
+    let mut bi = 0usize;
+    let mut bv = f32::NEG_INFINITY;
+    for (i, &x) in v.iter().enumerate() {
+        if x > bv {
+            bv = x;
+            bi = i;
+        }
+    }
+    bi
+}
+fn cosine(a: &[f32], b: &[f32]) -> f64 {
+    let (mut dot, mut na, mut nb) = (0.0f64, 0.0f64, 0.0f64);
+    for i in 0..a.len().min(b.len()) {
+        dot += a[i] as f64 * b[i] as f64;
+        na += (a[i] as f64) * (a[i] as f64);
+        nb += (b[i] as f64) * (b[i] as f64);
+    }
+    dot / (na.sqrt() * nb.sqrt() + 1e-12)
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: debug_minimax_batch <model.hfq>");
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(Path::new(&path)).expect("open model");
+    let config = <minimax::MiniMaxM2 as Architecture>::config_from_hfq(&hfq).expect("config");
+    let weights =
+        <minimax::MiniMaxM2 as Architecture>::load_weights(&mut hfq, &config, &mut gpu).expect("weights");
+    let mut state =
+        minimax::MiniMaxState::new_with_max_seq(&mut gpu, &config, 4096).expect("state");
+
+    let toks: Vec<u32> = vec![1u32, 1037, 2055, 3000, 410, 5202, 666, 7777];
+
+    // Sequential reference.
+    let mut seq_logits: Vec<Vec<f32>> = Vec::new();
+    state.reset();
+    for (i, &t) in toks.iter().enumerate() {
+        let l = minimax::forward::decode_step(&config, &weights, &mut state, &mut gpu, t, i as u32)
+            .expect("decode_step");
+        seq_logits.push(l);
+    }
+    eprintln!("sequential done; vocab={}", seq_logits[0].len());
+
+    for &b in &[1usize, 2, 4, 8] {
+        state.reset();
+        let bl = minimax::forward::forward_batch(&config, &weights, &mut state, &mut gpu, &toks[..b], 0)
+            .expect("forward_batch");
+        let am_b = argmax(&bl);
+        let am_s = argmax(&seq_logits[b - 1]);
+        let cos = cosine(&bl, &seq_logits[b - 1]);
+        eprintln!(
+            "B={:>2}: last-tok argmax batch={:>6} seq={:>6} match={:>5}  cosine={:.6}",
+            b,
+            am_b,
+            am_s,
+            am_b == am_s,
+            cos
+        );
+    }
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -224,7 +224,11 @@ impl DType {
     /// quant time — this helper governs only whether the loader
     /// attaches an already-emitted sidecar.
     pub fn supports_awq_sidecar(self) -> bool {
-        matches!(self, DType::MQ4G256 | DType::MQ3G256)
+        // MQ3G256Lloyd / MQ2G256Lloyd added 2026-05-28: they are "forward-path-ready"
+        // (flow through rotate_x_mq_for, which applies x/=awq_scale when a sidecar is
+        // attached) — see the doc block above. Enables AWQ×Lloyd composition once the
+        // quantizer emits sidecars for the Lloyd arms.
+        matches!(self, DType::MQ4G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ3G256Lloyd | DType::MQ2G256Lloyd)
     }
 }
 

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -33172,6 +33172,120 @@ impl Gpu {
         result
     }
 
+    /// MiniMax-M2 fused MoE gate_up GEMV for MQ3-Lloyd experts (3-bit +
+    /// 8-entry codebook, 112 B/group). Sibling of
+    /// `deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed` — identical grid +
+    /// expert-ptrs dispatch; only the per-group byte stride differs (112 vs 72).
+    #[allow(clippy::too_many_arguments)]
+    pub fn deepseek4_gemv_mq3g256_lloyd_moe_gate_up_indexed(
+        &mut self,
+        expert_ptrs: &GpuTensor,    // [n_exp] u64 device pointers
+        topk_indices: &GpuTensor,   // [k_top] i32
+        x_rot: &GpuTensor,          // [K] FWHT-rotated
+        y_gate: &GpuTensor,         // [k_top × M/2]
+        y_up:   &GpuTensor,         // [k_top × M/2]
+        m: usize, k: usize, k_top: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemv_mq3g256_lloyd_moe_gate_up_indexed",
+            kernels::GEMV_MQ3G256_LLOYD_MOE_GATE_UP_INDEXED_SRC,
+            "gemv_mq3g256_lloyd_moe_gate_up_k8_indexed",
+        )?;
+        let pp = expert_ptrs.buf.as_ptr();
+        let ip = topk_indices.buf.as_ptr();
+        let xp = x_rot.buf.as_ptr();
+        let ygp = y_gate.buf.as_ptr();
+        let yup = y_up.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &pp as *const _ as *mut c_void,
+            &ip as *const _ as *mut c_void,
+            &xp as *const _ as *mut c_void,
+            &ygp as *const _ as *mut c_void,
+            &yup as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+        ];
+        // MQ3-Lloyd: 112 bytes / 256-weight group.
+        let mq3_weight_bytes = m * (k / 256) * 112;
+        let bytes = (k_top as usize) * (mq3_weight_bytes + k * 4 + m * 4);
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemv", "deepseek4_gemv_mq3g256_lloyd_moe_gate_up_indexed", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemv_mq3g256_lloyd_moe_gate_up_k8_indexed",
+            [m as u32, k_top as u32, 1], [32, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(pp); b.push_ptr(ip); b.push_ptr(xp);
+                b.push_ptr(ygp); b.push_ptr(yup);
+                b.push_i32(m_val); b.push_i32(k_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
+    /// MiniMax-M2 fused MoE down GEMV with scaled residual add for MQ3-Lloyd
+    /// experts (3-bit + 8-entry codebook, 112 B/group). Sibling of
+    /// `deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed` — only
+    /// the per-group byte stride differs (112 vs 72).
+    #[allow(clippy::too_many_arguments)]
+    pub fn deepseek4_gemv_mq3g256_lloyd_moe_down_residual_scaled_indexed(
+        &mut self,
+        expert_ptrs: &GpuTensor,
+        topk_indices: &GpuTensor,
+        topk_weights: &GpuTensor,
+        rot_batch: &GpuTensor,      // [k_top × K]
+        x_residual: &GpuTensor,     // [M]
+        m: usize, k: usize, k_top: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemv_mq3g256_lloyd_moe_down_indexed",
+            kernels::GEMV_MQ3G256_LLOYD_MOE_DOWN_INDEXED_SRC,
+            "gemv_mq3g256_lloyd_moe_down_residual_scaled_k8_indexed",
+        )?;
+        let pp  = expert_ptrs.buf.as_ptr();
+        let ip  = topk_indices.buf.as_ptr();
+        let wp  = topk_weights.buf.as_ptr();
+        let rbp = rot_batch.buf.as_ptr();
+        let xrp = x_residual.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &pp  as *const _ as *mut c_void,
+            &ip  as *const _ as *mut c_void,
+            &wp  as *const _ as *mut c_void,
+            &rbp as *const _ as *mut c_void,
+            &xrp as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+        ];
+        // MQ3-Lloyd: 112 bytes / 256-weight group.
+        let mq3_weight_bytes = m * (k / 256) * 112;
+        let bytes = (k_top as usize) * (mq3_weight_bytes + k * 4 + m * 4);
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemv", "deepseek4_gemv_mq3g256_lloyd_moe_down_residual_scaled_indexed", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemv_mq3g256_lloyd_moe_down_residual_scaled_k8_indexed",
+            [m as u32, k_top as u32, 1], [32, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(pp); b.push_ptr(ip); b.push_ptr(wp);
+                b.push_ptr(rbp); b.push_ptr(xrp);
+                b.push_i32(m_val); b.push_i32(k_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// K4-unrolled variant of
     /// `deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed_batched`.
     /// 4 independent accumulators per thread for ILP. FMA-order-epsilon

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2596,6 +2596,16 @@ pub const GEMV_MQ2G256_LLOYD_MOE_GATE_UP_INDEXED_SRC: &str =
 pub const GEMV_MQ2G256_LLOYD_MOE_DOWN_INDEXED_SRC: &str =
     include_str!("../../../kernels/src/gemv_mq2g256_lloyd_moe_down_indexed.hip");
 
+/// MQ3-Lloyd MoE indexed family: routed-experts gate_up + down with
+/// device-side topk routing + per-expert pointer table. Mirrors the
+/// MQ2-Lloyd MoE indexed kernels (3-bit + 8-entry codebook, 112 B/group).
+/// X must be FWHT-pre-rotated by the caller.
+pub const GEMV_MQ3G256_LLOYD_MOE_GATE_UP_INDEXED_SRC: &str =
+    include_str!("../../../kernels/src/gemv_mq3g256_lloyd_moe_gate_up_indexed.hip");
+
+pub const GEMV_MQ3G256_LLOYD_MOE_DOWN_INDEXED_SRC: &str =
+    include_str!("../../../kernels/src/gemv_mq3g256_lloyd_moe_down_indexed.hip");
+
 /// Strict superset of fused_rmsnorm_mq_rotate that ALSO writes the
 /// plain (non-FWHT) RMSNormed output to a second buffer. Eliminates the
 /// follow-up rmsnorm_f32 / rmsnorm_batched launch in call sites that

--- a/docs/investigations/2026-05-30-strix-halo-memory/README.md
+++ b/docs/investigations/2026-05-30-strix-halo-memory/README.md
@@ -1,0 +1,100 @@
+# Strix Halo (gfx1151) beyond-carveout memory: can hipfire run >VRAM models without Vulkan?
+
+**Status (2026-05-30):** Investigated on hipx (AMD Ryzen AI Max+ 395 / Radeon
+8060S, gfx1151, 128 GB unified LPDDR5x). **Finding: yes — the KMD GTT-GEM path
+works and reaches memory beyond the VRAM carveout at ~55–65% of carveout read
+bandwidth, no Vulkan required.** `hipMallocManaged` is dead on RDNA3.5;
+`hipHostMalloc` works but is slow; direct `AMDGPU_GEM_DOMAIN_GTT` allocation via
+libdrm_amdgpu + dma-buf + `hipImportExternalMemory` is the viable route.
+
+## Why this matters
+
+MiniMax-M2.7 mq2-lloyd (86 GB) runs on a single Strix Halo today because it fits
+the **96 GB VRAM carveout**; `hipMalloc` uses the carveout and OOMs above it.
+The bigger tiers (mq3 102, mq3-lloyd 109, mq4 124 GB) exceed the carveout. The
+question: can hipfire address memory beyond the carveout — like llama.cpp's
+Vulkan backend appears to — through its ROCm/KMD-direct stack, without adopting
+Vulkan (out of scope, issue #44)?
+
+## Hardware memory topology (hipx, measured)
+
+- Unified 128 GB LPDDR5x (~256 GB/s peak), shared CPU+GPU (it's an APU).
+- BIOS split today: **96 GiB VRAM carveout** + ~30 GB system RAM.
+- amdgpu **GTT pool = 15.2 GiB** (`mem_info_gtt_total`, `amdgpu.gttsize` default).
+- HSA pools: the gfx1151 agent exposes **only** the 96 GiB carveout
+  (COARSE-GRAINED + EXTENDED-FINE-GRAINED, "Accessible by all: FALSE"). There is
+  **no GTT pool on the GPU agent**; system RAM is only on the CPU agent as a
+  FINE-GRAINED (coherent) pool. So no HSA-level fast path beyond the carveout.
+- gfx1151 = HIP **device 1**, renderD129 (device 0 / renderD128 = a 7–8 GB RX
+  5700 XT, gfx1010). Pin `HIP_VISIBLE_DEVICES=1` ALONE (compounding with
+  `ROCR_VISIBLE_DEVICES` → empty device set).
+
+## Allocation paths tested (byte-strided kernel; ratios are the signal)
+
+| path | works? | WRITE | READ | capacity | notes |
+|---|---|---|---|---|---|
+| `hipMalloc` (carveout) | ✅ | 70–119 | 86–108 GB/s | 96 GB | the fast tier; the only thing `hipMalloc` reaches |
+| `hipMallocManaged` | ❌ | — | — | — | **OOM even at 50 GB** (inside carveout). `gfx1151:xnack+` is an invalid target — **RDNA3.5 has no XNACK**. Managed memory is non-functional here. |
+| `hipHostMalloc` mapped (coherent) | ✅ | ~30 | ~50 GB/s | system RAM | dev ptr == host ptr (zero-copy); slow coherent aperture |
+| `hipHostMalloc` write-combined | ✅ | ~26 | ~58 GB/s | system RAM | flag didn't help; alloc slow (1.4–5.9 s/20 GB) |
+| **GTT-GEM (KMD + dma-buf + HIP import)** | ✅ | 29–36 | **58–69 GB/s** | GTT (15 GB, growable) | `AMDGPU_GEM_DOMAIN_GTT` BO → dma-buf → `hipImportExternalMemory`. The viable beyond-carveout path. |
+
+Apples-to-apples at 10 GB: carveout READ **107.8** vs GTT-GEM READ **69.1**
+(~64%); GTT-GEM at 14 GB drops to 57.7 (~54%), converging toward the host-pinned
+~58. Absolute peaks are undermeasured (uint8 strided kernel — latency/occupancy
+bound, not peak BW); the **carveout-vs-GTT ratio (~55–65% read)** is the result.
+
+## Interpretation
+
+- **There is a real GPU→system-RAM fabric bottleneck (~58–69 GB/s) on gfx1151**,
+  independent of allocator. The carveout (GPU-local) is the fast tier; anything
+  in system RAM (GTT or host-pinned) tops out ~60–65% of carveout read. GART
+  mapping (GTT-GEM) beats the coherent host-pinned aperture at small sizes but
+  converges at scale.
+- **Vulkan has no advantage here.** radv hits the same fabric and the same
+  carveout-vs-system split. The reason a Strix Halo box runs a 105 GB Q3 model
+  at ~32 t/s is almost certainly a **larger BIOS carveout** (model in fast VRAM),
+  not fast GTT — i.e. the carveout-size lever, which both Vulkan and hipfire
+  share equally. hipfire is **not behind on the mechanism.**
+- **GTT-GEM is a viable capacity extension at a read penalty**, best used as a
+  hybrid: dense/hot tensors (attention, router, lm_head) in the carveout; cold
+  routed experts in GTT-GEM. A MoE reads only k/N experts per token, so the
+  ~35–45% read penalty only touches expert reads — the path to run **mq4
+  (124 GB, exceeds any single carveout)** on one Strix Halo without Vulkan.
+
+## Recommendation / levers
+
+1. **mq3 / mq3-lloyd (≤~112 GB): raise the BIOS VRAM carveout** so they fit fast
+   VRAM. Zero code; the same thing the fast-benchmark boxes do. (Deferred —
+   needs physical/UEFI access; hipx reportedly caps at 96 GB, to be confirmed.)
+2. **mq4 / anything > max carveout: carveout + GTT-GEM hybrid** placement. The
+   real hipfire-native unlock; `redline/src/drm.rs` already has the
+   libdrm_amdgpu `AMDGPU_GEM_DOMAIN_GTT` binding + CS structs. Work: wire a
+   GTT-GEM allocation path into the `rdna-compute` allocator (alloc GTT BO →
+   dma-buf export → `hipImportExternalMemory` → device ptr; kernels unchanged),
+   behind a hot/cold placement policy in the weight loader.
+3. **Dead end: managed memory** (`hipMallocManaged`) — non-functional on RDNA3.5
+   (no XNACK). Do not pursue.
+
+## Reproduction
+
+Test programs (this dir): `gtt_probe.cpp` (KMD GTT-GEM + dma-buf + HIP import),
+`managed_spike.cpp` (`hipMallocManaged`), `host_spike.cpp` (`hipHostMalloc`),
+`dev_bw.cpp` (carveout baseline). Build: `hipcc --offload-arch=gfx1151 -O3 X.cpp
+-o X [-I/usr/include/libdrm -ldrm_amdgpu]`. Run pinned: `HIP_VISIBLE_DEVICES=1
+./gtt_probe 10`. Needs membership in the `render` group for /dev/dri/renderD129.
+
+## Open items
+
+- Vectorized (uint4/float4) bandwidth test to firm the absolute ceiling + confirm
+  the ~60% ratio holds at peak.
+- `amdgpu.gttsize` bump (reboot) to grow GTT past 15 GB (bounded by system RAM;
+  trades against carveout size).
+- Confirm hipx's BIOS max carveout (lever #1).
+
+## Separate: NPU
+
+The AI Max's XDNA2 NPU (~50 TOPS INT8) is unused. Different driver (`amdxdna`) +
+toolchain (IRON/Peano), not HIP; strong for INT8 GEMM but limited local memory
+and a dataflow programming model — non-obvious fit for a 229 B MoE trunk, more
+plausible as a drafter / spec-decode offload. Scope separately, not folded here.

--- a/docs/investigations/2026-05-30-strix-halo-memory/dev_bw.cpp
+++ b/docs/investigations/2026-05-30-strix-halo-memory/dev_bw.cpp
@@ -1,0 +1,15 @@
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <chrono>
+static double now_s(){return std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();}
+#define CK(x) do{hipError_t e=(x);if(e!=hipSuccess){printf("ERR %s: %s\n",#x,hipGetErrorString(e));return 1;}}while(0)
+__global__ void writek(uint8_t* p,size_t n){size_t i=blockIdx.x*(size_t)blockDim.x+threadIdx.x,s=(size_t)gridDim.x*blockDim.x;for(;i<n;i+=s)p[i]=(uint8_t)(i&0x7f);}
+__global__ void sumk(const uint8_t* p,size_t n,unsigned long long* o){size_t i=blockIdx.x*(size_t)blockDim.x+threadIdx.x,s=(size_t)gridDim.x*blockDim.x;unsigned long long a=0;for(;i<n;i+=s)a+=p[i];atomicAdd(o,a);}
+int main(int c,char**v){double gb=c>1?atof(v[1]):40.0;size_t n=(size_t)(gb*1073741824.0);
+ uint8_t* p=nullptr; if(hipMalloc((void**)&p,n)!=hipSuccess){printf("hipMalloc FAIL\n");return 2;}
+ int th=256,bl=8192; double t1=now_s();hipLaunchKernelGGL(writek,dim3(bl),dim3(th),0,0,p,n);CK(hipDeviceSynchronize());double ws=now_s()-t1;
+ printf("CARVEOUT WRITE %.1fGB: %.1f GB/s\n",gb,gb/ws);
+ unsigned long long*d;CK(hipMalloc((void**)&d,8));CK(hipMemset(d,0,8));double t2=now_s();hipLaunchKernelGGL(sumk,dim3(bl),dim3(th),0,0,p,n,d);CK(hipDeviceSynchronize());double rs=now_s()-t2;
+ printf("CARVEOUT READ  %.1fGB: %.1f GB/s\n",gb,gb/rs); hipFree(p);return 0;}

--- a/docs/investigations/2026-05-30-strix-halo-memory/gtt_probe.cpp
+++ b/docs/investigations/2026-05-30-strix-halo-memory/gtt_probe.cpp
@@ -1,0 +1,75 @@
+// GTT-GEM bandwidth probe for gfx1151 (the autorocm KMD path).
+// Allocates an AMDGPU_GEM_DOMAIN_GTT buffer directly via libdrm_amdgpu (GART-
+// mapped, GPU-local — the same allocation class radv uses), exports it as a
+// dma-buf, imports it into HIP, and measures GPU compute read/write bandwidth.
+// This is the path hipMalloc/hipMallocManaged/hipHostMalloc can't reach.
+#include <hip/hip_runtime.h>
+#include <amdgpu.h>
+#include <amdgpu_drm.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
+#include <chrono>
+
+static double now_s(){ return std::chrono::duration<double>(
+    std::chrono::steady_clock::now().time_since_epoch()).count(); }
+#define HK(x) do{ hipError_t e=(x); if(e!=hipSuccess){ \
+    printf("HIP ERR %s: %s\n",#x,hipGetErrorString(e)); return 1; } }while(0)
+
+__global__ void writek(uint8_t* p,size_t n){
+    size_t i=blockIdx.x*(size_t)blockDim.x+threadIdx.x,s=(size_t)gridDim.x*blockDim.x;
+    for(;i<n;i+=s) p[i]=(uint8_t)(i&0x7f);
+}
+__global__ void sumk(const uint8_t* p,size_t n,unsigned long long* o){
+    size_t i=blockIdx.x*(size_t)blockDim.x+threadIdx.x,s=(size_t)gridDim.x*blockDim.x;
+    unsigned long long a=0; for(;i<n;i+=s) a+=p[i]; atomicAdd(o,a);
+}
+
+int main(int argc,char**argv){
+    double gb = argc>1?atof(argv[1]):10.0;
+    size_t n = (size_t)(gb*1073741824.0);
+    const char* node = argc>2?argv[2]:"/dev/dri/renderD129";
+
+    int fd=open(node,O_RDWR|O_CLOEXEC);
+    if(fd<0){ printf("open %s fail\n",node); return 1; }
+    amdgpu_device_handle dev; uint32_t maj,mn;
+    if(amdgpu_device_initialize(fd,&maj,&mn,&dev)){ printf("amdgpu_device_initialize fail\n"); return 1; }
+    printf("amdgpu drm %u.%u on %s\n",maj,mn,node);
+
+    struct amdgpu_bo_alloc_request req; memset(&req,0,sizeof(req));
+    req.alloc_size=n; req.phys_alignment=0x1000;
+    req.preferred_heap=AMDGPU_GEM_DOMAIN_GTT; req.flags=0;
+    amdgpu_bo_handle bo;
+    int r=amdgpu_bo_alloc(dev,&req,&bo);
+    if(r){ printf("amdgpu_bo_alloc(GTT %.1fGB) fail rc=%d\n",gb,r); return 2; }
+    printf("GTT-domain BO alloc %.1f GB ok\n",gb); fflush(stdout);
+
+    uint32_t dmafd=0;
+    r=amdgpu_bo_export(bo,amdgpu_bo_handle_type_dma_buf_fd,&dmafd);
+    if(r){ printf("amdgpu_bo_export fail rc=%d\n",r); return 3; }
+    printf("dma-buf fd=%u\n",dmafd); fflush(stdout);
+
+    hipExternalMemory_t ext;
+    hipExternalMemoryHandleDesc hd; memset(&hd,0,sizeof(hd));
+    hd.type=hipExternalMemoryHandleTypeOpaqueFd; hd.handle.fd=(int)dmafd; hd.size=n;
+    HK(hipImportExternalMemory(&ext,&hd));
+    void* dptr=nullptr;
+    hipExternalMemoryBufferDesc bd; memset(&bd,0,sizeof(bd));
+    bd.offset=0; bd.size=n; bd.flags=0;
+    HK(hipExternalMemoryGetMappedBuffer(&dptr,ext,&bd));
+    printf("HIP imported GTT buffer -> dev ptr=%p\n",dptr); fflush(stdout);
+
+    int th=256,bl=8192;
+    double t1=now_s(); hipLaunchKernelGGL(writek,dim3(bl),dim3(th),0,0,(uint8_t*)dptr,n); HK(hipDeviceSynchronize());
+    double ws=now_s()-t1; printf("GTT-GEM WRITE %.1fGB: %.2fs = %.1f GB/s\n",gb,ws,gb/ws); fflush(stdout);
+
+    unsigned long long* d; HK(hipMalloc((void**)&d,8)); HK(hipMemset(d,0,8));
+    double t2=now_s(); hipLaunchKernelGGL(sumk,dim3(bl),dim3(th),0,0,(const uint8_t*)dptr,n,d); HK(hipDeviceSynchronize());
+    double rs=now_s()-t2; unsigned long long hs=0; HK(hipMemcpy(&hs,d,8,hipMemcpyDeviceToHost));
+    printf("GTT-GEM READ  %.1fGB: %.2fs = %.1f GB/s  sum=%llu\n",gb,rs,gb/rs,hs);
+    printf("OK GTT-GEM zero-copy %.1f GB\n",gb);
+    return 0;
+}

--- a/docs/investigations/2026-05-30-strix-halo-memory/host_spike.cpp
+++ b/docs/investigations/2026-05-30-strix-halo-memory/host_spike.cpp
@@ -1,0 +1,68 @@
+// hipHostMalloc zero-copy spike for gfx1151 (Strix Halo APU).
+// Allocates pinned host memory (system RAM), maps it to a device pointer, and
+// has a kernel write/read it directly — no hipMemcpy. Measures the effective
+// GPU<->host-pinned bandwidth. Green + decent BW = the viable >carveout path
+// (capacity then bounded by system-RAM size / BIOS carveout split).
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <chrono>
+
+static double now_s() {
+    return std::chrono::duration<double>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+#define CK(x) do { hipError_t e=(x); if(e!=hipSuccess){ \
+    printf("ERR %s: %s\n",#x,hipGetErrorString(e)); fflush(stdout); return 1; } } while(0)
+
+__global__ void writek(uint8_t* p, size_t n) {
+    size_t i = blockIdx.x*(size_t)blockDim.x + threadIdx.x;
+    size_t stride = (size_t)gridDim.x*blockDim.x;
+    for (; i < n; i += stride) p[i] = (uint8_t)(i & 0x7f);
+}
+__global__ void sumk(const uint8_t* p, size_t n, unsigned long long* out) {
+    size_t i = blockIdx.x*(size_t)blockDim.x + threadIdx.x;
+    size_t stride = (size_t)gridDim.x*blockDim.x;
+    unsigned long long acc = 0;
+    for (; i < n; i += stride) acc += p[i];
+    atomicAdd(out, acc);
+}
+
+int main(int argc, char** argv) {
+    double gb = argc > 1 ? atof(argv[1]) : 20.0;
+    size_t n = (size_t)(gb * 1073741824.0);
+    hipDeviceProp_t prop; CK(hipGetDeviceProperties(&prop, 0));
+    printf("dev: %s (%s)\n", prop.name, prop.gcnArchName);
+
+    uint8_t* hp = nullptr;
+    printf("hipHostMalloc %.1f GB (mapped)...\n", gb); fflush(stdout);
+    double a0 = now_s();
+    hipError_t e = hipHostMalloc((void**)&hp, n, hipHostMallocMapped);
+    if (e != hipSuccess) { printf("HOST ALLOC FAIL: %s\n", hipGetErrorString(e)); return 2; }
+    printf("  alloc ok %.2fs\n", now_s()-a0); fflush(stdout);
+
+    uint8_t* dp = nullptr;
+    CK(hipHostGetDevicePointer((void**)&dp, hp, 0));
+    printf("  device ptr ok (host=%p dev=%p)\n", (void*)hp, (void*)dp); fflush(stdout);
+
+    int th = 256, bl = 8192;
+    double t1 = now_s();
+    hipLaunchKernelGGL(writek, dim3(bl), dim3(th), 0, 0, dp, n);
+    CK(hipDeviceSynchronize());
+    double ws = now_s()-t1;
+    printf("WRITE %.1fGB (gpu->host-pinned): %.2fs = %.1f GB/s\n", gb, ws, gb/ws); fflush(stdout);
+
+    unsigned long long* d; CK(hipMalloc((void**)&d, 8)); CK(hipMemset(d, 0, 8));
+    double t2 = now_s();
+    hipLaunchKernelGGL(sumk, dim3(bl), dim3(th), 0, 0, dp, n, d);
+    CK(hipDeviceSynchronize());
+    unsigned long long hsum = 0; CK(hipMemcpy(&hsum, d, 8, hipMemcpyDeviceToHost));
+    double rs = now_s()-t2;
+    printf("READ  %.1fGB (gpu<-host-pinned): %.2fs = %.1f GB/s  sum=%llu\n", gb, rs, gb/rs, hsum);
+    printf("host coherent check: hp[12345]=%d (expect %d)\n", (int)hp[12345], (int)(12345 & 0x7f));
+
+    hipHostFree(hp); hipFree(d);
+    printf("OK %.1f GB host-pinned zero-copy\n", gb);
+    return 0;
+}

--- a/docs/investigations/2026-05-30-strix-halo-memory/managed_spike.cpp
+++ b/docs/investigations/2026-05-30-strix-halo-memory/managed_spike.cpp
@@ -1,0 +1,63 @@
+// Managed-memory oversubscription spike for gfx1151 (Strix Halo).
+// Allocates `GB` of hipMallocManaged (can exceed the 96GB VRAM carveout),
+// writes every byte from a kernel (forces page residency), reads it back,
+// reports bandwidth. Green = managed/unified path is viable for hipfire.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <chrono>
+
+static double now_s() {
+    return std::chrono::duration<double>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+#define CK(x) do { hipError_t e=(x); if(e!=hipSuccess){ \
+    printf("ERR %s: %s\n",#x,hipGetErrorString(e)); fflush(stdout); return 1; } } while(0)
+
+__global__ void writek(uint8_t* p, size_t n) {
+    size_t i = blockIdx.x*(size_t)blockDim.x + threadIdx.x;
+    size_t stride = (size_t)gridDim.x*blockDim.x;
+    for (; i < n; i += stride) p[i] = (uint8_t)(i & 0x7f);
+}
+__global__ void sumk(const uint8_t* p, size_t n, unsigned long long* out) {
+    size_t i = blockIdx.x*(size_t)blockDim.x + threadIdx.x;
+    size_t stride = (size_t)gridDim.x*blockDim.x;
+    unsigned long long acc = 0;
+    for (; i < n; i += stride) acc += p[i];
+    atomicAdd(out, acc);
+}
+
+int main(int argc, char** argv) {
+    double gb = argc > 1 ? atof(argv[1]) : 100.0;
+    size_t n = (size_t)(gb * 1073741824.0);
+    hipDeviceProp_t prop; CK(hipGetDeviceProperties(&prop, 0));
+    printf("dev: %s (%s)\n", prop.name, prop.gcnArchName);
+    size_t fb=0, tb=0; hipMemGetInfo(&fb, &tb);
+    printf("hipMemGetInfo: free=%.1f total=%.1f GB\n", fb/1.073741824e9, tb/1.073741824e9);
+
+    uint8_t* p = nullptr;
+    printf("hipMallocManaged %.1f GB (n=%zu)...\n", gb, n); fflush(stdout);
+    double a0 = now_s();
+    hipError_t e = hipMallocManaged((void**)&p, n, hipMemAttachGlobal);
+    if (e != hipSuccess) { printf("ALLOC FAIL: %s\n", hipGetErrorString(e)); return 2; }
+    printf("  alloc ok %.2fs\n", now_s()-a0); fflush(stdout);
+
+    int th = 256, bl = 8192;
+    double t1 = now_s();
+    hipLaunchKernelGGL(writek, dim3(bl), dim3(th), 0, 0, p, n);
+    CK(hipDeviceSynchronize());
+    double ws = now_s()-t1;
+    printf("WRITE %.1fGB: %.2fs = %.1f GB/s\n", gb, ws, gb/ws); fflush(stdout);
+
+    unsigned long long* d; CK(hipMallocManaged((void**)&d, 8)); *d = 0;
+    double t2 = now_s();
+    hipLaunchKernelGGL(sumk, dim3(bl), dim3(th), 0, 0, p, n, d);
+    CK(hipDeviceSynchronize());
+    double rs = now_s()-t2;
+    printf("READ  %.1fGB: %.2fs = %.1f GB/s  sum=%llu\n", gb, rs, gb/rs, *d); fflush(stdout);
+
+    hipFree(p); hipFree(d);
+    printf("OK %.1f GB\n", gb);
+    return 0;
+}

--- a/docs/methodology/arch-port-validation.md
+++ b/docs/methodology/arch-port-validation.md
@@ -1,0 +1,144 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 Kaden Schutt
+hipfire — see LICENSE and NOTICE in the project root.
+-->
+# Architecture-port validation methodology
+
+How to bring up a new model architecture in hipfire and **prove the forward
+pass is correct cheaply** — before spending GPU-hours quantizing the real
+weights or chasing coherence on a 200B model. This is the method used for the
+MiniMax-M2 port (2026-05-29); it caught 3 real bugs in seconds-per-iteration on
+a tiny model with no GPU-hours wasted.
+
+> TL;DR: build a **dimension-faithful tiny random-weight oracle** from the
+> *reference* implementation, compare **per-layer hidden states** (not final
+> logits), and when a layer diverges, **bisect within the layer** and
+> **precision-sweep** to separate a real arch bug from quantization noise.
+
+## Why this works
+
+A new arch port is mostly *plumbing existing kernels in the right order*. The
+failure modes are: wrong norm convention, wrong RoPE convention, wrong
+gate/up split, wrong routing math, a kernel-shape/`k_top` mismatch, a
+dtype/rotation mismatch. **All of these produce a per-layer cosine well below
+1.0; quantization noise does not.** So a per-layer cosine harness against a
+trusted reference localizes the bug to a layer and a sub-block in minutes.
+
+Doing this on a *tiny* model (2 layers, hidden 256) means each iteration is
+~5 s and needs no real weights — you decouple *arch correctness* from *weight
+download* and *quantization quality*.
+
+## The loop
+
+1. **Build a tiny reference oracle from the reference implementation.**
+   Use the HF `transformers` (or upstream) modeling code — the *ground truth* —
+   to instantiate a small random-weight model and dump its per-layer hidden
+   states. Use `scripts/gen_tiny_oracle.py` (adapt the per-arch block). Critical
+   dim rules (see Pitfalls): keep the *real* `head_dim`/`rotary_dim`, make every
+   2D weight `k % group_size == 0`, and match any **hardcoded kernel `k_top`**.
+
+2. **Dump per-layer POST-residual hidden states from both sides** in the shared
+   `HFHS` binary format (`magic "HFHS\0\0\0\0"`, `<IIII>` = n_layers, n_pos,
+   hidden, reserved, then `n_layers × [n_pos, hidden]` f32, row-major). The HF
+   side is in the gen script; the hipfire side is a tiny example mirroring
+   `crates/hipfire-arch-*/examples/dump_*_hidden_states.rs` (run `decode_step`
+   per position with a per-layer capture hook). Convention: capture the
+   residual **after each decoder layer, before the final norm** — match it on
+   both sides.
+
+3. **Compare with `scripts/compare_hidden_states.py`.** It prints per-layer
+   `rms`, `rel_L2`, `mean_cos`, `min_cos`. Read the drift profile:
+   - cosine ≈ 1.0 (≥0.999 for Q8-grade, ≥0.99 for 4-bit experts) → correct.
+   - cosine flat across layers but < 1 → uniform per-layer error (quant noise
+     *or* a per-layer systematic bug — disambiguate in step 5).
+   - cosine craters at a specific layer / compounds → structural bug there.
+
+4. **Bisect within the diverging layer.** Add a second capture point (e.g.
+   post-attention, pre-MoE) gated by an env var, and dump the **isolated
+   block output** (`block_out = post_block − pre_block`). MiniMax: post-attn
+   was 0.9999 (attention correct) but isolated `moe_out` cosine was 0.07
+   (orthogonal) → the bug was entirely in the MoE.
+
+5. **Precision-sweep to separate quant-noise from arch-bug.** Re-quantize the
+   suspect block at a *higher* precision (e.g. 4-bit → 6-bit) and re-compare.
+   - error shrinks ∝ precision → it was quant noise; the arch is fine.
+   - error **unchanged** → structural bug, independent of bit-width. (MiniMax:
+     MQ4→MQ6 didn't move the 0.96 → proved it wasn't quant.)
+
+6. **Stage-dump + cross-check in Python to root-cause.** Dump the block's
+   intermediates (router logits, top-k indices/weights, gate/up, down) from
+   hipfire and recompute the *same* in numpy/torch from the F32 weights.
+   Compare each stage; the first stage that diverges is the bug. (MiniMax:
+   routing indices matched but logits were 30× → F16 router hit the lm-head
+   GEMM kernel; later, the expert gate matched but the final output was
+   orthogonal + **non-deterministic** → a hardcoded-`k8` kernel reading past a
+   top-2 buffer.)
+
+7. **Resolve ambiguities by reading the kernel/dispatch source, not guessing.**
+   RoPE convention (rotate_half vs interleaved), `route_scale`, FWHT-rotation
+   matching between quantizer and `rotate_x_mq`, FP8 dequant multiply-vs-divide
+   — every one was verified against the `.hip` kernel or a numeric reference
+   (e.g. dequant a real tensor in torch → check the distribution is sane)
+   before trusting it.
+
+## Pitfall checklist (bake into the tiny-oracle dims)
+
+These are the traps that cost iterations on MiniMax — encode them in the tiny
+config so they can't bite:
+
+- **Match hardcoded kernel `k_top`.** The indexed-MoE GEMV kernels are often
+  hardcoded (`_k8_` → top-8) with no `k_top` parameter. A tiny model with a
+  *different* top-k overflows the output buffers and reads garbage
+  (non-deterministic!). Set the tiny `num_experts_per_tok` to the kernel's
+  hardcoded value (and `num_local_experts` > k_top for real sparsity).
+- **`k % group_size == 0`** for every quantized 2D weight (G256 → every dim a
+  multiple of 256). The expert intermediate is the usual offender; size the
+  tiny model so even the down projection is divisible.
+- **Use the real `head_dim` / `rotary_dim`.** Attention/RoPE kernels are tuned
+  for specific head_dim (e.g. 128); a tiny `head_dim=32` may hit an untested
+  path. Shrink the *number* of heads/layers, not head_dim.
+- **Keep routing/precision-sensitive tensors at Q8, never F16.** `weight_gemv`'s
+  F16 arm dispatches the lm-head batched GEMM kernel, which is wrong for a
+  router's tiny output dim (m = n_experts). Q8 (`gemv_q8_0`) is well-behaved at
+  any m.
+- **The reference oracle must match the *runtime* layout.** If the HF modeling
+  stores experts packed (`gate_up_proj [E,2I,H]`) but your loader/kernels want
+  split (`experts.E.w1/w2/w3`), re-split the saved tensors so the oracle and
+  hipfire consume the same numbers (numerically identical, just reorganized).
+- **Standard vs Gemma RMSNorm.** Check whether the norm is `weight * x̂` or
+  `(1+weight) * x̂` before loading norm weights; a wrong `+1` corrupts every
+  layer uniformly.
+
+## Reusable artifacts
+
+- `scripts/gen_tiny_oracle.py` — generalized tiny-oracle generator (adapt the
+  marked per-arch block: config builder, the post-attention hook module path,
+  any packed→split re-split). `scripts/gen_tiny_minimax.py` is the worked
+  example.
+- `scripts/compare_hidden_states.py` — arch-agnostic HFHS comparator.
+- `crates/hipfire-arch-*/examples/dump_*_hidden_states.rs` — the hipfire-side
+  per-layer dumper pattern (clone per arch; ~80 lines: load HFQ, per-token
+  `decode_step` with a `capture: &mut [Vec<f32>]` hook, write HFHS).
+
+## When this does NOT generalize
+
+This validates *plumbing* against existing kernels. It assumes the new arch
+**maps onto kernels that already exist** (attention family × MoE/quant family).
+MiniMax-M2 needed **zero new kernels** — that was the enabler. An arch that
+needs a *new* HIP kernel (e.g. a quant format with no indexed-decode MoE GEMV)
+needs kernel-level oracles too, and the cosine harness can only validate it
+once that kernel exists. Map the closest existing arch + the shared helpers
+(via a codebase survey) *before* writing, to confirm the kernel coverage.
+
+## Worked example: MiniMax-M2 (arch_id 10)
+
+- Template: qwen35 GQA attention + deepseek4 sigmoid-bias MoE routing, **0 new
+  kernels**.
+- Oracle: HF `transformers` `MiniMaxM2`, tiny (2L, hidden 256, **head_dim 128 /
+  rotary 64**, inter 256 [÷256], **16 experts top-8** [matches `_k8`]), packed→split.
+- Bugs caught: (1) tiny used top-2 vs hardcoded-k8 kernel → buffer overflow;
+  (2) F16 router → lm-head GEMM kernel → 30× logits; (3) initial confusion
+  between quant-noise and bug, resolved by the MQ4→MQ6 precision sweep.
+- Result: per-layer cosine **0.9996** (mq4 experts) / **0.9987** (mq2-lloyd),
+  attention isolated 0.99990, routing exact — all on a tiny model, no GPU-hours.

--- a/docs/plans/dflash-trainer.md
+++ b/docs/plans/dflash-trainer.md
@@ -1,0 +1,169 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 Kaden Schutt
+hipfire — see LICENSE and NOTICE in the project root.
+-->
+# DFlash trainer (hipfire-native) — design & build plan
+
+**Status: PLAN — not started.** Authored 2026-05-29 during the MiniMax-M2 DFlash
+scoping. This is the design + sequencing for a Rust/HIP-native trainer for DFlash
+speculative-decode *draft* models.
+
+## TL;DR
+
+Build a hipfire-native trainer so every hipfire target arch can get a *matched*
+DFlash drafter on-device, without leaving the Rust/hipfire world (no
+SpecForge/sglang/PyTorch in the loop). The justification is **infrastructure for
+arch-intake automation + full pipeline ownership** — *not* training speed.
+Two reasons speed is the wrong frame:
+
+- The drafter backward is **dense bf16 GEMM**, which rocBLAS already saturates on
+  MI300X. hipfire's edge (quantization + fused *inference* kernels) doesn't apply to
+  full-precision training.
+- The dominant cost is **running the target to produce the distillation signal**, not
+  the drafter backward. The 600M drafter's own forward+backward is ~8 h on 8×MI300X;
+  the "3–6 days" in published Kimi recipes is the **1T target** + a 1.2B drafter +
+  long context. For a 229B target + ~600M drafter, expect **~a day**.
+
+So: build it for ownership and reuse across arches, and because hipfire is genuinely
+advantaged at the *data-gen* phase (fast quantized target + existing hidden-state
+dumping). Do **not** put it on the critical path of the first MiniMax drafter.
+
+## Background
+
+**DFlash** (z-lab, [arXiv 2602.06036](https://arxiv.org/abs/2602.06036)) is a block-
+diffusion draft model for speculative decoding: a small decoder drafts a *block* of B
+tokens in parallel; the target verifies them in one batched pass; the longest matching
+prefix is accepted. z-lab ships trained drafters on HF (MiniMax-M2.5/M2.7 are
+**manually gated**) and open *inference* backends (transformers/sglang/vLLM/MLX), but
+the *training* recipe is "coming soon." The community trainer is
+[SpecForge](https://github.com/sgl-project/SpecForge) (sgl-project); florianleibert's
+`kimi-k26-dflash-mi300x` README documents a 3-phase SpecForge pipeline on MI300X.
+
+A drafter is **per-(target arch)** — it conditions on that target's hidden states and
+borrows its (frozen) embed + lm_head. So each new hipfire arch wants its own.
+
+## The drafter we train
+
+Matches hipfire's existing inference contract (`hipfire-runtime/src/dflash.rs`,
+`DflashWeights::load`, arch_id 20):
+
+- **Arch:** 5–6 layer Qwen3-style decoder + an `fc` projector that maps concatenated
+  target hidden states (from N chosen target layers) → draft hidden. Block-causal /
+  block-diffusion with `mask_token_id` (block_size 16 train, 8 infer).
+- **Shares (frozen):** the target's embedding + lm_head — the drafter has *no* vocab
+  head of its own; it emits hidden states and the caller applies the target lm_head.
+- **Size (MiniMax, hidden 3072):** ~600M params, BF16 → ~1.1–1.2 GB. (Kimi's is 1.2B.)
+- **Output:** B hidden rows → target lm_head → B candidate tokens.
+
+A trained drafter is converted to hfq via the existing `dflash_convert` binary
+(`--mq4`/`--mq3`/`--keep-f32`) and run through the hipfire DFlash inference path.
+
+## The 3-phase pipeline
+
+1. **Data-gen ("regenerate") — hipfire's real advantage.** Run the *target* over a
+   corpus (PerfectBlend-style, ~1M samples) to produce target-distribution responses
+   and capture hidden states at the chosen `target_layer_ids`. hipfire already has the
+   fast quantized target + `dump_minimax_hidden_states` (per-layer hidden capture).
+   This is the dominant compute; doing it in hipfire avoids re-standing-up the 229B
+   target in sglang. **Cache caveat:** full hiddens for 1M × 4K × hidden × N layers is
+   hundreds of TB — *cannot* cache naively. Stream from the target during training, or
+   cache a managed subset / re-run per epoch on the fast quantized target.
+2. **Train.** 6-epoch block-diffusion distillation: drafter forward → block of logits
+   via target lm_head → block-diffusion loss vs the target's tokens/distribution →
+   backward → Adam. ~8 h for 600M on 8×MI300X @ ~35% MFU.
+3. **Convert + validate.** `dflash_convert` → hfq; `scripts/coherence-gate-dflash.sh`
+   (q8 KV, max=256, byte-identical prompt + md5); measure τ (acceptance length).
+
+## What hipfire must add (the trainer subsystem)
+
+hipfire is inference-only — **no backward, no optimizer**. The trainer is a *bounded,
+fixed-arch* subsystem (not a general autograd framework):
+
+- **Forward — HAVE IT.** Drafter forward = `dflash.rs::draft_forward`. Target forward +
+  hidden capture = `dump_minimax_hidden_states` / the arch forward.
+- **Backward (hand-coded for the fixed drafter arch):**
+  - transposed-GEMM backward — reuse the existing GEMM (dW, dX are GEMMs with transposes).
+  - rmsnorm backward; SwiGLU/MLP backward; the `fc` projector backward.
+  - **attention backward via gradient checkpointing** — recompute the *flash-attn
+    forward* (already owned) per layer in the backward, materialize that one layer's
+    scores transiently, run a standard softmax+matmul backward. **No fused
+    flash-attn-backward kernel needed** — the scary kernel is sidestepped.
+  - embedding + lm_head are **frozen** (no grad) — they're the target's.
+  - block-diffusion loss + backward (objective per the DFlash paper).
+- **Optimizer:** Adam (elementwise; m/v in fp32). ~4.8 GB state for 600M — fine.
+- **Driver:** data loader over (target hiddens, target tokens); micro-batching + grad
+  accumulation; bf16 compute + fp32 master weights; activation checkpointing; LR
+  schedule + warmup; checkpoint save/resume; metric logging (loss, per-block accept).
+- **Distributed:** data-parallel across the 8 MI300X (gradient all-reduce). TP not
+  needed (drafter is tiny); the *target* in data-gen may shard (separate concern,
+  tracked with the hiptrx TP work).
+
+## Cost & sizing (MiniMax)
+
+- Drafter training FLOPs ≈ `6·N·D` = 6 × 0.6e9 × (1M samples × 4K ctx × 6 epochs ≈ 28B
+  tokens) ≈ **1e20 FLOPs** → ~8 h on 8×MI300X @ 35% MFU.
+- Data-gen (229B target over the corpus) is the larger phase but hipfire-fast; total
+  ≈ **~1 day**, not the Kimi "3–6 days" (those are 1T-target / 1.2B-drafter numbers).
+- Optimizer + bf16 master + activations: comfortably within a single MI300X's 192 GB
+  for a 600M drafter; data-parallel for throughput.
+
+## Sequencing & scope
+
+1. **Inference first (the keystone, needed regardless of drafter source):** the hipfire
+   DFlash *inference* path for minimax — a **batched verify forward** (process B
+   positions at once; minimax is batch-1 even for prefill today), `hidden_rb`
+   extraction at `target_layer_ids`, batched lm_head, `spec_step_dflash_minimax`
+   (port from qwen35, *drop* the DeltaNet rollback — minimax is pure FA), daemon
+   registration. **Bonus: the batched forward also fixes minimax's slow per-token-AR
+   prefill.** No new GPU kernels (batches the existing pipeline). ~3–5 days.
+2. **First drafter — don't block on the trainer.** Either the hybrid (hipfire data-gen
+   → SpecForge train) or z-lab access if granted. Gets MiniMax-DFlash live soonest.
+3. **The Rust trainer — deliberate infra investment** (this doc). ~1–2 weeks for the
+   subsystem, justified by reuse across every future arch (the intake-automation goal),
+   not by minimax. Build the backward/optimizer/driver, then train a minimax drafter
+   end-to-end as the first customer.
+4. **Generalize:** parameterize the trainer over the target arch (qwen35 / deepseek4 /
+   minimax / future) so "quantize + train a drafter" becomes a standard intake step.
+
+## Open questions / risks
+
+- **Block-diffusion objective details** — the exact loss + mask schedule from the DFlash
+  paper; reimplement faithfully. *Biggest unknown.*
+- **Hidden-state cache** — too big to materialize fully; pick stream-vs-cache strategy.
+- **SpecForge MiniMax support** — for the hybrid path, does SpecForge already target the
+  MiniMax arch or does it need adding?
+- **MFU on the small drafter** — many small ops; fusion + CUDA-graph-equivalent capture
+  to keep the GPUs fed.
+- **Validation** — τ + `coherence-gate-dflash.sh`; a matched drafter should reach
+  ~60–75% acceptance (st=8 viable) vs ~50% for a cross-version one.
+
+## Milestones
+
+1. hipfire DFlash *inference* for minimax (batched verify forward + spec-step + daemon) — also a prefill win.
+2. hipfire target-conditioning data-gen pipeline (reuse `dump_minimax_hidden_states` + generation).
+3. Trainer core: backward kernels (checkpointed attention) + Adam + block-diffusion loss + driver.
+4. E2E: train a MiniMax drafter → `dflash_convert` → validate τ + coherence-gate-dflash.
+5. Generalize over target arch → an arch-intake step.
+
+## Next program: MTP (after DFlash)
+
+MTP (native multi-token prediction) is the follow-on, and it **reuses most of this**:
+
+- **Shared keystone.** MTP verification also needs the batched target forward + the
+  spec-step loop (milestone 1). Build it once for DFlash; MTP rides on it.
+- **Shared trainer.** MiniMax's checkpoint has `use_mtp:true` but **no `mtp.*` weights**
+  — so MTP means *training/extracting* an MTP head, which is exactly what the DFlash
+  trainer's data-gen + small-model-training infra does. The MTP head is even simpler
+  than the DFlash drafter (no block diffusion; conditions on the single last hidden +
+  next-token embedding, deepseek4-style `mtp_forward`).
+- **Why DFlash first:** the z-lab DFlash artifact + SpecForge give a head start (drafter
+  for free if access lands), and DFlash-solo has historically been the higher-leverage
+  decode-accel lever. MTP is viable for MoE (A3B hit ~260 tok/s on R9700), so it's worth
+  doing — just second, recycling the DFlash batched-forward + trainer groundwork.
+
+## References
+
+- DFlash paper: arXiv 2602.06036 · repo: github.com/z-lab/dflash · SpecForge: github.com/sgl-project/SpecForge
+- florianleibert/kimi-k26-dflash-mi300x (SpecForge MI300X recipe; st=2, NUMA off, max_num_seqs=32)
+- hipfire: `crates/hipfire-runtime/src/dflash.rs` (drafter, arch-agnostic), `crates/hipfire-arch-qwen35/src/speculative.rs` (`spec_step_dflash`, the qwen35-coupled bits to port/strip), `crates/hipfire-arch-qwen35/src/qwen35.rs::forward_prefill_batch_with_pbs` (batched-verify template), `crates/hipfire-arch-minimax/src/forward.rs` (batch-1 only — needs the batched forward), `crates/hipfire-quantize/src/bin/dflash_convert.rs` (draft → hfq, arch_id 20)

--- a/docs/plans/minimax-rdna-wmma-coverage.md
+++ b/docs/plans/minimax-rdna-wmma-coverage.md
@@ -1,0 +1,112 @@
+# MiniMax-M2.7 — RDNA3+ WMMA kernel coverage & the MQ3-Lloyd gap
+
+**Status (2026-05-30):** MiniMax-M2.7 is *correctness-portable* to RDNA3+ today,
+but GEMV-bound in prefill. Fast RDNA prefill needs two things: (1) a batched
+forward, and (2) grouped-WMMA MoE GEMM. There is exactly **one** new-kernel gap
+(MQ3-Lloyd grouped). RDNA e2e validation is partly reachable today — hipx
+(Strix Halo gfx1151, 96 GB) fits the mq2 / mq2-lloyd tiers — but the larger
+tiers (mq3-lloyd, mq4) exceed it; that slice is **deferred**. This doc flags both.
+
+## Why this matters
+
+`generate_minimax` uses **per-token GEMV for everything** (q/k/v/o via
+`weight_gemv`, MoE via the A3B/deepseek4 `gemv_*_indexed` decode kernels,
+generic rmsnorm/rope/qk-norm, `attention_q8_0_kv`). MiniMax is batch-1 even in
+prefill. That path runs correctly on **any** arch — kernels are JIT-compiled per
+GPU (`ensure_kernel`/hiprtc), no MFMA, no WMMA, no arch gate — but it never
+batches, so prefill is GEMV-bound. Fast RDNA prefill = a **batched forward**
+(the DFlash batched-verify keystone, see `docs/plans/dflash-trainer.md`) feeding
+**grouped-WMMA MoE GEMM**.
+
+## Coverage map (what already exists on gfx11/gfx12)
+
+| forward path | dtype | grouped/batched WMMA kernel | status |
+|---|---|---|---|
+| dense q/k/v/o, router, lm_head | Q8 | `gemm_gate_up_q8_0_wmma` + Q8 batched + `attention_q8_0_kv_batched` | ✅ exists |
+| MoE gate/up + down | MQ4 (HFQ4) | `gemm_hfq4g256_moe_grouped_mmq.{gfx1151,gfx11_dgpu,gfx12}` | ✅ exists |
+| MoE gate/up + down | MQ2-Lloyd | `gemm_mq2g256_lloyd_moe_grouped_wmma_{k2,4w_k2,4w_k2_cnd,4w_k2_n32,8w_k2}` | ✅ exists (5 variants, wired) |
+| MoE gate/up + down | **MQ3-Lloyd** | — only per-token `gemv_mq3g256_lloyd_moe_{gate_up,down}_indexed` | ❌ **GAP** |
+
+So once the batched forward exists, the **mq4** and **mq2-lloyd** tiers get fast
+RDNA prefill with **zero new kernels** — just route their batched MoE through the
+existing grouped kernels. (Earlier in this thread I mis-scoped this as "the Lloyd
+formats are the gap" — wrong; MQ2-Lloyd grouped already exists. Caught by the
+grep-existing-variants-first discipline.)
+
+## The one gap: MQ3-Lloyd grouped-WMMA MoE GEMM
+
+Tiers that need it: **mq3** (uniform MQ3-Lloyd), **mq3-lloyd** (gate/up
+MQ3-Lloyd), **mq2** (down MQ3-Lloyd). One kernel covers all three.
+
+It is a **graft of two existing kernels**, not from-scratch:
+- grouped scatter / per-expert tile structure: `gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2.hip`
+- 3-bit / 8-entry codebook dequant WMMA inner loop: `gemm_gate_up_mq3g256_lloyd_wmma.gfx12.hip`
+
+## Probe-based dev loop (fast inner loop, slow gate)
+
+The repo already has the tiny-probe harness convention; use it:
+
+1. **Occupancy** — `gfx-kernel-metadata` skill: compile for gfx1151/gfx12, read
+   VGPR/SGPR/LDS/spills from the `.hsaco`. **No GPU run** — doable even on the
+   mi300/CDNA box via cross-compile. Catches register blowup instantly.
+2. **Correctness** — fork `test_gemm_fused_mq3g256_lloyd_wmma.rs` (CPU **fp64**
+   reference, f16-roundtripped inputs, max-abs/rel error). Exact, seconds. A bug
+   reads as `0.4` rel-error, not as subtle token drift hidden in quant noise.
+3. **Perf** — fork `bench_mq2g256_lloyd_moe_4w.rs`: isolated µs A/B vs the MQ3
+   per-token indexed baseline (WARMUP/TRIALS already wired).
+4. **GATE (survivors only)** — e2e fresh-process `scripts/probe_commits.sh` +
+   `coherence-gate.sh`, on RDNA hardware.
+
+**Hard rule:** a microbench win is a *hypothesis, not a result.* This codebase's
+memory has multiple WMMA-Lloyd/MMQ kernels that won the microbench then failed
+e2e or coherence (synth-win → prod-falsify: `fp8_wmma_hfp4g32`, `sgpr_lut`,
+`dot2_trickle_down`, the i8-MMQ-MoE-grouped family). The probes *kill bad
+variants fast and find geometry*; the **gate** is always e2e + coherence.
+
+## Prerequisite
+
+The **batched MiniMax forward** (DFlash batched-verify keystone). Nothing batched
+dispatches today, so a WMMA kernel written before it has no caller. Build the
+batched forward first — it independently fixes slow prefill — then wire the
+existing grouped kernels (mq4, mq2-lloyd) and finally add the MQ3-Lloyd grouped.
+
+## Validation reality (the flagged gap)
+
+WMMA **executes only on RDNA3/4** — mi300 (CDNA/gfx942) cannot run it. RDNA
+validation target = Strix Halo via `ssh hipx`.
+
+**hipx specifics (verified 2026-05-30 from kfd topology):**
+- The **8060S iGPU = gfx1151** (WMMA-capable, wave32) is **HIP device 1**
+  (`HIP_VISIBLE_DEVICES=1` / `ROCR_VISIBLE_DEVICES=1`), with a **96 GB dedicated
+  VRAM carveout** (kfd node 2) plus GTT spill → **~103 GB addressable** (a real
+  localmaxxing run hit 103 GB there). Device 0 is an RX 5700 XT (gfx1010, RDNA1,
+  7 GB, **no WMMA**). NB: `free -g` shows ~30 GB — that is the *host/CPU*
+  partition (kfd node 0), **not** the iGPU pool; don't size MiniMax against it.
+- **Tier fit on device 1 (~96 GB carveout, ~103 GB with GTT):**
+  | tier | size | fits hipx? |
+  |---|---|---|
+  | mq2 | 79 GB | ✅ comfortable |
+  | mq2-lloyd | 86 GB | ✅ comfortable |
+  | mq3 | 102 GB | ⚠️ GTT-edge, tight with KV/scratch |
+  | mq3-lloyd | 109 GB | ❌ exceeds |
+  | mq4 | 124 GB | ❌ exceeds |
+- **What hipx CAN do:** full e2e RDNA coherence + perf for **mq2 + mq2-lloyd**.
+  Since mq2's **down** projection is MQ3-Lloyd, the mq2 tier exercises the
+  **MQ3-Lloyd grouped *down* path e2e** — so the new kernel's down side gets a
+  real end-to-end RDNA gate, not just a microbench.
+- **The deferred slice:** the **MQ3-Lloyd grouped *gate/up* path** lives in the
+  mq3 / mq3-lloyd tiers (102–109 GB), which don't fit (mq3 borderline). On hipx
+  it is **microbench-only** (steps 1–3 above use tiny synthetic E=1 tensors —
+  VRAM is irrelevant). Full gate/up e2e + the mq4 tier need a larger RDNA VRAM
+  pool or multi-GPU PP — no such RDNA config in the fleet today. Flagged.
+
+## Bottom line
+
+- New-kernel surface = **1** (MQ3-Lloyd grouped-WMMA MoE), graftable from 2
+  existing kernels.
+- **hipx (gfx1151 / device 1, 96 GB) validates a lot:** full e2e for mq2 +
+  mq2-lloyd, and mq2 covers the MQ3-Lloyd grouped *down* path e2e; the new
+  kernel's *gate/up* path is microbench-validatable there always.
+- **Only the MQ3-Lloyd gate/up *full-e2e* (mq3 / mq3-lloyd tiers) and the mq4
+  tier are blocked** on RDNA memory capacity (>96 GB) — flagged, deferred to a
+  larger RDNA pool / multi-GPU PP.

--- a/docs/plans/minimax-rdna-wmma-coverage.md
+++ b/docs/plans/minimax-rdna-wmma-coverage.md
@@ -1,7 +1,8 @@
 # MiniMax-M2.7 — RDNA3+ WMMA kernel coverage & the MQ3-Lloyd gap
 
-**Status (2026-05-30):** MiniMax-M2.7 is *correctness-portable* to RDNA3+ today,
-but GEMV-bound in prefill. Fast RDNA prefill needs two things: (1) a batched
+**Status (2026-05-30):** MiniMax-M2.7's forward path is **empirically validated on
+RDNA3.5 (gfx1151 / Strix Halo)** — see "Empirical RDNA validation" below. It is
+correctness-portable but GEMV-bound in prefill. Fast RDNA prefill needs two things: (1) a batched
 forward, and (2) grouped-WMMA MoE GEMM. There is exactly **one** new-kernel gap
 (MQ3-Lloyd grouped). RDNA e2e validation is partly reachable today — hipx
 (Strix Halo gfx1151, 96 GB) fits the mq2 / mq2-lloyd tiers — but the larger
@@ -99,6 +100,34 @@ validation target = Strix Halo via `ssh hipx`.
   it is **microbench-only** (steps 1–3 above use tiny synthetic E=1 tensors —
   VRAM is irrelevant). Full gate/up e2e + the mq4 tier need a larger RDNA VRAM
   pool or multi-GPU PP — no such RDNA config in the fleet today. Flagged.
+
+## Empirical RDNA validation (2026-05-30)
+
+First real run of MiniMax-M2.7 kernels on RDNA hardware — the tiny random-weight
+oracle (`scripts/gen_tiny_minimax.py`: 2 layers, hidden 256, 16 experts/top-8),
+`dump_minimax_hidden_states` pinned to **hipx HIP device 1 = gfx1151** (runtime
+reported "GPU dev 0: gfx1151 (103.1 GB VRAM, HIP 7.2)"), compared with
+`compare_hidden_states.py`.
+
+**Correctness — gfx1151 hidden states vs the PyTorch oracle (per-layer cosine):**
+
+| tiny tier | kernels exercised | mean cos | min cos |
+|---|---|---|---|
+| tiny-mq3 | **MQ3-Lloyd MoE decode (the ported kernel)** | 0.99944 | 0.99857 |
+| tiny-tpl | MQ4 MoE | 0.99873 | 0.99617 |
+| tiny-dnmq4 | MQ2-Lloyd + MQ4 mixed | 0.99899 | 0.99653 |
+
+All ~0.999 — the quantization band, matching the impl validation on gfx942.
+
+**Cross-arch parity — gfx1151 vs gfx942 (CDNA3), identical inputs:** `mq3` and
+`dnmq4` both **cos = 1.000000, diff_rms = 0.0** — bit-identical between
+RDNA3.5/wave32 and CDNA3/wave64 (f32-MAC GEMV + Lloyd codebook dequant are
+deterministic across the two archs).
+
+This validates the **forward/decode path** (GEMV, Lloyd MoE decode incl. the
+MQ3-Lloyd port, MQ4 MoE, Q8 attention, rmsnorm, rope, qk-norm) on real RDNA3.5.
+It does **not** touch the WMMA grouped-prefill kernels (still the gap). Full-model
+e2e coherence on gfx1151 (mq2-lloyd, 86 GB, fits the 103 GB) is the next step.
 
 ## Bottom line
 

--- a/docs/plans/minimax-rdna-wmma-coverage.md
+++ b/docs/plans/minimax-rdna-wmma-coverage.md
@@ -83,12 +83,15 @@ validation target = Strix Halo via `ssh hipx`.
   localmaxxing run hit 103 GB there). Device 0 is an RX 5700 XT (gfx1010, RDNA1,
   7 GB, **no WMMA**). NB: `free -g` shows ~30 GB — that is the *host/CPU*
   partition (kfd node 0), **not** the iGPU pool; don't size MiniMax against it.
-- **Tier fit on device 1 (~96 GB carveout, ~103 GB with GTT):**
+- **Tier fit on device 1 (~96 GB carveout; the 103 GB total is GTT-inclusive but
+  `hipMalloc` only reaches the carveout). Footprint ≈ file + small overhead ONLY
+  after the expert-packing fix (68c1b808); pre-fix it was ~1.35× file and NOTHING
+  fit (mq2-lloyd OOM'd at L46). Sizes below are post-fix:**
   | tier | size | fits hipx? |
   |---|---|---|
-  | mq2 | 79 GB | ✅ comfortable |
-  | mq2-lloyd | 86 GB | ✅ comfortable |
-  | mq3 | 102 GB | ⚠️ GTT-edge, tight with KV/scratch |
+  | mq2 | 79 GB | ✅ (footprint ≈ 80 GB) |
+  | mq2-lloyd | 86 GB | ✅ **verified loads + runs, 23.6 tok/s** |
+  | mq3 | 102 GB | ❌ exceeds 96 GB carveout |
   | mq3-lloyd | 109 GB | ❌ exceeds |
   | mq4 | 124 GB | ❌ exceeds |
 - **What hipx CAN do:** full e2e RDNA coherence + perf for **mq2 + mq2-lloyd**.
@@ -126,8 +129,24 @@ deterministic across the two archs).
 
 This validates the **forward/decode path** (GEMV, Lloyd MoE decode incl. the
 MQ3-Lloyd port, MQ4 MoE, Q8 attention, rmsnorm, rope, qk-norm) on real RDNA3.5.
-It does **not** touch the WMMA grouped-prefill kernels (still the gap). Full-model
-e2e coherence on gfx1151 (mq2-lloyd, 86 GB, fits the 103 GB) is the next step.
+It does **not** touch the WMMA grouped-prefill kernels (still the gap).
+
+### Full-model e2e on gfx1151 + the expert-packing fix (commit 68c1b808)
+
+The first full-tier load OOM'd: mq2-lloyd's 86 GB **file** had a ~114 GB
+**resident** footprint (~1.35×), exceeding the 96 GB carveout (`hipMalloc` caps
+there; the extra ~7 GB to 103 GB is GTT, which device allocations don't reach).
+Root cause: the loader did a separate `upload_raw`/hipMalloc **per expert** —
+~31.7k tiny allocations, each rounded up to HIP's allocation granularity → ~20 GB
+of pure fragmentation. Fixed by adopting deepseek4's `upload_layer_routed_experts`
+pattern (pack all experts of a layer into ONE blob + a base+e*stride pointer
+table; bit-identical output, validated above). Footprint now ≈ file + small
+overhead.
+
+**After the fix, mq2-lloyd (86 GB) loads and runs on gfx1151:** correct
+Rayleigh-scattering answer, full `<think>` then clean two-sentence reply, clean
+EOS (270/320 tok), **23.6 tok/s** decode. First real-model MiniMax run on RDNA
+hardware. The fix shrinks footprint on every box (mi300 serve too).
 
 ## Bottom line
 

--- a/kernels/src/gemv_mq3g256_lloyd_moe_down_indexed.hip
+++ b/kernels/src/gemv_mq3g256_lloyd_moe_down_indexed.hip
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Index-aware fused MoE down GEMV with scaled residual for MQ3-Lloyd
+// (3-bit + per-block 8-entry fp16 codebook, 112 B/group). Sibling of
+// gemv_mq2g256_lloyd_moe_down_residual_scaled_k8_indexed — same expert-ptrs
+// dispatch + atomicAdd residual, but the per-group decode is the 8-entry
+// codebook lookup over 3-bit indices.
+//
+// `rot_batch[krank * K .. krank * K + K]` must be FWHT-pre-rotated for the
+// down projection (each top-k expert has its own post-gate-up activation;
+// each needs an independent rotation before this kernel sees it).
+//
+// atomicAdd into x_residual accumulates topk_weights[krank] * (W_down · rot_batch[krank])
+// across all top-k experts and rows. One launch replaces k_top per-expert
+// scaled-gemv-residual launches.
+//
+// Block layout (112 B / 256 weights): see
+// gemv_mq3g256_lloyd_moe_gate_up_indexed.hip for design notes.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_mq3g256_lloyd_moe_down_residual_scaled_k8_indexed(
+    const unsigned long long* __restrict__ expert_ptrs, // [n_exp] device pointers
+    const int*   __restrict__ topk_indices,              // [k_top]
+    const float* __restrict__ topk_weights,              // [k_top]
+    const float* __restrict__ rot_batch,                 // [k_top × K] FWHT-rotated
+    float*       __restrict__ x_residual,                // [M]
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int krank = blockIdx.y;
+    const int tid = threadIdx.x;
+
+    const int expert_id = topk_indices[krank];
+    const char* __restrict__ A =
+        reinterpret_cast<const char*>(expert_ptrs[expert_id]);
+    const float* __restrict__ x = rot_batch + (long long)krank * K;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 112;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = tid * 3;
+
+    // 32-slot LDS codebook: 4 groups × 8 entries.
+    __shared__ float cb_lds[32];
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 112;
+        const char* gp1 = gp0 + 112;
+        const char* gp2 = gp1 + 112;
+        const char* gp3 = gp2 + 112;
+
+        // Cooperative load: 32 threads × 1 fp16 → 32 fp32 entries in LDS.
+        // thread tid → group (tid >> 3), entry (tid & 7).
+        {
+            const __half* cb_h =
+                (const __half*)(gp0 + (long long)(tid >> 3) * 112);
+            cb_lds[tid] = __half2float(cb_h[tid & 7]);
+        }
+        __syncthreads();
+
+        const unsigned char* d0 = (const unsigned char*)(gp0 + 16) + boff;
+        const unsigned char* d1 = (const unsigned char*)(gp1 + 16) + boff;
+        const unsigned char* d2 = (const unsigned char*)(gp2 + 16) + boff;
+        const unsigned char* d3 = (const unsigned char*)(gp3 + 16) + boff;
+
+        unsigned int pk0 = (unsigned int)d0[0] | ((unsigned int)d0[1] << 8) | ((unsigned int)d0[2] << 16);
+        unsigned int pk1 = (unsigned int)d1[0] | ((unsigned int)d1[1] << 8) | ((unsigned int)d1[2] << 16);
+        unsigned int pk2 = (unsigned int)d2[0] | ((unsigned int)d2[1] << 8) | ((unsigned int)d2[2] << 16);
+        unsigned int pk3 = (unsigned int)d3[0] | ((unsigned int)d3[1] << 8) | ((unsigned int)d3[2] << 16);
+
+        int base = g * 256 + tid * 8;
+
+        #define DOG3_LDS(pk, lds, b, a)                               \
+            (a) += cb_lds[(lds) + ( (pk)        & 7u)] * x[(b)]       \
+                 + cb_lds[(lds) + (((pk) >>  3) & 7u)] * x[(b) + 1]   \
+                 + cb_lds[(lds) + (((pk) >>  6) & 7u)] * x[(b) + 2]   \
+                 + cb_lds[(lds) + (((pk) >>  9) & 7u)] * x[(b) + 3]   \
+                 + cb_lds[(lds) + (((pk) >> 12) & 7u)] * x[(b) + 4]   \
+                 + cb_lds[(lds) + (((pk) >> 15) & 7u)] * x[(b) + 5]   \
+                 + cb_lds[(lds) + (((pk) >> 18) & 7u)] * x[(b) + 6]   \
+                 + cb_lds[(lds) + (((pk) >> 21) & 7u)] * x[(b) + 7]
+
+        DOG3_LDS(pk0,  0, base,        acc0);
+        DOG3_LDS(pk1,  8, base + 256,  acc1);
+        DOG3_LDS(pk2, 16, base + 512,  acc2);
+        DOG3_LDS(pk3, 24, base + 768,  acc3);
+        #undef DOG3_LDS
+    }
+
+    #define TAIL_LOAD_AND_DOT(g_expr, acc) do {                                 \
+        const int g = (g_expr);                                                  \
+        const char* gp = row_ptr + g * 112;                                      \
+        if (tid < 8) {                                                           \
+            cb_lds[tid] = __half2float(((const __half*)gp)[tid]);                \
+        }                                                                        \
+        __syncthreads();                                                         \
+        const unsigned char* d = (const unsigned char*)(gp + 16) + boff;         \
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8)         \
+                        | ((unsigned int)d[2] << 16);                            \
+        int base = g * 256 + tid * 8;                                            \
+        (acc) += cb_lds[ (pk)        & 7u] * x[base]                             \
+               + cb_lds[((pk) >>  3) & 7u] * x[base + 1]                         \
+               + cb_lds[((pk) >>  6) & 7u] * x[base + 2]                         \
+               + cb_lds[((pk) >>  9) & 7u] * x[base + 3]                         \
+               + cb_lds[((pk) >> 12) & 7u] * x[base + 4]                         \
+               + cb_lds[((pk) >> 15) & 7u] * x[base + 5]                         \
+               + cb_lds[((pk) >> 18) & 7u] * x[base + 6]                         \
+               + cb_lds[((pk) >> 21) & 7u] * x[base + 7];                        \
+    } while (0)
+
+    if (tail >= 1) TAIL_LOAD_AND_DOT( quads << 2,       acc0);
+    if (tail >= 2) TAIL_LOAD_AND_DOT((quads << 2) + 1,  acc1);
+    if (tail >= 3) TAIL_LOAD_AND_DOT((quads << 2) + 2,  acc2);
+    #undef TAIL_LOAD_AND_DOT
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) {
+        const float scale = topk_weights[krank];
+        atomicAdd(&x_residual[row], scale * acc);
+    }
+}

--- a/kernels/src/gemv_mq3g256_lloyd_moe_gate_up_indexed.hip
+++ b/kernels/src/gemv_mq3g256_lloyd_moe_gate_up_indexed.hip
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Index-aware fused MoE gate_up GEMV for MQ3-Lloyd (3-bit + per-block 8-entry
+// fp16 codebook, 112 B/group). Sibling of
+// gemv_mq2g256_lloyd_moe_gate_up_indexed — same grid + expert-ptrs dispatch,
+// but the per-group decode is an 8-entry codebook lookup over 3-bit indices
+// instead of MQ2's 4-entry/2-bit decode.
+//
+// X must be FWHT-pre-rotated by the caller (MQ-family kernels rotate X
+// once per token, then re-use the rotated vector across all top-k experts).
+//
+// Block layout (112 B / 256 weights):
+//   [0..16)   : 8 × fp16 codebook entries (sorted ascending)
+//   [16..112) : 96 bytes packed 3-bit indices (32 chunks × 3 bytes,
+//               8 weights/chunk; per-thread 3-byte little-endian load,
+//               (pk >> (3*i)) & 7u for i in 0..8). Same cross-byte layout
+//               as uniform HFQ3-G256 / gemv_mq3g256_lloyd.
+//
+// Grid: [M, k_top, 1], block [32]. Output split: row<M/2 → y_gate, ≥M/2 → y_up.
+//
+// LDS codebook is 32 slots (4 groups × 8 entries). The K4 cooperative load
+// uses all 32 threads (group = tid>>3, entry = tid&7); the tail load uses
+// tid<8 for the single leftover group.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_mq3g256_lloyd_moe_gate_up_k8_indexed(
+    const unsigned long long* __restrict__ expert_ptrs, // [n_exp] device pointers
+    const int* __restrict__ topk_indices,                // [k_top]
+    const float* __restrict__ x_rot,                     // [K] (FWHT-rotated)
+    float* __restrict__ y_gate,                          // [k_top × mi]
+    float* __restrict__ y_up,                            // [k_top × mi]
+    int M, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int krank = blockIdx.y;
+    const int tid = threadIdx.x;
+
+    const int expert_id = topk_indices[krank];
+    const char* __restrict__ A =
+        reinterpret_cast<const char*>(expert_ptrs[expert_id]);
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 112;
+    const char* row_ptr = A + (long long)row * row_bytes;
+    const int boff = tid * 3;  // 3 bytes of indices per group per thread
+
+    // 32-slot LDS codebook: 4 groups × 8 entries. Group g's codebook
+    // occupies cb_lds[g*8 .. g*8+8].
+    __shared__ float cb_lds[32];
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f, acc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    // ----- main K4 loop -----
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        const char* gp0 = row_ptr + g * 112;
+        const char* gp1 = gp0 + 112;
+        const char* gp2 = gp1 + 112;
+        const char* gp3 = gp2 + 112;
+
+        // Cooperative load: 32 threads × 1 fp16 → 32 fp32 entries in LDS.
+        // thread tid → group (tid >> 3), entry (tid & 7).
+        {
+            const __half* cb_h =
+                (const __half*)(gp0 + (long long)(tid >> 3) * 112);
+            cb_lds[tid] = __half2float(cb_h[tid & 7]);
+        }
+        __syncthreads();
+
+        // Load 3 packed bytes (one per group, this thread's 3 bytes).
+        const unsigned char* d0 = (const unsigned char*)(gp0 + 16) + boff;
+        const unsigned char* d1 = (const unsigned char*)(gp1 + 16) + boff;
+        const unsigned char* d2 = (const unsigned char*)(gp2 + 16) + boff;
+        const unsigned char* d3 = (const unsigned char*)(gp3 + 16) + boff;
+
+        unsigned int pk0 = (unsigned int)d0[0] | ((unsigned int)d0[1] << 8) | ((unsigned int)d0[2] << 16);
+        unsigned int pk1 = (unsigned int)d1[0] | ((unsigned int)d1[1] << 8) | ((unsigned int)d1[2] << 16);
+        unsigned int pk2 = (unsigned int)d2[0] | ((unsigned int)d2[1] << 8) | ((unsigned int)d2[2] << 16);
+        unsigned int pk3 = (unsigned int)d3[0] | ((unsigned int)d3[1] << 8) | ((unsigned int)d3[2] << 16);
+
+        int base = g * 256 + tid * 8;
+
+        #define DOG3_LDS(pk, lds, b, a)                                   \
+            (a) += cb_lds[(lds) + ( (pk)        & 7u)] * x_rot[(b)]       \
+                 + cb_lds[(lds) + (((pk) >>  3) & 7u)] * x_rot[(b) + 1]   \
+                 + cb_lds[(lds) + (((pk) >>  6) & 7u)] * x_rot[(b) + 2]   \
+                 + cb_lds[(lds) + (((pk) >>  9) & 7u)] * x_rot[(b) + 3]   \
+                 + cb_lds[(lds) + (((pk) >> 12) & 7u)] * x_rot[(b) + 4]   \
+                 + cb_lds[(lds) + (((pk) >> 15) & 7u)] * x_rot[(b) + 5]   \
+                 + cb_lds[(lds) + (((pk) >> 18) & 7u)] * x_rot[(b) + 6]   \
+                 + cb_lds[(lds) + (((pk) >> 21) & 7u)] * x_rot[(b) + 7]
+
+        DOG3_LDS(pk0,  0, base,        acc0);
+        DOG3_LDS(pk1,  8, base + 256,  acc1);
+        DOG3_LDS(pk2, 16, base + 512,  acc2);
+        DOG3_LDS(pk3, 24, base + 768,  acc3);
+        #undef DOG3_LDS
+    }
+
+    // ----- tail loop (1, 2, or 3 leftover groups) -----
+    #define TAIL_LOAD_AND_DOT(g_expr, acc) do {                                 \
+        const int g = (g_expr);                                                  \
+        const char* gp = row_ptr + g * 112;                                      \
+        if (tid < 8) {                                                           \
+            cb_lds[tid] = __half2float(((const __half*)gp)[tid]);                \
+        }                                                                        \
+        __syncthreads();                                                         \
+        const unsigned char* d = (const unsigned char*)(gp + 16) + boff;         \
+        unsigned int pk = (unsigned int)d[0] | ((unsigned int)d[1] << 8)         \
+                        | ((unsigned int)d[2] << 16);                            \
+        int base = g * 256 + tid * 8;                                            \
+        (acc) += cb_lds[ (pk)        & 7u] * x_rot[base]                         \
+               + cb_lds[((pk) >>  3) & 7u] * x_rot[base + 1]                     \
+               + cb_lds[((pk) >>  6) & 7u] * x_rot[base + 2]                     \
+               + cb_lds[((pk) >>  9) & 7u] * x_rot[base + 3]                     \
+               + cb_lds[((pk) >> 12) & 7u] * x_rot[base + 4]                     \
+               + cb_lds[((pk) >> 15) & 7u] * x_rot[base + 5]                     \
+               + cb_lds[((pk) >> 18) & 7u] * x_rot[base + 6]                     \
+               + cb_lds[((pk) >> 21) & 7u] * x_rot[base + 7];                    \
+    } while (0)
+
+    if (tail >= 1) TAIL_LOAD_AND_DOT( quads << 2,       acc0);
+    if (tail >= 2) TAIL_LOAD_AND_DOT((quads << 2) + 1,  acc1);
+    if (tail >= 3) TAIL_LOAD_AND_DOT((quads << 2) + 2,  acc2);
+    #undef TAIL_LOAD_AND_DOT
+
+    float acc = (acc0 + acc1) + (acc2 + acc3);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) {
+        const int mi = M >> 1;
+        if (row < mi) {
+            y_gate[krank * mi + row] = acc;
+        } else {
+            y_up[krank * mi + (row - mi)] = acc;
+        }
+    }
+}

--- a/scripts/gen_tiny_minimax.py
+++ b/scripts/gen_tiny_minimax.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+"""Generate a tiny random-weight MiniMax-M2 oracle for hipfire arch validation.
+
+Uses the BUILT-IN transformers `MiniMaxM2` (compatible with the installed
+transformers; the checkpoint's bundled custom modeling needs a newer API).
+The built-in impl is a faithful MiniMax-M2: per-LAYER QK-norm (RMSNorm on the
+flat n_heads*head_dim / n_kv*head_dim vector), partial rotate_half RoPE
+(rotary_dim = head_dim*partial_rotary_factor), sigmoid+bias top-k routing
+(gather-unbiased + normalize, no scaling), SwiGLU experts, no shared expert.
+
+Dims keep attention in the real regime (head_dim=128, rotary_dim=64) and make
+every 2D weight k%256==0 (HFQ4G256-quantizable): hidden=256, 4Q/2KV hd128,
+inter=256, 8 experts top-2, 2 layers, vocab=512.
+
+Built-in stores experts PACKED (gate_up_proj[E,2I,H], down_proj[E,H,I]); the
+real ckpt + hipfire loader want SPLIT (block_sparse_moe.experts.E.w{1,2,3}).
+So we RE-SPLIT the state_dict before saving model.safetensors (numerically
+identical, just reorganized): w1=gate_up[:I], w3=gate_up[I:], w2=down.
+
+Outputs into <out>:
+  model.safetensors + config.json  (SPLIT layout, flat arch fields → hipfire)
+  oracle_hidden.hfhs               (HF per-layer post-residual, pre-final-norm)
+  tokens.hfkldr                    (fixed token chunk for both dumpers)
+"""
+import argparse, json, struct, sys
+from pathlib import Path
+import torch
+from transformers import MiniMaxM2Config, MiniMaxM2ForCausalLM
+from safetensors.torch import save_file
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", default="/workspace/minimax-tiny")
+    p.add_argument("--n-ctx", type=int, default=16)
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+def main():
+    args = parse_args()
+    torch.manual_seed(args.seed)
+    n_layers, inter, hidden = 2, 256, 256
+    # top-8 to match the hardcoded "k8" indexed-MoE GEMV kernels (the real
+    # MiniMax-M2 is also top-8). 16 experts → genuine top-8 sparsity.
+    cfg = MiniMaxM2Config(
+        vocab_size=512, hidden_size=hidden, intermediate_size=inter,
+        num_hidden_layers=n_layers, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=128, num_local_experts=16, num_experts_per_tok=8,
+        max_position_embeddings=512, rms_norm_eps=1e-6, tie_word_embeddings=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 5_000_000.0,
+                         "partial_rotary_factor": 0.5},  # rotary_dim = 128*0.5 = 64
+    )
+    model = MiniMaxM2ForCausalLM(cfg).to(torch.float32).eval()
+    # Spread the routing bias so top-k selection is non-trivial.
+    with torch.no_grad():
+        for layer in model.model.layers:
+            b = layer.mlp.e_score_correction_bias
+            b.copy_(torch.randn_like(b) * 0.1)
+
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    # Fixed token chunk (seeded).
+    g = torch.Generator().manual_seed(args.seed + 1)
+    tokens = torch.randint(0, cfg.vocab_size, (args.n_ctx,), generator=g).tolist()
+    print(f"tokens ({args.n_ctx}): {tokens}", flush=True)
+    with open(out / "tokens.hfkldr", "wb") as f:
+        f.write(b"HFKLDR\0\0"); hdr = bytearray(24)
+        struct.pack_into("<I", hdr, 4, args.n_ctx); struct.pack_into("<I", hdr, 12, 1)
+        f.write(hdr); f.write(struct.pack(f"<{args.n_ctx}I", *tokens))
+
+    # Forward (+ hidden states) and pre-final-norm hook.
+    input_ids = torch.tensor([tokens], dtype=torch.long)
+    with torch.no_grad():
+        res = model(input_ids, output_hidden_states=True)
+    hs = res.hidden_states
+    cap = {}
+    h = model.model.norm.register_forward_pre_hook(lambda m, i: cap.__setitem__("x", i[0].detach()))
+    with torch.no_grad():
+        _ = model(input_ids)
+    h.remove()
+    post_last = cap["x"][0]
+    with open(out / "oracle_hidden.hfhs", "wb") as f:
+        f.write(b"HFHS\0\0\0\0"); f.write(struct.pack("<IIII", n_layers, args.n_ctx, hidden, 0))
+        for k in range(n_layers):
+            t = hs[k + 1][0] if k < n_layers - 1 else post_last
+            assert tuple(t.shape) == (args.n_ctx, hidden), (k, t.shape)
+            arr = t.float().cpu().contiguous().numpy()
+            f.write(arr.tobytes())
+            print(f"  layer {k}: rms={float((arr.astype('float64')**2).mean()**0.5):.4f}", flush=True)
+
+    # Post-ATTENTION residual oracle (input to each post_attention_layernorm),
+    # for attention-vs-MoE divergence localization.
+    pa = {}
+    handles = []
+    for li, layer in enumerate(model.model.layers):
+        handles.append(layer.post_attention_layernorm.register_forward_pre_hook(
+            (lambda idx: (lambda m, i: pa.__setitem__(idx, i[0].detach())))(li)))
+    with torch.no_grad():
+        _ = model(input_ids)
+    for h2 in handles:
+        h2.remove()
+    with open(out / "oracle_postattn.hfhs", "wb") as f:
+        f.write(b"HFHS\0\0\0\0"); f.write(struct.pack("<IIII", n_layers, args.n_ctx, hidden, 0))
+        for k in range(n_layers):
+            arr = pa[k][0].float().cpu().contiguous().numpy()
+            assert arr.shape == (args.n_ctx, hidden), (k, arr.shape)
+            f.write(arr.tobytes())
+    print(f"wrote {out}/oracle_postattn.hfhs", flush=True)
+
+    # Re-split PACKED → SPLIT and save model.safetensors.
+    sd = model.state_dict()
+    split = {}
+    for name, t in sd.items():
+        t = t.detach().to(torch.float32).contiguous()
+        if name.endswith("mlp.experts.gate_up_proj"):           # [E, 2I, H]
+            pre = name[:-len("mlp.experts.gate_up_proj")]
+            for e in range(cfg.num_local_experts):
+                split[f"{pre}block_sparse_moe.experts.{e}.w1.weight"] = t[e][:inter, :].contiguous()
+                split[f"{pre}block_sparse_moe.experts.{e}.w3.weight"] = t[e][inter:, :].contiguous()
+        elif name.endswith("mlp.experts.down_proj"):             # [E, H, I]
+            pre = name[:-len("mlp.experts.down_proj")]
+            for e in range(cfg.num_local_experts):
+                split[f"{pre}block_sparse_moe.experts.{e}.w2.weight"] = t[e].contiguous()
+        elif name.endswith("mlp.gate.weight"):
+            split[name.replace("mlp.gate.weight", "block_sparse_moe.gate.weight")] = t
+        elif name.endswith("mlp.e_score_correction_bias"):
+            split[name.replace("mlp.e_score_correction_bias",
+                               "block_sparse_moe.e_score_correction_bias")] = t
+        else:
+            split[name] = t  # attn / norms / embed / lm_head — unchanged HF names
+    save_file(split, str(out / "model.safetensors"))
+    print(f"re-split → {len(split)} tensors", flush=True)
+
+    # config.json with flat arch fields (real-ckpt convention hipfire parses).
+    conf = json.loads((out / "config.json").read_text()) if (out / "config.json").exists() else {}
+    conf.update(dict(
+        architectures=["MiniMaxM2ForCausalLM"], model_type="minimax_m2",
+        vocab_size=512, hidden_size=hidden, intermediate_size=inter,
+        num_hidden_layers=n_layers, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=128, num_local_experts=16, num_experts_per_tok=8,
+        rotary_dim=64, rope_theta=5_000_000.0, rms_norm_eps=1e-6,
+        use_qk_norm=True, use_routing_bias=True, scoring_func="sigmoid",
+        max_position_embeddings=512, num_mtp_modules=0, tie_word_embeddings=False,
+    ))
+    (out / "config.json").write_text(json.dumps(conf, indent=2))
+    print(f"wrote {out}/config.json (flat arch fields)", flush=True)
+    print(f"DONE → {out}", flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_tiny_oracle.py
+++ b/scripts/gen_tiny_oracle.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+"""Generalized tiny random-weight ORACLE generator for hipfire arch ports.
+
+Builds a dimension-faithful *tiny* model from the reference (HF transformers)
+implementation and dumps per-layer hidden states, so a new hipfire arch port's
+forward pass can be validated to cosine≈1 in seconds, with no real weights and
+no GPU-hours. See docs/methodology/arch-port-validation.md for the full method.
+
+Outputs into <out>:
+  model.safetensors + config.json   (the layout hipfire ingests; re-split if needed)
+  oracle_hidden.hfhs                 (HF per-layer post-residual, PRE final-norm)
+  oracle_postattn.hfhs               (HF per-layer post-ATTENTION residual; for bisection)
+  tokens.hfkldr                      (fixed token chunk both dumpers read)
+
+HFHS = magic "HFHS\\0\\0\\0\\0" + <IIII>(n_layers,n_pos,hidden,0) + n_layers×[n_pos,hidden] f32.
+HFKLDR = magic "HFKLDR\\0\\0" + 24B hdr (n_ctx@[4:8], n_chunk@[12:16]) + n_ctx u32 tokens @32.
+
+──────────────────────────────────────────────────────────────────────────────
+PORTING A NEW ARCH: edit only the `ARCH ADAPTATION` block below. Pick dims per
+the pitfall checklist (docs/methodology/arch-port-validation.md):
+  • keep REAL head_dim / rotary_dim (shrink #heads/#layers, not head_dim)
+  • every quantized 2D weight: k % group_size == 0 (usually 256)
+  • match any hardcoded kernel k_top (e.g. _k8 kernels → num_experts_per_tok=8)
+  • routing/precision-sensitive tensors stay Q8 (handled at quantize time)
+  • re-split packed→split if the loader/kernels expect split experts
+──────────────────────────────────────────────────────────────────────────────
+"""
+import argparse, json, struct, sys
+from pathlib import Path
+import torch
+
+
+# ===================== ARCH ADAPTATION (edit per arch) ======================
+def build_model_and_config(seed: int):
+    """Return (model, hf_config, n_layers, hidden). Tiny, real head_dim/rotary,
+    dims divisible by the quant group size, top-k matching the kernel."""
+    from transformers import MiniMaxM2Config, MiniMaxM2ForCausalLM  # ← arch import
+    torch.manual_seed(seed)
+    n_layers, inter, hidden = 2, 256, 256
+    cfg = MiniMaxM2Config(
+        vocab_size=512, hidden_size=hidden, intermediate_size=inter,
+        num_hidden_layers=n_layers, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=128,                       # REAL head_dim (not shrunk)
+        num_local_experts=16, num_experts_per_tok=8,   # top-8 matches the _k8 kernels
+        max_position_embeddings=512, rms_norm_eps=1e-6, tie_word_embeddings=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 5_000_000.0,
+                         "partial_rotary_factor": 0.5},  # rotary_dim = 128*0.5 = 64
+    )
+    model = MiniMaxM2ForCausalLM(cfg).to(torch.float32).eval()
+    # Optional: perturb routing bias so top-k selection is non-trivial.
+    with torch.no_grad():
+        for layer in model.model.layers:
+            b = layer.mlp.e_score_correction_bias
+            b.copy_(torch.randn_like(b) * 0.1)
+    return model, cfg, n_layers, hidden
+
+
+def post_attn_modules(model):
+    """Modules whose INPUT is the post-attention residual (pre-MoE/FFN), one per
+    layer, for the bisection oracle. Typically the post_attention_layernorm."""
+    return [layer.post_attention_layernorm for layer in model.model.layers]
+
+
+def final_norm_module(model):
+    """The final norm; its INPUT is the post-last-layer pre-norm hidden state."""
+    return model.model.norm
+
+
+def resplit_state_dict(sd, cfg):
+    """Reorganize the saved state_dict to the layout hipfire ingests. Return a
+    new dict. Identity if the reference already matches. MiniMax: HF packs
+    experts (gate_up_proj[E,2I,H]/down_proj[E,H,I]) but the real ckpt + hipfire
+    want split block_sparse_moe.experts.E.{w1,w2,w3}."""
+    inter = cfg.intermediate_size
+    out = {}
+    for name, t in sd.items():
+        t = t.detach().to(torch.float32).contiguous()
+        if name.endswith("mlp.experts.gate_up_proj"):
+            pre = name[:-len("mlp.experts.gate_up_proj")]
+            for e in range(cfg.num_local_experts):
+                out[f"{pre}block_sparse_moe.experts.{e}.w1.weight"] = t[e][:inter, :].contiguous()
+                out[f"{pre}block_sparse_moe.experts.{e}.w3.weight"] = t[e][inter:, :].contiguous()
+        elif name.endswith("mlp.experts.down_proj"):
+            pre = name[:-len("mlp.experts.down_proj")]
+            for e in range(cfg.num_local_experts):
+                out[f"{pre}block_sparse_moe.experts.{e}.w2.weight"] = t[e].contiguous()
+        elif name.endswith("mlp.gate.weight"):
+            out[name.replace("mlp.gate.weight", "block_sparse_moe.gate.weight")] = t
+        elif name.endswith("mlp.e_score_correction_bias"):
+            out[name.replace("mlp.e_score_correction_bias",
+                             "block_sparse_moe.e_score_correction_bias")] = t
+        else:
+            out[name] = t
+    return out
+
+
+def flat_config_fields(cfg):
+    """Flat config fields hipfire's `*Config::from_hfq` parses (the real-ckpt
+    convention), in case the HF config nests them differently."""
+    return dict(
+        architectures=["MiniMaxM2ForCausalLM"], model_type="minimax_m2",
+        vocab_size=cfg.vocab_size, hidden_size=cfg.hidden_size,
+        intermediate_size=cfg.intermediate_size, num_hidden_layers=cfg.num_hidden_layers,
+        num_attention_heads=cfg.num_attention_heads, num_key_value_heads=cfg.num_key_value_heads,
+        head_dim=128, num_local_experts=cfg.num_local_experts,
+        num_experts_per_tok=cfg.num_experts_per_tok, rotary_dim=64, rope_theta=5_000_000.0,
+        rms_norm_eps=1e-6, use_qk_norm=True, use_routing_bias=True, scoring_func="sigmoid",
+        max_position_embeddings=512, num_mtp_modules=0, tie_word_embeddings=False,
+    )
+# =================== END ARCH ADAPTATION ====================================
+
+
+def write_hfhs(path, tensors, n_layers, n_ctx, hidden):
+    with open(path, "wb") as f:
+        f.write(b"HFHS\0\0\0\0")
+        f.write(struct.pack("<IIII", n_layers, n_ctx, hidden, 0))
+        for k in range(n_layers):
+            arr = tensors[k].float().cpu().contiguous().numpy()
+            assert arr.shape == (n_ctx, hidden), (k, arr.shape)
+            f.write(arr.tobytes())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="/workspace/minimax-tiny")
+    ap.add_argument("--n-ctx", type=int, default=16)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    model, cfg, n_layers, hidden = build_model_and_config(args.seed)
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    # Fixed token chunk.
+    g = torch.Generator().manual_seed(args.seed + 1)
+    tokens = torch.randint(0, cfg.vocab_size, (args.n_ctx,), generator=g).tolist()
+    with open(out / "tokens.hfkldr", "wb") as f:
+        f.write(b"HFKLDR\0\0"); hdr = bytearray(24)
+        struct.pack_into("<I", hdr, 4, args.n_ctx); struct.pack_into("<I", hdr, 12, 1)
+        f.write(hdr); f.write(struct.pack(f"<{args.n_ctx}I", *tokens))
+    print(f"tokens: {tokens}", flush=True)
+
+    input_ids = torch.tensor([tokens], dtype=torch.long)
+
+    # Per-layer POST-residual (pre final-norm): hs[k+1] for k<last, hook for last.
+    with torch.no_grad():
+        hs = model(input_ids, output_hidden_states=True).hidden_states
+    cap = {}
+    h = final_norm_module(model).register_forward_pre_hook(
+        lambda m, i: cap.__setitem__("x", i[0].detach()))
+    with torch.no_grad():
+        _ = model(input_ids)
+    h.remove()
+    layer_out = [hs[k + 1][0] if k < n_layers - 1 else cap["x"][0] for k in range(n_layers)]
+    write_hfhs(out / "oracle_hidden.hfhs", layer_out, n_layers, args.n_ctx, hidden)
+    for k in range(n_layers):
+        rms = float((layer_out[k].float() ** 2).mean() ** 0.5)
+        print(f"  layer {k}: post-residual rms={rms:.4f}", flush=True)
+
+    # Per-layer POST-ATTENTION residual (input to each post_attn norm) for bisection.
+    pa, handles = {}, []
+    for li, mod in enumerate(post_attn_modules(model)):
+        handles.append(mod.register_forward_pre_hook(
+            (lambda idx: (lambda m, i: pa.__setitem__(idx, i[0].detach())))(li)))
+    with torch.no_grad():
+        _ = model(input_ids)
+    for hd in handles:
+        hd.remove()
+    write_hfhs(out / "oracle_postattn.hfhs", [pa[k][0] for k in range(n_layers)],
+               n_layers, args.n_ctx, hidden)
+
+    # Save model.safetensors in the hipfire-ingest layout + flat config.json.
+    from safetensors.torch import save_file
+    save_file(resplit_state_dict(model.state_dict(), cfg), str(out / "model.safetensors"))
+    conf = json.loads((out / "config.json").read_text()) if (out / "config.json").exists() else {}
+    conf.update(flat_config_fields(cfg))
+    (out / "config.json").write_text(json.dumps(conf, indent=2))
+    print(f"DONE → {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hfq_inject_chat_template.py
+++ b/scripts/hfq_inject_chat_template.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Inject a chat_template.jinja into an existing .hfq's metadata WITHOUT re-quantizing.
+
+HFQ layout: [32B header] [metadata JSON] [tensor index (sizes, no offsets)] [tensor data].
+The index stores per-tensor *sizes*; the loader computes offsets cumulatively from the
+header's data_offset (hfq.rs:163 `cumulative_offset = data_offset`). So we only grow the
+metadata, bump data_offset by the delta, and copy the index + tensor bytes through verbatim.
+"""
+import struct, json, sys, shutil
+
+def find_json_end(buf: bytes) -> int:
+    depth = 0; in_str = False; esc = False
+    for i, b in enumerate(buf):
+        if esc: esc = False; continue
+        if b == 0x5c and in_str: esc = True; continue   # backslash inside string
+        if b == 0x22: in_str = not in_str; continue       # quote
+        if not in_str:
+            if b == 0x7b: depth += 1                       # {
+            elif b == 0x7d:                                # }
+                depth -= 1
+                if depth == 0: return i + 1
+    raise ValueError("no matching close brace for metadata JSON")
+
+def inject(src: str, dst: str, jinja_path: str) -> bool:
+    with open(src, "rb") as f:
+        prefix = bytearray(f.read(0))  # placeholder
+        head = f.read(32)
+        assert head[:4] == b"HFQM", f"not an HFQM container: {head[:4]!r}"
+        metadata_offset = struct.unpack_from("<Q", head, 16)[0]
+        data_offset = struct.unpack_from("<Q", head, 24)[0]
+        f.seek(0)
+        prefix = bytearray(f.read(metadata_offset))        # header + any pre-metadata gap
+        meta_region = f.read(data_offset - metadata_offset)  # [metadata JSON][index][pad]
+
+    je = find_json_end(meta_region)
+    md = json.loads(meta_region[:je].decode("utf-8"))
+    index_and_pad = meta_region[je:]
+
+    tc = md.get("tokenizer_config")
+    if not isinstance(tc, dict):
+        tc = {}
+    existing = tc.get("chat_template")
+    if isinstance(existing, str) and existing.strip():
+        print(f"  {src}: already has a chat_template ({len(existing)} chars); skipping")
+        return False
+
+    tpl = open(jinja_path, encoding="utf-8").read()
+    tc["chat_template"] = tpl
+    md["tokenizer_config"] = tc
+    new_meta = json.dumps(md, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    new_data_offset = metadata_offset + len(new_meta) + len(index_and_pad)
+    struct.pack_into("<Q", prefix, 24, new_data_offset)    # patch data_offset only
+
+    with open(dst, "wb") as out:
+        out.write(prefix)
+        out.write(new_meta)
+        out.write(index_and_pad)
+        with open(src, "rb") as f:
+            f.seek(data_offset)
+            shutil.copyfileobj(f, out, 64 * 1024 * 1024)
+
+    print(f"  {src} -> {dst}: data_offset {data_offset} -> {new_data_offset} "
+          f"(+{new_data_offset - data_offset}), template {len(tpl)} chars")
+    return True
+
+if __name__ == "__main__":
+    inject(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/scripts/minimax_expert_routing_importance.py
+++ b/scripts/minimax_expert_routing_importance.py
@@ -1,0 +1,91 @@
+import gguf, numpy as np
+
+R = gguf.GGUFReader("/workspace/imatrix_unsloth_minimax.gguf")
+T = {t.name: t for t in R.tensors}
+
+NL, NE = 62, 256
+
+def get(name):
+    t = T.get(name)
+    return None if t is None else np.array(t.data, dtype=np.float32)
+
+# Per-layer routing counts + per-expert activation energy (gate input = MoE input).
+counts = np.zeros((NL, NE), dtype=np.float64)
+energy = np.zeros((NL, NE), dtype=np.float64)   # mean per-routing activation energy (gate)
+denergy = np.zeros((NL, NE), dtype=np.float64)  # down-input energy
+for n in range(NL):
+    c = get(f"blk.{n}.ffn_gate_exps.weight.counts")
+    s = get(f"blk.{n}.ffn_gate_exps.weight.in_sum2")   # [K, NE] flat, expert-major e*K+j
+    d = get(f"blk.{n}.ffn_down_exps.weight.in_sum2")
+    if c is None or s is None:
+        continue
+    c = c.reshape(-1)[:NE]
+    counts[n] = c
+    K = s.size // NE
+    s2 = s.reshape(NE, K)            # in_sum2[e][j]
+    energy[n] = s2.sum(axis=1) / np.maximum(c, 1)   # mean |x|^2 per routing
+    if d is not None:
+        Kd = d.size // NE
+        denergy[n] = d.reshape(NE, Kd).sum(axis=1) / np.maximum(c, 1)
+
+tot = counts.sum(axis=1)  # total routings per layer (= n_tok * top_k, ~const)
+print(f"routings/layer: min={tot.min():.0f} max={tot.max():.0f} (= n_tok*top_k)")
+print()
+
+# --- Routing concentration: top-K coverage per layer ---
+print("=== ROUTING CONCENTRATION (fraction of routings handled by top-K experts) ===")
+print(f"{'layer':>5} {'top8':>6} {'top16':>6} {'top32':>6} {'top64':>6} {'maxfrac':>8} {'gini':>6}")
+def gini(x):
+    x = np.sort(x); n = len(x); cum = np.cumsum(x)
+    return 0.0 if cum[-1] == 0 else (n + 1 - 2*np.sum(cum)/cum[-1]) / n
+cov = {8: [], 16: [], 32: [], 64: []}
+for n in range(NL):
+    c = counts[n]; s = np.sort(c)[::-1]; t = c.sum()
+    if t == 0: continue
+    row = {k: s[:k].sum()/t for k in cov}
+    for k in cov: cov[k].append(row[k])
+    if n % 8 == 0 or n in (1, NL-1):
+        print(f"{n:>5} {row[8]:>6.2f} {row[16]:>6.2f} {row[32]:>6.2f} {row[64]:>6.2f} {s[0]/t:>8.3f} {gini(c):>6.3f}")
+print(f"{'MEAN':>5} {np.mean(cov[8]):>6.2f} {np.mean(cov[16]):>6.2f} {np.mean(cov[32]):>6.2f} {np.mean(cov[64]):>6.2f}")
+print()
+
+# --- Are the same expert INDICES hot across layers? ---
+print("=== CROSS-LAYER HOTNESS (do hot experts repeat across layers?) ===")
+topsets = [set(np.argsort(counts[n])[::-1][:32]) for n in range(NL) if counts[n].sum() > 0]
+freq = np.zeros(NE)
+for ts in topsets:
+    for e in ts: freq[e] += 1
+hot_global = np.argsort(freq)[::-1][:16]
+print(f"experts in top-32 of the most layers: {[(int(e), int(freq[e])) for e in hot_global[:10]]}")
+print(f"  (count = # of {len(topsets)} layers where that expert is top-32) — high => global hot expert")
+print(f"  experts top-32 in >50% of layers: {int((freq > len(topsets)*0.5).sum())} / 256")
+print()
+
+# --- Importance = counts (selection freq) weighted by activation magnitude ---
+imp = counts * np.sqrt(np.maximum(energy, 0))   # ~ counts * typical |x|
+print("=== PROMOTION LEVERAGE: promote top-K experts/layer (by count) to higher precision ===")
+print(f"{'K/layer':>8} {'rout_cov':>9} {'imp_cov':>8} {'size mq6':>9} {'size mq4':>9}")
+# base sizes (per the produced files): mq2-lloyd=67.5GB experts; mq6~2.8x, mq4~1.8x of mq2-lloyd per expert
+GB_MQ2 = 67.5
+for K in (8, 16, 32, 48, 64):
+    rc, ic = [], []
+    for n in range(NL):
+        c = counts[n]; t = c.sum()
+        if t == 0: continue
+        order = np.argsort(c)[::-1][:K]
+        rc.append(c[order].sum()/t)
+        it = imp[n].sum()
+        ic.append(imp[n][order].sum()/it if it > 0 else 0)
+    frac = K / NE
+    # promoted experts cost (mult-1)x extra; mq6~2.8x, mq4~1.8x the mq2-lloyd per-expert bytes
+    sz6 = GB_MQ2 + GB_MQ2 * frac * (2.8 - 1.0)
+    sz4 = GB_MQ2 + GB_MQ2 * frac * (1.8 - 1.0)
+    print(f"{K:>8} {np.mean(rc):>9.2f} {np.mean(ic):>8.2f} {sz6:>7.1f}GB {sz4:>7.1f}GB")
+print()
+print("rout_cov = fraction of token->expert routings that hit a PROMOTED (high-precision) expert")
+print("imp_cov  = fraction of activation-weighted importance covered by the promoted set")
+
+# --- gate/up vs down: which projection carries more energy (where to spend bits) ---
+print()
+ge = energy[counts > 0].mean(); de = denergy[counts > 0].mean()
+print(f"=== mean per-routing energy: gate/up-input={ge:.3f}  down-input={de:.3f}  (ratio {de/ge:.2f}) ===")

--- a/scripts/minimax_marginal_moe_error.py
+++ b/scripts/minimax_marginal_moe_error.py
@@ -1,0 +1,46 @@
+import struct, numpy as np
+
+def load(p):
+    b = open(p, "rb").read()
+    assert b[:8] == b"HFHS\0\0\0\0", p
+    nl, npos, h, _ = struct.unpack_from("<IIII", b, 8)
+    return np.frombuffer(b, dtype=np.float32, offset=24).reshape(nl, npos, h)
+
+import sys
+pm2_path = sys.argv[1] if len(sys.argv) > 1 else "/workspace/sens-mq2.hfhs"
+pa2_path = sys.argv[2] if len(sys.argv) > 2 else "/workspace/sens-mq2-pa.hfhs"
+pm4 = load("/workspace/sens-mq4.hfhs"); pa4 = load("/workspace/sens-mq4-pa.hfhs")
+pm2 = load(pm2_path); pa2 = load(pa2_path)
+print(f"# comparing {pm2_path} vs mq4 reference")
+nl = pm4.shape[0]
+
+def cos(x, y):
+    x = x.ravel().astype(np.float64); y = y.ravel().astype(np.float64)
+    return float(x @ y / ((np.linalg.norm(x) * np.linalg.norm(y)) + 1e-12))
+
+def rms(x):
+    return float(np.sqrt((x.astype(np.float64) ** 2).mean()))
+
+print("  L   in_cos  moe_cos  moe_mag4  moe_err  err/mag")
+rows = []
+for L in range(nl):
+    moe4 = pm4[L] - pa4[L]; moe2 = pm2[L] - pa2[L]
+    ic = cos(pa2[L], pa4[L]); mc = cos(moe2, moe4)
+    mag = rms(moe4); err = rms(moe2 - moe4); ratio = err / (mag + 1e-9)
+    rows.append((L, ic, mc, mag, err, ratio))
+    print(f"{L:>3} {ic:>8.4f} {mc:>8.4f} {mag:>9.4f} {err:>8.4f} {ratio:>8.3f}")
+
+print("=== top-15 by lowest MoE-output cosine (most-diverged expert block) ===")
+for r in sorted(rows, key=lambda r: r[2])[:15]:
+    print(f"  L{r[0]:>2} moe_cos={r[2]:.4f} mag={r[3]:.3f} err/mag={r[5]:.3f}")
+
+print("=== top-15 by err/mag (relative quant error, contribution-weighted) ===")
+for r in sorted(rows, key=lambda r: -r[5])[:15]:
+    print(f"  L{r[0]:>2} err/mag={r[5]:.3f} moe_cos={r[2]:.4f} mag={r[3]:.3f}")
+
+# Suggest a promotion set: layers whose MoE block is both high-magnitude and
+# high relative error (the ones 2-bit hurts most in absolute terms).
+thr = sorted([r[5] for r in rows])[int(nl * 0.55)]  # promote ~upper 45% by err/mag
+promote = sorted([r[0] for r in rows if r[5] >= thr])
+print(f"=== suggested promote set (err/mag >= {thr:.3f}, {len(promote)} layers) ===")
+print(" ", promote)


### PR DESCRIPTION
## Summary

Adds **MiniMax-M2.7** support to hipfire (`arch_id = 10`, crate `hipfire-arch-minimax`)
— a 229B-parameter (~10B active) MoE: GQA attention with per-layer QK-norm,
partial-rotate RoPE, a 256-expert top-8 sigmoid+bias router (DeepSeek-V3-style),
SwiGLU experts, **no shared expert**. 62 layers, hidden 3072, vocab 200064.

The model **runs end-to-end on both CDNA (gfx942) and RDNA 3.5 (gfx1151 / Strix
Halo)** — the first real-model MiniMax run on RDNA hardware. Five quant tiers are
published at [`hipfire-models/hipfire-MiniMax-M2.7`](https://huggingface.co/hipfire-models/hipfire-MiniMax-M2.7).

Branch is merged up to date with `master` (oracle-validated post-merge).

## What it adds

- **`hipfire-arch-minimax`** — config / weight-ingestion / forward pass (FP8 e4m3
  + F32 block-scale source -> MQ4/MQ3-Lloyd/MQ2-Lloyd).
- **MQ3-Lloyd indexed-decode MoE GEMV kernels** (3-bit / 8-entry codebook).
- **Per-projection mixed-dtype dispatch** -- the *down* projection is promoted
  independently of gate/up. MiniMax has no shared expert, so 2-bit experts collapse
  into loops; the down projection's input carries ~588x the gate/up energy (~24x
  error amplification), so promoting only `w2` (to >=3-bit) restores coherence.
- **AWQ on routed experts** (gate/up only; shared per-layer activation scale).
- **Packed-expert loader** (deepseek4 `upload_layer_routed_experts` pattern) --
  one blob + pointer table per layer instead of ~31.7k per-expert `hipMalloc`s,
  saving ~20 GB of allocation-granularity fragmentation (mq2-lloyd: ~114 GB -> fits
  the 96 GB gfx1151 carveout).
- **Daemon serve wiring** + chat template, incl. two fixes: the `[e~[` (200020)
  end-of-turn token is now the EOS (was misresolved -> never completed), and the
  template-primed `<think>` opener is re-emitted so the serve reasoning_content /
  content split engages.
- **HFQ chat-template inject tool** (`scripts/hfq_inject_chat_template.py`) -- embed
  a chat template into an existing `.hfq` without re-quantizing.

## Quant tiers (HF)

| file | gate/up . down | size |
|------|----------------|------|
| `.mq4` | MQ4 . MQ4 | 124 GB |
| `.mq3-lloyd` | MQ3-Lloyd+AWQ . MQ4 | 110 GB |
| `.mq3` | MQ3-Lloyd uniform | 103 GB |
| `.mq2-lloyd` | MQ2-Lloyd+AWQ . MQ4 | 86 GB |
| `.mq2` | MQ2-Lloyd+AWQ . MQ3-Lloyd | 79 GB |

## Validation

- **Forward oracle vs PyTorch** (`transformers` `MiniMaxM2`, dimension-faithful tiny
  random-weight model): per-layer hidden-state cosine **0.9996** mq4 / **0.9994**
  mq3-lloyd; attention isolated 0.99990; routing exact.
- **Cross-arch parity** gfx1151 vs gfx942 on identical inputs: **cos 1.000000,
  diff_rms 0.0** (bit-identical wave32 vs wave64).
- **Real-model coherence**: correct generations across all five tiers (greedy +
  sampling).
- **Multiturn serve**: 3-turn `/v1/chat/completions` -- context retained, clean EOS,
  reasoning routed to `reasoning_content`, content clean.

## Current perf (gfx1151 / Strix Halo, mq2-lloyd, warmed)

This is a **correctness-first port; decode kernels are not yet gfx1151-tuned.**

- **Decode: ~26.8 tok/s** (warmed).
- **TTFT: ~2.0 s** -- prefill is per-token (no batched prefill kernel yet).
- Fits the 96 GB VRAM carveout: mq2 / mq2-lloyd. Bigger tiers (mq3+) exceed any
  single Strix Halo carveout -- run via the documented carveout+GTT hybrid or
  multi-GPU PP.

## Known limitations / next

- **Perfmaxx pending** (next work): rocprof on gfx1151 shows `gemv_q8_0` (dense Q8)
  ~50% of GPU time, the two MoE-decode GEMVs ~38% -- all cross-arch, none
  gfx1151-tuned. (`gemv_q8_0_wide` is a known gfx1151 trap; the multi-row pattern is
  the validated lever.)
- **No DFlash / MTP spec-decode yet** -- the batched-verify forward is the keystone
  (`docs/plans/dflash-trainer.md`).
- Beyond-carveout memory on gfx1151 is documented in
  `docs/investigations/2026-05-30-strix-halo-memory/` (managed memory dead on RDNA3.5;
  KMD GTT-GEM viable at ~60% carveout bandwidth).

Docs: `docs/plans/minimax-rdna-wmma-coverage.md`,
`docs/investigations/2026-05-30-strix-halo-memory/`, `docs/plans/dflash-trainer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
