### PR TITLE
fix(deepseek4): revert MMQLOAD default — long-context attractor on mq2lloyd

### DIFF
--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -6699,9 +6699,12 @@ fn ffn_batched(
             _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
         } && (2 * im) % 64 == 0
           && hidden % 256 == 0;
-        // MMQ-style index-pack preload (#356, default ON for 4w; opt out via =0).
+        // MMQ-style index-pack preload (#356). Reverted to OPT-IN: the preload
+        // hoisted only 8 of 16 weight packs, decoding half the MQ2 weights wrong
+        // → long-context attractor on DS4 mq2lloyd (root-caused by @nwoolmer on
+        // gfx1151; the corrected kernel measured flat, so no reason to default it).
         let use_mmqload = use_lloyd_4w && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() != Ok("0");
+            .as_deref() == Ok("1");
         // Barrier-free nosync variant (#356, opt in via =1).
         let use_nosync = use_mmqload && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
             .as_deref() == Ok("1");
@@ -6887,8 +6890,9 @@ fn ffn_batched(
             _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
         } && hidden % 64 == 0
           && im % 256 == 0;
+        // Opt-in (see use_mmqload above — same #356 long-context attractor).
         let use_mmqload_down = use_lloyd_4w_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() != Ok("0");
+            .as_deref() == Ok("1");
         let use_nosync_down = use_mmqload_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
             .as_deref() == Ok("1");
         // n32_env / cnd_env / eightw_env reused from the gate_up block above.


### PR DESCRIPTION
## Problem (live on master)

The 4w MoE grouped-GEMM **MMQ index-pack preload** (`mmqload`) was flipped to **default-ON** in `4e9787e9` and reached `master` via the already-merged **#358** (consolidation of #349+#355+#356).

@nwoolmer root-caused a real bug in that kernel ([#358 comment](https://github.com/Kaden-Schutt/hipfire/pull/358#issuecomment-4580633064)): the preload hoisted only **8 of the 16** weight packs per K-group and applied each to two K-tiles, so **half the MQ2 weights decoded wrong** → a **long-context attractor** on `deepseek-v4-flash.mq2lloyd` (uniq 0.117, `"…also also…"`). His corrected kernel measured **flat** vs baseline (the original "+19-25%" was the bug reading half the data), so there's no perf reason to default it.

## Fix

Revert both `use_mmqload` / `use_mmqload_down` from default-on (`!= Ok("0")`) back to **opt-in** (`== Ok("1")`). The default 4w path returns to the clean `_4w_k2` baseline (verified attractor-free by @nwoolmer). The mmqload kernel stays reachable via `HIPFIRE_DEEPSEEK4_MOE_MMQLOAD=1` for research; fully removing the kernel files is follow-up cleanup (tracked in #356).

This is a **revert to the previously-shipped opt-in default**, so it restores known-good behavior.

## Validation

**Not GPU-revalidated in this PR** — the gfx1151 box (where it reproduces) is occupied, and hiptrx is gfx1201 where the gfx11 mmqload path doesn't dispatch. Relying on @nwoolmer's gfx1151 verification (before: ATTRACTOR uniq 0.117 / NaN; after-baseline: CLEAN uniq 0.617, correct LRU answer). The GPU-free `build` + `test` checks gate this PR; the DS4 `coherence-gate-dflash` should be run on gfx1151 before any future un-revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)