### PR TITLE
fix(cli): Missing config options in record

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3985,6 +3985,16 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       desc: "Phase 3 sparse-attention threshold (plumbing only; the kernel hasn't shipped). Source-token counts below this would fall back to dense drafter forward. Default 32768.",
       range: [0, 524288], step: 1024,
     },
+    mtp_mode: {
+      label: "mtp_mode",
+      desc: "Multi-token prediction speculative decode. off = disabled, on = always, auto = arch heuristic.",
+      options: ["off", "on", "auto"],
+    },
+    mtp_k: {
+      label: "mtp_k",
+      desc: "Number of draft tokens per multi-token-prediction spec-decode window (1-10).",
+      range: [1, 10], step: 1,
+    },
   };
 
   let selected = 0;


### PR DESCRIPTION
## Summary

There were missing options in the cli tool that made the `config` sub-command to throw an error. Like the following

```bash
$ hipfire config

hipfire config  /home/shrisha/.hipfire/config.json
GPU: gfx1030 · auto = asym3

4119 |       write(`${C.yellow}  Recommended: \`unset HIPFIRE_GRAPH\` unless you are debugging.${C.reset}\n`);
4120 |     }
4121 |     write(`\n`);
4122 | 
4123 |     // Column widths
4124 |     const labelW = Math.max(...keys.map(k => meta[k].label.length)) + 2;
                                                         ^
TypeError: undefined is not an object (evaluating 'meta[k].label')
      at <anonymous> (/home/shrisha/.hipfire/cli/index.ts:4124:51)
      at map (1:11)
      at render (/home/shrisha/.hipfire/cli/index.ts:4124:37)
      at <anonymous> (/home/shrisha/.hipfire/cli/index.ts:4431:5)
      at new Promise (1:11)
      at configTui (/home/shrisha/.hipfire/cli/index.ts:4247:10)
      at /home/shrisha/.hipfire/cli/index.ts:5719:31
 ```

This fixes https://github.com/Kaden-Schutt/hipfire/issues/350