### PR TITLE
feat(lfm2moe): LFM2.5-8B-A1B port (arch_id 11) — validated forward, coherent, perf + KLD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+# GPU-free continuous integration.
+#
+# hipfire loads the HIP/ROCm runtime via dlopen at *runtime* (see
+# crates/hip-bridge — libloading, no build.rs, no link-time -lamdhip64),
+# so the entire workspace compiles and unit-tests on a stock runner with
+# no GPU and no ROCm installed. The GPU-bound gates (test_kernels,
+# coherence-gate.sh, speed-gate.sh) need real RDNA hardware and run on a
+# self-hosted runner instead — see .github/workflows/gpu-gates.yml (TODO).
+#
+# Required vs advisory: `build` and `test` are the load-bearing
+# "is it broken" gates and are intended to be required status checks on
+# master. `fmt` and `clippy` start advisory (not required) because this
+# repo predates CI and likely carries lint/format debt; promote them to
+# required after a cleanup pass (flip clippy to `-D warnings`).
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Supersede in-flight runs when a PR gets new pushes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # NOTE: deliberately NOT setting `RUSTFLAGS: -D warnings` yet. This repo
+  # predates CI and may carry rustc-warning debt; denying warnings now would
+  # red the build on legacy code. Add it after a warning-cleanup pass.
+
+jobs:
+  build:
+    name: build (workspace, no GPU)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build workspace (lib + bins + examples + tests)
+        run: cargo build --release --workspace --all-targets --locked
+      - name: Build daemon example (real shipped binary, arch features on)
+        run: >
+          cargo build --release --locked
+          -p hipfire-runtime --example daemon
+          --features arch-qwen35,arch-qwen35-vl,arch-llama,arch-qwen2,arch-deepseek4,arch-dots-ocr
+
+  test:
+    name: unit tests (lib, no GPU)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run workspace lib unit tests
+        # --lib only: unit tests inside library targets are GPU-free
+        # (detector logic, sampler, framing, quant math). Integration
+        # tests / examples that dispatch kernels need the self-hosted
+        # GPU runner and are intentionally excluded here.
+        run: cargo test --lib --workspace --locked
+
+  fmt:
+    name: rustfmt (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: clippy (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # No -D warnings yet: surface lint debt without blocking. Promote to
+      # `-- -D warnings` (and add to required checks) after a cleanup pass.
+      - run: cargo clippy --workspace --all-targets --locked

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,157 @@
+name: Claude PR Review
+
+# Tier 2 of the validation pipeline: an in-repo agent that reviews each PR
+# against hipfire's contribution rules and posts one comment. It is GPU-free —
+# it reads the diff + the repo's own docs and reasons about them; it does NOT
+# build, run kernels, or verify coherence/perf. Those are GPU-bound and handled
+# by the self-hosted GPU gates (Tier 3). Review-only: the agent gets read +
+# PR-comment access and never write/commit access.
+#
+# Auth: a Claude Pro/Max subscription via CLAUDE_CODE_OAUTH_TOKEN. Generate it
+# with `claude setup-token` (Claude v1.0.44+), then:
+#     gh secret set CLAUDE_CODE_OAUTH_TOKEN
+# To use metered API billing instead, set ANTHROPIC_API_KEY and swap the input
+# below. Until a credential secret exists the review step skips and the job is a
+# green no-op — safe to merge before the secret is added.
+#
+# Fork PRs: GitHub withholds secrets from fork-originated `pull_request` runs,
+# so the token is empty there and the review skips. The auto-review therefore
+# covers branches pushed to THIS repo (collaborators). Outside/fork PRs get the
+# agent review once a maintainer brings the branch in-repo — the same trust
+# boundary the Tier-3 GPU gates use (never run untrusted PR code with secrets).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  # id-token + read-only GITHUB_TOKEN + no github_token input below = the action
+  # exchanges this OIDC token for an installed-Claude-App token, which posts the
+  # review AS claude[bot] and carries its own write scope. Mirrors the
+  # /install-github-app canonical workflow; granting GITHUB_TOKEN *write* is what
+  # made earlier versions post as github-actions[bot] instead.
+  id-token: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude review (advisory)
+    runs-on: ubuntu-latest
+    # secrets are unavailable on fork PRs, so HAS_TOKEN is false there → skip.
+    env:
+      HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+    steps:
+      - name: Checkout
+        if: ${{ env.HAS_TOKEN == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        if: ${{ env.HAS_TOKEN == 'true' }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # No github_token input on purpose (see id-token note above): with
+          # read-only GITHUB_TOKEN perms the action must use the OIDC-exchanged
+          # Claude App token to post, which is what makes the comment author
+          # claude[bot]. CLAUDE_CODE_OAUTH_TOKEN still handles Anthropic/model auth.
+          # Post the review as a tracking comment (tag mode). Without this the
+          # automatic agent-mode run produces output with nowhere to land
+          # ("No buffered inline comments") and posts nothing.
+          track_progress: "true"
+          # Denylist (not an allowlist): an allowlist would also have to name
+          # the action's internal comment-posting tools — whose names aren't a
+          # stable public contract under track_progress — and omitting them is
+          # what made an earlier run post nothing. So instead we leave the
+          # comment tools available and explicitly block everything that lets
+          # the agent change state or reach out: file mutation (Edit/Write/
+          # MultiEdit/NotebookEdit), shell (Bash), the web (WebSearch/WebFetch),
+          # and sub-agent spawning (Agent). Net: read the diff + post a comment,
+          # nothing else. Runs only on trusted in-repo branches (fork PRs skip).
+          claude_args: |
+            --max-turns 20
+            --disallowedTools Edit,Write,MultiEdit,NotebookEdit,Bash,WebSearch,WebFetch,Agent
+          prompt: |
+            You are the first-pass PR reviewer for hipfire, an RDNA-native LLM
+            inference engine in Rust. Your job is to SHORTEN human review —
+            surface only what matters, be concise, and if the PR is clean say so
+            in a line. You CANNOT run the GPU here: never assert a kernel is
+            correct, coherent, or faster; instead flag what the GPU gates
+            (test_kernels / coherence-gate / speed-gate) must confirm.
+
+            Read CLAUDE.md and CONTRIBUTING.md first (source of truth). Then
+            review the diff, prioritizing the failure modes that have ACTUALLY
+            bitten this repo — ordered by how often they recur in its git
+            history. Comment only when something is off:
+
+            1. HANGS / DEADLOCKS / ZOMBIES — the single most common defect class
+               here. Flag any new blocking wait, drain, channel recv, stream
+               sync, JIT/compile, daemon-lifecycle, or spec-decode loop that
+               lacks a timeout or a guaranteed termination condition. Real past
+               bugs: drain() deadlock on daemon crash; --exp bench variants
+               hanging with no timeout; decode "stuck on newline token"; graph
+               capture hanging on an arch. A new unbounded loop/wait is suspect.
+
+            2. PERF CLAIMS — be skeptical; this repo has a long graveyard of
+               "FALSIFIED" levers that looked good in one-shell A/B and died on a
+               fresh probe. Any tok/s, τ, or speedup claim MUST include a prompt
+               md5 + a binary md5, and cross-commit claims MUST use
+               scripts/probe_commits.sh (fresh process). Flag claims missing
+               these. Extra-suspicious: tight-stddev spec-decode benches (real
+               acceptance noise is wider); one-shell A/B with no fresh probe; any
+               perf/coherence number measured on asym3 KV (weak fixture — use q8
+               or fwht; DFlash gates must use q8/fwht).
+
+            3. COHERENCE / ATTRACTORS — if the diff touches kernels / dispatch /
+               forward pass / quant / fusion / rotation / rmsnorm / sampling /
+               spec-decode, the PR MUST cite coherence-gate.sh (and
+               coherence-gate-dflash.sh if spec-decode is touched). Flag missing
+               gate evidence. Watch for changes that could induce token
+               attractors / loops / special-token leaks.
+
+            4. DISPATCH ROUTING — crates/rdna-compute/src/dispatch.rs is the
+               most-edited and most-reverted file in the repo. For any change to
+               a dispatch predicate or kernel selection: does the new arm have a
+               correct fallback, and could it silently re-route OTHER
+               (arch × dtype × workload) combos onto a wrong/slower path? Gaps
+               recur in BOTH directions. New perf kernels should ship OPT-IN
+               (env-gated) until validated across the arch matrix — flag new
+               default-ON kernel paths (many were reverted with "make truly
+               opt-in").
+
+            5. SERVE / DAEMON / CLI — the user-facing path breaks constantly.
+               Scrutinize: EOS / stop-token resolution and <think> re-emit (do
+               NOT assume ChatML EOS); prompt framing applied AFTER a reload or
+               arch switch; repeat_penalty defaults; seq_pos / boundary-token
+               desync from synthetic tokens; and — this bit twice (#319 → #351) —
+               a NEW config/runtime field added without the matching CLI meta /
+               wiring entry. Flag a new config field that isn't plumbed
+               end-to-end (struct → CLI meta → daemon).
+
+            6. GATES BYPASSED — flag any --no-verify, skipped pre-commit hook, or
+               "gate skipped" without explicit maintainer sign-off in the PR.
+
+            7. MEMSET / STREAMS — a new async memset helper silently degrades to a
+               SYNC memset unless the caller set active_stream = Some(...). Flag
+               new gated async memsets whose caller leaves active_stream = None.
+
+            8. ATTRIBUTION — new source files need an SPDX header (Apache-2.0
+               default) + "Copyright (c) <year> <author>". New files authored in
+               this repo use Kaden Schutt as the holder; don't carry another
+               contributor's header into a new file.
+
+            9. CORRECTNESS — real bugs, panics / NaN / OOM on edge inputs, unsafe
+               misuse. Skip style and nits — clippy/fmt own those.
+
+            Output ONE comment: a one-line verdict (LGTM / Minor / Needs work),
+            then bulleted findings with file:line, then a final "GPU gates still
+            required:" line naming which gates a maintainer must run before merge
+            based on what the diff touched — or "none" for docs / CI /
+            tooling-only diffs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,6 +484,64 @@ For dataclass benches:
 - Confirmation that the regression appears across genres (not just one
   prompt that happens to hit a different distribution)
 
+### Pinned Hugging Face bench fixture
+
+For hiptrx dense Qwen3.6-27B AWQ MTP/DFlash perf work, do not identify
+the canonical trunk by local filename. Local filenames drift and lookalike
+AWQ/MQ4 files are not comparable.
+
+The canonical trunk is whichever local artifact byte-matches the current
+Hugging Face `.mq4` artifact:
+
+- HF repo: `schuttdev/hipfire-qwen3.6-27b`
+- HF file: `qwen3.6-27b.mq4`
+- HF repo commit when pinned: `f9b326a657f14cbc400e384ff84a4b9b4b726ba2`
+- File size: `14984158208`
+- SHA-256 / HF `x-linked-etag`:
+  `86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc`
+
+Before reporting dense 3.6 AWQ MTP/DFlash results, verify the candidate
+trunk with `sha256sum` and require the digest above. If Hugging Face has
+published a newer `.mq4`, refresh the HF headers first and pin the new
+`x-linked-etag`/size in the report.
+
+Reports that use a trunk with a different digest are not comparable and
+should be discarded.
+
+### Pinned A3B MoE DFlash fixtures
+
+For hiptrx Qwen3.6-35B-A3B MoE DFlash perf/profiling work, use the
+following command shape and do not substitute other prompts unless the
+user explicitly updates this fixture section:
+
+```bash
+./target/release/examples/dflash_spec_demo \
+  --target /home/kaden/.hipfire/models/qwen3.6-35b-a3b.mq4-awq-mi300x \
+  --draft /home/kaden/.hipfire/models/qwen36-35b-a3b-dflash-mq4.hfq \
+  --prompt-file <allowed-prompt> \
+  --max 256 --temp 0.0 --no-chatml --kv-mode q8 --ctx 4096 \
+  --block-size 6 --no-adaptive-b
+```
+
+Pinned artifacts:
+
+- target md5: `edde51ec1dac0f2bd42cff5ef1cb8944`
+- draft md5: `8254bbe1ffe31edf2b38f3889d6325f1`
+
+The only permitted prompt fixtures for this A3B MoE DFlash thread are:
+
+- `benchmarks/prompts/merge_sort_thinking_off.txt`
+  - md5: `253c7ac50857fe6d0e10fb0d2c5e35c0`
+  - best observed post-MoE tape replay fix: `151.00 tok/s`, tau `2.711`,
+    accept rate `0.5422`, `45` cycles, `168` emitted tokens.
+- `benchmarks/prompts/humaneval_3_below_zero.txt`
+  - md5: `37c5aad9f9efe93b5c47f27256bdf149`
+  - best observed before the MoE tape replay optimization: `127.61 tok/s`,
+    tau `3.714`.
+
+Runs using any other prompt are exploratory only and must not be compared
+against the A3B MoE DFlash perfmaxx line.
+
 ---
 
 ## 6 · Common pitfalls (history of what bit us)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hipfire-arch-lfm2moe"
+version = "0.1.0"
+dependencies = [
+ "hip-bridge",
+ "hipfire-runtime",
+ "rdna-compute",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hipfire-arch-llama"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "hip-bridge",
  "hipfire-arch-deepseek4",
  "hipfire-arch-dots-ocr",
+ "hipfire-arch-lfm2moe",
  "hipfire-arch-llama",
  "hipfire-arch-minimax",
  "hipfire-arch-qwen2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/hipfire-arch-llama",
     "crates/hipfire-arch-deepseek4",
     "crates/hipfire-arch-minimax",
+    "crates/hipfire-arch-lfm2moe",
     "crates/hipfire-arch-toy",
     "crates/hipfire-arch-qwen2",
     "crates/hipfire-arch-dots-ocr",

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -224,7 +224,7 @@ const CONFIG_DEFAULTS: HipfireConfig = {
 
 function validateConfigValue(key: string, value: any): boolean {
   switch (key) {
-    case "kv_cache": return ["auto", "q8", "asym4", "asym3", "asym2", "turbo", "turbo4", "turbo3", "turbo2"].includes(value);
+    case "kv_cache": return ["auto", "q8", "asym4", "asym3", "asym2", "fwht4", "fwht3", "fwht2", "turbo", "turbo4", "turbo3", "turbo2"].includes(value);
     case "flash_mode": return ["auto", "always", "never"].includes(value);
     case "temperature": return typeof value === "number" && value >= 0 && value <= 2;
     case "top_p": return typeof value === "number" && value > 0 && value <= 1;
@@ -777,30 +777,33 @@ interface ArchDefaults {
 }
 
 function archDefaults(arch: string): ArchDefaults {
-  // Default KV cache policy (RotorQuant asymmetric):
-  //   asym3 (K 3-bit rotated + V Q8) is the default across arches — 5.5×
-  //   compression vs fp32 with verbatim rare-token recall on head_dim=256
-  //   models (Qwen 3.5 family). Memory-tight cards get asym2 (6.0×, still
-  //   recall-safe for common tokens). Users can override to `q8` for
-  //   maximum quality or `asym4` for extra K precision headroom.
+  // Default KV cache policy (FWHT-rotated, DFlash-safe):
+  //   fwht3 (K 3-bit FWHT-rotated + V Q8) is the default across arches — same
+  //   ~5.5× compression and byte layout as asym3, but the K-rotation basis
+  //   matches the MQ4 weight/draft FWHT convention, so DFlash speculative
+  //   acceptance stays high. asym3/asym4 use a Givens basis the draft was not
+  //   calibrated against → degraded acceptance / attractors with DFlash (which
+  //   is default-on for the 27B). Memory-tight cards get fwht2 (the asym2 byte
+  //   tier, FWHT-rotated). Override to `q8` for byte-exact reference quality,
+  //   or the `asym*` modes for the legacy Givens behavior.
   switch (arch) {
-    // RDNA3 — asym3 everywhere; 24 GB cards fit full context easily.
-    case "gfx1100": return { kv_cache: "asym3", vram_gb: 24 };  // 7900 XTX
-    case "gfx1101": return { kv_cache: "asym3", vram_gb: 16 };  // 7900 XT
-    case "gfx1102": return { kv_cache: "asym3", vram_gb: 12 };  // 7800 XT
-    case "gfx1151": return { kv_cache: "asym2", vram_gb: 16 };  // Strix Halo APU (shared mem — tight)
+    // RDNA3
+    case "gfx1100": return { kv_cache: "fwht3", vram_gb: 24 };  // 7900 XTX
+    case "gfx1101": return { kv_cache: "fwht3", vram_gb: 16 };  // 7900 XT
+    case "gfx1102": return { kv_cache: "fwht3", vram_gb: 12 };  // 7800 XT
+    case "gfx1151": return { kv_cache: "fwht2", vram_gb: 16 };  // Strix Halo APU (shared mem — tight)
     // RDNA4
     case "gfx1200": case "gfx1201":
-      return { kv_cache: "asym3", vram_gb: 16 };                // 9070 XT
+      return { kv_cache: "fwht3", vram_gb: 16 };                // 9070 XT
     // RDNA2
-    case "gfx1030": return { kv_cache: "asym3", vram_gb: 32 };  // V620 (32 GB — plenty of headroom)
-    case "gfx1031": return { kv_cache: "asym3", vram_gb: 12 };  // 6700 XT
-    case "gfx1032": return { kv_cache: "asym2", vram_gb: 8 };   // 6600 XT (8 GB — asym2 for headroom)
+    case "gfx1030": return { kv_cache: "fwht3", vram_gb: 32 };  // V620 (32 GB — plenty of headroom)
+    case "gfx1031": return { kv_cache: "fwht3", vram_gb: 12 };  // 6700 XT
+    case "gfx1032": return { kv_cache: "fwht2", vram_gb: 8 };   // 6600 XT (8 GB — fwht2 for headroom)
     // RDNA1
-    case "gfx1010": return { kv_cache: "asym2", vram_gb: 8 };   // 5700 XT
-    case "gfx1013": return { kv_cache: "asym2", vram_gb: 14 };  // BC-250 APU
-    // Fallback — unknown arch, asym3 is the new safe default.
-    default: return { kv_cache: "asym3", vram_gb: 8 };
+    case "gfx1010": return { kv_cache: "fwht2", vram_gb: 8 };   // 5700 XT
+    case "gfx1013": return { kv_cache: "fwht2", vram_gb: 14 };  // BC-250 APU
+    // Fallback — unknown arch, fwht3 is the safe DFlash-compatible default.
+    default: return { kv_cache: "fwht3", vram_gb: 8 };
   }
 }
 
@@ -3795,8 +3798,8 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
   const meta: Record<string, FieldMeta> = {
     kv_cache: {
       label: "kv_cache",
-      desc: "KV cache quantization (more bits = higher quality, more VRAM)",
-      options: ["auto", "q8", "asym4", "asym3", "asym2"],
+      desc: "KV cache quant (fwht default: FWHT-rotated, more accurate than asym at equal VRAM; q8 = reference)",
+      options: ["auto", "q8", "fwht4", "fwht3", "fwht2", "asym4", "asym3", "asym2"],
     },
     flash_mode: {
       label: "flash_mode",
@@ -5803,7 +5806,7 @@ Examples:
       if (typeof defaultVal === "number" && isNaN(parsed as number)) { console.error(`${key} requires a number`); process.exit(1); }
       if (!validateConfigValue(key, parsed)) {
         const hints: Record<string, string> = {
-          kv_cache: "one of: auto, q8, asym4, asym3, asym2 (turbo/turbo2/turbo3/turbo4 aliases also accepted)",
+          kv_cache: "one of: auto, q8, fwht4, fwht3, fwht2, asym4, asym3, asym2 (turbo/turbo2/turbo3/turbo4 are legacy asym aliases)",
           flash_mode: "one of: auto, always, never (applies to Q8 path; asym modes are flash-only)",
           temperature: "number between 0 and 2",
           top_p: "number in (0, 1]",

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3290,7 +3290,7 @@ async function benchRun(e: Engine, prompt: string, maxTokens: number, timeoutMs 
 // Synthetic prefill measurement: runs `bench_prefill` on the daemon which
 // times forward_prefill_batch over N deterministic tokens from a zeroed
 // state. Returns tok/s and ms, or null on error (e.g. N > max_seq).
-async function benchPrefill(e: Engine, tokens: number, timeoutMs = 60_000): Promise<{ tokS: number; ms: number } | null> {
+async function benchPrefill(e: Engine, tokens: number, timeoutMs = Number(process.env.HIPFIRE_BENCH_PP_TIMEOUT_MS) || 60_000): Promise<{ tokS: number; ms: number } | null> {
   try {
     await withTimeout(e.send({ type: "bench_prefill", tokens }), 5_000, "bench_prefill send");
     const res = await withTimeout(e.recv(), timeoutMs, `bench_prefill (${tokens} tok)`);
@@ -3500,7 +3500,13 @@ async function bench(model: string, runs: number, experimental: boolean, prompt:
     // don't depend on prompt tokenization. Older daemons ignore the command
     // and return an error; we silently skip in that case. Each size is run
     // `runs` times so we can report variance.
-    const ppSizes = [128, 512, 1024, 2048].filter(n => n + 32 <= loadMsg.params.max_seq);
+    // Override the canonical pp ladder with HIPFIRE_BENCH_PP="128,512,1024,..."
+    // for incremental context ramps (e.g. validating a new attention path).
+    const ppDefault = [128, 512, 1024, 2048];
+    const ppSizes = (process.env.HIPFIRE_BENCH_PP
+      ? process.env.HIPFIRE_BENCH_PP.split(",").map(s => parseInt(s.trim(), 10)).filter(n => Number.isInteger(n) && n > 0)
+      : ppDefault
+    ).filter(n => n + 32 <= loadMsg.params.max_seq);
     const ppResults: { size: number; samples: number[]; ms: number[] }[] = [];
     if (ppSizes.length > 0) {
       process.stderr.write("  prefill: ");

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3988,6 +3988,16 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
       desc: "Phase 3 sparse-attention threshold (plumbing only; the kernel hasn't shipped). Source-token counts below this would fall back to dense drafter forward. Default 32768.",
       range: [0, 524288], step: 1024,
     },
+    mtp_mode: {
+      label: "mtp_mode",
+      desc: "Multi-token prediction speculative decode. off = disabled, on = always, auto = arch heuristic.",
+      options: ["off", "on", "auto"],
+    },
+    mtp_k: {
+      label: "mtp_k",
+      desc: "Number of draft tokens per multi-token-prediction spec-decode window (1-10).",
+      range: [1, 10], step: 1,
+    },
   };
 
   let selected = 0;

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2108,6 +2108,11 @@ async function serve(port: number, host: string) {
         // tool-call samples weighted on structured tokens; tracked in
         // MANUAL_REVIEW.md against #111.
         function parseToolCalls(text: string): { content: string | null; tool_calls: any[] | null } {
+          // Non-Qwen tool-call syntaxes the `<tool_call>{json}` parser below can't
+          // see. DeepSeek V4's DSML is parsed daemon-side and arrives as structured
+          // `tool_calls` events, so only LFM2.5 + MiniMax-M2 are handled here.
+          if (text.includes("<|tool_call_start|>")) return parseBracketCallToolCalls(text); // LFM2.5 (arch 11)
+          if (text.includes("<minimax:tool_call>")) return parseXmlInvokeToolCalls(text);   // MiniMax-M2 (arch 10)
           if (!text.includes("<tool_call>")) return { content: text, tool_calls: null };
           const pattern = /<tool_call>\s*(.*?)\s*<\/tool_call>|<tool_call>\s*(.*)/gs;
           const matches = [...text.matchAll(pattern)];
@@ -2146,6 +2151,125 @@ async function serve(port: number, host: string) {
             console.error(`[hipfire] tool_call: repaired ${repaired} malformed block(s) (MQ4 #111 stopgap)`);
           }
           const before = text.slice(0, text.indexOf("<tool_call>")).trim();
+          return { content: before || null, tool_calls };
+        }
+
+        // ── Non-Qwen tool-call parsers (LFM2.5, MiniMax-M2) ──────────────────
+        function makeCallId(): string {
+          return `call_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+        }
+
+        // Split `s` on top-level `sep` — chars not inside (), [], {} or a quoted
+        // string. Lets us separate calls / args without tripping on commas inside
+        // nested args or string literals.
+        function splitTopLevel(s: string, sep: string): string[] {
+          const out: string[] = [];
+          let depth = 0, q: string | null = null, esc = false, cur = "";
+          for (const ch of s) {
+            if (esc) { cur += ch; esc = false; continue; }
+            if (q) {
+              cur += ch;
+              if (ch === "\\") esc = true;
+              else if (ch === q) q = null;
+              continue;
+            }
+            if (ch === "'" || ch === '"') { q = ch; cur += ch; continue; }
+            if (ch === "(" || ch === "[" || ch === "{") { depth++; cur += ch; continue; }
+            if (ch === ")" || ch === "]" || ch === "}") { depth--; cur += ch; continue; }
+            if (ch === sep && depth === 0) { out.push(cur); cur = ""; continue; }
+            cur += ch;
+          }
+          if (cur.length) out.push(cur);
+          return out;
+        }
+
+        // Index of the first top-level `=` (key/value separator), -1 if none.
+        function topLevelEq(s: string): number {
+          let depth = 0, q: string | null = null, esc = false;
+          for (let i = 0; i < s.length; i++) {
+            const ch = s[i];
+            if (esc) { esc = false; continue; }
+            if (q) { if (ch === "\\") esc = true; else if (ch === q) q = null; continue; }
+            if (ch === "'" || ch === '"') { q = ch; continue; }
+            if (ch === "(" || ch === "[" || ch === "{") depth++;
+            else if (ch === ")" || ch === "]" || ch === "}") depth--;
+            else if (ch === "=" && depth === 0) return i;
+          }
+          return -1;
+        }
+
+        // Parse a Python-ish argument value (LFM2 emits `k='v'`, `k="v"`, `k=1`,
+        // `k=True`, `k=[...]`). Try JSON first; map Python literals; else raw str.
+        function parsePyValue(v: string): any {
+          v = v.trim();
+          if (v === "True") return true;
+          if (v === "False") return false;
+          if (v === "None") return null;
+          if (v.length >= 2 && v[0] === "'" && v[v.length - 1] === "'") {
+            const body = v.slice(1, -1).replace(/\\'/g, "'").replace(/(?<!\\)"/g, '\\"');
+            try { return JSON.parse('"' + body + '"'); } catch { return v.slice(1, -1); }
+          }
+          try { return JSON.parse(v); } catch { return v; }
+        }
+
+        // LFM2.5 (arch 11): <|tool_call_start|>[ name(k=v, ...), name2(...) ]<|tool_call_end|>
+        function parseBracketCallToolCalls(text: string): { content: string | null; tool_calls: any[] | null } {
+          const startTag = "<|tool_call_start|>", endTag = "<|tool_call_end|>";
+          const si = text.indexOf(startTag);
+          const before = text.slice(0, si).trim();
+          let inner = text.slice(si + startTag.length);
+          const ei = inner.indexOf(endTag);
+          if (ei >= 0) inner = inner.slice(0, ei);
+          inner = inner.trim();
+          if (inner.startsWith("[")) inner = inner.slice(1);
+          if (inner.endsWith("]")) inner = inner.slice(0, -1);
+          const tool_calls: any[] = [];
+          for (const callStr of splitTopLevel(inner, ",").map((s) => s.trim()).filter(Boolean)) {
+            const m = callStr.match(/^([A-Za-z_][\w.]*)\s*\(([\s\S]*)\)\s*$/);
+            if (!m) continue;
+            const name = m[1];
+            const argsStr = m[2].trim();
+            const args: Record<string, any> = {};
+            let pos = 0;
+            if (argsStr) {
+              for (const partRaw of splitTopLevel(argsStr, ",")) {
+                const part = partRaw.trim();
+                if (!part) continue;
+                const eq = topLevelEq(part);
+                if (eq < 0) { args[String(pos++)] = parsePyValue(part); continue; }
+                args[part.slice(0, eq).trim()] = parsePyValue(part.slice(eq + 1));
+              }
+            }
+            tool_calls.push({ id: makeCallId(), type: "function", function: { name, arguments: JSON.stringify(args) } });
+          }
+          if (!tool_calls.length) return { content: text, tool_calls: null };
+          return { content: before || null, tool_calls };
+        }
+
+        // MiniMax-M2 (arch 10): <minimax:tool_call><invoke name="fn">
+        //   <parameter name="k">v</parameter>...</invoke>...</minimax:tool_call>
+        function parseXmlInvokeToolCalls(text: string): { content: string | null; tool_calls: any[] | null } {
+          const startTag = "<minimax:tool_call>";
+          const si = text.indexOf(startTag);
+          const before = text.slice(0, si).trim();
+          let region = text.slice(si + startTag.length);
+          const ei = region.indexOf("</minimax:tool_call>");
+          if (ei >= 0) region = region.slice(0, ei);
+          const tool_calls: any[] = [];
+          const invokeRe = /<invoke\s+name="([^"]+)"\s*>([\s\S]*?)(?:<\/invoke>|$)/g;
+          for (const im of region.matchAll(invokeRe)) {
+            const name = im[1];
+            const args: Record<string, any> = {};
+            const paramRe = /<parameter\s+name="([^"]+)"\s*>([\s\S]*?)<\/parameter>/g;
+            for (const pm of im[2].matchAll(paramRe)) {
+              const raw = pm[2].replace(/^\s*\n/, "").replace(/\n\s*$/, "").trim();
+              let val: any;
+              try { val = JSON.parse(raw); } catch { val = raw; }
+              args[pm[1]] = val;
+            }
+            tool_calls.push({ id: makeCallId(), type: "function", function: { name, arguments: JSON.stringify(args) } });
+          }
+          if (!tool_calls.length) return { content: text, tool_calls: null };
           return { content: before || null, tool_calls };
         }
 

--- a/cli/parse_tool_calls.test.ts
+++ b/cli/parse_tool_calls.test.ts
@@ -462,3 +462,14 @@ test("MiniMax-M2 preserves assistant content before the tool call", () => {
   expect(r.content).toBe("Let me check.");
   expect(r.tool_calls![0].function.name).toBe("f");
 });
+
+// Exact bytes the real MiniMax-M2 *embedded* chat_template renders for an
+// assistant tool call (note the leading indentation before <parameter> that
+// the template emits) — captured via jinja2 render of the model's own template.
+test("MiniMax-M2 real embedded-template emission (indented) parses", () => {
+  const out = '<minimax:tool_call>\n<invoke name="get_weather">\n                <parameter name="location">Paris</parameter>\n                <parameter name="units">metric</parameter>\n                </invoke>\n</minimax:tool_call>';
+  const r = parseXmlInvokeToolCalls(out);
+  expect(r.tool_calls!.length).toBe(1);
+  expect(r.tool_calls![0].function.name).toBe("get_weather");
+  expect(JSON.parse(r.tool_calls![0].function.arguments)).toEqual({ location: "Paris", units: "metric" });
+});

--- a/cli/parse_tool_calls.test.ts
+++ b/cli/parse_tool_calls.test.ts
@@ -304,3 +304,161 @@ test("<function=NAME>{JSON} (MQ4 corruption shape) still parses via probe-(2)", 
   expect(r!.arguments).toEqual({ path: "/etc/passwd" });
   expect(r!.repaired).toBe(true);
 });
+
+// ── Non-Qwen tool-call parsers (LFM2.5 arch 11, MiniMax-M2 arch 10) ──────────
+// Duplicated from cli/index.ts:parseToolCalls — keep in sync.
+function makeCallId(): string {
+  return `call_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+}
+function splitTopLevel(s: string, sep: string): string[] {
+  const out: string[] = [];
+  let depth = 0, q: string | null = null, esc = false, cur = "";
+  for (const ch of s) {
+    if (esc) { cur += ch; esc = false; continue; }
+    if (q) { cur += ch; if (ch === "\\") esc = true; else if (ch === q) q = null; continue; }
+    if (ch === "'" || ch === '"') { q = ch; cur += ch; continue; }
+    if (ch === "(" || ch === "[" || ch === "{") { depth++; cur += ch; continue; }
+    if (ch === ")" || ch === "]" || ch === "}") { depth--; cur += ch; continue; }
+    if (ch === sep && depth === 0) { out.push(cur); cur = ""; continue; }
+    cur += ch;
+  }
+  if (cur.length) out.push(cur);
+  return out;
+}
+function topLevelEq(s: string): number {
+  let depth = 0, q: string | null = null, esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (esc) { esc = false; continue; }
+    if (q) { if (ch === "\\") esc = true; else if (ch === q) q = null; continue; }
+    if (ch === "'" || ch === '"') { q = ch; continue; }
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") depth--;
+    else if (ch === "=" && depth === 0) return i;
+  }
+  return -1;
+}
+function parsePyValue(v: string): any {
+  v = v.trim();
+  if (v === "True") return true;
+  if (v === "False") return false;
+  if (v === "None") return null;
+  if (v.length >= 2 && v[0] === "'" && v[v.length - 1] === "'") {
+    const body = v.slice(1, -1).replace(/\\'/g, "'").replace(/(?<!\\)"/g, '\\"');
+    try { return JSON.parse('"' + body + '"'); } catch { return v.slice(1, -1); }
+  }
+  try { return JSON.parse(v); } catch { return v; }
+}
+function parseBracketCallToolCalls(text: string): { content: string | null; tool_calls: any[] | null } {
+  const startTag = "<|tool_call_start|>", endTag = "<|tool_call_end|>";
+  const si = text.indexOf(startTag);
+  const before = text.slice(0, si).trim();
+  let inner = text.slice(si + startTag.length);
+  const ei = inner.indexOf(endTag);
+  if (ei >= 0) inner = inner.slice(0, ei);
+  inner = inner.trim();
+  if (inner.startsWith("[")) inner = inner.slice(1);
+  if (inner.endsWith("]")) inner = inner.slice(0, -1);
+  const tool_calls: any[] = [];
+  for (const callStr of splitTopLevel(inner, ",").map((s) => s.trim()).filter(Boolean)) {
+    const m = callStr.match(/^([A-Za-z_][\w.]*)\s*\(([\s\S]*)\)\s*$/);
+    if (!m) continue;
+    const name = m[1];
+    const argsStr = m[2].trim();
+    const args: Record<string, any> = {};
+    let pos = 0;
+    if (argsStr) {
+      for (const partRaw of splitTopLevel(argsStr, ",")) {
+        const part = partRaw.trim();
+        if (!part) continue;
+        const eq = topLevelEq(part);
+        if (eq < 0) { args[String(pos++)] = parsePyValue(part); continue; }
+        args[part.slice(0, eq).trim()] = parsePyValue(part.slice(eq + 1));
+      }
+    }
+    tool_calls.push({ id: makeCallId(), type: "function", function: { name, arguments: JSON.stringify(args) } });
+  }
+  if (!tool_calls.length) return { content: text, tool_calls: null };
+  return { content: before || null, tool_calls };
+}
+function parseXmlInvokeToolCalls(text: string): { content: string | null; tool_calls: any[] | null } {
+  const startTag = "<minimax:tool_call>";
+  const si = text.indexOf(startTag);
+  const before = text.slice(0, si).trim();
+  let region = text.slice(si + startTag.length);
+  const ei = region.indexOf("</minimax:tool_call>");
+  if (ei >= 0) region = region.slice(0, ei);
+  const tool_calls: any[] = [];
+  const invokeRe = /<invoke\s+name="([^"]+)"\s*>([\s\S]*?)(?:<\/invoke>|$)/g;
+  for (const im of region.matchAll(invokeRe)) {
+    const name = im[1];
+    const args: Record<string, any> = {};
+    const paramRe = /<parameter\s+name="([^"]+)"\s*>([\s\S]*?)<\/parameter>/g;
+    for (const pm of im[2].matchAll(paramRe)) {
+      const raw = pm[2].replace(/^\s*\n/, "").replace(/\n\s*$/, "").trim();
+      let val: any;
+      try { val = JSON.parse(raw); } catch { val = raw; }
+      args[pm[1]] = val;
+    }
+    tool_calls.push({ id: makeCallId(), type: "function", function: { name, arguments: JSON.stringify(args) } });
+  }
+  if (!tool_calls.length) return { content: text, tool_calls: null };
+  return { content: before || null, tool_calls };
+}
+
+// LFM2.5 — the exact bytes the model emitted in the e2e verification.
+test("LFM2.5 <|tool_call_start|>[fn(k=\"v\")] parses to OpenAI tool_calls", () => {
+  const r = parseBracketCallToolCalls('<|tool_call_start|>[get_weather(location="Paris")]<|tool_call_end|>');
+  expect(r.tool_calls).not.toBeNull();
+  expect(r.tool_calls!.length).toBe(1);
+  expect(r.tool_calls![0].function.name).toBe("get_weather");
+  expect(JSON.parse(r.tool_calls![0].function.arguments)).toEqual({ location: "Paris" });
+  expect(r.content).toBeNull();
+});
+
+test("LFM2.5 single-quoted strings + typed args (int/bool) coerce", () => {
+  const r = parseBracketCallToolCalls("<|tool_call_start|>[set(name='Bob', age=42, active=True, note=None)]<|tool_call_end|>");
+  expect(JSON.parse(r.tool_calls![0].function.arguments)).toEqual({ name: "Bob", age: 42, active: true, note: null });
+});
+
+test("LFM2.5 multiple calls + string arg containing a comma", () => {
+  const r = parseBracketCallToolCalls('<|tool_call_start|>[a(x=1), b(msg="hello, world", arr=[1,2])]<|tool_call_end|>');
+  expect(r.tool_calls!.length).toBe(2);
+  expect(r.tool_calls![0].function.name).toBe("a");
+  expect(JSON.parse(r.tool_calls![1].function.arguments)).toEqual({ msg: "hello, world", arr: [1, 2] });
+});
+
+test("LFM2.5 zero-arg call", () => {
+  const r = parseBracketCallToolCalls("<|tool_call_start|>[now()]<|tool_call_end|>");
+  expect(r.tool_calls![0].function.name).toBe("now");
+  expect(JSON.parse(r.tool_calls![0].function.arguments)).toEqual({});
+});
+
+test("LFM2.5 unclosed end tag still parses (defensive)", () => {
+  const r = parseBracketCallToolCalls('<|tool_call_start|>[get_weather(location="Paris")]');
+  expect(r.tool_calls![0].function.name).toBe("get_weather");
+});
+
+// MiniMax-M2 — <minimax:tool_call><invoke name><parameter name> XML.
+test("MiniMax-M2 <minimax:tool_call><invoke> parses to OpenAI tool_calls", () => {
+  const out = '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">Paris</parameter>\n</invoke>\n</minimax:tool_call>';
+  const r = parseXmlInvokeToolCalls(out);
+  expect(r.tool_calls!.length).toBe(1);
+  expect(r.tool_calls![0].function.name).toBe("get_weather");
+  expect(JSON.parse(r.tool_calls![0].function.arguments)).toEqual({ location: "Paris" });
+});
+
+test("MiniMax-M2 typed (json) parameter values coerce; multiple invokes", () => {
+  const out = '<minimax:tool_call>\n<invoke name="search"><parameter name="q">cats</parameter><parameter name="limit">5</parameter></invoke>\n<invoke name="ping"></invoke>\n</minimax:tool_call>';
+  const r = parseXmlInvokeToolCalls(out);
+  expect(r.tool_calls!.length).toBe(2);
+  expect(JSON.parse(r.tool_calls![0].function.arguments)).toEqual({ q: "cats", limit: 5 });
+  expect(JSON.parse(r.tool_calls![1].function.arguments)).toEqual({});
+});
+
+test("MiniMax-M2 preserves assistant content before the tool call", () => {
+  const out = 'Let me check.\n<minimax:tool_call>\n<invoke name="f"><parameter name="x">1</parameter></invoke>\n</minimax:tool_call>';
+  const r = parseXmlInvokeToolCalls(out);
+  expect(r.content).toBe("Let me check.");
+  expect(r.tool_calls![0].function.name).toBe("f");
+});

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -6699,9 +6699,12 @@ fn ffn_batched(
             _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
         } && (2 * im) % 64 == 0
           && hidden % 256 == 0;
-        // MMQ-style index-pack preload (#356, default ON for 4w; opt out via =0).
+        // MMQ-style index-pack preload (#356). Reverted to OPT-IN: the preload
+        // hoisted only 8 of 16 weight packs, decoding half the MQ2 weights wrong
+        // → long-context attractor on DS4 mq2lloyd (root-caused by @nwoolmer on
+        // gfx1151; the corrected kernel measured flat, so no reason to default it).
         let use_mmqload = use_lloyd_4w && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() != Ok("0");
+            .as_deref() == Ok("1");
         // Barrier-free nosync variant (#356, opt in via =1).
         let use_nosync = use_mmqload && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
             .as_deref() == Ok("1");
@@ -6887,8 +6890,9 @@ fn ffn_batched(
             _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
         } && hidden % 64 == 0
           && im % 256 == 0;
+        // Opt-in (see use_mmqload above — same #356 long-context attractor).
         let use_mmqload_down = use_lloyd_4w_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() != Ok("0");
+            .as_deref() == Ok("1");
         let use_nosync_down = use_mmqload_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
             .as_deref() == Ok("1");
         // n32_env / cnd_env / eightw_env reused from the gate_up block above.

--- a/crates/hipfire-arch-lfm2moe/Cargo.toml
+++ b/crates/hipfire-arch-lfm2moe/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+[package]
+name = "hipfire-arch-lfm2moe"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+rdna-compute = { path = "../rdna-compute" }
+hip-bridge = { path = "../hip-bridge" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[features]
+# Mirror minimax: rdna-compute host-readback helpers and hybrid-state plumbing
+# live behind `deltanet`. The conv/attention/MoE kernels the forward uses are
+# ungated; the new LFM2 short-conv kernel is ungated too.
+default = ["deltanet"]
+deltanet = ["rdna-compute/deltanet", "hipfire-runtime/deltanet"]

--- a/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
+++ b/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
@@ -1,0 +1,93 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 Kaden Schutt
+hipfire — see LICENSE and NOTICE in the project root.
+-->
+# LFM2.5-8B-A1B (arch_id 11) — status & next steps
+
+## Status: forward VALIDATED, real model COHERENT, decode ~250 tok/s (gfx1201)
+
+Shipped on branch `lfm2moe/impl` (off `minimax/m2.7-impl`):
+
+- **crate `hipfire-arch-lfm2moe`** — config / loader / forward (free-fn
+  `decode_step`) / examples (`dump_lfm2moe_hidden_states`, `infer_lfm2moe`).
+- **kernel `conv1d_gated_decode.hip`** (+ dispatch wrapper) — the LIV double-gated
+  short-conv decode op (B·x pre-gate, depthwise causal conv runtime-K, C·conv_out
+  post-gate, rolling conv-state advance) fused in one launch.
+- **quantizer** — `"lfm2_moe" => 11`, `is_lfm2moe` ingest (bf16 → experts MQ4G256,
+  expert_bias F32, all else Q8).
+- **daemon** — arch_id 11 registered (LoadedModel slots, load branch,
+  `generate_lfm2moe`, Cargo `arch-lfm2moe`).
+
+**Validation:** tiny-oracle per-layer cosine 0.99996 → 0.99931 (≥0.999, 4-bit
+experts) vs HF `Lfm2MoeForCausalLM`; real mq4 model coherent through the daemon
+(Tokyo / working Fibonacci / 80 km/h), ~247–253 tok/s decode.
+
+## Architecture recap (ground truth: transformers lfm2_moe + repo config.json)
+- 24 layers; `layer_types` = 18 `conv` + 6 `full_attention` (attn at L 2,6,10,14,18,21).
+- FFN: layers 0–1 dense SwiGLU (inter 7168); 2–23 top-4 MoE (32 experts, moe_inter 1792).
+- hidden 2048, 32 q-heads / 8 kv-heads, head_dim 64, RoPE θ 5e6, RMSNorm eps 1e-5
+  (standard, no +1), conv K=3 depthwise, tie_word_embeddings, vocab 128000.
+- MoE routing: sigmoid(gate) + expert_bias (selection only) → top-4 → gather
+  unbiased → norm_topk → scale (1.0). Maps to `deepseek4_moe_topk_bias_aware_f32`.
+
+## Next steps (priority order)
+
+### 1. Perf: profile + tune decode (task #9)
+Current ~250 tok/s is correctness-first (per-token prefill, no batching, no fusion
+beyond what minimax reuses). To push max perf on gfx1201:
+- **Warm baseline first** (per CLAUDE.md perf rules): `HIPFIRE_DPM_WARMUP_SECS=10`,
+  fresh process, byte-identical prompt + md5, median of 3–5. Within-session band
+  on gfx11/12 is ±1–3%; treat ≥5% as real.
+- **rocprof attribution** on a decode run to find the hot kernels. Likely suspects:
+  the 18× conv layers (each = in_proj gemv + conv + out_proj gemv), the 22× MoE
+  blocks (router + 2 indexed GEMVs + combine), the 6× attention.
+- **conv kernel occupancy** — use the `gfx-kernel-metadata` skill on
+  `conv1d_gated_decode.hsaco` (VGPR/SGPR/LDS/spill). It's channel-parallel, 1
+  thread/channel, 256 block — probably fine, but verify zero spills and that the
+  `win[KMAX=8]` local array doesn't force VGPR pressure (K=3 only needs win[3]).
+  Consider a compile-time-K specialization (`conv1d_gated_decode_k3`) to drop the
+  bounds loop, like qwen35's compile-time-K4 conv1d_decode.
+- **Fuse the conv gates into in_proj/out_proj** if the 3 conv launches/layer show
+  up hot — e.g. a fused in_proj+gate or out_proj-residual (minimax's MoE uses
+  `weight_gemv_residual` fusion; conv out_proj already does).
+- **MoE GEMV variant sweep** — confirm the batched k4 path is optimal vs the
+  non-batched indexed path at batch=1; the wave64 vs wave32 split is auto (gfx1201
+  is wave32). Check whether `moe_down_combine` + separate down can fuse to the
+  residual-scaled down (minimax's MQ2-Lloyd path does this — no hfq4 equivalent yet).
+- **Re-validate after every gain**: cosine (tiny) must stay ≥0.999 AND coherence
+  gate must stay PASS. A tok/s win that breaks either is a regression (see CLAUDE.md
+  synth-win→prod-falsify history).
+
+### 2. Quality: KLD vs llama.cpp / higher-precision sweep
+- The current mq4 (4-bit experts) is the VRAM-efficient default. Run a precision
+  sweep (experts mq4 → mq6 → q8) and measure KLD/perplexity vs an f16 reference
+  (or llama.cpp if it gains lfm2_moe support) to quantify the 4-bit quality cost.
+- Per-tensor tiering (e.g. first/last MoE layers mq6, middle mq4) à la the K-map
+  path is a lever if KLD is too high.
+
+### 3. Prefill batching (perf, larger win for long prompts)
+- Currently prefill is per-token `decode_step` (same as minimax bring-up). A
+  batched prefill kernel set (like qwen35's `forward_prefill_batch`) would speed
+  long-context prompt ingestion substantially. Requires a batched conv1d scan
+  (the `conv1d_silu_split_f32_n` N-token scan is the reference shape) + batched
+  attention/MoE. Non-trivial; only worth it once decode is tuned.
+
+### 4. Coherence gate entry (task #8)
+- Added 2 lfm2 rows to `scripts/coherence-gate.sh` (lfm2-cap, lfm2-reason). They
+  skip automatically when the model file is absent. Keep them in the matrix.
+
+### 5. Spec-decode / DFlash (optional, large effort)
+- The conv-state cache already has a tree/snapshot pattern in qwen35
+  (`conv1d_silu_split_tree`, speculative.rs conv_state_bufs). If LFM2 ever needs
+  spec-decode, that's the reference — but it's out of scope for the base port.
+
+## Known caveats
+- **Chat framing required**: raw completion prompts loop on this instruct/thinking
+  model. The daemon ChatFrame handles it; `infer_lfm2moe` with a bare prompt will
+  degenerate (not an arch bug — cosine ≥0.999 proves the forward).
+- **conv_L_cache non-snake-case warning** in config.rs (the serde field mirrors the
+  HF config key `conv_L_cache`) — harmless `#[warn(non_snake_case)]`; add
+  `#[allow(non_snake_case)]` or `#[serde(rename)]` to silence if desired.
+- **MoE GEMV is the `_k8`-named family with runtime k_top=4** — correct (the name
+  is historical; k_top is a runtime arg). No `_k4` GEMV kernel was needed.

--- a/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
+++ b/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
@@ -43,21 +43,33 @@ make default: KLD/PPL vs Q8 first. See design doc "PERF TUNING".
 (Measurement note: an early "+18%" was an EOS-truncation artifact and a "WASH"
 was a fabricated number — corrected; the +7.2% is from grep-able matched logs.)
 
-### 1. Perf: further tuning (task #9, ongoing) — baseline 241 tok/s (Q8) / 259 (proj-MQ4)
-Decode is bandwidth-bound but launch-overhead matters at batch=1. Levers that cut
-LAUNCH COUNT (not just bytes):
-- **Warm baseline first** (per CLAUDE.md perf rules): `HIPFIRE_DPM_WARMUP_SECS=10`,
-  fresh process, byte-identical prompt + md5, median of 3–5. Within-session band
-  on gfx11/12 is ±1–3%; treat ≥5% as real.
-- **rocprof attribution** on a decode run to find the hot kernels. Likely suspects:
-  the 18× conv layers (each = in_proj gemv + conv + out_proj gemv), the 22× MoE
-  blocks (router + 2 indexed GEMVs + combine), the 6× attention.
-- **conv kernel occupancy** — use the `gfx-kernel-metadata` skill on
-  `conv1d_gated_decode.hsaco` (VGPR/SGPR/LDS/spill). It's channel-parallel, 1
-  thread/channel, 256 block — probably fine, but verify zero spills and that the
-  `win[KMAX=8]` local array doesn't force VGPR pressure (K=3 only needs win[3]).
-  Consider a compile-time-K specialization (`conv1d_gated_decode_k3`) to drop the
-  bounds loop, like qwen35's compile-time-K4 conv1d_decode.
+### TESTED NEGATIVE — compile-time-K3 conv: no-op (+0.25%, within noise), reverted
+Implemented `conv1d_gated_decode_k3_f32` (unrolled 3-tap, no runtime-K loop /
+win[] array), dispatched on K==3, verified bit-identical (tiny cosine 0.99910).
+Matched A/B (5× 256-tok, fresh process): **242.1 vs 241.5 tok/s = +0.25%, within
+noise.** The conv kernel is launch/latency-bound (one tiny single launch, ~3
+FMAs), not ALU-bound — unrolling buys nothing. "K3 = launch-count reducer" was a
+mis-framing: it's one already-single launch. Reverted (complexity for no gain).
+See design doc "Tested NEGATIVE" for detail. **Do not re-attempt.**
+
+### 1. Perf: further tuning (task #9) — baseline 241 tok/s (Q8) / 259 (proj-MQ4 opt-in)
+Real decode bound at batch=1 is launch OVERHEAD (~330 launches/tok), not the conv
+body. Levers that genuinely cut launch COUNT (all higher-effort, all need cosine
++ coherence re-validation):
+- **HIP graph capture** of the per-token kernel sequence — amortize per-launch
+  cost across the ~330 launches; likely the biggest single decode lever.
+- **rmsnorm→gemv fusion** for the Q8 path (the existing fused-rmsnorm-rotate is
+  MQ-only; a Q8 fused variant would remove 1 launch × 24 layers).
+- **MoE down+combine fusion** — an hfq4 residual-scaled-down kernel (the
+  MQ2-Lloyd path already fuses these; no hfq4 equivalent yet) removes 1 launch ×
+  22 layers.
+- **Bandwidth axis**: proj-MQ4 (+7.2%, shipped opt-in); MQ6-proj untried
+  middle-ground (less quality loss, ~half the saving).
+- **Prefill batching** (large win for long prompts; needs batched conv1d scan +
+  batched attn/MoE — substantial).
+Always: warm first (`HIPFIRE_DPM_WARMUP_SECS=10`, fresh process, byte-identical
+prompt, median of ≥3 MATCHED full-length runs — NOT EOS-truncated). Treat ≥5% as
+real; re-validate cosine + coherence after every gain.
 - **Fuse the conv gates into in_proj/out_proj** if the 3 conv launches/layer show
   up hot — e.g. a fused in_proj+gate or out_proj-residual (minimax's MoE uses
   `weight_gemv_residual` fusion; conv out_proj already does).

--- a/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
+++ b/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
@@ -5,7 +5,7 @@ hipfire — see LICENSE and NOTICE in the project root.
 -->
 # LFM2.5-8B-A1B (arch_id 11) — status & next steps
 
-## Status: forward VALIDATED, real model COHERENT, decode ~250 tok/s (gfx1201)
+## Status: forward VALIDATED, real model COHERENT, decode 241 tok/s (Q8) / 259 tok/s (proj-MQ4 opt-in) on gfx1201
 
 Shipped on branch `lfm2moe/impl` (off `minimax/m2.7-impl`):
 
@@ -33,9 +33,19 @@ experts) vs HF `Lfm2MoeForCausalLM`; real mq4 model coherent through the daemon
 
 ## Next steps (priority order)
 
-### 1. Perf: profile + tune decode (task #9)
-Current ~250 tok/s is correctness-first (per-token prefill, no batching, no fusion
-beyond what minimax reuses). To push max perf on gfx1201:
+### 0. DONE — proj-MQ4 perf lever (+7.2%, opt-in): `HIPFIRE_LFM2_PROJ_MQ4=1`
+4-bit-ing the dense projections (conv in/out_proj, attn q/k/v/out, dense MLP)
+gives **258.8 vs 241.5 tok/s = +7.2%** on matched full-256-tok runs (6 runs each,
+±0.1%), real model coherent (Paris / 80 km/h). OFF by default due to a quality
+cost (tiny-oracle cosine 0.94 < 0.99 4-bit gate — quant noise, milder on the real
+wide projections). Fast variant model: `~/.hipfire/models/lfm2.5-8b-a1b.mq4p`. To
+make default: KLD/PPL vs Q8 first. See design doc "PERF TUNING".
+(Measurement note: an early "+18%" was an EOS-truncation artifact and a "WASH"
+was a fabricated number — corrected; the +7.2% is from grep-able matched logs.)
+
+### 1. Perf: further tuning (task #9, ongoing) — baseline 241 tok/s (Q8) / 259 (proj-MQ4)
+Decode is bandwidth-bound but launch-overhead matters at batch=1. Levers that cut
+LAUNCH COUNT (not just bytes):
 - **Warm baseline first** (per CLAUDE.md perf rules): `HIPFIRE_DPM_WARMUP_SECS=10`,
   fresh process, byte-identical prompt + md5, median of 3–5. Within-session band
   on gfx11/12 is ±1–3%; treat ≥5% as real.

--- a/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
+++ b/crates/hipfire-arch-lfm2moe/NEXT-STEPS.md
@@ -33,6 +33,19 @@ experts) vs HF `Lfm2MoeForCausalLM`; real mq4 model coherent through the daemon
 
 ## Next steps (priority order)
 
+### 0. DONE — MQ6-experts QUALITY lever (opt-in): `HIPFIRE_LFM2_EXPERT_MQ6=1`
+rocprofv3 showed decode is BANDWIDTH-bound (gemv_q8_0 = 49.5%); bf16-referenced
+KLD showed the 4-bit EXPERTS (not the projections) dominate the quality gap. So
+added 6-bit experts via a new HFQ6 indexed MoE GEMV kernel
+(`gemv_hfq6g256_moe_gate_up_k8_indexed_batched`; the `_down_*_expanded` sibling
+already existed) + forward routing on MQ6G256 expert dtype + quantizer flag.
+Model `lfm2.5-8b-a1b.mq6e`: **KL vs bf16 0.424→0.135 (−68%), top-1 72.7→79.5%,
+for −16% decode (241→203 tok/s) + 1.8 GB VRAM (4.6→6.4).** Coherent (chat-framed
+coherence_probe verdict OK, 0 hard/0 soft). Opt-in; default stays mq4 (max speed).
+See design doc "MQ6-experts". NOTE: the bare-prompt `infer_lfm2moe` smoke loops
+("France is France is") — that's the documented bare-completion artifact (mq4
+does it too), NOT a kernel bug; validate coherence via the daemon/ChatFrame.
+
 ### 0. DONE — proj-MQ4 perf lever (+7.2%, opt-in): `HIPFIRE_LFM2_PROJ_MQ4=1`
 4-bit-ing the dense projections (conv in/out_proj, attn q/k/v/out, dense MLP)
 gives **258.8 vs 241.5 tok/s = +7.2%** on matched full-256-tok runs (6 runs each,

--- a/crates/hipfire-arch-lfm2moe/assets/chat_template.jinja
+++ b/crates/hipfire-arch-lfm2moe/assets/chat_template.jinja
@@ -1,0 +1,115 @@
+{{- bos_token -}}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+
+{%- macro format_arg_value(arg_value) -%}
+    {%- if arg_value is string -%}
+        {{- "'" + arg_value + "'" -}}
+    {%- elif arg_value is mapping -%}
+        {{- arg_value | tojson -}}
+    {%- else -%}
+        {{- arg_value | string -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro parse_content(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- else -%}
+        {%- set _ns = namespace(result="") -%}
+        {%- for item in content -%}
+            {%- if item["type"] == "image" -%}
+                {%- set _ns.result = _ns.result + "<image>" -%}
+            {%- elif item["type"] == "text" -%}
+                {%- set _ns.result = _ns.result + item["text"] -%}
+            {%- else -%}
+                {%- set _ns.result = _ns.result + item | tojson -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {{- _ns.result -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_tool_calls(tool_calls) -%}
+    {%- set tool_calls_ns = namespace(tool_calls=[]) -%}
+    {%- for tool_call in tool_calls -%}
+        {%- set func_name = tool_call["function"]["name"] -%}
+        {%- set func_args = tool_call["function"]["arguments"] -%}
+        {%- set args_ns = namespace(arg_strings=[]) -%}
+        {%- for arg_name, arg_value in func_args.items() -%}
+            {%- set args_ns.arg_strings = args_ns.arg_strings + [arg_name + "=" + format_arg_value(arg_value)] -%}
+        {%- endfor -%}
+        {%- set tool_calls_ns.tool_calls = tool_calls_ns.tool_calls + [func_name + "(" + (args_ns.arg_strings | join(", ")) + ")"] -%}
+    {%- endfor -%}
+    {{- "<|tool_call_start|>[" + (tool_calls_ns.tool_calls | join(", ")) + "]<|tool_call_end|>" -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(system_prompt="", last_user_index=-1) -%}
+{%- if messages[0]["role"] == "system" -%}
+    {%- if messages[0].get("content") -%}
+        {%- set ns.system_prompt = parse_content(messages[0]["content"]) -%}
+    {%- endif -%}
+    {%- set messages = messages[1:] -%}
+{%- endif -%}
+{%- if tools -%}
+    {%- set ns.system_prompt = ns.system_prompt + ("\n" if ns.system_prompt else "") + "List of tools: [" -%}
+    {%- for tool in tools -%}
+        {%- if tool is not string -%}
+            {%- set tool = tool | tojson -%}
+        {%- endif -%}
+        {%- set ns.system_prompt = ns.system_prompt + tool -%}
+        {%- if not loop.last -%}
+            {%- set ns.system_prompt = ns.system_prompt + ", " -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- set ns.system_prompt = ns.system_prompt + "]" -%}
+{%- endif -%}
+{%- if ns.system_prompt -%}
+    {{- "<|im_start|>system\n" + ns.system_prompt + "<|im_end|>\n" -}}
+{%- endif -%}
+{%- for message in messages -%}
+    {%- if message["role"] == "user" -%}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- for message in messages -%}
+    {{- "<|im_start|>" + message.role + "\n" -}}
+    {%- if message.role == "assistant" -%}
+        {%- generation -%}
+        {%- if message.thinking is defined and (preserve_thinking or loop.index0 > ns.last_user_index) -%}
+            {{- "<think>" + message.thinking + "</think>" -}}
+        {%- endif -%}
+        {%- set _cfm_tag = "CONTINUE_FINAL_MESSAGE_TAG " -%}
+        {%- set _has_cfm = false -%}
+        {%- if message.content is defined -%}
+            {%- set content = parse_content(message.content) -%}
+            {%- if not (preserve_thinking or loop.index0 > ns.last_user_index) -%}
+                {%- if "</think>" in content -%}
+                    {%- set content = content.split("</think>")[-1] | trim -%}
+                {%- endif -%}
+            {%- endif -%}
+            {%- if message.tool_calls is defined and content.endswith(_cfm_tag) -%}
+                {%- set _has_cfm = true -%}
+                {%- set _trunc_len = (content | length) - (_cfm_tag | length) -%}
+                {{- content[:_trunc_len] -}}
+            {%- else -%}
+                {{- content -}}
+            {%- endif -%}
+        {%- endif -%}
+        {%- if message.tool_calls is defined -%}
+            {{- render_tool_calls(message.tool_calls) -}}
+        {%- endif -%}
+        {%- if _has_cfm -%}
+            {{- _cfm_tag -}}
+        {%- endif -%}
+        {{- "<|im_end|>\n" -}}
+        {%- endgeneration -%}
+    {%- else %}
+        {%- if message.get("content") -%}
+            {{- parse_content(message["content"]) -}}
+        {%- endif -%}
+        {{- "<|im_end|>\n" -}}
+    {%- endif %}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/crates/hipfire-arch-lfm2moe/examples/dump_lfm2moe_hidden_states.rs
+++ b/crates/hipfire-arch-lfm2moe/examples/dump_lfm2moe_hidden_states.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! Dump per-layer hidden states from the LFM2.5-MoE forward for offline
+//! comparison against the HF transformers oracle (arch bring-up validation).
+//!
+//! Reads a JSON array of token ids, runs `decode_step_capture` per position
+//! with all layers captured, and writes a single HFHS binary of post-layer
+//! (pre-final-norm) hidden states — byte-format-compatible with
+//! `scripts/gen_tiny_lfm2moe.py` + `scripts/compare_hidden_states.py`.
+//!
+//! Usage:
+//!   dump_lfm2moe_hidden_states --model <hfq> --tokens <tokens.json> --out <hfhs>
+//!   [--capture-postmixer]   (capture post-conv/attn residual instead of post-layer)
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_arch_lfm2moe::config::Lfm2MoeConfig;
+    use hipfire_arch_lfm2moe::forward::decode_step_capture;
+    use hipfire_arch_lfm2moe::lfm2moe::{Lfm2MoeState, Lfm2MoeWeights};
+    use hipfire_runtime::hfq::HfqFile;
+    use std::fs::File;
+    use std::io::{BufWriter, Write};
+    use std::path::PathBuf;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model: Option<PathBuf> = None;
+    let mut tokens_path: Option<PathBuf> = None;
+    let mut out_path: Option<PathBuf> = None;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model" => { model = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--tokens" => { tokens_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--out" => { out_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--capture-postmixer" => {
+                std::env::set_var("HIPFIRE_LFM2_CAPTURE_POSTMIXER", "1");
+                i += 1;
+            }
+            other => { eprintln!("unknown arg: {other}"); std::process::exit(1); }
+        }
+    }
+    let model = model.expect("--model required");
+    let tokens_path = tokens_path.expect("--tokens required");
+    let out_path = out_path.expect("--out required");
+
+    // ---- read tokens (JSON array of ints) ----
+    let tokens: Vec<u32> = {
+        let s = std::fs::read_to_string(&tokens_path).expect("read tokens");
+        let v: Vec<i64> = serde_json::from_str(&s).expect("parse tokens json");
+        v.into_iter().map(|t| t as u32).collect()
+    };
+    let n_ctx = tokens.len();
+    eprintln!("read {n_ctx} tokens from {}", tokens_path.display());
+
+    // ---- load model ----
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(&model).expect("open model");
+    let cfg = Lfm2MoeConfig::from_hfq(&hfq).expect("config");
+    eprintln!(
+        "arch=lfm2moe hidden={} layers={} (attn={} conv={}) heads={}/{} head_dim={} \
+         experts={}/{} dense={} convK={} vocab={}",
+        cfg.hidden_size, cfg.num_hidden_layers, cfg.num_attention_layers(),
+        cfg.num_conv_layers(), cfg.num_attention_heads, cfg.num_key_value_heads,
+        cfg.head_dim, cfg.num_experts, cfg.num_experts_per_tok, cfg.num_dense_layers,
+        cfg.conv_kernel_size, cfg.vocab_size,
+    );
+    let weights = Lfm2MoeWeights::load(&mut hfq, &cfg, &mut gpu).expect("weights");
+    let mut state = Lfm2MoeState::new_with_max_seq(&mut gpu, &cfg, n_ctx + 16).expect("state");
+
+    // ---- per-token forward with per-layer capture ----
+    let mut capture: Vec<Vec<f32>> =
+        vec![Vec::with_capacity(n_ctx * cfg.hidden_size); cfg.num_hidden_layers];
+    let t0 = std::time::Instant::now();
+    for (pos, &tok) in tokens.iter().enumerate() {
+        decode_step_capture(&cfg, &weights, &mut state, &mut gpu, tok, pos as u32, &mut capture)
+            .expect("decode_step_capture");
+    }
+    eprintln!("forward complete in {:.2}s", t0.elapsed().as_secs_f64());
+
+    // ---- write HFHS ----
+    if let Some(parent) = out_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let mut out = BufWriter::new(File::create(&out_path).expect("create out"));
+    out.write_all(b"HFHS\0\0\0\0").unwrap();
+    out.write_all(&(cfg.num_hidden_layers as u32).to_le_bytes()).unwrap();
+    out.write_all(&(n_ctx as u32).to_le_bytes()).unwrap();
+    out.write_all(&(cfg.hidden_size as u32).to_le_bytes()).unwrap();
+    out.write_all(&0u32.to_le_bytes()).unwrap();
+    for (l, buf) in capture.iter().enumerate() {
+        assert_eq!(buf.len(), n_ctx * cfg.hidden_size, "layer {l} size");
+        let bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 4) };
+        out.write_all(bytes).unwrap();
+        let rms = (buf.iter().map(|&v| (v as f64) * (v as f64)).sum::<f64>() / buf.len() as f64)
+            .sqrt();
+        eprintln!("  layer {l}: rms={rms:.4}");
+    }
+    out.flush().unwrap();
+    eprintln!("wrote {}", out_path.display());
+}

--- a/crates/hipfire-arch-lfm2moe/examples/graph_parity_lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/examples/graph_parity_lfm2moe.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! hipGraph parity check for LFM2.5-MoE (HIPFIRE_LFM2_GRAPH).
+//!
+//! Runs the SAME token sequence twice on two independent decode states:
+//!   A) direct path     (decode_step_inner via decode_step)
+//!   B) hipGraph path   (decode_step_with_graph, warmup + capture + replay)
+//! and reports per-position cosine + max-abs-delta between the full logits
+//! vectors. Graph capture corrupts silently via stale kernarg scalars, so a
+//! per-position logits cos >= 0.999999 (and argmax match) is the correctness
+//! gate. Validation scaffold — not part of the shipped engine.
+//!
+//! Usage: graph_parity_lfm2moe --model <hfq> --tokens <tokens.json>
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_arch_lfm2moe::config::Lfm2MoeConfig;
+    use hipfire_arch_lfm2moe::forward::{decode_step, decode_step_with_graph};
+    use hipfire_arch_lfm2moe::lfm2moe::{Lfm2MoeState, Lfm2MoeWeights};
+    use hipfire_runtime::hfq::HfqFile;
+    use std::path::PathBuf;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model: Option<PathBuf> = None;
+    let mut tokens_path: Option<PathBuf> = None;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model" => { model = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--tokens" => { tokens_path = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            other => { eprintln!("unknown arg: {other}"); std::process::exit(1); }
+        }
+    }
+    let model = model.expect("--model required");
+    let tokens_path = tokens_path.expect("--tokens required");
+
+    let tokens: Vec<u32> = {
+        let s = std::fs::read_to_string(&tokens_path).expect("read tokens");
+        let v: Vec<i64> = serde_json::from_str(&s).expect("parse tokens json");
+        v.into_iter().map(|t| t as u32).collect()
+    };
+    let n = tokens.len();
+
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(&model).expect("open model");
+    let cfg = Lfm2MoeConfig::from_hfq(&hfq).expect("config");
+    let weights = Lfm2MoeWeights::load(&mut hfq, &cfg, &mut gpu).expect("weights");
+
+    // ---- Pass A: direct ----
+    let mut state_a = Lfm2MoeState::new_with_max_seq(&mut gpu, &cfg, n + 16).expect("state A");
+    let mut logits_a: Vec<Vec<f32>> = Vec::with_capacity(n);
+    for (pos, &t) in tokens.iter().enumerate() {
+        let l = decode_step(&cfg, &weights, &mut state_a, &mut gpu, t, pos as u32)
+            .expect("direct decode_step");
+        logits_a.push(l);
+    }
+
+    // ---- Pass B: hipGraph capture/replay (fresh state) ----
+    let mut state_b = Lfm2MoeState::new_with_max_seq(&mut gpu, &cfg, n + 16).expect("state B");
+    let mut logits_b: Vec<Vec<f32>> = Vec::with_capacity(n);
+    for (pos, &t) in tokens.iter().enumerate() {
+        let l = decode_step_with_graph(&cfg, &weights, &mut state_b, &mut gpu, t, pos as u32)
+            .expect("graph decode_step_with_graph");
+        logits_b.push(l);
+    }
+
+    let argmax = |v: &[f32]| -> usize {
+        let mut bi = 0; let mut bv = f32::NEG_INFINITY;
+        for (i, &x) in v.iter().enumerate() { if x > bv { bv = x; bi = i; } }
+        bi
+    };
+
+    let mut min_cos = f64::INFINITY;
+    let mut max_abs = 0f64;
+    let mut argmax_mismatch = 0usize;
+    println!("=== LFM2.5-MoE hipGraph parity (direct vs graph), {n} positions ===");
+    for pos in 0..n {
+        let a = &logits_a[pos];
+        let b = &logits_b[pos];
+        let (mut dot, mut na, mut nb, mut md) = (0f64, 0f64, 0f64, 0f64);
+        for (x, y) in a.iter().zip(b.iter()) {
+            let (x, y) = (*x as f64, *y as f64);
+            dot += x * y; na += x * x; nb += y * y;
+            md = md.max((x - y).abs());
+        }
+        let cos = dot / (na.sqrt() * nb.sqrt());
+        let am_a = argmax(a); let am_b = argmax(b);
+        if am_a != am_b { argmax_mismatch += 1; }
+        min_cos = min_cos.min(cos);
+        max_abs = max_abs.max(md);
+        println!(
+            "  pos {pos:2}: cos={cos:.8} max|delta|={md:.6e} argmax_direct={am_a} argmax_graph={am_b} {}",
+            if am_a == am_b { "" } else { "<<< ARGMAX MISMATCH" }
+        );
+    }
+    println!("--- min cos={min_cos:.8}  max|delta|={max_abs:.6e}  argmax_mismatches={argmax_mismatch}/{n} ---");
+    if min_cos >= 0.999999 && argmax_mismatch == 0 {
+        println!("GRAPH PARITY PASS");
+    } else {
+        println!("GRAPH PARITY FAIL");
+        std::process::exit(2);
+    }
+}

--- a/crates/hipfire-arch-lfm2moe/examples/infer_lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/examples/infer_lfm2moe.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! Minimal LFM2.5-MoE greedy inference — real-model e2e coherence check.
+//! Loads an HFQ, runs prefill + greedy decode via `decode_step`, prints text.
+//!
+//! Usage: infer_lfm2moe --model <hfq> [--prompt <text>] [--max N]
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_arch_lfm2moe::config::Lfm2MoeConfig;
+    use hipfire_arch_lfm2moe::forward::decode_step;
+    use hipfire_arch_lfm2moe::lfm2moe::{Lfm2MoeState, Lfm2MoeWeights};
+    use hipfire_runtime::hfq::HfqFile;
+    use hipfire_runtime::tokenizer::Tokenizer;
+    use std::path::PathBuf;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model: Option<PathBuf> = None;
+    let mut prompt = "The capital of France is".to_string();
+    let mut max: usize = 64;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model" => { model = Some(PathBuf::from(&argv[i + 1])); i += 2; }
+            "--prompt" => { prompt = argv[i + 1].clone(); i += 2; }
+            "--max" => { max = argv[i + 1].parse().expect("--max"); i += 2; }
+            other => { eprintln!("unknown arg {other}"); std::process::exit(1); }
+        }
+    }
+    let model = model.expect("--model required");
+
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(&model).expect("open model");
+    let cfg = Lfm2MoeConfig::from_hfq(&hfq).expect("config");
+    eprintln!(
+        "lfm2moe hidden={} layers={} experts={}/{} vocab={}",
+        cfg.hidden_size, cfg.num_hidden_layers, cfg.num_experts,
+        cfg.num_experts_per_tok, cfg.vocab_size
+    );
+    let tok = Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer");
+    let t_load = std::time::Instant::now();
+    let weights = Lfm2MoeWeights::load(&mut hfq, &cfg, &mut gpu).expect("weights");
+    eprintln!("loaded weights in {:.1}s", t_load.elapsed().as_secs_f64());
+
+    let prompt_ids = tok.encode(&prompt);
+    eprintln!("prompt {:?} → {} tokens", prompt, prompt_ids.len());
+    let max_seq = prompt_ids.len() + max + 16;
+    let mut state = Lfm2MoeState::new_with_max_seq(&mut gpu, &cfg, max_seq).expect("state");
+
+    let argmax = |v: &[f32]| -> u32 {
+        let mut bi = 0u32;
+        let mut bv = f32::NEG_INFINITY;
+        for (i, &x) in v.iter().enumerate() {
+            if x > bv { bv = x; bi = i as u32; }
+        }
+        bi
+    };
+
+    // Prefill (per-token; correctness-first).
+    let t0 = std::time::Instant::now();
+    let mut logits = Vec::new();
+    for (pos, &t) in prompt_ids.iter().enumerate() {
+        logits = decode_step(&cfg, &weights, &mut state, &mut gpu, t, pos as u32).expect("prefill");
+    }
+    eprintln!("prefill {} tok in {:.2}s", prompt_ids.len(), t0.elapsed().as_secs_f64());
+
+    // Greedy decode.
+    let mut gen = Vec::new();
+    let mut pos = prompt_ids.len();
+    let t1 = std::time::Instant::now();
+    for _ in 0..max {
+        let next = argmax(&logits);
+        gen.push(next);
+        // LFM2.5 EOS = 124900; also stop on common ids.
+        if matches!(next, 124900 | 124899 | 2) { break; }
+        logits = decode_step(&cfg, &weights, &mut state, &mut gpu, next, pos as u32).expect("decode");
+        pos += 1;
+    }
+    let dt = t1.elapsed().as_secs_f64();
+    eprintln!("decoded {} tok in {:.2}s ({:.1} tok/s)", gen.len(), dt, gen.len() as f64 / dt);
+    println!("=== PROMPT ===\n{prompt}\n=== GENERATION ===\n{}", tok.decode(&gen));
+    eprintln!("token ids: {:?}", &gen[..gen.len().min(40)]);
+}

--- a/crates/hipfire-arch-lfm2moe/examples/kld_logits.rs
+++ b/crates/hipfire-arch-lfm2moe/examples/kld_logits.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! kld_logits — per-position KL-divergence between two models' next-token
+//! logits over a fixed token-id list.
+//!
+//! For each position i in the token list, both model-a (reference) and
+//! model-b (candidate) are fed tokens[0..=i] (per-token prefill via
+//! `decode_step`), and the next-token logits at position i are captured.
+//! We then compute KL(softmax(ref_i) || softmax(cand_i)) per position and
+//! report the distribution (mean / median / p99 / max / frac>0.1).
+//!
+//! Currently wired for arch_id 11 (LFM2.5-MoE). The `run_model` dispatch
+//! reads arch_id from the HFQ metadata; other arches panic with a clear
+//! message (extend the match to add them).
+//!
+//! Usage:
+//!   kld_logits --model-a <ref.hfq> --model-b <cand.hfq> \
+//!              --tokens <tokens.json> [--max N]
+//!
+//!   --tokens : JSON array of u32 token ids, e.g. [504, 2849, 8868, ...]
+//!   --max    : cap on the number of positions evaluated (default: all)
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+use std::fs;
+
+#[cfg(feature = "deltanet")]
+struct Args {
+    model_a: String,
+    model_b: Option<String>,
+    tokens: String,
+    max: usize,
+    dump: Option<String>,
+}
+
+#[cfg(feature = "deltanet")]
+fn parse_args() -> Args {
+    let argv: Vec<String> = std::env::args().collect();
+    let mut model_a: Option<String> = None;
+    let mut model_b: Option<String> = None;
+    let mut tokens: Option<String> = None;
+    let mut max: usize = usize::MAX;
+    let mut dump: Option<String> = None;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--model-a" => { model_a = Some(argv[i + 1].clone()); i += 2; }
+            "--model-b" => { model_b = Some(argv[i + 1].clone()); i += 2; }
+            "--tokens" => { tokens = Some(argv[i + 1].clone()); i += 2; }
+            "--max" => { max = argv[i + 1].parse().expect("--max"); i += 2; }
+            // --dump <file>: run model-a only, write its per-position logits to a
+            // binary (u32 n_pos, u32 vocab, then n_pos*vocab f32 LE), and exit.
+            // Used to capture each variant's logits for offline KL vs a bf16
+            // reference (the true ground truth — Q8 has its own quant error so it
+            // must NOT be the reference).
+            "--dump" => { dump = Some(argv[i + 1].clone()); i += 2; }
+            other => { eprintln!("unknown arg {other}"); std::process::exit(1); }
+        }
+    }
+    Args {
+        model_a: model_a.expect("--model-a required"),
+        model_b,
+        tokens: tokens.expect("--tokens required"),
+        max,
+        dump,
+    }
+}
+
+/// Write per-position logits as: u32 n_pos, u32 vocab, then n_pos*vocab f32 LE.
+#[cfg(feature = "deltanet")]
+fn dump_logits(path: &str, logits: &[Vec<f32>]) {
+    use std::io::Write;
+    let n = logits.len() as u32;
+    let vocab = if logits.is_empty() { 0 } else { logits[0].len() } as u32;
+    let mut f = std::io::BufWriter::new(std::fs::File::create(path).expect("create dump"));
+    f.write_all(&n.to_le_bytes()).unwrap();
+    f.write_all(&vocab.to_le_bytes()).unwrap();
+    for row in logits {
+        for &v in row {
+            f.write_all(&v.to_le_bytes()).unwrap();
+        }
+    }
+    eprintln!("dumped {n} positions × {vocab} vocab → {path}");
+}
+
+#[cfg(feature = "deltanet")]
+fn detect_arch_id(path: &str) -> Result<u32, String> {
+    use hipfire_runtime::hfq::HfqFile;
+    use std::path::Path;
+    let hfq = HfqFile::open(Path::new(path)).map_err(|e| format!("open {path}: {e}"))?;
+    Ok(hfq.arch_id)
+}
+
+#[cfg(feature = "deltanet")]
+fn load_tokens(path: &str) -> Vec<u32> {
+    let raw = fs::read_to_string(path).expect("read tokens json");
+    serde_json::from_str(&raw).expect("parse tokens json (expected JSON array of u32)")
+}
+
+/// Run `path` over the token list, returning the per-position next-token
+/// logits vector (one Vec<f32> per evaluated position).
+#[cfg(feature = "deltanet")]
+fn run_model(path: &str, args: &Args) -> Vec<Vec<f32>> {
+    let arch_id = detect_arch_id(path).expect("read arch_id");
+    match arch_id {
+        11 => run_lfm2moe(path, args),
+        other => panic!("kld_logits: unsupported arch_id {other} (only 11/lfm2moe wired)"),
+    }
+}
+
+#[cfg(feature = "deltanet")]
+fn run_lfm2moe(path: &str, args: &Args) -> Vec<Vec<f32>> {
+    use hipfire_arch_lfm2moe::config::Lfm2MoeConfig;
+    use hipfire_arch_lfm2moe::forward::decode_step;
+    use hipfire_arch_lfm2moe::lfm2moe::{Lfm2MoeState, Lfm2MoeWeights};
+    use hipfire_runtime::hfq::HfqFile;
+    use std::path::Path;
+
+    let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
+    let mut hfq = HfqFile::open(Path::new(path)).expect("open model");
+    let cfg = Lfm2MoeConfig::from_hfq(&hfq).expect("config");
+    eprintln!(
+        "[{}] lfm2moe hidden={} layers={} experts={}/{} vocab={}",
+        path, cfg.hidden_size, cfg.num_hidden_layers, cfg.num_experts,
+        cfg.num_experts_per_tok, cfg.vocab_size
+    );
+    let weights = Lfm2MoeWeights::load(&mut hfq, &cfg, &mut gpu).expect("weights");
+
+    let tokens = load_tokens(&args.tokens);
+    let n = tokens.len().min(args.max);
+    let max_seq = n + 16;
+    let mut state = Lfm2MoeState::new_with_max_seq(&mut gpu, &cfg, max_seq).expect("state");
+
+    let mut all_logits = Vec::with_capacity(n);
+    for (pos, &tok) in tokens.iter().take(n).enumerate() {
+        let logits = decode_step(&cfg, &weights, &mut state, &mut gpu, tok, pos as u32)
+            .expect("decode_step");
+        all_logits.push(logits);
+    }
+    all_logits
+}
+
+/// KL(softmax(ref) || softmax(cand)) in nats, computed in a numerically
+/// stable way (subtract per-vector max before exp).
+#[cfg(feature = "deltanet")]
+fn compute_kl(ref_logits: &[f32], cand_logits: &[f32]) -> f64 {
+    assert_eq!(ref_logits.len(), cand_logits.len(), "logit vector length mismatch");
+
+    let ref_max = ref_logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max) as f64;
+    let cand_max = cand_logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max) as f64;
+
+    let mut ref_sum = 0.0f64;
+    let mut cand_sum = 0.0f64;
+    for i in 0..ref_logits.len() {
+        ref_sum += ((ref_logits[i] as f64) - ref_max).exp();
+        cand_sum += ((cand_logits[i] as f64) - cand_max).exp();
+    }
+    let log_ref_sum = ref_sum.ln() + ref_max;
+    let log_cand_sum = cand_sum.ln() + cand_max;
+
+    // KL = sum_i p_i * (log p_i - log q_i)
+    //    = sum_i p_i * ((ref_i - log_ref_sum) - (cand_i - log_cand_sum))
+    let mut kl = 0.0f64;
+    for i in 0..ref_logits.len() {
+        let log_p = (ref_logits[i] as f64) - log_ref_sum;
+        let p = log_p.exp();
+        if p <= 0.0 {
+            continue;
+        }
+        let log_q = (cand_logits[i] as f64) - log_cand_sum;
+        kl += p * (log_p - log_q);
+    }
+    // Guard tiny negative values from FP rounding.
+    if kl < 0.0 && kl > -1e-9 {
+        kl = 0.0;
+    }
+    kl
+}
+
+#[cfg(feature = "deltanet")]
+fn percentile(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * q).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[cfg(feature = "deltanet")]
+fn print_summary(kls: &[f64]) {
+    let n = kls.len();
+    if n == 0 {
+        eprintln!("no positions evaluated");
+        return;
+    }
+    let mut sorted = kls.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let mean = kls.iter().sum::<f64>() / n as f64;
+    let median = percentile(&sorted, 0.50);
+    let p99 = percentile(&sorted, 0.99);
+    let max = *sorted.last().unwrap();
+    let frac_gt_0_1 = kls.iter().filter(|&&k| k > 0.1).count() as f64 / n as f64;
+
+    println!("=== KL-divergence summary (ref || cand), nats ===");
+    println!("positions   : {n}");
+    println!("mean        : {mean:.6}");
+    println!("median      : {median:.6}");
+    println!("p99         : {p99:.6}");
+    println!("max         : {max:.6}");
+    println!("frac > 0.1  : {frac_gt_0_1:.4}");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    let args = parse_args();
+
+    // --dump mode: run model-a only, write its logits, exit (no model-b / KL).
+    if let Some(ref dump_path) = args.dump {
+        eprintln!("=== dump model: {} ===", args.model_a);
+        let logits = run_model(&args.model_a, &args);
+        dump_logits(dump_path, &logits);
+        return;
+    }
+
+    eprintln!("=== model-a (reference): {} ===", args.model_a);
+    let ref_logits = run_model(&args.model_a, &args);
+    let model_b = args.model_b.clone().expect("--model-b required (or use --dump)");
+    eprintln!("=== model-b (candidate): {} ===", model_b);
+    let cand_logits = run_model(&model_b, &args);
+
+    let n = ref_logits.len().min(cand_logits.len());
+    let mut kls = Vec::with_capacity(n);
+    for i in 0..n {
+        kls.push(compute_kl(&ref_logits[i], &cand_logits[i]));
+    }
+
+    print_summary(&kls);
+}

--- a/crates/hipfire-arch-lfm2moe/src/config.rs
+++ b/crates/hipfire-arch-lfm2moe/src/config.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! LFM2.5-MoE config, parsed from the HFQ `metadata_json` envelope (which
+//! carries the source `config.json` wholesale under the `config` key).
+//!
+//! Ground truth: LiquidAI/LFM2.5-8B-A1B config.json + transformers
+//! `Lfm2MoeConfig`/`modeling_lfm2_moe.py` (read 2026-05-29):
+//!   hidden 2048, 24 layers, 32 q-heads / 8 kv-heads, head_dim 64,
+//!   layer_types interleave 18 "conv" + 6 "full_attention",
+//!   num_dense_layers 2 (dense SwiGLU MLP), the rest top-4 MoE (32 experts,
+//!   moe_intermediate 1792, sigmoid+expert_bias routing, norm_topk_prob),
+//!   conv_L_cache 3 (depthwise causal short-conv), rope_theta 5e6, eps 1e-5,
+//!   standard RMSNorm (weight * x̂, no +1), tie_word_embeddings.
+
+use hipfire_runtime::hfq::HfqFile;
+use serde::Deserialize;
+
+/// Per-layer mixer kind, decoded from `layer_types`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MixerKind {
+    /// Double-gated LIV short-convolution (depthwise causal, kernel = conv_L_cache).
+    Conv,
+    /// GQA attention with per-head QK-norm + full-dim rotate_half RoPE.
+    Attention,
+}
+
+/// Typed LFM2.5-MoE shape constants.
+#[derive(Clone, Debug)]
+pub struct Lfm2MoeConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    /// Short-conv kernel size (HF `conv_L_cache`); decode conv-state holds K-1.
+    pub conv_kernel_size: usize,
+    /// Dense-MLP FFN intermediate size (HF `intermediate_size`).
+    pub intermediate_size: usize,
+    /// Expert (MoE) FFN intermediate size (HF `moe_intermediate_size`).
+    pub moe_intermediate_size: usize,
+    pub num_experts: usize,
+    pub num_experts_per_tok: usize,
+    /// The first `num_dense_layers` MLP layers are dense SwiGLU; the rest MoE.
+    pub num_dense_layers: usize,
+    pub rope_theta: f32,
+    pub rms_norm_eps: f32,
+    pub max_position_embeddings: usize,
+    /// Renormalize the top-k gathered router weights to sum 1.
+    pub norm_topk_prob: bool,
+    /// Router adds `expert_bias` for selection only (aux-loss-free routing).
+    pub use_expert_bias: bool,
+    /// Scale applied to the combined expert output (HF `routed_scaling_factor`).
+    pub routed_scaling_factor: f32,
+    /// lm_head shares embed_tokens.
+    pub tie_word_embeddings: bool,
+    /// Per-layer mixer choice (length == num_hidden_layers).
+    pub layer_types: Vec<MixerKind>,
+}
+
+#[derive(Deserialize)]
+struct RawRope {
+    #[serde(default = "default_rope_theta")]
+    rope_theta: f32,
+}
+
+#[derive(Deserialize)]
+struct RawLfm2MoeConfig {
+    vocab_size: usize,
+    hidden_size: usize,
+    num_hidden_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    #[serde(default)]
+    head_dim: Option<usize>,
+    #[serde(default = "default_conv_l")]
+    conv_L_cache: usize,
+    intermediate_size: usize,
+    moe_intermediate_size: usize,
+    num_experts: usize,
+    num_experts_per_tok: usize,
+    #[serde(default)]
+    num_dense_layers: usize,
+    #[serde(default)]
+    rope_parameters: Option<RawRope>,
+    #[serde(default = "default_rope_theta")]
+    rope_theta: f32,
+    #[serde(default = "default_eps")]
+    norm_eps: f32,
+    #[serde(default = "default_max_pos")]
+    max_position_embeddings: usize,
+    #[serde(default = "default_true")]
+    norm_topk_prob: bool,
+    #[serde(default = "default_true")]
+    use_expert_bias: bool,
+    #[serde(default = "default_routed_scale")]
+    routed_scaling_factor: f32,
+    #[serde(default = "default_true")]
+    tie_word_embeddings: bool,
+    /// "conv" | "full_attention" per layer.
+    layer_types: Vec<String>,
+}
+
+fn default_rope_theta() -> f32 {
+    1_000_000.0
+}
+fn default_conv_l() -> usize {
+    3
+}
+fn default_eps() -> f32 {
+    1e-5
+}
+fn default_max_pos() -> usize {
+    128_000
+}
+fn default_true() -> bool {
+    true
+}
+fn default_routed_scale() -> f32 {
+    1.0
+}
+
+impl Lfm2MoeConfig {
+    pub fn from_hfq(hfq: &HfqFile) -> Result<Self, String> {
+        let wrapper: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
+            .map_err(|e| format!("lfm2moe: metadata_json not valid JSON: {e}"))?;
+        let inner = wrapper
+            .get("config")
+            .ok_or_else(|| "lfm2moe: metadata_json missing `config` wrapper".to_string())?;
+        Self::from_config_value(inner)
+    }
+
+    /// Parse from a raw `config.json` Value (the inner `config` blob).
+    pub fn from_config_value(inner: &serde_json::Value) -> Result<Self, String> {
+        let raw: RawLfm2MoeConfig = serde_json::from_value(inner.clone())
+            .map_err(|e| format!("lfm2moe: parsing config failed: {e}"))?;
+        let head_dim = raw
+            .head_dim
+            .unwrap_or(raw.hidden_size / raw.num_attention_heads);
+        // rope_theta lives under rope_parameters in LFM2.5; fall back to a flat
+        // rope_theta (older configs) then the default.
+        let rope_theta = raw
+            .rope_parameters
+            .as_ref()
+            .map(|r| r.rope_theta)
+            .unwrap_or(raw.rope_theta);
+        if raw.layer_types.len() != raw.num_hidden_layers {
+            return Err(format!(
+                "lfm2moe: layer_types len {} != num_hidden_layers {}",
+                raw.layer_types.len(),
+                raw.num_hidden_layers
+            ));
+        }
+        let layer_types = raw
+            .layer_types
+            .iter()
+            .map(|s| match s.as_str() {
+                "full_attention" | "attention" | "attn" => Ok(MixerKind::Attention),
+                "conv" | "short_conv" | "conv1d" => Ok(MixerKind::Conv),
+                other => Err(format!("lfm2moe: unknown layer_type {other:?}")),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Lfm2MoeConfig {
+            vocab_size: raw.vocab_size,
+            hidden_size: raw.hidden_size,
+            num_hidden_layers: raw.num_hidden_layers,
+            num_attention_heads: raw.num_attention_heads,
+            num_key_value_heads: raw.num_key_value_heads,
+            head_dim,
+            conv_kernel_size: raw.conv_L_cache,
+            intermediate_size: raw.intermediate_size,
+            moe_intermediate_size: raw.moe_intermediate_size,
+            num_experts: raw.num_experts,
+            num_experts_per_tok: raw.num_experts_per_tok,
+            num_dense_layers: raw.num_dense_layers,
+            rope_theta,
+            rms_norm_eps: raw.norm_eps,
+            max_position_embeddings: raw.max_position_embeddings,
+            norm_topk_prob: raw.norm_topk_prob,
+            use_expert_bias: raw.use_expert_bias,
+            routed_scaling_factor: raw.routed_scaling_factor,
+            tie_word_embeddings: raw.tie_word_embeddings,
+            layer_types,
+        })
+    }
+
+    /// q projection output width (n_heads * head_dim).
+    pub fn q_dim(&self) -> usize {
+        self.num_attention_heads * self.head_dim
+    }
+    /// k/v projection output width (n_kv_heads * head_dim).
+    pub fn kv_dim(&self) -> usize {
+        self.num_key_value_heads * self.head_dim
+    }
+    pub fn mixer(&self, layer: usize) -> MixerKind {
+        self.layer_types[layer]
+    }
+    pub fn is_attention(&self, layer: usize) -> bool {
+        self.layer_types[layer] == MixerKind::Attention
+    }
+    /// The first `num_dense_layers` FFN blocks are dense SwiGLU; the rest MoE.
+    pub fn is_dense_ffn(&self, layer: usize) -> bool {
+        layer < self.num_dense_layers
+    }
+    /// Number of attention layers (== KvCache slots needed).
+    pub fn num_attention_layers(&self) -> usize {
+        self.layer_types
+            .iter()
+            .filter(|&&t| t == MixerKind::Attention)
+            .count()
+    }
+    /// Number of conv layers (== conv-state cache slots needed).
+    pub fn num_conv_layers(&self) -> usize {
+        self.layer_types
+            .iter()
+            .filter(|&&t| t == MixerKind::Conv)
+            .count()
+    }
+}

--- a/crates/hipfire-arch-lfm2moe/src/forward.rs
+++ b/crates/hipfire-arch-lfm2moe/src/forward.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! LFM2.5-MoE forward pass (free functions — hot-path static dispatch).
+//!
+//! Per-layer pipeline (pre-norm; mixer = conv OR attention, FFN = dense OR MoE):
+//!   tmp = operator_norm(h)
+//!   if conv:   h += out_proj( C_gate ⊙ depthwise_causal_conv( B_gate ⊙ x ) )   [in_proj→conv→out_proj]
+//!   if attn:   h += out_proj( attn( qk_norm(q/k) + full-RoPE, v ) )             [GQA, Q8 KV]
+//!   ffn_tmp = ffn_norm(h)
+//!   if dense:  h += w2( silu(w1·ffn_tmp) ⊙ (w3·ffn_tmp) )                        [SwiGLU, Q8]
+//!   if moe:    h += combine( experts( sigmoid+bias top-4 route(ffn_tmp) ) )      [FWHT MQ4 experts]
+//! then logits = lm_head( embedding_norm(h) )   (lm_head tied to embed_tokens).
+//!
+//! Non-expert linears (attention q/k/v/out, conv in/out, dense w1/w2/w3, router)
+//! are Q8 (plain input). Routed experts are FWHT-pre-rotated MQ4G256: the input
+//! is rotated (`rotate_x_mq_for`) and the silu output rotated
+//! (`fused_silu_mul_rotate_mq_batched_for`) before the indexed-MoE GEMVs —
+//! exactly qwen35's / minimax's MoE path, but with k_top = num_experts_per_tok
+//! = 4 (the batched GEMV variants take k_top as a runtime arg).
+
+use crate::config::Lfm2MoeConfig;
+use crate::lfm2moe::{Ffn, Lfm2MoeState, Lfm2MoeWeights, Mixer};
+use hipfire_runtime::llama::{
+    fused_silu_mul_rotate_mq_batched_for, rotate_x_mq_for, weight_gemv, weight_gemv_residual,
+};
+use rdna_compute::Gpu;
+
+/// Decode one token; returns the full logits vector.
+pub fn decode_step(
+    cfg: &Lfm2MoeConfig,
+    weights: &Lfm2MoeWeights,
+    state: &mut Lfm2MoeState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+) -> Result<Vec<f32>, String> {
+    decode_step_inner(cfg, weights, state, gpu, token_id, position, None)?;
+    gpu.download_f32(&state.logits)
+        .map_err(|e| format!("lfm2moe: download logits: {e:?}"))
+}
+
+/// Decode one token, appending each layer's post-residual hidden state
+/// (after the full layer, before the final norm) to `capture[layer]` — used by
+/// the oracle dumper. Set `HIPFIRE_LFM2_CAPTURE_POSTMIXER` to capture the
+/// post-mixer residual (pre-FFN) instead, for conv/attn-vs-FFN localization.
+pub fn decode_step_capture(
+    cfg: &Lfm2MoeConfig,
+    weights: &Lfm2MoeWeights,
+    state: &mut Lfm2MoeState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+    capture: &mut [Vec<f32>],
+) -> Result<(), String> {
+    decode_step_inner(cfg, weights, state, gpu, token_id, position, Some(capture))
+}
+
+fn decode_step_inner(
+    cfg: &Lfm2MoeConfig,
+    weights: &Lfm2MoeWeights,
+    state: &mut Lfm2MoeState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+    mut capture: Option<&mut [Vec<f32>]>,
+) -> Result<(), String> {
+    let hidden = cfg.hidden_size;
+    let head_dim = cfg.head_dim;
+    let n_heads = cfg.num_attention_heads;
+    let n_kv = cfg.num_key_value_heads;
+    let moe_inter = cfg.moe_intermediate_size;
+    let n_exp = cfg.num_experts;
+    let k_top = cfg.num_experts_per_tok;
+    let eps = cfg.rms_norm_eps;
+    let seq_len = position as usize + 1;
+    let capture_postmixer = std::env::var_os("HIPFIRE_LFM2_CAPTURE_POSTMIXER").is_some();
+
+    // Device position scalar (i32) for rope / kv-write / attention.
+    gpu.hip
+        .memcpy_htod(&state.pos_buf, &(position as i32).to_ne_bytes())
+        .map_err(|e| format!("lfm2moe: htod pos: {e:?}"))?;
+
+    // Embedding lookup → residual stream h (Q8 table).
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, hidden)
+        .map_err(|e| format!("lfm2moe: embed lookup: {e:?}"))?;
+
+    for (l, layer) in weights.layers.iter().enumerate() {
+        // ── Mixer block (pre-norm) ──────────────────────────────────────────
+        gpu.rmsnorm_f32(&state.h, &layer.operator_norm, &state.tmp, eps)
+            .map_err(|e| format!("lfm2moe L{l}: operator rmsnorm: {e:?}"))?;
+
+        match &layer.mixer {
+            Mixer::Conv(c) => {
+                // in_proj → [3*hidden] (B | C_gate | x), Q8 plain.
+                weight_gemv(gpu, &c.in_proj, &state.tmp, &state.conv_bcx)
+                    .map_err(|e| format!("lfm2moe L{l}: conv in_proj: {e}"))?;
+                // double-gated depthwise causal short-conv (advances conv state).
+                gpu.conv1d_gated_decode_f32(
+                    &state.conv_bcx,
+                    &state.conv_states[c.conv_state_idx],
+                    &c.conv_weight,
+                    &state.conv_y,
+                    1,
+                    hidden,
+                    cfg.conv_kernel_size,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: conv gated decode: {e:?}"))?;
+                // out_proj + residual: h += W_out · y (Q8).
+                weight_gemv_residual(gpu, &c.out_proj, &state.conv_y, &state.h)
+                    .map_err(|e| format!("lfm2moe L{l}: conv out_proj: {e}"))?;
+            }
+            Mixer::Attention(a) => {
+                weight_gemv(gpu, &a.wq, &state.tmp, &state.fa_q)
+                    .map_err(|e| format!("lfm2moe L{l}: q_proj: {e}"))?;
+                weight_gemv(gpu, &a.wk, &state.tmp, &state.fa_k)
+                    .map_err(|e| format!("lfm2moe L{l}: k_proj: {e}"))?;
+                weight_gemv(gpu, &a.wv, &state.tmp, &state.fa_v)
+                    .map_err(|e| format!("lfm2moe L{l}: v_proj: {e}"))?;
+
+                // Per-HEAD QK-norm: RMSNorm over each head's head_dim slice,
+                // sharing the [head_dim] weight across heads (batch = n_heads).
+                gpu.rmsnorm_batched(&state.fa_q, &a.q_norm, &state.fa_q, n_heads, head_dim, eps)
+                    .map_err(|e| format!("lfm2moe L{l}: q_norm: {e:?}"))?;
+                gpu.rmsnorm_batched(&state.fa_k, &a.k_norm, &state.fa_k, n_kv, head_dim, eps)
+                    .map_err(|e| format!("lfm2moe L{l}: k_norm: {e:?}"))?;
+
+                // Full-dim rotate_half RoPE (no partial rotary).
+                gpu.rope_f32(
+                    &state.fa_q,
+                    &state.fa_k,
+                    &state.pos_buf,
+                    n_heads,
+                    n_kv,
+                    head_dim,
+                    cfg.rope_theta,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: rope: {e:?}"))?;
+
+                // KV cache write (Q8) + GQA flash attention.
+                let kv_idx = a.kv_idx;
+                gpu.kv_cache_write_q8_0(
+                    &state.kv.k_gpu[kv_idx],
+                    &state.fa_k,
+                    &state.pos_buf,
+                    n_kv,
+                    head_dim,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: kv write k: {e:?}"))?;
+                gpu.kv_cache_write_q8_0(
+                    &state.kv.v_gpu[kv_idx],
+                    &state.fa_v,
+                    &state.pos_buf,
+                    n_kv,
+                    head_dim,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: kv write v: {e:?}"))?;
+                gpu.attention_q8_0_kv(
+                    &state.fa_q,
+                    &state.kv.k_gpu[kv_idx],
+                    &state.kv.v_gpu[kv_idx],
+                    &state.fa_attn_out,
+                    &state.pos_buf,
+                    seq_len,
+                    n_heads,
+                    n_kv,
+                    head_dim,
+                    state.kv.physical_cap,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: attention: {e:?}"))?;
+
+                // out_proj + residual: h += W_out · attn_out (Q8).
+                weight_gemv_residual(gpu, &a.wo, &state.fa_attn_out, &state.h)
+                    .map_err(|e| format!("lfm2moe L{l}: out_proj: {e}"))?;
+            }
+        }
+
+        if capture_postmixer {
+            if let Some(cap) = capture.as_deref_mut() {
+                let h = gpu
+                    .download_f32(&state.h)
+                    .map_err(|e| format!("lfm2moe L{l}: postmixer capture: {e:?}"))?;
+                cap[l].extend_from_slice(&h);
+            }
+        }
+
+        // ── FFN block (pre-norm): dense SwiGLU OR top-4 MoE ─────────────────
+        gpu.rmsnorm_f32(&state.h, &layer.ffn_norm, &state.ffn_tmp, eps)
+            .map_err(|e| format!("lfm2moe L{l}: ffn rmsnorm: {e:?}"))?;
+
+        match &layer.ffn {
+            Ffn::Dense(d) => {
+                weight_gemv(gpu, &d.w1, &state.ffn_tmp, &state.dense_gate)
+                    .map_err(|e| format!("lfm2moe L{l}: dense w1: {e}"))?;
+                weight_gemv(gpu, &d.w3, &state.ffn_tmp, &state.dense_up)
+                    .map_err(|e| format!("lfm2moe L{l}: dense w3: {e}"))?;
+                gpu.silu_mul_f32(&state.dense_gate, &state.dense_up, &state.dense_act)
+                    .map_err(|e| format!("lfm2moe L{l}: dense silu_mul: {e:?}"))?;
+                weight_gemv_residual(gpu, &d.w2, &state.dense_act, &state.h)
+                    .map_err(|e| format!("lfm2moe L{l}: dense w2: {e}"))?;
+            }
+            Ffn::Moe(m) => {
+                // FWHT-rotate the FFN input for the MQ4 experts (router stays plain).
+                rotate_x_mq_for(gpu, &m.experts[0].gate_up, &state.ffn_tmp, &state.ffn_x_rot, hidden)
+                    .map_err(|e| format!("lfm2moe L{l}: ffn rotate: {e:?}"))?;
+
+                // Router: sigmoid(logits) + bias-aware top-k (gather unbiased,
+                // renormalize, scale). expert_bias steers SELECTION only.
+                weight_gemv(gpu, &m.router, &state.ffn_tmp, &state.router_logits)
+                    .map_err(|e| format!("lfm2moe L{l}: router: {e}"))?;
+                gpu.sigmoid_f32(&state.router_logits)
+                    .map_err(|e| format!("lfm2moe L{l}: sigmoid: {e:?}"))?;
+                gpu.deepseek4_moe_topk_bias_aware_f32(
+                    &state.router_logits,
+                    &m.expert_bias,
+                    &state.topk_indices,
+                    &state.topk_weights,
+                    n_exp as i32,
+                    k_top as i32,
+                    cfg.routed_scaling_factor,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: topk: {e:?}"))?;
+
+                // gate_up (rotated input, batched k_top) → silu·mul·rotate → down → combine.
+                gpu.gemv_hfq4g256_moe_gate_up_k8_indexed_batched(
+                    &m.expert_gate_up_ptrs,
+                    &state.topk_indices,
+                    &state.ffn_x_rot,
+                    &state.gate_batch,
+                    &state.up_batch,
+                    2 * moe_inter,
+                    hidden,
+                    k_top,
+                    1,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: gate_up: {e:?}"))?;
+
+                fused_silu_mul_rotate_mq_batched_for(
+                    gpu,
+                    &m.experts[0].down,
+                    &state.gate_batch,
+                    &state.up_batch,
+                    &state.rot_batch,
+                    moe_inter,
+                    k_top,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: silu_mul_rotate: {e:?}"))?;
+
+                gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
+                    &m.expert_down_ptrs,
+                    &state.topk_indices,
+                    &state.rot_batch,
+                    &state.down_expanded,
+                    hidden,
+                    moe_inter,
+                    k_top,
+                    1,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: down: {e:?}"))?;
+
+                gpu.moe_down_combine_k8_batched(
+                    &state.down_expanded,
+                    &state.topk_weights,
+                    &state.h,
+                    hidden,
+                    k_top,
+                    1,
+                )
+                .map_err(|e| format!("lfm2moe L{l}: combine: {e:?}"))?;
+            }
+        }
+
+        // Capture post-layer residual (pre final-norm) for the oracle compare.
+        if !capture_postmixer {
+            if let Some(cap) = capture.as_deref_mut() {
+                let h = gpu
+                    .download_f32(&state.h)
+                    .map_err(|e| format!("lfm2moe L{l}: capture download: {e:?}"))?;
+                cap[l].extend_from_slice(&h);
+            }
+        }
+    }
+    state.n_tokens = seq_len;
+
+    // Final RMSNorm + lm_head (tied to embed_tokens, Q8).
+    gpu.rmsnorm_f32(&state.h, &weights.embedding_norm, &state.final_norm_buf, eps)
+        .map_err(|e| format!("lfm2moe: final rmsnorm: {e:?}"))?;
+    weight_gemv(gpu, &weights.lm_head, &state.final_norm_buf, &state.logits)
+        .map_err(|e| format!("lfm2moe: lm_head: {e}"))?;
+    Ok(())
+}

--- a/crates/hipfire-arch-lfm2moe/src/forward.rs
+++ b/crates/hipfire-arch-lfm2moe/src/forward.rs
@@ -26,6 +26,11 @@ use hipfire_runtime::llama::{
 use rdna_compute::{DType, Gpu};
 
 /// Decode one token; returns the full logits vector.
+///
+/// Routes to the hipGraph capture/replay path when `HIPFIRE_LFM2_GRAPH=1`
+/// (default OFF → exact prior behavior). The graph path amortizes the ~377
+/// per-token kernel launches by replaying a single captured graph; see
+/// `decode_step_with_graph`.
 pub fn decode_step(
     cfg: &Lfm2MoeConfig,
     weights: &Lfm2MoeWeights,
@@ -34,9 +39,22 @@ pub fn decode_step(
     token_id: u32,
     position: u32,
 ) -> Result<Vec<f32>, String> {
+    if graph_enabled() {
+        return decode_step_with_graph(cfg, weights, state, gpu, token_id, position);
+    }
     decode_step_inner(cfg, weights, state, gpu, token_id, position, None)?;
     gpu.download_f32(&state.logits)
         .map_err(|e| format!("lfm2moe: download logits: {e:?}"))
+}
+
+/// `HIPFIRE_LFM2_GRAPH=1` opt-in switch. Default OFF (unset / "0") →
+/// byte-identical to the legacy per-launch decode path. Parsed once.
+fn graph_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENV: OnceLock<bool> = OnceLock::new();
+    *ENV.get_or_init(|| {
+        matches!(std::env::var("HIPFIRE_LFM2_GRAPH").ok().as_deref(), Some("1"))
+    })
 }
 
 /// Decode one token, appending each layer's post-residual hidden state
@@ -62,6 +80,41 @@ fn decode_step_inner(
     gpu: &mut Gpu,
     token_id: u32,
     position: u32,
+    capture: Option<&mut [Vec<f32>]>,
+) -> Result<(), String> {
+    let hidden = cfg.hidden_size;
+
+    // Device position scalar (i32) for rope / kv-write / attention.
+    gpu.hip
+        .memcpy_htod(&state.pos_buf, &(position as i32).to_ne_bytes())
+        .map_err(|e| format!("lfm2moe: htod pos: {e:?}"))?;
+
+    // Embedding lookup → residual stream h (Q8 table).
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, hidden)
+        .map_err(|e| format!("lfm2moe: embed lookup: {e:?}"))?;
+
+    decode_step_layers_and_head(cfg, weights, state, gpu, position, capture)
+}
+
+/// Per-layer mixer/FFN stack + final norm + lm_head. Reads the residual
+/// stream `state.h` (already seeded by the embedding lookup) and the device
+/// position scalar `state.pos_buf` (already staged); writes `state.logits`.
+///
+/// This is the hipGraph-captureable region: it issues only kernel launches
+/// that read STABLE device buffers and (on the MoE path) compute their
+/// topk/positions on-device, so a single capture replays correctly at every
+/// later position once `state.pos_buf` is refreshed. The per-token-varying
+/// embedding lookup (token_id is a kernarg) and the `pos_buf` htod are the
+/// caller's responsibility OUTSIDE the captured region.
+///
+/// `capture` (oracle dumper) is incompatible with hipGraph capture — it issues
+/// a sync `download_f32` per layer. The graph path always passes `None`.
+fn decode_step_layers_and_head(
+    cfg: &Lfm2MoeConfig,
+    weights: &Lfm2MoeWeights,
+    state: &mut Lfm2MoeState,
+    gpu: &mut Gpu,
+    position: u32,
     mut capture: Option<&mut [Vec<f32>]>,
 ) -> Result<(), String> {
     let hidden = cfg.hidden_size;
@@ -74,15 +127,6 @@ fn decode_step_inner(
     let eps = cfg.rms_norm_eps;
     let seq_len = position as usize + 1;
     let capture_postmixer = std::env::var_os("HIPFIRE_LFM2_CAPTURE_POSTMIXER").is_some();
-
-    // Device position scalar (i32) for rope / kv-write / attention.
-    gpu.hip
-        .memcpy_htod(&state.pos_buf, &(position as i32).to_ne_bytes())
-        .map_err(|e| format!("lfm2moe: htod pos: {e:?}"))?;
-
-    // Embedding lookup → residual stream h (Q8 table).
-    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, hidden)
-        .map_err(|e| format!("lfm2moe: embed lookup: {e:?}"))?;
 
     for (l, layer) in weights.layers.iter().enumerate() {
         // ── Mixer block (pre-norm) ──────────────────────────────────────────
@@ -321,4 +365,102 @@ fn decode_step_inner(
     weight_gemv(gpu, &weights.lm_head, &state.final_norm_buf, &state.logits)
         .map_err(|e| format!("lfm2moe: lm_head: {e}"))?;
     Ok(())
+}
+
+/// hipGraph-amortized decode_step. Opt-in via `HIPFIRE_LFM2_GRAPH=1`
+/// (default OFF → exact `decode_step_inner` behavior). Mirrors the working
+/// DeepSeek-V4 integration (`decode_step_with_graph`).
+///
+/// Three-state machine driven by `state.graph_warmed_up` and `gpu.graph_exec`:
+///   1. !warmed_up                 → direct dispatch once (so kernel JIT and
+///                                    any lazy hipMalloc happen OUTSIDE the
+///                                    captured region), set the flag.
+///   2. warmed_up && no graph      → embedding+pos direct, then capture the
+///                                    layer loop + head, instantiate, launch
+///                                    once for this position's output.
+///   3. graph instantiated         → embedding+pos direct, then `graph_launch`
+///                                    re-runs the captured ops which re-read
+///                                    `state.pos_buf` (refreshed below) and the
+///                                    KV / conv-state / topk device buffers.
+///
+/// Per-token-varying values handled OUTSIDE the captured region:
+///   * `token_id` — baked into `embedding_lookup_q8`'s kernarg, so the
+///     embedding lookup runs DIRECT each token (writes `state.h`); the
+///     captured region begins at layer 0's rmsnorm reading `state.h`.
+///   * `position` — staged into the STABLE device buffer `state.pos_buf` via a
+///     direct `memcpy_htod` before each `graph_launch`; every captured kernel
+///     (rope/kv-write/attention) reads `pos_buf` from the device, so replay at
+///     a new position is correct without re-capture. The attention kernel's
+///     launch-baked `block_size`/`shared_mem` are sized to `max_seq` under
+///     capture (see `attention_q8_0_kv` in dispatch.rs), so one capture
+///     replays correctly at every later position.
+///
+/// `state.n_tokens` is advanced here to match `decode_step_inner` semantics.
+pub fn decode_step_with_graph(
+    cfg: &Lfm2MoeConfig,
+    weights: &Lfm2MoeWeights,
+    state: &mut Lfm2MoeState,
+    gpu: &mut Gpu,
+    token_id: u32,
+    position: u32,
+) -> Result<Vec<f32>, String> {
+    let hidden = cfg.hidden_size;
+
+    // ── Warmup phase: direct dispatch, no capture ──────────────────────────
+    // Run the legacy path once so inline JIT / lazy scratch alloc happen
+    // before any stream capture (capturing a hipMalloc errors).
+    if !state.graph_warmed_up {
+        state.graph_warmed_up = true;
+        decode_step_inner(cfg, weights, state, gpu, token_id, position, None)?;
+        return gpu
+            .download_f32(&state.logits)
+            .map_err(|e| format!("lfm2moe: download logits (graph warmup): {e:?}"));
+    }
+
+    // Capture/replay needs an explicit (non-null) stream.
+    if gpu.active_stream.is_none() {
+        let s = gpu
+            .hip
+            .stream_create()
+            .map_err(|e| format!("lfm2moe: stream_create: {e:?}"))?;
+        gpu.active_stream = Some(s);
+    }
+
+    // Per-token-varying ops, DIRECT (outside the captured region).
+    // pos_buf: refreshed each token; the captured kernels re-read it on replay.
+    gpu.hip
+        .memcpy_htod(&state.pos_buf, &(position as i32).to_ne_bytes())
+        .map_err(|e| format!("lfm2moe: htod pos (graph): {e:?}"))?;
+    // embedding lookup: token_id is a kernarg → must run per-token, not captured.
+    gpu.embedding_lookup_q8(&weights.embed, &state.h, token_id, hidden)
+        .map_err(|e| format!("lfm2moe: embed lookup (graph): {e:?}"))?;
+
+    if gpu.graph_exec.is_none() {
+        // ── Capture phase ──────────────────────────────────────────────────
+        gpu.begin_graph_capture()
+            .map_err(|e| format!("lfm2moe: begin_graph_capture: {e:?}"))?;
+        decode_step_layers_and_head(cfg, weights, state, gpu, position, None)?;
+        gpu.end_graph_capture()
+            .map_err(|e| format!("lfm2moe: end_graph_capture: {e:?}"))?;
+        // Recorded, not executed — launch once so this position's logits are real.
+        gpu.graph_launch()
+            .map_err(|e| format!("lfm2moe: graph_launch (capture-end): {e:?}"))?;
+        eprintln!(
+            "[LFM2.5-MoE hipGraph] captured forward — {} kernarg blobs retained",
+            gpu.capture_blobs.len()
+        );
+        // decode_step_layers_and_head set n_tokens; capture-end launch ran it.
+    } else {
+        // ── Replay phase ────────────────────────────────────────────────────
+        gpu.graph_launch()
+            .map_err(|e| format!("lfm2moe: graph_launch (replay): {e:?}"))?;
+        // Mirror decode_step_layers_and_head's `state.n_tokens = position + 1`,
+        // which the replayed graph does NOT execute (it is host-side state).
+        state.n_tokens = position as usize + 1;
+    }
+
+    // Logits download outside the captured region (sync D2H on the null stream;
+    // completes after the captured kernels finish on the captured stream).
+    gpu.download_f32(&state.logits)
+        .map_err(|e| format!("lfm2moe: download logits (graph): {e:?}"))
 }

--- a/crates/hipfire-arch-lfm2moe/src/forward.rs
+++ b/crates/hipfire-arch-lfm2moe/src/forward.rs
@@ -23,7 +23,7 @@ use crate::lfm2moe::{Ffn, Lfm2MoeState, Lfm2MoeWeights, Mixer};
 use hipfire_runtime::llama::{
     fused_silu_mul_rotate_mq_batched_for, rotate_x_mq_for, weight_gemv, weight_gemv_residual,
 };
-use rdna_compute::Gpu;
+use rdna_compute::{DType, Gpu};
 
 /// Decode one token; returns the full logits vector.
 pub fn decode_step(
@@ -221,18 +221,38 @@ fn decode_step_inner(
                 .map_err(|e| format!("lfm2moe L{l}: topk: {e:?}"))?;
 
                 // gate_up (rotated input, batched k_top) → silu·mul·rotate → down → combine.
-                gpu.gemv_hfq4g256_moe_gate_up_k8_indexed_batched(
-                    &m.expert_gate_up_ptrs,
-                    &state.topk_indices,
-                    &state.ffn_x_rot,
-                    &state.gate_batch,
-                    &state.up_batch,
-                    2 * moe_inter,
-                    hidden,
-                    k_top,
-                    1,
-                )
-                .map_err(|e| format!("lfm2moe L{l}: gate_up: {e:?}"))?;
+                // Experts are uniform per layer (gate_up/down share dtype). MQ6G256
+                // experts use the HFQ6 (200 B/group, 6-bit) indexed kernels; MQ4G256
+                // (default) uses the HFQ4 (136 B/group, 4-bit) siblings. Both consume
+                // the same FWHT-rotated `ffn_x_rot` — only the weight dequant differs.
+                let experts_mq6 = m.experts[0].gate_up.gpu_dtype == DType::MQ6G256;
+                if experts_mq6 {
+                    gpu.gemv_hfq6g256_moe_gate_up_k8_indexed_batched(
+                        &m.expert_gate_up_ptrs,
+                        &state.topk_indices,
+                        &state.ffn_x_rot,
+                        &state.gate_batch,
+                        &state.up_batch,
+                        2 * moe_inter,
+                        hidden,
+                        k_top,
+                        1,
+                    )
+                    .map_err(|e| format!("lfm2moe L{l}: gate_up(mq6): {e:?}"))?;
+                } else {
+                    gpu.gemv_hfq4g256_moe_gate_up_k8_indexed_batched(
+                        &m.expert_gate_up_ptrs,
+                        &state.topk_indices,
+                        &state.ffn_x_rot,
+                        &state.gate_batch,
+                        &state.up_batch,
+                        2 * moe_inter,
+                        hidden,
+                        k_top,
+                        1,
+                    )
+                    .map_err(|e| format!("lfm2moe L{l}: gate_up: {e:?}"))?;
+                }
 
                 fused_silu_mul_rotate_mq_batched_for(
                     gpu,
@@ -245,17 +265,31 @@ fn decode_step_inner(
                 )
                 .map_err(|e| format!("lfm2moe L{l}: silu_mul_rotate: {e:?}"))?;
 
-                gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
-                    &m.expert_down_ptrs,
-                    &state.topk_indices,
-                    &state.rot_batch,
-                    &state.down_expanded,
-                    hidden,
-                    moe_inter,
-                    k_top,
-                    1,
-                )
-                .map_err(|e| format!("lfm2moe L{l}: down: {e:?}"))?;
+                if experts_mq6 {
+                    gpu.gemv_hfq6g256_moe_down_k8_indexed_batched_expanded(
+                        &m.expert_down_ptrs,
+                        &state.topk_indices,
+                        &state.rot_batch,
+                        &state.down_expanded,
+                        hidden,
+                        moe_inter,
+                        k_top,
+                        1,
+                    )
+                    .map_err(|e| format!("lfm2moe L{l}: down(mq6): {e:?}"))?;
+                } else {
+                    gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
+                        &m.expert_down_ptrs,
+                        &state.topk_indices,
+                        &state.rot_batch,
+                        &state.down_expanded,
+                        hidden,
+                        moe_inter,
+                        k_top,
+                        1,
+                    )
+                    .map_err(|e| format!("lfm2moe L{l}: down: {e:?}"))?;
+                }
 
                 gpu.moe_down_combine_k8_batched(
                     &state.down_expanded,

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! LFM2.5-MoE weights + decode state.
+//!
+//! HFQ files carry RAW HF tensor names; the loader looks each up by exact
+//! name (no rename). Mirrors the MiniMax-M2 loader (shared `WeightTensor`,
+//! `KvCache`, indexed-MoE GEMV kernels) and adds:
+//!   * a per-layer mixer split (conv vs attention) from `layer_types`,
+//!   * a per-layer FFN split (dense SwiGLU vs top-4 MoE) from `num_dense_layers`,
+//!   * a rolling conv-state cache (one [hidden,(K-1)] f32 ring buffer per conv
+//!     layer) — the conv analog of the KV cache.
+//!
+//! Expert weights ship pre-split (w1/w2/w3); the loader byte-fuses w1‖w3 into
+//! the per-expert `gate_up` blob the indexed GEMV kernels expect (exactly the
+//! minimax convention). lm_head is tied to embed_tokens.
+
+use crate::config::{Lfm2MoeConfig, MixerKind};
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::llama::{f16_to_f32, KvCache, WeightTensor};
+use rdna_compute::{DType, Gpu, GpuTensor};
+
+// ───────────────────────── HFQ load helpers ─────────────────────────
+
+fn read_tensor(hfq: &HfqFile, name: &str) -> Result<(u8, Vec<u8>), String> {
+    let (info, data) = hfq
+        .tensor_data_vec(name)
+        .ok_or_else(|| format!("lfm2moe: tensor not found in HFQ: {name}"))?;
+    Ok((info.quant_type, data))
+}
+
+/// Load a 1D/raw F16/F32 vector → F32 GpuTensor with the given shape.
+/// LFM2 uses STANDARD RMSNorm (`weight * x̂`, no +1 offset — verified against
+/// Lfm2MoeRMSNorm), so no offset is baked in. Also used for the depthwise conv
+/// filter ([hidden, K]) and the F32 expert_bias.
+fn load_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: &[usize]) -> Result<GpuTensor, String> {
+    let (qt, data) = read_tensor(hfq, name)?;
+    let f32_data: Vec<f32> = match qt {
+        1 => data
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        2 => data
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+        3 => {
+            // Q8_0: 32-elem blocks [f16 scale | 32 i8]. Dequant to f32.
+            dequant_q8_0(&data)
+        }
+        _ => return Err(format!("lfm2moe: expected F16/F32/Q8 for {name}, got qt={qt}")),
+    };
+    gpu.upload_f32(&f32_data, shape)
+        .map_err(|e| format!("lfm2moe: upload {name}: {e:?}"))
+}
+
+/// Minimal Q8_0 dequant (32-elem blocks: little-endian f16 scale + 32 int8).
+fn dequant_q8_0(data: &[u8]) -> Vec<f32> {
+    let mut out = Vec::with_capacity(data.len() / 34 * 32);
+    for blk in data.chunks_exact(34) {
+        let scale = f16_to_f32(u16::from_le_bytes([blk[0], blk[1]]));
+        for &q in &blk[2..34] {
+            out.push((q as i8) as f32 * scale);
+        }
+    }
+    out
+}
+
+fn load_wt(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+) -> Result<WeightTensor, String> {
+    let (qt, data) = read_tensor(hfq, name)?;
+    wt_from_raw(gpu, qt, &data, m, k).map_err(|e| format!("lfm2moe: load_wt {name}: {e}"))
+}
+
+/// quant_type → DType mapping (mirrors minimax::wt_from_raw); uploads raw
+/// bytes and tags the dtype for kernel dispatch.
+fn wt_from_raw(gpu: &mut Gpu, qt: u8, data: &[u8], m: usize, k: usize) -> Result<WeightTensor, String> {
+    let dtype = match qt {
+        3 => DType::Q8_0,
+        6 => DType::HFQ4G256,
+        8 => DType::HFQ6G256,
+        13 => DType::MQ4G256,
+        15 => DType::MQ6G256,
+        17 => DType::MQ3G256,
+        18 => DType::MQ2G256,
+        19 => DType::MQ2G256Lloyd,
+        20 => DType::MQ3G256Lloyd,
+        30 => DType::MQ4G256Lloyd,
+        1 => DType::F16,
+        other => return Err(format!("unsupported quant_type {other}")),
+    };
+    let buf = gpu
+        .upload_raw(data, &[data.len()])
+        .map_err(|e| format!("upload_raw: {e:?}"))?;
+    Ok(WeightTensor {
+        buf,
+        gpu_dtype: dtype,
+        m,
+        k,
+        row_stride: 0,
+        paro: None,
+        awq_scale: None,
+    })
+}
+
+// ──────────────────────────── Weights ────────────────────────────
+
+/// LIV short-conv mixer weights.
+pub struct ConvWeights {
+    /// in_proj: [3*hidden, hidden] — produces B | C_gate | x.
+    pub in_proj: WeightTensor,
+    /// Depthwise causal filter, squeezed [hidden, K] F32.
+    pub conv_weight: GpuTensor,
+    /// out_proj: [hidden, hidden].
+    pub out_proj: WeightTensor,
+    /// Index into the conv-state ring-buffer cache.
+    pub conv_state_idx: usize,
+}
+
+/// GQA attention mixer weights (per-head QK-norm + full-dim rotate_half RoPE).
+pub struct AttnWeights {
+    pub wq: WeightTensor,
+    pub wk: WeightTensor,
+    pub wv: WeightTensor,
+    pub wo: WeightTensor,
+    /// Per-head QK-norm weight, [head_dim].
+    pub q_norm: GpuTensor,
+    pub k_norm: GpuTensor,
+    /// Index into the KV cache.
+    pub kv_idx: usize,
+}
+
+pub enum Mixer {
+    Conv(ConvWeights),
+    Attention(AttnWeights),
+}
+
+/// Dense SwiGLU MLP (first `num_dense_layers` layers).
+pub struct DenseFfn {
+    pub w1: WeightTensor, // gate [inter, hidden]
+    pub w3: WeightTensor, // up   [inter, hidden]
+    pub w2: WeightTensor, // down [hidden, inter]
+}
+
+/// One MoE expert: fused gate(w1)‖up(w3) and down(w2).
+pub struct ExpertWeights {
+    pub gate_up: WeightTensor, // [2*moe_inter, hidden]
+    pub down: WeightTensor,    // [hidden, moe_inter]
+}
+
+/// Top-4 MoE FFN (sigmoid + expert_bias routing).
+pub struct MoeFfn {
+    pub router: WeightTensor,        // feed_forward.gate.weight [n_exp, hidden]
+    pub expert_bias: GpuTensor,      // feed_forward.expert_bias [n_exp] F32
+    pub experts: Vec<ExpertWeights>, // keep alive (buffers owned here)
+    pub expert_gate_up_ptrs: GpuTensor, // [2*n_exp] F32 = n_exp u64 device ptrs
+    pub expert_down_ptrs: GpuTensor,
+}
+
+pub enum Ffn {
+    Dense(DenseFfn),
+    Moe(MoeFfn),
+}
+
+pub struct Lfm2MoeLayerWeights {
+    pub operator_norm: GpuTensor, // pre-mixer RMSNorm
+    pub ffn_norm: GpuTensor,      // pre-FFN RMSNorm
+    pub mixer: Mixer,
+    pub ffn: Ffn,
+}
+
+pub struct Lfm2MoeWeights {
+    pub embed: GpuTensor,        // model.embed_tokens.weight (raw, for embedding_lookup)
+    pub embedding_norm: GpuTensor, // model.embedding_norm.weight (final norm)
+    pub lm_head: WeightTensor,   // tied = embed_tokens (loaded as Q8 weight)
+    pub layers: Vec<Lfm2MoeLayerWeights>,
+}
+
+impl Lfm2MoeWeights {
+    pub fn load(hfq: &mut HfqFile, cfg: &Lfm2MoeConfig, gpu: &mut Gpu) -> Result<Self, String> {
+        let hidden = cfg.hidden_size;
+        let q_dim = cfg.q_dim();
+        let kv_dim = cfg.kv_dim();
+        let head_dim = cfg.head_dim;
+        let dense_inter = cfg.intermediate_size;
+        let moe_inter = cfg.moe_intermediate_size;
+        let n_exp = cfg.num_experts;
+        let k_conv = cfg.conv_kernel_size;
+
+        // Globals. embed_tokens is the shared (tied) lm_head.
+        let (_eqt, embed_bytes) = read_tensor(hfq, "model.embed_tokens.weight")?;
+        let embed = gpu
+            .upload_raw(&embed_bytes, &[embed_bytes.len()])
+            .map_err(|e| format!("lfm2moe: upload embed: {e:?}"))?;
+        let embedding_norm = load_f32(hfq, gpu, "model.embedding_norm.weight", &[hidden])?;
+        // lm_head: tied → reuse embed_tokens.weight as a Q8 weight tensor.
+        let lm_head = load_wt(hfq, gpu, "model.embed_tokens.weight", cfg.vocab_size, hidden)?;
+
+        let mut conv_state_count = 0usize;
+        let mut kv_count = 0usize;
+
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for l in 0..cfg.num_hidden_layers {
+            let p = format!("model.layers.{l}");
+            let operator_norm = load_f32(hfq, gpu, &format!("{p}.operator_norm.weight"), &[hidden])?;
+            let ffn_norm = load_f32(hfq, gpu, &format!("{p}.ffn_norm.weight"), &[hidden])?;
+
+            // ── Mixer: conv vs attention ──────────────────────────────────
+            let mixer = match cfg.mixer(l) {
+                MixerKind::Conv => {
+                    let in_proj =
+                        load_wt(hfq, gpu, &format!("{p}.conv.in_proj.weight"), 3 * hidden, hidden)?;
+                    // conv.conv.weight ships [hidden,1,K] → loaded flat as [hidden,K] f32.
+                    let conv_weight =
+                        load_f32(hfq, gpu, &format!("{p}.conv.conv.weight"), &[hidden * k_conv])?;
+                    let out_proj =
+                        load_wt(hfq, gpu, &format!("{p}.conv.out_proj.weight"), hidden, hidden)?;
+                    let conv_state_idx = conv_state_count;
+                    conv_state_count += 1;
+                    Mixer::Conv(ConvWeights {
+                        in_proj,
+                        conv_weight,
+                        out_proj,
+                        conv_state_idx,
+                    })
+                }
+                MixerKind::Attention => {
+                    let wq = load_wt(hfq, gpu, &format!("{p}.self_attn.q_proj.weight"), q_dim, hidden)?;
+                    let wk = load_wt(hfq, gpu, &format!("{p}.self_attn.k_proj.weight"), kv_dim, hidden)?;
+                    let wv = load_wt(hfq, gpu, &format!("{p}.self_attn.v_proj.weight"), kv_dim, hidden)?;
+                    let wo = load_wt(hfq, gpu, &format!("{p}.self_attn.out_proj.weight"), hidden, q_dim)?;
+                    // Per-HEAD QK-norm: weight is [head_dim], applied to each head.
+                    let q_norm =
+                        load_f32(hfq, gpu, &format!("{p}.self_attn.q_layernorm.weight"), &[head_dim])?;
+                    let k_norm =
+                        load_f32(hfq, gpu, &format!("{p}.self_attn.k_layernorm.weight"), &[head_dim])?;
+                    let kv_idx = kv_count;
+                    kv_count += 1;
+                    Mixer::Attention(AttnWeights {
+                        wq,
+                        wk,
+                        wv,
+                        wo,
+                        q_norm,
+                        k_norm,
+                        kv_idx,
+                    })
+                }
+            };
+
+            // ── FFN: dense SwiGLU vs top-4 MoE ────────────────────────────
+            let ffn = if cfg.is_dense_ffn(l) {
+                let w1 = load_wt(hfq, gpu, &format!("{p}.feed_forward.w1.weight"), dense_inter, hidden)?;
+                let w3 = load_wt(hfq, gpu, &format!("{p}.feed_forward.w3.weight"), dense_inter, hidden)?;
+                let w2 = load_wt(hfq, gpu, &format!("{p}.feed_forward.w2.weight"), hidden, dense_inter)?;
+                Ffn::Dense(DenseFfn { w1, w3, w2 })
+            } else {
+                let router =
+                    load_wt(hfq, gpu, &format!("{p}.feed_forward.gate.weight"), n_exp, hidden)?;
+                let expert_bias =
+                    load_f32(hfq, gpu, &format!("{p}.feed_forward.expert_bias"), &[n_exp])?;
+                // Byte-fuse w1‖w3 → gate_up [2*moe_inter, hidden]; w2 → down.
+                let mut experts = Vec::with_capacity(n_exp);
+                for e in 0..n_exp {
+                    let ep = format!("{p}.feed_forward.experts.{e}");
+                    let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
+                    let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
+                    let mut gate_up_bytes = w1;
+                    gate_up_bytes.extend_from_slice(&w3);
+                    let gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * moe_inter, hidden)
+                        .map_err(|e2| format!("lfm2moe: fuse gate_up L{l}E{e}: {e2}"))?;
+                    let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
+                    let down = wt_from_raw(gpu, qt2, &w2, hidden, moe_inter)
+                        .map_err(|e2| format!("lfm2moe: down L{l}E{e}: {e2}"))?;
+                    experts.push(ExpertWeights { gate_up, down });
+                }
+                let gu_bytes: Vec<u8> = experts
+                    .iter()
+                    .flat_map(|e| (e.gate_up.buf.buf.as_ptr() as u64).to_ne_bytes())
+                    .collect();
+                let dn_bytes: Vec<u8> = experts
+                    .iter()
+                    .flat_map(|e| (e.down.buf.buf.as_ptr() as u64).to_ne_bytes())
+                    .collect();
+                let expert_gate_up_ptrs = gpu
+                    .alloc_tensor(&[2 * n_exp], DType::F32)
+                    .map_err(|e| format!("lfm2moe: alloc gu_ptrs: {e:?}"))?;
+                let expert_down_ptrs = gpu
+                    .alloc_tensor(&[2 * n_exp], DType::F32)
+                    .map_err(|e| format!("lfm2moe: alloc dn_ptrs: {e:?}"))?;
+                gpu.hip
+                    .memcpy_htod(&expert_gate_up_ptrs.buf, &gu_bytes)
+                    .map_err(|e| format!("lfm2moe: htod gu_ptrs: {e:?}"))?;
+                gpu.hip
+                    .memcpy_htod(&expert_down_ptrs.buf, &dn_bytes)
+                    .map_err(|e| format!("lfm2moe: htod dn_ptrs: {e:?}"))?;
+                Ffn::Moe(MoeFfn {
+                    router,
+                    expert_bias,
+                    experts,
+                    expert_gate_up_ptrs,
+                    expert_down_ptrs,
+                })
+            };
+
+            layers.push(Lfm2MoeLayerWeights {
+                operator_norm,
+                ffn_norm,
+                mixer,
+                ffn,
+            });
+        }
+
+        let _ = (conv_state_count, kv_count);
+        Ok(Lfm2MoeWeights {
+            embed,
+            embedding_norm,
+            lm_head,
+            layers,
+        })
+    }
+}
+
+// ──────────────────────────── State ────────────────────────────
+
+/// Per-decode GPU scratch + KV cache (attention layers) + conv-state cache
+/// (conv layers). Buffers are eager-allocated.
+pub struct Lfm2MoeState {
+    pub kv: KvCache,
+    /// One rolling [hidden, K-1] f32 ring buffer per conv layer (zero-init).
+    pub conv_states: Vec<GpuTensor>,
+    pub pos_buf: hip_bridge::DeviceBuffer, // device i32 position scalar
+    pub max_seq: usize,
+    pub n_tokens: usize,
+
+    // residual + shared scratch
+    pub h: GpuTensor,    // [hidden] residual stream
+    pub tmp: GpuTensor,  // [hidden] norm output (mixer input)
+
+    // attention scratch
+    pub fa_q: GpuTensor,        // [q_dim]
+    pub fa_k: GpuTensor,        // [kv_dim]
+    pub fa_v: GpuTensor,        // [kv_dim]
+    pub fa_attn_out: GpuTensor, // [q_dim]
+
+    // conv scratch
+    pub conv_bcx: GpuTensor, // [3*hidden] in_proj output (B|C|x)
+    pub conv_y: GpuTensor,   // [hidden] gated conv output (out_proj input)
+
+    // ffn scratch
+    pub ffn_tmp: GpuTensor,       // [hidden] rmsnorm(h)
+    pub ffn_x_rot: GpuTensor,     // [hidden] FWHT(rmsnorm(h)) for MQ4 experts
+    pub dense_gate: GpuTensor,    // [dense_inter]
+    pub dense_up: GpuTensor,      // [dense_inter]
+    pub dense_act: GpuTensor,     // [dense_inter] silu(gate)*up
+    pub router_logits: GpuTensor, // [n_exp]
+    pub topk_indices: GpuTensor,  // [k_top] i32-in-F32
+    pub topk_weights: GpuTensor,  // [k_top]
+    pub gate_batch: GpuTensor,    // [k_top*moe_inter]
+    pub up_batch: GpuTensor,      // [k_top*moe_inter]
+    pub rot_batch: GpuTensor,     // [k_top*moe_inter]
+    pub down_expanded: GpuTensor, // [k_top*hidden]
+
+    // head
+    pub final_norm_buf: GpuTensor, // [hidden]
+    pub logits: GpuTensor,         // [vocab]
+}
+
+impl Lfm2MoeState {
+    pub fn new(gpu: &mut Gpu, cfg: &Lfm2MoeConfig) -> Result<Self, String> {
+        let max_seq = cfg.max_position_embeddings.min(8192);
+        Self::new_with_max_seq(gpu, cfg, max_seq)
+    }
+
+    pub fn new_with_max_seq(
+        gpu: &mut Gpu,
+        cfg: &Lfm2MoeConfig,
+        max_seq: usize,
+    ) -> Result<Self, String> {
+        let hidden = cfg.hidden_size;
+        let q_dim = cfg.q_dim();
+        let kv_dim = cfg.kv_dim();
+        let dense_inter = cfg.intermediate_size;
+        let moe_inter = cfg.moe_intermediate_size;
+        let n_exp = cfg.num_experts;
+        let k = cfg.num_experts_per_tok;
+        let k_conv = cfg.conv_kernel_size;
+
+        // FWHT sign LUT must exist before any rotate_x_mq / fused rotate kernel.
+        gpu.ensure_mq_signs()
+            .map_err(|e| format!("lfm2moe: ensure_mq_signs: {e:?}"))?;
+
+        // KV cache: one slot per ATTENTION layer (conv layers carry no KV).
+        let n_attn = cfg.num_attention_layers().max(1);
+        let kv = KvCache::new_gpu_q8(gpu, n_attn, cfg.num_key_value_heads, cfg.head_dim, max_seq)
+            .map_err(|e| format!("lfm2moe: kv cache: {e:?}"))?;
+
+        // Conv-state cache: one [hidden,(K-1)] f32 ring buffer per CONV layer.
+        let conv_hist = hidden * (k_conv - 1);
+        let zeros = vec![0u8; conv_hist * 4];
+        let mut conv_states = Vec::with_capacity(cfg.num_conv_layers());
+        for _ in 0..cfg.num_conv_layers() {
+            let cs = gpu
+                .alloc_tensor(&[conv_hist], DType::F32)
+                .map_err(|e| format!("lfm2moe: alloc conv_state: {e:?}"))?;
+            gpu.hip
+                .memcpy_htod(&cs.buf, &zeros)
+                .map_err(|e| format!("lfm2moe: zero conv_state: {e:?}"))?;
+            conv_states.push(cs);
+        }
+
+        let pos_buf = gpu
+            .hip
+            .malloc(4)
+            .map_err(|e| format!("lfm2moe: pos_buf malloc: {e:?}"))?;
+
+        let alloc = |g: &mut Gpu, n: usize, label: &str| -> Result<GpuTensor, String> {
+            g.alloc_tensor(&[n], DType::F32)
+                .map_err(|e| format!("lfm2moe: alloc {label}: {e:?}"))
+        };
+
+        Ok(Lfm2MoeState {
+            kv,
+            conv_states,
+            pos_buf,
+            max_seq,
+            n_tokens: 0,
+            h: alloc(gpu, hidden, "h")?,
+            tmp: alloc(gpu, hidden, "tmp")?,
+            fa_q: alloc(gpu, q_dim, "fa_q")?,
+            fa_k: alloc(gpu, kv_dim, "fa_k")?,
+            fa_v: alloc(gpu, kv_dim, "fa_v")?,
+            fa_attn_out: alloc(gpu, q_dim, "fa_attn_out")?,
+            conv_bcx: alloc(gpu, 3 * hidden, "conv_bcx")?,
+            conv_y: alloc(gpu, hidden, "conv_y")?,
+            ffn_tmp: alloc(gpu, hidden, "ffn_tmp")?,
+            ffn_x_rot: alloc(gpu, hidden, "ffn_x_rot")?,
+            dense_gate: alloc(gpu, dense_inter, "dense_gate")?,
+            dense_up: alloc(gpu, dense_inter, "dense_up")?,
+            dense_act: alloc(gpu, dense_inter, "dense_act")?,
+            router_logits: alloc(gpu, n_exp, "router_logits")?,
+            topk_indices: alloc(gpu, k, "topk_indices")?,
+            topk_weights: alloc(gpu, k, "topk_weights")?,
+            gate_batch: alloc(gpu, k * moe_inter, "gate_batch")?,
+            up_batch: alloc(gpu, k * moe_inter, "up_batch")?,
+            rot_batch: alloc(gpu, k * moe_inter, "rot_batch")?,
+            down_expanded: alloc(gpu, k * hidden, "down_expanded")?,
+            final_norm_buf: alloc(gpu, hidden, "final_norm_buf")?,
+            logits: alloc(gpu, cfg.vocab_size, "logits")?,
+        })
+    }
+
+    /// Reset for a new sequence: clear conv state and token count.
+    pub fn reset(&mut self, gpu: &mut Gpu) -> Result<(), String> {
+        self.n_tokens = 0;
+        for cs in &self.conv_states {
+            let zeros = vec![0u8; cs.numel() * 4];
+            gpu.hip
+                .memcpy_htod(&cs.buf, &zeros)
+                .map_err(|e| format!("lfm2moe: reset conv_state: {e:?}"))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -378,6 +378,10 @@ pub struct Lfm2MoeState {
     /// One rolling [hidden, K-1] f32 ring buffer per conv layer (zero-init).
     pub conv_states: Vec<GpuTensor>,
     pub pos_buf: hip_bridge::DeviceBuffer, // device i32 position scalar
+    /// hipGraph (HIPFIRE_LFM2_GRAPH) warmup latch: false until the first
+    /// decode runs direct (so kernel JIT / lazy alloc happen outside any
+    /// stream capture). Unused when the graph path is disabled.
+    pub graph_warmed_up: bool,
     pub max_seq: usize,
     pub n_tokens: usize,
 
@@ -471,6 +475,7 @@ impl Lfm2MoeState {
             kv,
             conv_states,
             pos_buf,
+            graph_warmed_up: false,
             max_seq,
             n_tokens: 0,
             h: alloc(gpu, hidden, "h")?,

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -28,6 +28,25 @@ fn read_tensor(hfq: &HfqFile, name: &str) -> Result<(u8, Vec<u8>), String> {
     Ok((info.quant_type, data))
 }
 
+/// Load an LFM2 AWQ shared gate_up-scale sidecar (1D F16, length k) → F32
+/// GpuTensor. Mirror of minimax `load_mm_awq_scale`. Returns None if the
+/// sidecar is absent or malformed, so non-AWQ models load cleanly (the
+/// attached `awq_scale` stays None and `rotate_x_mq_for` takes the plain path).
+fn load_lfm2_awq_scale(hfq: &HfqFile, gpu: &mut Gpu, name: &str, k: usize) -> Option<GpuTensor> {
+    let (qt, data) = read_tensor(hfq, name).ok()?;
+    if qt != 1 { return None; } // 1 = F16
+    if data.len() != k * 2 {
+        eprintln!("lfm2moe AWQ sidecar {name}: {} bytes != {} (k*2); skipping", data.len(), k * 2);
+        return None;
+    }
+    let f32_data: Vec<f32> = data
+        .chunks_exact(2)
+        .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+        .collect();
+    let f32_bytes: Vec<u8> = f32_data.iter().flat_map(|&v| v.to_le_bytes()).collect();
+    gpu.upload_raw(&f32_bytes, &[f32_data.len()]).ok()
+}
+
 /// Load a 1D/raw F16/F32 vector → F32 GpuTensor with the given shape.
 /// LFM2 uses STANDARD RMSNorm (`weight * x̂`, no +1 offset — verified against
 /// Lfm2MoeRMSNorm), so no offset is baked in. Also used for the depthwise conv
@@ -271,11 +290,36 @@ impl Lfm2MoeWeights {
                     let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
                     let mut gate_up_bytes = w1;
                     gate_up_bytes.extend_from_slice(&w3);
-                    let gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * moe_inter, hidden)
+                    let mut gate_up = wt_from_raw(gpu, qt1, &gate_up_bytes, 2 * moe_inter, hidden)
                         .map_err(|e2| format!("lfm2moe: fuse gate_up L{l}E{e}: {e2}"))?;
                     let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
-                    let down = wt_from_raw(gpu, qt2, &w2, hidden, moe_inter)
+                    let mut down = wt_from_raw(gpu, qt2, &w2, hidden, moe_inter)
                         .map_err(|e2| format!("lfm2moe: down L{l}E{e}: {e2}"))?;
+                    // AWQ scales: shared per layer, emitted once on expert 0 by the
+                    // quantizer (full port of minimax 3c676d00 BOTH-projection AWQ).
+                    // Attach the gate_up scale (len hidden) to expert 0's gate_up and
+                    // the down scale (len moe_inter) to expert 0's down; the forward
+                    // reads both from experts[0] and divides x/s in the unrotated
+                    // basis via the AWQ-aware rotate_x_mq_for (gate_up input) and
+                    // fused_silu_mul_rotate_mq_batched_for (post-SwiGLU intermediate
+                    // for down). down (w2) is the most quant-sensitive proj, so its
+                    // AWQ is the whole point. No-op on non-AWQ files.
+                    if e == 0 {
+                        gate_up.awq_scale = load_lfm2_awq_scale(
+                            hfq, gpu,
+                            &format!("{p}.feed_forward.awq_scale_gate_up.weight"),
+                            hidden);
+                        if gate_up.awq_scale.is_some() {
+                            eprintln!("lfm2moe: AWQ gate_up scale attached at {p} (expert-0 representative)");
+                        }
+                        down.awq_scale = load_lfm2_awq_scale(
+                            hfq, gpu,
+                            &format!("{p}.feed_forward.awq_scale_down.weight"),
+                            moe_inter);
+                        if down.awq_scale.is_some() {
+                            eprintln!("lfm2moe: AWQ down scale attached at {p} (expert-0 representative)");
+                        }
+                    }
                     experts.push(ExpertWeights { gate_up, down });
                 }
                 let gu_bytes: Vec<u8> = experts

--- a/crates/hipfire-arch-lfm2moe/src/lib.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lib.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//! LFM2.5-8B-A1B architecture (arch_id 11): a HYBRID model interleaving
+//! double-gated LIV short-convolution mixers (18 layers) with GQA+QK-norm
+//! attention mixers (6 layers), feeding a DeepSeek-style sigmoid-bias top-4
+//! MoE FFN (layers >= num_dense_layers) or a dense SwiGLU MLP (the first
+//! `num_dense_layers` layers). Per-layer mixer choice comes from the
+//! checkpoint's `layer_types`. Forward pass is free functions in `forward.rs`,
+//! mirroring the MiniMax-M2 (arch_id 10) port.
+//!
+//! Kernel coverage (all pre-existing except one small conv variant):
+//!   * attention   -> per-head QK-norm (rmsnorm_batched) + full-dim rotate_half
+//!                    RoPE (rope_f32) + Q8 GQA flash attention
+//!   * MoE routing -> deepseek4_moe_topk_bias_aware (sigmoid + expert_bias,
+//!                    runtime k_top = num_experts_per_tok = 4)
+//!   * MoE experts -> gemv_hfq4g256_moe_{gate_up,down} indexed (FWHT MQ4, k=4)
+//!   * dense MLP   -> Q8 SwiGLU (w1 gate, w3 up, silu_mul, w2 down)
+//!   * LIV conv    -> conv1d_gated_decode_f32 (NEW: K=3, fused B*x / C*conv_out
+//!                    gates + rolling conv-state cache)
+pub mod config;
+pub mod forward;
+pub mod lfm2moe;
+
+pub use config::{Lfm2MoeConfig, MixerKind};
+pub use forward::{decode_step, decode_step_capture};
+pub use lfm2moe::{Lfm2MoeState, Lfm2MoeWeights};
+
+/// Architecture id for LFM2.5-MoE.
+pub const ARCH_ID: u32 = 11;

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -253,12 +253,37 @@ fn decode_step_body(
         gpu.kv_cache_write_q8_0(&state.kv.v_gpu[l], &state.fa_v, &state.pos_buf,
             cfg.num_key_value_heads, cfg.head_dim)
             .map_err(|e| format!("minimax L{l}: kv write v: {e:?}"))?;
-        gpu.attention_q8_0_kv(
-            &state.fa_q, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &state.fa_attn_out,
-            &state.pos_buf, seq_len, cfg.num_attention_heads, cfg.num_key_value_heads,
-            cfg.head_dim, state.kv.physical_cap,
-        )
-        .map_err(|e| format!("minimax L{l}: attention: {e:?}"))?;
+        // Attention dispatch (hybrid, mirrors qwen35:9312):
+        //   - capture_mode (hipGraph): always flash — the single-workgroup
+        //     `attention_q8_0_kv` requests `(max_seq+block+head_dim)*4` LDS
+        //     under capture, which exceeds the 64 KB gfx11/gfx12 budget at
+        //     physical_cap ≳ 16K. The flash tile kernel's LDS is
+        //     `(128+head_dim)*4` ≈ const, independent of seq_len.
+        //   - flash_mode==2 (always, default on gfx11/gfx12): flash at any ctx.
+        //   - flash_mode==1 (auto): flash at ctx >= 2048.
+        //   - seq_len > 15000: forced flash regardless (the LDS-resident
+        //     kernel can't fit scores[seq_len] above ~16K).
+        // Below those thresholds the validated single-workgroup kernel stays
+        // the fast path for short contexts.
+        let use_flash = gpu.capture_mode
+            || state.flash_mode == 2
+            || (state.flash_mode == 1 && seq_len >= 2048)
+            || seq_len > 15000;
+        if use_flash {
+            gpu.attention_flash_q8_0(
+                &state.fa_q, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &state.fa_attn_out,
+                &state.pos_buf, seq_len, cfg.num_attention_heads, cfg.num_key_value_heads,
+                cfg.head_dim, state.kv.physical_cap, &state.flash_partials,
+            )
+            .map_err(|e| format!("minimax L{l}: flash attention: {e:?}"))?;
+        } else {
+            gpu.attention_q8_0_kv(
+                &state.fa_q, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &state.fa_attn_out,
+                &state.pos_buf, seq_len, cfg.num_attention_heads, cfg.num_key_value_heads,
+                cfg.head_dim, state.kv.physical_cap,
+            )
+            .map_err(|e| format!("minimax L{l}: attention: {e:?}"))?;
+        }
 
         // o_proj + residual: h += W_o · attn_out.
         weight_gemv_residual(gpu, &layer.wo, &state.fa_attn_out, &state.h)
@@ -526,12 +551,44 @@ pub fn forward_batch(
             &state.kv.v_gpu[l], &fv, &pos_array, cfg.num_key_value_heads, cfg.head_dim, b,
         )
         .map_err(|e| format!("minimax L{l} batch kv write v: {e:?}"))?;
-        gpu.attention_q8_0_kv_batched(
-            &fq, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &attn_out, &pos_array,
-            cfg.num_attention_heads, cfg.num_key_value_heads, cfg.head_dim,
-            max_seq, max_ctx, b,
-        )
-        .map_err(|e| format!("minimax L{l} batch attention: {e:?}"))?;
+        // The batched LDS-resident kernel materializes scores[max_ctx] in
+        // shared memory, so it caps at max_ctx ≲ 16K on gfx11/gfx12 (64 KB
+        // LDS). Above that, fall back to the per-row flash path (one
+        // single-position `attention_flash_q8_0` per batch row, serialized,
+        // reusing `state.flash_partials`) — mirrors qwen35:7173. Below the
+        // cap the batched kernel stays the fast prefill path.
+        const LDS_CTX_LIMIT: usize = 15000;
+        if max_ctx > LDS_CTX_LIMIT {
+            let pos_buf_tmp = gpu
+                .hip
+                .malloc(4)
+                .map_err(|e| format!("minimax L{l} batch flash pos malloc: {e:?}"))?;
+            for bi in 0..b {
+                let pos_bi = start_pos + bi;
+                let seq_len_bi = pos_bi + 1;
+                let pos_i32 = pos_bi as i32;
+                gpu.hip
+                    .memcpy_htod(&pos_buf_tmp, &pos_i32.to_ne_bytes())
+                    .map_err(|e| format!("minimax L{l} batch flash htod pos: {e:?}"))?;
+                let q_bi = fq.sub_offset(bi * q_dim, q_dim);
+                let out_bi = attn_out.sub_offset(bi * q_dim, q_dim);
+                gpu.attention_flash_q8_0(
+                    &q_bi, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &out_bi,
+                    &pos_buf_tmp, seq_len_bi, cfg.num_attention_heads,
+                    cfg.num_key_value_heads, cfg.head_dim, state.kv.physical_cap,
+                    &state.flash_partials,
+                )
+                .map_err(|e| format!("minimax L{l} batch flash attention: {e:?}"))?;
+            }
+            let _ = gpu.hip.free(pos_buf_tmp);
+        } else {
+            gpu.attention_q8_0_kv_batched(
+                &fq, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &attn_out, &pos_array,
+                cfg.num_attention_heads, cfg.num_key_value_heads, cfg.head_dim,
+                max_seq, max_ctx, b,
+            )
+            .map_err(|e| format!("minimax L{l} batch attention: {e:?}"))?;
+        }
         gpu.gemm_q8_0_batched(&layer.wo.buf, &attn_out, &o, hidden, q_dim, b)
             .map_err(|e| format!("minimax L{l} batch o_proj: {e:?}"))?;
         gpu.add_inplace_f32(&x, &o)

--- a/crates/hipfire-arch-minimax/src/forward.rs
+++ b/crates/hipfire-arch-minimax/src/forward.rs
@@ -238,9 +238,15 @@ fn decode_step_body(
         .map_err(|e| format!("minimax L{l}: rope: {e:?}"))?;
 
         // KV cache write (Q8) + GQA attention. The attention kernel reads the
-        // live KV length from `pos_buf[0]+1`; we pass `state.max_seq` as the
-        // geometry hint (NOT `seq_len`) so the captured launch grid / shared-mem
-        // is sized for the max and stays valid as the cache grows on replay.
+        // live KV length from `pos_buf[0]+1`; pass the ACTUAL `seq_len` as the
+        // geometry hint so the launch sizes its dynamic LDS (`scores[]`) to the
+        // current length — matching qwen35 / llama / lfm2moe. Passing
+        // `state.max_seq` here over-requested LDS = (max_seq+block+head_dim)*4,
+        // which exceeds the 64 KB gfx11 LDS limit at max_seq ≳ 16K (observed:
+        // `hipModuleLaunchKernel: invalid argument` on gfx1151 at max_seq=32768,
+        // fine at 4096). Graph-capture sizing is handled separately by the
+        // dispatch's `capture_mode` branch (sizes to `physical_cap`), so the
+        // non-capture hint must be the real length, not the max.
         gpu.kv_cache_write_q8_0(&state.kv.k_gpu[l], &state.fa_k, &state.pos_buf,
             cfg.num_key_value_heads, cfg.head_dim)
             .map_err(|e| format!("minimax L{l}: kv write k: {e:?}"))?;
@@ -249,7 +255,7 @@ fn decode_step_body(
             .map_err(|e| format!("minimax L{l}: kv write v: {e:?}"))?;
         gpu.attention_q8_0_kv(
             &state.fa_q, &state.kv.k_gpu[l], &state.kv.v_gpu[l], &state.fa_attn_out,
-            &state.pos_buf, state.max_seq, cfg.num_attention_heads, cfg.num_key_value_heads,
+            &state.pos_buf, seq_len, cfg.num_attention_heads, cfg.num_key_value_heads,
             cfg.head_dim, state.kv.physical_cap,
         )
         .map_err(|e| format!("minimax L{l}: attention: {e:?}"))?;

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -430,6 +430,19 @@ pub struct MiniMaxState {
     pub fa_v: GpuTensor,   // [kv_dim]
     pub fa_attn_out: GpuTensor, // [q_dim]
     pub flash_partials: GpuTensor,
+    /// Flash-attention tri-state for the Q8 decode/prefill attention path.
+    /// Mirrors qwen35's `flash_mode`:
+    ///   0 = never  — single-workgroup `attention_q8_0_kv` until the >15K
+    ///                LDS sanity cap (then forced flash anyway).
+    ///   1 = auto   — flash at ctx >= 2048.
+    ///   2 = always — flash at every ctx.
+    /// Default 2 on graph-capable archs (gfx11/gfx12) so the warmup-eager and
+    /// captured-replay decode steps use the SAME kernel (the single-workgroup
+    /// kernel has variable block_size + variable shared-mem and is NOT
+    /// capture-safe; a mode-1 default would mix kernels direct-vs-graph at
+    /// small ctx and diverge the fp32 reduction order). Override via
+    /// `HIPFIRE_ATTN_FLASH=never|auto|always`.
+    pub flash_mode: u8,
 
     // residual + embedding
     pub h: GpuTensor, // [hidden] residual stream
@@ -492,14 +505,34 @@ impl MiniMaxState {
             g.alloc_tensor(&[n], DType::F32)
                 .map_err(|e| format!("minimax: alloc {label}: {e:?}"))
         };
-        // Flash-attn partials: [n_heads * max_tiles * (2+head_dim)]; max_tiles
-        // bounded by ceil(max_seq/tile). Use a generous tile bound of 64.
-        let max_tiles = (max_seq / 256).max(1) + 1;
+        // Flash-attn partials for the tile+reduce two-kernel path
+        // (`attention_flash_q8_0`). The dispatch uses TILE_SIZE=128 and sizes
+        // the per-head row stride by `max_tiles = ceil(physical_cap/128)`, so
+        // the buffer MUST be `n_heads * ceil(physical_cap/128) * (2+head_dim)`
+        // floats — the prior tile=256 / (max_seq/256+1) sizing UNDER-allocated
+        // by ~2× and would corrupt the reduce read at long context. Decode is
+        // batch=1 (one query position per dispatch) and the long-prefill path
+        // serializes one flash call per row reusing this same buffer, so no
+        // batch multiplier is needed.
+        const FLASH_TILE: usize = 128;
+        let max_tiles = (kv.physical_cap + FLASH_TILE - 1) / FLASH_TILE;
         let flash_partials = alloc(
             gpu,
             cfg.num_attention_heads * max_tiles * (2 + cfg.head_dim),
             "flash_partials",
         )?;
+        // Flash tri-state: default 2 (always flash) on graph-capable archs so
+        // warmup-eager and captured-replay decode use the identical kernel.
+        let flash_mode = match std::env::var("HIPFIRE_ATTN_FLASH").as_deref() {
+            Ok("never") | Ok("0") | Ok("off") => 0u8,
+            Ok("always") | Ok("2") | Ok("force") => 2u8,
+            Ok("auto") | Ok("1") | Ok("on") => 1u8,
+            _ => {
+                let graph_capable_arch =
+                    gpu.arch.starts_with("gfx12") || gpu.arch.starts_with("gfx11");
+                if graph_capable_arch { 2 } else { 1 }
+            }
+        };
 
         Ok(MiniMaxState {
             kv,
@@ -515,6 +548,7 @@ impl MiniMaxState {
             fa_v: alloc(gpu, kv_dim, "fa_v")?,
             fa_attn_out: alloc(gpu, q_dim, "fa_attn_out")?,
             flash_partials,
+            flash_mode,
             h: alloc(gpu, hidden, "h")?,
             ffn_tmp: alloc(gpu, hidden, "ffn_tmp")?,
             ffn_x_rot: alloc(gpu, hidden, "ffn_x_rot")?,

--- a/crates/hipfire-arch-qwen35/src/mtp_head.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_head.rs
@@ -59,14 +59,23 @@
 //! - KV rollback / batched verify: this is a single-token forward, the
 //!   verify-loop equivalent for MTP would be Task 11.
 
-use crate::qwen35::{Qwen35Config, Qwen35Weights};
+use crate::qwen35::Qwen35Weights;
 use hip_bridge::{DeviceBuffer, HipResult};
 use hipfire_runtime::hfq::{HfqFile, HfqTensorInfo};
-use hipfire_runtime::llama::{self, f16_to_f32, weight_gemv, EmbeddingFormat, WeightTensor};
+use hipfire_runtime::llama::{
+    self, f16_to_f32, fused_silu_mul_rotate_mq_batched_for, fused_silu_mul_rotate_mq_for,
+    rotate_x_mq_for, weight_gemv, EmbeddingFormat, WeightTensor,
+};
 use rdna_compute::{DType, Gpu, GpuTensor};
 use std::path::Path;
 
 // ─── Config ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Qwen35MtpFfnKind {
+    Dense,
+    Moe,
+}
 
 /// All dimensions and hyperparams the MTP head needs. Loaded from the
 /// `.mtp` file's metadata JSON; nothing is hardcoded per model size.
@@ -77,6 +86,12 @@ pub struct Qwen35MtpHeadConfig {
     pub n_head_kv: usize,
     pub head_dim: usize,
     pub n_ff: usize,
+    pub ffn_kind: Qwen35MtpFfnKind,
+    pub num_experts: usize,
+    pub num_experts_per_tok: usize,
+    pub moe_intermediate_size: usize,
+    pub shared_expert_intermediate_size: usize,
+    pub norm_topk_prob: bool,
     pub vocab_size: usize,
     pub rope_theta: f32,
     /// Partial-rotary factor; defaults to 0.25 to mirror Qwen3.5 trunk.
@@ -109,6 +124,35 @@ impl Qwen35MtpHeadConfig {
         let n_head_kv = gu("n_head_kv");
         let head_dim = gu("n_embd_head");
         let n_ff = gu("n_ff");
+        let ffn_kind = match meta
+            .get("ffn_kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("dense")
+        {
+            "dense" => Qwen35MtpFfnKind::Dense,
+            "moe" => Qwen35MtpFfnKind::Moe,
+            other => panic!(".mtp metadata has unsupported ffn_kind='{other}'"),
+        };
+        let num_experts = meta
+            .get("num_experts")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let num_experts_per_tok = meta
+            .get("num_experts_per_tok")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let moe_intermediate_size = meta
+            .get("moe_intermediate_size")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let shared_expert_intermediate_size = meta
+            .get("shared_expert_intermediate_size")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let norm_topk_prob = meta
+            .get("norm_topk_prob")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
         let vocab_size = gu("vocab_size");
         // partial_rotary_factor lives nested under config_text_config; fall
         // back to 0.25 (Qwen3.5 default) when absent.
@@ -125,14 +169,59 @@ impl Qwen35MtpHeadConfig {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
         Self {
-            n_embd, n_head, n_head_kv, head_dim, n_ff,
-            vocab_size, rope_theta, n_rot, rms_norm_eps, max_seq,
+            n_embd,
+            n_head,
+            n_head_kv,
+            head_dim,
+            n_ff,
+            ffn_kind,
+            num_experts,
+            num_experts_per_tok,
+            moe_intermediate_size,
+            shared_expert_intermediate_size,
+            norm_topk_prob,
+            vocab_size,
+            rope_theta,
+            n_rot,
+            rms_norm_eps,
+            max_seq,
             tie_word_embeddings,
         }
     }
 }
 
 // ─── Weights ─────────────────────────────────────────────────────────────
+
+pub struct Qwen35MtpDenseFfnWeights {
+    pub gate: WeightTensor, // [n_ff, n_embd]
+    pub up: WeightTensor,   // [n_ff, n_embd]
+    pub down: WeightTensor, // [n_embd, n_ff]
+}
+
+pub struct Qwen35MtpMoeExpertWeights {
+    pub gate_up: WeightTensor, // [2 * moe_intermediate, n_embd]
+    pub down: WeightTensor,    // [n_embd, moe_intermediate]
+}
+
+pub struct Qwen35MtpMoeSharedExpertWeights {
+    pub gate: WeightTensor, // [shared_expert_intermediate, n_embd]
+    pub up: WeightTensor,   // [shared_expert_intermediate, n_embd]
+    pub down: WeightTensor, // [n_embd, shared_expert_intermediate]
+}
+
+pub struct Qwen35MtpMoeFfnWeights {
+    pub router: WeightTensor, // [num_experts, n_embd]
+    pub shared_expert: Qwen35MtpMoeSharedExpertWeights,
+    pub shared_expert_gate: WeightTensor, // [1, n_embd]
+    pub experts: Vec<Qwen35MtpMoeExpertWeights>,
+    pub expert_gate_up_ptrs: GpuTensor,
+    pub expert_down_ptrs: GpuTensor,
+}
+
+pub enum Qwen35MtpFfnWeights {
+    Dense(Qwen35MtpDenseFfnWeights),
+    Moe(Qwen35MtpMoeFfnWeights),
+}
 
 /// All 15 GPU-resident MTP head tensors (+2 optional FastMTP-style
 /// vocab-compression sidecar tensors). Ownership is tied to the head
@@ -147,14 +236,12 @@ pub struct Qwen35MtpHeadWeights {
     pub attn_q_norm: GpuTensor,
     pub attn_k_norm: GpuTensor,
     // 2D weights (MQ4 / Q8)
-    pub eh_proj: WeightTensor,   // [n_embd, 2 * n_embd]
-    pub wq: WeightTensor,        // [2 * head_dim * n_head, n_embd]
-    pub wk: WeightTensor,        // [head_dim * n_head_kv, n_embd]
-    pub wv: WeightTensor,        // [head_dim * n_head_kv, n_embd]
-    pub wo: WeightTensor,        // [n_embd, head_dim * n_head]
-    pub ffn_gate: WeightTensor,  // [n_ff, n_embd]
-    pub ffn_up: WeightTensor,    // [n_ff, n_embd]
-    pub ffn_down: WeightTensor,  // [n_embd, n_ff]
+    pub eh_proj: WeightTensor, // [n_embd, 2 * n_embd]
+    pub wq: WeightTensor,      // [2 * head_dim * n_head, n_embd]
+    pub wk: WeightTensor,      // [head_dim * n_head_kv, n_embd]
+    pub wv: WeightTensor,      // [head_dim * n_head_kv, n_embd]
+    pub wo: WeightTensor,      // [n_embd, head_dim * n_head]
+    pub ffn: Qwen35MtpFfnWeights,
 
     // Optional FastMTP-style vocab-compression sidecar (present iff the
     // .mtp metadata says `has_compressed_lm_head_draft: true`).
@@ -164,12 +251,14 @@ pub struct Qwen35MtpHeadWeights {
     //   Shape [compressed_vocab_size, n_embd]. ~7.7x BW reduction at K=32K
     //   on a 248K-vocab Qwen3.5/3.6.
     // - `lm_head_draft_vocab_map`: host-side u32 array mapping draft idx
-    //   -> full vocab idx. Tiny (32K * 4 = 128KB), kept on CPU because the
-    //   argmax remap is a single scalar lookup per draft step (no benefit
-    //   from GPU residence).
+    //   -> full vocab idx. Kept for host fallback paths and diagnostics.
+    // - `lm_head_draft_vocab_map_gpu`: same map on-device for the greedy
+    //   MTP token-chain path, where draft idx -> full token must happen
+    //   without a per-step D2H sync.
     // - `compressed_vocab_size`: K. Cached for fast access in forward.
     pub lm_head_draft: Option<WeightTensor>,
     pub lm_head_draft_vocab_map: Option<Vec<u32>>,
+    pub lm_head_draft_vocab_map_gpu: Option<GpuTensor>,
     pub compressed_vocab_size: Option<usize>,
 }
 
@@ -187,11 +276,31 @@ impl Qwen35MtpHeadWeights {
         let _ = gpu.free_tensor(self.wk.buf);
         let _ = gpu.free_tensor(self.wv.buf);
         let _ = gpu.free_tensor(self.wo.buf);
-        let _ = gpu.free_tensor(self.ffn_gate.buf);
-        let _ = gpu.free_tensor(self.ffn_up.buf);
-        let _ = gpu.free_tensor(self.ffn_down.buf);
+        match self.ffn {
+            Qwen35MtpFfnWeights::Dense(ffn) => {
+                let _ = gpu.free_tensor(ffn.gate.buf);
+                let _ = gpu.free_tensor(ffn.up.buf);
+                let _ = gpu.free_tensor(ffn.down.buf);
+            }
+            Qwen35MtpFfnWeights::Moe(ffn) => {
+                let _ = gpu.free_tensor(ffn.router.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert_gate.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert.gate.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert.up.buf);
+                let _ = gpu.free_tensor(ffn.shared_expert.down.buf);
+                let _ = gpu.free_tensor(ffn.expert_gate_up_ptrs);
+                let _ = gpu.free_tensor(ffn.expert_down_ptrs);
+                for expert in ffn.experts {
+                    let _ = gpu.free_tensor(expert.gate_up.buf);
+                    let _ = gpu.free_tensor(expert.down.buf);
+                }
+            }
+        }
         if let Some(lm_d) = self.lm_head_draft {
             let _ = gpu.free_tensor(lm_d.buf);
+        }
+        if let Some(vmap) = self.lm_head_draft_vocab_map_gpu {
+            let _ = gpu.free_tensor(vmap);
         }
     }
 }
@@ -203,35 +312,51 @@ impl Qwen35MtpHeadWeights {
 /// `Qwen35Scratch` but sized for the MTP head's single block + LM head.
 pub struct Qwen35MtpHeadScratch {
     // Activation stages
-    pub tok_embd: GpuTensor,    // [n_embd]
-    pub e_norm: GpuTensor,      // [n_embd]
-    pub h_norm: GpuTensor,      // [n_embd]
-    pub concat: GpuTensor,      // [2 * n_embd]
-    pub cur: GpuTensor,         // [n_embd] — primary residual stream
-    pub residual: GpuTensor,    // [n_embd] — saved for inpSA
-    pub tmp: GpuTensor,         // [n_embd] — RMSNorm output scratch
+    pub tok_embd: GpuTensor, // [n_embd]
+    pub e_norm: GpuTensor,   // [n_embd]
+    pub h_norm: GpuTensor,   // [n_embd]
+    pub concat: GpuTensor,   // [2 * n_embd]
+    pub cur: GpuTensor,      // [n_embd] — primary residual stream
+    pub residual: GpuTensor, // [n_embd] — saved for inpSA
+    pub tmp: GpuTensor,      // [n_embd] — RMSNorm output scratch
 
     // Attention sub-block
-    pub q_full: GpuTensor,      // [2 * head_dim * n_head]
-    pub q: GpuTensor,           // [head_dim * n_head]
-    pub gate: GpuTensor,        // [head_dim * n_head]
-    pub k: GpuTensor,           // [head_dim * n_head_kv]
-    pub v: GpuTensor,           // [head_dim * n_head_kv]
-    pub attn_out: GpuTensor,    // [head_dim * n_head]
-    pub o: GpuTensor,           // [n_embd]
+    pub q_full: GpuTensor,   // [2 * head_dim * n_head]
+    pub q: GpuTensor,        // [head_dim * n_head]
+    pub gate: GpuTensor,     // [head_dim * n_head]
+    pub k: GpuTensor,        // [head_dim * n_head_kv]
+    pub v: GpuTensor,        // [head_dim * n_head_kv]
+    pub attn_out: GpuTensor, // [head_dim * n_head]
+    pub o: GpuTensor,        // [n_embd]
 
     // FFN sub-block
-    pub gate_ffn: GpuTensor,    // [n_ff]
-    pub up: GpuTensor,          // [n_ff]
-    pub ffn_hidden: GpuTensor,  // [n_ff]
-    pub ffn_out: GpuTensor,     // [n_embd]
+    pub gate_ffn: GpuTensor,   // [n_ff]
+    pub up: GpuTensor,         // [n_ff]
+    pub ffn_hidden: GpuTensor, // [n_ff]
+    pub ffn_out: GpuTensor,    // [n_embd]
+
+    // MoE FFN scratch, allocated only for ffn_kind=moe.
+    pub moe_router_logits: Option<GpuTensor>, // [num_experts]
+    pub moe_scalar_buf: Option<GpuTensor>,    // [1]
+    pub moe_x_rot: Option<GpuTensor>,         // [n_embd]
+    pub moe_gate_up_buf: Option<GpuTensor>,   // [2 * max(moe_intermediate, shared_intermediate)]
+    pub moe_gate_buf: Option<GpuTensor>,      // [max(moe_intermediate, shared_intermediate)]
+    pub moe_up_buf: Option<GpuTensor>,        // [max(moe_intermediate, shared_intermediate)]
+    pub moe_ffn_hidden: Option<GpuTensor>,    // [max(moe_intermediate, shared_intermediate)]
+    pub moe_ffn_out: Option<GpuTensor>,       // [n_embd]
+    pub moe_gate_batch: Option<GpuTensor>,    // [top_k * moe_intermediate]
+    pub moe_up_batch: Option<GpuTensor>,      // [top_k * moe_intermediate]
+    pub moe_rot_batch: Option<GpuTensor>,     // [top_k * moe_intermediate]
+    pub moe_topk_indices: Option<GpuTensor>,  // [top_k]
+    pub moe_topk_weights: Option<GpuTensor>,  // [top_k]
+    pub moe_down_expanded: Option<GpuTensor>, // [top_k * n_embd]
 
     // Snapshot of the post-FFN, pre-LM-head-norm hidden — caller can
     // capture this and feed back as `prev_hidden` for an n+2 prediction.
-    pub t_mtp_out: GpuTensor,   // [n_embd]
+    pub t_mtp_out: GpuTensor, // [n_embd]
 
     // LM head output
-    pub logits: GpuTensor,      // [vocab_size]
+    pub logits: GpuTensor, // [vocab_size]
 
     // Optional FastMTP-style compressed-logits scratch — sized
     // [compressed_vocab_size] when the head was loaded with a sidecar.
@@ -254,6 +379,10 @@ impl Qwen35MtpHeadScratch {
         let dim = config.n_embd;
         let q_dim = config.head_dim * config.n_head;
         let kv_dim = config.head_dim * config.n_head_kv;
+        let moe_max_inter = config
+            .moe_intermediate_size
+            .max(config.shared_expert_intermediate_size);
+        let alloc_moe = config.ffn_kind == Qwen35MtpFfnKind::Moe;
         Ok(Self {
             tok_embd: gpu.alloc_tensor(&[dim], DType::F32)?,
             e_norm: gpu.alloc_tensor(&[dim], DType::F32)?,
@@ -273,6 +402,85 @@ impl Qwen35MtpHeadScratch {
             up: gpu.alloc_tensor(&[config.n_ff], DType::F32)?,
             ffn_hidden: gpu.alloc_tensor(&[config.n_ff], DType::F32)?,
             ffn_out: gpu.alloc_tensor(&[dim], DType::F32)?,
+            moe_router_logits: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts], DType::F32)?)
+            } else {
+                None
+            },
+            moe_scalar_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[1], DType::F32)?)
+            } else {
+                None
+            },
+            moe_x_rot: if alloc_moe {
+                Some(gpu.alloc_tensor(&[dim], DType::F32)?)
+            } else {
+                None
+            },
+            moe_gate_up_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[2 * moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_gate_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_up_buf: if alloc_moe {
+                Some(gpu.alloc_tensor(&[moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_ffn_hidden: if alloc_moe {
+                Some(gpu.alloc_tensor(&[moe_max_inter], DType::F32)?)
+            } else {
+                None
+            },
+            moe_ffn_out: if alloc_moe {
+                Some(gpu.alloc_tensor(&[dim], DType::F32)?)
+            } else {
+                None
+            },
+            moe_gate_batch: if alloc_moe {
+                Some(gpu.alloc_tensor(
+                    &[config.num_experts_per_tok * config.moe_intermediate_size],
+                    DType::F32,
+                )?)
+            } else {
+                None
+            },
+            moe_up_batch: if alloc_moe {
+                Some(gpu.alloc_tensor(
+                    &[config.num_experts_per_tok * config.moe_intermediate_size],
+                    DType::F32,
+                )?)
+            } else {
+                None
+            },
+            moe_rot_batch: if alloc_moe {
+                Some(gpu.alloc_tensor(
+                    &[config.num_experts_per_tok * config.moe_intermediate_size],
+                    DType::F32,
+                )?)
+            } else {
+                None
+            },
+            moe_topk_indices: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts_per_tok], DType::F32)?)
+            } else {
+                None
+            },
+            moe_topk_weights: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts_per_tok], DType::F32)?)
+            } else {
+                None
+            },
+            moe_down_expanded: if alloc_moe {
+                Some(gpu.alloc_tensor(&[config.num_experts_per_tok * dim], DType::F32)?)
+            } else {
+                None
+            },
             t_mtp_out: gpu.alloc_tensor(&[dim], DType::F32)?,
             logits: gpu.alloc_tensor(&[config.vocab_size], DType::F32)?,
             logits_compressed: None,
@@ -296,7 +504,9 @@ impl Qwen35MtpHeadScratch {
     /// Idempotent — a no-op if already allocated to the right size. Call
     /// once after head load when the head reports a compressed_vocab_size.
     pub fn ensure_compressed_logits(
-        &mut self, gpu: &mut Gpu, compressed_vocab_size: usize,
+        &mut self,
+        gpu: &mut Gpu,
+        compressed_vocab_size: usize,
     ) -> HipResult<()> {
         if let Some(existing) = self.logits_compressed.as_ref() {
             if existing.numel() == compressed_vocab_size {
@@ -309,9 +519,7 @@ impl Qwen35MtpHeadScratch {
                 let _ = gpu.free_tensor(old);
             }
         }
-        self.logits_compressed = Some(
-            gpu.alloc_tensor(&[compressed_vocab_size], DType::F32)?,
-        );
+        self.logits_compressed = Some(gpu.alloc_tensor(&[compressed_vocab_size], DType::F32)?);
         Ok(())
     }
 
@@ -334,6 +542,48 @@ impl Qwen35MtpHeadScratch {
         let _ = gpu.free_tensor(self.up);
         let _ = gpu.free_tensor(self.ffn_hidden);
         let _ = gpu.free_tensor(self.ffn_out);
+        if let Some(t) = self.moe_router_logits {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_scalar_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_x_rot {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_gate_up_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_gate_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_up_buf {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_ffn_hidden {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_ffn_out {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_gate_batch {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_up_batch {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_rot_batch {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_topk_indices {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_topk_weights {
+            let _ = gpu.free_tensor(t);
+        }
+        if let Some(t) = self.moe_down_expanded {
+            let _ = gpu.free_tensor(t);
+        }
         let _ = gpu.free_tensor(self.t_mtp_out);
         let _ = gpu.free_tensor(self.logits);
         if let Some(lc) = self.logits_compressed {
@@ -425,13 +675,25 @@ impl Qwen35MtpHeadKvCache {
     ) -> HipResult<Self> {
         let inner = match kv_mode {
             MtpKvMode::Q8 => hipfire_runtime::llama::KvCache::new_gpu_q8(
-                gpu, /* n_layers */ 1, config.n_head_kv, config.head_dim, config.max_seq,
+                gpu,
+                /* n_layers */ 1,
+                config.n_head_kv,
+                config.head_dim,
+                config.max_seq,
             )?,
             MtpKvMode::Asym3 => hipfire_runtime::llama::KvCache::new_gpu_asym3(
-                gpu, /* n_layers */ 1, config.n_head_kv, config.head_dim, config.max_seq,
+                gpu,
+                /* n_layers */ 1,
+                config.n_head_kv,
+                config.head_dim,
+                config.max_seq,
             )?,
             MtpKvMode::Fwht4 => hipfire_runtime::llama::KvCache::new_gpu_fwht4(
-                gpu, /* n_layers */ 1, config.n_head_kv, config.head_dim, config.max_seq,
+                gpu,
+                /* n_layers */ 1,
+                config.n_head_kv,
+                config.head_dim,
+                config.max_seq,
             )?,
         };
         Ok(Self {
@@ -452,12 +714,10 @@ impl Qwen35MtpHeadKvCache {
             let v_n = self.inner.v_gpu[layer].numel();
             let zeros_k = vec![0.0f32; k_n];
             let zeros_v = vec![0.0f32; v_n];
-            let kb: &[u8] = unsafe {
-                std::slice::from_raw_parts(zeros_k.as_ptr() as *const u8, k_n * 4)
-            };
-            let vb: &[u8] = unsafe {
-                std::slice::from_raw_parts(zeros_v.as_ptr() as *const u8, v_n * 4)
-            };
+            let kb: &[u8] =
+                unsafe { std::slice::from_raw_parts(zeros_k.as_ptr() as *const u8, k_n * 4) };
+            let vb: &[u8] =
+                unsafe { std::slice::from_raw_parts(zeros_v.as_ptr() as *const u8, v_n * 4) };
             gpu.hip.memcpy_htod(&self.inner.k_gpu[layer].buf, kb)?;
             gpu.hip.memcpy_htod(&self.inner.v_gpu[layer].buf, vb)?;
         }
@@ -551,11 +811,7 @@ pub fn load_mtp_head_bundled(
 ///
 /// `max_seq` bounds the per-position KV cache later allocated by
 /// [`Qwen35MtpHeadKvCache::new`]; pick to match your decode budget.
-pub fn load_mtp_head(
-    path: &Path,
-    gpu: &mut Gpu,
-    max_seq: usize,
-) -> HipResult<Qwen35MtpHead> {
+pub fn load_mtp_head(path: &Path, gpu: &mut Gpu, max_seq: usize) -> HipResult<Qwen35MtpHead> {
     load_mtp_head_at_offset(path, gpu, max_seq, 0)
 }
 
@@ -568,16 +824,22 @@ pub fn load_mtp_head_at_offset(
     max_seq: usize,
     base_offset: u64,
 ) -> HipResult<Qwen35MtpHead> {
-    let hfq = HfqFile::open_at_offset(path, base_offset)
-        .unwrap_or_else(|e| panic!("open .mtp file {} @ offset {base_offset}: {e}", path.display()));
+    let hfq = HfqFile::open_at_offset(path, base_offset).unwrap_or_else(|e| {
+        panic!(
+            "open .mtp file {} @ offset {base_offset}: {e}",
+            path.display()
+        )
+    });
     assert_eq!(
-        hfq.arch_id, 21,
+        hfq.arch_id,
+        21,
         ".mtp file at {} has arch_id={} (expected 21 = QWEN35_MTP_HEAD); \
          is this actually an MTP head extracted by mtp_extract?",
-        path.display(), hfq.arch_id
+        path.display(),
+        hfq.arch_id
     );
-    let meta: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
-        .expect(".mtp metadata JSON parse failed");
+    let meta: serde_json::Value =
+        serde_json::from_str(&hfq.metadata_json).expect(".mtp metadata JSON parse failed");
     let config = Qwen35MtpHeadConfig::from_metadata(&meta, max_seq);
 
     // ── Norms (F32, 1D) ─────────────────────────────────────────────────
@@ -594,67 +856,100 @@ pub fn load_mtp_head_at_offset(
     // τ=2.00 on 27B-3.5 LRU bench. The MTP head trains its `mtp.norm` with
     // the trunk per-layer convention, NOT the trunk final-norm convention.
     let shared_head_norm = load_norm_raw(&hfq, gpu, "shared_head_norm", n_embd)?;
-    let enorm           = load_norm_raw(&hfq, gpu, "enorm",            n_embd)?;
-    let hnorm           = load_norm_raw(&hfq, gpu, "hnorm",            n_embd)?;
-    let attn_norm       = load_norm_raw(&hfq, gpu, "attn_norm",        n_embd)?;
-    let attn_post_norm  = load_norm_raw(&hfq, gpu, "attn_post_norm",   n_embd)?;
-    let attn_q_norm     = load_norm_raw(&hfq, gpu, "attn_q_norm",      head_dim)?;
-    let attn_k_norm     = load_norm_raw(&hfq, gpu, "attn_k_norm",      head_dim)?;
+    let enorm = load_norm_raw(&hfq, gpu, "enorm", n_embd)?;
+    let hnorm = load_norm_raw(&hfq, gpu, "hnorm", n_embd)?;
+    let attn_norm = load_norm_raw(&hfq, gpu, "attn_norm", n_embd)?;
+    let attn_post_norm = load_norm_raw(&hfq, gpu, "attn_post_norm", n_embd)?;
+    let attn_q_norm = load_norm_raw(&hfq, gpu, "attn_q_norm", head_dim)?;
+    let attn_k_norm = load_norm_raw(&hfq, gpu, "attn_k_norm", head_dim)?;
 
     // ── 2D weights ──────────────────────────────────────────────────────
     let q_full_dim = 2 * head_dim * config.n_head;
-    let kv_dim     = head_dim * config.n_head_kv;
-    let q_dim      = head_dim * config.n_head;
+    let kv_dim = head_dim * config.n_head_kv;
+    let q_dim = head_dim * config.n_head;
 
-    let eh_proj  = load_weight_raw(&hfq, gpu, "eh_proj",  n_embd,    2 * n_embd)?;
-    let wq       = load_weight_raw(&hfq, gpu, "wq",       q_full_dim, n_embd)?;
-    let wk       = load_weight_raw(&hfq, gpu, "wk",       kv_dim,    n_embd)?;
-    let wv       = load_weight_raw(&hfq, gpu, "wv",       kv_dim,    n_embd)?;
-    let wo       = load_weight_raw(&hfq, gpu, "wo",       n_embd,    q_dim)?;
-    let ffn_gate = load_weight_raw(&hfq, gpu, "ffn_gate", config.n_ff, n_embd)?;
-    let ffn_up   = load_weight_raw(&hfq, gpu, "ffn_up",   config.n_ff, n_embd)?;
-    let ffn_down = load_weight_raw(&hfq, gpu, "ffn_down", n_embd,      config.n_ff)?;
+    let eh_proj = load_weight_raw(&hfq, gpu, "eh_proj", n_embd, 2 * n_embd)?;
+    let wq = load_weight_raw(&hfq, gpu, "wq", q_full_dim, n_embd)?;
+    let wk = load_weight_raw(&hfq, gpu, "wk", kv_dim, n_embd)?;
+    let wv = load_weight_raw(&hfq, gpu, "wv", kv_dim, n_embd)?;
+    let wo = load_weight_raw(&hfq, gpu, "wo", n_embd, q_dim)?;
+    let ffn = match config.ffn_kind {
+        Qwen35MtpFfnKind::Dense => Qwen35MtpFfnWeights::Dense(Qwen35MtpDenseFfnWeights {
+            gate: load_weight_raw(&hfq, gpu, "ffn_gate", config.n_ff, n_embd)?,
+            up: load_weight_raw(&hfq, gpu, "ffn_up", config.n_ff, n_embd)?,
+            down: load_weight_raw(&hfq, gpu, "ffn_down", n_embd, config.n_ff)?,
+        }),
+        Qwen35MtpFfnKind::Moe => {
+            assert_eq!(
+                config.num_experts_per_tok, 8,
+                "MoE MTP runtime currently supports top_k=8, got {}",
+                config.num_experts_per_tok
+            );
+            Qwen35MtpFfnWeights::Moe(load_mtp_moe_ffn(&hfq, gpu, &config)?)
+        }
+    };
 
     // ── Optional FastMTP-style compressed lm_head_draft + vocab map ────
     let has_compressed = meta
         .get("has_compressed_lm_head_draft")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let (lm_head_draft, lm_head_draft_vocab_map, compressed_vocab_size) =
-        if has_compressed {
-            let cvs = meta
-                .get("compressed_vocab_size")
-                .and_then(|v| v.as_u64())
-                .expect("metadata claims has_compressed_lm_head_draft but lacks compressed_vocab_size")
-                as usize;
-            assert!(cvs > 0, "compressed_vocab_size must be positive");
-            let lm_d = load_weight_raw(&hfq, gpu, "lm_head_draft.weight", cvs, n_embd)?;
-            let (vmap_info, vmap_bytes) = hfq
-                .tensor_data_vec("lm_head_draft.vocab_map")
-                .expect("compressed sidecar missing vocab_map tensor");
-            assert_eq!(
-                vmap_info.shape, vec![cvs as u32],
-                "lm_head_draft.vocab_map shape != [compressed_vocab_size]"
-            );
-            assert_eq!(
-                vmap_bytes.len(), cvs * 4,
-                "lm_head_draft.vocab_map byte count != {} (got {})",
-                cvs * 4, vmap_bytes.len()
-            );
-            let vmap: Vec<u32> = vmap_bytes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect();
-            (Some(lm_d), Some(vmap), Some(cvs))
-        } else {
-            (None, None, None)
-        };
+    let (
+        lm_head_draft,
+        lm_head_draft_vocab_map,
+        lm_head_draft_vocab_map_gpu,
+        compressed_vocab_size,
+    ) = if has_compressed {
+        let cvs = meta
+            .get("compressed_vocab_size")
+            .and_then(|v| v.as_u64())
+            .expect("metadata claims has_compressed_lm_head_draft but lacks compressed_vocab_size")
+            as usize;
+        assert!(cvs > 0, "compressed_vocab_size must be positive");
+        let lm_d = load_weight_raw(&hfq, gpu, "lm_head_draft.weight", cvs, n_embd)?;
+        let (vmap_info, vmap_bytes) = hfq
+            .tensor_data_vec("lm_head_draft.vocab_map")
+            .expect("compressed sidecar missing vocab_map tensor");
+        assert_eq!(
+            vmap_info.shape,
+            vec![cvs as u32],
+            "lm_head_draft.vocab_map shape != [compressed_vocab_size]"
+        );
+        assert_eq!(
+            vmap_bytes.len(),
+            cvs * 4,
+            "lm_head_draft.vocab_map byte count != {} (got {})",
+            cvs * 4,
+            vmap_bytes.len()
+        );
+        let vmap: Vec<u32> = vmap_bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        let vmap_gpu = gpu.upload_raw(&vmap_bytes, &[vmap_bytes.len()])?;
+        (Some(lm_d), Some(vmap), Some(vmap_gpu), Some(cvs))
+    } else {
+        (None, None, None, None)
+    };
 
     let weights = Qwen35MtpHeadWeights {
-        shared_head_norm, enorm, hnorm, attn_norm, attn_post_norm,
-        attn_q_norm, attn_k_norm,
-        eh_proj, wq, wk, wv, wo, ffn_gate, ffn_up, ffn_down,
-        lm_head_draft, lm_head_draft_vocab_map, compressed_vocab_size,
+        shared_head_norm,
+        enorm,
+        hnorm,
+        attn_norm,
+        attn_post_norm,
+        attn_q_norm,
+        attn_k_norm,
+        eh_proj,
+        wq,
+        wk,
+        wv,
+        wo,
+        ffn,
+        lm_head_draft,
+        lm_head_draft_vocab_map,
+        lm_head_draft_vocab_map_gpu,
+        compressed_vocab_size,
     };
 
     Ok(Qwen35MtpHead { config, weights })
@@ -665,7 +960,10 @@ pub fn load_mtp_head_at_offset(
 /// · (1 + weight)`). All `.mtp` norms ship as quant_type=2 (F32) per the
 /// `mtp_extract` packing rule.
 fn load_norm_raw(
-    hfq: &HfqFile, gpu: &mut Gpu, name: &str, expected_n: usize,
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    expected_n: usize,
 ) -> HipResult<GpuTensor> {
     load_norm_raw_with_offset(hfq, gpu, name, expected_n, true)
 }
@@ -676,22 +974,29 @@ fn load_norm_raw(
 /// `mtp.norm.weight` (shared_head_norm) is the equivalent of the trunk's
 /// final norm — should also be RAW. Pass apply_plus_one=false for that one.
 fn load_norm_raw_with_offset(
-    hfq: &HfqFile, gpu: &mut Gpu, name: &str, expected_n: usize, apply_plus_one: bool,
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    expected_n: usize,
+    apply_plus_one: bool,
 ) -> HipResult<GpuTensor> {
     let (info, data) = hfq
         .tensor_data_vec(name)
         .unwrap_or_else(|| panic!(".mtp tensor '{name}' missing"));
     let mut f32_data: Vec<f32> = match info.quant_type {
-        1 => data.chunks_exact(2)
+        1 => data
+            .chunks_exact(2)
             .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
             .collect(),
-        2 => data.chunks_exact(4)
+        2 => data
+            .chunks_exact(4)
             .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect(),
         other => panic!("norm '{name}' has unexpected qt={other} (expected F16 or F32)"),
     };
     assert_eq!(
-        f32_data.len(), expected_n,
+        f32_data.len(),
+        expected_n,
         "norm '{name}': loaded {} elems but expected {expected_n}",
         f32_data.len(),
     );
@@ -706,7 +1011,9 @@ fn load_norm_raw_with_offset(
     // representation). Off-by-one risk is small: the trunk does the same
     // +1 for `shared_expert_intermediate.norm` etc.
     if apply_plus_one {
-        for v in &mut f32_data { *v += 1.0; }
+        for v in &mut f32_data {
+            *v += 1.0;
+        }
     }
     gpu.upload_f32(&f32_data, &[expected_n])
 }
@@ -715,7 +1022,11 @@ fn load_norm_raw_with_offset(
 /// the supported quant types into a [`WeightTensor`]; m and k are passed
 /// in (the mtp container stores shape but we trust caller-supplied dims).
 fn load_weight_raw(
-    hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize,
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
 ) -> HipResult<WeightTensor> {
     let (info, data) = hfq
         .tensor_data_vec(name)
@@ -724,13 +1035,68 @@ fn load_weight_raw(
     weight_tensor_from_raw(gpu, info.quant_type, &data, m, k, name)
 }
 
+fn load_mtp_moe_ffn(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    config: &Qwen35MtpHeadConfig,
+) -> HipResult<Qwen35MtpMoeFfnWeights> {
+    let n_exp = config.num_experts;
+    let dim = config.n_embd;
+    let mi = config.moe_intermediate_size;
+    let smi = config.shared_expert_intermediate_size;
+    assert!(n_exp > 0, "MoE MTP config has num_experts=0");
+    assert!(mi > 0, "MoE MTP config has moe_intermediate_size=0");
+    assert!(
+        smi > 0,
+        "MoE MTP config has shared_expert_intermediate_size=0"
+    );
+
+    let router = load_weight_raw(hfq, gpu, "moe_router", n_exp, dim)?;
+    let shared_expert_gate = load_weight_raw(hfq, gpu, "moe_shared_expert_gate", 1, dim)?;
+    let shared_expert = Qwen35MtpMoeSharedExpertWeights {
+        gate: load_weight_raw(hfq, gpu, "moe_shared_gate", smi, dim)?,
+        up: load_weight_raw(hfq, gpu, "moe_shared_up", smi, dim)?,
+        down: load_weight_raw(hfq, gpu, "moe_shared_down", dim, smi)?,
+    };
+
+    let mut experts = Vec::with_capacity(n_exp);
+    for x in 0..n_exp {
+        let gate_up = load_weight_raw(hfq, gpu, &format!("moe_experts.{x}.gate_up"), 2 * mi, dim)?;
+        let down = load_weight_raw(hfq, gpu, &format!("moe_experts.{x}.down"), dim, mi)?;
+        experts.push(Qwen35MtpMoeExpertWeights { gate_up, down });
+    }
+
+    let mut gu_ptrs: Vec<u64> = Vec::with_capacity(n_exp);
+    let mut dn_ptrs: Vec<u64> = Vec::with_capacity(n_exp);
+    for e in &experts {
+        gu_ptrs.push(e.gate_up.buf.buf.as_ptr() as u64);
+        dn_ptrs.push(e.down.buf.buf.as_ptr() as u64);
+    }
+    let gu_bytes: Vec<u8> = gu_ptrs.iter().flat_map(|p| p.to_ne_bytes()).collect();
+    let dn_bytes: Vec<u8> = dn_ptrs.iter().flat_map(|p| p.to_ne_bytes()).collect();
+    let expert_gate_up_ptrs = gpu.alloc_tensor(&[2 * n_exp], DType::F32)?;
+    let expert_down_ptrs = gpu.alloc_tensor(&[2 * n_exp], DType::F32)?;
+    gpu.hip.memcpy_htod(&expert_gate_up_ptrs.buf, &gu_bytes)?;
+    gpu.hip.memcpy_htod(&expert_down_ptrs.buf, &dn_bytes)?;
+
+    Ok(Qwen35MtpMoeFfnWeights {
+        router,
+        shared_expert,
+        shared_expert_gate,
+        experts,
+        expert_gate_up_ptrs,
+        expert_down_ptrs,
+    })
+}
+
 /// Cross-check the on-disk shape against the caller's expected (m, k).
 /// Catches silent dim mismatches (e.g. tied vocab, head split done wrong).
 fn sanity_check_2d_shape(name: &str, info: &HfqTensorInfo, m: usize, k: usize) {
     if info.shape.len() != 2 {
         panic!(
             ".mtp tensor '{name}': expected 2D shape, got {}D = {:?}",
-            info.shape.len(), info.shape,
+            info.shape.len(),
+            info.shape,
         );
     }
     let on_disk_m = info.shape[0] as usize;
@@ -749,7 +1115,12 @@ fn sanity_check_2d_shape(name: &str, info: &HfqTensorInfo, m: usize, k: usize) {
 /// dispatch table from `qwen35::load_weight_tensor_raw`, restricted to the
 /// quant types `mtp_extract` actually emits (MQ4, Q8_F16=Q8_0, F16, F32).
 fn weight_tensor_from_raw(
-    gpu: &Gpu, quant_type: u8, data: &[u8], m: usize, k: usize, name: &str,
+    gpu: &Gpu,
+    quant_type: u8,
+    data: &[u8],
+    m: usize,
+    k: usize,
+    name: &str,
 ) -> HipResult<WeightTensor> {
     match quant_type {
         13 => {
@@ -759,33 +1130,63 @@ fn weight_tensor_from_raw(
                 ".mtp tensor '{name}' is MQ4G256 with K={k} not divisible by 256"
             );
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::MQ4G256,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         3 => {
             // Q8_F16 (group_size=32, 34 bytes/group) — same byte layout as
             // GGML Q8_0; existing gemv_q8_0 dispatch works directly.
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::Q8_0, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::Q8_0,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         1 => {
             // F16 → dequantize on host, upload as F32 (no GPU-native F16
             // GEMV; the trunk does the same conversion in load_weight_tensor_raw).
-            let f32_data: Vec<f32> = data.chunks_exact(2)
+            let f32_data: Vec<f32> = data
+                .chunks_exact(2)
                 .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
                 .collect();
             let bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
-                    f32_data.as_ptr() as *const u8,
-                    f32_data.len() * 4,
-                )
+                std::slice::from_raw_parts(f32_data.as_ptr() as *const u8, f32_data.len() * 4)
             };
             let buf = gpu.upload_raw(bytes, &[m, k])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::F32,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         2 => {
             // F32 raw.
             let buf = gpu.upload_raw(data, &[m, k])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::F32,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         other => panic!(
             ".mtp tensor '{name}': unsupported quant_type={other} \
@@ -842,13 +1243,25 @@ pub fn mtp_head_forward(
     // `scratch.t_mtp_out` and leaves `scratch.ffn_out` holding the same
     // hidden (alias for the LM-head path).
     mtp_head_forward_block_only(
-        gpu, head, scratch, kv, next_token, prev_hidden, None, pos,
+        gpu,
+        head,
+        scratch,
+        kv,
+        next_token,
+        prev_hidden,
+        None,
+        pos,
         trunk_weights,
     )?;
 
     // Standard single-step lm_head: shared_head_norm + GEMV over t_mtp_out.
     let w = &head.weights;
-    gpu.rmsnorm_f32(&scratch.t_mtp_out, &w.shared_head_norm, &scratch.tmp, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_f32(
+        &scratch.t_mtp_out,
+        &w.shared_head_norm,
+        &scratch.tmp,
+        cfg.rms_norm_eps,
+    )?;
     weight_gemv(gpu, lm_head_weights, &scratch.tmp, &scratch.logits)?;
 
     Ok(())
@@ -882,32 +1295,58 @@ pub fn mtp_head_forward_compressed(
     pos: usize,
     trunk_weights: &Qwen35Weights,
 ) -> HipResult<()> {
-    let cfg = &head.config;
-    let w = &head.weights;
-    let lm_head_draft = w.lm_head_draft.as_ref()
-        .expect("mtp_head_forward_compressed called but head has no lm_head_draft sidecar");
-    let logits_c = scratch.logits_compressed.as_ref()
-        .expect("mtp_head_forward_compressed: scratch.logits_compressed not allocated; \
-                 call Qwen35MtpHeadScratch::ensure_compressed_logits first");
-
-    assert_eq!(
-        lm_head_draft.k, cfg.n_embd,
-        "mtp_head_forward_compressed: lm_head_draft.k={} but n_embd={}",
-        lm_head_draft.k, cfg.n_embd,
-    );
-
     // Block forward — identical to mtp_head_forward; produces t_mtp_out.
     mtp_head_forward_block_only(
-        gpu, head, scratch, kv, next_token, prev_hidden, None, pos,
+        gpu,
+        head,
+        scratch,
+        kv,
+        next_token,
+        prev_hidden,
+        None,
+        pos,
         trunk_weights,
     )?;
 
-    // Compressed lm_head dispatch: shared_head_norm into tmp, then GEMV
-    // against the K-row compressed weight matrix into logits_compressed.
-    gpu.rmsnorm_f32(&scratch.t_mtp_out, &w.shared_head_norm, &scratch.tmp, cfg.rms_norm_eps)?;
-    weight_gemv(gpu, lm_head_draft, &scratch.tmp, logits_c)?;
+    mtp_head_apply_lm_head_draft(gpu, head, scratch)?;
 
     Ok(())
+}
+
+/// Applies the compressed draft LM head to `scratch.t_mtp_out`.
+///
+/// This is the shared tail of the host-mediated compressed path and the
+/// device-token-chain path. Keeping it in one helper prevents those paths from
+/// drifting if the compressed head gains another post-block transform.
+pub fn mtp_head_apply_lm_head_draft(
+    gpu: &mut Gpu,
+    head: &Qwen35MtpHead,
+    scratch: &Qwen35MtpHeadScratch,
+) -> HipResult<()> {
+    let cfg = &head.config;
+    let w = &head.weights;
+    let lm_head_draft = w
+        .lm_head_draft
+        .as_ref()
+        .expect("mtp_head_apply_lm_head_draft called but head has no lm_head_draft sidecar");
+    let logits_c = scratch.logits_compressed.as_ref().expect(
+        "mtp_head_apply_lm_head_draft: scratch.logits_compressed not allocated; \
+                 call Qwen35MtpHeadScratch::ensure_compressed_logits first",
+    );
+
+    assert_eq!(
+        lm_head_draft.k, cfg.n_embd,
+        "mtp_head_apply_lm_head_draft: lm_head_draft.k={} but n_embd={}",
+        lm_head_draft.k, cfg.n_embd,
+    );
+
+    gpu.rmsnorm_f32(
+        &scratch.t_mtp_out,
+        &w.shared_head_norm,
+        &scratch.tmp,
+        cfg.rms_norm_eps,
+    )?;
+    weight_gemv(gpu, lm_head_draft, &scratch.tmp, logits_c)
 }
 
 /// Block-only variant of [`mtp_head_forward`]: runs the NextN concat +
@@ -952,12 +1391,11 @@ pub fn mtp_head_forward_block_only(
     trunk_weights: &Qwen35Weights,
 ) -> HipResult<()> {
     let cfg = &head.config;
-    let w = &head.weights;
     let n_embd = cfg.n_embd;
-    let kv_dim = cfg.head_dim * cfg.n_head_kv;
 
     assert_eq!(
-        prev_hidden.numel(), n_embd,
+        prev_hidden.numel(),
+        n_embd,
         "mtp_head_forward_block_only: prev_hidden has {} elems but expected n_embd={n_embd}",
         prev_hidden.numel(),
     );
@@ -969,7 +1407,61 @@ pub fn mtp_head_forward_block_only(
 
     // Upload position scalar for the RoPE / attention kernels.
     let pos_i32 = pos as i32;
-    gpu.hip.memcpy_htod(&scratch.pos_buf, &pos_i32.to_ne_bytes())?;
+    gpu.hip
+        .memcpy_htod(&scratch.pos_buf, &pos_i32.to_ne_bytes())?;
+
+    mtp_head_forward_block_only_with_pos_buf(
+        gpu,
+        head,
+        scratch,
+        kv,
+        next_token,
+        prev_hidden,
+        next_token_embed,
+        &scratch.pos_buf,
+        pos,
+        pos + 1,
+        trunk_weights,
+    )
+}
+
+/// Graph-capturable variant of [`mtp_head_forward_block_only`].
+///
+/// `pos_buf` must point at an i32 device slot containing `pos`. Captured
+/// proposal graphs pass a stable per-step slot here and update the slot bytes
+/// before each graph launch, avoiding scalar position arguments baked into
+/// captured nodes. `seq_len_hint` controls the attention launch shape and
+/// shared-memory reservation; graph callers pass a tier cap that is >= every
+/// replayed `pos + 1`.
+#[allow(clippy::too_many_arguments)]
+pub fn mtp_head_forward_block_only_with_pos_buf(
+    gpu: &mut Gpu,
+    head: &Qwen35MtpHead,
+    scratch: &Qwen35MtpHeadScratch,
+    kv: &mut Qwen35MtpHeadKvCache,
+    next_token: u32,
+    prev_hidden: &GpuTensor,
+    next_token_embed: Option<&GpuTensor>,
+    pos_buf: &DeviceBuffer,
+    pos: usize,
+    seq_len_hint: usize,
+    trunk_weights: &Qwen35Weights,
+) -> HipResult<()> {
+    let cfg = &head.config;
+    let w = &head.weights;
+    let n_embd = cfg.n_embd;
+
+    assert_eq!(
+        prev_hidden.numel(),
+        n_embd,
+        "mtp_head_forward_block_only_with_pos_buf: prev_hidden has {} elems but expected n_embd={n_embd}",
+        prev_hidden.numel(),
+    );
+    assert!(
+        pos < kv.max_seq,
+        "mtp_head_forward_block_only_with_pos_buf: pos={pos} >= kv.max_seq={}",
+        kv.max_seq,
+    );
 
     // ── 1. Token embedding (table lookup OR caller-supplied override) ────
     let dim_bytes = n_embd * 4;
@@ -982,23 +1474,34 @@ pub fn mtp_head_forward_block_only(
         // Lossy-recursion path: feed the caller's pre-computed activation
         // directly into the e_norm input slot. Aliasing-safe (separate
         // backing buffers — caller passes the previous step's t_mtp_out).
-        gpu.hip.memcpy_dtod_at(&scratch.tok_embd.buf, 0, &embed.buf, 0, dim_bytes)?;
+        gpu.memcpy_dtod_at_auto(&scratch.tok_embd.buf, 0, &embed.buf, 0, dim_bytes)?;
     } else {
         embed_lookup_into(gpu, trunk_weights, &scratch.tok_embd, next_token, n_embd)?;
     }
 
     // ── 2. RMSNorm both inputs to the NextN projection ───────────────────
-    gpu.rmsnorm_f32(&scratch.tok_embd, &w.enorm, &scratch.e_norm, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_f32(
+        &scratch.tok_embd,
+        &w.enorm,
+        &scratch.e_norm,
+        cfg.rms_norm_eps,
+    )?;
     gpu.rmsnorm_f32(prev_hidden, &w.hnorm, &scratch.h_norm, cfg.rms_norm_eps)?;
 
     // ── 3. concat = [e_norm | h_norm], then cur = eh_proj @ concat ───────
-    gpu.hip.memcpy_dtod_at(&scratch.concat.buf, 0, &scratch.e_norm.buf, 0, dim_bytes)?;
-    gpu.hip.memcpy_dtod_at(&scratch.concat.buf, dim_bytes, &scratch.h_norm.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(&scratch.concat.buf, 0, &scratch.e_norm.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(
+        &scratch.concat.buf,
+        dim_bytes,
+        &scratch.h_norm.buf,
+        0,
+        dim_bytes,
+    )?;
     weight_gemv(gpu, &w.eh_proj, &scratch.concat, &scratch.cur)?;
 
     // Save inpSA for the attention residual (cur is about to be norm'd
     // out-of-place into scratch.tmp).
-    gpu.hip.memcpy_dtod_at(&scratch.residual.buf, 0, &scratch.cur.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(&scratch.residual.buf, 0, &scratch.cur.buf, 0, dim_bytes)?;
 
     // ── 4. Pre-attn norm + Q/K/V projections ─────────────────────────────
     gpu.rmsnorm_f32(&scratch.cur, &w.attn_norm, &scratch.tmp, cfg.rms_norm_eps)?;
@@ -1007,23 +1510,43 @@ pub fn mtp_head_forward_block_only(
     // Q (head-major first half) and gate (second half) per-head. Mirror
     // qwen35.rs:2402-2414.
     weight_gemv(gpu, &w.wq, &scratch.tmp, &scratch.q_full)?;
-    gpu.deinterleave_f32(&scratch.q_full, &scratch.q, &scratch.gate, cfg.n_head, cfg.head_dim)?;
+    gpu.deinterleave_f32(
+        &scratch.q_full,
+        &scratch.q,
+        &scratch.gate,
+        cfg.n_head,
+        cfg.head_dim,
+    )?;
     gpu.rmsnorm_batched(
-        &scratch.q, &w.attn_q_norm, &scratch.q,
-        cfg.n_head, cfg.head_dim, cfg.rms_norm_eps,
+        &scratch.q,
+        &w.attn_q_norm,
+        &scratch.q,
+        cfg.n_head,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     weight_gemv(gpu, &w.wk, &scratch.tmp, &scratch.k)?;
     weight_gemv(gpu, &w.wv, &scratch.tmp, &scratch.v)?;
     gpu.rmsnorm_batched(
-        &scratch.k, &w.attn_k_norm, &scratch.k,
-        cfg.n_head_kv, cfg.head_dim, cfg.rms_norm_eps,
+        &scratch.k,
+        &w.attn_k_norm,
+        &scratch.k,
+        cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     // ── 5. RoPE (partial-interleaved, mirrors trunk's full-attn layer) ───
     gpu.rope_partial_interleaved_f32(
-        &scratch.q, &scratch.k, &scratch.pos_buf,
-        cfg.n_head, cfg.n_head_kv, cfg.head_dim, cfg.n_rot, cfg.rope_theta,
+        &scratch.q,
+        &scratch.k,
+        pos_buf,
+        cfg.n_head,
+        cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.n_rot,
+        cfg.rope_theta,
     )?;
 
     // ── 6+7. KV cache write + attention (dispatch on kv.kv_mode) ─────────
@@ -1037,33 +1560,67 @@ pub fn mtp_head_forward_block_only(
     match kv.kv_mode {
         MtpKvMode::Q8 => {
             gpu.kv_cache_write_q8_0(
-                &kv.inner.k_gpu[0], &scratch.k, &scratch.pos_buf,
-                cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.k_gpu[0],
+                &scratch.k,
+                pos_buf,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.kv_cache_write_q8_0(
-                &kv.inner.v_gpu[0], &scratch.v, &scratch.pos_buf,
-                cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.v_gpu[0],
+                &scratch.v,
+                pos_buf,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.attention_q8_0_kv(
-                &scratch.q, &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.attn_out, &scratch.pos_buf, pos + 1,
-                cfg.n_head, cfg.n_head_kv, cfg.head_dim, kv.inner.physical_cap,
+                &scratch.q,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.attn_out,
+                pos_buf,
+                seq_len_hint,
+                cfg.n_head,
+                cfg.n_head_kv,
+                cfg.head_dim,
+                kv.inner.physical_cap,
             )?;
         }
         MtpKvMode::Asym3 => {
-            let ct = kv.inner.givens_cos.as_ref()
+            let ct = kv
+                .inner
+                .givens_cos
+                .as_ref()
                 .expect("MtpKvMode::Asym3 requires kv.inner.givens_cos to be Some");
-            let st = kv.inner.givens_sin.as_ref()
+            let st = kv
+                .inner
+                .givens_sin
+                .as_ref()
                 .expect("MtpKvMode::Asym3 requires kv.inner.givens_sin to be Some");
             gpu.kv_cache_write_asym3_fused(
-                &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.k, &scratch.v, &scratch.pos_buf,
-                ct, st, cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.k,
+                &scratch.v,
+                pos_buf,
+                ct,
+                st,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.attention_flash_asym3(
-                &scratch.q, &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.attn_out, &scratch.pos_buf, ct, st, pos + 1,
-                cfg.n_head, cfg.n_head_kv, cfg.head_dim, kv.inner.physical_cap,
+                &scratch.q,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.attn_out,
+                pos_buf,
+                ct,
+                st,
+                seq_len_hint,
+                cfg.n_head,
+                cfg.n_head_kv,
+                cfg.head_dim,
+                kv.inner.physical_cap,
                 &scratch.flash_partials,
             )?;
         }
@@ -1071,19 +1628,40 @@ pub fn mtp_head_forward_block_only(
             // Fwht uses the asym4-shaped k/v buffers + the cos/sin slots hold
             // signs1/signs2 (128 elements each). FWHT operates on 128-element
             // halves; head_dim=256 processes 2 halves reusing the same signs.
-            let ct = kv.inner.givens_cos.as_ref()
+            let ct = kv
+                .inner
+                .givens_cos
+                .as_ref()
                 .expect("MtpKvMode::Fwht4 requires kv.inner.givens_cos (signs1) to be Some");
-            let st = kv.inner.givens_sin.as_ref()
+            let st = kv
+                .inner
+                .givens_sin
+                .as_ref()
                 .expect("MtpKvMode::Fwht4 requires kv.inner.givens_sin (signs2) to be Some");
             gpu.kv_cache_write_fwht4_fused(
-                &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.k, &scratch.v, &scratch.pos_buf,
-                ct, st, cfg.n_head_kv, cfg.head_dim,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.k,
+                &scratch.v,
+                pos_buf,
+                ct,
+                st,
+                cfg.n_head_kv,
+                cfg.head_dim,
             )?;
             gpu.attention_flash_fwht4(
-                &scratch.q, &kv.inner.k_gpu[0], &kv.inner.v_gpu[0],
-                &scratch.attn_out, &scratch.pos_buf, ct, st, pos + 1,
-                cfg.n_head, cfg.n_head_kv, cfg.head_dim, kv.inner.physical_cap,
+                &scratch.q,
+                &kv.inner.k_gpu[0],
+                &kv.inner.v_gpu[0],
+                &scratch.attn_out,
+                pos_buf,
+                ct,
+                st,
+                seq_len_hint,
+                cfg.n_head,
+                cfg.n_head_kv,
+                cfg.head_dim,
+                kv.inner.physical_cap,
                 &scratch.flash_partials,
             )?;
         }
@@ -1104,17 +1682,153 @@ pub fn mtp_head_forward_block_only(
     // (post-attention-layernorm in HF lingo = pre-FFN norm here, with the
     // "attn_post_norm" name reflecting its source position in the .mtp
     // metadata file).
-    gpu.rmsnorm_f32(&scratch.o, &w.attn_post_norm, &scratch.tmp, cfg.rms_norm_eps)?;
-    weight_gemv(gpu, &w.ffn_gate, &scratch.tmp, &scratch.gate_ffn)?;
-    weight_gemv(gpu, &w.ffn_up,   &scratch.tmp, &scratch.up)?;
-    gpu.silu_mul_f32(&scratch.gate_ffn, &scratch.up, &scratch.ffn_hidden)?;
-    weight_gemv(gpu, &w.ffn_down, &scratch.ffn_hidden, &scratch.ffn_out)?;
-    gpu.add_inplace_f32(&scratch.ffn_out, &scratch.o)?;
+    gpu.rmsnorm_f32(
+        &scratch.o,
+        &w.attn_post_norm,
+        &scratch.tmp,
+        cfg.rms_norm_eps,
+    )?;
+    match &w.ffn {
+        Qwen35MtpFfnWeights::Dense(ffn) => {
+            weight_gemv(gpu, &ffn.gate, &scratch.tmp, &scratch.gate_ffn)?;
+            weight_gemv(gpu, &ffn.up, &scratch.tmp, &scratch.up)?;
+            gpu.silu_mul_f32(&scratch.gate_ffn, &scratch.up, &scratch.ffn_hidden)?;
+            weight_gemv(gpu, &ffn.down, &scratch.ffn_hidden, &scratch.ffn_out)?;
+            gpu.add_inplace_f32(&scratch.ffn_out, &scratch.o)?;
+        }
+        Qwen35MtpFfnWeights::Moe(ffn) => {
+            gpu.memcpy_dtod_at_auto(&scratch.ffn_out.buf, 0, &scratch.o.buf, 0, dim_bytes)?;
+            mtp_moe_ffn_decode(gpu, ffn, &scratch.tmp, &scratch.ffn_out, cfg, scratch)?;
+        }
+    }
     // scratch.ffn_out now holds the post-FFN, pre-LM-head-norm hidden.
 
     // Snapshot for callers that want to chain into n+2 prediction OR feed
     // into the batched `mtp_head_apply_lm_head_batched` end-of-chain reduce.
-    gpu.hip.memcpy_dtod_at(&scratch.t_mtp_out.buf, 0, &scratch.ffn_out.buf, 0, dim_bytes)?;
+    gpu.memcpy_dtod_at_auto(
+        &scratch.t_mtp_out.buf,
+        0,
+        &scratch.ffn_out.buf,
+        0,
+        dim_bytes,
+    )?;
+
+    Ok(())
+}
+
+fn mtp_moe_ffn_decode(
+    gpu: &mut Gpu,
+    ffn: &Qwen35MtpMoeFfnWeights,
+    x_norm: &GpuTensor,
+    x_residual: &GpuTensor,
+    cfg: &Qwen35MtpHeadConfig,
+    scratch: &Qwen35MtpHeadScratch,
+) -> HipResult<()> {
+    let dim = cfg.n_embd;
+    let mi = cfg.moe_intermediate_size;
+    let smi = cfg.shared_expert_intermediate_size;
+    let k_top = cfg.num_experts_per_tok;
+    assert_eq!(k_top, 8, "MoE MTP decode currently expects top_k=8");
+    assert_eq!(ffn.experts.len(), cfg.num_experts);
+
+    let router_logits = scratch
+        .moe_router_logits
+        .as_ref()
+        .expect("MoE MTP scratch not allocated");
+    let scalar_buf = scratch.moe_scalar_buf.as_ref().expect("MoE MTP scratch");
+    let x_rot = scratch.moe_x_rot.as_ref().expect("MoE MTP scratch");
+    let gate_buf = scratch.moe_gate_buf.as_ref().expect("MoE MTP scratch");
+    let up_buf = scratch.moe_up_buf.as_ref().expect("MoE MTP scratch");
+    let ffn_hidden = scratch.moe_ffn_hidden.as_ref().expect("MoE MTP scratch");
+    let ffn_out = scratch.moe_ffn_out.as_ref().expect("MoE MTP scratch");
+    let gate_batch = scratch.moe_gate_batch.as_ref().expect("MoE MTP scratch");
+    let up_batch = scratch.moe_up_batch.as_ref().expect("MoE MTP scratch");
+    let rot_batch = scratch.moe_rot_batch.as_ref().expect("MoE MTP scratch");
+    let topk_indices = scratch.moe_topk_indices.as_ref().expect("MoE MTP scratch");
+    let topk_weights = scratch.moe_topk_weights.as_ref().expect("MoE MTP scratch");
+    let down_expanded = scratch.moe_down_expanded.as_ref().expect("MoE MTP scratch");
+
+    weight_gemv(gpu, &ffn.router, x_norm, router_logits)?;
+    gpu.softmax_f32(router_logits)?;
+    gpu.moe_topk_renorm_k8(
+        router_logits,
+        topk_indices,
+        topk_weights,
+        cfg.num_experts,
+        cfg.norm_topk_prob,
+    )?;
+
+    weight_gemv(gpu, &ffn.shared_expert_gate, x_norm, scalar_buf)?;
+    let shared_gate = gate_buf.sub_offset(0, smi);
+    let shared_up = up_buf.sub_offset(0, smi);
+    weight_gemv(gpu, &ffn.shared_expert.gate, x_norm, &shared_gate)?;
+    weight_gemv(gpu, &ffn.shared_expert.up, x_norm, &shared_up)?;
+    if ffn.shared_expert.down.gpu_dtype == DType::MQ4G256 {
+        gpu.ensure_mq_signs()?;
+        let x_rot_alias = GpuTensor {
+            buf: unsafe { gpu.mq_x_rot.as_ref().unwrap().buf.alias() },
+            shape: vec![gpu.mq_x_rot.as_ref().unwrap().buf.size() / 4],
+            dtype: DType::F32,
+        };
+        fused_silu_mul_rotate_mq_for(
+            gpu,
+            &ffn.shared_expert.down,
+            &shared_gate,
+            &shared_up,
+            &x_rot_alias,
+            smi,
+        )?;
+        gpu.gemv_hfq4g256_residual_sigmoid_scaled_gpu(
+            &ffn.shared_expert.down.buf,
+            &x_rot_alias,
+            x_residual,
+            scalar_buf,
+            ffn.shared_expert.down.m,
+            ffn.shared_expert.down.k,
+        )?;
+    } else {
+        gpu.sigmoid_f32(scalar_buf)?;
+        let shared_hid = ffn_hidden.sub_offset(0, smi);
+        gpu.silu_mul_f32(&shared_gate, &shared_up, &shared_hid)?;
+        weight_gemv(gpu, &ffn.shared_expert.down, &shared_hid, ffn_out)?;
+        gpu.scaled_add_inplace_gpu_scalar_f32(x_residual, ffn_out, scalar_buf)?;
+    }
+
+    let e0 = ffn.experts.first().expect("MoE MTP has no routed experts");
+    assert_eq!(
+        e0.gate_up.gpu_dtype,
+        DType::MQ4G256,
+        "MoE MTP routed gate_up currently requires MQ4G256"
+    );
+    assert_eq!(
+        e0.down.gpu_dtype,
+        DType::MQ4G256,
+        "MoE MTP routed down currently requires MQ4G256"
+    );
+    rotate_x_mq_for(gpu, &e0.gate_up, x_norm, x_rot, dim)?;
+    gpu.gemv_hfq4g256_moe_gate_up_k8_indexed(
+        &ffn.expert_gate_up_ptrs,
+        topk_indices,
+        x_rot,
+        gate_batch,
+        up_batch,
+        2 * mi,
+        e0.gate_up.k,
+    )?;
+    fused_silu_mul_rotate_mq_batched_for(
+        gpu, &e0.down, gate_batch, up_batch, rot_batch, mi, k_top,
+    )?;
+    gpu.gemv_hfq4g256_moe_down_k8_indexed_batched_expanded(
+        &ffn.expert_down_ptrs,
+        topk_indices,
+        rot_batch,
+        down_expanded,
+        e0.down.m,
+        e0.down.k,
+        k_top,
+        1,
+    )?;
+    gpu.moe_down_combine_k8_batched(down_expanded, topk_weights, x_residual, e0.down.m, k_top, 1)?;
 
     Ok(())
 }
@@ -1158,66 +1872,120 @@ pub fn mtp_head_apply_lm_head_batched(
     assert!(
         t_mtp_outs_stacked.numel() >= n * n_embd,
         "t_mtp_outs_stacked too small: {} < n*n_embd ({})",
-        t_mtp_outs_stacked.numel(), n * n_embd,
+        t_mtp_outs_stacked.numel(),
+        n * n_embd,
     );
     assert!(
         tmp_batched.numel() >= n * n_embd,
         "tmp_batched too small: {} < n*n_embd ({})",
-        tmp_batched.numel(), n * n_embd,
+        tmp_batched.numel(),
+        n * n_embd,
     );
     assert!(
         logits_batched.numel() >= n * vocab,
         "logits_batched too small: {} < n*vocab ({})",
-        logits_batched.numel(), n * vocab,
+        logits_batched.numel(),
+        n * vocab,
     );
 
     // Per-row shared_head_norm.
-    gpu.rmsnorm_batched(t_mtp_outs_stacked, &w.shared_head_norm, tmp_batched,
-                        n, n_embd, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_batched(
+        t_mtp_outs_stacked,
+        &w.shared_head_norm,
+        tmp_batched,
+        n,
+        n_embd,
+        cfg.rms_norm_eps,
+    )?;
 
     // Per-dtype batched LM head dispatch (mirrors mtp_probe.rs:278+).
     let logits_view = logits_batched.sub_offset(0, n * vocab);
     match lm_head_weights.gpu_dtype {
         DType::Q8_0 => {
             gpu.gemm_q8_0_batched(
-                &lm_head_weights.buf, tmp_batched, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                tmp_batched,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &lm_head_weights.buf, tmp_batched, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                tmp_batched,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::MQ4G256 => {
             let rot_view = rot_batched.sub_offset(0, n * lm_head_weights.k);
-            llama::rotate_x_mq_batched_for(gpu, lm_head_weights, tmp_batched, &rot_view, lm_head_weights.k, n)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                lm_head_weights,
+                tmp_batched,
+                &rot_view,
+                lm_head_weights.k,
+                n,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &lm_head_weights.buf, &rot_view, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                &rot_view,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::MQ3G256 => {
             let rot_view = rot_batched.sub_offset(0, n * lm_head_weights.k);
-            llama::rotate_x_mq_batched_for(gpu, lm_head_weights, tmp_batched, &rot_view, lm_head_weights.k, n)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                lm_head_weights,
+                tmp_batched,
+                &rot_view,
+                lm_head_weights.k,
+                n,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &lm_head_weights.buf, &rot_view, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                &rot_view,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &lm_head_weights.buf, tmp_batched, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                tmp_batched,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         DType::MQ6G256 => {
             let rot_view = rot_batched.sub_offset(0, n * lm_head_weights.k);
-            llama::rotate_x_mq_batched_for(gpu, lm_head_weights, tmp_batched, &rot_view, lm_head_weights.k, n)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                lm_head_weights,
+                tmp_batched,
+                &rot_view,
+                lm_head_weights.k,
+                n,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &lm_head_weights.buf, &rot_view, &logits_view,
-                lm_head_weights.m, lm_head_weights.k, n,
+                &lm_head_weights.buf,
+                &rot_view,
+                &logits_view,
+                lm_head_weights.m,
+                lm_head_weights.k,
+                n,
             )?;
         }
         _ => {
@@ -1243,11 +2011,15 @@ fn embed_lookup_into(
     dim: usize,
 ) -> HipResult<()> {
     match weights.embd_format {
-        EmbeddingFormat::HFQ4G256 => gpu.embedding_lookup_hfq4g256(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::HFQ4G128 => gpu.embedding_lookup_hfq4g128(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::Q8_0     => gpu.embedding_lookup_q8(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::Q4K      => gpu.embedding_lookup_q4k(&weights.token_embd, out, token, dim),
-        EmbeddingFormat::F32      => gpu.embedding_lookup(&weights.token_embd, out, token, dim),
+        EmbeddingFormat::HFQ4G256 => {
+            gpu.embedding_lookup_hfq4g256(&weights.token_embd, out, token, dim)
+        }
+        EmbeddingFormat::HFQ4G128 => {
+            gpu.embedding_lookup_hfq4g128(&weights.token_embd, out, token, dim)
+        }
+        EmbeddingFormat::Q8_0 => gpu.embedding_lookup_q8(&weights.token_embd, out, token, dim),
+        EmbeddingFormat::Q4K => gpu.embedding_lookup_q4k(&weights.token_embd, out, token, dim),
+        EmbeddingFormat::F32 => gpu.embedding_lookup(&weights.token_embd, out, token, dim),
     }
 }
 
@@ -1268,26 +2040,26 @@ pub struct Qwen35MtpHeadBatchedScratch {
     pub q_dim: usize,
     pub kv_dim: usize,
     // Activations
-    pub tok_embd: GpuTensor,    // [max_n × n_embd]
-    pub e_norm: GpuTensor,      // [max_n × n_embd]
-    pub h_norm: GpuTensor,      // [max_n × n_embd]
-    pub concat: GpuTensor,      // [max_n × 2 × n_embd]
-    pub cur: GpuTensor,         // [max_n × n_embd]
-    pub residual: GpuTensor,    // [max_n × n_embd]
-    pub tmp: GpuTensor,         // [max_n × n_embd]
+    pub tok_embd: GpuTensor, // [max_n × n_embd]
+    pub e_norm: GpuTensor,   // [max_n × n_embd]
+    pub h_norm: GpuTensor,   // [max_n × n_embd]
+    pub concat: GpuTensor,   // [max_n × 2 × n_embd]
+    pub cur: GpuTensor,      // [max_n × n_embd]
+    pub residual: GpuTensor, // [max_n × n_embd]
+    pub tmp: GpuTensor,      // [max_n × n_embd]
     // Attention sub-block
-    pub q_full: GpuTensor,      // [max_n × 2 × q_dim]
-    pub q: GpuTensor,           // [max_n × q_dim]
-    pub gate: GpuTensor,        // [max_n × q_dim]
-    pub k: GpuTensor,           // [max_n × kv_dim]
-    pub v: GpuTensor,           // [max_n × kv_dim]
-    pub attn_out: GpuTensor,    // [max_n × q_dim]
-    pub o: GpuTensor,           // [max_n × n_embd]
+    pub q_full: GpuTensor,   // [max_n × 2 × q_dim]
+    pub q: GpuTensor,        // [max_n × q_dim]
+    pub gate: GpuTensor,     // [max_n × q_dim]
+    pub k: GpuTensor,        // [max_n × kv_dim]
+    pub v: GpuTensor,        // [max_n × kv_dim]
+    pub attn_out: GpuTensor, // [max_n × q_dim]
+    pub o: GpuTensor,        // [max_n × n_embd]
     // FFN sub-block
-    pub gate_ffn: GpuTensor,    // [max_n × n_ff]
-    pub up: GpuTensor,          // [max_n × n_ff]
-    pub ffn_hidden: GpuTensor,  // [max_n × n_ff]
-    pub ffn_out: GpuTensor,     // [max_n × n_embd]
+    pub gate_ffn: GpuTensor,   // [max_n × n_ff]
+    pub up: GpuTensor,         // [max_n × n_ff]
+    pub ffn_hidden: GpuTensor, // [max_n × n_ff]
+    pub ffn_out: GpuTensor,    // [max_n × n_embd]
     /// Stacked post-FFN, pre-LM-head-norm hidden — feeds
     /// `mtp_head_apply_lm_head_batched` directly. [max_n × n_embd]
     pub t_mtp_outs: GpuTensor,
@@ -1297,7 +2069,10 @@ pub struct Qwen35MtpHeadBatchedScratch {
 
 impl Qwen35MtpHeadBatchedScratch {
     pub fn new(gpu: &mut Gpu, config: &Qwen35MtpHeadConfig, max_n: usize) -> HipResult<Self> {
-        assert!(max_n >= 1, "Qwen35MtpHeadBatchedScratch: max_n must be >= 1");
+        assert!(
+            max_n >= 1,
+            "Qwen35MtpHeadBatchedScratch: max_n must be >= 1"
+        );
         let dim = config.n_embd;
         let q_dim = config.head_dim * config.n_head;
         let kv_dim = config.head_dim * config.n_head_kv;
@@ -1373,8 +2148,7 @@ fn weight_gemm_batched(
         DType::HFQ4G256 => gpu.gemm_hfq4g256(&w.buf, x_batched, y_batched, w.m, w.k, n),
         DType::MQ4G256 => {
             // MQ4 needs an FWHT-rotated x first (matches trunk lm_head + dflash patterns).
-            let rot = rotated_x_scratch
-                .expect("MQ4 batched gemm requires rotated_x_scratch");
+            let rot = rotated_x_scratch.expect("MQ4 batched gemm requires rotated_x_scratch");
             llama::rotate_x_mq_batched_for(gpu, w, x_batched, rot, w.k, n)?;
             gpu.gemm_hfq4g256(&w.buf, rot, y_batched, w.m, w.k, n)
         }
@@ -1457,23 +2231,29 @@ pub fn mtp_head_forward_block_batched(
 
     assert_eq!(next_tokens.len(), n, "next_tokens.len() != n");
     assert_eq!(positions.len(), n, "positions.len() != n");
-    assert!(n <= scratch.max_n, "n={n} > scratch.max_n={}", scratch.max_n);
-    assert!(prev_hiddens_stacked.numel() >= n * dim,
+    assert!(
+        n <= scratch.max_n,
+        "n={n} > scratch.max_n={}",
+        scratch.max_n
+    );
+    assert!(
+        prev_hiddens_stacked.numel() >= n * dim,
         "prev_hiddens_stacked too small: {} < n*dim ({})",
-        prev_hiddens_stacked.numel(), n * dim);
+        prev_hiddens_stacked.numel(),
+        n * dim
+    );
     for &p in positions {
         assert!(
             (p as usize) < kv.max_seq,
-            "position {p} >= kv.max_seq {}", kv.max_seq,
+            "position {p} >= kv.max_seq {}",
+            kv.max_seq,
         );
     }
 
     // Upload positions (i32 stored in F32-typed buffer; aliasing is fine since
     // the kernels read raw bytes via memcpy_htod into the F32 buffer).
     {
-        let bytes = unsafe {
-            std::slice::from_raw_parts(positions.as_ptr() as *const u8, n * 4)
-        };
+        let bytes = unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, n * 4) };
         gpu.hip.memcpy_htod(&scratch.positions.buf, bytes)?;
     }
 
@@ -1489,20 +2269,31 @@ pub fn mtp_head_forward_block_batched(
     let e_norm_view = scratch.e_norm.sub_offset(0, n * dim);
     let prev_view = prev_hiddens_stacked.sub_offset(0, n * dim);
     let h_norm_view = scratch.h_norm.sub_offset(0, n * dim);
-    gpu.rmsnorm_batched(&tok_embd_view, &w.enorm, &e_norm_view, n, dim, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_batched(
+        &tok_embd_view,
+        &w.enorm,
+        &e_norm_view,
+        n,
+        dim,
+        cfg.rms_norm_eps,
+    )?;
     gpu.rmsnorm_batched(&prev_view, &w.hnorm, &h_norm_view, n, dim, cfg.rms_norm_eps)?;
 
     // ── 3. Build concat = [e_norm | h_norm] per slot ─────────────────────
     // Layout: concat[i] = [e_norm[i, 0..dim], h_norm[i, 0..dim]] (length 2*dim).
     for i in 0..n {
         gpu.hip.memcpy_dtod_at(
-            &scratch.concat.buf, i * 2 * dim_bytes,
-            &scratch.e_norm.buf, i * dim_bytes,
+            &scratch.concat.buf,
+            i * 2 * dim_bytes,
+            &scratch.e_norm.buf,
+            i * dim_bytes,
             dim_bytes,
         )?;
         gpu.hip.memcpy_dtod_at(
-            &scratch.concat.buf, i * 2 * dim_bytes + dim_bytes,
-            &scratch.h_norm.buf, i * dim_bytes,
+            &scratch.concat.buf,
+            i * 2 * dim_bytes + dim_bytes,
+            &scratch.h_norm.buf,
+            i * dim_bytes,
             dim_bytes,
         )?;
     }
@@ -1510,14 +2301,18 @@ pub fn mtp_head_forward_block_batched(
     // cur = eh_proj @ concat (per-slot). w.eh_proj has m=n_embd, k=2*n_embd.
     let concat_view = scratch.concat.sub_offset(0, n * 2 * dim);
     let cur_view = scratch.cur.sub_offset(0, n * dim);
-    weight_gemm_batched(gpu, &w.eh_proj, &concat_view, &cur_view, n, rotated_x_scratch)?;
+    weight_gemm_batched(
+        gpu,
+        &w.eh_proj,
+        &concat_view,
+        &cur_view,
+        n,
+        rotated_x_scratch,
+    )?;
 
     // Save residual (inpSA) for the post-attn add.
-    gpu.hip.memcpy_dtod_at(
-        &scratch.residual.buf, 0,
-        &scratch.cur.buf, 0,
-        n * dim_bytes,
-    )?;
+    gpu.hip
+        .memcpy_dtod_at(&scratch.residual.buf, 0, &scratch.cur.buf, 0, n * dim_bytes)?;
 
     // ── 4. Pre-attn norm + Q/K/V projections ─────────────────────────────
     let tmp_view = scratch.tmp.sub_offset(0, n * dim);
@@ -1530,7 +2325,14 @@ pub fn mtp_head_forward_block_batched(
     // Deinterleave per-head into Q + Gate. Output: [n × n_head × head_dim] each.
     let q_view = scratch.q.sub_offset(0, n * q_dim);
     let gate_view = scratch.gate.sub_offset(0, n * q_dim);
-    gpu.deinterleave_f32_batched(&q_full_view, &q_view, &gate_view, cfg.n_head, cfg.head_dim, n)?;
+    gpu.deinterleave_f32_batched(
+        &q_full_view,
+        &q_view,
+        &gate_view,
+        cfg.n_head,
+        cfg.head_dim,
+        n,
+    )?;
 
     // attn_q_norm: per-head normalization of Q.
     // rmsnorm_batched treats `batch` as "rows of length n", and gates the
@@ -1539,8 +2341,12 @@ pub fn mtp_head_forward_block_batched(
     // `batch = n * n_head`, `n = head_dim`. Same convention as the trunk's
     // per-head q_norm at qwen35.rs.
     gpu.rmsnorm_batched(
-        &q_view, &w.attn_q_norm, &q_view,
-        n * cfg.n_head, cfg.head_dim, cfg.rms_norm_eps,
+        &q_view,
+        &w.attn_q_norm,
+        &q_view,
+        n * cfg.n_head,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     // K, V projections.
@@ -1549,14 +2355,25 @@ pub fn mtp_head_forward_block_batched(
     weight_gemm_batched(gpu, &w.wk, &tmp_view, &k_view, n, rotated_x_scratch)?;
     weight_gemm_batched(gpu, &w.wv, &tmp_view, &v_view, n, rotated_x_scratch)?;
     gpu.rmsnorm_batched(
-        &k_view, &w.attn_k_norm, &k_view,
-        n * cfg.n_head_kv, cfg.head_dim, cfg.rms_norm_eps,
+        &k_view,
+        &w.attn_k_norm,
+        &k_view,
+        n * cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.rms_norm_eps,
     )?;
 
     // ── 5. Batched RoPE on Q + K ─────────────────────────────────────────
     gpu.rope_partial_interleaved_f32_batched(
-        &q_view, &k_view, &scratch.positions,
-        cfg.n_head, cfg.n_head_kv, cfg.head_dim, cfg.n_rot, cfg.rope_theta, n,
+        &q_view,
+        &k_view,
+        &scratch.positions,
+        cfg.n_head,
+        cfg.n_head_kv,
+        cfg.head_dim,
+        cfg.n_rot,
+        cfg.rope_theta,
+        n,
     )?;
 
     // ── 6. v1 simplification: per-slot K/V writes + attention = V
@@ -1577,12 +2394,18 @@ pub fn mtp_head_forward_block_batched(
         let v_row = scratch.v.sub_offset(i * kv_dim, kv_dim);
         let pos_slot = scratch.positions.sub_offset(i, 1);
         gpu.kv_cache_write_q8_0(
-            &kv.inner.k_gpu[0], &k_row, &pos_slot.buf,
-            cfg.n_head_kv, cfg.head_dim,
+            &kv.inner.k_gpu[0],
+            &k_row,
+            &pos_slot.buf,
+            cfg.n_head_kv,
+            cfg.head_dim,
         )?;
         gpu.kv_cache_write_q8_0(
-            &kv.inner.v_gpu[0], &v_row, &pos_slot.buf,
-            cfg.n_head_kv, cfg.head_dim,
+            &kv.inner.v_gpu[0],
+            &v_row,
+            &pos_slot.buf,
+            cfg.n_head_kv,
+            cfg.head_dim,
         )?;
     }
 
@@ -1592,17 +2415,15 @@ pub fn mtp_head_forward_block_batched(
     let attn_out_view = scratch.attn_out.sub_offset(0, n * q_dim);
     if cfg.n_head == cfg.n_head_kv {
         // No GQA expansion: attn_out := V row-by-row.
-        gpu.hip.memcpy_dtod_at(
-            &scratch.attn_out.buf, 0,
-            &scratch.v.buf, 0,
-            n * kv_dim * 4,
-        )?;
+        gpu.hip
+            .memcpy_dtod_at(&scratch.attn_out.buf, 0, &scratch.v.buf, 0, n * kv_dim * 4)?;
     } else {
         let ratio = cfg.n_head / cfg.n_head_kv;
         assert!(
             cfg.n_head % cfg.n_head_kv == 0,
             "n_head ({}) must be divisible by n_head_kv ({})",
-            cfg.n_head, cfg.n_head_kv,
+            cfg.n_head,
+            cfg.n_head_kv,
         );
         // Per-slot per-head expand: attn_out[i, h, d] = V[i, h/ratio, d].
         for i in 0..n {
@@ -1611,8 +2432,10 @@ pub fn mtp_head_forward_block_batched(
                 let src_off = (i * kv_dim + kv_h * cfg.head_dim) * 4;
                 let dst_off = (i * q_dim + h * cfg.head_dim) * 4;
                 gpu.hip.memcpy_dtod_at(
-                    &scratch.attn_out.buf, dst_off,
-                    &scratch.v.buf, src_off,
+                    &scratch.attn_out.buf,
+                    dst_off,
+                    &scratch.v.buf,
+                    src_off,
                     cfg.head_dim * 4,
                 )?;
             }
@@ -1631,22 +2454,52 @@ pub fn mtp_head_forward_block_batched(
     gpu.add_inplace_f32(&o_view, &res_view)?;
 
     // ── 9. POST-attn norm + SwiGLU FFN + residual ────────────────────────
-    gpu.rmsnorm_batched(&o_view, &w.attn_post_norm, &tmp_view, n, dim, cfg.rms_norm_eps)?;
+    gpu.rmsnorm_batched(
+        &o_view,
+        &w.attn_post_norm,
+        &tmp_view,
+        n,
+        dim,
+        cfg.rms_norm_eps,
+    )?;
 
     let gate_ffn_view = scratch.gate_ffn.sub_offset(0, n * cfg.n_ff);
     let up_view = scratch.up.sub_offset(0, n * cfg.n_ff);
     let ffn_hidden_view = scratch.ffn_hidden.sub_offset(0, n * cfg.n_ff);
     let ffn_out_view = scratch.ffn_out.sub_offset(0, n * dim);
-    weight_gemm_batched(gpu, &w.ffn_gate, &tmp_view, &gate_ffn_view, n, rotated_x_scratch)?;
-    weight_gemm_batched(gpu, &w.ffn_up,   &tmp_view, &up_view,       n, rotated_x_scratch)?;
-    gpu.silu_mul_f32(&gate_ffn_view, &up_view, &ffn_hidden_view)?;
-    weight_gemm_batched(gpu, &w.ffn_down, &ffn_hidden_view, &ffn_out_view, n, rotated_x_scratch)?;
-    gpu.add_inplace_f32(&ffn_out_view, &o_view)?;
+    match &w.ffn {
+        Qwen35MtpFfnWeights::Dense(ffn) => {
+            weight_gemm_batched(
+                gpu,
+                &ffn.gate,
+                &tmp_view,
+                &gate_ffn_view,
+                n,
+                rotated_x_scratch,
+            )?;
+            weight_gemm_batched(gpu, &ffn.up, &tmp_view, &up_view, n, rotated_x_scratch)?;
+            gpu.silu_mul_f32(&gate_ffn_view, &up_view, &ffn_hidden_view)?;
+            weight_gemm_batched(
+                gpu,
+                &ffn.down,
+                &ffn_hidden_view,
+                &ffn_out_view,
+                n,
+                rotated_x_scratch,
+            )?;
+            gpu.add_inplace_f32(&ffn_out_view, &o_view)?;
+        }
+        Qwen35MtpFfnWeights::Moe(_) => {
+            panic!("batched MTP head forward does not support MoE FFN yet; use serial MTP");
+        }
+    }
 
     // ── 10. Snapshot post-FFN hidden into t_mtp_outs ─────────────────────
     gpu.hip.memcpy_dtod_at(
-        &scratch.t_mtp_outs.buf, 0,
-        &scratch.ffn_out.buf, 0,
+        &scratch.t_mtp_outs.buf,
+        0,
+        &scratch.ffn_out.buf,
+        0,
         n * dim_bytes,
     )?;
 

--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -30,14 +30,13 @@
 //! Greedy-only (temp=0). No DDTree, no PLD, no rejection sampling — that's
 //! Task 11 territory.
 
-use crate::mtp_head::{
-    self, Qwen35MtpHead, Qwen35MtpHeadKvCache, Qwen35MtpHeadScratch,
-};
+use crate::mtp_head::{self, Qwen35MtpHead, Qwen35MtpHeadKvCache, Qwen35MtpHeadScratch};
 use crate::qwen35::{self, Qwen35Weights};
 use crate::speculative::{DeltaNetSnapshot, GdnTape, ModelSlot};
-use hip_bridge::HipResult;
+use hip_bridge::{Event, Graph, GraphExec, HipResult, Stream};
 use hipfire_runtime::llama;
 use rdna_compute::{DType, Gpu, GpuTensor};
+use std::time::Instant;
 
 // ─── Sampling primitives (host-side, used by temp>0 spec-decode path) ────
 
@@ -48,19 +47,136 @@ use rdna_compute::{DType, Gpu, GpuTensor};
 #[derive(Copy, Clone, Debug)]
 pub struct MtpSamplingConfig {
     pub temp: f32,
-    pub top_k: usize,     // 0 = disabled (no top-K cutoff)
-    pub top_p: f32,       // 1.0 = disabled (no nucleus cutoff)
-    pub min_p: f32,       // 0.0 = disabled (no min-prob cutoff)
+    pub top_k: usize, // 0 = disabled (no top-K cutoff)
+    pub top_p: f32,   // 1.0 = disabled (no nucleus cutoff)
+    pub min_p: f32,   // 0.0 = disabled (no min-prob cutoff)
 }
 
 impl Default for MtpSamplingConfig {
     fn default() -> Self {
-        Self { temp: 0.0, top_k: 0, top_p: 1.0, min_p: 0.0 }
+        Self {
+            temp: 0.0,
+            top_k: 0,
+            top_p: 1.0,
+            min_p: 0.0,
+        }
     }
 }
 
 impl MtpSamplingConfig {
-    pub fn is_greedy(&self) -> bool { self.temp <= 0.0 }
+    pub fn is_greedy(&self) -> bool {
+        self.temp <= 0.0
+    }
+}
+
+fn mtp_device_token_chain_enabled_from_env() -> bool {
+    // Default on: this path is token-identical in greedy mode and removes the
+    // proposal-loop host data dependency needed for later graph capture.
+    match std::env::var("HIPFIRE_MTP_DEVICE_TOKEN_CHAIN") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    }
+}
+
+fn mtp_snapshot_overlap_enabled_from_env() -> bool {
+    // Default off: current gfx1201 benches show this stream split regresses,
+    // but the hook is useful as an opt-in cross-arch experiment.
+    match std::env::var("HIPFIRE_MTP_SNAPSHOT_OVERLAP") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "on" || v == "yes"
+        }
+        Err(_) => false,
+    }
+}
+
+fn mtp_gpu_greedy_accept_enabled_from_env() -> bool {
+    // Default on for greedy device-token-chain MTP: candidates and verify
+    // argmaxes are already on-device, so the prefix accept + bonus selection
+    // can stay there until a compact two-int result is needed on host.
+    match std::env::var("HIPFIRE_MTP_GPU_ACCEPT") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    }
+}
+
+fn mtp_q8_verify_wmma_enabled_from_env_value(value: Option<&str>) -> bool {
+    match value {
+        None => true,
+        Some(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+    }
+}
+
+fn mtp_q8_verify_wmma_enabled_from_env() -> bool {
+    // Default on for MTP q8 verify: the chunked dispatch only routes to gfx12
+    // WMMA when the arch/shape supports it, otherwise it falls back to scalar.
+    // Prompt-sweep parity is clean; opt out with HIPFIRE_MTP_Q8_VERIFY_WMMA=0.
+    mtp_q8_verify_wmma_enabled_from_env_value(
+        std::env::var("HIPFIRE_MTP_Q8_VERIFY_WMMA").ok().as_deref(),
+    )
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum MtpProposalGraphPolicy {
+    Off,
+    Auto,
+    On,
+}
+
+fn mtp_proposal_graph_policy_from_env_value(value: Option<&str>) -> MtpProposalGraphPolicy {
+    // Opt-in for now: q8 proposal graph capture is token-identical, but
+    // remains neutral/slightly negative on the canonical gfx1201 A3B K=5
+    // smoke after PR #5/#6 lowered verify cost (2026-05-28: 192.99 tok/s
+    // unset vs 191.44 tok/s graph=on, same output md5).
+    match value {
+        None => MtpProposalGraphPolicy::Off,
+        Some(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "0" | "false" | "off" | "no" => MtpProposalGraphPolicy::Off,
+            "1" | "true" | "on" | "yes" => MtpProposalGraphPolicy::On,
+            "auto" | "" => MtpProposalGraphPolicy::Auto,
+            _ => MtpProposalGraphPolicy::Auto,
+        },
+    }
+}
+
+fn mtp_proposal_graph_policy_from_env() -> MtpProposalGraphPolicy {
+    mtp_proposal_graph_policy_from_env_value(
+        std::env::var("HIPFIRE_MTP_PROPOSAL_GRAPH").ok().as_deref(),
+    )
+}
+
+fn mtp_proposal_graph_eligible_for(
+    policy: MtpProposalGraphPolicy,
+    use_device_token_chain: bool,
+    use_full_vocab: bool,
+    kv_mode: crate::mtp_head::MtpKvMode,
+) -> bool {
+    policy != MtpProposalGraphPolicy::Off
+        && use_device_token_chain
+        && !use_full_vocab
+        && kv_mode == crate::mtp_head::MtpKvMode::Q8
+}
+
+fn mtp_device_token_chain_eligible_for(
+    embd_format: llama::EmbeddingFormat,
+    use_sampling: bool,
+    use_p_min: bool,
+) -> bool {
+    !use_sampling
+        && !use_p_min
+        && matches!(
+            embd_format,
+            llama::EmbeddingFormat::HFQ4G256 | llama::EmbeddingFormat::Q8_0
+        )
 }
 
 /// Reproducible xorshift64* RNG. Cheap, fast, no `rand` dep.
@@ -92,13 +208,12 @@ impl MtpRng {
 /// All arithmetic is host-side f64 for the softmax stability + cumulative
 /// sums, then cast back to f32 for the returned probability. The vocab is
 /// typically 32K (compressed) or 248K (full); a few μs per call.
-pub fn sample_from_logits(
-    logits: &[f32],
-    cfg: &MtpSamplingConfig,
-    rng: &mut MtpRng,
-) -> (u32, f32) {
+pub fn sample_from_logits(logits: &[f32], cfg: &MtpSamplingConfig, rng: &mut MtpRng) -> (u32, f32) {
     assert!(!logits.is_empty(), "sample_from_logits: empty logits row");
-    assert!(cfg.temp > 0.0, "sample_from_logits: temp must be > 0; caller must branch on greedy");
+    assert!(
+        cfg.temp > 0.0,
+        "sample_from_logits: temp must be > 0; caller must branch on greedy"
+    );
 
     // 1. Build (id, scaled_logit) pairs.
     let inv_temp = 1.0 / cfg.temp as f64;
@@ -128,18 +243,25 @@ pub fn sample_from_logits(
             e
         })
         .collect();
-    for p in probs.iter_mut() { *p /= sum_exp; }
+    for p in probs.iter_mut() {
+        *p /= sum_exp;
+    }
 
     // 5. min_p: drop tokens with normalized prob < min_p * top_prob.
     if cfg.min_p > 0.0 {
         let top_p_val = probs[0];
         let thresh = (cfg.min_p as f64) * top_p_val;
-        let cutoff = probs.iter().position(|&p| p < thresh).unwrap_or(probs.len());
+        let cutoff = probs
+            .iter()
+            .position(|&p| p < thresh)
+            .unwrap_or(probs.len());
         pairs.truncate(cutoff.max(1));
         probs.truncate(cutoff.max(1));
         // Renormalize after min_p.
         let s: f64 = probs.iter().sum();
-        for p in probs.iter_mut() { *p /= s; }
+        for p in probs.iter_mut() {
+            *p /= s;
+        }
     }
 
     // 6. top_p (nucleus): cumulative-prob cutoff.
@@ -157,7 +279,9 @@ pub fn sample_from_logits(
         probs.truncate(cutoff);
         // Renormalize after top_p.
         let s: f64 = probs.iter().sum();
-        for p in probs.iter_mut() { *p /= s; }
+        for p in probs.iter_mut() {
+            *p /= s;
+        }
     }
 
     // 7. Multinomial sample.
@@ -191,14 +315,18 @@ pub fn softmax_prob_at_temp(logits: &[f32], idx: usize, temp: f32) -> f32 {
     let mut max_scaled = f64::NEG_INFINITY;
     for &l in logits.iter() {
         let s = l as f64 * inv_t;
-        if s > max_scaled { max_scaled = s; }
+        if s > max_scaled {
+            max_scaled = s;
+        }
     }
     let mut sum_exp = 0.0_f64;
     let mut target_e = 0.0_f64;
     for (i, &l) in logits.iter().enumerate() {
         let e = ((l as f64) * inv_t - max_scaled).exp();
         sum_exp += e;
-        if i == idx { target_e = e; }
+        if i == idx {
+            target_e = e;
+        }
     }
     (target_e / sum_exp) as f32
 }
@@ -233,6 +361,12 @@ pub struct MtpSpecState {
 
     /// Trunk DN snapshot for rollback before replay.
     pub trunk_snap: DeltaNetSnapshot,
+
+    /// Side stream used to overlap `trunk_snap.save_from` with the MTP
+    /// proposal loop. The event orders the side-stream copy after any
+    /// prior-cycle main-stream work that may still be updating DN state.
+    pub trunk_snap_stream: Option<Stream>,
+    pub trunk_snap_start_event: Option<Event>,
 
     /// Persistent batch scratch for the trunk's batched verify forward.
     /// Sized to `max_n + 1` so verify always fits in one chunk.
@@ -272,6 +406,32 @@ pub struct MtpSpecState {
     /// GPU-side argmax destination for the K-step batched argmax over
     /// `mtp_lm_logits`. Shape `[max_n]` i32 stored as F32 slots.
     pub mtp_lm_argmax: GpuTensor,
+
+    /// Greedy device-token chain for compressed-serial MTP. Slot 0 is seeded
+    /// with `last_committed`; step k writes slot k+1 after argmax/remap, and
+    /// step k+1 embeds slot k directly from GPU memory. Shape `[max_n + 1]`
+    /// i32 stored in F32-typed slots.
+    pub mtp_token_chain: GpuTensor,
+
+    /// Single-token embedding scratch used by the device-token-chain path.
+    /// The existing MTP block forward consumes it through its embedding
+    /// override hook, avoiding a larger forward-path refactor.
+    pub mtp_token_embed: GpuTensor,
+
+    /// Per-step absolute MTP positions for proposal-graph replay. Shape
+    /// `[max_n]` i32 stored in F32 slots. The captured graph reads each slot
+    /// by pointer, while the host refreshes the values before every launch.
+    pub mtp_positions: GpuTensor,
+
+    /// Captured q8 compressed proposal graph for the greedy device-token-chain
+    /// path. It belongs to this state because the graph bakes scratch/weight
+    /// pointers into captured kernel nodes.
+    mtp_proposal_graph: Option<Graph>,
+    mtp_proposal_graph_exec: Option<GraphExec>,
+    mtp_proposal_graph_blobs: Vec<Vec<u8>>,
+    mtp_proposal_graph_seq_cap: usize,
+    mtp_proposal_graph_warmed: bool,
+    mtp_proposal_graph_disabled: bool,
 
     /// Optional FastMTP-style compressed batched-logits output, shape
     /// `[max_n * compressed_vocab_size]`. Populated by
@@ -347,9 +507,7 @@ impl MtpSpecState {
         head: &Qwen35MtpHead,
         max_n: usize,
     ) -> HipResult<Self> {
-        Self::new_for_slot_with_kv_mode(
-            gpu, target, head, max_n, crate::mtp_head::MtpKvMode::Q8,
-        )
+        Self::new_for_slot_with_kv_mode(gpu, target, head, max_n, crate::mtp_head::MtpKvMode::Q8)
     }
 
     /// Like [`Self::new_for_slot`] but allocates the MTP head's KV cache in
@@ -385,6 +543,17 @@ impl MtpSpecState {
         let verify_rot = gpu.alloc_tensor(&[(max_n + 1) * dim], DType::F32)?;
         let verify_argmax = gpu.alloc_tensor(&[max_n + 1], DType::F32)?;
         let trunk_snap = DeltaNetSnapshot::new_for(gpu, &target.dn_state)?;
+        // Snapshot overlap resources are construction-time only; set the env
+        // before creating MtpSpecState when comparing the opt-in path.
+        let (trunk_snap_stream, trunk_snap_start_event) = if mtp_snapshot_overlap_enabled_from_env()
+        {
+            (
+                Some(gpu.hip.stream_create()?),
+                Some(gpu.hip.event_create()?),
+            )
+        } else {
+            (None, None)
+        };
         let trunk_pbs = qwen35::PrefillBatchScratch::new(gpu, &target.config, max_n + 1)?;
         let trunk_gdn_tape = GdnTape::new_for_config(gpu, &target.config, max_n + 1)?;
         let mtp_scratch = Qwen35MtpHeadScratch::new(gpu, &head.config)?;
@@ -396,6 +565,9 @@ impl MtpSpecState {
         let mtp_lm_rot = gpu.alloc_tensor(&[max_n * dim], DType::F32)?;
         let mtp_lm_logits = gpu.alloc_tensor(&[max_n * vocab], DType::F32)?;
         let mtp_lm_argmax = gpu.alloc_tensor(&[max_n], DType::F32)?;
+        let mtp_token_chain = gpu.alloc_tensor(&[max_n + 1], DType::F32)?;
+        let mtp_token_embed = gpu.alloc_tensor(&[dim], DType::F32)?;
+        let mtp_positions = gpu.alloc_tensor(&[max_n], DType::F32)?;
 
         // Per-step top-2 scratches for p_min early-exit (16 B total, always
         // allocated — only used when state.p_min > 0).
@@ -418,6 +590,8 @@ impl MtpSpecState {
             verify_rot,
             verify_argmax,
             trunk_snap,
+            trunk_snap_stream,
+            trunk_snap_start_event,
             trunk_pbs,
             trunk_gdn_tape,
             mtp_scratch,
@@ -427,6 +601,15 @@ impl MtpSpecState {
             mtp_lm_rot,
             mtp_lm_logits,
             mtp_lm_argmax,
+            mtp_token_chain,
+            mtp_token_embed,
+            mtp_positions,
+            mtp_proposal_graph: None,
+            mtp_proposal_graph_exec: None,
+            mtp_proposal_graph_blobs: Vec::new(),
+            mtp_proposal_graph_seq_cap: 0,
+            mtp_proposal_graph_warmed: false,
+            mtp_proposal_graph_disabled: false,
             mtp_lm_logits_compressed: None,
             mtp_topk_idx,
             mtp_topk_logp,
@@ -450,9 +633,21 @@ impl MtpSpecState {
     /// Reseeds BOTH the host RNG (used for the residual accept rule) and the
     /// on-device RNG (used by `gpu.sample_top_p`).
     pub fn set_sampling(&mut self, cfg: MtpSamplingConfig, seed: u64) {
-        assert!(cfg.temp >= 0.0, "set_sampling: temp must be >= 0.0, got {}", cfg.temp);
-        assert!(cfg.top_p > 0.0 && cfg.top_p <= 1.0, "set_sampling: top_p must be in (0,1], got {}", cfg.top_p);
-        assert!(cfg.min_p >= 0.0 && cfg.min_p <= 1.0, "set_sampling: min_p must be in [0,1], got {}", cfg.min_p);
+        assert!(
+            cfg.temp >= 0.0,
+            "set_sampling: temp must be >= 0.0, got {}",
+            cfg.temp
+        );
+        assert!(
+            cfg.top_p > 0.0 && cfg.top_p <= 1.0,
+            "set_sampling: top_p must be in (0,1], got {}",
+            cfg.top_p
+        );
+        assert!(
+            cfg.min_p >= 0.0 && cfg.min_p <= 1.0,
+            "set_sampling: min_p must be in [0,1], got {}",
+            cfg.min_p
+        );
         self.sampling = cfg;
         self.rng = MtpRng::new(seed);
         // GPU rng uses u32; mix the lower + upper halves so different seeds
@@ -475,9 +670,7 @@ impl MtpSpecState {
     /// compressed batched-lm_head dispatch path. Idempotent — reallocates
     /// only if the existing tensor has the wrong size. Call once after
     /// loading a head with a sidecar (cvs = `head.weights.compressed_vocab_size`).
-    pub fn ensure_compressed_lm_logits(
-        &mut self, gpu: &mut Gpu, cvs: usize,
-    ) -> HipResult<()> {
+    pub fn ensure_compressed_lm_logits(&mut self, gpu: &mut Gpu, cvs: usize) -> HipResult<()> {
         let needed = self.max_n * cvs;
         if let Some(existing) = self.mtp_lm_logits_compressed.as_ref() {
             if existing.numel() == needed {
@@ -487,9 +680,7 @@ impl MtpSpecState {
                 let _ = gpu.free_tensor(old);
             }
         }
-        self.mtp_lm_logits_compressed = Some(
-            gpu.alloc_tensor(&[needed], DType::F32)?,
-        );
+        self.mtp_lm_logits_compressed = Some(gpu.alloc_tensor(&[needed], DType::F32)?);
         Ok(())
     }
 
@@ -503,8 +694,10 @@ impl MtpSpecState {
         dim: usize,
     ) -> HipResult<()> {
         gpu.hip.memcpy_dtod_at(
-            &self.prev_hidden.buf, 0,
-            &target_scratch_tmp.buf, 0,
+            &self.prev_hidden.buf,
+            0,
+            &target_scratch_tmp.buf,
+            0,
             dim * 4,
         )
     }
@@ -521,8 +714,10 @@ impl MtpSpecState {
         dim: usize,
     ) -> HipResult<()> {
         gpu.hip.memcpy_dtod_at(
-            &self.prev_hidden.buf, 0,
-            &self.verify_hidden.buf, row * dim * 4,
+            &self.prev_hidden.buf,
+            0,
+            &self.verify_hidden.buf,
+            row * dim * 4,
             dim * 4,
         )
     }
@@ -538,11 +733,35 @@ impl MtpSpecState {
         let _ = gpu.free_tensor(self.mtp_lm_rot);
         let _ = gpu.free_tensor(self.mtp_lm_logits);
         let _ = gpu.free_tensor(self.mtp_lm_argmax);
+        let _ = gpu.free_tensor(self.mtp_token_chain);
+        let _ = gpu.free_tensor(self.mtp_token_embed);
+        let _ = gpu.free_tensor(self.mtp_positions);
+        if let Some(exec) = self.mtp_proposal_graph_exec {
+            let _ = gpu.hip.graph_exec_destroy(exec);
+        }
+        if let Some(graph) = self.mtp_proposal_graph {
+            let _ = gpu.hip.graph_destroy(graph);
+        }
+        drop(self.mtp_proposal_graph_blobs);
         if let Some(lc) = self.mtp_lm_logits_compressed {
             let _ = gpu.free_tensor(lc);
         }
+        let _ = gpu.free_tensor(self.mtp_topk_idx);
+        let _ = gpu.free_tensor(self.mtp_topk_logp);
+        let _ = gpu.free_tensor(self.mtp_sample_result);
+        let _ = gpu.free_tensor(self.mtp_sample_repeat_buf);
+        let _ = gpu.free_tensor(self.mtp_gather_idx_draft);
+        let _ = gpu.free_tensor(self.mtp_gather_prob_draft);
+        let _ = gpu.free_tensor(self.mtp_gather_idx_verify);
+        let _ = gpu.free_tensor(self.mtp_gather_prob_verify);
         // DeltaNetSnapshot's DeviceBuffers free on drop.
         drop(self.trunk_snap);
+        if let Some(event) = self.trunk_snap_start_event {
+            let _ = gpu.hip.event_destroy(event);
+        }
+        if let Some(stream) = self.trunk_snap_stream {
+            let _ = gpu.hip.stream_destroy(stream);
+        }
         self.trunk_pbs.free_gpu(gpu);
         self.trunk_gdn_tape.free_gpu(gpu);
         self.mtp_scratch.free_gpu(gpu);
@@ -579,6 +798,389 @@ pub struct MtpSpecResult {
     /// only set by [`spec_step_mtp_compressed_serial`]; other spec_step
     /// variants always replay and report `false`.
     pub replay_skipped: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GreedyTrunkSpineAccept {
+    committed: Vec<u32>,
+    accept_count: usize,
+    hit_eos: bool,
+}
+
+fn build_trunk_spine_verify_tokens(last_committed: u32, candidates: &[u32]) -> Vec<u32> {
+    let mut verify_tokens = Vec::with_capacity(candidates.len() + 1);
+    verify_tokens.push(last_committed);
+    verify_tokens.extend_from_slice(candidates);
+    verify_tokens
+}
+
+fn embed_device_token_into(
+    gpu: &mut Gpu,
+    weights: &Qwen35Weights,
+    out: &GpuTensor,
+    token_id: &GpuTensor,
+    dim: usize,
+) -> HipResult<()> {
+    match weights.embd_format {
+        llama::EmbeddingFormat::HFQ4G256 => {
+            gpu.embedding_lookup_hfq4g256_batched(&weights.token_embd, out, token_id, 1, dim)
+        }
+        llama::EmbeddingFormat::Q8_0 => {
+            gpu.embedding_lookup_q8_batched(&weights.token_embd, out, token_id, 1, dim)
+        }
+        other => panic!("device-token MTP chain does not support embedding format {other:?}"),
+    }
+}
+
+fn upload_mtp_proposal_graph_inputs(
+    gpu: &mut Gpu,
+    state: &MtpSpecState,
+    last_committed: u32,
+    cur_pos: usize,
+    max_n: usize,
+) -> HipResult<()> {
+    assert!(
+        cur_pos + max_n <= state.mtp_kv.max_seq,
+        "MTP proposal positions [{}..{}) exceed kv max_seq {}",
+        cur_pos,
+        cur_pos + max_n,
+        state.mtp_kv.max_seq,
+    );
+
+    let seed_token = last_committed as i32;
+    let seed_bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(&seed_token as *const i32 as *const u8, 4) };
+    gpu.hip
+        .memcpy_htod(&state.mtp_token_chain.buf, seed_bytes)?;
+
+    let positions: Vec<i32> = (0..max_n).map(|k| (cur_pos + k) as i32).collect();
+    let pos_bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, max_n * 4) };
+    gpu.hip.memcpy_htod(&state.mtp_positions.buf, pos_bytes)
+}
+
+fn mtp_proposal_graph_seq_cap(cur_pos: usize, max_n: usize, kv_max_seq: usize) -> usize {
+    let needed = cur_pos + max_n;
+    needed.next_power_of_two().max(256).min(kv_max_seq)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_mtp_proposal_graph_body_q8(
+    gpu: &mut Gpu,
+    target: &ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    cur_pos: usize,
+    max_n: usize,
+    dim: usize,
+    cvs: usize,
+    seq_cap: usize,
+) -> HipResult<()> {
+    debug_assert_eq!(state.mtp_kv.kv_mode, crate::mtp_head::MtpKvMode::Q8);
+    let dim_bytes = dim * 4;
+    let logits_c = state
+        .mtp_scratch
+        .logits_compressed
+        .as_ref()
+        .expect("proposal graph requires compressed logits scratch");
+    let vocab_map_gpu = head
+        .weights
+        .lm_head_draft_vocab_map_gpu
+        .as_ref()
+        .expect("proposal graph requires GPU vocab_map");
+    let argmax_view = state.mtp_lm_argmax.sub_offset(0, 1);
+
+    for k in 0..max_n {
+        let token_slot = state.mtp_token_chain.sub_offset(k, 1);
+        embed_device_token_into(
+            gpu,
+            &target.weights,
+            &state.mtp_token_embed,
+            &token_slot,
+            dim,
+        )?;
+
+        let pos_slot = state.mtp_positions.sub_offset(k, 1);
+        if k == 0 {
+            mtp_head::mtp_head_forward_block_only_with_pos_buf(
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                0,
+                &state.prev_hidden,
+                Some(&state.mtp_token_embed),
+                &pos_slot.buf,
+                cur_pos + k,
+                seq_cap,
+                &target.weights,
+            )?;
+        } else {
+            let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+            mtp_head::mtp_head_forward_block_only_with_pos_buf(
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                0,
+                &prev_row,
+                Some(&state.mtp_token_embed),
+                &pos_slot.buf,
+                cur_pos + k,
+                seq_cap,
+                &target.weights,
+            )?;
+        }
+        mtp_head::mtp_head_apply_lm_head_draft(gpu, head, &state.mtp_scratch)?;
+        gpu.argmax_token_chain_f32(
+            logits_c,
+            &argmax_view,
+            &state.mtp_token_chain,
+            Some(vocab_map_gpu),
+            cvs,
+            k + 1,
+        )?;
+
+        if k + 1 < max_n {
+            gpu.memcpy_dtod_at_auto(
+                &state.mtp_t_outs.buf,
+                k * dim_bytes,
+                &state.mtp_scratch.t_mtp_out.buf,
+                0,
+                dim_bytes,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn begin_mtp_proposal_graph_capture(gpu: &mut Gpu) -> HipResult<()> {
+    gpu.capture_blobs.clear();
+    gpu.capture_mode = true;
+    let stream = gpu
+        .active_stream
+        .as_ref()
+        .expect("proposal graph capture requires an explicit stream");
+    gpu.hip.stream_begin_capture(stream, 0)
+}
+
+fn end_mtp_proposal_graph_capture(gpu: &mut Gpu) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
+    gpu.capture_mode = false;
+    let stream = gpu.active_stream.as_ref().unwrap();
+    let graph = gpu.hip.stream_end_capture(stream)?;
+    let exec = gpu.hip.graph_instantiate(&graph)?;
+    let blobs = std::mem::take(&mut gpu.capture_blobs);
+    Ok((graph, exec, blobs))
+}
+
+fn abort_mtp_proposal_graph_capture(gpu: &mut Gpu) {
+    if gpu.capture_mode {
+        if let Some(stream) = gpu.active_stream.as_ref() {
+            let _ = gpu.hip.stream_end_capture(stream);
+        }
+        gpu.capture_mode = false;
+    }
+    gpu.capture_blobs.clear();
+}
+
+fn destroy_mtp_proposal_graph(gpu: &mut Gpu, state: &mut MtpSpecState) {
+    if let Some(exec) = state.mtp_proposal_graph_exec.take() {
+        let _ = gpu.hip.graph_exec_destroy(exec);
+    }
+    if let Some(graph) = state.mtp_proposal_graph.take() {
+        let _ = gpu.hip.graph_destroy(graph);
+    }
+    state.mtp_proposal_graph_blobs.clear();
+    state.mtp_proposal_graph_seq_cap = 0;
+}
+
+fn greedy_trunk_spine_accept(
+    candidates: &[u32],
+    argmax_per_pos: &[u32],
+    eos_token_id: u32,
+) -> GreedyTrunkSpineAccept {
+    assert!(
+        argmax_per_pos.len() >= candidates.len() + 1,
+        "greedy_trunk_spine_accept: need at least candidates+1 argmax rows \
+         (got {}, candidates={})",
+        argmax_per_pos.len(),
+        candidates.len(),
+    );
+
+    let mut accept_count = 0usize;
+    let mut hit_eos = false;
+    let mut committed: Vec<u32> = Vec::with_capacity(candidates.len() + 1);
+
+    for (k, &candidate) in candidates.iter().enumerate() {
+        if argmax_per_pos[k] == candidate {
+            committed.push(candidate);
+            accept_count += 1;
+            if candidate == eos_token_id {
+                hit_eos = true;
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    if !hit_eos {
+        let bonus = argmax_per_pos[accept_count];
+        committed.push(bonus);
+        if bonus == eos_token_id {
+            hit_eos = true;
+        }
+    }
+
+    GreedyTrunkSpineAccept {
+        committed,
+        accept_count,
+        hit_eos,
+    }
+}
+
+fn assemble_greedy_accept_from_gpu_result(
+    candidates: &[u32],
+    accept_count: usize,
+    bonus_token_or_no_bonus: i32,
+    eos_token_id: u32,
+) -> GreedyTrunkSpineAccept {
+    assert!(
+        accept_count <= candidates.len(),
+        "gpu greedy accept returned accept_count={} for {} candidates",
+        accept_count,
+        candidates.len()
+    );
+
+    let mut committed: Vec<u32> = Vec::with_capacity(candidates.len() + 1);
+    committed.extend_from_slice(&candidates[..accept_count]);
+
+    let hit_eos = if bonus_token_or_no_bonus < 0 {
+        assert!(
+            accept_count > 0 && candidates[accept_count - 1] == eos_token_id,
+            "gpu greedy accept returned no bonus without an accepted EOS"
+        );
+        true
+    } else {
+        let bonus = bonus_token_or_no_bonus as u32;
+        committed.push(bonus);
+        bonus == eos_token_id
+    };
+
+    GreedyTrunkSpineAccept {
+        committed,
+        accept_count,
+        hit_eos,
+    }
+}
+
+/// DS4-style Qwen MTP prefill fill.
+///
+/// Runs trunk prefill once while capturing post-output-norm hidden for every
+/// prompt token, then runs the MTP block-only path over those same prompt
+/// positions. The MTP layer enters decode with a warm private KV cache instead
+/// of starting at the first generated token.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TrunkSpinePrefillTimings {
+    pub trunk_prefill_secs: f64,
+    pub mtp_prompt_fill_secs: f64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn prefill_trunk_and_mtp_cache(
+    gpu: &mut Gpu,
+    target: &mut ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    prompt_tokens: &[u32],
+    start_pos: usize,
+) -> HipResult<TrunkSpinePrefillTimings> {
+    if prompt_tokens.is_empty() {
+        return Ok(TrunkSpinePrefillTimings::default());
+    }
+
+    let dim = target.config.dim;
+    let dim_bytes = dim * 4;
+    let prompt_hidden = gpu.alloc_tensor(&[prompt_tokens.len() * dim], DType::F32)?;
+
+    let result = (|| -> HipResult<TrunkSpinePrefillTimings> {
+        let t_trunk = Instant::now();
+        qwen35::forward_prefill_batch(
+            gpu,
+            &target.weights,
+            &target.config,
+            prompt_tokens,
+            start_pos,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            None,
+            Some(&prompt_hidden),
+            None,
+            None,
+        )?;
+        let trunk_prefill_secs = t_trunk.elapsed().as_secs_f64();
+
+        let t_mtp_fill = Instant::now();
+        for (i, &token) in prompt_tokens.iter().enumerate() {
+            let hidden_row = prompt_hidden.sub_offset(i * dim, dim);
+            mtp_head::mtp_head_forward_block_only(
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                token,
+                &hidden_row,
+                None,
+                start_pos + i,
+                &target.weights,
+            )?;
+        }
+
+        let last = prompt_tokens.len() - 1;
+        gpu.hip.memcpy_dtod_at(
+            &state.prev_hidden.buf,
+            0,
+            &prompt_hidden.buf,
+            last * dim_bytes,
+            dim_bytes,
+        )?;
+        let mtp_prompt_fill_secs = t_mtp_fill.elapsed().as_secs_f64();
+        Ok(TrunkSpinePrefillTimings {
+            trunk_prefill_secs,
+            mtp_prompt_fill_secs,
+        })
+    })();
+
+    let _ = gpu.free_tensor(prompt_hidden);
+    result
+}
+
+/// Explicit DS4-shaped Qwen MTP spec step.
+///
+/// This is the discrete-token trunk spine: serial MTP proposals, one trunk
+/// batched verify, greedy/sampling accept, then rollback/replay only when the
+/// full verify state cannot be kept. It intentionally delegates to the mature
+/// compressed-serial implementation, whose name describes the lm_head storage
+/// mode rather than the spine architecture.
+#[allow(clippy::too_many_arguments)]
+pub fn spec_step_mtp_trunk_spine(
+    gpu: &mut Gpu,
+    target: &mut ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    cur_pos: usize,
+    last_committed: u32,
+    eos_token_id: u32,
+) -> HipResult<MtpSpecResult> {
+    spec_step_mtp_compressed_serial(
+        gpu,
+        target,
+        head,
+        state,
+        cur_pos,
+        last_committed,
+        eos_token_id,
+    )
 }
 
 /// One MTP-only spec-decode cycle (greedy, temp=0).
@@ -703,9 +1305,9 @@ pub fn spec_step_mtp(
                 head,
                 &state.mtp_scratch,
                 &mut state.mtp_kv,
-                0,                  // sentinel: ignored when next_token_embed is Some(_)
-                &prev_row,          // prev_hidden = step k-1's t_mtp_out
-                Some(&prev_row),    // embed override = step k-1's t_mtp_out (lossy)
+                0,               // sentinel: ignored when next_token_embed is Some(_)
+                &prev_row,       // prev_hidden = step k-1's t_mtp_out
+                Some(&prev_row), // embed override = step k-1's t_mtp_out (lossy)
                 cur_pos + k,
                 trunk_weights,
             )?;
@@ -714,8 +1316,10 @@ pub fn spec_step_mtp(
         // next step can read it AND so the end-of-chain batched lm_head
         // can ingest the whole stack.
         gpu.hip.memcpy_dtod_at(
-            &state.mtp_t_outs.buf, k * dim_bytes,
-            &state.mtp_scratch.t_mtp_out.buf, 0,
+            &state.mtp_t_outs.buf,
+            k * dim_bytes,
+            &state.mtp_scratch.t_mtp_out.buf,
+            0,
             dim_bytes,
         )?;
     }
@@ -746,9 +1350,7 @@ pub fn spec_step_mtp(
     let mut argmax_host: Vec<i32> = vec![0; max_n];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_host.as_mut_ptr() as *mut u8, max_n * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, max_n * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &lm_argmax_view.buf)?;
     }
@@ -768,7 +1370,7 @@ pub fn spec_step_mtp(
     // `forward_prefill_batch_with_pbs` writes per-position post-output-norm
     // hidden into `state.verify_hidden` when per_token_hidden_out is Some.
     // Trunk KV cache and dn_state advance by max_n+1 (= verify_tokens.len()).
-    qwen35::forward_prefill_batch_with_pbs(
+    qwen35::forward_prefill_batch_with_pbs_opts(
         gpu,
         trunk_weights,
         &target.config,
@@ -782,8 +1384,9 @@ pub fn spec_step_mtp(
         None, // gdn_tape
         None, // tree_verify
         Some(&state.trunk_pbs),
-        None, // mask_override
-        None, // max_layer
+        None,  // mask_override
+        None,  // max_layer
+        false, // MTP computes all verify logits from verify_hidden below
     )?;
 
     // ── 5. Per-position lm_head + batched argmax ─────────────────────────
@@ -796,43 +1399,101 @@ pub fn spec_step_mtp(
     let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
     match w_out.gpu_dtype {
         DType::Q8_0 => {
-            // gemm_q8_0_batched supports up to 64 rows in one launch.
-            gpu.gemm_q8_0_batched(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
-            )?;
+            if mtp_q8_verify_wmma_enabled_from_env() {
+                gpu.gemm_q8_0_batched_chunked(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            } else {
+                gpu.gemm_q8_0_batched(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ4G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ3G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ6G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         _ => {
@@ -851,9 +1512,7 @@ pub fn spec_step_mtp(
     let mut argmax_host: Vec<i32> = vec![0; n_verify];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_host.as_mut_ptr() as *mut u8, n_verify * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, n_verify * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
     }
@@ -935,7 +1594,10 @@ pub fn spec_step_mtp(
             &mut target.kv_cache,
             &mut target.dn_state,
             &target.scratch,
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )?;
     } else {
         // advance == 1: only the seed (last_committed) is "replayed". This
@@ -1017,19 +1679,29 @@ pub fn spec_step_mtp_compressed(
 
     // Precondition: head must have compressed sidecar loaded + caller must
     // have allocated the compressed batched-logits scratch.
-    let lm_head_draft = head.weights.lm_head_draft.as_ref()
+    let lm_head_draft = head
+        .weights
+        .lm_head_draft
+        .as_ref()
         .expect("spec_step_mtp_compressed requires head loaded with --vocab-sidecar");
-    let vocab_map = head.weights.lm_head_draft_vocab_map.as_ref()
+    let vocab_map = head
+        .weights
+        .lm_head_draft_vocab_map
+        .as_ref()
         .expect("compressed head missing vocab_map");
-    let cvs = head.weights.compressed_vocab_size
+    let cvs = head
+        .weights
+        .compressed_vocab_size
         .expect("compressed head missing compressed_vocab_size");
-    let logits_c_batched = state.mtp_lm_logits_compressed.as_ref()
-        .expect("MtpSpecState::mtp_lm_logits_compressed not allocated; \
-                 call ensure_compressed_lm_logits(gpu, cvs) after head load");
+    let logits_c_batched = state.mtp_lm_logits_compressed.as_ref().expect(
+        "MtpSpecState::mtp_lm_logits_compressed not allocated; \
+                 call ensure_compressed_lm_logits(gpu, cvs) after head load",
+    );
     assert!(
         logits_c_batched.numel() >= max_n * cvs,
         "mtp_lm_logits_compressed too small: {} < max_n*cvs ({})",
-        logits_c_batched.numel(), max_n * cvs,
+        logits_c_batched.numel(),
+        max_n * cvs,
     );
 
     if gpu.active_stream.is_none() {
@@ -1053,24 +1725,35 @@ pub fn spec_step_mtp_compressed(
     for k in 0..max_n {
         if k == 0 {
             mtp_head::mtp_head_forward_block_only(
-                gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                last_committed, &state.prev_hidden, None, cur_pos + k,
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                last_committed,
+                &state.prev_hidden,
+                None,
+                cur_pos + k,
                 trunk_weights,
             )?;
         } else {
             let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
             mtp_head::mtp_head_forward_block_only(
-                gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                0,                  // ignored when next_token_embed = Some
+                gpu,
+                head,
+                &state.mtp_scratch,
+                &mut state.mtp_kv,
+                0, // ignored when next_token_embed = Some
                 &prev_row,
-                Some(&prev_row),    // lossy embed override
+                Some(&prev_row), // lossy embed override
                 cur_pos + k,
                 trunk_weights,
             )?;
         }
         gpu.hip.memcpy_dtod_at(
-            &state.mtp_t_outs.buf, k * dim_bytes,
-            &state.mtp_scratch.t_mtp_out.buf, 0,
+            &state.mtp_t_outs.buf,
+            k * dim_bytes,
+            &state.mtp_scratch.t_mtp_out.buf,
+            0,
             dim_bytes,
         )?;
     }
@@ -1085,8 +1768,13 @@ pub fn spec_step_mtp_compressed(
     let lm_rot_view = state.mtp_lm_rot.sub_offset(0, max_n * dim);
     let lm_logits_view = logits_c_batched.sub_offset(0, max_n * cvs);
     mtp_head::mtp_head_apply_lm_head_batched(
-        gpu, head, lm_head_draft,
-        &t_outs_view, &lm_tmp_view, &lm_rot_view, &lm_logits_view,
+        gpu,
+        head,
+        lm_head_draft,
+        &t_outs_view,
+        &lm_tmp_view,
+        &lm_rot_view,
+        &lm_logits_view,
         max_n,
     )?;
 
@@ -1096,9 +1784,7 @@ pub fn spec_step_mtp_compressed(
     let mut argmax_host: Vec<i32> = vec![0; max_n];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_host.as_mut_ptr() as *mut u8, max_n * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, max_n * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &lm_argmax_view.buf)?;
     }
@@ -1113,14 +1799,12 @@ pub fn spec_step_mtp_compressed(
     }
 
     // ── 2. Trunk verify on [last_committed, c1, ..., c_max_n] ─────────────
-    let mut verify_tokens: Vec<u32> = Vec::with_capacity(max_n + 1);
-    verify_tokens.push(last_committed);
-    verify_tokens.extend_from_slice(&candidates);
+    let verify_tokens = build_trunk_spine_verify_tokens(last_committed, &candidates);
     let n_verify = verify_tokens.len();
 
     state.trunk_snap.save_from(&target.dn_state, gpu)?;
 
-    qwen35::forward_prefill_batch_with_pbs(
+    qwen35::forward_prefill_batch_with_pbs_opts(
         gpu,
         trunk_weights,
         &target.config,
@@ -1134,8 +1818,9 @@ pub fn spec_step_mtp_compressed(
         None,
         None,
         Some(&state.trunk_pbs),
-        None, // mask_override
-        None, // max_layer
+        None,  // mask_override
+        None,  // max_layer
+        false, // MTP computes all verify logits from verify_hidden below
     )?;
 
     // ── 3. Trunk batched lm_head over verify positions ─────────────────────
@@ -1143,42 +1828,101 @@ pub fn spec_step_mtp_compressed(
     let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
     match w_out.gpu_dtype {
         DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
-            )?;
+            if mtp_q8_verify_wmma_enabled_from_env() {
+                gpu.gemm_q8_0_batched_chunked(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            } else {
+                gpu.gemm_q8_0_batched(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ4G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ3G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ6G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         _ => {
@@ -1195,9 +1939,7 @@ pub fn spec_step_mtp_compressed(
     let mut argmax_v_host: Vec<i32> = vec![0; n_verify];
     {
         let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_v_host.as_mut_ptr() as *mut u8, n_verify * 4,
-            )
+            std::slice::from_raw_parts_mut(argmax_v_host.as_mut_ptr() as *mut u8, n_verify * 4)
         };
         gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
     }
@@ -1246,7 +1988,10 @@ pub fn spec_step_mtp_compressed(
             &mut target.kv_cache,
             &mut target.dn_state,
             &target.scratch,
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )?;
     } else {
         qwen35::forward_scratch(
@@ -1332,20 +2077,44 @@ pub fn spec_step_mtp_compressed_serial(
     let (vocab_map_opt, cvs): (Option<&Vec<u32>>, usize) = if use_full_vocab {
         (None, vocab)
     } else {
-        let _ = head.weights.lm_head_draft.as_ref()
+        let _ = head
+            .weights
+            .lm_head_draft
+            .as_ref()
             .expect("compressed head missing lm_head_draft");
-        let vm = head.weights.lm_head_draft_vocab_map.as_ref()
+        let vm = head
+            .weights
+            .lm_head_draft_vocab_map
+            .as_ref()
             .expect("compressed head missing vocab_map");
-        let c = head.weights.compressed_vocab_size
+        let c = head
+            .weights
+            .compressed_vocab_size
             .expect("compressed head missing compressed_vocab_size");
-        let _ = state.mtp_scratch.logits_compressed.as_ref()
-            .expect("Qwen35MtpHeadScratch::logits_compressed not allocated; \
-                     call mtp_scratch.ensure_compressed_logits(gpu, cvs) after head load");
+        let _ = state.mtp_scratch.logits_compressed.as_ref().expect(
+            "Qwen35MtpHeadScratch::logits_compressed not allocated; \
+                     call mtp_scratch.ensure_compressed_logits(gpu, cvs) after head load",
+        );
         (Some(vm), c)
     };
 
     if gpu.active_stream.is_none() {
         gpu.active_stream = Some(gpu.hip.stream_create()?);
+    }
+    let overlap_trunk_snap = mtp_snapshot_overlap_enabled_from_env()
+        && state.trunk_snap_stream.is_some()
+        && state.trunk_snap_start_event.is_some();
+    if overlap_trunk_snap {
+        let snap_event = state.trunk_snap_start_event.as_ref().unwrap();
+        let snap_stream = state.trunk_snap_stream.as_ref().unwrap();
+        {
+            let active_stream = gpu.active_stream.as_ref().unwrap();
+            gpu.hip.event_record(snap_event, Some(active_stream))?;
+            gpu.hip.stream_wait_event(snap_stream, snap_event)?;
+        }
+        state
+            .trunk_snap
+            .save_from_async_on(&target.dn_state, gpu, snap_stream)?;
     }
 
     let dim_bytes = dim * 4;
@@ -1368,7 +2137,11 @@ pub fn spec_step_mtp_compressed_serial(
     // verify, but we stop spending compute speculating further.
     let p_min = state.p_min;
     let use_p_min = p_min > 0.0;
-    let log_p_min = if use_p_min { p_min.ln() } else { f32::NEG_INFINITY };
+    let log_p_min = if use_p_min {
+        p_min.ln()
+    } else {
+        f32::NEG_INFINITY
+    };
     let mut chain_truncated = false;
 
     // Sampling vs greedy: when sampling.temp > 0, K-chain SAMPLES from each
@@ -1392,197 +2165,401 @@ pub fn spec_step_mtp_compressed_serial(
     // Cached host buffer for per-step draft logits readback (sampling only).
     // Sized to whichever vocab the dispatch path uses (compressed cvs or
     // full 248K vocab). Allocated once outside the loop.
-    let mut draft_logits_host: Vec<f32> = if use_sampling {
+    let draft_logits_host: Vec<f32> = if use_sampling {
         let n = if use_full_vocab { vocab } else { cvs };
         vec![0.0; n]
     } else {
         Vec::new()
     };
-
-    // ── 1. K serial discrete-token roundtrips ─────────────────────────────
-    for k in 0..max_n {
-        let next_tok = if k == 0 { last_committed } else { candidates[k - 1] };
-
-        // Forward: in compressed mode, mtp_head_forward_compressed runs
-        // block_only + rmsnorm + small GEMV against lm_head_draft in one
-        // call. In full-vocab mode we run block_only here and do the
-        // rmsnorm + trunk-lm_head GEMV manually below.
-        if use_full_vocab {
-            if k == 0 {
-                mtp_head::mtp_head_forward_block_only(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &state.prev_hidden, None, cur_pos + k, trunk_weights,
-                )?;
-            } else {
-                let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
-                mtp_head::mtp_head_forward_block_only(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &prev_row, None, cur_pos + k, trunk_weights,
-                )?;
-            }
-            // rmsnorm(t_mtp_out, shared_head_norm) → tmp, then trunk lm_head
-            // GEMV → full_vocab_logits_view. weight_gemv dispatches the right
-            // kernel (gemv_mq4g256_with_rotate / gemv_q8_0 / etc.) on the
-            // trunk's output dtype.
-            gpu.rmsnorm_f32(
-                &state.mtp_scratch.t_mtp_out,
-                &head.weights.shared_head_norm,
-                &state.mtp_scratch.tmp,
-                head.config.rms_norm_eps,
-            )?;
-            llama::weight_gemv(
-                gpu,
-                &trunk_weights.output,
-                &state.mtp_scratch.tmp,
-                &full_vocab_logits_view,
-            )?;
+    let use_device_token_chain = mtp_device_token_chain_enabled_from_env()
+        && mtp_device_token_chain_eligible_for(trunk_weights.embd_format, use_sampling, use_p_min);
+    if use_device_token_chain && !use_full_vocab {
+        assert!(
+            head.weights.lm_head_draft_vocab_map_gpu.is_some(),
+            "compressed MTP device-token chain requires GPU vocab_map"
+        );
+    }
+    let proposal_graph_policy = mtp_proposal_graph_policy_from_env();
+    let use_proposal_graph = !state.mtp_proposal_graph_disabled
+        && mtp_proposal_graph_eligible_for(
+            proposal_graph_policy,
+            use_device_token_chain,
+            use_full_vocab,
+            state.mtp_kv.kv_mode,
+        );
+    let proposal_graph_seq_cap = if use_proposal_graph {
+        mtp_proposal_graph_seq_cap(cur_pos, max_n, state.mtp_kv.max_seq)
+    } else {
+        0
+    };
+    if use_proposal_graph
+        && state.mtp_proposal_graph_exec.is_some()
+        && proposal_graph_seq_cap > state.mtp_proposal_graph_seq_cap
+    {
+        destroy_mtp_proposal_graph(gpu, state);
+        state.mtp_proposal_graph_warmed = true;
+    }
+    if use_device_token_chain {
+        if use_proposal_graph {
+            upload_mtp_proposal_graph_inputs(gpu, state, last_committed, cur_pos, max_n)?;
         } else {
-            if k == 0 {
-                mtp_head::mtp_head_forward_compressed(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &state.prev_hidden, cur_pos + k, trunk_weights,
-                )?;
-            } else {
-                let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
-                mtp_head::mtp_head_forward_compressed(
-                    gpu, head, &state.mtp_scratch, &mut state.mtp_kv,
-                    next_tok, &prev_row, cur_pos + k, trunk_weights,
-                )?;
-            }
-        }
-
-        // Pick the logits buffer to argmax over (mode-dependent).
-        let logits_for_argmax: &GpuTensor = if use_full_vocab {
-            &full_vocab_logits_view
-        } else {
-            state.mtp_scratch.logits_compressed.as_ref().unwrap()
-        };
-        let argmax_vocab = cvs;  // = full vocab in full-vocab mode, = compressed vocab in compressed mode
-
-        let draft_idx: usize;
-        if use_sampling {
-            // GPU sample_top_p: kernel does the whole top_k(=20) + top_p +
-            // multinomial sample on-device. Returns 8 B (token id + new rng
-            // state). Eliminates the full 1 MB draft logits D2H + host
-            // softmax sample (~600 μs each step → ~3 ms/cycle saved).
-            //
-            // sample_top_p modifies logits in-place ONLY if repeat_penalty > 1
-            // and repeat_window > 0; we pass 1.0/0 so logits are untouched
-            // and the subsequent prob-gather sees the same values.
-            let (token_u32, new_rng) = gpu.sample_top_p(
-                logits_for_argmax,
-                &state.mtp_sample_result,
-                &state.mtp_sample_repeat_buf,
-                argmax_vocab,
-                sampling.temp,
-                sampling.top_p,
-                state.gpu_rng_state,
-                /* repeat_window */ 0,
-                /* repeat_penalty */ 1.0,
-            )?;
-            state.gpu_rng_state = new_rng;
-            draft_idx = token_u32 as usize;
-            assert!(draft_idx < argmax_vocab,
-                "draft sample {draft_idx} out of argmax_vocab {argmax_vocab}");
-
-            // GPU p_draft gather: H2D the sampled token id, run the gather
-            // kernel with n_rows=1, D2H 4 B prob. Replaces the host
-            // softmax_prob_at_temp call (~600 μs).
-            let token_i32: i32 = token_u32 as i32;
-            let idx_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(&token_i32 as *const i32 as *const u8, 4)
-            };
-            gpu.hip.memcpy_htod(&state.mtp_gather_idx_draft.buf, idx_bytes)?;
-            gpu.softmax_prob_gather_batched_f32(
-                logits_for_argmax,
-                &state.mtp_gather_idx_draft,
-                &state.mtp_gather_prob_draft,
-                argmax_vocab,
-                sampling.temp,
-                /* n_rows */ 1,
-            )?;
-            let mut p_draft_host: [f32; 1] = [0.0];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(p_draft_host.as_mut_ptr() as *mut u8, 4)
-                };
-                gpu.hip.memcpy_dtoh(bytes, &state.mtp_gather_prob_draft.buf)?;
-            }
-            draft_probs.push(p_draft_host[0]);
-
-            let token_id = match vocab_map_opt {
-                Some(vm) => vm[draft_idx],
-                None => draft_idx as u32,
-            };
-            candidates.push(token_id);
-            // draft_logits_host is unused on the GPU sampling path; left
-            // allocated for symmetry with the (now-removed) host-sample
-            // fallback. Compiler will elide.
-            let _ = &draft_logits_host;
-        } else if use_p_min {
-            // Top-2 with log-softmax probs: 8 B idx + 8 B logp D2H per step.
-            gpu.topk_logsumexp_batched_f32(
-                logits_for_argmax, &state.mtp_topk_idx, &state.mtp_topk_logp,
-                argmax_vocab, /* k */ 2, /* b */ 1,
-            )?;
-            let mut idx_host: [i32; 2] = [0, 0];
-            let mut logp_host: [f32; 2] = [0.0, 0.0];
-            {
-                let idx_bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, 8)
-                };
-                gpu.hip.memcpy_dtoh(idx_bytes, &state.mtp_topk_idx.buf)?;
-                let logp_bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(logp_host.as_mut_ptr() as *mut u8, 8)
-                };
-                gpu.hip.memcpy_dtoh(logp_bytes, &state.mtp_topk_logp.buf)?;
-            }
-            draft_idx = idx_host[0] as usize;
-            assert!(draft_idx < argmax_vocab,
-                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}");
-            // Compressed: remap via vocab_map. Full-vocab: idx IS the token id.
-            let token_id = match vocab_map_opt {
-                Some(vm) => vm[draft_idx],
-                None => draft_idx as u32,
-            };
-            candidates.push(token_id);
-
-            // Check confidence AFTER pushing — keep this candidate, just
-            // skip future steps if confidence is below threshold.
-            if logp_host[0] < log_p_min {
-                chain_truncated = true;
-                break;
-            }
-        } else {
-            gpu.argmax_f32_batched(logits_for_argmax, &argmax_view, argmax_vocab, 1)?;
-            let mut argmax_host: [i32; 1] = [0];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(
-                        argmax_host.as_mut_ptr() as *mut u8, 4,
-                    )
-                };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
-            }
-            draft_idx = argmax_host[0] as usize;
-            assert!(draft_idx < argmax_vocab,
-                "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}");
-            let token_id = match vocab_map_opt {
-                Some(vm) => vm[draft_idx],
-                None => draft_idx as u32,
-            };
-            candidates.push(token_id);
-        }
-
-        if k + 1 < max_n {
-            gpu.hip.memcpy_dtod_at(
-                &state.mtp_t_outs.buf, k * dim_bytes,
-                &state.mtp_scratch.t_mtp_out.buf, 0,
-                dim_bytes,
-            )?;
+            let seed_token = last_committed as i32;
+            let seed_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(&seed_token as *const i32 as *const u8, 4) };
+            gpu.hip
+                .memcpy_htod(&state.mtp_token_chain.buf, seed_bytes)?;
         }
     }
-    let drafts_generated = candidates.len();
+
+    // ── 1. K serial discrete-token roundtrips ─────────────────────────────
+    let mut proposal_graph_ran = false;
+    if use_proposal_graph {
+        if let Some(exec) = state.mtp_proposal_graph_exec.as_ref() {
+            let stream = gpu.active_stream.as_ref().unwrap();
+            gpu.hip.graph_launch(exec, stream)?;
+            proposal_graph_ran = true;
+        } else if state.mtp_proposal_graph_warmed {
+            let capture_result: HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> = (|| {
+                begin_mtp_proposal_graph_capture(gpu)?;
+                if let Err(e) = run_mtp_proposal_graph_body_q8(
+                    gpu,
+                    target,
+                    head,
+                    state,
+                    cur_pos,
+                    max_n,
+                    dim,
+                    cvs,
+                    proposal_graph_seq_cap,
+                ) {
+                    abort_mtp_proposal_graph_capture(gpu);
+                    return Err(e);
+                }
+                end_mtp_proposal_graph_capture(gpu)
+            })();
+            match capture_result {
+                Ok((graph, exec, blobs)) => {
+                    state.mtp_proposal_graph = Some(graph);
+                    state.mtp_proposal_graph_exec = Some(exec);
+                    state.mtp_proposal_graph_blobs = blobs;
+                    state.mtp_proposal_graph_seq_cap = proposal_graph_seq_cap;
+                    let stream = gpu.active_stream.as_ref().unwrap();
+                    gpu.hip
+                        .graph_launch(state.mtp_proposal_graph_exec.as_ref().unwrap(), stream)?;
+                    proposal_graph_ran = true;
+                }
+                Err(e) if proposal_graph_policy == MtpProposalGraphPolicy::On => return Err(e),
+                Err(e) => {
+                    abort_mtp_proposal_graph_capture(gpu);
+                    state.mtp_proposal_graph_disabled = true;
+                    eprintln!("[mtp-proposal-graph] disabled after capture failure: {}", e);
+                }
+            }
+        } else {
+            state.mtp_proposal_graph_warmed = true;
+        }
+    }
+
+    if !proposal_graph_ran {
+        for k in 0..max_n {
+            let next_tok = if use_device_token_chain {
+                0
+            } else if k == 0 {
+                last_committed
+            } else {
+                candidates[k - 1]
+            };
+            let next_token_embed = if use_device_token_chain {
+                let token_slot = state.mtp_token_chain.sub_offset(k, 1);
+                embed_device_token_into(
+                    gpu,
+                    trunk_weights,
+                    &state.mtp_token_embed,
+                    &token_slot,
+                    dim,
+                )?;
+                Some(&state.mtp_token_embed)
+            } else {
+                None
+            };
+
+            // Forward: in compressed mode, mtp_head_forward_compressed runs
+            // block_only + rmsnorm + small GEMV against lm_head_draft in one
+            // call. In full-vocab mode we run block_only here and do the
+            // rmsnorm + trunk-lm_head GEMV manually below.
+            if use_full_vocab {
+                if k == 0 {
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &state.prev_hidden,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                } else {
+                    let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &prev_row,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                }
+                // rmsnorm(t_mtp_out, shared_head_norm) → tmp, then trunk lm_head
+                // GEMV → full_vocab_logits_view. weight_gemv dispatches the right
+                // kernel (gemv_mq4g256_with_rotate / gemv_q8_0 / etc.) on the
+                // trunk's output dtype.
+                gpu.rmsnorm_f32(
+                    &state.mtp_scratch.t_mtp_out,
+                    &head.weights.shared_head_norm,
+                    &state.mtp_scratch.tmp,
+                    head.config.rms_norm_eps,
+                )?;
+                llama::weight_gemv(
+                    gpu,
+                    &trunk_weights.output,
+                    &state.mtp_scratch.tmp,
+                    &full_vocab_logits_view,
+                )?;
+            } else if use_device_token_chain {
+                if k == 0 {
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &state.prev_hidden,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                } else {
+                    let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                    mtp_head::mtp_head_forward_block_only(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &prev_row,
+                        next_token_embed,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                }
+                mtp_head::mtp_head_apply_lm_head_draft(gpu, head, &state.mtp_scratch)?;
+            } else {
+                if k == 0 {
+                    mtp_head::mtp_head_forward_compressed(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &state.prev_hidden,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                } else {
+                    let prev_row = state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                    mtp_head::mtp_head_forward_compressed(
+                        gpu,
+                        head,
+                        &state.mtp_scratch,
+                        &mut state.mtp_kv,
+                        next_tok,
+                        &prev_row,
+                        cur_pos + k,
+                        trunk_weights,
+                    )?;
+                }
+            }
+
+            // Pick the logits buffer to argmax over (mode-dependent).
+            let logits_for_argmax: &GpuTensor = if use_full_vocab {
+                &full_vocab_logits_view
+            } else {
+                state.mtp_scratch.logits_compressed.as_ref().unwrap()
+            };
+            let argmax_vocab = cvs; // = full vocab in full-vocab mode, = compressed vocab in compressed mode
+
+            let draft_idx: usize;
+            if use_sampling {
+                // GPU sample_top_p: kernel does the whole top_k(=20) + top_p +
+                // multinomial sample on-device. Returns 8 B (token id + new rng
+                // state). Eliminates the full 1 MB draft logits D2H + host
+                // softmax sample (~600 μs each step → ~3 ms/cycle saved).
+                //
+                // sample_top_p modifies logits in-place ONLY if repeat_penalty > 1
+                // and repeat_window > 0; we pass 1.0/0 so logits are untouched
+                // and the subsequent prob-gather sees the same values.
+                let (token_u32, new_rng) = gpu.sample_top_p(
+                    logits_for_argmax,
+                    &state.mtp_sample_result,
+                    &state.mtp_sample_repeat_buf,
+                    argmax_vocab,
+                    sampling.temp,
+                    sampling.top_p,
+                    state.gpu_rng_state,
+                    /* repeat_window */ 0,
+                    /* repeat_penalty */ 1.0,
+                )?;
+                state.gpu_rng_state = new_rng;
+                draft_idx = token_u32 as usize;
+                assert!(
+                    draft_idx < argmax_vocab,
+                    "draft sample {draft_idx} out of argmax_vocab {argmax_vocab}"
+                );
+
+                // GPU p_draft gather: H2D the sampled token id, run the gather
+                // kernel with n_rows=1, D2H 4 B prob. Replaces the host
+                // softmax_prob_at_temp call (~600 μs).
+                let token_i32: i32 = token_u32 as i32;
+                let idx_bytes: &[u8] =
+                    unsafe { std::slice::from_raw_parts(&token_i32 as *const i32 as *const u8, 4) };
+                gpu.hip
+                    .memcpy_htod(&state.mtp_gather_idx_draft.buf, idx_bytes)?;
+                gpu.softmax_prob_gather_batched_f32(
+                    logits_for_argmax,
+                    &state.mtp_gather_idx_draft,
+                    &state.mtp_gather_prob_draft,
+                    argmax_vocab,
+                    sampling.temp,
+                    /* n_rows */ 1,
+                )?;
+                let mut p_draft_host: [f32; 1] = [0.0];
+                {
+                    let bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(p_draft_host.as_mut_ptr() as *mut u8, 4)
+                    };
+                    gpu.hip
+                        .memcpy_dtoh(bytes, &state.mtp_gather_prob_draft.buf)?;
+                }
+                draft_probs.push(p_draft_host[0]);
+
+                let token_id = match vocab_map_opt {
+                    Some(vm) => vm[draft_idx],
+                    None => draft_idx as u32,
+                };
+                candidates.push(token_id);
+                // draft_logits_host is unused on the GPU sampling path; left
+                // allocated for symmetry with the (now-removed) host-sample
+                // fallback. Compiler will elide.
+                let _ = &draft_logits_host;
+            } else if use_p_min {
+                // Top-2 with log-softmax probs: 8 B idx + 8 B logp D2H per step.
+                gpu.topk_logsumexp_batched_f32(
+                    logits_for_argmax,
+                    &state.mtp_topk_idx,
+                    &state.mtp_topk_logp,
+                    argmax_vocab,
+                    /* k */ 2,
+                    /* b */ 1,
+                )?;
+                let mut idx_host: [i32; 2] = [0, 0];
+                let mut logp_host: [f32; 2] = [0.0, 0.0];
+                {
+                    let idx_bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, 8)
+                    };
+                    gpu.hip.memcpy_dtoh(idx_bytes, &state.mtp_topk_idx.buf)?;
+                    let logp_bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(logp_host.as_mut_ptr() as *mut u8, 8)
+                    };
+                    gpu.hip.memcpy_dtoh(logp_bytes, &state.mtp_topk_logp.buf)?;
+                }
+                draft_idx = idx_host[0] as usize;
+                assert!(
+                    draft_idx < argmax_vocab,
+                    "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
+                );
+                // Compressed: remap via vocab_map. Full-vocab: idx IS the token id.
+                let token_id = match vocab_map_opt {
+                    Some(vm) => vm[draft_idx],
+                    None => draft_idx as u32,
+                };
+                candidates.push(token_id);
+
+                // Check confidence AFTER pushing — keep this candidate, just
+                // skip future steps if confidence is below threshold.
+                if logp_host[0] < log_p_min {
+                    chain_truncated = true;
+                    break;
+                }
+            } else if use_device_token_chain {
+                let vocab_map_gpu = if use_full_vocab {
+                    None
+                } else {
+                    head.weights.lm_head_draft_vocab_map_gpu.as_ref()
+                };
+                gpu.argmax_token_chain_f32(
+                    logits_for_argmax,
+                    &argmax_view,
+                    &state.mtp_token_chain,
+                    vocab_map_gpu,
+                    argmax_vocab,
+                    k + 1,
+                )?;
+            } else {
+                gpu.argmax_f32_batched(logits_for_argmax, &argmax_view, argmax_vocab, 1)?;
+                let mut argmax_host: [i32; 1] = [0];
+                {
+                    let bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(argmax_host.as_mut_ptr() as *mut u8, 4)
+                    };
+                    gpu.hip.memcpy_dtoh(bytes, &argmax_view.buf)?;
+                }
+                draft_idx = argmax_host[0] as usize;
+                assert!(
+                    draft_idx < argmax_vocab,
+                    "draft argmax {draft_idx} out of argmax_vocab {argmax_vocab}"
+                );
+                let token_id = match vocab_map_opt {
+                    Some(vm) => vm[draft_idx],
+                    None => draft_idx as u32,
+                };
+                candidates.push(token_id);
+            }
+
+            if k + 1 < max_n {
+                gpu.memcpy_dtod_at_auto(
+                    &state.mtp_t_outs.buf,
+                    k * dim_bytes,
+                    &state.mtp_scratch.t_mtp_out.buf,
+                    0,
+                    dim_bytes,
+                )?;
+            }
+        }
+    }
+    let drafts_generated = if use_device_token_chain {
+        debug_assert!(
+            !use_sampling && !use_p_min,
+            "device-token chain assumes an untruncated greedy chain"
+        );
+        let candidate_view = state.mtp_token_chain.sub_offset(1, max_n);
+        let mut candidate_host: Vec<i32> = vec![0; max_n];
+        {
+            let bytes: &mut [u8] = unsafe {
+                std::slice::from_raw_parts_mut(candidate_host.as_mut_ptr() as *mut u8, max_n * 4)
+            };
+            gpu.hip.memcpy_dtoh(bytes, &candidate_view.buf)?;
+        }
+        candidates.extend(candidate_host.into_iter().map(|t| t as u32));
+        max_n
+    } else {
+        candidates.len()
+    };
 
     // ── 2. Trunk verify ───────────────────────────────────────────────────
     let mut verify_tokens: Vec<u32> = Vec::with_capacity(max_n + 1);
@@ -1590,7 +2567,12 @@ pub fn spec_step_mtp_compressed_serial(
     verify_tokens.extend_from_slice(&candidates);
     let n_verify = verify_tokens.len();
 
-    state.trunk_snap.save_from(&target.dn_state, gpu)?;
+    if overlap_trunk_snap {
+        gpu.hip
+            .stream_synchronize(state.trunk_snap_stream.as_ref().unwrap())?;
+    } else {
+        state.trunk_snap.save_from(&target.dn_state, gpu)?;
+    }
 
     // GDN-tape capture happens only when the verify takes the batched (PBS)
     // path; otherwise the forward silently drops to a tape-less per-token loop
@@ -1616,54 +2598,124 @@ pub fn spec_step_mtp_compressed_serial(
         None
     };
 
-    qwen35::forward_prefill_batch_with_pbs(
-        gpu, trunk_weights, &target.config, &verify_tokens, cur_pos,
-        &mut target.kv_cache, &mut target.dn_state, &target.scratch,
-        None, Some(&state.verify_hidden), verify_tape, None,
-        Some(&state.trunk_pbs), None, // mask_override
-        None, // max_layer
+    qwen35::forward_prefill_batch_with_pbs_opts(
+        gpu,
+        trunk_weights,
+        &target.config,
+        &verify_tokens,
+        cur_pos,
+        &mut target.kv_cache,
+        &mut target.dn_state,
+        &target.scratch,
+        None,
+        Some(&state.verify_hidden),
+        verify_tape,
+        None,
+        Some(&state.trunk_pbs),
+        None,  // mask_override
+        None,  // max_layer
+        false, // MTP computes all verify logits from verify_hidden below
     )?;
 
     let w_out = &trunk_weights.output;
     let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
     match w_out.gpu_dtype {
         DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
-            )?;
+            if mtp_q8_verify_wmma_enabled_from_env() {
+                gpu.gemm_q8_0_batched_chunked(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            } else {
+                gpu.gemm_q8_0_batched(
+                    &w_out.buf,
+                    &state.verify_hidden,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
         }
         DType::HFQ4G256 => {
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ4G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq4g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ3G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq3g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::HFQ6G256 => {
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &state.verify_hidden, &logits_view,
-                w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         DType::MQ6G256 => {
             let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
-            llama::rotate_x_mq_batched_for(gpu, w_out, &state.verify_hidden, &rot, w_out.k, n_verify)?;
+            llama::rotate_x_mq_batched_for(
+                gpu,
+                w_out,
+                &state.verify_hidden,
+                &rot,
+                w_out.k,
+                n_verify,
+            )?;
             gpu.gemm_hfq6g256_batched_lmhead(
-                &w_out.buf, &rot, &logits_view, w_out.m, w_out.k, n_verify,
+                &w_out.buf,
+                &rot,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
             )?;
         }
         _ => {
@@ -1674,19 +2726,6 @@ pub fn spec_step_mtp_compressed_serial(
             }
         }
     }
-
-    let argmax_v = state.verify_argmax.sub_offset(0, n_verify);
-    gpu.argmax_f32_batched(&logits_view, &argmax_v, vocab, n_verify)?;
-    let mut argmax_v_host: Vec<i32> = vec![0; n_verify];
-    {
-        let bytes: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(
-                argmax_v_host.as_mut_ptr() as *mut u8, n_verify * 4,
-            )
-        };
-        gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
-    }
-    let argmax_per_pos: Vec<u32> = argmax_v_host.into_iter().map(|x| x as u32).collect();
 
     let mut accept_count = 0usize;
     let mut hit_eos = false;
@@ -1723,14 +2762,14 @@ pub fn spec_step_mtp_compressed_serial(
         // dispatch the gather kernel, D2H K probs. Replaces the 6 MB D2H
         // of full verify_logits + K host softmax_prob_at_temp calls.
         let cand_indices: Vec<i32> = candidates[..drafts_generated]
-            .iter().map(|&t| t as i32).collect();
+            .iter()
+            .map(|&t| t as i32)
+            .collect();
         let idx_bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(
-                cand_indices.as_ptr() as *const u8,
-                drafts_generated * 4,
-            )
+            std::slice::from_raw_parts(cand_indices.as_ptr() as *const u8, drafts_generated * 4)
         };
-        gpu.hip.memcpy_htod(&state.mtp_gather_idx_verify.buf, idx_bytes)?;
+        gpu.hip
+            .memcpy_htod(&state.mtp_gather_idx_verify.buf, idx_bytes)?;
         gpu.softmax_prob_gather_batched_f32(
             &logits_view,
             &state.mtp_gather_idx_verify,
@@ -1747,7 +2786,8 @@ pub fn spec_step_mtp_compressed_serial(
                     drafts_generated * 4,
                 )
             };
-            gpu.hip.memcpy_dtoh(bytes, &state.mtp_gather_prob_verify.buf)?;
+            gpu.hip
+                .memcpy_dtoh(bytes, &state.mtp_gather_prob_verify.buf)?;
         }
 
         for k in 0..drafts_generated {
@@ -1791,25 +2831,54 @@ pub fn spec_step_mtp_compressed_serial(
         }
     } else {
         // ── Legacy greedy / argmax-match accept rule ─────────────────────
-        for k in 0..drafts_generated {
-            if argmax_per_pos[k] == candidates[k] {
-                committed.push(candidates[k]);
-                accept_count += 1;
-                if candidates[k] == eos_token_id {
-                    hit_eos = true;
-                    break;
-                }
-            } else {
-                break;
+        let argmax_v = state.verify_argmax.sub_offset(0, n_verify);
+        gpu.argmax_f32_batched(&logits_view, &argmax_v, vocab, n_verify)?;
+
+        let use_gpu_accept = use_device_token_chain && mtp_gpu_greedy_accept_enabled_from_env();
+        let accepted = if use_gpu_accept {
+            let candidate_device = state.mtp_token_chain.sub_offset(1, drafts_generated);
+            let accept_result = state.verify_argmax.sub_offset(0, 2);
+            gpu.greedy_accept_from_argmax_i32(
+                &argmax_v,
+                &candidate_device,
+                &accept_result,
+                drafts_generated,
+                eos_token_id,
+            )?;
+            let mut accept_host: [i32; 2] = [0, 0];
+            {
+                let bytes: &mut [u8] = unsafe {
+                    std::slice::from_raw_parts_mut(accept_host.as_mut_ptr() as *mut u8, 8)
+                };
+                gpu.hip.memcpy_dtoh(bytes, &accept_result.buf)?;
             }
-        }
-        if !hit_eos {
-            let bonus = argmax_per_pos[accept_count];
-            committed.push(bonus);
-            if bonus == eos_token_id {
-                hit_eos = true;
+            assemble_greedy_accept_from_gpu_result(
+                &candidates[..drafts_generated],
+                accept_host[0] as usize,
+                accept_host[1],
+                eos_token_id,
+            )
+        } else {
+            let mut argmax_v_host: Vec<i32> = vec![0; n_verify];
+            {
+                let bytes: &mut [u8] = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        argmax_v_host.as_mut_ptr() as *mut u8,
+                        n_verify * 4,
+                    )
+                };
+                gpu.hip.memcpy_dtoh(bytes, &argmax_v.buf)?;
             }
-        }
+            let argmax_per_pos: Vec<u32> = argmax_v_host.into_iter().map(|x| x as u32).collect();
+            greedy_trunk_spine_accept(
+                &candidates[..drafts_generated],
+                &argmax_per_pos,
+                eos_token_id,
+            )
+        };
+        committed = accepted.committed;
+        accept_count = accepted.accept_count;
+        hit_eos = accepted.hit_eos;
     }
 
     let advance = committed.len();
@@ -1841,9 +2910,10 @@ pub fn spec_step_mtp_compressed_serial(
     // conv/GDN recurrence for the accepted prefix. Full trunk forward replay
     // was the dominant non-verify cost in the MTP cycle.
     //
-    // The trunk_snap.save_from() call earlier in the cycle is still made
-    // unconditionally (~1 ms, unavoidable since we don't know advance
-    // until verify completes); only the restore + tape replay are gated.
+    // The trunk_snap save is still made unconditionally (we don't know
+    // advance until verify completes). An opt-in side-stream path can start
+    // it before proposal and wait before verify; only the restore + tape
+    // replay are gated.
     //
     // On EOS we still take the replay branch: even though no further
     // forwards happen, the caller's KV cache must reflect ONLY the
@@ -1871,14 +2941,29 @@ pub fn spec_step_mtp_compressed_serial(
             if advance >= 2 {
                 let replay = &verify_tokens[..advance];
                 qwen35::forward_prefill_batch(
-                    gpu, trunk_weights, &target.config, replay, cur_pos,
-                    &mut target.kv_cache, &mut target.dn_state, &target.scratch,
-                    None, None, None, None,
+                    gpu,
+                    trunk_weights,
+                    &target.config,
+                    replay,
+                    cur_pos,
+                    &mut target.kv_cache,
+                    &mut target.dn_state,
+                    &target.scratch,
+                    None,
+                    None,
+                    None,
+                    None,
                 )?;
             } else {
                 qwen35::forward_scratch(
-                    gpu, trunk_weights, &target.config, verify_tokens[0], cur_pos,
-                    &mut target.kv_cache, &mut target.dn_state, &target.scratch,
+                    gpu,
+                    trunk_weights,
+                    &target.config,
+                    verify_tokens[0],
+                    cur_pos,
+                    &mut target.kv_cache,
+                    &mut target.dn_state,
+                    &target.scratch,
                 )?;
             }
         }
@@ -1893,4 +2978,152 @@ pub fn spec_step_mtp_compressed_serial(
         chain_truncated,
         replay_skipped,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trunk_spine_verify_tokens_are_seed_plus_candidates() {
+        let tokens = build_trunk_spine_verify_tokens(42, &[7, 8, 9]);
+
+        assert_eq!(tokens, vec![42, 7, 8, 9]);
+    }
+
+    #[test]
+    fn trunk_spine_accepts_longest_prefix_then_bonus() {
+        let accepted = greedy_trunk_spine_accept(&[11, 12, 13], &[11, 99, 55, 66], 2);
+
+        assert_eq!(accepted.committed, vec![11, 99]);
+        assert_eq!(accepted.accept_count, 1);
+        assert!(!accepted.hit_eos);
+    }
+
+    #[test]
+    fn trunk_spine_stops_without_bonus_when_accepted_candidate_is_eos() {
+        let accepted = greedy_trunk_spine_accept(&[11, 2, 13], &[11, 2, 55, 66], 2);
+
+        assert_eq!(accepted.committed, vec![11, 2]);
+        assert_eq!(accepted.accept_count, 2);
+        assert!(accepted.hit_eos);
+    }
+
+    #[test]
+    fn gpu_greedy_accept_result_matches_host_accept_semantics() {
+        let mismatch_bonus = assemble_greedy_accept_from_gpu_result(&[11, 12, 13], 1, 99, 2);
+        assert_eq!(mismatch_bonus.committed, vec![11, 99]);
+        assert_eq!(mismatch_bonus.accept_count, 1);
+        assert!(!mismatch_bonus.hit_eos);
+
+        let accepted_eos = assemble_greedy_accept_from_gpu_result(&[11, 2, 13], 2, -1, 2);
+        assert_eq!(accepted_eos.committed, vec![11, 2]);
+        assert_eq!(accepted_eos.accept_count, 2);
+        assert!(accepted_eos.hit_eos);
+
+        let bonus_eos = assemble_greedy_accept_from_gpu_result(&[11, 12, 13], 3, 2, 2);
+        assert_eq!(bonus_eos.committed, vec![11, 12, 13, 2]);
+        assert_eq!(bonus_eos.accept_count, 3);
+        assert!(bonus_eos.hit_eos);
+    }
+
+    #[test]
+    fn device_token_chain_is_greedy_only_and_embedding_gated() {
+        assert!(mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G256,
+            false,
+            false
+        ));
+        assert!(mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::Q8_0,
+            false,
+            false
+        ));
+        assert!(!mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G128,
+            false,
+            false
+        ));
+        assert!(!mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G256,
+            true,
+            false
+        ));
+        assert!(!mtp_device_token_chain_eligible_for(
+            llama::EmbeddingFormat::HFQ4G256,
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn proposal_graph_policy_is_opt_in_and_q8_device_chain_only() {
+        assert!(mtp_q8_verify_wmma_enabled_from_env_value(None));
+        assert!(!mtp_q8_verify_wmma_enabled_from_env_value(Some("0")));
+        assert!(!mtp_q8_verify_wmma_enabled_from_env_value(Some("off")));
+        assert!(mtp_q8_verify_wmma_enabled_from_env_value(Some("1")));
+        assert!(mtp_q8_verify_wmma_enabled_from_env_value(Some("ON")));
+
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(None),
+            MtpProposalGraphPolicy::Off
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("0")),
+            MtpProposalGraphPolicy::Off
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("off")),
+            MtpProposalGraphPolicy::Off
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("1")),
+            MtpProposalGraphPolicy::On
+        );
+        assert_eq!(
+            mtp_proposal_graph_policy_from_env_value(Some("ON")),
+            MtpProposalGraphPolicy::On
+        );
+
+        assert!(mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            false,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            true,
+            true,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Auto,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Asym3,
+        ));
+        assert!(mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::On,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+        assert!(!mtp_proposal_graph_eligible_for(
+            MtpProposalGraphPolicy::Off,
+            true,
+            false,
+            crate::mtp_head::MtpKvMode::Q8,
+        ));
+
+        assert_eq!(mtp_proposal_graph_seq_cap(27, 5, 4096), 256);
+        assert_eq!(mtp_proposal_graph_seq_cap(260, 5, 4096), 512);
+        assert_eq!(mtp_proposal_graph_seq_cap(3000, 5, 4096), 4096);
+    }
 }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -4458,8 +4458,9 @@ pub struct PrefillBatchScratch {
 
     // Path 2 (SGLang-style scatter + grouped-WMMA-GEMM) scratch. All
     // allocated when num_experts > 0; gated at runtime by
-    // HIPFIRE_MOE_GROUPED_GEMM=1. m_total_max = max_batch * k_top +
-    // num_experts * (BLOCK_M - 1) with BLOCK_M=16.
+    // HIPFIRE_MOE_GROUPED_GEMM=1. m_total_max is tile-aligned:
+    // align_up(max_batch * k_top + num_experts * (BLOCK_M - 1), BLOCK_M)
+    // with BLOCK_M=16.
     //
     //   moe_expert_token_counts: [num_experts] i32 (raw → padded)
     //   moe_expert_offsets:      [num_experts + 1] i32 (exclusive prefix)
@@ -4575,7 +4576,11 @@ impl PrefillBatchScratch {
                 Some(gpu.alloc_tensor(&[(config.num_experts + 1) * 4], DType::Raw)?)
             } else { None },
             moe_sorted_slot_index: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
                 Some(gpu.alloc_tensor(&[m_total_max * 4], DType::Raw)?)
             } else { None },
             moe_inverse_perm: if config.num_experts > 0 {
@@ -4583,15 +4588,27 @@ impl PrefillBatchScratch {
                 Some(gpu.alloc_tensor(&[total_slots_max * 4], DType::Raw)?)
             } else { None },
             moe_expert_tile_ids: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
-                Some(gpu.alloc_tensor(&[(m_total_max / 16 + 1) * 4], DType::Raw)?)
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
+                Some(gpu.alloc_tensor(&[(m_total_max / MOE_GROUPED_BLOCK_M) * 4], DType::Raw)?)
             } else { None },
             moe_y_gate_up_grouped: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
                 Some(gpu.alloc_tensor(&[m_total_max * 2 * config.moe_intermediate_size], DType::F32)?)
             } else { None },
             moe_y_down_grouped: if config.num_experts > 0 {
-                let m_total_max = max_batch * config.num_experts_per_tok + config.num_experts * 15;
+                let m_total_max = moe_grouped_m_total_max(
+                    max_batch,
+                    config.num_experts_per_tok,
+                    config.num_experts,
+                );
                 Some(gpu.alloc_tensor(&[m_total_max * config.dim], DType::F32)?)
             } else { None },
             dn_s_tape_q8: if config.linear_num_value_heads > 0 {
@@ -4681,6 +4698,46 @@ impl PrefillBatchScratch {
 /// on prompt seeding of long prompts).
 pub const PREFILL_MAX_BATCH: usize = 256;
 
+const MOE_GROUPED_BLOCK_M: usize = 16;
+
+#[inline]
+fn prefill_should_emit_last_token_logits(
+    has_per_token_hidden_out: bool,
+    needs_last_token_logits: bool,
+) -> bool {
+    !has_per_token_hidden_out || needs_last_token_logits
+}
+
+#[inline]
+fn align_up_usize(x: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (x + align - 1) & !(align - 1)
+}
+
+#[inline]
+fn moe_grouped_m_total_max(max_batch: usize, k_top: usize, n_exp: usize) -> usize {
+    // Every grouped-GEMM tile consumes 16 sorted slots. The scatter kernel
+    // initializes sentinel tile ids up to this bound, so the bound itself must
+    // be tile-aligned; otherwise the final launched tile can read an
+    // uninitialized expert id.
+    align_up_usize(
+        max_batch * k_top + n_exp * (MOE_GROUPED_BLOCK_M - 1),
+        MOE_GROUPED_BLOCK_M,
+    )
+}
+
+#[inline]
+fn moe_grouped_m_total_bound(total_slots: usize, n_exp: usize) -> usize {
+    // Actual grouped rows are sum_e align_up(count_e, BLOCK_M). Only experts
+    // that receive at least one slot can contribute padding, so small verify
+    // batches do not need to launch the full all-experts worst case.
+    let live_expert_bound = total_slots.min(n_exp);
+    align_up_usize(
+        total_slots + live_expert_bound * (MOE_GROUPED_BLOCK_M - 1),
+        MOE_GROUPED_BLOCK_M,
+    )
+}
+
 /// Host-side helper: upload token ids and positions to a `PrefillBatchScratch`
 /// via sync `memcpy_htod`. Call this BEFORE entering a hipGraph capture to
 /// pre-populate `pbs.tokens` and `pbs.positions`, then pass `pre_uploaded:
@@ -4733,6 +4790,41 @@ pub fn forward_prefill_batch_single_chunk_captured(
     per_token_hidden_out: Option<&GpuTensor>,
     gdn_tape: Option<&mut crate::speculative::GdnTape>,
     tree_verify: Option<TreeVerifyCtx<'_>>,
+) -> HipResult<()> {
+    forward_prefill_batch_single_chunk_captured_opts(
+        gpu,
+        weights,
+        config,
+        tokens,
+        start_pos,
+        kv_cache,
+        dn_state,
+        scratch,
+        pbs,
+        hidden_rb,
+        per_token_hidden_out,
+        gdn_tape,
+        tree_verify,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn forward_prefill_batch_single_chunk_captured_opts(
+    gpu: &mut Gpu,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    tokens: &[u32],
+    start_pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch: &Qwen35Scratch,
+    pbs: &PrefillBatchScratch,
+    hidden_rb: Option<&HiddenStateRingBuffer>,
+    per_token_hidden_out: Option<&GpuTensor>,
+    gdn_tape: Option<&mut crate::speculative::GdnTape>,
+    tree_verify: Option<TreeVerifyCtx<'_>>,
+    needs_last_token_logits: bool,
 ) -> HipResult<()> {
     let n = tokens.len();
     debug_assert!(n > 0 && n <= pbs.max_batch,
@@ -4904,6 +4996,7 @@ pub fn forward_prefill_batch_single_chunk_captured(
         true, // pre_uploaded: caller must have run upload_prefill_batch_inputs
         None, // band: full-stack single-GPU path
         None, // mask_override: captured-prefill caller does not use the MTP probe hook
+        needs_last_token_logits,
         None, // max_layer: single-chunk captured path always runs the full stack
     )
 }
@@ -4930,6 +5023,43 @@ pub fn forward_prefill_batch(
     )
 }
 
+pub fn forward_prefill_batch_with_pbs(
+    gpu: &mut Gpu,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    tokens: &[u32],
+    start_pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch: &Qwen35Scratch,
+    hidden_rb: Option<&mut HiddenStateRingBuffer>,
+    per_token_hidden_out: Option<&GpuTensor>,
+    gdn_tape: Option<&mut crate::speculative::GdnTape>,
+    tree_verify: Option<TreeVerifyCtx<'_>>,
+    pbs_in: Option<&PrefillBatchScratch>,
+    mask_override: Option<MaskEmbedOverride<'_>>,
+    max_layer: Option<usize>,
+) -> HipResult<()> {
+    forward_prefill_batch_with_pbs_opts(
+        gpu,
+        weights,
+        config,
+        tokens,
+        start_pos,
+        kv_cache,
+        dn_state,
+        scratch,
+        hidden_rb,
+        per_token_hidden_out,
+        gdn_tape,
+        tree_verify,
+        pbs_in,
+        mask_override,
+        max_layer,
+        true, // preserve legacy post-condition: scratch.logits is last-token logits
+    )
+}
+
 /// Like `forward_prefill_batch`, but accepts a caller-owned `PrefillBatchScratch`
 /// so the ~25 per-cycle tensor allocations can be amortized across many calls.
 ///
@@ -4939,7 +5069,12 @@ pub fn forward_prefill_batch(
 /// up to `pbs.max_batch`. Callers driving DFlash verify should size `pbs`
 /// to the maximum block size they'll ever request (e.g. `block_size` or
 /// `1 + tree_budget`) so everything fits in one chunk.
-pub fn forward_prefill_batch_with_pbs(
+///
+/// `needs_last_token_logits = false` is only for callers that pass
+/// `per_token_hidden_out` and compute their own logits from those hidden rows.
+/// The default wrapper keeps this true to protect existing callers that rely on
+/// `scratch.logits` being populated with the last token's logits.
+pub fn forward_prefill_batch_with_pbs_opts(
     gpu: &mut Gpu,
     weights: &Qwen35Weights,
     config: &Qwen35Config,
@@ -4955,6 +5090,7 @@ pub fn forward_prefill_batch_with_pbs(
     pbs_in: Option<&PrefillBatchScratch>,
     mask_override: Option<MaskEmbedOverride<'_>>,
     max_layer: Option<usize>,
+    needs_last_token_logits: bool,
 ) -> HipResult<()> {
     // Upper bound on the PrefillBatchScratch — large prompts get split
     // into chunks of this size and processed in a loop.
@@ -5176,6 +5312,7 @@ pub fn forward_prefill_batch_with_pbs(
                 false, // pre_uploaded: default path uploads inside
                 None,  // band: full-stack single-GPU path
                 mo_for_chunk,
+                needs_last_token_logits,
                 max_layer,
             )?;
             if let Some(rb) = hidden_rb.as_mut() {
@@ -5401,11 +5538,6 @@ fn paro_batched_admit_enabled_from_env(value: Option<&str>) -> bool {
     value != Some("0")
 }
 
-/// MQ6 admit is gated behind `HIPFIRE_MOE_MQ6_ADMIT=1` because of a
-/// known correctness regression on AWQ A3B (token attractor `!!!!!`)
-/// when the new MQ6 dispatch path is exercised — the 4 new MQ6 kernels
-/// pass synthetic channel tests at FP16 ULP precision but produce
-/// garbage activations in production. Bisection of the offending
 /// Threshold below which batching overhead isn't worth the alloc + per-layer
 /// dispatch — single-token prefill must not take the batched path.
 const MIN_BATCH: usize = 2;
@@ -5433,6 +5565,10 @@ pub fn prefill_batch_pbs_eligible(
     // MoE batched path requires K_TOP=8 (hard-coded in the indexed kernels) and
     // num_experts ≤ 1024 (bound of the batched top-K shared mem).
     let moe_topk_ok = config.num_experts_per_tok == 8 && config.num_experts <= 1024;
+    let admit_mq6 = mq6_batched_admit_enabled_from_env(
+        std::env::var("HIPFIRE_MOE_MQ6_ADMIT").ok().as_deref(),
+        arch,
+    );
     !force_fallback
         && n >= MIN_BATCH
         && dn_state.quant == StateQuant::Q8
@@ -5461,7 +5597,7 @@ pub fn prefill_batch_pbs_eligible(
                     && is_batchable_la(l.w_beta.gpu_dtype, arch)
                     && is_batchable_la(l.w_alpha.gpu_dtype, arch)
                     && is_batchable_la(l.wo.gpu_dtype, arch)
-                    && moe_ffn_batched_admissible(&l.ffn),
+                    && moe_ffn_batched_admissible(&l.ffn, admit_mq6),
             LayerWeights::FullAttnMoe(l) =>
                 moe_topk_ok
                     && moe_router_logits_present
@@ -5469,13 +5605,24 @@ pub fn prefill_batch_pbs_eligible(
                     && is_batchable_la(l.wk.gpu_dtype, arch)
                     && is_batchable_la(l.wv.gpu_dtype, arch)
                     && is_batchable_la(l.wo.gpu_dtype, arch)
-                    && moe_ffn_batched_admissible(&l.ffn),
+                    && moe_ffn_batched_admissible(&l.ffn, admit_mq6),
         })
 }
 
-/// dispatch site is pending. Default-off preserves the pre-fan-out
-/// behavior (AWQ A3B → per-token fallback, coherent at ~53 tok/s).
-fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights) -> bool {
+/// Whether MQ6 MoE FFN projections can enter batched prefill. After the
+/// grouped tile-bound fix, gfx12 defaults to admit because its HFQ6
+/// grouped-WMMA path is present and production-smoked; gfx11 and older stay
+/// default-off because the MQ6 grouped sister is not implemented there and the
+/// indexed fallback still lacks an MQ6 gate_up batched kernel.
+fn mq6_batched_admit_enabled_from_env(value: Option<&str>, arch: &str) -> bool {
+    match value {
+        Some("0") | Some("off") | Some("false") => false,
+        Some("1") | Some("on") | Some("true") => true,
+        _ => arch.starts_with("gfx12"),
+    }
+}
+
+fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights, admit_mq6: bool) -> bool {
     // F32 router/shared_gate admit (PARO checkpoints — router is FP16-dense,
     // expanded to F32 on GPU; shared_expert_gate likewise. See
     // load_fp16_weight_from_source at qwen35.rs:1177). The dispatch arms in
@@ -5506,12 +5653,6 @@ fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights) -> bool {
             return true;
         }
     }
-
-    // MQ6 admit env gate (default off — see comment above)
-    static MQ6_ADMIT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let admit_mq6 = *MQ6_ADMIT.get_or_init(|| {
-        std::env::var("HIPFIRE_MOE_MQ6_ADMIT").as_deref() == Ok("1")
-    });
 
     if admit_mq6 {
         // Per-projection MQ4 OR MQ6 admit.
@@ -5807,9 +5948,9 @@ fn prefill_moe_ffn_body_batched(
     let mut path2_m_total: usize = 0;
     if path2_eligible {
         // Stage 1 scatter pipeline. The scratch buffers are sized for
-        // m_total_max = max_batch * k_top + n_exp * 15; here m_total ≤
-        // n * k_top + n_exp * 15. Block size 16 (the WMMA tile row count).
-        const BLOCK_M: usize = 16;
+        // worst-case max_batch. Runtime launch bounds use the tighter live
+        // slot upper bound below. Block size 16 (the WMMA tile row count).
+        const BLOCK_M: usize = MOE_GROUPED_BLOCK_M;
         let counts = pbs.moe_expert_token_counts.as_ref().expect("path2 scratch");
         let offsets = pbs.moe_expert_offsets.as_ref().expect("path2 scratch");
         let sorted = pbs.moe_sorted_slot_index.as_ref().expect("path2 scratch");
@@ -5817,12 +5958,13 @@ fn prefill_moe_ffn_body_batched(
         let tile_ids = pbs.moe_expert_tile_ids.as_ref().expect("path2 scratch");
         let y_gu_grouped = pbs.moe_y_gate_up_grouped.as_ref().expect("path2 scratch");
         let total_slots = n * k_top;
-        // m_total upper bound — sized in PrefillBatchScratch::new with
-        // max_batch * k_top + n_exp * (BLOCK_M - 1). The scatter fused
-        // kernel pre-fills expert_tile_ids[0..m_total_max/16] with -1;
-        // the grouped GEMM and unscatter early-return on those tiles, so
-        // we can skip the m_total dtoh sync entirely. Saves ~50µs/layer.
-        let m_total_max = n * k_top + n_exp * (BLOCK_M - 1);
+        // m_total upper bound — scratch is sized in PrefillBatchScratch::new
+        // with the all-experts worst case, while this launch only needs slots
+        // plus padding for experts that can be non-empty at this N.
+        // The scatter fused kernel pre-fills every tile id in this aligned
+        // bound with -1; grouped GEMM early-returns on sentinel tiles, so we
+        // can skip the m_total dtoh sync entirely. Saves ~50µs/layer.
+        let m_total_max = moe_grouped_m_total_bound(total_slots, n_exp);
 
         // Fused scatter pipeline: one launch replaces histogram + offsets
         // + permute. Saves 2 launches × ~75µs × MoE layers.
@@ -6137,6 +6279,7 @@ fn forward_prefill_chunk(
     pre_uploaded: bool,
     band: Option<&PrefillBandCtx<'_>>,
     mask_override: Option<MaskEmbedOverride<'_>>,
+    needs_last_token_logits: bool,
     max_layer: Option<usize>,
 ) -> HipResult<()> {
     let n = tokens.len();
@@ -8236,11 +8379,13 @@ fn forward_prefill_chunk(
                 &pbs.x_batch, &weights.output_norm, &dst_view,
                 n, dim, config.norm_eps,
             )?;
-            // Still populate s.logits with the last-token logits for callers
-            // that rely on it (the legacy prefill path's post-condition).
-            let last = n - 1;
-            let last_view = dst.sub_offset((offset_rows + last) * dim, dim);
-            weight_gemv(gpu, &weights.output, &last_view, &s.logits)?;
+            if prefill_should_emit_last_token_logits(true, needs_last_token_logits) {
+                // Still populate s.logits with the last-token logits for
+                // callers that rely on it (the legacy prefill post-condition).
+                let last = n - 1;
+                let last_view = dst.sub_offset((offset_rows + last) * dim, dim);
+                weight_gemv(gpu, &weights.output, &last_view, &s.logits)?;
+            }
         } else {
             // Legacy path: only last-token logits.
             // Use _auto so the D→D copy routes through the active stream
@@ -10990,6 +11135,7 @@ pub fn forward_prefill_batch_multi(
                         false, // pre_uploaded
                         Some(&band_ctx),
                         None, // mask_override: multi-GPU PP path doesn't use the MTP probe hook
+                        true, // needs_last_token_logits: preserve multi-GPU post-condition
                         None, // max_layer: multi-GPU PP path runs full stack
                     )?;
                 }
@@ -11093,5 +11239,51 @@ mod tests {
         assert!(paro_batched_admit_enabled_from_env(Some("1")));
         assert!(paro_batched_admit_enabled_from_env(Some("surprise")));
         assert!(!paro_batched_admit_enabled_from_env(Some("0")));
+    }
+
+    #[test]
+    fn mq6_batched_admit_defaults_to_gfx12_only() {
+        assert!(mq6_batched_admit_enabled_from_env(None, "gfx1201"));
+        assert!(mq6_batched_admit_enabled_from_env(None, "gfx1200"));
+        assert!(!mq6_batched_admit_enabled_from_env(None, "gfx1100"));
+        assert!(!mq6_batched_admit_enabled_from_env(None, "gfx942"));
+        assert!(mq6_batched_admit_enabled_from_env(Some("1"), "gfx1100"));
+        assert!(!mq6_batched_admit_enabled_from_env(Some("0"), "gfx1201"));
+    }
+
+    #[test]
+    fn prefill_last_token_logits_policy_requires_explicit_opt_out() {
+        assert!(prefill_should_emit_last_token_logits(false, true));
+        assert!(prefill_should_emit_last_token_logits(true, true));
+        assert!(prefill_should_emit_last_token_logits(false, false));
+        assert!(!prefill_should_emit_last_token_logits(true, false));
+    }
+
+    #[test]
+    fn moe_grouped_m_total_max_is_tile_aligned() {
+        let small_verify = moe_grouped_m_total_max(3, 8, 256);
+        assert_eq!(small_verify % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(small_verify, 3872);
+
+        let prompt_prefill = moe_grouped_m_total_max(27, 8, 256);
+        assert_eq!(prompt_prefill % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(prompt_prefill, 4064);
+
+        let full_chunk = moe_grouped_m_total_max(256, 8, 256);
+        assert_eq!(full_chunk, 5888);
+    }
+
+    #[test]
+    fn moe_grouped_m_total_bound_is_tight_for_small_batches() {
+        let small_verify = moe_grouped_m_total_bound(24, 256);
+        assert_eq!(small_verify % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(small_verify, 384);
+
+        let prompt_prefill = moe_grouped_m_total_bound(216, 256);
+        assert_eq!(prompt_prefill % MOE_GROUPED_BLOCK_M, 0);
+        assert_eq!(prompt_prefill, 3456);
+
+        let full_chunk = moe_grouped_m_total_bound(2048, 256);
+        assert_eq!(full_chunk, 5888);
     }
 }

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -16,15 +16,209 @@
 //! on different models sharing the same MQ scratch (which we won't, since
 //! speculative decode serializes draft-generate then target-verify).
 
+use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
+use hip_bridge::{DeviceBuffer, HipResult, Stream};
 use hipfire_runtime::dflash::{self, DflashConfig, DflashScratch, DflashWeights};
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{self, KvCache};
-use crate::qwen35::{self, DeltaNetState, Qwen35Config, Qwen35Scratch, Qwen35Weights};
 use hipfire_runtime::tokenizer::{Tokenizer, TokenizerError};
-use hip_bridge::{DeviceBuffer, HipResult};
 use rdna_compute::{Gpu, GpuTensor};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+fn dflash_q8_lmhead_wmma_enabled_from_env() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("HIPFIRE_DFLASH_Q8_LMHEAD_WMMA") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    })
+}
+
+fn dflash_gemm_q8_lmhead(
+    gpu: &mut Gpu,
+    w_out: &llama::WeightTensor,
+    x: &GpuTensor,
+    y: &GpuTensor,
+    n: usize,
+) -> HipResult<()> {
+    if dflash_q8_lmhead_wmma_enabled_from_env() {
+        return gpu.gemm_q8_0_batched_chunked(&w_out.buf, x, y, w_out.m, w_out.k, n);
+    }
+
+    const Q8_LM_MAX: usize = 64;
+    let mut chunk_start = 0usize;
+    while chunk_start < n {
+        let chunk_end = (chunk_start + Q8_LM_MAX).min(n);
+        let chunk_n = chunk_end - chunk_start;
+        let x_chunk = x.sub_offset(chunk_start * w_out.k, chunk_n * w_out.k);
+        let y_chunk = y.sub_offset(chunk_start * w_out.m, chunk_n * w_out.m);
+        gpu.gemm_q8_0_batched(&w_out.buf, &x_chunk, &y_chunk, w_out.m, w_out.k, chunk_n)?;
+        chunk_start = chunk_end;
+    }
+    Ok(())
+}
+
+fn dflash_moe_verify_graph_lmhead_enabled_from_env_value(value: Option<&str>) -> bool {
+    match value {
+        Some(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        None => true,
+    }
+}
+
+fn dflash_moe_verify_graph_lmhead_eligible(
+    num_experts: usize,
+    want_full_logits: bool,
+    tree_verify_present: bool,
+    env_value: Option<&str>,
+) -> bool {
+    // MoE-only: dense DFlash keeps the old forward-only verify graph. The
+    // extended graph is also greedy-only because sampling needs full logits.
+    num_experts > 0
+        && !want_full_logits
+        && !tree_verify_present
+        && dflash_moe_verify_graph_lmhead_enabled_from_env_value(env_value)
+}
+
+fn dflash_moe_draft_ffn_graph_eligible(
+    num_experts: usize,
+    ctx_slice_present: bool,
+    pld_present: bool,
+    use_temp_sampling: bool,
+    env_value: Option<&str>,
+) -> bool {
+    // The draft FFN graph captures fixed-B per-layer work. Keep it off for
+    // dense, PLD, ctx-slice diagnostics, and sampling until each path is
+    // separately benched/coherence-gated.
+    num_experts > 0
+        && !ctx_slice_present
+        && !pld_present
+        && !use_temp_sampling
+        && dflash_moe_verify_graph_lmhead_enabled_from_env_value(env_value)
+}
+
+fn dflash_batched_lm_head_supported(dtype: rdna_compute::DType) -> bool {
+    matches!(
+        dtype,
+        rdna_compute::DType::Q8_0
+            | rdna_compute::DType::HFQ4G256
+            | rdna_compute::DType::MQ4G256
+            | rdna_compute::DType::MQ3G256
+            | rdna_compute::DType::HFQ6G256
+            | rdna_compute::DType::MQ6G256
+    )
+}
+
+fn dflash_enqueue_verify_lm_head(
+    gpu: &mut Gpu,
+    w_out: &llama::WeightTensor,
+    final_hidden: &GpuTensor,
+    verify_scratch: &VerifyScratch,
+    b: usize,
+    vocab: usize,
+) -> HipResult<()> {
+    let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
+    match w_out.gpu_dtype {
+        rdna_compute::DType::Q8_0 => {
+            dflash_gemm_q8_lmhead(gpu, w_out, final_hidden, &logits_batch, b)?;
+        }
+        rdna_compute::DType::HFQ4G256 => {
+            gpu.gemm_hfq4g256_batched_lmhead(
+                &w_out.buf,
+                final_hidden,
+                &logits_batch,
+                w_out.m,
+                w_out.k,
+                b,
+            )?;
+        }
+        rdna_compute::DType::MQ4G256 => {
+            assert!(
+                b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                "verify_scratch.rot undersized: b*k={} > max_n*hidden_k={}",
+                b * w_out.k,
+                verify_scratch.max_n * verify_scratch.hidden_k
+            );
+            let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+            llama::rotate_x_mq_batched_for(gpu, w_out, final_hidden, &rot, w_out.k, b)?;
+            gpu.gemm_hfq4g256_batched_lmhead(&w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b)?;
+        }
+        rdna_compute::DType::MQ3G256 => {
+            assert!(
+                b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                "verify_scratch.rot undersized for MQ3 lm_head: b*k={} > max_n*hidden_k={}",
+                b * w_out.k,
+                verify_scratch.max_n * verify_scratch.hidden_k
+            );
+            let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+            llama::rotate_x_mq_batched_for(gpu, w_out, final_hidden, &rot, w_out.k, b)?;
+            gpu.gemm_hfq3g256_batched_lmhead(&w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b)?;
+        }
+        rdna_compute::DType::HFQ6G256 => {
+            gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf,
+                final_hidden,
+                &logits_batch,
+                w_out.m,
+                w_out.k,
+                b,
+            )?;
+        }
+        rdna_compute::DType::MQ6G256 => {
+            assert!(
+                b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
+                "verify_scratch.rot undersized for MQ6 lm_head: b*k={} > max_n*hidden_k={}",
+                b * w_out.k,
+                verify_scratch.max_n * verify_scratch.hidden_k
+            );
+            let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
+            llama::rotate_x_mq_batched_for(gpu, w_out, final_hidden, &rot, w_out.k, b)?;
+            gpu.gemm_hfq6g256_batched_lmhead(&w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b)?;
+        }
+        other => {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("DFlash verify graph lm_head unsupported dtype {other:?}"),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn dflash_enqueue_verify_lm_head_argmax(
+    gpu: &mut Gpu,
+    w_out: &llama::WeightTensor,
+    final_hidden: &GpuTensor,
+    verify_scratch: &VerifyScratch,
+    b: usize,
+    vocab: usize,
+) -> HipResult<()> {
+    dflash_enqueue_verify_lm_head(gpu, w_out, final_hidden, verify_scratch, b, vocab)?;
+    let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
+    let argmax_buf = verify_scratch.argmax.sub_offset(0, b);
+    gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, b)
+}
+
+fn dflash_download_verify_argmax(
+    gpu: &Gpu,
+    verify_scratch: &VerifyScratch,
+    b: usize,
+) -> HipResult<Vec<u32>> {
+    let argmax_buf = verify_scratch.argmax.sub_offset(0, b);
+    let mut host_idx = vec![0i32; b];
+    {
+        let bytes: &mut [u8] =
+            unsafe { std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, b * 4) };
+        gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
+    }
+    Ok(host_idx.into_iter().map(|idx| idx as u32).collect())
+}
 
 /// Task #93 Phase B seed-prediction oracle counters.
 ///
@@ -126,7 +320,11 @@ pub fn read_ddtree_meta_stats() -> DdtreeMetaStats {
         cycles: c,
         total_nodes: DDTREE_META_TOTAL_NODES.load(Ordering::Relaxed),
         max_nodes: DDTREE_META_MAX_NODES.load(Ordering::Relaxed),
-        min_nodes: if c == 0 { 0 } else { DDTREE_META_MIN_NODES.load(Ordering::Relaxed) },
+        min_nodes: if c == 0 {
+            0
+        } else {
+            DDTREE_META_MIN_NODES.load(Ordering::Relaxed)
+        },
     }
 }
 
@@ -222,7 +420,10 @@ impl ModelSlot {
             hip_bridge::HipError::new(0, &format!("open {} ({}): {}", path.display(), name, e))
         })?;
         let config = qwen35::config_from_hfq(&hfq).ok_or_else(|| {
-            hip_bridge::HipError::new(0, &format!("invalid Qwen3.5 config in {} ({})", path.display(), name))
+            hip_bridge::HipError::new(
+                0,
+                &format!("invalid Qwen3.5 config in {} ({})", path.display(), name),
+            )
         })?;
         let weights = qwen35::load_weights(&mut hfq, &config, gpu)?;
 
@@ -525,6 +726,31 @@ impl DeltaNetSnapshot {
         Ok(())
     }
 
+    /// Async copy live state → backup on `stream`.
+    ///
+    /// Caller owns cross-stream ordering. MTP trunk-spine uses this as an
+    /// opt-in experiment to overlap DN snapshot copy with proposal work.
+    pub fn save_from_async_on(
+        &mut self,
+        state: &DeltaNetState,
+        gpu: &Gpu,
+        stream: &Stream,
+    ) -> HipResult<()> {
+        for (dst, src) in self.s_matrix_bufs.iter().zip(state.s_matrices.iter()) {
+            gpu.hip
+                .memcpy_dtod_async_at(dst, 0, &src.buf, 0, src.buf.size(), stream)?;
+        }
+        for (dst, src) in self.s_scale_bufs.iter().zip(state.s_scales.iter()) {
+            gpu.hip
+                .memcpy_dtod_async_at(dst, 0, &src.buf, 0, src.buf.size(), stream)?;
+        }
+        for (dst, src) in self.conv_state_bufs.iter().zip(state.conv_states.iter()) {
+            gpu.hip
+                .memcpy_dtod_async_at(dst, 0, &src.buf, 0, src.buf.size(), stream)?;
+        }
+        Ok(())
+    }
+
     /// Copy backup → live state (rewinds the recurrent state to the snapshot point).
     pub fn restore_to(&self, state: &mut DeltaNetState, gpu: &mut Gpu) -> HipResult<()> {
         for (src, dst) in self.s_matrix_bufs.iter().zip(state.s_matrices.iter()) {
@@ -582,12 +808,12 @@ pub struct GdnTape {
     pub alpha_bufs: Vec<GpuTensor>,
     pub beta_bufs: Vec<GpuTensor>,
     /// Replay scratch (shared across layers — serial replay is fine).
-    pub q_raw_scratch: GpuTensor,   // [max_n × k_dim]
-    pub k_raw_scratch: GpuTensor,   // [max_n × k_dim]
-    pub v_scratch: GpuTensor,       // [max_n × v_dim]
-    pub q_scratch: GpuTensor,       // [max_n × v_dim] (post repeat-interleave)
-    pub k_scratch: GpuTensor,       // [max_n × v_dim]
-    pub attn_scratch: GpuTensor,    // [max_n × v_dim]
+    pub q_raw_scratch: GpuTensor, // [max_n × k_dim]
+    pub k_raw_scratch: GpuTensor, // [max_n × k_dim]
+    pub v_scratch: GpuTensor,     // [max_n × v_dim]
+    pub q_scratch: GpuTensor,     // [max_n × v_dim] (post repeat-interleave)
+    pub k_scratch: GpuTensor,     // [max_n × v_dim]
+    pub attn_scratch: GpuTensor,  // [max_n × v_dim]
 }
 
 impl GdnTape {
@@ -630,10 +856,10 @@ impl GdnTape {
             beta_bufs,
             q_raw_scratch: gpu.alloc_tensor(&[max_n * k_dim], rdna_compute::DType::F32)?,
             k_raw_scratch: gpu.alloc_tensor(&[max_n * k_dim], rdna_compute::DType::F32)?,
-            v_scratch:     gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
-            q_scratch:     gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
-            k_scratch:     gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
-            attn_scratch:  gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            v_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            q_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            k_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
+            attn_scratch: gpu.alloc_tensor(&[max_n * v_dim], rdna_compute::DType::F32)?,
         })
     }
 
@@ -681,8 +907,7 @@ impl GdnTape {
         dn_state: &mut qwen35::DeltaNetState,
         n_steps: usize,
     ) -> HipResult<()> {
-        let graph_enabled =
-            std::env::var("HIPFIRE_REPLAY_GRAPH").ok().as_deref() == Some("1");
+        let graph_enabled = std::env::var("HIPFIRE_REPLAY_GRAPH").ok().as_deref() == Some("1");
         let can_graph = graph_enabled && gpu.active_stream.is_some();
 
         if can_graph && gpu.replay_has_graph(n_steps) {
@@ -706,9 +931,9 @@ impl GdnTape {
                 gpu.replay_graph_launch(n_steps)?;
                 return Ok(());
             } else {
-                let _ = gpu.hip.stream_end_capture(
-                    gpu.active_stream.as_ref().unwrap(),
-                );
+                let _ = gpu
+                    .hip
+                    .stream_end_capture(gpu.active_stream.as_ref().unwrap());
                 gpu.capture_mode = false;
                 gpu.capture_blobs.clear();
                 return r;
@@ -729,7 +954,10 @@ impl GdnTape {
         dn_state: &mut qwen35::DeltaNetState,
         n_steps: usize,
     ) -> HipResult<()> {
-        assert!(n_steps <= self.max_n, "replay_gdn: n_steps {n_steps} > max_n");
+        assert!(
+            n_steps <= self.max_n,
+            "replay_gdn: n_steps {n_steps} > max_n"
+        );
         let n_v_heads = self.n_v_heads;
         let n_key_heads = self.n_key_heads;
         let hd = self.key_head_dim;
@@ -788,8 +1016,20 @@ impl GdnTape {
                 )?;
             } else {
                 let bytes = n_steps * k_dim * 4;
-                gpu.hip.memcpy_dtod_at(&self.q_scratch.buf, 0, &self.q_raw_scratch.buf, 0, bytes)?;
-                gpu.hip.memcpy_dtod_at(&self.k_scratch.buf, 0, &self.k_raw_scratch.buf, 0, bytes)?;
+                gpu.hip.memcpy_dtod_at(
+                    &self.q_scratch.buf,
+                    0,
+                    &self.q_raw_scratch.buf,
+                    0,
+                    bytes,
+                )?;
+                gpu.hip.memcpy_dtod_at(
+                    &self.k_scratch.buf,
+                    0,
+                    &self.k_raw_scratch.buf,
+                    0,
+                    bytes,
+                )?;
             }
 
             // 4. GDN recurrence — advances S_state.
@@ -841,32 +1081,47 @@ impl GdnTape {
         for layer in 0..self.qkv_bufs.len() {
             // qkv
             gpu.kv_compact_gather(
-                &self.qkv_bufs[layer], gather_scratch, gather_indices_dev,
-                qkv_row_bytes, n_positions,
+                &self.qkv_bufs[layer],
+                gather_scratch,
+                gather_indices_dev,
+                qkv_row_bytes,
+                n_positions,
             )?;
             gpu.hip.memcpy_dtod_at(
-                &self.qkv_bufs[layer].buf, 0,
-                &gather_scratch.buf, 0,
+                &self.qkv_bufs[layer].buf,
+                0,
+                &gather_scratch.buf,
+                0,
                 n_positions * qkv_row_bytes,
             )?;
             // alpha
             gpu.kv_compact_gather(
-                &self.alpha_bufs[layer], gather_scratch, gather_indices_dev,
-                alpha_row_bytes, n_positions,
+                &self.alpha_bufs[layer],
+                gather_scratch,
+                gather_indices_dev,
+                alpha_row_bytes,
+                n_positions,
             )?;
             gpu.hip.memcpy_dtod_at(
-                &self.alpha_bufs[layer].buf, 0,
-                &gather_scratch.buf, 0,
+                &self.alpha_bufs[layer].buf,
+                0,
+                &gather_scratch.buf,
+                0,
                 n_positions * alpha_row_bytes,
             )?;
             // beta
             gpu.kv_compact_gather(
-                &self.beta_bufs[layer], gather_scratch, gather_indices_dev,
-                alpha_row_bytes, n_positions,
+                &self.beta_bufs[layer],
+                gather_scratch,
+                gather_indices_dev,
+                alpha_row_bytes,
+                n_positions,
             )?;
             gpu.hip.memcpy_dtod_at(
-                &self.beta_bufs[layer].buf, 0,
-                &gather_scratch.buf, 0,
+                &self.beta_bufs[layer].buf,
+                0,
+                &gather_scratch.buf,
+                0,
                 n_positions * alpha_row_bytes,
             )?;
         }
@@ -875,11 +1130,7 @@ impl GdnTape {
 }
 
 impl DeltaNetTape {
-    pub fn new_for(
-        gpu: &mut Gpu,
-        state: &DeltaNetState,
-        n_slots: usize,
-    ) -> HipResult<Self> {
+    pub fn new_for(gpu: &mut Gpu, state: &DeltaNetState, n_slots: usize) -> HipResult<Self> {
         let mut slots = Vec::with_capacity(n_slots);
         for _ in 0..n_slots {
             slots.push(DeltaNetSnapshot::new_for(gpu, state)?);
@@ -891,12 +1142,7 @@ impl DeltaNetTape {
         self.slots.len()
     }
 
-    pub fn save_at(
-        &mut self,
-        slot: usize,
-        state: &DeltaNetState,
-        gpu: &mut Gpu,
-    ) -> HipResult<()> {
+    pub fn save_at(&mut self, slot: usize, state: &DeltaNetState, gpu: &mut Gpu) -> HipResult<()> {
         self.slots[slot].save_from(state, gpu)
     }
 
@@ -925,8 +1171,12 @@ impl DeltaNetTape {
 /// `[1, 8, 15, 22, 29]`, matching the hard-coded indices in the HuggingFace
 /// `z-lab/Qwen3.5-9B-DFlash` config.
 pub fn dflash_extract_layer_ids(num_target_layers: usize, num_extract: usize) -> Vec<usize> {
-    if num_extract == 0 { return Vec::new(); }
-    if num_extract == 1 { return vec![1]; }
+    if num_extract == 0 {
+        return Vec::new();
+    }
+    if num_extract == 1 {
+        return vec![1];
+    }
     let start: f32 = 1.0;
     let end: f32 = (num_target_layers as i32 - 3).max(1) as f32;
     let step = (end - start) / (num_extract as f32 - 1.0);
@@ -1012,23 +1262,16 @@ impl DdtreeScratch {
         n_fa_layers: usize,
     ) -> HipResult<Self> {
         let max_n = 1 + max_budget;
-        let attn_bias = gpu.alloc_tensor(
-            &[max_n * max_n],
-            rdna_compute::DType::F32,
-        )?;
-        let parent_indices = gpu.alloc_tensor(
-            &[max_n * 4],
-            rdna_compute::DType::Raw,
-        )?;
+        let attn_bias = gpu.alloc_tensor(&[max_n * max_n], rdna_compute::DType::F32)?;
+        let parent_indices = gpu.alloc_tensor(&[max_n * 4], rdna_compute::DType::Raw)?;
         // Path B per-FA-layer pre-RoPE K capture. Sized once at session
         // init. Empty on n_fa_layers=0 → capture is a no-op even if the
         // env gate is set (slow-path-kill won't have data to consume).
         let mut pre_rope_k: Vec<GpuTensor> = Vec::with_capacity(n_fa_layers);
         for _ in 0..n_fa_layers {
-            pre_rope_k.push(gpu.alloc_tensor(
-                &[max_n * n_kv_heads * head_dim],
-                rdna_compute::DType::F32,
-            )?);
+            pre_rope_k.push(
+                gpu.alloc_tensor(&[max_n * n_kv_heads * head_dim], rdna_compute::DType::F32)?,
+            );
         }
 
         // Widest bytes-per-position across KV quant modes we might run under.
@@ -1040,24 +1283,14 @@ impl DdtreeScratch {
         let widest_k_bpp = q8_bpp.max(asym3_k_bpp).max(asym4_k_bpp).max(asym2_k_bpp);
         let widest_v_bpp = q8_bpp;
 
-        let kv_gather_indices = gpu.alloc_tensor(
-            &[max_n * 4],
-            rdna_compute::DType::Raw,
-        )?;
+        let kv_gather_indices = gpu.alloc_tensor(&[max_n * 4], rdna_compute::DType::Raw)?;
         // Raw byte buffers sized to hold `max_n` full K / V rows.
-        let kv_gather_scratch_k = gpu.alloc_tensor(
-            &[(max_n * widest_k_bpp + 3) / 4],
-            rdna_compute::DType::F32,
-        )?;
-        let kv_gather_scratch_v = gpu.alloc_tensor(
-            &[(max_n * widest_v_bpp + 3) / 4],
-            rdna_compute::DType::F32,
-        )?;
+        let kv_gather_scratch_k =
+            gpu.alloc_tensor(&[(max_n * widest_k_bpp + 3) / 4], rdna_compute::DType::F32)?;
+        let kv_gather_scratch_v =
+            gpu.alloc_tensor(&[(max_n * widest_v_bpp + 3) / 4], rdna_compute::DType::F32)?;
         // Tape rows are F32 projections, so sized in F32 elements directly.
-        let tape_gather_scratch = gpu.alloc_tensor(
-            &[max_n * qkv_dim],
-            rdna_compute::DType::F32,
-        )?;
+        let tape_gather_scratch = gpu.alloc_tensor(&[max_n * qkv_dim], rdna_compute::DType::F32)?;
 
         Ok(Self {
             max_n,
@@ -1207,8 +1440,10 @@ impl HiddenStateRingBuffer {
         let mut layer_bufs = Vec::with_capacity(num_extract);
         let mut staging_bufs = Vec::with_capacity(num_extract);
         for _ in 0..num_extract {
-            layer_bufs.push(gpu.alloc_tensor(&[max_positions * hidden_dim], rdna_compute::DType::F32)?);
-            staging_bufs.push(gpu.alloc_tensor(&[max_batch * hidden_dim], rdna_compute::DType::F32)?);
+            layer_bufs
+                .push(gpu.alloc_tensor(&[max_positions * hidden_dim], rdna_compute::DType::F32)?);
+            staging_bufs
+                .push(gpu.alloc_tensor(&[max_batch * hidden_dim], rdna_compute::DType::F32)?);
         }
         Ok(Self {
             layer_bufs,
@@ -1226,19 +1461,16 @@ impl HiddenStateRingBuffer {
     /// index into `layer_bufs`/`extract_layers` for that layer. Otherwise None.
     #[inline]
     pub fn extract_slot(&self, target_layer_idx: usize) -> Option<usize> {
-        self.extract_layers.iter().position(|&l| l == target_layer_idx)
+        self.extract_layers
+            .iter()
+            .position(|&l| l == target_layer_idx)
     }
 
     /// Copy `x` (shape `[hidden_dim]`) into the ring buffer slot for the given
     /// extraction layer at the CURRENT head position. Call once per extracted
     /// layer per forward pass, then `advance_head()` at the end of the forward
     /// to move to the next slot.
-    pub fn write_at_head(
-        &self,
-        gpu: &mut Gpu,
-        extract_idx: usize,
-        x: &GpuTensor,
-    ) -> HipResult<()> {
+    pub fn write_at_head(&self, gpu: &mut Gpu, extract_idx: usize, x: &GpuTensor) -> HipResult<()> {
         let offset = self.head * self.hidden_dim * 4;
         gpu.hip.memcpy_dtod_at(
             &self.layer_bufs[extract_idx].buf,
@@ -1324,22 +1556,26 @@ impl HiddenStateRingBuffer {
         src: &GpuTensor,
         n: usize,
     ) -> HipResult<()> {
-        debug_assert!(n <= self.max_batch,
-            "write_rows_to_staging: n {} > max_batch {}", n, self.max_batch);
+        debug_assert!(
+            n <= self.max_batch,
+            "write_rows_to_staging: n {} > max_batch {}",
+            n,
+            self.max_batch
+        );
         let row_bytes = self.hidden_dim * 4;
         let bytes = n * row_bytes;
         if let Some(stream) = gpu.active_stream.as_ref() {
             gpu.hip.memcpy_dtod_async_at(
-                &self.staging_bufs[extract_idx].buf, 0,
-                &src.buf, 0,
-                bytes, stream,
+                &self.staging_bufs[extract_idx].buf,
+                0,
+                &src.buf,
+                0,
+                bytes,
+                stream,
             )
         } else {
-            gpu.hip.memcpy_dtod_at(
-                &self.staging_bufs[extract_idx].buf, 0,
-                &src.buf, 0,
-                bytes,
-            )
+            gpu.hip
+                .memcpy_dtod_at(&self.staging_bufs[extract_idx].buf, 0, &src.buf, 0, bytes)
         }
     }
 
@@ -1369,20 +1605,26 @@ impl HiddenStateRingBuffer {
         for ei in 0..self.layer_bufs.len() {
             if head + n <= max_pos {
                 gpu.hip.memcpy_dtod_at(
-                    &self.layer_bufs[ei].buf, head * row_bytes,
-                    &self.staging_bufs[ei].buf, 0,
+                    &self.layer_bufs[ei].buf,
+                    head * row_bytes,
+                    &self.staging_bufs[ei].buf,
+                    0,
                     n * row_bytes,
                 )?;
             } else {
                 let first = max_pos - head;
                 gpu.hip.memcpy_dtod_at(
-                    &self.layer_bufs[ei].buf, head * row_bytes,
-                    &self.staging_bufs[ei].buf, 0,
+                    &self.layer_bufs[ei].buf,
+                    head * row_bytes,
+                    &self.staging_bufs[ei].buf,
+                    0,
                     first * row_bytes,
                 )?;
                 gpu.hip.memcpy_dtod_at(
-                    &self.layer_bufs[ei].buf, 0,
-                    &self.staging_bufs[ei].buf, first * row_bytes,
+                    &self.layer_bufs[ei].buf,
+                    0,
+                    &self.staging_bufs[ei].buf,
+                    first * row_bytes,
                     (n - first) * row_bytes,
                 )?;
             }
@@ -1426,7 +1668,9 @@ fn softmax_temp_into(logits: &[f32], temp: f32, out: &mut Vec<f32>) {
     let mut max = f32::NEG_INFINITY;
     for &v in logits {
         let s = v * inv_t;
-        if s > max { max = s; }
+        if s > max {
+            max = s;
+        }
     }
     let mut sum = 0.0f32;
     for &v in logits {
@@ -1435,7 +1679,9 @@ fn softmax_temp_into(logits: &[f32], temp: f32, out: &mut Vec<f32>) {
         sum += e;
     }
     let inv_sum = 1.0 / sum;
-    for p in out.iter_mut() { *p *= inv_sum; }
+    for p in out.iter_mut() {
+        *p *= inv_sum;
+    }
 }
 
 /// Draw a categorical sample from `probs` given uniform u ∈ [0, 1).
@@ -1444,7 +1690,9 @@ fn sample_categorical(probs: &[f32], u: f32) -> u32 {
     let mut acc = 0.0f32;
     for (i, &p) in probs.iter().enumerate() {
         acc += p;
-        if u < acc { return i as u32; }
+        if u < acc {
+            return i as u32;
+        }
     }
     (probs.len() - 1) as u32
 }
@@ -1457,7 +1705,9 @@ fn sample_residual(p_target: &[f32], p_draft: &[f32], u: f32) -> u32 {
     let mut sum = 0.0f32;
     for i in 0..p_target.len() {
         let d = p_target[i] - p_draft[i];
-        if d > 0.0 { sum += d; }
+        if d > 0.0 {
+            sum += d;
+        }
     }
     if sum <= 0.0 {
         // Degenerate case (p_draft >= p_target everywhere). Should not
@@ -1471,7 +1721,9 @@ fn sample_residual(p_target: &[f32], p_draft: &[f32], u: f32) -> u32 {
         let d = p_target[i] - p_draft[i];
         if d > 0.0 {
             acc += d;
-            if u_scaled < acc { return i as u32; }
+            if u_scaled < acc {
+                return i as u32;
+            }
         }
     }
     (p_target.len() - 1) as u32
@@ -1509,12 +1761,7 @@ impl NgramCache {
     /// Record the triple `(a, b) → c` in the cache.
     #[inline]
     pub fn observe(&mut self, a: u32, b: u32, c: u32) {
-        *self
-            .bigram
-            .entry((a, b))
-            .or_default()
-            .entry(c)
-            .or_insert(0) += 1;
+        *self.bigram.entry((a, b)).or_default().entry(c).or_insert(0) += 1;
     }
 
     /// Predict `c` from last-two `(a, b)` if the max-count next-token
@@ -1570,7 +1817,11 @@ pub struct PldMatcher {
 
 impl Default for PldMatcher {
     fn default() -> Self {
-        Self { ngram_lens: vec![5, 4, 3], max_extract: 8, min_extract: 3 }
+        Self {
+            ngram_lens: vec![5, 4, 3],
+            max_extract: 8,
+            min_extract: 3,
+        }
     }
 }
 
@@ -1648,7 +1899,11 @@ impl PldMatcher {
 
         let (n, tokens) = best?;
         let consensus = firsts.iter().filter(|&&t| t == tokens[0]).count();
-        Some(PldMatch { tokens, n, consensus })
+        Some(PldMatch {
+            tokens,
+            n,
+            consensus,
+        })
     }
 }
 
@@ -1784,9 +2039,7 @@ pub fn spec_step_greedy(
     //   drafted[0] verified by target_logits_at_pos  (logits at pos)
     //   drafted[i] (i >= 1) verified by target_mid_logits[i-1] (logits at pos+i)
     let mut accepted: usize = 0;
-    if !target_logits_at_pos.is_empty()
-        && argmax_u32(&target_logits_at_pos) == drafted[0]
-    {
+    if !target_logits_at_pos.is_empty() && argmax_u32(&target_logits_at_pos) == drafted[0] {
         accepted = 1;
         for i in 1..k {
             if argmax_u32(&target_mid_logits[i - 1]) == drafted[i] {
@@ -1844,6 +2097,10 @@ pub struct DflashVerifyOutput {
     pub logits_per_pos: Vec<f32>,
 }
 
+fn dflash_use_gdn_tape_replay(caller_supplied_tape: bool, verify_populates_tape: bool) -> bool {
+    caller_supplied_tape && verify_populates_tape
+}
+
 /// Run the target on `draft_tokens` (length B) positions starting at
 /// `start_pos`. Advances `target.kv_cache` and `target.dn_state` by B
 /// positions. Writes B hidden-state rows into `hidden_rb` (ring head
@@ -1871,7 +2128,14 @@ pub fn verify_dflash_block(
     verify_scratch: &VerifyScratch,
 ) -> HipResult<DflashVerifyOutput> {
     verify_dflash_block_inner(
-        gpu, target, draft_tokens, start_pos, hidden_rb, gdn_tape, want_full_logits, None,
+        gpu,
+        target,
+        draft_tokens,
+        start_pos,
+        hidden_rb,
+        gdn_tape,
+        want_full_logits,
+        None,
         verify_scratch,
     )
 }
@@ -1900,7 +2164,13 @@ pub fn verify_dflash_block_tree(
     verify_scratch: &VerifyScratch,
 ) -> HipResult<DflashVerifyOutput> {
     verify_dflash_block_inner(
-        gpu, target, draft_tokens, start_pos, hidden_rb, gdn_tape, want_full_logits,
+        gpu,
+        target,
+        draft_tokens,
+        start_pos,
+        hidden_rb,
+        gdn_tape,
+        want_full_logits,
         Some(tree_verify),
         verify_scratch,
     )
@@ -1921,8 +2191,12 @@ fn verify_dflash_block_inner(
     let vocab = target.config.vocab_size;
     let dim = target.config.dim;
 
-    assert!(b <= verify_scratch.max_n,
-        "verify_scratch max_n {} < b {}", verify_scratch.max_n, b);
+    assert!(
+        b <= verify_scratch.max_n,
+        "verify_scratch max_n {} < b {}",
+        verify_scratch.max_n,
+        b
+    );
     assert_eq!(verify_scratch.dim, dim, "verify_scratch dim mismatch");
     assert_eq!(verify_scratch.vocab, vocab, "verify_scratch vocab mismatch");
 
@@ -1930,6 +2204,15 @@ fn verify_dflash_block_inner(
     // the actual current `b` (≤ max_n) so downstream kernels see the right
     // shapes. sub_offset returns a non-owning view; do NOT free these.
     let final_hidden = verify_scratch.final_hidden.sub_offset(0, b * dim);
+    let tree_verify_present = tree_verify.is_some();
+    let moe_lmhead_graph_env = std::env::var("HIPFIRE_DFLASH_MOE_VERIFY_GRAPH_LMHEAD").ok();
+    let moe_lmhead_graph_ok =
+        dflash_moe_verify_graph_lmhead_eligible(
+            target.config.num_experts,
+            want_full_logits,
+            tree_verify_present,
+            moe_lmhead_graph_env.as_deref(),
+        ) && dflash_batched_lm_head_supported(target.weights.output.gpu_dtype);
 
     // Graph-capture path eligibility. The captured forward bakes in:
     //   - N (the batch size) — via kernel grid dims
@@ -1968,8 +2251,9 @@ fn verify_dflash_block_inner(
     // the parent_indices-driven conv1d path. DO NOT ENABLE in production.
     //
     // Gate kept live so the next session can bisect without re-plumbing.
-    let tree_graph_enabled = std::env::var("HIPFIRE_VERIFY_GRAPH_TREE").ok().as_deref() == Some("1");
-    if tree_graph_enabled && tree_verify.is_some() {
+    let tree_graph_enabled =
+        std::env::var("HIPFIRE_VERIFY_GRAPH_TREE").ok().as_deref() == Some("1");
+    if tree_graph_enabled && tree_verify_present {
         static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
         if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
             eprintln!(
@@ -1977,12 +2261,13 @@ fn verify_dflash_block_inner(
             );
         }
     }
-    let tree_ok_for_graph = tree_verify.is_none() || tree_graph_enabled;
+    let tree_ok_for_graph = !tree_verify_present || tree_graph_enabled;
     let verify_graph_ok = std::env::var("HIPFIRE_VERIFY_GRAPH").ok().as_deref() != Some("0")
         && tree_ok_for_graph
         && matches!(
             target.weights.embd_format,
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 | hipfire_runtime::llama::EmbeddingFormat::Q8_0,
+            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256
+                | hipfire_runtime::llama::EmbeddingFormat::Q8_0,
         )
         && verify_scratch.prefill_batch.is_some();
 
@@ -1998,6 +2283,7 @@ fn verify_dflash_block_inner(
     } else {
         None
     };
+    let mut graph_includes_lmhead_argmax = false;
 
     let batch_result = if verify_graph_ok {
         let pbs = verify_scratch.prefill_batch.as_ref().unwrap();
@@ -2010,6 +2296,8 @@ fn verify_dflash_block_inner(
         }
         if gpu.verify_has_graph(b) {
             vg_mode = "replay";
+            graph_includes_lmhead_argmax =
+                moe_lmhead_graph_ok && gpu.verify_graph_has_lmhead_argmax(b);
             // Replay path: kernels read pbs.tokens/pbs.positions/dn_state/
             // kv_cache contents that were freshly updated above + upstream.
             gpu.verify_graph_launch(b)?;
@@ -2022,7 +2310,7 @@ fn verify_dflash_block_inner(
             // hits "hipMalloc not permitted under stream capture" the first
             // time any kernel is compiled inline. One warmup per distinct b.
             gpu.verify_mark_warmup_done(b);
-            let r = qwen35::forward_prefill_batch_single_chunk_captured(
+            let r = qwen35::forward_prefill_batch_single_chunk_captured_opts(
                 gpu,
                 &target.weights,
                 &target.config,
@@ -2036,16 +2324,21 @@ fn verify_dflash_block_inner(
                 Some(&final_hidden),
                 gdn_tape,
                 tree_verify,
+                false, // DFlash computes all verify logits from final_hidden below
             );
             if r.is_ok() {
-                eprintln!("[verify-graph] warmup for B={} complete — capture next cycle at this B", b);
+                eprintln!(
+                    "[verify-graph] warmup for B={} complete — capture next cycle at this B",
+                    b
+                );
             }
             r
         } else {
             vg_mode = "capture";
             // Capture path: first call at this B after warmup.
+            let capture_lmhead_argmax = moe_lmhead_graph_ok;
             gpu.begin_verify_graph_capture(b)?;
-            let r = qwen35::forward_prefill_batch_single_chunk_captured(
+            let r = qwen35::forward_prefill_batch_single_chunk_captured_opts(
                 gpu,
                 &target.weights,
                 &target.config,
@@ -2059,10 +2352,29 @@ fn verify_dflash_block_inner(
                 Some(&final_hidden),
                 gdn_tape,
                 tree_verify,
+                false, // DFlash computes all verify logits from final_hidden below
             );
+            let r = if r.is_ok() && capture_lmhead_argmax {
+                r.and_then(|_| {
+                    dflash_enqueue_verify_lm_head_argmax(
+                        gpu,
+                        &target.weights.output,
+                        &final_hidden,
+                        verify_scratch,
+                        b,
+                        vocab,
+                    )
+                })
+            } else {
+                r
+            };
             if r.is_ok() {
                 let blob_count = gpu.capture_blobs.len();
                 gpu.end_verify_graph_capture()?;
+                if capture_lmhead_argmax {
+                    gpu.verify_mark_graph_lmhead_argmax(b);
+                    graph_includes_lmhead_argmax = true;
+                }
                 // Under `hipStreamBeginCapture`, kernels + memcpys on the
                 // captured stream are RECORDED, not executed. final_hidden
                 // and hidden_rb staging are left stale. Launching the graph
@@ -2074,19 +2386,23 @@ fn verify_dflash_block_inner(
                 gpu.verify_graph_launch(b)?;
                 eprintln!(
                     "[verify-graph] captured for B={} with {} blobs (cache size: {})",
-                    b, blob_count, gpu.verify_graph_count(),
+                    b,
+                    blob_count,
+                    gpu.verify_graph_count(),
                 );
             } else {
                 // If capture failed, tear down the partial capture so we fall
                 // back to the direct path next cycle cleanly.
-                let _ = gpu.hip.stream_end_capture(gpu.active_stream.as_ref().unwrap());
+                let _ = gpu
+                    .hip
+                    .stream_end_capture(gpu.active_stream.as_ref().unwrap());
                 gpu.capture_mode = false;
                 gpu.capture_blobs.clear();
             }
             r
         }
     } else {
-        qwen35::forward_prefill_batch_with_pbs(
+        qwen35::forward_prefill_batch_with_pbs_opts(
             gpu,
             &target.weights,
             &target.config,
@@ -2100,8 +2416,9 @@ fn verify_dflash_block_inner(
             gdn_tape,
             tree_verify,
             verify_scratch.prefill_batch.as_ref(),
-            None, // mask_override: speculative verify path doesn't use the MTP probe hook
-            None, // max_layer: DFlash verify always runs the full stack
+            None,  // mask_override: speculative verify path doesn't use the MTP probe hook
+            None,  // max_layer: DFlash verify always runs the full stack
+            false, // DFlash computes all verify logits from final_hidden below
         )
     };
 
@@ -2129,7 +2446,7 @@ fn verify_dflash_block_inner(
     batch_result?;
 
     // Per-position lm_head. Fast paths in priority order:
-    //   Q8_0      → batched gemm_q8_0_batched (one launch + one D2H).
+    //   Q8_0      → DFlash-scoped Q8 lm_head dispatcher (gfx12 WMMA by default).
     //   MQ4G256   → batched rotate + gemm_hfq4g256 (one launch + one D2H).
     //   HFQ4G256  → batched gemm_hfq4g256 directly.
     //   else      → B sequential weight_gemv calls + B downloads (legacy).
@@ -2137,95 +2454,22 @@ fn verify_dflash_block_inner(
     let mut logits_per_pos: Vec<f32> = Vec::with_capacity(b * vocab);
     let mut argmax_per_pos: Vec<u32> = Vec::with_capacity(b);
 
-    let try_batched = match w_out.gpu_dtype {
-        rdna_compute::DType::Q8_0
-        | rdna_compute::DType::HFQ4G256
-        | rdna_compute::DType::MQ4G256
-        | rdna_compute::DType::MQ3G256
-        | rdna_compute::DType::HFQ6G256
-        | rdna_compute::DType::MQ6G256 => true,
-        _ => false,
-    };
+    let try_batched = dflash_batched_lm_head_supported(w_out.gpu_dtype);
 
-    if try_batched {
+    if graph_includes_lmhead_argmax {
+        debug_assert!(!want_full_logits);
+        // The MoE-only extended verify graph already enqueued lm_head+argmax.
+        // Mirror MTP's graph shape: keep device work captured, then perform
+        // the single small D2H read after graph launch.
+        argmax_per_pos = dflash_download_verify_argmax(gpu, verify_scratch, b)?;
+    } else if try_batched {
         let logits_batch = verify_scratch.logits.sub_offset(0, b * vocab);
-        // Q8_0 gemm_q8_0_batched has a hard MAX_BATCH=64 in the kernel, so
-        // tree-verify blocks exceeding 64 (budget + 1 > 64) need chunking.
-        // MQ4/HFQ4/HFQ6/MQ6 kernels have no such cap — they take the single-shot path.
-        //
-        // INVARIANT: this path MUST stay on `gemm_q8_0_batched` (the substrate),
-        // NOT the Tier 3 `gemm_qkv_q8_0_wmma` family. The substrate matches
-        // `gemv_q8_0`'s single-accumulator reduction order, preserving byte-exact
-        // greedy parity with decode — required for DFlash+Q8 spec-verify to ever
-        // be a valid eval target (see docs/plans/q8-fused-prefill-kernels.md
-        // §Constraints — "greedy-parity invariant"). The WMMA family uses a
-        // hardware-determined reduction order and will not match.
-        match w_out.gpu_dtype {
-            rdna_compute::DType::Q8_0 => {
-                const Q8_LM_MAX: usize = 64;
-                let mut chunk_start = 0usize;
-                while chunk_start < b {
-                    let chunk_end = (chunk_start + Q8_LM_MAX).min(b);
-                    let chunk_n = chunk_end - chunk_start;
-                    let x_chunk = final_hidden.sub_offset(chunk_start * dim, chunk_n * dim);
-                    let y_chunk = logits_batch.sub_offset(chunk_start * vocab, chunk_n * vocab);
-                    // DO NOT route this through the Q8 WMMA dispatcher — see
-                    // greedy-parity invariant above.
-                    gpu.gemm_q8_0_batched(
-                        &w_out.buf, &x_chunk, &y_chunk, w_out.m, w_out.k, chunk_n,
-                    )?;
-                    chunk_start = chunk_end;
-                }
-            }
-            rdna_compute::DType::HFQ4G256 => {
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &final_hidden, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::MQ4G256 => {
-                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized: b*k={} > max_n*hidden_k={}",
-                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
-                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                // AWQ-aware rotation: when `w_out.awq_scale.is_some()` (lm_head
-                // has an AWQ sidecar attached), `_for` dispatches the AWQ
-                // variant that divides x by s before FWHT. Numerically
-                // identical to `rotate_x_mq_batched` when no sidecar exists.
-                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::MQ3G256 => {
-                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ3 lm_head: b*k={} > max_n*hidden_k={}",
-                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
-                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                // AWQ-aware rotation; see the MQ4 arm above for rationale.
-                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
-                gpu.gemm_hfq3g256_batched_lmhead(
-                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::HFQ6G256 => {
-                // Phase A.4: gfx906 dp4a path for HFQ6 lm_head batched.
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &final_hidden, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            rdna_compute::DType::MQ6G256 => {
-                // Phase A.4: rotate-then-batched lm_head for MQ6.
-                assert!(b * w_out.k <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ6 lm_head: b*k={} > max_n*hidden_k={}",
-                    b * w_out.k, verify_scratch.max_n * verify_scratch.hidden_k);
-                let rot = verify_scratch.rot.sub_offset(0, b * w_out.k);
-                llama::rotate_x_mq_batched_for(gpu, w_out, &final_hidden, &rot, w_out.k, b)?;
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &rot, &logits_batch, w_out.m, w_out.k, b,
-                )?;
-            }
-            _ => unreachable!(),
-        }
+        // Q8_0 routes through the DFlash lm_head helper so the gfx12 WMMA
+        // arm can be coherence-gated independently of MTP. Set
+        // HIPFIRE_DFLASH_Q8_LMHEAD_WMMA=0 to force the legacy scalar chunks.
+        // MQ4/HFQ4/HFQ6/MQ6 kernels have no 64-row cap and take the
+        // single-shot path.
+        dflash_enqueue_verify_lm_head(gpu, w_out, &final_hidden, verify_scratch, b, vocab)?;
         if want_full_logits {
             // Rejection-sampling path needs full target distribution.
             // Cost: B × vocab × 4 bytes D2H per verify (~15 MB at B=16 × 248K).
@@ -2241,16 +2485,7 @@ fn verify_dflash_block_inner(
             // PCIe D2H per verify on the 4B Q8 lm_head (~3-5 ms/iter).
             let argmax_buf = verify_scratch.argmax.sub_offset(0, b);
             gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, b)?;
-            let mut host_idx = vec![0i32; b];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, b * 4)
-                };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
-            }
-            for &idx in &host_idx {
-                argmax_per_pos.push(idx as u32);
-            }
+            argmax_per_pos = dflash_download_verify_argmax(gpu, verify_scratch, b)?;
         }
         // Greedy path doesn't need `logits_per_pos`; leave empty to avoid
         // the 15 MB D2H. If temp>0 sampling is added later, reinstate the
@@ -2260,7 +2495,10 @@ fn verify_dflash_block_inner(
         for i in 0..b {
             let hidden_row = final_hidden.sub_offset(i * dim, dim);
             llama::weight_gemv(
-                gpu, &target.weights.output, &hidden_row, &target.scratch.logits,
+                gpu,
+                &target.weights.output,
+                &hidden_row,
+                &target.scratch.logits,
             )?;
             let row = gpu.download_f32(&target.scratch.logits)?;
             debug_assert_eq!(row.len(), vocab);
@@ -2273,7 +2511,9 @@ fn verify_dflash_block_inner(
         gpu.hip.device_synchronize()?;
         eprintln!(
             "[vg-time] B={} mode={} elapsed_us={}",
-            b, vg_mode, t0.elapsed().as_micros()
+            b,
+            vg_mode,
+            t0.elapsed().as_micros()
         );
     }
 
@@ -2334,13 +2574,19 @@ pub fn scatter_hidden_block_to_interleaved(
     block_size: usize,
     n_rows: usize,
 ) -> HipResult<()> {
-    assert!(n_rows <= block_size, "scatter: n_rows {n_rows} > block_size {block_size}");
+    assert!(
+        n_rows <= block_size,
+        "scatter: n_rows {n_rows} > block_size {block_size}"
+    );
     let num_extract = hidden_rb.extract_layers.len();
     let hidden = hidden_rb.hidden_dim;
     let max_pos = hidden_rb.max_positions;
     let head = hidden_rb.head;
     let written = hidden_rb.written;
-    assert!(block_size <= written, "scatter: block_size {block_size} > written {written}");
+    assert!(
+        block_size <= written,
+        "scatter: block_size {block_size} > written {written}"
+    );
     let row_bytes = hidden * 4;
     let start_slot = (head + max_pos - block_size) % max_pos;
 
@@ -2377,7 +2623,10 @@ pub fn download_hidden_block(
     // `head` points to where the NEXT write will land. After B advances,
     // the most recent B sit at ring slots (head - B) mod max_pos ..
     // (head - 1) mod max_pos.
-    assert!(b <= written, "verify must have written at least B rows to ring buffer");
+    assert!(
+        b <= written,
+        "verify must have written at least B rows to ring buffer"
+    );
     let head = hidden_rb.head;
     let start_slot = (head + max_pos - b) % max_pos;
     let row_bytes = hidden * 4;
@@ -2399,7 +2648,8 @@ pub fn download_hidden_block(
                     b * row_bytes,
                 )
             };
-            gpu.hip.memcpy_dtoh_at(dst_bytes, src_buf, start_slot * row_bytes)?;
+            gpu.hip
+                .memcpy_dtoh_at(dst_bytes, src_buf, start_slot * row_bytes)?;
         } else {
             // Two-segment ring wrap: tail of buffer, then head.
             let first_rows = max_pos - start_slot;
@@ -2410,10 +2660,14 @@ pub fn download_hidden_block(
                     first_rows * row_bytes,
                 )
             };
-            gpu.hip.memcpy_dtoh_at(dst_first_bytes, src_buf, start_slot * row_bytes)?;
+            gpu.hip
+                .memcpy_dtoh_at(dst_first_bytes, src_buf, start_slot * row_bytes)?;
             let dst_second_bytes: &mut [u8] = unsafe {
                 std::slice::from_raw_parts_mut(
-                    layer_data_flat.as_mut_ptr().add(dst_offset_floats + first_rows * hidden) as *mut u8,
+                    layer_data_flat
+                        .as_mut_ptr()
+                        .add(dst_offset_floats + first_rows * hidden)
+                        as *mut u8,
                     second_rows * row_bytes,
                 )
             };
@@ -2541,9 +2795,8 @@ pub fn spec_step_dflash(
     // use only for diagnostics. When disabled, zero cost beyond a handful
     // of Instant::now() calls.
     static PHASE_ON_ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let phase_on = *PHASE_ON_ENV.get_or_init(|| {
-        std::env::var("HIPFIRE_SPEC_PHASES").ok().as_deref() == Some("1")
-    });
+    let phase_on = *PHASE_ON_ENV
+        .get_or_init(|| std::env::var("HIPFIRE_SPEC_PHASES").ok().as_deref() == Some("1"));
     if phase_on {
         gpu.hip.device_synchronize()?;
     }
@@ -2572,11 +2825,18 @@ pub fn spec_step_dflash(
     // Forces the per-row host download even when RP is off (extra D2H per
     // cycle); off-by-default for that reason.
     static NGRAM_BLOCK_ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let ngram_block_env = *NGRAM_BLOCK_ENV.get_or_init(|| {
-        std::env::var("HIPFIRE_DFLASH_NGRAM_BLOCK").ok().as_deref() == Some("1")
-    });
+    let ngram_block_env = *NGRAM_BLOCK_ENV
+        .get_or_init(|| std::env::var("HIPFIRE_DFLASH_NGRAM_BLOCK").ok().as_deref() == Some("1"));
     let ngram_block_active = !use_temp_sampling && ngram_block_env;
     let host_path_active = rp_active || ngram_block_active;
+    let draft_ffn_graph_env = std::env::var("HIPFIRE_DFLASH_MOE_DRAFT_FFN_GRAPH").ok();
+    let draft_ffn_graph = dflash_moe_draft_ffn_graph_eligible(
+        target.config.num_experts,
+        ctx_slice.is_some(),
+        pld_spine.is_some(),
+        use_temp_sampling,
+        draft_ffn_graph_env.as_deref(),
+    );
 
     if let Some(pld) = pld_spine {
         // PLD spine path: drafted tokens come from context-suffix match.
@@ -2599,267 +2859,313 @@ pub fn spec_step_dflash(
             }
         }
     } else {
-    // ── 2. noise_embedding = target.embed_tokens(block) written directly
-    // into draft_scratch.x on GPU (no host round-trip). Target and draft
-    // share the same Gpu, so the embedding lookup can target the draft's
-    // scratch buffer. Avoids 16 × D2H + one H2D per iter (~1 ms saved).
-    for (i, &tok) in block.iter().enumerate() {
-        let dst = draft_scratch.x.sub_offset(i * h, h);
-        match target.weights.embd_format {
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
-                gpu.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
+        // ── 2. noise_embedding = target.embed_tokens(block) written directly
+        // into draft_scratch.x on GPU (no host round-trip). Target and draft
+        // share the same Gpu, so the embedding lookup can target the draft's
+        // scratch buffer. Avoids 16 × D2H + one H2D per iter (~1 ms saved).
+        for (i, &tok) in block.iter().enumerate() {
+            let dst = draft_scratch.x.sub_offset(i * h, h);
+            match target.weights.embd_format {
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G256 => {
+                    gpu.embedding_lookup_hfq4g256(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
+                    gpu.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
+                    gpu.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
+                }
+                hipfire_runtime::llama::EmbeddingFormat::F32 => {
+                    gpu.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
+                }
+                _ => panic!("dflash: unsupported target embedding format for noise lookup"),
             }
-            hipfire_runtime::llama::EmbeddingFormat::HFQ4G128 => {
-                gpu.embedding_lookup_hfq4g128(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::Q8_0 => {
-                gpu.embedding_lookup_q8(&target.weights.token_embd, &dst, tok, h)?
-            }
-            hipfire_runtime::llama::EmbeddingFormat::F32 => {
-                gpu.embedding_lookup(&target.weights.token_embd, &dst, tok, h)?
-            }
-            _ => panic!("dflash: unsupported target embedding format for noise lookup"),
         }
-    }
 
-    // ── 3. Position arrays + optional context slice ─────────────────────
-    // Q positions: the absolute positions of the block slots,
-    //   [position + compact_offset .. position + B + compact_offset).
-    // K positions by default: absolute positions of all populated target_hidden
-    // rows (potentially non-contiguous after a TriAttention eviction), then
-    // the same block slots.
-    //
-    // Pre-eviction: positions are contiguous [0..position+B), so the
-    // abs_positions vec contains [0..position) and this matches the old
-    // behaviour byte-for-byte.
-    // Post-eviction: abs_positions contains the subset retained by the last
-    // FA layer's top-B mask, paired with the correct pre-eviction absolute
-    // positions so draft RoPE aligns with target.
-    //
-    // If `ctx_slice = Some(N)` is set, restrict the draft's context view to
-    // the last `N` rows of target_hidden_host, with RoPE positions
-    // [position-N..position+B). Eviction-aware abs positions are not tracked
-    // on this diagnostic path — callers using it don't expect FlashCASK.
-    let effective_ctx_len = match ctx_slice {
-        Some(n) => n.min(position),
-        None => draft_scratch.target_hidden_abs_positions.len().min(position),
-    };
-    let ctx_start = position - effective_ctx_len;
-    let co = target.kv_cache.compact_offset as i32;
-    let positions_q: Vec<i32> =
-        ((position as i32 + co)..(position as i32 + b as i32 + co)).collect();
-    let positions_k: Vec<i32> = if ctx_slice.is_some() {
-        // Diagnostic path: keep legacy contiguous layout. abs_positions isn't
-        // tracked here and eviction isn't supported with ctx_slice anyway.
-        (ctx_start as i32..(position + b) as i32).collect()
-    } else {
-        let mut v = Vec::with_capacity(effective_ctx_len + b);
-        let th_abs = &draft_scratch.target_hidden_abs_positions;
-        let start_idx = th_abs.len().saturating_sub(effective_ctx_len);
-        v.extend_from_slice(&th_abs[start_idx..]);
-        for p in 0..b {
-            v.push(position as i32 + p as i32 + co);
-        }
-        v
-    };
-
-    // Slice target_hidden_host to the last effective_ctx_len rows. When
-    // ctx_slice is None, this is a no-op (ctx_start = 0). Row stride is
-    // num_extract × hidden = ne * h.
-    //
-    // Fast path (ctx_slice == None, 2026-04-16): `draft_scratch.target_hidden`
-    // is already populated via D2D scatter at the END of the previous cycle
-    // (or seed_target_hidden_from_prompt for the first cycle). We pass
-    // `target_hidden = None` to draft_forward so it skips the H2D upload
-    // entirely — kills the per-cycle CPU roundtrip.
-    //
-    // ctx_slice=Some(N) still goes through the CPU shadow (target_hidden_host
-    // Vec) because its moving-window semantics don't map onto the append-only
-    // GPU buffer without an extra D2D shuffle. It's a diagnostic path anyway.
-    let (th_arg, _th_offset): (Option<&[f32]>, usize) = if ctx_slice.is_some() {
-        let th_offset = ctx_start * ne * h;
-        (Some(&target_hidden_host[th_offset..]), th_offset)
-    } else {
-        (None, 0)
-    };
-
-    // ── 4. draft_forward ────────────────────────────────────────────────
-    // noise_embedding = None: we wrote embeddings directly into
-    // draft_scratch.x above via D2D (no host round-trip).
-    dflash::draft_forward(
-        gpu,
-        draft_weights,
-        draft_cfg,
-        None,
-        th_arg,
-        &positions_q,
-        &positions_k,
-        b,
-        effective_ctx_len,
-        draft_scratch,
-    )?;
-
-    // ── 5. Apply target.lm_head to draft hidden positions 1..B ──────────
-    // Fast path: a single batched GEMM against target.weights.output over
-    // (B-1) hidden rows at once. Drops lm_head from ~40 ms (B-1 serial
-    // weight_gemv + downloads) to ~8 ms (one batched GEMM + one download)
-    // for MQ4/HFQ4 lm_heads. Falls back to the per-row loop when the
-    // output weight dtype isn't covered by the batched gemm dispatch.
-    //
-    // Temperature-sampling mode (temp > 0): we must DOWNLOAD the full
-    // (B-1, vocab) draft logits, softmax + sample + record p_draft[token]
-    // for later rejection acceptance. The greedy GPU-argmax path is kept
-    // intact for temp == 0 so we don't regress that case.
-    let w_out = &target.weights.output;
-    let use_batched_gemm = matches!(
-        w_out.gpu_dtype,
-        rdna_compute::DType::HFQ4G256
-        | rdna_compute::DType::MQ4G256
-        | rdna_compute::DType::MQ3G256
-        | rdna_compute::DType::HFQ6G256
-        | rdna_compute::DType::MQ6G256,
-    );
-    let use_q8_staged = matches!(w_out.gpu_dtype, rdna_compute::DType::Q8_0);
-    if use_batched_gemm || use_q8_staged {
-        // Unified batched path: one GEMM over B-1 rows, GPU-side argmax,
-        // download just (B-1) × 4 bytes of indices.
+        // ── 3. Position arrays + optional context slice ─────────────────────
+        // Q positions: the absolute positions of the block slots,
+        //   [position + compact_offset .. position + B + compact_offset).
+        // K positions by default: absolute positions of all populated target_hidden
+        // rows (potentially non-contiguous after a TriAttention eviction), then
+        // the same block slots.
         //
-        // Reuses `verify_scratch.logits` and `.rot` — same buffers the target
-        // verify uses. Draft calls this BEFORE verify in the cycle, so
-        // there's no aliasing. The verify call overwrites these buffers
-        // afterward. Avoids 2-3 hipMalloc/Free pairs per cycle.
-        let batch = b - 1;
-        assert!(batch <= verify_scratch.max_n,
-            "verify_scratch max_n {} < draft batch {}", verify_scratch.max_n, batch);
-        let hidden_rows = draft_scratch.x.sub_offset(h, batch * h);
-        let logits_batch = verify_scratch.logits.sub_offset(0, batch * vocab);
+        // Pre-eviction: positions are contiguous [0..position+B), so the
+        // abs_positions vec contains [0..position) and this matches the old
+        // behaviour byte-for-byte.
+        // Post-eviction: abs_positions contains the subset retained by the last
+        // FA layer's top-B mask, paired with the correct pre-eviction absolute
+        // positions so draft RoPE aligns with target.
+        //
+        // If `ctx_slice = Some(N)` is set, restrict the draft's context view to
+        // the last `N` rows of target_hidden_host, with RoPE positions
+        // [position-N..position+B). Eviction-aware abs positions are not tracked
+        // on this diagnostic path — callers using it don't expect FlashCASK.
+        let effective_ctx_len = match ctx_slice {
+            Some(n) => n.min(position),
+            None => draft_scratch
+                .target_hidden_abs_positions
+                .len()
+                .min(position),
+        };
+        let ctx_start = position - effective_ctx_len;
+        let co = target.kv_cache.compact_offset as i32;
+        let positions_q: Vec<i32> =
+            ((position as i32 + co)..(position as i32 + b as i32 + co)).collect();
+        let positions_k: Vec<i32> = if ctx_slice.is_some() {
+            // Diagnostic path: keep legacy contiguous layout. abs_positions isn't
+            // tracked here and eviction isn't supported with ctx_slice anyway.
+            (ctx_start as i32..(position + b) as i32).collect()
+        } else {
+            let mut v = Vec::with_capacity(effective_ctx_len + b);
+            let th_abs = &draft_scratch.target_hidden_abs_positions;
+            let start_idx = th_abs.len().saturating_sub(effective_ctx_len);
+            v.extend_from_slice(&th_abs[start_idx..]);
+            for p in 0..b {
+                v.push(position as i32 + p as i32 + co);
+            }
+            v
+        };
 
-        match w_out.gpu_dtype {
-            rdna_compute::DType::Q8_0 => {
-                // INVARIANT: substrate-only (greedy-parity with decode); see the
-                // earlier Q8_0 spec-verify path in this file for the full rationale.
-                // Do not route through the Q8 WMMA dispatcher.
-                gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)?;
-            }
-            rdna_compute::DType::HFQ4G256 => {
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::MQ4G256 => {
-                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for draft lm_head");
-                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                // AWQ-aware rotation; same rationale as the target-verify
-                // arms above.
-                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq4g256_batched_lmhead(
-                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::MQ3G256 => {
-                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ3 draft lm_head");
-                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq3g256_batched_lmhead(
-                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::HFQ6G256 => {
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            rdna_compute::DType::MQ6G256 => {
-                assert!(batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
-                    "verify_scratch.rot undersized for MQ6 draft lm_head");
-                let rotated = verify_scratch.rot.sub_offset(0, batch * h);
-                llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
-                gpu.gemm_hfq6g256_batched_lmhead(
-                    &w_out.buf, &rotated, &logits_batch, w_out.m, w_out.k, batch,
-                )?;
-            }
-            _ => unreachable!(),
-        }
+        // Slice target_hidden_host to the last effective_ctx_len rows. When
+        // ctx_slice is None, this is a no-op (ctx_start = 0). Row stride is
+        // num_extract × hidden = ne * h.
+        //
+        // Fast path (ctx_slice == None, 2026-04-16): `draft_scratch.target_hidden`
+        // is already populated via D2D scatter at the END of the previous cycle
+        // (or seed_target_hidden_from_prompt for the first cycle). We pass
+        // `target_hidden = None` to draft_forward so it skips the H2D upload
+        // entirely — kills the per-cycle CPU roundtrip.
+        //
+        // ctx_slice=Some(N) still goes through the CPU shadow (target_hidden_host
+        // Vec) because its moving-window semantics don't map onto the append-only
+        // GPU buffer without an extra D2D shuffle. It's a diagnostic path anyway.
+        let (th_arg, _th_offset): (Option<&[f32]>, usize) = if ctx_slice.is_some() {
+            let th_offset = ctx_start * ne * h;
+            (Some(&target_hidden_host[th_offset..]), th_offset)
+        } else {
+            (None, 0)
+        };
 
-        if use_temp_sampling {
-            // Full D2H of (B-1)×vocab logits, CPU softmax+sample.
-            let host_logits = gpu.download_f32(&logits_batch)?;
-            debug_assert_eq!(host_logits.len(), batch * vocab);
-            draft_softmaxes.reserve(batch);
-            for i in 0..batch {
-                let row = &host_logits[i * vocab..(i + 1) * vocab];
-                let mut probs = Vec::with_capacity(vocab);
-                softmax_temp_into(row, temp, &mut probs);
-                let u = xorshift_next_unit(rng_state);
-                let t = sample_categorical(&probs, u);
-                draft_probs_at_drafted.push(probs[t as usize]);
-                drafted.push(t);
-                draft_softmaxes.push(probs);
+        // ── 4. draft_forward ────────────────────────────────────────────────
+        // noise_embedding = None: we wrote embeddings directly into
+        // draft_scratch.x above via D2D (no host round-trip).
+        dflash::draft_forward_opts(
+            gpu,
+            draft_weights,
+            draft_cfg,
+            None,
+            th_arg,
+            &positions_q,
+            &positions_k,
+            b,
+            effective_ctx_len,
+            draft_scratch,
+            draft_ffn_graph,
+        )?;
+
+        // ── 5. Apply target.lm_head to draft hidden positions 1..B ──────────
+        // Fast path: a single batched GEMM against target.weights.output over
+        // (B-1) hidden rows at once. Drops lm_head from ~40 ms (B-1 serial
+        // weight_gemv + downloads) to ~8 ms (one batched GEMM + one download)
+        // for MQ4/HFQ4 lm_heads. Falls back to the per-row loop when the
+        // output weight dtype isn't covered by the batched gemm dispatch.
+        //
+        // Temperature-sampling mode (temp > 0): we must DOWNLOAD the full
+        // (B-1, vocab) draft logits, softmax + sample + record p_draft[token]
+        // for later rejection acceptance. The greedy GPU-argmax path is kept
+        // intact for temp == 0 so we don't regress that case.
+        let w_out = &target.weights.output;
+        let use_batched_gemm = matches!(
+            w_out.gpu_dtype,
+            rdna_compute::DType::HFQ4G256
+                | rdna_compute::DType::MQ4G256
+                | rdna_compute::DType::MQ3G256
+                | rdna_compute::DType::HFQ6G256
+                | rdna_compute::DType::MQ6G256,
+        );
+        let use_q8_staged = matches!(w_out.gpu_dtype, rdna_compute::DType::Q8_0);
+        if use_batched_gemm || use_q8_staged {
+            // Unified batched path: one GEMM over B-1 rows, GPU-side argmax,
+            // download just (B-1) × 4 bytes of indices.
+            //
+            // Reuses `verify_scratch.logits` and `.rot` — same buffers the target
+            // verify uses. Draft calls this BEFORE verify in the cycle, so
+            // there's no aliasing. The verify call overwrites these buffers
+            // afterward. Avoids 2-3 hipMalloc/Free pairs per cycle.
+            let batch = b - 1;
+            assert!(
+                batch <= verify_scratch.max_n,
+                "verify_scratch max_n {} < draft batch {}",
+                verify_scratch.max_n,
+                batch
+            );
+            let hidden_rows = draft_scratch.x.sub_offset(h, batch * h);
+            let logits_batch = verify_scratch.logits.sub_offset(0, batch * vocab);
+
+            match w_out.gpu_dtype {
+                rdna_compute::DType::Q8_0 => {
+                    dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)?;
+                }
+                rdna_compute::DType::HFQ4G256 => {
+                    gpu.gemm_hfq4g256_batched_lmhead(
+                        &w_out.buf,
+                        &hidden_rows,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::MQ4G256 => {
+                    assert!(
+                        batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                        "verify_scratch.rot undersized for draft lm_head"
+                    );
+                    let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                    // AWQ-aware rotation; same rationale as the target-verify
+                    // arms above.
+                    llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
+                    gpu.gemm_hfq4g256_batched_lmhead(
+                        &w_out.buf,
+                        &rotated,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::MQ3G256 => {
+                    assert!(
+                        batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                        "verify_scratch.rot undersized for MQ3 draft lm_head"
+                    );
+                    let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                    llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
+                    gpu.gemm_hfq3g256_batched_lmhead(
+                        &w_out.buf,
+                        &rotated,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::HFQ6G256 => {
+                    gpu.gemm_hfq6g256_batched_lmhead(
+                        &w_out.buf,
+                        &hidden_rows,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                rdna_compute::DType::MQ6G256 => {
+                    assert!(
+                        batch * h <= verify_scratch.max_n * verify_scratch.hidden_k,
+                        "verify_scratch.rot undersized for MQ6 draft lm_head"
+                    );
+                    let rotated = verify_scratch.rot.sub_offset(0, batch * h);
+                    llama::rotate_x_mq_batched_for(gpu, w_out, &hidden_rows, &rotated, h, batch)?;
+                    gpu.gemm_hfq6g256_batched_lmhead(
+                        &w_out.buf,
+                        &rotated,
+                        &logits_batch,
+                        w_out.m,
+                        w_out.k,
+                        batch,
+                    )?;
+                }
+                _ => unreachable!(),
             }
-        } else if host_path_active {
-            // RP / n-gram-block path: apply per-row penalties before argmax
-            // so draft and target pick from the same reshaped distribution.
-            // Keeps spec-decode aligned (τ doesn't collapse from mismatched
-            // argmaxes — both sides see identical -inf logits on banned toks).
-            let host_logits = gpu.download_f32(&logits_batch)?;
-            debug_assert_eq!(host_logits.len(), batch * vocab);
-            let mut row = vec![0f32; vocab];
-            for i in 0..batch {
-                row.copy_from_slice(&host_logits[i * vocab..(i + 1) * vocab]);
-                if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
+
+            if use_temp_sampling {
+                // Full D2H of (B-1)×vocab logits, CPU softmax+sample.
+                let host_logits = gpu.download_f32(&logits_batch)?;
+                debug_assert_eq!(host_logits.len(), batch * vocab);
+                draft_softmaxes.reserve(batch);
+                for i in 0..batch {
+                    let row = &host_logits[i * vocab..(i + 1) * vocab];
+                    let mut probs = Vec::with_capacity(vocab);
+                    softmax_temp_into(row, temp, &mut probs);
+                    let u = xorshift_next_unit(rng_state);
+                    let t = sample_categorical(&probs, u);
+                    draft_probs_at_drafted.push(probs[t as usize]);
+                    drafted.push(t);
+                    draft_softmaxes.push(probs);
                 }
-                if ngram_block_active {
-                    llama::apply_ngram_block(&mut row, prev_committed);
+            } else if host_path_active {
+                // RP / n-gram-block path: apply per-row penalties before argmax
+                // so draft and target pick from the same reshaped distribution.
+                // Keeps spec-decode aligned (τ doesn't collapse from mismatched
+                // argmaxes — both sides see identical -inf logits on banned toks).
+                let host_logits = gpu.download_f32(&logits_batch)?;
+                debug_assert_eq!(host_logits.len(), batch * vocab);
+                let mut row = vec![0f32; vocab];
+                for i in 0..batch {
+                    row.copy_from_slice(&host_logits[i * vocab..(i + 1) * vocab]);
+                    if rp_active {
+                        llama::apply_repeat_penalty(
+                            &mut row,
+                            prev_committed,
+                            repeat_window,
+                            repeat_penalty,
+                        );
+                    }
+                    if ngram_block_active {
+                        llama::apply_ngram_block(&mut row, prev_committed);
+                    }
+                    drafted.push(argmax_u32(&row));
                 }
-                drafted.push(argmax_u32(&row));
+            } else {
+                // GPU argmax over (B-1) rows — one kernel, small D2H.
+                let argmax_buf = verify_scratch.argmax.sub_offset(0, batch);
+                gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, batch)?;
+                let mut host_idx = vec![0i32; batch];
+                {
+                    let bytes: &mut [u8] = unsafe {
+                        std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, batch * 4)
+                    };
+                    gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
+                }
+                for &idx in &host_idx {
+                    drafted.push(idx as u32);
+                }
             }
         } else {
-            // GPU argmax over (B-1) rows — one kernel, small D2H.
-            let argmax_buf = verify_scratch.argmax.sub_offset(0, batch);
-            gpu.argmax_f32_batched(&logits_batch, &argmax_buf, vocab, batch)?;
-            let mut host_idx = vec![0i32; batch];
-            {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(host_idx.as_mut_ptr() as *mut u8, batch * 4)
-                };
-                gpu.hip.memcpy_dtoh(bytes, &argmax_buf.buf)?;
-            }
-            for &idx in &host_idx {
-                drafted.push(idx as u32);
+            // Fallback: per-row weight_gemv loop.
+            for i in 1..b {
+                let hidden_row = draft_scratch.x.sub_offset(i * h, h);
+                llama::weight_gemv(gpu, w_out, &hidden_row, &target.scratch.logits)?;
+                let logits = gpu.download_f32(&target.scratch.logits)?;
+                debug_assert_eq!(logits.len(), vocab);
+                if use_temp_sampling {
+                    let mut probs = Vec::with_capacity(vocab);
+                    softmax_temp_into(&logits, temp, &mut probs);
+                    let u = xorshift_next_unit(rng_state);
+                    let t = sample_categorical(&probs, u);
+                    draft_probs_at_drafted.push(probs[t as usize]);
+                    drafted.push(t);
+                    draft_softmaxes.push(probs);
+                } else if host_path_active {
+                    let mut row = logits.clone();
+                    if rp_active {
+                        llama::apply_repeat_penalty(
+                            &mut row,
+                            prev_committed,
+                            repeat_window,
+                            repeat_penalty,
+                        );
+                    }
+                    if ngram_block_active {
+                        llama::apply_ngram_block(&mut row, prev_committed);
+                    }
+                    drafted.push(argmax_u32(&row));
+                } else {
+                    drafted.push(argmax_u32(&logits));
+                }
             }
         }
-    } else {
-        // Fallback: per-row weight_gemv loop.
-        for i in 1..b {
-            let hidden_row = draft_scratch.x.sub_offset(i * h, h);
-            llama::weight_gemv(gpu, w_out, &hidden_row, &target.scratch.logits)?;
-            let logits = gpu.download_f32(&target.scratch.logits)?;
-            debug_assert_eq!(logits.len(), vocab);
-            if use_temp_sampling {
-                let mut probs = Vec::with_capacity(vocab);
-                softmax_temp_into(&logits, temp, &mut probs);
-                let u = xorshift_next_unit(rng_state);
-                let t = sample_categorical(&probs, u);
-                draft_probs_at_drafted.push(probs[t as usize]);
-                drafted.push(t);
-                draft_softmaxes.push(probs);
-            } else if host_path_active {
-                let mut row = logits.clone();
-                if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
-                }
-                if ngram_block_active {
-                    llama::apply_ngram_block(&mut row, prev_committed);
-                }
-                drafted.push(argmax_u32(&row));
-            } else {
-                drafted.push(argmax_u32(&logits));
-            }
-        }
-    }
     } // close else (DFlash draft path)
 
     for i in 1..b {
@@ -2919,31 +3225,34 @@ pub fn spec_step_dflash(
     // re-running the target.
     target_snap.save_from(&target.dn_state, gpu)?;
     // Mutable variable to allow both verify capture + rollback replay usage.
-    let mut gdn_tape_opt = gdn_tape;
-    // MoE targets can't populate the tape: forward_prefill_batch_with_pbs's
-    // eligibility check rejects MoE (qwen35.rs `DeltaNetMoe|FullAttnMoe => false`),
-    // so verify falls through to the per-token loop which doesn't write the
-    // tape. With Some(tape) downstream `replay_gdn` then runs on zero-init
-    // buffers, corrupting `dn_state.conv_states` and hanging the next cycle.
-    // Force None so the fallback replay path (batched forward on committed
-    // tokens) runs instead — correct at ~3-5 ms/cycle extra vs proper tape
-    // replay. Remove once batched MoE prefill + tape recording lands.
-    let target_has_moe = target.weights.layers.iter().any(|lw| matches!(
-        lw,
-        qwen35::LayerWeights::DeltaNetMoe(_) | qwen35::LayerWeights::FullAttnMoe(_),
-    ));
-    if target_has_moe {
-        gdn_tape_opt = None;
-    }
+    let moe_router_logits_present = verify_scratch
+        .prefill_batch
+        .as_ref()
+        .map(|pbs| pbs.moe_router_logits_batch.is_some())
+        .unwrap_or(true);
+    let verify_populates_tape = qwen35::prefill_batch_pbs_eligible(
+        &target.weights,
+        &target.config,
+        &target.dn_state,
+        b,
+        gpu.arch.as_str(),
+        moe_router_logits_present,
+    );
+    let use_tape_replay = dflash_use_gdn_tape_replay(gdn_tape.is_some(), verify_populates_tape);
+    let mut gdn_tape_opt = if use_tape_replay { gdn_tape } else { None };
 
     if phase_on {
         gpu.hip.device_synchronize()?;
     }
     let t_verify_start = std::time::Instant::now();
     let verify_out = verify_dflash_block(
-        gpu, target, &block, position, hidden_rb,
+        gpu,
+        target,
+        &block,
+        position,
+        hidden_rb,
         gdn_tape_opt.as_deref_mut(),
-        use_temp_sampling || host_path_active,  // full target logits needed for rejection sampling, RP, or n-gram block
+        use_temp_sampling || host_path_active, // full target logits needed for rejection sampling, RP, or n-gram block
         verify_scratch,
     )?;
 
@@ -2980,7 +3289,11 @@ pub fn spec_step_dflash(
         // δ==0 reduces to vanilla SpS. Paper's strongest setting is δ=1.0.
         let use_cactus = cactus_delta > 0.0;
         for i in 0..b - 1 {
-            softmax_temp_into(&tgt_logits[i * vocab..(i + 1) * vocab], temp, &mut target_probs);
+            softmax_temp_into(
+                &tgt_logits[i * vocab..(i + 1) * vocab],
+                temp,
+                &mut target_probs,
+            );
             let t = block[i + 1] as usize;
             let p_d = draft_probs_at_drafted[i].max(f32::MIN_POSITIVE);
             let p_t = target_probs[t];
@@ -3006,7 +3319,9 @@ pub fn spec_step_dflash(
                     let gamma_star = accept_prob;
                     if qn >= 1.0 - 1e-6 {
                         // Degenerate: q is (near) one-hot on t; h is one-hot on t too.
-                        for v in target_probs.iter_mut() { *v = 0.0; }
+                        for v in target_probs.iter_mut() {
+                            *v = 0.0;
+                        }
                         target_probs[t] = 1.0;
                     } else {
                         let scale = (1.0 - gamma_star) / (1.0 - qn);
@@ -3016,9 +3331,7 @@ pub fn spec_step_dflash(
                     }
                 }
                 let u2 = xorshift_next_unit(rng_state);
-                rejected_bonus = Some(sample_residual(
-                    &target_probs, &draft_softmaxes[i], u2,
-                ));
+                rejected_bonus = Some(sample_residual(&target_probs, &draft_softmaxes[i], u2));
                 break;
             }
         }
@@ -3027,7 +3340,11 @@ pub fn spec_step_dflash(
         } else {
             // All accepted: sample from target_softmax at position B-1.
             let i = b - 1;
-            softmax_temp_into(&tgt_logits[i * vocab..(i + 1) * vocab], temp, &mut target_probs);
+            softmax_temp_into(
+                &tgt_logits[i * vocab..(i + 1) * vocab],
+                temp,
+                &mut target_probs,
+            );
             let u = xorshift_next_unit(rng_state);
             sample_categorical(&target_probs, u)
         };
@@ -3044,7 +3361,12 @@ pub fn spec_step_dflash(
             for i in 0..b {
                 row.copy_from_slice(&tgt_logits[i * vocab..(i + 1) * vocab]);
                 if rp_active {
-                    llama::apply_repeat_penalty(&mut row, prev_committed, repeat_window, repeat_penalty);
+                    llama::apply_repeat_penalty(
+                        &mut row,
+                        prev_committed,
+                        repeat_window,
+                        repeat_penalty,
+                    );
                 }
                 if ngram_block_active {
                     llama::apply_ngram_block(&mut row, prev_committed);
@@ -3231,7 +3553,11 @@ pub fn spec_step_dflash(
     // batched call instead of (accept+1) sequential decodes.
     if let Some(tape) = gdn_tape_opt.as_deref() {
         tape.replay_gdn(
-            gpu, &target.weights, &target.config, &mut target.dn_state, accept_len + 1,
+            gpu,
+            &target.weights,
+            &target.config,
+            &mut target.dn_state,
+            accept_len + 1,
         )?;
     } else {
         let replay_tokens = &committed[..accept_len + 1];
@@ -3244,7 +3570,10 @@ pub fn spec_step_dflash(
             &mut target.kv_cache,
             &mut target.dn_state,
             &target.scratch,
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )?;
     }
     // Target state is now at position + accept_len + 1. KV cache has
@@ -3255,23 +3584,38 @@ pub fn spec_step_dflash(
     if phase_on {
         gpu.hip.device_synchronize()?;
         let t_end = std::time::Instant::now();
-        let us_draft   = t_draft_end.duration_since(t_spec_start).as_micros();
-        let us_ngram   = t_verify_start.duration_since(t_draft_end).as_micros();
-        let us_verify  = t_verify_end.duration_since(t_verify_start).as_micros();
-        let us_accept  = t_accept_end.duration_since(t_verify_end).as_micros();
+        let us_draft = t_draft_end.duration_since(t_spec_start).as_micros();
+        let us_ngram = t_verify_start.duration_since(t_draft_end).as_micros();
+        let us_verify = t_verify_end.duration_since(t_verify_start).as_micros();
+        let us_accept = t_accept_end.duration_since(t_verify_end).as_micros();
         let us_scatter = t_scatter_end.duration_since(t_accept_end).as_micros();
         let us_restore = t_restore_end.duration_since(t_scatter_end).as_micros();
-        let us_replay  = t_end.duration_since(t_restore_end).as_micros();
-        let us_total   = t_end.duration_since(t_spec_start).as_micros();
+        let us_replay = t_end.duration_since(t_restore_end).as_micros();
+        let us_total = t_end.duration_since(t_spec_start).as_micros();
         eprintln!(
             "[phase] B={} accept={} draft={}µs ngram={}µs verify={}µs \
              cmpr={}µs scatter={}µs restore={}µs replay={}µs | total={}µs",
-            b, accept_len, us_draft, us_ngram, us_verify, us_accept,
-            us_scatter, us_restore, us_replay, us_total,
+            b,
+            accept_len,
+            us_draft,
+            us_ngram,
+            us_verify,
+            us_accept,
+            us_scatter,
+            us_restore,
+            us_replay,
+            us_total,
         );
     }
-    let _ = (t_phase, t_draft_end, t_verify_start, t_verify_end,
-             t_accept_end, t_scatter_end, t_restore_end);
+    let _ = (
+        t_phase,
+        t_draft_end,
+        t_verify_start,
+        t_verify_end,
+        t_accept_end,
+        t_scatter_end,
+        t_restore_end,
+    );
 
     Ok(SpecStepResult {
         accepted: accept_len,
@@ -3372,7 +3716,7 @@ fn run_dflash_draft_for_logits(
 
     let gemm_result = match w_out.gpu_dtype {
         rdna_compute::DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
+            dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)
         }
         rdna_compute::DType::HFQ4G256 => {
             gpu.gemm_hfq4g256(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
@@ -3537,7 +3881,7 @@ fn run_dflash_draft_for_topk_gpu(
     let w_out = &target.weights.output;
     let gemm_result = match w_out.gpu_dtype {
         rdna_compute::DType::Q8_0 => {
-            gpu.gemm_q8_0_batched(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
+            dflash_gemm_q8_lmhead(gpu, w_out, &hidden_rows, &logits_batch, batch)
         }
         rdna_compute::DType::HFQ4G256 => {
             gpu.gemm_hfq4g256(&w_out.buf, &hidden_rows, &logits_batch, w_out.m, w_out.k, batch)
@@ -3606,7 +3950,12 @@ fn run_dflash_draft_for_topk_gpu(
     let topk_idx_gpu = gpu.alloc_tensor(&[batch * k], rdna_compute::DType::F32)?;
     let topk_val_gpu = gpu.alloc_tensor(&[batch * k], rdna_compute::DType::F32)?;
     let topk_result = gpu.topk_logsumexp_batched_f32(
-        &logits_batch, &topk_idx_gpu, &topk_val_gpu, vocab, k, batch,
+        &logits_batch,
+        &topk_idx_gpu,
+        &topk_val_gpu,
+        vocab,
+        k,
+        batch,
     );
     let _ = gpu.free_tensor(logits_batch);
     if let Err(e) = topk_result {
@@ -3618,12 +3967,10 @@ fn run_dflash_draft_for_topk_gpu(
     // Step 6: D2H just the top-K outputs (tiny — 8 × 15 × 4 = 480 bytes for k=8).
     let mut idx_host: Vec<i32> = vec![0i32; batch * k];
     let mut val_host: Vec<f32> = vec![0f32; batch * k];
-    let idx_bytes: &mut [u8] = unsafe {
-        std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, batch * k * 4)
-    };
-    let val_bytes: &mut [u8] = unsafe {
-        std::slice::from_raw_parts_mut(val_host.as_mut_ptr() as *mut u8, batch * k * 4)
-    };
+    let idx_bytes: &mut [u8] =
+        unsafe { std::slice::from_raw_parts_mut(idx_host.as_mut_ptr() as *mut u8, batch * k * 4) };
+    let val_bytes: &mut [u8] =
+        unsafe { std::slice::from_raw_parts_mut(val_host.as_mut_ptr() as *mut u8, batch * k * 4) };
     gpu.hip.memcpy_dtoh(idx_bytes, &topk_idx_gpu.buf)?;
     gpu.hip.memcpy_dtoh(val_bytes, &topk_val_gpu.buf)?;
     let _ = gpu.free_tensor(topk_idx_gpu);
@@ -3903,8 +4250,11 @@ pub fn spec_step_ddtree(
     // batch-size-equal to DFlash but tokens-correct. Some cross-cycle
     // numerical drift vs baseline is the tradeoff; output should remain
     // a valid target-greedy sequence.
-    let topk1_is_committed_prefix = accept_len > 0 && committed[1..=accept_len].iter().enumerate()
-        .all(|(d, &tok)| tok == top_tokens[d * tree_topk]);
+    let topk1_is_committed_prefix = accept_len > 0
+        && committed[1..=accept_len]
+            .iter()
+            .enumerate()
+            .all(|(d, &tok)| tok == top_tokens[d * tree_topk]);
     let tape_block: Vec<u32> = if topk1_is_committed_prefix || accept_len == 0 {
         // Safe to use full-B top-1 block (byte-exact with DFlash path).
         let mut vb: Vec<u32> = Vec::with_capacity(b);
@@ -4078,8 +4428,15 @@ pub fn spec_step_ddtree_batched(
     if tree.nodes.is_empty() {
         target_snap.save_from(&target.dn_state, gpu)?;
         qwen35::forward_scratch_with_hidden(
-            gpu, &target.weights, &target.config, seed_token, position,
-            &mut target.kv_cache, &mut target.dn_state, &target.scratch, hidden_rb,
+            gpu,
+            &target.weights,
+            &target.config,
+            seed_token,
+            position,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            hidden_rb,
         )?;
         let logits0 = gpu.download_f32(&target.scratch.logits)?;
         let bonus = argmax_u32(&logits0);
@@ -4109,7 +4466,8 @@ pub fn spec_step_ddtree_batched(
     assert!(
         big_n <= scratch.max_n,
         "tree big_n {} exceeds scratch.max_n {} (increase DdtreeScratch size)",
-        big_n, scratch.max_n,
+        big_n,
+        scratch.max_n,
     );
     {
         let mask_bytes = unsafe {
@@ -4136,7 +4494,8 @@ pub fn spec_step_ddtree_batched(
         let parent_bytes = unsafe {
             std::slice::from_raw_parts(parent_host.as_ptr() as *const u8, parent_host.len() * 4)
         };
-        gpu.hip.memcpy_htod(&scratch.parent_indices.buf, parent_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.parent_indices.buf, parent_bytes)?;
     }
 
     // ── 6. Snapshot pre-seed target state ─────────────────────────────────
@@ -4175,7 +4534,9 @@ pub fn spec_step_ddtree_batched(
     // overhead until the slow-path branch is replaced. Keep gated until
     // the eyeball-tested smoke (see PRD trap surface) passes.
     let pre_rope_capture = if std::env::var("HIPFIRE_DDTREE_PATH_B_CAPTURE")
-        .ok().as_deref() == Some("1")
+        .ok()
+        .as_deref()
+        == Some("1")
         && !scratch.pre_rope_k.is_empty()
     {
         Some(scratch.pre_rope_k.as_slice())
@@ -4185,12 +4546,23 @@ pub fn spec_step_ddtree_batched(
     let ctx = qwen35::TreeVerifyCtx {
         positions: &verify_positions,
         attn_bias: &attn_bias_view,
-        parent_indices: if use_tree_la { Some(&parent_view) } else { None },
+        parent_indices: if use_tree_la {
+            Some(&parent_view)
+        } else {
+            None
+        },
         pre_rope_k_capture: pre_rope_capture,
     };
     let t_pre_verify = t_all.elapsed();
     let verify_out = verify_dflash_block_tree(
-        gpu, target, &verify_tokens, position, hidden_rb, Some(gdn_tape), false, ctx,
+        gpu,
+        target,
+        &verify_tokens,
+        position,
+        hidden_rb,
+        Some(gdn_tape),
+        false,
+        ctx,
         verify_scratch,
     )?;
     let posterior = verify_out.argmax_per_pos;
@@ -4237,7 +4609,9 @@ pub fn spec_step_ddtree_batched(
     // at same depth otherwise race and the LAST write wins regardless of
     // which sibling was committed).
     let force_slow = std::env::var("HIPFIRE_DDTREE_FORCE_SLOW").ok().as_deref() == Some("1");
-    let spine_accept = accepted_node_indices.iter().enumerate()
+    let spine_accept = accepted_node_indices
+        .iter()
+        .enumerate()
         .all(|(i, &ni)| ni == i);
     let fast_tape_ok = !force_slow && spine_accept;
     // Per-cycle fast/slow accounting. HIPFIRE_DDTREE_TAPE_DUMP=1 emits a
@@ -4273,8 +4647,11 @@ pub fn spec_step_ddtree_batched(
             accept_len + 1,
         )?;
         hidden_rows_written = big_n;
-    } else if std::env::var("HIPFIRE_DDTREE_PATH_B_CAPTURE").ok().as_deref() == Some("1")
-              && !scratch.pre_rope_k.is_empty()
+    } else if std::env::var("HIPFIRE_DDTREE_PATH_B_CAPTURE")
+        .ok()
+        .as_deref()
+        == Some("1")
+        && !scratch.pre_rope_k.is_empty()
     {
         // Path B slow-path-kill (opt-in, WIP). Replaces the ~40-50 ms full
         // re-verify with a gather + per-commit RoPE + quant-write chain
@@ -4304,7 +4681,8 @@ pub fn spec_step_ddtree_batched(
         let tape_idx_bytes: &[u8] = unsafe {
             std::slice::from_raw_parts(tape_idx_host.as_ptr() as *const u8, n_positions * 4)
         };
-        gpu.hip.memcpy_htod(&scratch.parent_indices.buf, tape_idx_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.parent_indices.buf, tape_idx_bytes)?;
         gdn_tape.gather_accepted(
             gpu,
             &scratch.parent_indices,
@@ -4325,7 +4703,9 @@ pub fn spec_step_ddtree_batched(
         // For V: V doesn't carry a position-dependent rotation, so a
         // pure byte gather (raced slot → committed slot) is correct. Same
         // pattern Path A used.
-        let pbs = verify_scratch.prefill_batch.as_ref()
+        let pbs = verify_scratch
+            .prefill_batch
+            .as_ref()
             .expect("Path B requires VerifyScratch.prefill_batch (set during DdtreeScratch init)");
 
         // Tree-verify K source indices (one per accepted committed slot, in
@@ -4339,19 +4719,24 @@ pub fn spec_step_ddtree_batched(
         };
         // Reuse parent_indices buffer for the K gather indices (it was
         // already used for the tape gather above; re-upload now).
-        gpu.hip.memcpy_htod(&scratch.parent_indices.buf, k_src_idx_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.parent_indices.buf, k_src_idx_bytes)?;
 
         // Committed slot positions for RoPE + KV write: [start_pos+0..start_pos+accept_len].
         let pos_host: Vec<i32> = (0..n_positions).map(|i| (position + i) as i32).collect();
-        let pos_bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(pos_host.as_ptr() as *const u8, n_positions * 4)
-        };
-        gpu.hip.memcpy_htod(&scratch.kv_gather_indices.buf, pos_bytes)?;
+        let pos_bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(pos_host.as_ptr() as *const u8, n_positions * 4) };
+        gpu.hip
+            .memcpy_htod(&scratch.kv_gather_indices.buf, pos_bytes)?;
 
         // Absolute KV slots for V gather: [position+0, position+1+acc[0], ...]
         // (V is the same as Path A: byte gather from raced slots to committed).
         let v_src_abs_host: Vec<i32> = std::iter::once(position as i32)
-            .chain(accepted_node_indices.iter().map(|&i| (position + 1 + i) as i32))
+            .chain(
+                accepted_node_indices
+                    .iter()
+                    .map(|&i| (position + 1 + i) as i32),
+            )
             .collect();
         let v_src_abs_bytes: &[u8] = unsafe {
             std::slice::from_raw_parts(v_src_abs_host.as_ptr() as *const u8, n_positions * 4)
@@ -4359,15 +4744,25 @@ pub fn spec_step_ddtree_batched(
         // Park the V indices in the tape_gather_scratch's first 4×n bytes —
         // tape gather is done; the buffer is free until next cycle. (Avoids
         // adding yet another tiny i32 buffer to DdtreeScratch.)
-        gpu.hip.memcpy_htod(&scratch.tape_gather_scratch.buf, v_src_abs_bytes)?;
+        gpu.hip
+            .memcpy_htod(&scratch.tape_gather_scratch.buf, v_src_abs_bytes)?;
 
         let v_bpp = n_kv_heads * (head_dim / 32) * 34; // Q8 V (all asym* modes use Q8 V)
 
         let n_rot = (target.config.head_dim as f32 * target.config.partial_rotary_factor) as usize;
 
-        for (fa_idx, layer_idx) in target.config.layer_types.iter()
+        for (fa_idx, layer_idx) in target
+            .config
+            .layer_types
+            .iter()
             .enumerate()
-            .filter_map(|(li, lt)| if *lt == qwen35::LayerType::FullAttention { Some(li) } else { None })
+            .filter_map(|(li, lt)| {
+                if *lt == qwen35::LayerType::FullAttention {
+                    Some(li)
+                } else {
+                    None
+                }
+            })
             .enumerate()
         {
             // 1. Gather pre-RoPE K rows by k_src_idx into pbs.fa_k_batch.
@@ -4383,9 +4778,15 @@ pub fn spec_step_ddtree_batched(
             // 2. Apply RoPE in-place to gathered K with committed positions.
             //    Q is throwaway — fa_q_batch is large enough.
             gpu.rope_partial_interleaved_f32_batched(
-                &pbs.fa_q_batch, &pbs.fa_k_batch, &scratch.kv_gather_indices,
-                target.config.n_heads, target.config.n_kv_heads, target.config.head_dim,
-                n_rot, target.config.rope_theta, n_positions,
+                &pbs.fa_q_batch,
+                &pbs.fa_k_batch,
+                &scratch.kv_gather_indices,
+                target.config.n_heads,
+                target.config.n_kv_heads,
+                target.config.head_dim,
+                n_rot,
+                target.config.rope_theta,
+                n_positions,
             )?;
 
             // 3. V gather via the existing kv_compact_gather pattern.
@@ -4393,7 +4794,8 @@ pub fn spec_step_ddtree_batched(
                 &kv.v_gpu[layer_idx],
                 &scratch.kv_gather_scratch_v,
                 &scratch.tape_gather_scratch,
-                v_bpp, n_positions,
+                v_bpp,
+                n_positions,
             )?;
 
             // 4. Quant-write K (rotated, in pbs.fa_k_batch) + V (gathered,
@@ -4414,10 +4816,16 @@ pub fn spec_step_ddtree_batched(
                 // proper gather of the raced-but-correctly-quantized V
                 // values. So the garbage V write is a transient no-op.
                 gpu.kv_cache_write_asym3_batched(
-                    &kv.k_gpu[layer_idx], &kv.v_gpu[layer_idx],
-                    &pbs.fa_k_batch, &pbs.fa_v_batch,
+                    &kv.k_gpu[layer_idx],
+                    &kv.v_gpu[layer_idx],
+                    &pbs.fa_k_batch,
+                    &pbs.fa_v_batch,
                     &scratch.kv_gather_indices,
-                    ct, st, n_kv_heads, head_dim, n_positions,
+                    ct,
+                    st,
+                    n_kv_heads,
+                    head_dim,
+                    n_positions,
                 )?;
                 // V byte-gather: read pre-quantized V from raced slots
                 // [position+0, position+1+acc[0], ...] into a contiguous
@@ -4430,11 +4838,14 @@ pub fn spec_step_ddtree_batched(
                     &kv.v_gpu[layer_idx],
                     &scratch.kv_gather_scratch_v,
                     &scratch.tape_gather_scratch,
-                    v_bpp, n_positions,
+                    v_bpp,
+                    n_positions,
                 )?;
                 gpu.hip.memcpy_dtod_at(
-                    &kv.v_gpu[layer_idx].buf, position * v_bpp,
-                    &scratch.kv_gather_scratch_v.buf, 0,
+                    &kv.v_gpu[layer_idx].buf,
+                    position * v_bpp,
+                    &scratch.kv_gather_scratch_v.buf,
+                    0,
                     n_positions * v_bpp,
                 )?;
             } else {
@@ -4442,8 +4853,10 @@ pub fn spec_step_ddtree_batched(
                 // but with the matching kv_cache_write_*_batched call.
                 // For initial Phase 2 prototype, panic so we notice if a
                 // non-asym3 model accidentally enables Path B.
-                panic!("Path B Phase 2 only supports asym3 KV today (got: q8={} asym4={} asym2={})",
-                    kv.quant_q8, kv.quant_asym4, kv.quant_asym2);
+                panic!(
+                    "Path B Phase 2 only supports asym3 KV today (got: q8={} asym4={} asym2={})",
+                    kv.quant_q8, kv.quant_asym4, kv.quant_asym2
+                );
             }
         }
 
@@ -4465,7 +4878,13 @@ pub fn spec_step_ddtree_batched(
         let tape_block: Vec<u32> = committed[..accept_len + 1].to_vec();
         target_snap.restore_to(&mut target.dn_state, gpu)?;
         let _tape_verify = verify_dflash_block(
-            gpu, target, &tape_block, position, hidden_rb, Some(gdn_tape), false,
+            gpu,
+            target,
+            &tape_block,
+            position,
+            hidden_rb,
+            Some(gdn_tape),
+            false,
             verify_scratch,
         )?;
         target_snap.restore_to(&mut target.dn_state, gpu)?;
@@ -4637,8 +5056,15 @@ pub fn spec_step_ddtree_path_c(
     if main_path.is_empty() {
         target_snap.save_from(&target.dn_state, gpu)?;
         qwen35::forward_scratch_with_hidden(
-            gpu, &target.weights, &target.config, seed_token, position,
-            &mut target.kv_cache, &mut target.dn_state, &target.scratch, hidden_rb,
+            gpu,
+            &target.weights,
+            &target.config,
+            seed_token,
+            position,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            hidden_rb,
         )?;
         let logits0 = gpu.download_f32(&target.scratch.logits)?;
         let bonus = argmax_u32(&logits0);
@@ -4666,7 +5092,13 @@ pub fn spec_step_ddtree_path_c(
     //       phase poisoning — RoPE phases match committed slots exactly.
     //       This is the entire "Step 1" of the PRD's three-step pattern.
     let main_verify_out = verify_dflash_block(
-        gpu, target, &verify_tokens, position, hidden_rb, Some(gdn_tape), false,
+        gpu,
+        target,
+        &verify_tokens,
+        position,
+        hidden_rb,
+        Some(gdn_tape),
+        false,
         verify_scratch,
     )?;
     let main_posterior = main_verify_out.argmax_per_pos;
@@ -4729,7 +5161,10 @@ pub fn spec_step_ddtree_path_c(
         static PATH_C_BRANCH_TOKENS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
     }
     PATH_C_TOTAL.with(|c| c.set(c.get() + 1));
-    let verbose = std::env::var("HIPFIRE_DDTREE_PATH_C_VERBOSE").ok().as_deref() == Some("1");
+    let verbose = std::env::var("HIPFIRE_DDTREE_PATH_C_VERBOSE")
+        .ok()
+        .as_deref()
+        == Some("1");
     let mut diag_phase2 = false;
     let mut diag_fork_sibling = false;
     let mut diag_candidate = false;
@@ -4741,7 +5176,8 @@ pub fn spec_step_ddtree_path_c(
         snaps.main_end_snap.save_from(&target.dn_state, gpu)?;
 
         // Find the unique candidate branch.
-        let branches = hipfire_runtime::ddtree::enumerate_branches(&tree, &main_path, accepted_main);
+        let branches =
+            hipfire_runtime::ddtree::enumerate_branches(&tree, &main_path, accepted_main);
         diag_fork_sibling = branches
             .iter()
             .any(|b| b.fork_depth as usize == accepted_main);
@@ -4792,16 +5228,21 @@ pub fn spec_step_ddtree_path_c(
             } else {
                 tree.nodes[main_path[accepted_main - 1]].token
             };
-            let mut branch_chain_tokens: Vec<u32> =
-                Vec::with_capacity(1 + branch.chain.len());
+            let mut branch_chain_tokens: Vec<u32> = Vec::with_capacity(1 + branch.chain.len());
             branch_chain_tokens.push(parent_tok);
             for &ni in &branch.chain {
                 branch_chain_tokens.push(tree.nodes[ni].token);
             }
             let branch_start_pos = position + accepted_main;
             let branch_verify_out = verify_dflash_block(
-                gpu, target, &branch_chain_tokens, branch_start_pos, hidden_rb,
-                Some(gdn_tape), false, verify_scratch,
+                gpu,
+                target,
+                &branch_chain_tokens,
+                branch_start_pos,
+                hidden_rb,
+                Some(gdn_tape),
+                false,
+                verify_scratch,
             )?;
             let branch_posterior = branch_verify_out.argmax_per_pos;
             debug_assert_eq!(branch_posterior.len(), 1 + branch.chain.len());
@@ -4836,7 +5277,9 @@ pub fn spec_step_ddtree_path_c(
                 // Step 3: drive DN state to "after position + accepted_main +
                 // accepted_branch" via tape replay on the branch tape we
                 // just captured (rows [0..1+accepted_branch]).
-                snaps.parent_pre_snap.restore_to(&mut target.dn_state, gpu)?;
+                snaps
+                    .parent_pre_snap
+                    .restore_to(&mut target.dn_state, gpu)?;
                 gdn_tape.replay_gdn(
                     gpu,
                     &target.weights,
@@ -4879,7 +5322,8 @@ pub fn spec_step_ddtree_path_c(
     }
     committed.push(effective_bonus);
 
-    let mut drafted: Vec<u32> = Vec::with_capacity(1 + main_path.len() + accepted_branch_indices.len());
+    let mut drafted: Vec<u32> =
+        Vec::with_capacity(1 + main_path.len() + accepted_branch_indices.len());
     drafted.push(seed_token);
     for &ni in &main_path {
         drafted.push(tree.nodes[ni].token);
@@ -4912,14 +5356,33 @@ pub fn spec_step_ddtree_path_c(
         let ba = PATH_C_BRANCH_ACCEPTED.with(|c| c.get());
         let bt = PATH_C_BRANCH_TOKENS.with(|c| c.get());
         let mean_branch = if ba > 0 { bt as f32 / ba as f32 } else { 0.0 };
-        let cand_rate = if p2 > 0 { 100.0 * cf as f32 / p2 as f32 } else { 0.0 };
-        let accept_rate = if cf > 0 { 100.0 * ba as f32 / cf as f32 } else { 0.0 };
+        let cand_rate = if p2 > 0 {
+            100.0 * cf as f32 / p2 as f32
+        } else {
+            0.0
+        };
+        let accept_rate = if cf > 0 {
+            100.0 * ba as f32 / cf as f32
+        } else {
+            0.0
+        };
         eprintln!(
             "[path-c] cycle: phase2={} acc_main={} fork_sibling={} candidate={} accept_branch={} \
              | cumul: cycles={} phase2={} fork_sib={} cand={} ({:.1}% of phase2) \
              accept={} ({:.1}% of cand) mean_branch_tok={:.2}",
-            diag_phase2, accepted_main, diag_fork_sibling, diag_candidate, diag_accept_branch,
-            total, p2, fs, cf, cand_rate, ba, accept_rate, mean_branch,
+            diag_phase2,
+            accepted_main,
+            diag_fork_sibling,
+            diag_candidate,
+            diag_accept_branch,
+            total,
+            p2,
+            fs,
+            cf,
+            cand_rate,
+            ba,
+            accept_rate,
+            mean_branch,
         );
     }
 
@@ -5021,7 +5484,8 @@ pub fn apply_eviction_retain_to_draft(
                 host.len() * std::mem::size_of::<f32>(),
             )
         };
-        gpu.hip.memcpy_dtoh(bytes, &draft_scratch.target_hidden.buf)?;
+        gpu.hip
+            .memcpy_dtoh(bytes, &draft_scratch.target_hidden.buf)?;
     }
     let budget = retain_mask.len();
     let mut compacted = Vec::with_capacity(budget * row_floats);
@@ -5038,13 +5502,10 @@ pub fn apply_eviction_retain_to_draft(
         );
     }
     let dst_bytes = budget * row_floats * std::mem::size_of::<f32>();
-    let compacted_bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(
-            compacted.as_ptr() as *const u8,
-            dst_bytes,
-        )
-    };
-    gpu.hip.memcpy_htod(&draft_scratch.target_hidden.buf, compacted_bytes)?;
+    let compacted_bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(compacted.as_ptr() as *const u8, dst_bytes) };
+    gpu.hip
+        .memcpy_htod(&draft_scratch.target_hidden.buf, compacted_bytes)?;
     draft_scratch.target_hidden_abs_positions = new_abs;
     draft_scratch.uploaded_target_hidden_rows = budget;
     // The per-layer k_ctx/v_ctx projection cache is indexed by the
@@ -5052,4 +5513,64 @@ pub fn apply_eviction_retain_to_draft(
     // the next draft_forward. One slow cycle per eviction is fine.
     draft_scratch.invalidate_draft_ctx_cache();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dflash_gdn_tape_replay_uses_actual_verify_eligibility() {
+        assert!(dflash_use_gdn_tape_replay(true, true));
+        assert!(!dflash_use_gdn_tape_replay(false, true));
+        assert!(!dflash_use_gdn_tape_replay(true, false));
+    }
+
+    #[test]
+    fn dflash_extended_verify_graph_is_moe_greedy_only() {
+        assert!(dflash_moe_verify_graph_lmhead_eligible(
+            256, false, false, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            0, false, false, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            256, true, false, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            256, false, true, None
+        ));
+        assert!(!dflash_moe_verify_graph_lmhead_eligible(
+            256,
+            false,
+            false,
+            Some("0")
+        ));
+    }
+
+    #[test]
+    fn dflash_draft_ffn_graph_is_moe_plain_dflash_only() {
+        assert!(dflash_moe_draft_ffn_graph_eligible(
+            256, false, false, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            0, false, false, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256, true, false, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256, false, true, false, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256, false, false, true, None
+        ));
+        assert!(!dflash_moe_draft_ffn_graph_eligible(
+            256,
+            false,
+            false,
+            false,
+            Some("0")
+        ));
+    }
 }

--- a/crates/hipfire-quantize/src/bin/mtp_extract.rs
+++ b/crates/hipfire-quantize/src/bin/mtp_extract.rs
@@ -8,8 +8,10 @@
 //!
 //! Empirical: every released dense Qwen3.5 (0.8B / 2B / 4B / 9B / 27B)
 //! and Qwen3.6-27B exposes the SAME 15 MTP-block tensors in safetensors.
-//! MoE variants (35B-A3B, 122B-A10B, 397B-A17B) inflate this to hundreds
-//! of expert tensors and are out of scope for this binary.
+//! MoE variants replace the dense FFN triple with a router, shared expert,
+//! scalar shared gate, and 3D stacked routed experts. The extractor splits
+//! those expert tensors into per-expert 2D weights so the runtime can reuse
+//! the same indexed MoE decode kernels as A3B trunk inference.
 //!
 //! Output container:
 //!   * arch_id = 21 (QWEN35_MTP_HEAD)
@@ -50,8 +52,8 @@ impl SafetensorsFile {
         let header_len = u64::from_le_bytes(mmap[0..8].try_into().unwrap()) as usize;
         let header_json = std::str::from_utf8(&mmap[8..8 + header_len])
             .expect("safetensors header is not valid utf8");
-        let raw: serde_json::Value = serde_json::from_str(header_json)
-            .expect("safetensors header JSON parse failed");
+        let raw: serde_json::Value =
+            serde_json::from_str(header_json).expect("safetensors header JSON parse failed");
         let mut tensors = HashMap::new();
         if let serde_json::Value::Object(map) = raw {
             for (k, v) in map {
@@ -152,6 +154,26 @@ fn to_f32(data: &[u8], dtype: &str) -> Vec<f32> {
     }
 }
 
+fn dtype_size(dtype: &str) -> usize {
+    match dtype {
+        "F16" | "BF16" => 2,
+        "F32" => 4,
+        other => panic!("unsupported input dtype: {other}"),
+    }
+}
+
+fn to_f32_range(data: &[u8], dtype: &str, elem_start: usize, elem_count: usize) -> Vec<f32> {
+    let elem_size = dtype_size(dtype);
+    let byte_start = elem_start * elem_size;
+    let byte_end = byte_start + elem_count * elem_size;
+    assert!(
+        byte_end <= data.len(),
+        "to_f32_range out of bounds: bytes {byte_start}..{byte_end} > {}",
+        data.len()
+    );
+    to_f32(&data[byte_start..byte_end], dtype)
+}
+
 fn f32_slice_to_f32_bytes(f32_data: &[f32]) -> Vec<u8> {
     let mut out = Vec::with_capacity(f32_data.len() * 4);
     for &v in f32_data {
@@ -193,11 +215,12 @@ fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     let mut state = seed;
     (0..n)
         .map(|_| {
-            state = state
-                .wrapping_mul(1103515245)
-                .wrapping_add(12345)
-                & 0x7fffffff;
-            if (state >> 16) & 1 == 1 { 1.0f32 } else { -1.0f32 }
+            state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
+            if (state >> 16) & 1 == 1 {
+                1.0f32
+            } else {
+                -1.0f32
+            }
         })
         .collect()
 }
@@ -353,22 +376,107 @@ fn write_hfq(
 /// matches the trunk extractor's natural dependency order at consume time).
 const MTP_NAMING_MAP: &[(&str, &str, bool, bool)] = &[
     // Norms (F32, 1D)
-    ("mtp.norm.weight",                              "shared_head_norm", true,  false),
-    ("mtp.pre_fc_norm_embedding.weight",             "enorm",            true,  false),
-    ("mtp.pre_fc_norm_hidden.weight",                "hnorm",            true,  false),
-    ("mtp.layers.0.input_layernorm.weight",          "attn_norm",        true,  false),
-    ("mtp.layers.0.post_attention_layernorm.weight", "attn_post_norm",   true,  false),
-    ("mtp.layers.0.self_attn.q_norm.weight",         "attn_q_norm",      true,  false),
-    ("mtp.layers.0.self_attn.k_norm.weight",         "attn_k_norm",      true,  false),
+    ("mtp.norm.weight", "shared_head_norm", true, false),
+    ("mtp.pre_fc_norm_embedding.weight", "enorm", true, false),
+    ("mtp.pre_fc_norm_hidden.weight", "hnorm", true, false),
+    (
+        "mtp.layers.0.input_layernorm.weight",
+        "attn_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.post_attention_layernorm.weight",
+        "attn_post_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.q_norm.weight",
+        "attn_q_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.k_norm.weight",
+        "attn_k_norm",
+        true,
+        false,
+    ),
     // 2D weights (MQ4 / Q8)
-    ("mtp.fc.weight",                                "eh_proj",          false, true),
-    ("mtp.layers.0.self_attn.q_proj.weight",         "wq",               false, true),
-    ("mtp.layers.0.self_attn.k_proj.weight",         "wk",               false, true),
-    ("mtp.layers.0.self_attn.v_proj.weight",         "wv",               false, true),
-    ("mtp.layers.0.self_attn.o_proj.weight",         "wo",               false, true),
-    ("mtp.layers.0.mlp.gate_proj.weight",            "ffn_gate",         false, true),
-    ("mtp.layers.0.mlp.up_proj.weight",              "ffn_up",           false, true),
-    ("mtp.layers.0.mlp.down_proj.weight",            "ffn_down",         false, true),
+    ("mtp.fc.weight", "eh_proj", false, true),
+    ("mtp.layers.0.self_attn.q_proj.weight", "wq", false, true),
+    ("mtp.layers.0.self_attn.k_proj.weight", "wk", false, true),
+    ("mtp.layers.0.self_attn.v_proj.weight", "wv", false, true),
+    ("mtp.layers.0.self_attn.o_proj.weight", "wo", false, true),
+    ("mtp.layers.0.mlp.gate_proj.weight", "ffn_gate", false, true),
+    ("mtp.layers.0.mlp.up_proj.weight", "ffn_up", false, true),
+    ("mtp.layers.0.mlp.down_proj.weight", "ffn_down", false, true),
+];
+
+const MTP_COMMON_NAMING_MAP: &[(&str, &str, bool, bool)] = &[
+    // Norms (F32, 1D)
+    ("mtp.norm.weight", "shared_head_norm", true, false),
+    ("mtp.pre_fc_norm_embedding.weight", "enorm", true, false),
+    ("mtp.pre_fc_norm_hidden.weight", "hnorm", true, false),
+    (
+        "mtp.layers.0.input_layernorm.weight",
+        "attn_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.post_attention_layernorm.weight",
+        "attn_post_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.q_norm.weight",
+        "attn_q_norm",
+        true,
+        false,
+    ),
+    (
+        "mtp.layers.0.self_attn.k_norm.weight",
+        "attn_k_norm",
+        true,
+        false,
+    ),
+    // NextN projection + attention weights.
+    ("mtp.fc.weight", "eh_proj", false, true),
+    ("mtp.layers.0.self_attn.q_proj.weight", "wq", false, true),
+    ("mtp.layers.0.self_attn.k_proj.weight", "wk", false, true),
+    ("mtp.layers.0.self_attn.v_proj.weight", "wv", false, true),
+    ("mtp.layers.0.self_attn.o_proj.weight", "wo", false, true),
+];
+
+const MTP_MOE_2D_NAMING_MAP: &[(&str, &str, bool, bool)] = &[
+    ("mtp.layers.0.mlp.gate.weight", "moe_router", false, true),
+    (
+        "mtp.layers.0.mlp.shared_expert_gate.weight",
+        "moe_shared_expert_gate",
+        false,
+        true,
+    ),
+    (
+        "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+        "moe_shared_gate",
+        false,
+        true,
+    ),
+    (
+        "mtp.layers.0.mlp.shared_expert.up_proj.weight",
+        "moe_shared_up",
+        false,
+        true,
+    ),
+    (
+        "mtp.layers.0.mlp.shared_expert.down_proj.weight",
+        "moe_shared_down",
+        false,
+        true,
+    ),
 ];
 
 // ─── Discovery ───────────────────────────────────────────────────────────
@@ -382,6 +490,18 @@ fn find_safetensors(dir: &Path) -> Vec<PathBuf> {
         .collect();
     files.sort();
     files
+}
+
+fn find_tensor<'a>(
+    st_files: &'a [SafetensorsFile],
+    name: &str,
+) -> Option<(&'a TensorMeta, &'a [u8])> {
+    for st in st_files {
+        if let Some((meta, data)) = st.tensor_data(name) {
+            return Some((meta, data));
+        }
+    }
+    None
 }
 
 // ─── CLI ─────────────────────────────────────────────────────────────────
@@ -418,6 +538,106 @@ struct Args {
     /// lm_head, MQ4G256) and a `lm_head_draft.vocab_map` (u32 IDs packed
     /// as f32 bit-cast). Tensor count goes 15 -> 17 when present.
     vocab_sidecar: Option<PathBuf>,
+}
+
+fn quantize_mtp_tensor(
+    hf_name: &str,
+    shape: &[usize],
+    f32_data: &[f32],
+    is_norm: bool,
+    is_2d: bool,
+    quant: QuantChoice,
+    force_q8: bool,
+    signs1: &[f32],
+    signs2: &[f32],
+) -> (QuantType, u32, Vec<u8>, &'static str) {
+    let n_elements: usize = shape.iter().product();
+    assert_eq!(
+        f32_data.len(),
+        n_elements,
+        "tensor {hf_name}: element count mismatch (got {}, expected {n_elements})",
+        f32_data.len()
+    );
+    if is_norm || !is_2d {
+        return (QuantType::F32, 0, f32_slice_to_f32_bytes(f32_data), "F32");
+    }
+
+    let k_dim = *shape.last().expect("2D weight has shape");
+    if force_q8 {
+        let q = quantize_q8f16(f32_data);
+        return (QuantType::Q8F16, 32, q, "Q8_F16");
+    }
+
+    match quant {
+        QuantChoice::Mq4 if k_dim % 256 == 0 && n_elements >= 256 => {
+            let q = quantize_mq4g256(f32_data, signs1, signs2);
+            (QuantType::MQ4G256, 256, q, "MQ4G256")
+        }
+        QuantChoice::Mq4 => {
+            eprintln!("  note: {hf_name} K={k_dim} not 256-aligned — falling back to Q8_F16");
+            let q = quantize_q8f16(f32_data);
+            (QuantType::Q8F16, 32, q, "Q8_F16")
+        }
+        QuantChoice::Q8 => {
+            let q = quantize_q8f16(f32_data);
+            (QuantType::Q8F16, 32, q, "Q8_F16")
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pack_safetensor_2d_or_norm(
+    st_files: &[SafetensorsFile],
+    st_name: &str,
+    hf_name: &str,
+    is_norm: bool,
+    is_2d: bool,
+    quant: QuantChoice,
+    force_q8: bool,
+    signs1: &[f32],
+    signs2: &[f32],
+    verbose: bool,
+) -> (HfqTensor, usize, usize) {
+    let (meta, raw) = find_tensor(st_files, st_name).unwrap_or_else(|| {
+        panic!(
+            "safetensors missing required MTP tensor '{st_name}' \
+             — is this actually a Qwen3.5/3.6 model with MTP head?"
+        )
+    });
+    let f32_data = to_f32(raw, &meta.dtype);
+    let shape_usize = meta.shape.clone();
+    let shape: Vec<u32> = shape_usize.iter().map(|d| *d as u32).collect();
+    let (quant_type, group_size, bytes, label) = quantize_mtp_tensor(
+        hf_name,
+        &shape_usize,
+        &f32_data,
+        is_norm,
+        is_2d,
+        quant,
+        force_q8,
+        signs1,
+        signs2,
+    );
+    if verbose {
+        eprintln!(
+            "  [{label:>7}] {hf_name:>24}  shape={:?}  in={:>10}B  out={:>10}B  \
+             (src={st_name})",
+            shape,
+            raw.len(),
+            bytes.len()
+        );
+    }
+    (
+        HfqTensor {
+            name: hf_name.to_string(),
+            quant_type,
+            shape,
+            group_size,
+            data: bytes,
+        },
+        raw.len(),
+        f32_data.len(),
+    )
 }
 
 fn parse_args() -> Args {
@@ -554,15 +774,21 @@ fn verify_round_trip(path: &Path, expected: &[HfqTensor], verbose: bool) {
         assert_eq!(name, exp.name, "verify: tensor[{i}] name mismatch");
         assert_eq!(qt, exp.quant_type as u8, "verify: tensor[{i}] qt mismatch");
         assert_eq!(shape, exp.shape, "verify: tensor[{i}] shape mismatch");
-        assert_eq!(group_size, exp.group_size, "verify: tensor[{i}] gs mismatch");
-        assert_eq!(data_size, exp.data.len(), "verify: tensor[{i}] data_size mismatch");
+        assert_eq!(
+            group_size, exp.group_size,
+            "verify: tensor[{i}] gs mismatch"
+        );
+        assert_eq!(
+            data_size,
+            exp.data.len(),
+            "verify: tensor[{i}] data_size mismatch"
+        );
 
         // Spot-check first/last byte of data region against the in-memory
         // tensor. This catches misaligned data_offset / forgotten padding.
         if !exp.data.is_empty() {
             assert_eq!(
-                mmap[cumulative],
-                exp.data[0],
+                mmap[cumulative], exp.data[0],
                 "verify: tensor[{i}]={name} first byte mismatch"
             );
             assert_eq!(
@@ -580,9 +806,7 @@ fn verify_round_trip(path: &Path, expected: &[HfqTensor], verbose: bool) {
             );
         }
     }
-    eprintln!(
-        "verify: PASS — {n_tensors} tensors round-trip clean (arch_id={arch_id})"
-    );
+    eprintln!("verify: PASS — {n_tensors} tensors round-trip clean (arch_id={arch_id})");
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────
@@ -613,9 +837,8 @@ fn main() {
             .and_then(|v| v.as_u64())
             .unwrap_or_else(|| panic!("config.json missing {k}"))
     };
-    let get_f64 = |k: &str| -> Option<f64> {
-        tc.get(k).or_else(|| config.get(k)).and_then(|v| v.as_f64())
-    };
+    let get_f64 =
+        |k: &str| -> Option<f64> { tc.get(k).or_else(|| config.get(k)).and_then(|v| v.as_f64()) };
 
     let n_embd = get_u64("hidden_size") as usize;
     let n_layer = get_u64("num_hidden_layers") as usize;
@@ -627,7 +850,37 @@ fn main() {
         .and_then(|v| v.as_u64())
         .map(|v| v as usize)
         .unwrap_or(n_embd / n_head);
-    let n_ff = get_u64("intermediate_size") as usize;
+    let intermediate_size = tc
+        .get("intermediate_size")
+        .or_else(|| config.get("intermediate_size"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize);
+    let num_experts = tc
+        .get("num_experts")
+        .or_else(|| config.get("num_experts"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let num_experts_per_tok = tc
+        .get("num_experts_per_tok")
+        .or_else(|| config.get("num_experts_per_tok"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let moe_intermediate_size = tc
+        .get("moe_intermediate_size")
+        .or_else(|| config.get("moe_intermediate_size"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let shared_expert_intermediate_size = tc
+        .get("shared_expert_intermediate_size")
+        .or_else(|| config.get("shared_expert_intermediate_size"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let norm_topk_prob = tc
+        .get("norm_topk_prob")
+        .or_else(|| config.get("norm_topk_prob"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let n_ff = intermediate_size.unwrap_or(moe_intermediate_size);
     let vocab_size = get_u64("vocab_size") as usize;
     let nextn_predict_layers = tc
         .get("mtp_num_hidden_layers")
@@ -678,6 +931,13 @@ fn main() {
         "  dims   : n_embd={n_embd} n_layer={n_layer} n_head={n_head} n_head_kv={n_head_kv} \
          head_dim={n_embd_head} n_ff={n_ff} vocab={vocab_size}"
     );
+    if num_experts > 0 {
+        eprintln!(
+            "  moe    : experts={num_experts} top_k={num_experts_per_tok} \
+             moe_intermediate={moe_intermediate_size} shared_intermediate={shared_expert_intermediate_size} \
+             norm_topk_prob={norm_topk_prob}"
+        );
+    }
     eprintln!(
         "  rope   : theta={rope_theta} sections={}",
         serde_json::to_string(&rope_sections).unwrap_or("null".into())
@@ -704,98 +964,187 @@ fn main() {
     let signs1 = gen_fwht_signs(42, 256);
     let signs2 = gen_fwht_signs(1042, 256);
 
-    let mut hfq_tensors: Vec<HfqTensor> = Vec::with_capacity(MTP_NAMING_MAP.len());
+    let dense_mtp = find_tensor(&st_files, "mtp.layers.0.mlp.gate_proj.weight").is_some();
+    let moe_mtp = find_tensor(&st_files, "mtp.layers.0.mlp.experts.gate_up_proj").is_some();
+    let ffn_kind = match (dense_mtp, moe_mtp) {
+        (true, _) => "dense",
+        (false, true) => "moe",
+        (false, false) => panic!(
+            "MTP FFN tensors not found: expected dense gate_proj/up_proj/down_proj \
+             or MoE experts.gate_up_proj"
+        ),
+    };
+
+    let estimated_tensors = if ffn_kind == "moe" {
+        MTP_COMMON_NAMING_MAP.len() + MTP_MOE_2D_NAMING_MAP.len() + 2 * num_experts
+    } else {
+        MTP_NAMING_MAP.len()
+    };
+    let mut hfq_tensors: Vec<HfqTensor> = Vec::with_capacity(estimated_tensors);
     let mut total_in_bytes: usize = 0;
     let mut total_out_bytes: usize = 0;
 
-    for (st_name, hf_name, is_norm, is_2d) in MTP_NAMING_MAP {
-        // Locate the tensor across shards.
-        let mut found: Option<(&SafetensorsFile, &TensorMeta, &[u8])> = None;
-        for st in &st_files {
-            if let Some((meta, data)) = st.tensor_data(st_name) {
-                found = Some((st, meta, data));
-                break;
-            }
-        }
-        let (_st, meta, raw) = found.unwrap_or_else(|| {
-            panic!(
-                "safetensors missing required MTP tensor '{st_name}' \
-                 — is this actually a Qwen3.5/3.6 dense model with MTP head?"
-            )
-        });
-
-        let in_bytes = raw.len();
-        total_in_bytes += in_bytes;
-
-        let f32_data = to_f32(raw, &meta.dtype);
-        let n_elements: usize = meta.shape.iter().product();
-        assert_eq!(
-            f32_data.len(),
-            n_elements,
-            "tensor {st_name}: element count mismatch (got {}, expected {n_elements})",
-            f32_data.len()
+    let base_map = if ffn_kind == "moe" {
+        MTP_COMMON_NAMING_MAP
+    } else {
+        MTP_NAMING_MAP
+    };
+    for (st_name, hf_name, is_norm, is_2d) in base_map {
+        let (tensor, in_bytes, _n_elems) = pack_safetensor_2d_or_norm(
+            &st_files,
+            st_name,
+            hf_name,
+            *is_norm,
+            *is_2d,
+            args.quant,
+            false,
+            &signs1,
+            &signs2,
+            args.verbose,
         );
-        let shape: Vec<u32> = meta.shape.iter().map(|d| *d as u32).collect();
-
-        // Quantization decision:
-        //   norms (1D *norm) → F32 (matches CLAUDE.md trunk pattern in
-        //                      `should_quantize`; precision-critical, small).
-        //   2D weights      → MQ4 / Q8 per --quant, with a Q8 fallback when
-        //                      MQ4's K%256==0 alignment is not satisfied.
-        let (quant_type, group_size, bytes, label) = if *is_norm || !*is_2d {
-            (
-                QuantType::F32,
-                0u32,
-                f32_slice_to_f32_bytes(&f32_data),
-                "F32",
-            )
-        } else {
-            // 2D weight. K is the innermost dim per safetensors convention.
-            let k_dim = *shape.last().expect("2D weight has shape") as usize;
-            match args.quant {
-                QuantChoice::Mq4 if k_dim % 256 == 0 && n_elements >= 256 => {
-                    let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
-                    (QuantType::MQ4G256, 256u32, q, "MQ4G256")
-                }
-                QuantChoice::Mq4 => {
-                    eprintln!(
-                        "  note: {hf_name} K={k_dim} not 256-aligned — falling back to Q8_F16"
-                    );
-                    let q = quantize_q8f16(&f32_data);
-                    (QuantType::Q8F16, 32u32, q, "Q8_F16")
-                }
-                QuantChoice::Q8 => {
-                    let q = quantize_q8f16(&f32_data);
-                    (QuantType::Q8F16, 32u32, q, "Q8_F16")
-                }
-            }
-        };
-
-        total_out_bytes += bytes.len();
-
-        if args.verbose {
-            eprintln!(
-                "  [{label:>7}] {hf_name:>18}  shape={:?}  in={:>9}B  out={:>9}B  \
-                 (src={st_name})",
-                shape, in_bytes, bytes.len()
-            );
-        }
-
-        hfq_tensors.push(HfqTensor {
-            name: hf_name.to_string(),
-            quant_type,
-            shape,
-            group_size,
-            data: bytes,
-        });
+        total_in_bytes += in_bytes;
+        total_out_bytes += tensor.data.len();
+        hfq_tensors.push(tensor);
     }
 
-    assert_eq!(
-        hfq_tensors.len(),
-        15,
-        "expected to pack exactly 15 MTP tensors before optional sidecar, got {}",
-        hfq_tensors.len()
-    );
+    if ffn_kind == "moe" {
+        assert!(
+            num_experts > 0,
+            "MoE MTP detected but config num_experts is 0"
+        );
+        assert_eq!(
+            num_experts_per_tok, 8,
+            "current MoE MTP runtime supports top_k=8; config has {num_experts_per_tok}"
+        );
+        assert!(
+            moe_intermediate_size > 0,
+            "MoE MTP requires moe_intermediate_size"
+        );
+        assert!(
+            shared_expert_intermediate_size > 0,
+            "MoE MTP requires shared_expert_intermediate_size"
+        );
+
+        for (st_name, hf_name, is_norm, is_2d) in MTP_MOE_2D_NAMING_MAP {
+            // Match the production A3B loader convention: routers and the
+            // scalar shared-expert gate stay Q8, expert/shared FFNs use the
+            // requested quant format.
+            let force_q8 = *hf_name == "moe_router" || *hf_name == "moe_shared_expert_gate";
+            let (tensor, in_bytes, _n_elems) = pack_safetensor_2d_or_norm(
+                &st_files,
+                st_name,
+                hf_name,
+                *is_norm,
+                *is_2d,
+                args.quant,
+                force_q8,
+                &signs1,
+                &signs2,
+                args.verbose,
+            );
+            total_in_bytes += in_bytes;
+            total_out_bytes += tensor.data.len();
+            hfq_tensors.push(tensor);
+        }
+
+        let (gate_up_meta, gate_up_raw) =
+            find_tensor(&st_files, "mtp.layers.0.mlp.experts.gate_up_proj")
+                .expect("MoE MTP missing experts.gate_up_proj");
+        let (down_meta, down_raw) = find_tensor(&st_files, "mtp.layers.0.mlp.experts.down_proj")
+            .expect("MoE MTP missing experts.down_proj");
+        assert_eq!(
+            gate_up_meta.shape,
+            vec![num_experts, 2 * moe_intermediate_size, n_embd],
+            "experts.gate_up_proj shape mismatch"
+        );
+        assert_eq!(
+            down_meta.shape,
+            vec![num_experts, n_embd, moe_intermediate_size],
+            "experts.down_proj shape mismatch"
+        );
+
+        let gate_up_elems = 2 * moe_intermediate_size * n_embd;
+        let down_elems = n_embd * moe_intermediate_size;
+        total_in_bytes += gate_up_raw.len() + down_raw.len();
+        for expert_idx in 0..num_experts {
+            let f32_data = to_f32_range(
+                gate_up_raw,
+                &gate_up_meta.dtype,
+                expert_idx * gate_up_elems,
+                gate_up_elems,
+            );
+            let hf_name = format!("moe_experts.{expert_idx}.gate_up");
+            let (quant_type, group_size, bytes, label) = quantize_mtp_tensor(
+                &hf_name,
+                &[2 * moe_intermediate_size, n_embd],
+                &f32_data,
+                false,
+                true,
+                args.quant,
+                false,
+                &signs1,
+                &signs2,
+            );
+            if args.verbose && (expert_idx < 4 || expert_idx + 4 >= num_experts) {
+                eprintln!(
+                    "  [{label:>7}] {hf_name:>24}  shape=[{}, {}]  out={:>10}B",
+                    2 * moe_intermediate_size,
+                    n_embd,
+                    bytes.len()
+                );
+            }
+            total_out_bytes += bytes.len();
+            hfq_tensors.push(HfqTensor {
+                name: hf_name,
+                quant_type,
+                shape: vec![(2 * moe_intermediate_size) as u32, n_embd as u32],
+                group_size,
+                data: bytes,
+            });
+        }
+        for expert_idx in 0..num_experts {
+            let f32_data = to_f32_range(
+                down_raw,
+                &down_meta.dtype,
+                expert_idx * down_elems,
+                down_elems,
+            );
+            let hf_name = format!("moe_experts.{expert_idx}.down");
+            let (quant_type, group_size, bytes, label) = quantize_mtp_tensor(
+                &hf_name,
+                &[n_embd, moe_intermediate_size],
+                &f32_data,
+                false,
+                true,
+                args.quant,
+                false,
+                &signs1,
+                &signs2,
+            );
+            if args.verbose && (expert_idx < 4 || expert_idx + 4 >= num_experts) {
+                eprintln!(
+                    "  [{label:>7}] {hf_name:>24}  shape=[{}, {}]  out={:>10}B",
+                    n_embd,
+                    moe_intermediate_size,
+                    bytes.len()
+                );
+            }
+            total_out_bytes += bytes.len();
+            hfq_tensors.push(HfqTensor {
+                name: hf_name,
+                quant_type,
+                shape: vec![n_embd as u32, moe_intermediate_size as u32],
+                group_size,
+                data: bytes,
+            });
+        }
+        if args.verbose && num_experts > 8 {
+            eprintln!(
+                "  ... packed {} routed experts for gate_up and down",
+                num_experts
+            );
+        }
+    }
 
     // ─── Optional FastMTP-style vocab-compression sidecar ─────────────────
     //
@@ -816,8 +1165,8 @@ fn main() {
         eprintln!("  sidecar: {}", sidecar_path.display());
         let sidecar_str = std::fs::read_to_string(sidecar_path)
             .unwrap_or_else(|e| panic!("cannot read sidecar {}: {e}", sidecar_path.display()));
-        let sidecar: serde_json::Value = serde_json::from_str(&sidecar_str)
-            .expect("sidecar JSON parse failed");
+        let sidecar: serde_json::Value =
+            serde_json::from_str(&sidecar_str).expect("sidecar JSON parse failed");
         let draft_to_full: Vec<u32> = sidecar
             .get("draft_to_full")
             .and_then(|v| v.as_array())
@@ -870,7 +1219,10 @@ fn main() {
                 lm_head_candidates
             )
         });
-        eprintln!("  lm_head src: {lm_name} dtype={} shape={:?}", lm_meta.dtype, lm_meta.shape);
+        eprintln!(
+            "  lm_head src: {lm_name} dtype={} shape={:?}",
+            lm_meta.dtype, lm_meta.shape
+        );
         assert_eq!(
             lm_meta.shape.len(),
             2,
@@ -926,7 +1278,9 @@ fn main() {
         total_out_bytes += lm_bytes.len();
         eprintln!(
             "  [{lm_label:>7}] {:>18}  shape=[{k_dim}, {h_dim}]  full_f32={:>10}B  out={:>10}B",
-            "lm_head_draft", lm_in_bytes, lm_bytes.len()
+            "lm_head_draft",
+            lm_in_bytes,
+            lm_bytes.len()
         );
         hfq_tensors.push(HfqTensor {
             name: "lm_head_draft.weight".to_string(),
@@ -958,7 +1312,17 @@ fn main() {
         compressed_vocab_size = Some(k_dim);
     }
 
-    let expected_tensor_count = if compressed_vocab_size.is_some() { 17 } else { 15 };
+    let expected_base_tensor_count = if ffn_kind == "moe" {
+        MTP_COMMON_NAMING_MAP.len() + MTP_MOE_2D_NAMING_MAP.len() + 2 * num_experts
+    } else {
+        MTP_NAMING_MAP.len()
+    };
+    let expected_tensor_count = expected_base_tensor_count
+        + if compressed_vocab_size.is_some() {
+            2
+        } else {
+            0
+        };
     assert_eq!(
         hfq_tensors.len(),
         expected_tensor_count,
@@ -972,9 +1336,7 @@ fn main() {
     let tie_word_embeddings = config
         .get("tie_word_embeddings")
         .and_then(|v| v.as_bool())
-        .or_else(|| {
-            tc.get("tie_word_embeddings").and_then(|v| v.as_bool())
-        })
+        .or_else(|| tc.get("tie_word_embeddings").and_then(|v| v.as_bool()))
         .unwrap_or(true);
 
     let metadata = serde_json::json!({
@@ -988,6 +1350,12 @@ fn main() {
         "n_head_kv": n_head_kv,
         "n_embd_head": n_embd_head,
         "n_ff": n_ff,
+        "ffn_kind": ffn_kind,
+        "num_experts": num_experts,
+        "num_experts_per_tok": num_experts_per_tok,
+        "moe_intermediate_size": moe_intermediate_size,
+        "shared_expert_intermediate_size": shared_expert_intermediate_size,
+        "norm_topk_prob": norm_topk_prob,
         "vocab_size": vocab_size,
         "rope_theta": rope_theta,
         "rope_sections": rope_sections,
@@ -1016,9 +1384,7 @@ fn main() {
     )
     .expect("write_hfq failed");
 
-    let file_size = std::fs::metadata(&args.output)
-        .expect("stat output")
-        .len();
+    let file_size = std::fs::metadata(&args.output).expect("stat output").len();
     eprintln!(
         "wrote {}: {:.2} MiB  ({} tensors, in={:.2} MiB, out={:.2} MiB)",
         args.output.display(),

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5469,8 +5469,54 @@ fn main() {
                 && meta.shape.len() == 2
                 && meta.shape[1] % 256 == 0
             {
-                let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                let mut f32_data = tensor_to_f32_with_optional_fp8_scale(
                     name, raw_data, meta, &fp8_scale_for, &st_files);
+                let k = meta.shape[1];
+                let m = meta.shape[0];
+                // AWQ shared-per-layer pre-scaling of the routed experts (--awq +
+                // --imatrix), full port of minimax 3c676d00's BOTH-projection
+                // behavior: gate(w1)/up(w3) get s_gate_up (MoE-input channels,
+                // len hidden=2048 = w1/w3 k); down(w2) gets s_down (intermediate
+                // channels, len moe_inter=1792 = w2 k). Math W·s @ x/s = W·x is
+                // exact for each. The forward divides the gate_up input via
+                // experts[0].gate_up.awq_scale (rotate_x_mq_for) AND divides the
+                // post-SwiGLU intermediate via experts[0].down.awq_scale
+                // (fused_silu_mul_rotate_mq_batched_for) — both already AWQ-aware.
+                // down (w2) is the most quant-sensitive proj (~24x the activation
+                // magnitude of gate/up), so AWQ-ing it is the whole point. The
+                // imatrix uses the SAME blk.N.ffn_{gate,up,down}_exps naming, so
+                // minimax_layer_awq_scales applies verbatim.
+                if awq_enabled {
+                    if let (Some(layer_n), Some(gg)) = (minimax_layer_index(name), imatrix_gguf.as_ref()) {
+                        let alpha = AWQ_ALPHA.get().copied().unwrap_or(0.55);
+                        let entry = mm_awq_cache.entry(layer_n)
+                            .or_insert_with(|| minimax_layer_awq_scales(gg, layer_n, alpha));
+                        if let Some((s_gu, s_dn)) = entry.as_ref() {
+                            // Per-projection scale: w2 uses s_down (its k = moe_inter),
+                            // w1/w3 use s_gate_up (their k = hidden). Each scale's len
+                            // must match the tensor's input dim; skip+warn on mismatch.
+                            let scale = if name.ends_with(".w2.weight") { s_dn } else { s_gu };
+                            if scale.len() == k {
+                                awq_pre_scale_weights(&mut f32_data, m, k, scale);
+                            } else {
+                                eprintln!("  lfm2 AWQ L{layer_n}: scale len {} != k {} ({name}); skipped", scale.len(), k);
+                            }
+                            if mm_awq_emitted.insert(layer_n) {
+                                hfq_tensors.push(HfqTensor {
+                                    name: format!("model.layers.{layer_n}.feed_forward.awq_scale_gate_up.weight"),
+                                    quant_type: QuantType::F16, shape: vec![s_gu.len() as u32],
+                                    group_size: 0, data: awq_scales_to_f16_bytes(s_gu), spilled_len: 0,
+                                });
+                                hfq_tensors.push(HfqTensor {
+                                    name: format!("model.layers.{layer_n}.feed_forward.awq_scale_down.weight"),
+                                    quant_type: QuantType::F16, shape: vec![s_dn.len() as u32],
+                                    group_size: 0, data: awq_scales_to_f16_bytes(s_dn), spilled_len: 0,
+                                });
+                                eprintln!("  AWQ-LFM: emitted gate_up + down scales for L{layer_n}");
+                            }
+                        }
+                    }
+                }
                 let signs1 = gen_fwht_signs(42, 256);
                 let signs2 = gen_fwht_signs(1042, 256);
                 // expert family choice: mq6 (HFQ6G256-compatible 6-bit, 200 B/group,

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -4983,6 +4983,11 @@ fn main() {
         // shared expert; FP8 E4M3 + F32 weight_scale_inv block-128 storage;
         // split per-expert w1/w3/w2 (like deepseek_v4). Crate hipfire-arch-minimax.
         "minimax_m2" => 10,
+        // LFM2.5-MoE (LiquidAI): hybrid 18 short-conv + 6 GQA-attn layers; 2 dense
+        // SwiGLU MLP + 22 top-4 MoE layers; sigmoid + expert_bias routing. bf16
+        // source, per-expert pre-split w1/w2/w3 (like minimax). Conv filter +
+        // expert_bias stay high precision. Crate hipfire-arch-lfm2moe.
+        "lfm2_moe" => 11,
         other => { eprintln!("Warning: unknown architecture '{other}', treating as llama"); 0 }
     };
     // --arch-id <u32> overrides the auto-detected id. Use when the
@@ -5012,7 +5017,11 @@ fn main() {
     // kernel family). Raw HF tensor names are written verbatim (no rename);
     // the hipfire loader looks them up.
     let is_minimax = arch_id == 10;
-    let is_moe_like = is_moe || is_deepseek4 || is_minimax;
+    // LFM2.5-MoE (arch_id 11): per-expert pre-split 2D experts (like minimax),
+    // bf16 source. Conv-block + dense-MLP + router + expert_bias get dedicated
+    // ingest branches; routed experts → MQ4G256, everything else → Q8.
+    let is_lfm2moe = arch_id == 11;
+    let is_moe_like = is_moe || is_deepseek4 || is_minimax || is_lfm2moe;
     // Q8 router: always on for MoE-class models.
     let q8_router = is_moe_like || q8_router_flag;
     if is_moe {
@@ -5023,6 +5032,9 @@ fn main() {
     }
     if is_minimax {
         eprintln!("  MiniMax-M2 detected — per-expert tensors ship pre-split; quantizing each as HFQ4G256 2D weight.");
+    }
+    if is_lfm2moe {
+        eprintln!("  LFM2.5-MoE detected — experts → MQ4G256, expert_bias → F32, all else (conv/attn/dense/router/embed) → Q8.");
     }
 
     // Extract layer count for K-map edge-layer promotion.
@@ -5437,6 +5449,71 @@ fn main() {
                 continue;
             }
             // Fall through to standard path for non-MQ2 formats.
+        }
+
+        // ── LFM2.5-MoE ingest (arch_id 11) ─────────────────────────────────────
+        // Routed experts → MQ4G256 (FWHT-pre-rotated 4-bit, byte-compatible with
+        // the indexed gemv_hfq4g256_moe_* kernels given FWHT-rotated input — the
+        // exact path the forward uses). expert_bias → raw F32 (tiny, precision-
+        // sensitive, added for top-k SELECTION only). Everything else (router
+        // gate, attn q/k/v/out_proj, conv in/out_proj, conv depthwise filter,
+        // dense w1/w2/w3, all norms, tied embed/lm_head) → Q8 (qt=3 Q8F16), which
+        // the loader maps to Q8_0 / embedding_lookup_q8. The dense+attn+conv
+        // params are a small fraction of an A1B model, so Q8 is free quality.
+        if is_lfm2moe {
+            let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
+            if name.contains(".feed_forward.experts.")
+                && (name.ends_with(".w1.weight")
+                    || name.ends_with(".w2.weight")
+                    || name.ends_with(".w3.weight"))
+                && meta.shape.len() == 2
+                && meta.shape[1] % 256 == 0
+            {
+                let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                    name, raw_data, meta, &fp8_scale_for, &st_files);
+                let signs1 = gen_fwht_signs(42, 256);
+                let signs2 = gen_fwht_signs(1042, 256);
+                let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                eprintln!("  {:>8}: {} {:?} ({:.1} KB → {:.1} KB)",
+                    "MQ4-LFM", name, meta.shape,
+                    raw_data.len() as f64 / 1024.0, q.len() as f64 / 1024.0);
+                hfq_tensors.push(HfqTensor {
+                    name: name.to_string(), quant_type: QuantType::MQ4G256,
+                    shape, group_size: 256, data: q, spilled_len: 0,
+                });
+                quantized_params += (meta.shape[0] * meta.shape[1]) as u64;
+                st_files[*file_idx].drop_tensor_pages(name);
+                if let Some(ref mut s) = spill {
+                    maybe_spill(&mut hfq_tensors, s, 2 * 1024 * 1024 * 1024);
+                }
+                continue;
+            }
+            if name.ends_with(".feed_forward.expert_bias") {
+                let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                    name, raw_data, meta, &fp8_scale_for, &st_files);
+                let mut bytes = Vec::with_capacity(f32_data.len() * 4);
+                for v in &f32_data { bytes.extend_from_slice(&v.to_le_bytes()); }
+                eprintln!("  {:>8}: {} {:?} (expert_bias F32)", "F32-LFM", name, meta.shape);
+                hfq_tensors.push(HfqTensor {
+                    name: name.to_string(), quant_type: QuantType::F32,
+                    shape, group_size: 1, data: bytes, spilled_len: 0,
+                });
+                st_files[*file_idx].drop_tensor_pages(name);
+                continue;
+            }
+            // All remaining LFM2 tensors → Q8 (qt=3). quantize_q8f16 handles any
+            // 1D/2D/3D shape elementwise (conv.conv.weight is [hidden,1,K]).
+            let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                name, raw_data, meta, &fp8_scale_for, &st_files);
+            let q = quantize_q8f16(&f32_data);
+            eprintln!("  {:>8}: {} {:?} (Q8)", "Q8-LFM", name, meta.shape);
+            hfq_tensors.push(HfqTensor {
+                name: name.to_string(), quant_type: QuantType::Q8F16,
+                shape, group_size: 32, data: q, spilled_len: 0,
+            });
+            quantized_params += n_elements as u64;
+            st_files[*file_idx].drop_tensor_pages(name);
+            continue;
         }
 
         // ── MiniMax-M2 router: keep Q8 ─────────────────────────────────────────

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5511,7 +5511,15 @@ fn main() {
             // the depthwise conv filter, and the tied embed/lm_head stay Q8
             // (precision-sensitive / tiny). OFF by default — flip on only after
             // the tiny-oracle cosine (≥0.99) + coherence gate confirm it.
-            if std::env::var_os("HIPFIRE_LFM2_PROJ_MQ4").is_some()
+            // MQ6 variant (HIPFIRE_LFM2_PROJ_MQ6=1) is the lower-quality-loss
+            // middle ground: 6-bit projections keep ~half the MQ4 bandwidth
+            // saving but at much lower KLD (MQ4-proj measured mean KL ≈0.96 nats
+            // vs Q8 on this model — large; MQ6 should be far smaller). If both
+            // flags are set, MQ6 wins (the safer of the two). 200 B/group vs
+            // MQ4's 136 B/group vs Q8's ~34 B/group-equivalent.
+            let proj_mq6 = std::env::var_os("HIPFIRE_LFM2_PROJ_MQ6").is_some();
+            let proj_mq4 = std::env::var_os("HIPFIRE_LFM2_PROJ_MQ4").is_some();
+            if (proj_mq6 || proj_mq4)
                 && meta.shape.len() == 2
                 && meta.shape[1] % 256 == 0
                 && (name.ends_with(".conv.in_proj.weight")
@@ -5528,10 +5536,15 @@ fn main() {
                     name, raw_data, meta, &fp8_scale_for, &st_files);
                 let signs1 = gen_fwht_signs(42, 256);
                 let signs2 = gen_fwht_signs(1042, 256);
-                let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
-                eprintln!("  {:>8}: {} {:?} (proj MQ4)", "MQ4P-LFM", name, meta.shape);
+                let (q, qt, tag) = if proj_mq6 {
+                    (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6P-LFM")
+                } else {
+                    (quantize_mq4g256(&f32_data, &signs1, &signs2), QuantType::MQ4G256, "MQ4P-LFM")
+                };
+                eprintln!("  {:>8}: {} {:?} (proj {})", tag, name, meta.shape,
+                    if proj_mq6 { "MQ6" } else { "MQ4" });
                 hfq_tensors.push(HfqTensor {
-                    name: name.to_string(), quant_type: QuantType::MQ4G256,
+                    name: name.to_string(), quant_type: qt,
                     shape, group_size: 256, data: q, spilled_len: 0,
                 });
                 quantized_params += (meta.shape[0] * meta.shape[1]) as u64;

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5473,12 +5473,22 @@ fn main() {
                     name, raw_data, meta, &fp8_scale_for, &st_files);
                 let signs1 = gen_fwht_signs(42, 256);
                 let signs2 = gen_fwht_signs(1042, 256);
-                let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                // expert family choice: mq6 (HFQ6G256-compatible 6-bit, 200 B/group,
+                // opt-in via HIPFIRE_LFM2_EXPERT_MQ6 for higher quality), else mq4
+                // (MQ4G256, 136 B/group, default + validated). Mirrors minimax's
+                // HIPFIRE_MINIMAX_EXPERT_MQ6 idiom. The forward routes to the HFQ6
+                // indexed gemv kernels when it sees MQ6G256 experts.
+                let expert_mq6 = std::env::var_os("HIPFIRE_LFM2_EXPERT_MQ6").is_some();
+                let (q, qt, tag) = if expert_mq6 {
+                    (quantize_mq6g256(&f32_data, &signs1, &signs2), QuantType::MQ6G256, "MQ6-LFM")
+                } else {
+                    (quantize_mq4g256(&f32_data, &signs1, &signs2), QuantType::MQ4G256, "MQ4-LFM")
+                };
                 eprintln!("  {:>8}: {} {:?} ({:.1} KB → {:.1} KB)",
-                    "MQ4-LFM", name, meta.shape,
+                    tag, name, meta.shape,
                     raw_data.len() as f64 / 1024.0, q.len() as f64 / 1024.0);
                 hfq_tensors.push(HfqTensor {
-                    name: name.to_string(), quant_type: QuantType::MQ4G256,
+                    name: name.to_string(), quant_type: qt,
                     shape, group_size: 256, data: q, spilled_len: 0,
                 });
                 quantized_params += (meta.shape[0] * meta.shape[1]) as u64;

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5501,6 +5501,47 @@ fn main() {
                 st_files[*file_idx].drop_tensor_pages(name);
                 continue;
             }
+            // Perf lever (HIPFIRE_LFM2_PROJ_MQ4=1): route the dense 2D linears —
+            // conv in/out_proj, attn q/k/v/out_proj, dense MLP w1/w2/w3 (experts
+            // already MQ4 above) — to MQ4G256 instead of Q8. Decode on this A1B
+            // model is weight-bandwidth-bound; these projections are ~30% of
+            // per-token weight reads, so 4-bit-ing them is the cleanest tok/s
+            // lever. weight_gemv's MQ4G256 arm FWHT-rotates the input internally,
+            // so the forward path needs no change. Router, expert_bias, all norms,
+            // the depthwise conv filter, and the tied embed/lm_head stay Q8
+            // (precision-sensitive / tiny). OFF by default — flip on only after
+            // the tiny-oracle cosine (≥0.99) + coherence gate confirm it.
+            if std::env::var_os("HIPFIRE_LFM2_PROJ_MQ4").is_some()
+                && meta.shape.len() == 2
+                && meta.shape[1] % 256 == 0
+                && (name.ends_with(".conv.in_proj.weight")
+                    || name.ends_with(".conv.out_proj.weight")
+                    || name.ends_with(".self_attn.q_proj.weight")
+                    || name.ends_with(".self_attn.k_proj.weight")
+                    || name.ends_with(".self_attn.v_proj.weight")
+                    || name.ends_with(".self_attn.out_proj.weight")
+                    || name.ends_with(".feed_forward.w1.weight")
+                    || name.ends_with(".feed_forward.w2.weight")
+                    || name.ends_with(".feed_forward.w3.weight"))
+            {
+                let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                    name, raw_data, meta, &fp8_scale_for, &st_files);
+                let signs1 = gen_fwht_signs(42, 256);
+                let signs2 = gen_fwht_signs(1042, 256);
+                let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
+                eprintln!("  {:>8}: {} {:?} (proj MQ4)", "MQ4P-LFM", name, meta.shape);
+                hfq_tensors.push(HfqTensor {
+                    name: name.to_string(), quant_type: QuantType::MQ4G256,
+                    shape, group_size: 256, data: q, spilled_len: 0,
+                });
+                quantized_params += (meta.shape[0] * meta.shape[1]) as u64;
+                st_files[*file_idx].drop_tensor_pages(name);
+                if let Some(ref mut s) = spill {
+                    maybe_spill(&mut hfq_tensors, s, 2 * 1024 * 1024 * 1024);
+                }
+                continue;
+            }
+
             // All remaining LFM2 tensors → Q8 (qt=3). quantize_q8f16 handles any
             // 1D/2D/3D shape elementwise (conv.conv.weight is [hidden,1,K]).
             let f32_data = tensor_to_f32_with_optional_fp8_scale(

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -40,7 +40,7 @@ description = "Inference orchestrator for RDNA GPUs"
 # block below) which serves both as documentation of which features
 # each example needs and as the gate for downstream library consumers
 # who attempt to build examples through their own build script.
-default = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-minimax", "arch-dots-ocr", "deltanet"]
+default = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-minimax", "arch-lfm2moe", "arch-dots-ocr", "deltanet"]
 deltanet = ["rdna-compute/deltanet"]
 arch-qwen35 = []
 arch-qwen35-vl = []
@@ -48,6 +48,7 @@ arch-llama = []
 arch-qwen2 = []
 arch-deepseek4 = []
 arch-minimax = []
+arch-lfm2moe = []
 arch-dots-ocr = []
 
 [dependencies]
@@ -98,6 +99,7 @@ hipfire-arch-llama = { path = "../hipfire-arch-llama" }
 hipfire-arch-qwen2 = { path = "../hipfire-arch-qwen2" }
 hipfire-arch-deepseek4 = { path = "../hipfire-arch-deepseek4" }
 hipfire-arch-minimax = { path = "../hipfire-arch-minimax" }
+hipfire-arch-lfm2moe = { path = "../hipfire-arch-lfm2moe" }
 hipfire-arch-dots-ocr = { path = "../hipfire-arch-dots-ocr" }
 hipfire-detect = { path = "../hipfire-detect" }
 hipfire-atlas = { path = "../hipfire-atlas" }
@@ -113,7 +115,7 @@ hipfire-atlas = { path = "../hipfire-atlas" }
 
 [[example]]
 name = "daemon"
-required-features = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-minimax", "arch-dots-ocr"]
+required-features = ["arch-qwen35", "arch-qwen35-vl", "arch-llama", "arch-qwen2", "arch-deepseek4", "arch-minimax", "arch-lfm2moe", "arch-dots-ocr"]
 
 [[example]]
 name = "hfq_split"

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1313,8 +1313,15 @@ fn main() {
                 // model. Pick arch-shaped defaults so a vanilla
                 // `/v1/chat/completions` POST (no sampling fields) works on
                 // both. Explicit per-request values still override either.
-                let (default_temp, default_top_p) = if m.arch_id == 9 || m.arch_id == 10 || m.arch_id == 11 {
-                    // DeepSeek V4 (9) + MiniMax-M2 (10) + LFM2.5-MoE (11): quantized instruct
+                let (default_temp, default_top_p) = if m.arch_id == 11 {
+                    // LFM2.5-MoE (11): Liquid's model card recommends specific
+                    // sampling — temperature=0.2, top_p=0.80 (+ repetition_penalty
+                    // 1.05, set below). Use those exact values, not the generic
+                    // MoE-instruct (temp=1.0) default — they're tuned for this
+                    // model and keep it on-distribution.
+                    (0.2_f64, 0.80_f64)
+                } else if m.arch_id == 9 || m.arch_id == 10 {
+                    // DeepSeek V4 (9) + MiniMax-M2 (10): quantized instruct
                     // MoE models that fall into block-level attractors under
                     // pure greedy. Default to the HF-recommended sampling
                     // (temp=1.0, top_p=1.0); explicit per-request values
@@ -1337,7 +1344,10 @@ fn main() {
                 // Root cause writeup: issue #258 comment "Bug B root cause"
                 // and docs/investigations/2026-05-15-9b-reasoning-loop/.
                 // Clients can still opt in to a non-1.0 value per request.
-                let repeat_penalty = msg.get("repeat_penalty").and_then(|v| v.as_f64()).unwrap_or(1.0) as f32;
+                // LFM2.5-MoE (arch_id 11): Liquid's card recommends
+                // repetition_penalty=1.05; default to it (others stay 1.0/off).
+                let default_repeat_penalty = if m.arch_id == 11 { 1.05_f64 } else { 1.0_f64 };
+                let repeat_penalty = msg.get("repeat_penalty").and_then(|v| v.as_f64()).unwrap_or(default_repeat_penalty) as f32;
                 // OpenAI-compatible `reasoning_effort` (also accept our custom
                 // `thinking_mode` alias) — only consumed by arch_id=9 today.
                 // Default = NonThink, matching the safe HF chat frame.

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -29,6 +29,8 @@ use hipfire_runtime::llama;
 use hipfire_runtime::multi_gpu::Gpus;
 use hipfire_arch_deepseek4 as deepseek4;
 use hipfire_arch_minimax as minimax;
+#[cfg(feature = "arch-lfm2moe")]
+use hipfire_arch_lfm2moe as lfm2moe;
 use hipfire_arch_llama::Llama;
 use hipfire_arch_qwen2::qwen2;
 use hipfire_arch_dots_ocr::dots_ocr;
@@ -629,6 +631,23 @@ struct LoadedModel {
     /// file scan (e.g. `<stem>-mtp.*`) or bundled MTP detection. Used by
     /// `mtp_mode = "auto"` to decide whether to enable spec-decode.
     mtp_weights_present: bool,
+    // LFM2.5-8B-A1B state (arch_id=11 — hipfire-arch-lfm2moe). Hybrid:
+    // double-gated LIV short-conv mixers interleaved with GQA+QK-norm
+    // attention, feeding a DeepSeek-style sigmoid-bias top-4 MoE FFN (or
+    // dense SwiGLU on the first num_dense_layers). KV cache + conv-state
+    // cache both live inside Lfm2MoeState; no separate field. NO
+    // PrefillBatchScratch — prefill is the per-token `decode_step` loop.
+    // None on every other arch path. Structurally mirrors MiniMax (10).
+    #[cfg(feature = "arch-lfm2moe")]
+    lfm2moe_config: Option<lfm2moe::config::Lfm2MoeConfig>,
+    #[cfg(feature = "arch-lfm2moe")]
+    lfm2moe_weights: Option<lfm2moe::lfm2moe::Lfm2MoeWeights>,
+    #[cfg(feature = "arch-lfm2moe")]
+    lfm2moe_state: Option<lfm2moe::lfm2moe::Lfm2MoeState>,
+    /// Cached EOS token id resolved at load time. Falls back to 1 if the
+    /// tokenizer lacks the special-token entry.
+    #[cfg(feature = "arch-lfm2moe")]
+    lfm2moe_eos_tok: u32,
     // dots.ocr state (arch_id=8 — Qwen2-VL family). The text decoder is
     // Qwen2: `dots_ocr_config.text` / `dots_ocr_weights.text` feed
     // `qwen2::forward_step*`, and the per-step decode state reuses the
@@ -1048,6 +1067,7 @@ fn main() {
                             8 => "dots-ocr",
                             9 => "deepseek4",
                             10 => "minimax_m2",
+                            11 => "lfm2moe",
                             _ => "qwen3",
                         };
                         let vl = m.vision_config.is_some() || m.dots_ocr_config.is_some();
@@ -1061,6 +1081,13 @@ fn main() {
                             (c.text.hidden_size, c.text.num_hidden_layers, c.text.vocab_size)
                         } else if let Some(ref c) = m.minimax_config {
                             (c.hidden_size, c.num_hidden_layers, c.vocab_size)
+                        } else if let Some((d, l, v)) = {
+                            #[cfg(feature = "arch-lfm2moe")]
+                            { m.lfm2moe_config.as_ref().map(|c| (c.hidden_size, c.num_hidden_layers, c.vocab_size)) }
+                            #[cfg(not(feature = "arch-lfm2moe"))]
+                            { None::<(usize, usize, usize)> }
+                        } {
+                            (d, l, v)
                         } else { (0, 0, 0) };
 
                         // Apply MTP config from load-message params.
@@ -1286,8 +1313,8 @@ fn main() {
                 // model. Pick arch-shaped defaults so a vanilla
                 // `/v1/chat/completions` POST (no sampling fields) works on
                 // both. Explicit per-request values still override either.
-                let (default_temp, default_top_p) = if m.arch_id == 9 || m.arch_id == 10 {
-                    // DeepSeek V4 (9) + MiniMax-M2 (10): quantized instruct
+                let (default_temp, default_top_p) = if m.arch_id == 9 || m.arch_id == 10 || m.arch_id == 11 {
+                    // DeepSeek V4 (9) + MiniMax-M2 (10) + LFM2.5-MoE (11): quantized instruct
                     // MoE models that fall into block-level attractors under
                     // pure greedy. Default to the HF-recommended sampling
                     // (temp=1.0, top_p=1.0); explicit per-request values
@@ -1565,6 +1592,11 @@ fn main() {
                     // No captured hipGraph on this path, so no graph
                     // invalidation needed.
                     if let Some(ref mut s) = m.minimax_state { s.reset(); }
+                    // arch_id=11 (LFM2.5-MoE): clear KV + conv-state cursors
+                    // between turns. reset() also zeroes the rolling conv
+                    // states on-GPU, so it takes `gpu` and returns Result.
+                    #[cfg(feature = "arch-lfm2moe")]
+                    if let Some(ref mut s) = m.lfm2moe_state { let _ = s.reset(&mut gpu); }
                     let _ = writeln!(stdout, r#"{{"type":"reset","seq_pos":0}}"#);
                 } else {
                     let _ = writeln!(stdout, r#"{{"type":"error","message":"no model loaded"}}"#);
@@ -1613,6 +1645,7 @@ fn main() {
                     7 => "qwen2",
                     9 => "deepseek4",
                     10 => "minimax_m2",
+                    11 => "lfm2moe",
                     _ => "qwen3",
                 }).unwrap_or("none");
                 // Count pre-compiled kernels
@@ -1692,6 +1725,10 @@ fn main() {
                 // MiniMax-M2 (arch_id=10): same — KV cache + scratch share
                 // MiniMaxState; reset its cursor for a cold prefill bench.
                 if let Some(ref mut s) = m.minimax_state { s.reset(); }
+                // LFM2.5-MoE (arch_id=11): same — KV + conv-state cache share
+                // Lfm2MoeState; reset cursors (takes gpu) for a cold bench.
+                #[cfg(feature = "arch-lfm2moe")]
+                if let Some(ref mut s) = m.lfm2moe_state { let _ = s.reset(&mut gpu); }
 
                 // Flush any residual GPU work so it doesn't bleed into the
                 // measured interval, then time forward_prefill_batch + a
@@ -1759,6 +1796,30 @@ fn main() {
                         }
                     }
                     ok
+                } else if cfg!(feature = "arch-lfm2moe") && m.arch_id == 11 {
+                    // LFM2.5-MoE warm-pass: per-token decode_step over the
+                    // synthetic prompt. Saturates the conv + GQA + QK-norm +
+                    // RoPE + top-4 MoE kernel set before any user-facing
+                    // generate. This IS the production prefill shape (no
+                    // batched kernel).
+                    #[cfg(feature = "arch-lfm2moe")]
+                    {
+                        let config = m.lfm2moe_config.as_ref().unwrap();
+                        let weights = m.lfm2moe_weights.as_ref().unwrap();
+                        let state = m.lfm2moe_state.as_mut().unwrap();
+                        let mut ok = true;
+                        for (i, &tok) in synthetic.iter().enumerate() {
+                            if lfm2moe::forward::decode_step(
+                                config, weights, state, &mut gpu, tok, i as u32,
+                            ).is_err() {
+                                ok = false;
+                                break;
+                            }
+                        }
+                        ok
+                    }
+                    #[cfg(not(feature = "arch-lfm2moe"))]
+                    { false }
                 } else {
                     let config = m.llama_config.as_ref().unwrap();
                     let weights = m.llama_weights.as_ref().unwrap();
@@ -2126,6 +2187,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
             minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2173,6 +2242,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
             minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             dots_ocr_config: Some(config), dots_ocr_weights: Some(weights),
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2237,6 +2314,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             deepseek4_pbs: Some(pbs), deepseek4_eos_tok: eos_tok,
             minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2308,6 +2393,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             minimax_config: Some(config), minimax_weights: Some(weights), minimax_state: Some(state),
             minimax_eos_tok: eos_tok,
             mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2318,6 +2411,78 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             dflash: None,
             chat_template,
         });
+    }
+
+    if hfq.arch_id == 11 {
+        // LFM2.5-8B-A1B (hipfire-arch-lfm2moe). Standalone bring-up — no
+        // eviction, no DFlash drafter, no PFlash, no VL, no spec-decode.
+        // Hybrid LIV short-conv + GQA attention feeding a top-4 MoE FFN.
+        // config + weights + state come from the crate's direct API
+        // (it does not implement the Architecture trait); prefill + decode
+        // both go through the per-token `lfm2moe::forward::decode_step` in
+        // the generate hot path. There is NO PrefillBatchScratch (no
+        // batched prefill kernel). Structurally mirrors MiniMax (10).
+        #[cfg(not(feature = "arch-lfm2moe"))]
+        {
+            let _ = (&mut hfq, path, max_seq, draft_path, kv_mode, state_quant_override, &cask, pp, gpu, tokenizer);
+            return Err("lfm2moe arch (id 11) not compiled in (enable feature arch-lfm2moe)".to_string());
+        }
+        #[cfg(feature = "arch-lfm2moe")]
+        {
+            if draft_path.is_some() {
+                return Err("DFlash not supported on arch_id=11 (LFM2.5-MoE). \
+                           Reload without a draft.".to_string());
+            }
+            if cask.sidecar.is_some() {
+                return Err("CASK eviction not supported on arch_id=11 (LFM2.5-MoE). \
+                           Reload without --cask-sidecar.".to_string());
+            }
+            if pp > 1 {
+                return Err("pipeline-parallel (pp>1) not supported on arch_id=11 (LFM2.5-MoE).".to_string());
+            }
+            let _ = kv_mode;
+            let _ = state_quant_override;
+            let config = lfm2moe::config::Lfm2MoeConfig::from_hfq(&hfq)?;
+            let weights = lfm2moe::lfm2moe::Lfm2MoeWeights::load(&mut hfq, &config, gpu)?;
+            // Size the KV + conv-state cache to the requested window.
+            let state = lfm2moe::lfm2moe::Lfm2MoeState::new_with_max_seq(gpu, &config, max_seq)
+                .map_err(|e| format!("lfm2moe: Lfm2MoeState::new_with_max_seq failed: {e}"))?;
+            // Resolve EOS via the tokenizer. LFM2.5 uses the standard
+            // ChatML-ish `<|im_end|>`; fall back to common alternates, then 1.
+            let eos_tok: u32 = {
+                let try_one = |s: &str| -> Option<u32> {
+                    let ids = tokenizer.encode(s);
+                    if ids.len() == 1 { Some(ids[0]) } else { None }
+                };
+                try_one("<|im_end|>")
+                    .or_else(|| try_one("</s>"))
+                    .or_else(|| try_one("<|endoftext|>"))
+                    .unwrap_or(1)
+            };
+            let chat_template = resolve_chat_template(&hfq, path);
+            return Ok(LoadedModel {
+                arch_id: hfq.arch_id,
+                pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
+                q35_config: None, q35_weights: None, q35_scratch: None,
+                kv_cache: None, dn_state: None,
+                llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
+                qwen2_config: None, qwen2_weights: None, qwen2_state: None,
+                deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
+                minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
+                lfm2moe_config: Some(config), lfm2moe_weights: Some(weights), lfm2moe_state: Some(state),
+                lfm2moe_eos_tok: eos_tok,
+                mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+                dots_ocr_config: None, dots_ocr_weights: None,
+                vision_config: None, vision_weights: None,
+                tokenizer: Some(tokenizer),
+                seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None,
+                conversation_tokens: Vec::new(),
+                asst_turn_cache: std::collections::HashMap::new(), decoded_vocab: None,
+                model_path: path.to_string(),
+                dflash: None,
+                chat_template,
+            });
+        }
     }
 
     if hfq.arch_id == 5 || hfq.arch_id == 6 {
@@ -2498,6 +2663,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
             minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config, vision_weights,
             tokenizer: Some(tokenizer),
@@ -2533,6 +2706,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
             minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
             mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             dots_ocr_config: None, dots_ocr_weights: None,
             vision_config: None, vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2633,6 +2814,14 @@ fn load_model_safetensors(
             mtp_mode: "auto".to_string(),
             mtp_k: 3,
             mtp_weights_present: false,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_config: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_weights: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_state: None,
+            #[cfg(feature = "arch-lfm2moe")]
+            lfm2moe_eos_tok: 0,
             vision_config: None,
             vision_weights: None,
             tokenizer: Some(tokenizer),
@@ -2707,6 +2896,14 @@ fn load_model_safetensors(
         mtp_mode: "auto".to_string(),
         mtp_k: 3,
         mtp_weights_present: false,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_config: None,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_weights: None,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_state: None,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_eos_tok: 0,
         vision_config: None,
         vision_weights: None,
         tokenizer: Some(tokenizer),
@@ -2845,6 +3042,14 @@ fn load_model_pp(
         deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
         minimax_config: None, minimax_weights: None, minimax_state: None, minimax_eos_tok: 0,
         mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_config: None,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_weights: None,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_state: None,
+        #[cfg(feature = "arch-lfm2moe")]
+        lfm2moe_eos_tok: 0,
         dots_ocr_config: None, dots_ocr_weights: None,
         vision_config: None, vision_weights: None,
         tokenizer: Some(tokenizer),
@@ -2965,6 +3170,12 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     // for the daemon's lifetime in the bring-up scope. Add free_gpu to the
     // minimax crate + explicit frees here when eviction lands.
     let _ = (&m.minimax_state, &m.minimax_weights);
+    // LFM2.5-MoE (arch_id=11): same bring-up scope as minimax — Lfm2MoeState /
+    // Lfm2MoeWeights expose no free_gpu in the scaffold, so they drop here
+    // without returning their device tensors to the pool. KNOWN LEAK on
+    // load/unload churn until eviction is wired for arch_id=11.
+    #[cfg(feature = "arch-lfm2moe")]
+    let _ = (&m.lfm2moe_state, &m.lfm2moe_weights);
     // Weights are the bulk of VRAM (~80%). Free them too so idle eviction
     // actually returns VRAM to the system, not just the cache.
     if let Some(w) = m.q35_weights { w.free_gpu(gpu); }
@@ -4236,6 +4447,23 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                  pflash_state, pflash_cfg, repeat_penalty, repeat_window,
                  think_mode);
         generate_minimax(
+            m, gpu, stdout, id, prompt, system_prompt,
+            temp, top_p, max_tokens, max_think_tokens, tools, messages_history,
+        );
+        return;
+    }
+    #[cfg(feature = "arch-lfm2moe")]
+    if m.arch_id == 11 {
+        // arch_id=11 (LFM2.5-MoE). Minimal AR bring-up — same shape as the
+        // qwen2 / deepseek4 / minimax short-circuits above. PFlash / DFlash /
+        // VL / multi-GPU / sampler-budget / grammar / tools-execution all
+        // bypass. We honour `system_prompt`, `temp`, `top_p`, and (via
+        // JinjaChatFrame) `messages_history` + `tools` rendering; spec-decode
+        // / MTP / grammar are out of scope for the scaffold.
+        let _ = (budget_alert_at_tok, budget_alert_text, assistant_prefix,
+                 pflash_state, pflash_cfg, repeat_penalty, repeat_window,
+                 think_mode);
+        generate_lfm2moe(
             m, gpu, stdout, id, prompt, system_prompt,
             temp, top_p, max_tokens, max_think_tokens, tools, messages_history,
         );
@@ -6640,6 +6868,227 @@ fn generate_minimax(
     }
 
     m.seq_pos = m.minimax_state.as_ref().unwrap().n_tokens;
+
+    let decode_ms = decode_t0.elapsed().as_millis().max(1);
+    let total_ms = t0.elapsed().as_millis().max(1);
+    let tok_s = if generated_count > 0 {
+        (generated_count as f64 * 1000.0) / decode_ms as f64
+    } else {
+        0.0
+    };
+    let _ = writeln!(
+        stdout,
+        r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.2},"prefill_ms":{},"total_ms":{}}}"#,
+        id, generated_count, tok_s, prefill_ms, total_ms,
+    );
+    let _ = stdout.flush();
+}
+
+/// LFM2.5-MoE (arch_id=11) generate path — minimal AR bring-up.
+///
+/// Structurally identical to `generate_minimax` (prefill = per-token loop,
+/// decode = per-token loop, JSONL `token` / `done` events). Only the arch
+/// types and `forward::decode_step` path differ. Out of scope (and not
+/// wired): spec-decode, MTP, grammar, tool-call parsing/execution, repeat
+/// penalty, multi-GPU, eviction/prefix-cache. Correctness first.
+#[cfg(feature = "arch-lfm2moe")]
+#[allow(clippy::too_many_arguments)]
+fn generate_lfm2moe(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    temp: f32,
+    top_p: f32,
+    max_tokens: usize,
+    max_think_tokens: usize,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+) {
+    if m.tokenizer.is_none() {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"tokenizer not loaded"}}"#, id);
+        let _ = stdout.flush();
+        return;
+    }
+    if m.lfm2moe_config.is_none() {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"lfm2moe_config missing on arch_id=11 generate"}}"#, id);
+        let _ = stdout.flush();
+        return;
+    }
+
+    // ── Prompt build (same two-path branch as the minimax AR path) ──
+    let prompt_ids: Vec<u32> = {
+        let tokenizer = m.tokenizer.as_ref().unwrap();
+        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
+        let try_jinja = jinja_enabled && m.chat_template.is_some();
+        if try_jinja {
+            let template = m.chat_template.as_ref().unwrap();
+            let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+                tokenizer,
+                template,
+                system: system_prompt,
+                user: prompt,
+                enable_thinking: max_think_tokens != 1,
+                bos_token: None,
+            };
+            let render_result = if tools.is_some() || messages_history.is_some() {
+                let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;
+                let messages_slice: &[hipfire_runtime::prompt_frame::Message] = match messages_history {
+                    Some(h) => h,
+                    None => {
+                        let mut v = Vec::new();
+                        if let Some(sys) = system_prompt {
+                            v.push(hipfire_runtime::prompt_frame::Message {
+                                role: hipfire_runtime::prompt_frame::Role::System,
+                                content: sys.to_string(),
+                                tool_calls: Vec::new(),
+                                tool_call_id: None,
+                            });
+                        }
+                        v.push(hipfire_runtime::prompt_frame::Message {
+                            role: hipfire_runtime::prompt_frame::Role::User,
+                            content: prompt.to_string(),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                        synthesized = v;
+                        &synthesized
+                    }
+                };
+                frame.render_messages(messages_slice, tools, None)
+            } else {
+                frame.render()
+            };
+            match render_result {
+                Ok(rendered) => tokenizer.encode(&rendered),
+                Err(e) => {
+                    eprintln!("[daemon] jinja render failed in lfm2moe path ({e}) — falling back to Plain");
+                    hipfire_runtime::prompt_frame::ChatFrame {
+                        tokenizer,
+                        system: system_prompt,
+                        user: prompt,
+                        assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                        raw: false,
+                    }
+                    .build()
+                }
+            }
+        } else {
+            hipfire_runtime::prompt_frame::ChatFrame {
+                tokenizer,
+                system: system_prompt,
+                user: prompt,
+                assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix::Plain,
+                raw: false,
+            }
+            .build()
+        }
+    };
+
+    if prompt_ids.is_empty() {
+        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"empty prompt after tokenize"}}"#, id);
+        let _ = stdout.flush();
+        return;
+    }
+
+    let eos_tok = m.lfm2moe_eos_tok;
+
+    // Capacity guard. No eviction on arch_id=11 — reset the KV + conv-state
+    // cursors when the requested run would overflow the budget.
+    let overflow = {
+        let state = m.lfm2moe_state.as_ref().unwrap();
+        state.n_tokens + prompt_ids.len() + max_tokens > state.max_seq
+    };
+    if overflow {
+        let (n, cap) = {
+            let state = m.lfm2moe_state.as_ref().unwrap();
+            (state.n_tokens, state.max_seq)
+        };
+        eprintln!(
+            "[daemon] arch_id=11 context full ({n}/{cap}) — resetting Lfm2MoeState",
+        );
+        let _ = m.lfm2moe_state.as_mut().unwrap().reset(gpu);
+        m.seq_pos = 0;
+        m.conversation_tokens.clear();
+    }
+
+    let t0 = Instant::now();
+
+    // ── Prefill: decode_step per prompt token. The LAST decode_step's logits
+    // are the predictions for the first generated token. ──
+    let mut last_logits: Vec<f32> = Vec::new();
+    {
+        let cfg = m.lfm2moe_config.as_ref().unwrap();
+        let weights = m.lfm2moe_weights.as_ref().unwrap();
+        let state = m.lfm2moe_state.as_mut().unwrap();
+        let mut position = state.n_tokens as u32;
+        for &tok in &prompt_ids {
+            match lfm2moe::forward::decode_step(cfg, weights, state, gpu, tok, position) {
+                Ok(logits) => last_logits = logits,
+                Err(e) => {
+                    emit_error_with_id(stdout, id, format!("lfm2moe prefill failed: {e:?}"));
+                    return;
+                }
+            }
+            position += 1;
+        }
+    }
+    for &tok in &prompt_ids {
+        m.conversation_tokens.push(tok);
+    }
+    let prefill_ms = t0.elapsed().as_millis();
+
+    // ── Decode loop. Sample host-side from the running logits vector. ──
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9E3779B97F4A7C15);
+    let mut rng = deepseek4::sampling::Xorshift::new(seed);
+
+    let mut generated_count: usize = 0;
+    let decode_t0 = Instant::now();
+    loop {
+        if generated_count >= max_tokens {
+            break;
+        }
+        let next_tok = deepseek4::sampling::sample_token(&last_logits, temp, 0, top_p, &mut rng);
+        if next_tok == eos_tok {
+            break;
+        }
+
+        let frag = {
+            let tokenizer = m.tokenizer.as_ref().unwrap();
+            tokenizer.decode(&[next_tok])
+        };
+        let envelope = serde_json::json!({
+            "type": "token",
+            "id": id,
+            "text": frag,
+        });
+        let _ = writeln!(stdout, "{}", envelope);
+        let _ = stdout.flush();
+        m.conversation_tokens.push(next_tok);
+        generated_count += 1;
+
+        let step = {
+            let cfg = m.lfm2moe_config.as_ref().unwrap();
+            let weights = m.lfm2moe_weights.as_ref().unwrap();
+            let state = m.lfm2moe_state.as_mut().unwrap();
+            let position = state.n_tokens as u32;
+            lfm2moe::forward::decode_step(cfg, weights, state, gpu, next_tok, position)
+        };
+        match step {
+            Ok(logits) => last_logits = logits,
+            Err(e) => {
+                emit_error_with_id(stdout, id, format!("lfm2moe decode failed: {e:?}"));
+                return;
+            }
+        }
+    }
+
+    m.seq_pos = m.lfm2moe_state.as_ref().unwrap().n_tokens;
 
     let decode_ms = decode_t0.elapsed().as_millis().max(1);
     let total_ms = t0.elapsed().as_millis().max(1);

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2259,23 +2259,50 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // All allocators go through the `_capped` entry points with
         // physical_cap derived above. Without eviction, physical_cap==max_seq
         // and these match the back-compat wrappers byte-for-byte.
+        // Hybrid Qwen3.5/3.6 = 48 DeltaNet (LinearAttention) + 16 FullAttention
+        // layers out of 64; only the FullAttention layers need a KV slot. The
+        // `_filtered` allocators skip KV alloc for the rest (~75% saved on the
+        // 27B). Dense / all-FullAttention models yield an all-true mask, so
+        // filtered == unfiltered (allocation no-op, output unchanged).
+        let is_kv_layer: Vec<bool> = config
+            .layer_types
+            .iter()
+            .map(|t| *t == LayerType::FullAttention)
+            .collect();
         let kv = match kv_mode.as_str() {
             "q8" => {
-                eprintln!("  KV cache: Q8");
-                llama::KvCache::new_gpu_q8_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_q8_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
             }
             "asym4" | "turbo4" => {
-                llama::KvCache::new_gpu_asym4_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                // asym4/asym2/fwht4 have no _capped_filtered yet; physical_cap ==
+                // max_seq when CASK eviction is off (the default), so _filtered is
+                // exact. (Fully CASK-aware capped+filtered variants: follow-up.)
+                llama::KvCache::new_gpu_asym4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
             }
             "asym2" | "turbo2" => {
-                llama::KvCache::new_gpu_asym2_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_asym2_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
             }
             "asym3" | "turbo3" | "turbo" | "auto" | "" => {
-                llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_asym3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+            }
+            // FWHT-rotated KV: same byte layout as the matching asym tier, but
+            // the K-rotation basis matches the MQ4 weight/draft FWHT convention,
+            // so DFlash speculative acceptance stays high (asym's Givens basis
+            // does not — see CLAUDE.md: "DFlash perf gates must use q8 or FWHT").
+            "fwht3" => {
+                llama::KvCache::new_gpu_fwht3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+            }
+            "fwht2" => {
+                llama::KvCache::new_gpu_fwht2_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+            }
+            "fwht4" => {
+                // fwht4 has no _capped_filtered yet; physical_cap == max_seq when
+                // CASK eviction is off (the default), so _filtered is exact here.
+                llama::KvCache::new_gpu_fwht4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
             }
             other => {
                 eprintln!("  KV cache: unrecognized '{other}', defaulting to asym3");
-                llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_asym3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
             }
         };
         // Q8 DeltaNet state can accumulate quality drift on long generation.
@@ -2533,12 +2560,23 @@ fn load_model_safetensors(
     let weights = qwen35::load_weights_paroquant(&source, &config, gpu)
         .map_err(|e| format!("load_weights_paroquant: {e:?}"))?;
 
-    // KV cache: default to asym3 (matches the main Qwen35 path)
+    // KV cache: filtered to FullAttention layers (hybrid Qwen3.5/3.6), mirroring
+    // the HFQ single-GPU path so AWQ/safetensors models also get the ~75% cut and
+    // honor the fwht* default. physical_cap == max_seq (no CASK on this path).
     let effective_max_seq = max_seq;
+    let is_kv_layer: Vec<bool> = config
+        .layer_types
+        .iter()
+        .map(|t| *t == LayerType::FullAttention)
+        .collect();
     let kv_cache = match kv_mode {
-        "q8" => llama::KvCache::new_gpu_q8_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-        _ => llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
+        "q8" => llama::KvCache::new_gpu_q8_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
+        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq),
+        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq),
+        "fwht4" => llama::KvCache::new_gpu_fwht4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq),
+        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
+        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
+        _ => llama::KvCache::new_gpu_asym3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
     }.map_err(|e| format!("KvCache: {e}"))?;
     let dn_state = DeltaNetState::new(gpu, &config)
         .map_err(|e| format!("DeltaNetState::new: {e:?}"))?;
@@ -2661,17 +2699,24 @@ fn load_model_pp(
 
     // KV cache (asym3 default, q8/asym4/asym2/fwht{4,3,2} selectable).
     // physical_cap == max_seq on this path — eviction is refused at load.
+    // Filtered to FullAttention layers (hybrid Qwen3.5/3.6): each KV slot lands
+    // on its layer's assigned device; non-KV layers get a 1-elem placeholder.
+    let is_kv_layer: Vec<bool> = config
+        .layer_types
+        .iter()
+        .map(|t| *t == LayerType::FullAttention)
+        .collect();
     let kv = match kv_mode.as_str() {
-        "q8" => llama::KvCache::new_gpu_q8_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "asym3" | "turbo3" | "turbo" | "auto" | "" => llama::KvCache::new_gpu_asym3_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "fwht4" => llama::KvCache::new_gpu_fwht4_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "q8" => llama::KvCache::new_gpu_q8_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "asym3" | "turbo3" | "turbo" | "auto" | "" => llama::KvCache::new_gpu_asym3_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "fwht4" => llama::KvCache::new_gpu_fwht4_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
         other => {
             eprintln!("  KV cache: unrecognized '{other}', defaulting to asym3");
-            llama::KvCache::new_gpu_asym3_capped_multi(&mut gpus, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?
+            llama::KvCache::new_gpu_asym3_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?
         }
     };
 

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -6941,7 +6941,12 @@ fn generate_lfm2moe(
                 system: system_prompt,
                 user: prompt,
                 enable_thinking: max_think_tokens != 1,
-                bos_token: None,
+                // LFM2.5's template prepends `{{ bos_token }}` = `<|startoftext|>`
+                // (config.json bos_token_id=124894), but our tokenizer's bos_id
+                // resolves to `<|endoftext|>` (124895) — so decode_bytes(bos_id)
+                // would render the WRONG special token. Pin the correct BOS here,
+                // mirroring the Gemma 4 precedent (see JinjaChatFrame::bos_token).
+                bos_token: Some("<|startoftext|>"),
             };
             let render_result = if tools.is_some() || messages_history.is_some() {
                 let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;

--- a/crates/hipfire-runtime/examples/eval_hipfire.rs
+++ b/crates/hipfire-runtime/examples/eval_hipfire.rs
@@ -76,8 +76,8 @@ fn main() {
             "--output" => { output = Some(PathBuf::from(&argv[i + 1])); i += 2; }
             "--kv-mode" => {
                 let v = argv[i + 1].clone();
-                if !matches!(v.as_str(), "q8" | "asym2" | "asym3" | "asym4") {
-                    eprintln!("--kv-mode must be one of: q8 asym2 asym3 asym4 (got {v})");
+                if !matches!(v.as_str(), "q8" | "asym2" | "asym3" | "asym4" | "fwht2" | "fwht3" | "fwht4") {
+                    eprintln!("--kv-mode must be one of: q8 asym2 asym3 asym4 fwht2 fwht3 fwht4 (got {v})");
                     std::process::exit(1);
                 }
                 kv_mode = v;
@@ -237,6 +237,13 @@ fn main() {
 
     // -------- KV cache + DeltaNet state + scratch --------
     let kv_max = n_ctx + 16;
+    // FWHT KV modes only have layer-filtered ctors; build the FA-layer mask
+    // from layer_types. Filtering is KLD-neutral (DeltaNet layers never read KV).
+    let is_kv_layer: Vec<bool> = config
+        .layer_types
+        .iter()
+        .map(|t| *t == qwen35::LayerType::FullAttention)
+        .collect();
     let mut kv_cache = match args.kv_mode.as_str() {
         "q8" => KvCache::new_gpu_q8(
             &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max
@@ -249,6 +256,15 @@ fn main() {
         ).unwrap(),
         "asym2" => KvCache::new_gpu_asym2(
             &mut gpu, config.n_layers, config.n_kv_heads, config.head_dim, kv_max
+        ).unwrap(),
+        "fwht4" => KvCache::new_gpu_fwht4_filtered(
+            &mut gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, kv_max
+        ).unwrap(),
+        "fwht3" => KvCache::new_gpu_fwht3_filtered(
+            &mut gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, kv_max
+        ).unwrap(),
+        "fwht2" => KvCache::new_gpu_fwht2_filtered(
+            &mut gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, kv_max
         ).unwrap(),
         other => panic!("unknown --kv-mode: {other}"),
     };

--- a/crates/hipfire-runtime/examples/mtp_only_demo.rs
+++ b/crates/hipfire-runtime/examples/mtp_only_demo.rs
@@ -43,6 +43,7 @@ fn main() {
     let mut chatml: bool = true;
     let mut compressed: bool = false;
     let mut compressed_serial: bool = false;
+    let mut trunk_spine: bool = false;
     let mut kv_mode_str: String = String::from("q8");
     let mut p_min: f32 = 0.0;
     // Sampling parameters (Unsloth-recommended for Qwen3.5/3.6 MTP):
@@ -57,34 +58,97 @@ fn main() {
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
-            "--target" => { target_path = Some(args[i + 1].clone()); i += 2; }
-            "--mtp-head" => { mtp_path = Some(args[i + 1].clone()); i += 2; }
-            "--prompt" => { prompt_str = Some(args[i + 1].clone()); i += 2; }
-            "--prompt-file" => { prompt_file = Some(args[i + 1].clone()); i += 2; }
-            "--max" => { max_tokens = args[i + 1].parse().unwrap(); i += 2; }
-            "--ctx" => { ctx_capacity = args[i + 1].parse().unwrap(); i += 2; }
-            "--temp" => { temp = args[i + 1].parse().unwrap(); i += 2; }
-            "--max-n" => { max_n = args[i + 1].parse().unwrap(); i += 2; }
-            "--no-chatml" => { chatml = false; i += 1; }
-            "--chatml" => { chatml = true; i += 1; }
-            "--compressed" => { compressed = true; i += 1; }
-            "--compressed-serial" => { compressed = true; compressed_serial = true; i += 1; }
-            "--kv-mode" => { kv_mode_str = args[i + 1].clone(); i += 2; }
-            "--mtp-p-min" => { p_min = args[i + 1].parse().unwrap(); i += 2; }
-            "--top-p" => { top_p = args[i + 1].parse().unwrap(); i += 2; }
-            "--top-k" => { top_k = args[i + 1].parse().unwrap(); i += 2; }
-            "--min-p" => { min_p = args[i + 1].parse().unwrap(); i += 2; }
-            "--seed" => { seed = args[i + 1].parse().unwrap(); i += 2; }
+            "--target" => {
+                target_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--mtp-head" => {
+                mtp_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--prompt" => {
+                prompt_str = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--prompt-file" => {
+                prompt_file = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--max" => {
+                max_tokens = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--ctx" => {
+                ctx_capacity = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--temp" => {
+                temp = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--max-n" => {
+                max_n = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--no-chatml" => {
+                chatml = false;
+                i += 1;
+            }
+            "--chatml" => {
+                chatml = true;
+                i += 1;
+            }
+            "--compressed" => {
+                compressed = true;
+                i += 1;
+            }
+            "--compressed-serial" => {
+                compressed = true;
+                compressed_serial = true;
+                i += 1;
+            }
+            "--trunk-spine" => {
+                trunk_spine = true;
+                compressed = true;
+                compressed_serial = true;
+                i += 1;
+            }
+            "--kv-mode" => {
+                kv_mode_str = args[i + 1].clone();
+                i += 2;
+            }
+            "--mtp-p-min" => {
+                p_min = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--top-p" => {
+                top_p = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--top-k" => {
+                top_k = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--min-p" => {
+                min_p = args[i + 1].parse().unwrap();
+                i += 2;
+            }
+            "--seed" => {
+                seed = args[i + 1].parse().unwrap();
+                i += 2;
+            }
             "-h" | "--help" => {
                 eprintln!(
                     "Usage: mtp_only_demo --target <trunk.hfq> --mtp-head <head.mtp> \\\n\
                      \t(--prompt \"Hello\" | --prompt-file <path>) \\\n\
                      \t[--max 64] [--ctx 4096] [--temp 0.0] [--max-n 4] \\\n\
-                     \t[--no-chatml] [--compressed]\n\
+                     \t[--no-chatml] [--compressed] [--compressed-serial] [--trunk-spine]\n\
                      \n\
                      --compressed: use FastMTP-style compressed lm_head_draft (K=1 path).\n\
                                    Requires .mtp head built with --vocab-sidecar.\n\
-                                   Forces max_n=1 since the compressed spec is K=1 only."
+                                   Forces max_n=1 since the compressed spec is K=1 only.\n\
+                     --compressed-serial: discrete-token serial MTP spine without prompt MTP fill.\n\
+                     --trunk-spine: DS4-style Qwen spine: prompt MTP fill + discrete-token serial verify."
                 );
                 std::process::exit(0);
             }
@@ -102,7 +166,7 @@ fn main() {
     let target_is_bundle = target_path.ends_with(".mq4-mtp");
     let mtp_path = match (mtp_path, target_is_bundle) {
         (Some(p), _) => Some(p),
-        (None, true) => None,  // resolved from bundle below
+        (None, true) => None, // resolved from bundle below
         (None, false) => {
             eprintln!("--mtp-head required for non-bundle .mq4 target (got '{target_path}')");
             std::process::exit(2);
@@ -129,15 +193,19 @@ fn main() {
         std::process::exit(2);
     }
     if temp > 0.0 && !compressed_serial {
-        eprintln!("error: --temp > 0 is only supported on --compressed-serial path \
-                   (other paths are greedy-only); got temp={temp}");
+        eprintln!(
+            "error: --temp > 0 is only supported on --compressed-serial path \
+                   (other paths are greedy-only); got temp={temp}"
+        );
         std::process::exit(2);
     }
     assert!(max_n >= 1 && max_n <= 8, "--max-n must be in [1,8]");
-    if compressed && max_n > 1 {
-        eprintln!("compressed K={max_n}: chains K block forwards with lossy embedding \
+    if compressed && !compressed_serial && max_n > 1 {
+        eprintln!(
+            "compressed K={max_n}: chains K block forwards with lossy embedding \
                    override (same OOD risk as plain K-step path). Batched compressed \
-                   lm_head over the K outputs amortizes the BW saving across the chain.");
+                   lm_head over the K outputs amortizes the BW saving across the chain."
+        );
     }
 
     let prompt = hipfire_runtime::tokenizer::maybe_normalize_prompt(&prompt_raw).into_owned();
@@ -145,10 +213,16 @@ fn main() {
 
     eprintln!("=== mtp_only_demo ===");
     eprintln!("target:     {target_path}");
-    eprintln!("mtp-head:   {}",
-        mtp_path.as_deref().unwrap_or("<bundled in target .mq4-mtp>"));
+    eprintln!(
+        "mtp-head:   {}",
+        mtp_path
+            .as_deref()
+            .unwrap_or("<bundled in target .mq4-mtp>")
+    );
     eprintln!("prompt md5: {prompt_hash}");
-    eprintln!("max={max_tokens} ctx={ctx_capacity} max_n={max_n} chatml={chatml}");
+    eprintln!(
+        "max={max_tokens} ctx={ctx_capacity} max_n={max_n} chatml={chatml} trunk_spine={trunk_spine}"
+    );
 
     // ── Init GPU + load trunk + load MTP head ──────────────────────────
     let mut gpu = rdna_compute::Gpu::init().expect("gpu init");
@@ -162,9 +236,8 @@ fn main() {
     slot_cfg.max_seq = ctx_capacity + max_tokens * (max_n + 1) + 16;
     let max_seq_total = slot_cfg.max_seq;
     let t_load = Instant::now();
-    let mut target = ModelSlot::load(
-        &mut gpu, Path::new(&target_path), "target", slot_cfg,
-    ).expect("load target");
+    let mut target = ModelSlot::load(&mut gpu, Path::new(&target_path), "target", slot_cfg)
+        .expect("load target");
     eprintln!("trunk loaded in {:.2}s", t_load.elapsed().as_secs_f64());
 
     // MTP head's max_seq mirrors the trunk's. The head's KV cache is one
@@ -172,16 +245,21 @@ fn main() {
     let t_mtp = Instant::now();
     let head = if let Some(ref mp) = mtp_path {
         // Explicit --mtp-head: standalone .mtp file (legacy path).
-        mtp_head::load_mtp_head(Path::new(mp), &mut gpu, max_seq_total)
-            .expect("load mtp head")
+        mtp_head::load_mtp_head(Path::new(mp), &mut gpu, max_seq_total).expect("load mtp head")
     } else {
         // Bundled .mq4-mtp: load MTP section embedded in target file.
         mtp_head::load_mtp_head_bundled(Path::new(&target_path), &mut gpu, max_seq_total)
             .expect("load bundled mtp head")
-            .expect("target ends in .mq4-mtp but no MTP bundle trailer found; \
-                     was the file produced by mq4_merge_mtp?")
+            .expect(
+                "target ends in .mq4-mtp but no MTP bundle trailer found; \
+                     was the file produced by mq4_merge_mtp?",
+            )
     };
-    let head_source = if mtp_path.is_some() { "standalone .mtp" } else { "bundled .mq4-mtp" };
+    let head_source = if mtp_path.is_some() {
+        "standalone .mtp"
+    } else {
+        "bundled .mq4-mtp"
+    };
     eprintln!("mtp head loaded in {:.2}s ({head_source}) — n_embd={} vocab={} n_rot={} rope_theta={} compressed_lm_head_draft={}",
               t_mtp.elapsed().as_secs_f64(),
               head.config.n_embd, head.config.vocab_size,
@@ -189,9 +267,14 @@ fn main() {
               head.weights.lm_head_draft.is_some());
 
     // Sanity dims
-    assert_eq!(head.config.n_embd, target.config.dim, "trunk/head dim mismatch");
-    assert_eq!(head.config.vocab_size, target.config.vocab_size,
-               "trunk/head vocab mismatch");
+    assert_eq!(
+        head.config.n_embd, target.config.dim,
+        "trunk/head dim mismatch"
+    );
+    assert_eq!(
+        head.config.vocab_size, target.config.vocab_size,
+        "trunk/head vocab mismatch"
+    );
 
     // ── Tokenize prompt ────────────────────────────────────────────────
     let tokenizer: Tokenizer = target.load_tokenizer().expect("trunk tokenizer");
@@ -214,7 +297,10 @@ fn main() {
         chat.extend_from_slice(&asst);
         chat.extend_from_slice(&nl);
         prompt_tokens = chat;
-        eprintln!("chatml wrap: prompt {} tokens after wrap", prompt_tokens.len());
+        eprintln!(
+            "chatml wrap: prompt {} tokens after wrap",
+            prompt_tokens.len()
+        );
     } else {
         eprintln!("prompt: {} tokens (no chatml)", prompt_tokens.len());
     }
@@ -222,21 +308,31 @@ fn main() {
     assert!(
         prompt_tokens.len() + max_tokens * (max_n + 1) + 16 <= max_seq_total,
         "prompt ({}) + max ({}) × (max_n + 1) ({}) won't fit in max_seq {}",
-        prompt_tokens.len(), max_tokens, max_n + 1, max_seq_total,
+        prompt_tokens.len(),
+        max_tokens,
+        max_n + 1,
+        max_seq_total,
     );
 
     // ── Allocate spec state ────────────────────────────────────────────
-    let kv_mode = hipfire_arch_qwen35::mtp_head::MtpKvMode::parse(&kv_mode_str)
-        .unwrap_or_else(|e| { eprintln!("{e}"); std::process::exit(2); });
+    let kv_mode =
+        hipfire_arch_qwen35::mtp_head::MtpKvMode::parse(&kv_mode_str).unwrap_or_else(|e| {
+            eprintln!("{e}");
+            std::process::exit(2);
+        });
     eprintln!("mtp-head kv-mode: {kv_mode:?}");
-    let mut state = MtpSpecState::new_for_slot_with_kv_mode(&mut gpu, &target, &head, max_n, kv_mode)
-        .expect("alloc MtpSpecState");
+    let mut state =
+        MtpSpecState::new_for_slot_with_kv_mode(&mut gpu, &target, &head, max_n, kv_mode)
+            .expect("alloc MtpSpecState");
     if p_min > 0.0 {
-        if !compressed_serial {
-            eprintln!("warning: --mtp-p-min only affects --compressed-serial path; ignored for the other two");
+        if !compressed_serial && !trunk_spine {
+            eprintln!("warning: --mtp-p-min only affects --compressed-serial/--trunk-spine path; ignored for the other two");
         }
         state.set_p_min(p_min);
-        eprintln!("mtp-p-min: {p_min} (early-exit chain at log P(argmax) < {:.4})", p_min.ln());
+        eprintln!(
+            "mtp-p-min: {p_min} (early-exit chain at log P(argmax) < {:.4})",
+            p_min.ln()
+        );
     }
     if temp > 0.0 {
         let cfg = hipfire_arch_qwen35::mtp_spec::MtpSamplingConfig {
@@ -261,22 +357,35 @@ fn main() {
     if compressed {
         match head.weights.compressed_vocab_size {
             Some(cvs) => {
-                state.mtp_scratch
+                state
+                    .mtp_scratch
                     .ensure_compressed_logits(&mut gpu, cvs)
                     .expect("alloc logits_compressed");
-                state.ensure_compressed_lm_logits(&mut gpu, cvs)
+                state
+                    .ensure_compressed_lm_logits(&mut gpu, cvs)
                     .expect("alloc mtp_lm_logits_compressed");
-                eprintln!("compressed: ON (cvs={cvs}, K={max_n}, mode=sidecar)");
+                if trunk_spine {
+                    eprintln!("trunk-spine: ON (sidecar draft lm_head, cvs={cvs}, K={max_n})");
+                } else {
+                    eprintln!("compressed: ON (cvs={cvs}, K={max_n}, mode=sidecar)");
+                }
             }
             None if compressed_serial => {
                 // Full-vocab discrete-token chain via trunk's lm_head.
                 // spec_step_mtp_compressed_serial dispatches against
                 // trunk_weights.output and writes into state.mtp_lm_logits.
-                eprintln!(
-                    "compressed: ON (mode=full-vocab, K={max_n}, vocab={}) — \
-                     trunk lm_head used per-step",
-                    target.config.vocab_size
-                );
+                if trunk_spine {
+                    eprintln!(
+                        "trunk-spine: ON (full-vocab draft lm_head, K={max_n}, vocab={})",
+                        target.config.vocab_size
+                    );
+                } else {
+                    eprintln!(
+                        "compressed: ON (mode=full-vocab, K={max_n}, vocab={}) — \
+                         trunk lm_head used per-step",
+                        target.config.vocab_size
+                    );
+                }
             }
             None => {
                 eprintln!(
@@ -303,43 +412,86 @@ fn main() {
     // on 232-token canonical prompt at 36 tok/s). Batched path runs the
     // same 232 tokens at ~540 tok/s (~0.43s), reclaiming ~6s of bench
     // wall time per run.
-    eprintln!("prefilling {} tokens (batched)...", prompt_tokens.len());
+    if trunk_spine {
+        eprintln!(
+            "prefilling {} tokens (batched trunk + MTP cache fill)...",
+            prompt_tokens.len()
+        );
+    } else {
+        eprintln!("prefilling {} tokens (batched)...", prompt_tokens.len());
+    }
     let t_prefill = Instant::now();
-    hipfire_arch_qwen35::qwen35::forward_prefill_batch(
-        &mut gpu,
-        &target.weights,
-        &target.config,
-        &prompt_tokens,
-        0,
-        &mut target.kv_cache,
-        &mut target.dn_state,
-        &target.scratch,
-        None,  // hidden_rb (not needed — MTP demo doesn't use ring buffer)
-        None,  // per_token_hidden_out (not needed for MTP seed)
-        None,  // gdn_tape
-        None,  // tree_verify
-    ).expect("prefill forward_prefill_batch");
+    let mut trunk_prefill_secs: Option<f64> = None;
+    let mut mtp_prompt_fill_secs: Option<f64> = None;
+    if trunk_spine {
+        let timings = mtp_spec::prefill_trunk_and_mtp_cache(
+            &mut gpu,
+            &mut target,
+            &head,
+            &mut state,
+            &prompt_tokens,
+            0,
+        )
+        .expect("prefill trunk + mtp cache");
+        trunk_prefill_secs = Some(timings.trunk_prefill_secs);
+        mtp_prompt_fill_secs = Some(timings.mtp_prompt_fill_secs);
+    } else {
+        hipfire_arch_qwen35::qwen35::forward_prefill_batch(
+            &mut gpu,
+            &target.weights,
+            &target.config,
+            &prompt_tokens,
+            0,
+            &mut target.kv_cache,
+            &mut target.dn_state,
+            &target.scratch,
+            None, // hidden_rb (not needed — MTP demo doesn't use ring buffer)
+            None, // per_token_hidden_out (not needed for MTP seed)
+            None, // gdn_tape
+            None, // tree_verify
+        )
+        .expect("prefill forward_prefill_batch");
+    }
     let prefill_secs = t_prefill.elapsed().as_secs_f64();
     let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
     eprintln!("prefill: {:.2}s ({:.1} tok/s)", prefill_secs, prefill_tok_s);
+    if let (Some(trunk_secs), Some(mtp_secs)) = (trunk_prefill_secs, mtp_prompt_fill_secs) {
+        let trunk_tok_s = prompt_tokens.len() as f64 / trunk_secs.max(1e-9);
+        eprintln!(
+            "prefill split: trunk={:.3}s ({:.1} tok/s) mtp_prompt_fill={:.3}s total={:.3}s",
+            trunk_secs, trunk_tok_s, mtp_secs, prefill_secs
+        );
+    }
 
     // Snapshot trunk's prev_hidden (post-output-norm at last prefill position).
-    state.capture_prev_hidden_from_scratch_tmp(
-        &gpu, &target.scratch.tmp, target.config.dim,
-    ).expect("capture prev_hidden");
+    if !trunk_spine {
+        state
+            .capture_prev_hidden_from_scratch_tmp(&gpu, &target.scratch.tmp, target.config.dim)
+            .expect("capture prev_hidden");
+    }
 
     // Pick the seed_token: argmax of the trunk's logits for the last prefill
     // position. This becomes cycle 0's `last_committed`.
-    let logits0 = gpu.download_f32(&target.scratch.logits)
+    let logits0 = gpu
+        .download_f32(&target.scratch.logits)
         .expect("download seed logits");
     let mut seed_token = 0u32;
     let mut best = f32::NEG_INFINITY;
     for (i, &v) in logits0.iter().enumerate() {
-        if v > best { best = v; seed_token = i as u32; }
+        if v > best {
+            best = v;
+            seed_token = i as u32;
+        }
     }
-    eprintln!("seed token (greedy after prefill): {} ('{}')",
-              seed_token,
-              tokenizer.decode(&[seed_token]).chars().take(16).collect::<String>());
+    eprintln!(
+        "seed token (greedy after prefill): {} ('{}')",
+        seed_token,
+        tokenizer
+            .decode(&[seed_token])
+            .chars()
+            .take(16)
+            .collect::<String>()
+    );
 
     // ── Spec-decode loop ───────────────────────────────────────────────
     //
@@ -355,11 +507,11 @@ fn main() {
     let mut cur_pos = prompt_tokens.len();
 
     let mut cycles = 0usize;
-    let mut accepted_total = 0usize;  // sum of accept_count across cycles
-    let mut bonus_total = 0usize;     // sum of "bonus committed" across cycles
-    let mut truncated_cycles = 0usize;  // cycles where p_min fired early-exit
-    let mut drafts_generated_total = 0usize;  // sum of drafts_generated across cycles
-    let mut replay_skipped_cycles = 0usize;  // full-accept cycles that skipped replay
+    let mut accepted_total = 0usize; // sum of accept_count across cycles
+    let mut bonus_total = 0usize; // sum of "bonus committed" across cycles
+    let mut truncated_cycles = 0usize; // cycles where p_min fired early-exit
+    let mut drafts_generated_total = 0usize; // sum of drafts_generated across cycles
+    let mut replay_skipped_cycles = 0usize; // full-accept cycles that skipped replay
 
     // HIPFIRE_PROFILE=1 + HIPFIRE_PROFILE_CYCLES=N: per-kernel profiling
     // armed after cycle 1 (post-JIT warmup), drained after N more cycles.
@@ -381,28 +533,61 @@ fn main() {
             eprintln!("hit max_seq {}; stopping", max_seq_total);
             break;
         }
-        let result = if compressed_serial {
+        let result = if trunk_spine {
+            mtp_spec::spec_step_mtp_trunk_spine(
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp_trunk_spine")
+        } else if compressed_serial {
             mtp_spec::spec_step_mtp_compressed_serial(
-                &mut gpu, &mut target, &head, &mut state,
-                cur_pos, last_committed, eos_token,
-            ).expect("spec_step_mtp_compressed_serial")
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp_compressed_serial")
         } else if compressed {
             mtp_spec::spec_step_mtp_compressed(
-                &mut gpu, &mut target, &head, &mut state,
-                cur_pos, last_committed, eos_token,
-            ).expect("spec_step_mtp_compressed")
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp_compressed")
         } else {
             mtp_spec::spec_step_mtp(
-                &mut gpu, &mut target, &head, &mut state,
-                cur_pos, last_committed, eos_token,
-            ).expect("spec_step_mtp")
+                &mut gpu,
+                &mut target,
+                &head,
+                &mut state,
+                cur_pos,
+                last_committed,
+                eos_token,
+            )
+            .expect("spec_step_mtp")
         };
 
         cycles += 1;
         accepted_total += result.accept_count;
         drafts_generated_total += result.drafts_generated;
-        if result.chain_truncated { truncated_cycles += 1; }
-        if result.replay_skipped { replay_skipped_cycles += 1; }
+        if result.chain_truncated {
+            truncated_cycles += 1;
+        }
+        if result.replay_skipped {
+            replay_skipped_cycles += 1;
+        }
 
         // Arm per-kernel profiler after cycle 1 (post-JIT warmup), drain after
         // profile_cycles_target additional cycles. Print kernel breakdown.
@@ -410,9 +595,7 @@ fn main() {
             rdna_compute::profile::start();
             profile_armed = true;
         }
-        if do_profile && profile_armed && !profile_done
-            && cycles >= 1 + profile_cycles_target
-        {
+        if do_profile && profile_armed && !profile_done && cycles >= 1 + profile_cycles_target {
             profile_done = true;
             if let Some(entries) = rdna_compute::profile::stop() {
                 use std::collections::HashMap;
@@ -425,11 +608,13 @@ fn main() {
                     ent.2 += e.bytes;
                 }
                 let mut kerns: Vec<_> = by_kernel.into_iter().collect();
-                kerns.sort_by(|a, b| b.1.0.partial_cmp(&a.1.0).unwrap());
+                kerns.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap());
                 let total_us: f64 = kerns.iter().map(|(_, (t, _, _))| t).sum();
                 eprintln!(
                     "\n=== PROFILE: {} kernel calls over {} cycles, {:.1}ms total kernel time ===",
-                    entries.len(), measured, total_us / 1000.0,
+                    entries.len(),
+                    measured,
+                    total_us / 1000.0,
                 );
                 eprintln!(
                     "  per-cycle kernel total: {:.2} ms",
@@ -440,7 +625,9 @@ fn main() {
                     "kernel", "calls", "total_ms", "us/call", "%", "MB",
                 );
                 for (kern, (us, n, bytes)) in &kerns {
-                    if *us / total_us < 0.005 { continue; }
+                    if *us / total_us < 0.005 {
+                        continue;
+                    }
                     eprintln!(
                         "  {kern:50} {n:>6} {:>10.2} {:>10.0} {:>6.1}% {:>10.1}",
                         us / 1000.0,
@@ -452,8 +639,9 @@ fn main() {
                 eprintln!("=== /PROFILE ===\n");
             }
         }
-        if !result.hit_eos || (result.committed.last().copied() != Some(eos_token)
-                               && result.accept_count < max_n) {
+        if !result.hit_eos
+            || (result.committed.last().copied() != Some(eos_token) && result.accept_count < max_n)
+        {
             // bonus committed unless we EOS-broke inside the chain. Counts
             // the explicit bonus argmax slot.
             bonus_total += 1;
@@ -509,8 +697,14 @@ fn main() {
         let truncated_pct = 100.0 * truncated_cycles as f64 / cycles.max(1) as f64;
         let avg_drafts = drafts_generated_total as f64 / cycles.max(1) as f64;
         println!("p_min:                {}", p_min);
-        println!("chain_truncated:      {} cycles ({:.1}%)", truncated_cycles, truncated_pct);
-        println!("avg_drafts_per_cycle: {:.3} (of max_n={})", avg_drafts, max_n);
+        println!(
+            "chain_truncated:      {} cycles ({:.1}%)",
+            truncated_cycles, truncated_pct
+        );
+        println!(
+            "avg_drafts_per_cycle: {:.3} (of max_n={})",
+            avg_drafts, max_n
+        );
     }
     println!("committed_total:      {}", total_committed);
     println!("committed_seed:       1");
@@ -520,6 +714,12 @@ fn main() {
     println!("tau:                  {:.4}", tau);
     println!("prefill_secs:         {:.3}", prefill_secs);
     println!("prefill_tok_s:        {:.2}", prefill_tok_s);
+    if let (Some(trunk_secs), Some(mtp_secs)) = (trunk_prefill_secs, mtp_prompt_fill_secs) {
+        let trunk_tok_s = prompt_tokens.len() as f64 / trunk_secs.max(1e-9);
+        println!("trunk_prefill_secs:   {:.3}", trunk_secs);
+        println!("trunk_prefill_tok_s:  {:.2}", trunk_tok_s);
+        println!("mtp_prompt_fill_secs: {:.3}", mtp_secs);
+    }
     println!("decode_secs:          {:.3}", decode_secs);
     println!("tok_s:                {:.2}", tok_per_s);
     println!("eos_hit:              {}", if hit_eos { "y" } else { "n" });

--- a/crates/hipfire-runtime/examples/test_q8kv.rs
+++ b/crates/hipfire-runtime/examples/test_q8kv.rs
@@ -211,6 +211,145 @@ fn main() {
     } else {
         eprintln!("FAIL: 8B dimensions wrong (got {:.4})", out8[0]);
     }
+
+    // Test 5: Flash (tile+reduce online-softmax) vs baseline single-workgroup
+    // parity. The flash path (attention_flash_q8_0) is what minimax uses for
+    // its native context window — its LDS is O(tile+head_dim), independent of
+    // seq_len, where the baseline materializes scores[seq_len] in LDS and caps
+    // at ~16K on gfx11/gfx12. Both compute the same math (different FP
+    // reduction order), so we require cosine ≥ 0.9999 / small max-abs-err at
+    // sizes where the baseline can still run, then prove flash runs (finite,
+    // sane) at a size the baseline cannot.
+    eprintln!("\n=== Flash vs baseline parity (GQA, head_dim=128) ===");
+    let n_h5 = 8usize;
+    let n_kv5 = 2usize;
+    let hd5 = 128usize;
+    let kv_dim5 = n_kv5 * hd5;
+    let tb5 = n_kv5 * (hd5 / 32); // blocks per position
+    let mut seed: u32 = 0x1234_5678;
+    let mut next = || {
+        seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        ((seed >> 9) as f32 / 8_388_608.0) - 1.0 // ~[-1, 1)
+    };
+    let to_bytes = |v: &[f32]| -> Vec<u8> {
+        unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4).to_vec() }
+    };
+
+    let mut all_pass = true;
+    for &seq in &[4usize, 64, 512, 2048] {
+        let physical_cap = seq;
+        let cb = physical_cap * tb5 * 34;
+        let ce = (cb + 3) / 4;
+        let d_kc = gpu.zeros(&[ce], rdna_compute::DType::F32).unwrap();
+        let d_vc = gpu.zeros(&[ce], rdna_compute::DType::F32).unwrap();
+        // Reuse one upload buffer per kind; overwrite per position.
+        let dk = gpu.zeros(&[kv_dim5], rdna_compute::DType::F32).unwrap();
+        let dv = gpu.zeros(&[kv_dim5], rdna_compute::DType::F32).unwrap();
+        for p in 0..seq {
+            let kbuf: Vec<f32> = (0..kv_dim5).map(|_| next()).collect();
+            let vbuf: Vec<f32> = (0..kv_dim5).map(|_| next()).collect();
+            gpu.hip.memcpy_htod(&dk.buf, &to_bytes(&kbuf)).unwrap();
+            gpu.hip.memcpy_htod(&dv.buf, &to_bytes(&vbuf)).unwrap();
+            gpu.hip.memcpy_htod(&pos_buf, &(p as i32).to_ne_bytes()).unwrap();
+            gpu.kv_cache_write_q8_0(&d_kc, &dk, &pos_buf, n_kv5, hd5).unwrap();
+            gpu.kv_cache_write_q8_0(&d_vc, &dv, &pos_buf, n_kv5, hd5).unwrap();
+        }
+        let qbuf: Vec<f32> = (0..n_h5 * hd5).map(|_| next()).collect();
+        let dq = gpu.upload_f32(&qbuf, &[n_h5 * hd5]).unwrap();
+        let out_base = gpu.zeros(&[n_h5 * hd5], rdna_compute::DType::F32).unwrap();
+        let out_flash = gpu.zeros(&[n_h5 * hd5], rdna_compute::DType::F32).unwrap();
+        let max_tiles = (physical_cap + 127) / 128;
+        let partials = gpu
+            .zeros(&[n_h5 * max_tiles * (2 + hd5)], rdna_compute::DType::F32)
+            .unwrap();
+        gpu.hip.memcpy_htod(&pos_buf, &((seq - 1) as i32).to_ne_bytes()).unwrap();
+        gpu.attention_q8_0_kv(
+            &dq, &d_kc, &d_vc, &out_base, &pos_buf, seq, n_h5, n_kv5, hd5, physical_cap,
+        )
+        .unwrap();
+        gpu.attention_flash_q8_0(
+            &dq, &d_kc, &d_vc, &out_flash, &pos_buf, seq, n_h5, n_kv5, hd5, physical_cap,
+            &partials,
+        )
+        .unwrap();
+        gpu.hip.device_synchronize().unwrap();
+        let a = gpu.download_f32(&out_base).unwrap();
+        let b = gpu.download_f32(&out_flash).unwrap();
+        let mut dot = 0.0f64;
+        let mut na = 0.0f64;
+        let mut nb = 0.0f64;
+        let mut maxerr = 0.0f32;
+        for i in 0..a.len() {
+            dot += a[i] as f64 * b[i] as f64;
+            na += (a[i] as f64).powi(2);
+            nb += (b[i] as f64).powi(2);
+            maxerr = maxerr.max((a[i] - b[i]).abs());
+        }
+        let cosine = dot / (na.sqrt() * nb.sqrt() + 1e-12);
+        let pass = cosine > 0.9999 && maxerr < 1e-2 && !b.iter().any(|x| x.is_nan());
+        eprintln!(
+            "  seq={seq:>5}: cosine={cosine:.6} max_abs_err={maxerr:.2e} -> {}",
+            if pass { "PASS" } else { "FAIL" }
+        );
+        all_pass &= pass;
+    }
+
+    // Large-context flash-only: a size the baseline single-workgroup kernel
+    // cannot serve (scores[seq]*4 + ... > 64 KB LDS). All K/V positions get
+    // an identical random vector, so softmax is uniform and the output must
+    // equal that V vector (mean of identical values). Proves flash runs and
+    // is numerically sane far beyond the 16K LDS wall.
+    eprintln!("\n=== Flash-only at >16K (baseline cannot run here) ===");
+    let big_seq = 20000usize;
+    let cbB = big_seq * tb5 * 34;
+    let ceB = (cbB + 3) / 4;
+    let d_kcB = gpu.zeros(&[ceB], rdna_compute::DType::F32).unwrap();
+    let d_vcB = gpu.zeros(&[ceB], rdna_compute::DType::F32).unwrap();
+    let kfix: Vec<f32> = (0..kv_dim5).map(|_| next()).collect();
+    let vfix: Vec<f32> = (0..kv_dim5).map(|_| next()).collect();
+    let dkB = gpu.upload_f32(&kfix, &[kv_dim5]).unwrap();
+    let dvB = gpu.upload_f32(&vfix, &[kv_dim5]).unwrap();
+    for p in 0..big_seq {
+        gpu.hip.memcpy_htod(&pos_buf, &(p as i32).to_ne_bytes()).unwrap();
+        gpu.kv_cache_write_q8_0(&d_kcB, &dkB, &pos_buf, n_kv5, hd5).unwrap();
+        gpu.kv_cache_write_q8_0(&d_vcB, &dvB, &pos_buf, n_kv5, hd5).unwrap();
+    }
+    let qB: Vec<f32> = (0..n_h5 * hd5).map(|_| next()).collect();
+    let dqB = gpu.upload_f32(&qB, &[n_h5 * hd5]).unwrap();
+    let outB = gpu.zeros(&[n_h5 * hd5], rdna_compute::DType::F32).unwrap();
+    let max_tilesB = (big_seq + 127) / 128;
+    let partialsB = gpu
+        .zeros(&[n_h5 * max_tilesB * (2 + hd5)], rdna_compute::DType::F32)
+        .unwrap();
+    gpu.hip.memcpy_htod(&pos_buf, &((big_seq - 1) as i32).to_ne_bytes()).unwrap();
+    gpu.attention_flash_q8_0(
+        &dqB, &d_kcB, &d_vcB, &outB, &pos_buf, big_seq, n_h5, n_kv5, hd5, big_seq, &partialsB,
+    )
+    .unwrap();
+    gpu.hip.device_synchronize().unwrap();
+    let ob = gpu.download_f32(&outB).unwrap();
+    // Expected: uniform attention over identical V → out[d] ≈ vfix dequantized.
+    // Compare head 0's first 32 dims against the V block-0 dequant of vfix.
+    let finite = !ob.iter().any(|x| x.is_nan() || x.is_infinite());
+    let mut maxerr_big = 0.0f32;
+    for d in 0..hd5 {
+        maxerr_big = maxerr_big.max((ob[d] - vfix[d]).abs());
+    }
+    let big_pass = finite && maxerr_big < 0.05;
+    eprintln!(
+        "  seq={big_seq}: head0[0..4]={:?} max|out-V|={:.3e} finite={finite} -> {}",
+        &ob[..4],
+        maxerr_big,
+        if big_pass { "PASS" } else { "FAIL" }
+    );
+    all_pass &= big_pass;
+
+    if all_pass {
+        eprintln!("\nPASS: flash parity + large-context flash all correct");
+    } else {
+        eprintln!("\nFAIL: flash parity/large-context check failed");
+        std::process::exit(1);
+    }
 }
 
 fn f16_to_f32(bits: u16) -> f32 {

--- a/crates/hipfire-runtime/examples/test_wmma_residual_gfx12.rs
+++ b/crates/hipfire-runtime/examples/test_wmma_residual_gfx12.rs
@@ -70,11 +70,22 @@ fn main() {
         match run_one(&mut gpu, m, k, n) {
             Ok(()) => {
                 total_pass += 1;
-                eprintln!("  {label:50} OK");
+                eprintln!("  residual {label:41} OK");
             }
             Err(e) => {
                 total_fail += 1;
-                eprintln!("  {label:50} FAIL");
+                eprintln!("  residual {label:41} FAIL");
+                eprintln!("{e}");
+            }
+        }
+        match run_one_lmhead(&mut gpu, m, k, n) {
+            Ok(()) => {
+                total_pass += 1;
+                eprintln!("  lmhead   {label:41} OK");
+            }
+            Err(e) => {
+                total_fail += 1;
+                eprintln!("  lmhead   {label:41} FAIL");
                 eprintln!("{e}");
             }
         }
@@ -85,6 +96,62 @@ fn main() {
     eprintln!("  Failed: {total_fail}");
     if total_fail > 0 {
         std::process::exit(1);
+    }
+}
+
+fn run_one_lmhead(gpu: &mut Gpu, m: usize, k: usize, n: usize) -> Result<(), String> {
+    assert_eq!(m % 16, 0);
+    assert_eq!(k % 256, 0, "K must be multiple of 256 (HFQ4G256 group size)");
+    assert_eq!(n % 16, 0, "N must be multiple of 16 (WMMA batch tile)");
+
+    let a_bytes = build_hfq4g256(m, k, 0xB4);
+    let a = gpu
+        .upload_raw(&a_bytes, &[m, k])
+        .map_err(|e| format!("upload a: {e}"))?;
+
+    let x_f32: Vec<f32> = (0..(n * k))
+        .map(|i| {
+            let b = (i / k) as i32;
+            let kk = (i % k) as i32;
+            ((b * 5 + kk * 3) % 37 - 18) as f32 * 0.04
+        })
+        .collect();
+    let x = gpu
+        .upload_f32(&x_f32, &[n, k])
+        .map_err(|e| format!("upload x: {e}"))?;
+
+    let y_zero = vec![0.0f32; n * m];
+    let y_ref = gpu
+        .upload_f32(&y_zero, &[n, m])
+        .map_err(|e| format!("upload y_ref init: {e}"))?;
+    gpu.gemm_hfq4g256_residual_fp16(&a, &x, &y_ref, m, k, n)
+        .map_err(|e| format!("dot2-fp16 residual zero-init: {e}"))?;
+    let ref_y = gpu
+        .download_f32(&y_ref)
+        .map_err(|e| format!("download y_ref: {e}"))?;
+
+    let y_dirty: Vec<f32> = (0..(n * m))
+        .map(|i| ((i * 19) % 29) as f32 * 0.01 + 0.25)
+        .collect();
+    let y_cand = gpu
+        .upload_f32(&y_dirty, &[n, m])
+        .map_err(|e| format!("upload y_cand dirty init: {e}"))?;
+    gpu.gemm_hfq4g256_lmhead_wmma_gfx12(&a, &x, &y_cand, m, k, n)
+        .map_err(|e| format!("wmma_gfx12 lmhead: {e}"))?;
+    let cand_y = gpu
+        .download_f32(&y_cand)
+        .map_err(|e| format!("download y_cand: {e}"))?;
+
+    gpu.free_tensor(a).ok();
+    gpu.free_tensor(x).ok();
+    gpu.free_tensor(y_ref).ok();
+    gpu.free_tensor(y_cand).ok();
+
+    let mut report = String::new();
+    if compare("Y_lmhead", n, m, &cand_y, &ref_y, &mut report) {
+        Ok(())
+    } else {
+        Err(report)
     }
 }
 

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -28,8 +28,9 @@
 
 use crate::hfq::{load_awq_scale, HfqFile};
 use crate::llama::WeightTensor;
-use hip_bridge::HipResult;
+use hip_bridge::{Graph, GraphExec, HipResult};
 use rdna_compute::{DType, Gpu, GpuTensor};
+use std::collections::{HashMap, HashSet};
 
 /// Max rows per call into `gemm_dispatch` for the MQ4/MQ3 (FWHT-rotated)
 /// path. The activation rotation scratch (`DflashScratch.mq_x_rot`) is
@@ -417,6 +418,12 @@ pub struct DflashScratch {
     /// reset rebuilds the full prefix in one shot — same cost as a
     /// pre-cache cycle, but amortized thereafter.
     pub draft_ctx_cached_rows: usize,
+
+    /// Per-layer, per-B graph cache for the fixed-shape FFN tail inside
+    /// `draft_forward_opts`. The attention/context part depends on `ctx_len`;
+    /// this FFN subgraph does not, so it can replay across DFlash cycles.
+    pub draft_ffn_graphs: Vec<HashMap<usize, (Graph, GraphExec, Vec<Vec<u8>>)>>,
+    pub draft_ffn_warmed_up: Vec<HashSet<usize>>,
 }
 
 impl DflashScratch {
@@ -480,9 +487,13 @@ impl DflashScratch {
         // = 128 MB. Trivial vs 24 GB VRAM.
         let mut k_ctx_cached = Vec::with_capacity(cfg.n_layers);
         let mut v_ctx_cached = Vec::with_capacity(cfg.n_layers);
+        let mut draft_ffn_graphs = Vec::with_capacity(cfg.n_layers);
+        let mut draft_ffn_warmed_up = Vec::with_capacity(cfg.n_layers);
         for _ in 0..cfg.n_layers {
             k_ctx_cached.push(gpu.alloc_tensor(&[l * kvd], DType::F32)?);
             v_ctx_cached.push(gpu.alloc_tensor(&[l * kvd], DType::F32)?);
+            draft_ffn_graphs.push(HashMap::new());
+            draft_ffn_warmed_up.push(HashSet::new());
         }
 
         Ok(DflashScratch {
@@ -519,6 +530,8 @@ impl DflashScratch {
             k_ctx_cached,
             v_ctx_cached,
             draft_ctx_cached_rows: 0,
+            draft_ffn_graphs,
+            draft_ffn_warmed_up,
         })
     }
 
@@ -546,6 +559,12 @@ impl DflashScratch {
     }
 
     pub fn free_gpu(self, gpu: &mut Gpu) {
+        for per_layer in self.draft_ffn_graphs {
+            for (_, (graph, exec, _blobs)) in per_layer {
+                let _ = gpu.hip.graph_exec_destroy(exec);
+                let _ = gpu.hip.graph_destroy(graph);
+            }
+        }
         let _ = gpu.free_tensor(self.x);
         let _ = gpu.free_tensor(self.x_norm);
         let _ = gpu.free_tensor(self.q);
@@ -709,6 +728,118 @@ fn gemm_dispatch(
     result
 }
 
+fn begin_draft_ffn_graph_capture(gpu: &mut Gpu) -> HipResult<()> {
+    gpu.capture_blobs.clear();
+    gpu.capture_mode = true;
+    let stream = gpu
+        .active_stream
+        .as_ref()
+        .expect("draft FFN graph capture requires an explicit stream");
+    gpu.hip.stream_begin_capture(stream, 0)
+}
+
+fn end_draft_ffn_graph_capture(
+    gpu: &mut Gpu,
+) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
+    gpu.capture_mode = false;
+    let stream = gpu.active_stream.as_ref().unwrap();
+    let graph = gpu.hip.stream_end_capture(stream)?;
+    let exec = gpu.hip.graph_instantiate(&graph)?;
+    let blobs = std::mem::take(&mut gpu.capture_blobs);
+    Ok((graph, exec, blobs))
+}
+
+fn abort_draft_ffn_graph_capture(gpu: &mut Gpu) {
+    if gpu.capture_mode {
+        if let Some(stream) = gpu.active_stream.as_ref() {
+            let _ = gpu.hip.stream_end_capture(stream);
+        }
+        gpu.capture_mode = false;
+    }
+    gpu.capture_blobs.clear();
+}
+
+fn draft_ffn_layer(
+    gpu: &mut Gpu,
+    layer: &DflashLayerWeights,
+    scratch: &mut DflashScratch,
+    b: usize,
+    h: usize,
+    eps: f32,
+    graph_safe: bool,
+) -> HipResult<()> {
+    if graph_safe {
+        gpu.memcpy_dtod_auto(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+    } else {
+        gpu.hip.memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+    }
+
+    gpu.rmsnorm_batched(
+        &scratch.x,
+        &layer.ffn_norm,
+        &scratch.x_norm,
+        b,
+        h,
+        eps,
+    )?;
+    gemm_dispatch(gpu, &scratch.x_norm, &layer.w_gate, &scratch.gate, b, scratch.mq_x_rot.as_ref())?;
+    gemm_dispatch(gpu, &scratch.x_norm, &layer.w_up,   &scratch.up,   b, scratch.mq_x_rot.as_ref())?;
+    gpu.silu_mul_f32(&scratch.gate, &scratch.up, &scratch.gate_up)?;
+    gemm_dispatch(gpu, &scratch.gate_up, &layer.w_down, &scratch.x, b, scratch.mq_x_rot.as_ref())?;
+    if graph_safe {
+        gpu.add_f32_graph_safe(&scratch.residual_ffn, &scratch.x, &scratch.x)
+    } else {
+        gpu.add_f32(&scratch.residual_ffn, &scratch.x, &scratch.x)
+    }
+}
+
+fn draft_ffn_layer_maybe_graph(
+    gpu: &mut Gpu,
+    layer: &DflashLayerWeights,
+    scratch: &mut DflashScratch,
+    layer_idx: usize,
+    b: usize,
+    h: usize,
+    eps: f32,
+    use_graph: bool,
+) -> HipResult<()> {
+    if !use_graph {
+        return draft_ffn_layer(gpu, layer, scratch, b, h, eps, false);
+    }
+
+    if gpu.active_stream.is_none() {
+        gpu.active_stream = Some(gpu.hip.stream_create()?);
+    }
+
+    if scratch.draft_ffn_graphs[layer_idx].contains_key(&b) {
+        let stream = gpu.active_stream.as_ref().unwrap();
+        let entry = scratch.draft_ffn_graphs[layer_idx]
+            .get(&b)
+            .unwrap_or_else(|| panic!("missing draft FFN graph for layer={layer_idx} b={b}"));
+        return gpu.hip.graph_launch(&entry.1, stream);
+    }
+
+    if !scratch.draft_ffn_warmed_up[layer_idx].contains(&b) {
+        scratch.draft_ffn_warmed_up[layer_idx].insert(b);
+        return draft_ffn_layer(gpu, layer, scratch, b, h, eps, false);
+    }
+
+    begin_draft_ffn_graph_capture(gpu)?;
+    let r = draft_ffn_layer(gpu, layer, scratch, b, h, eps, true);
+    if r.is_ok() {
+        let entry = end_draft_ffn_graph_capture(gpu)?;
+        scratch.draft_ffn_graphs[layer_idx].insert(b, entry);
+        let stream = gpu.active_stream.as_ref().unwrap();
+        let entry = scratch.draft_ffn_graphs[layer_idx]
+            .get(&b)
+            .unwrap_or_else(|| panic!("missing captured draft FFN graph for layer={layer_idx} b={b}"));
+        gpu.hip.graph_launch(&entry.1, stream)
+    } else {
+        abort_draft_ffn_graph_capture(gpu);
+        r
+    }
+}
+
 /// Upload f32 slice into a GPU tensor (bytes via memcpy_htod).
 fn upload_slice_f32(gpu: &Gpu, dst: &GpuTensor, data: &[f32]) -> HipResult<()> {
     let bytes: &[u8] = unsafe {
@@ -766,6 +897,34 @@ pub fn draft_forward(
     block_size: usize,
     ctx_len: usize,
     scratch: &mut DflashScratch,
+) -> HipResult<()> {
+    draft_forward_opts(
+        gpu,
+        weights,
+        cfg,
+        noise_embedding,
+        target_hidden,
+        positions_q,
+        positions_k,
+        block_size,
+        ctx_len,
+        scratch,
+        false,
+    )
+}
+
+pub fn draft_forward_opts(
+    gpu: &mut Gpu,
+    weights: &DflashWeights,
+    cfg: &DflashConfig,
+    noise_embedding: Option<&[f32]>,
+    target_hidden: Option<&[f32]>,
+    positions_q: &[i32],
+    positions_k: &[i32],
+    block_size: usize,
+    ctx_len: usize,
+    scratch: &mut DflashScratch,
+    graph_ffn: bool,
 ) -> HipResult<()> {
     let b = block_size;
     let l = ctx_len;
@@ -1053,15 +1212,21 @@ pub fn draft_forward(
         // x = residual_attn + attn_proj
         gpu.add_f32(&scratch.residual_attn, &scratch.attn_proj, &scratch.x)?;
 
-        // Residual for FFN.
-        gpu.hip.memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
-
-        // ffn_norm.
-        gpu.rmsnorm_batched(&scratch.x, &layer.ffn_norm, &scratch.x_norm, b, h, eps)?;
-
-        // gate = x_norm @ w_gate^T; up = x_norm @ w_up^T
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.w_gate, &scratch.gate, b, scratch.mq_x_rot.as_ref())?;
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.w_up,   &scratch.up,   b, scratch.mq_x_rot.as_ref())?;
+        // Fixed-shape FFN tail. MoE DFlash can optionally capture this as a
+        // per-layer/per-B hipGraph; the attention/context work above is left
+        // direct because `ctx_len` changes every accepted cycle.
+        let graph_ffn_active =
+            graph_ffn && !dbg && !crate::config::get().draft_gemm_dump;
+        draft_ffn_layer_maybe_graph(
+            gpu,
+            layer,
+            scratch,
+            li,
+            b,
+            h,
+            eps,
+            graph_ffn_active,
+        )?;
         // 2026-04-21: tried target's fused gemm_gate_up_hfq4g256 here (shared
         // FP16-X convert + interleaved gate/up GEMMs). Byte-exact A/B neutral
         // on 27B HumanEval (median 76.47 fused vs 76.74 baseline; ±7 % run-to-
@@ -1069,15 +1234,6 @@ pub fn draft_forward(
         // Kept per-weight dispatch for clarity. The real draft perf lever is
         // the ~56 ms of ffn_gemm per cycle (see HIPFIRE_DRAFT_SUBPHASE=1);
         // fusion alone doesn't move that number — kernel engineering does.
-
-        // SiLU(gate) * up → gate_up
-        gpu.silu_mul_f32(&scratch.gate, &scratch.up, &scratch.gate_up)?;
-
-        // x = w_down @ gate_up^T  (output [B, hidden])
-        gemm_dispatch(gpu, &scratch.gate_up, &layer.w_down, &scratch.x, b, scratch.mq_x_rot.as_ref())?;
-
-        // x = residual_ffn + x
-        gpu.add_f32(&scratch.residual_ffn, &scratch.x, &scratch.x)?;
 
         if let Some(t) = t3 {
             gpu.hip.device_synchronize()?;

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -3858,9 +3858,23 @@ impl KvCache {
         gpu: &mut Gpu, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
         max_seq_len: usize,
     ) -> HipResult<Self> {
+        Self::new_gpu_fwht3_capped_filtered(
+            gpu, is_kv_layer, n_kv_heads, head_dim, max_seq_len, max_seq_len,
+        )
+    }
+
+    /// Capped + filtered fwht3 — layer-filtered (skips non-KV layers) with an
+    /// explicit `physical_cap` for TriAttention/CASK eviction. Default path has
+    /// `physical_cap == max_seq_len` (no eviction). Byte layout identical to
+    /// `asym3_capped_filtered`; rotation primitive is signed-FWHT-256.
+    pub fn new_gpu_fwht3_capped_filtered(
+        gpu: &mut Gpu, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
         assert!(head_dim == 256, "fwht3 currently requires head_dim=256 (Qwen 3.5)");
         assert!(head_dim % 32 == 0);
-        let physical_cap = max_seq_len;
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len,
+            "physical_cap ({physical_cap}) must be in (0, max_seq_len={max_seq_len}]");
         let kv_dim = n_kv_heads * head_dim;
         let k_bph = 4 + (head_dim * 3) / 8;
         let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
@@ -4000,9 +4014,22 @@ impl KvCache {
         gpu: &mut Gpu, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
         max_seq_len: usize,
     ) -> HipResult<Self> {
+        Self::new_gpu_fwht2_capped_filtered(
+            gpu, is_kv_layer, n_kv_heads, head_dim, max_seq_len, max_seq_len,
+        )
+    }
+
+    /// Capped + filtered fwht2 — layer-filtered with explicit `physical_cap`
+    /// for TriAttention/CASK eviction. Byte layout identical to
+    /// `asym2_capped`; rotation primitive is signed-FWHT-128.
+    pub fn new_gpu_fwht2_capped_filtered(
+        gpu: &mut Gpu, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
         assert!(head_dim == 128 || head_dim == 256, "fwht2 requires head_dim=128 or 256");
         assert!(head_dim % 32 == 0);
-        let physical_cap = max_seq_len;
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len,
+            "physical_cap ({physical_cap}) must be in (0, max_seq_len={max_seq_len}]");
         let kv_dim = n_kv_heads * head_dim;
         let k_bph = 4 + head_dim / 4;
         let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
@@ -4520,6 +4547,124 @@ impl KvCache {
             layer_is_boundary: vec![], compact_offset: 0,
         })
     }
+
+    // ── Filtered multi-GPU ctors: skip KV alloc on non-FullAttention layers
+    // of the hybrid Qwen3.5/3.6 stack (1-elem placeholder keeps absolute layer
+    // indexing valid). Mirror the *_capped_multi ctors above byte-for-byte
+    // except they take an `is_kv_layer` mask and use the filtered allocator. ──
+    pub fn new_gpu_q8_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let total_blocks = n_kv_heads * (head_dim / 32);
+        let cache_elems = (physical_cap * total_blocks * 34 + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, cache_elems, cache_elems)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: true, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: false, quant_fwht: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_asym4_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 128 || head_dim == 256, "asym4 requires head_dim=128 or 256");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + head_dim / 2;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_bpp = n_kv_heads * (head_dim / 32) * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, k_elems, v_elems)?;
+        replicate_givens_to_all_devices(gpus, head_dim / 2, 42)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: true, quant_asym3: false, quant_asym2: false, quant_fwht: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_asym3_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 256, "asym3 currently requires head_dim=256 (Qwen 3.5)");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + (head_dim * 3) / 8;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_bpp = n_kv_heads * (head_dim / 32) * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, k_elems, v_elems)?;
+        replicate_givens_to_all_devices(gpus, head_dim / 2, 42)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: true, quant_asym2: false, quant_fwht: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_asym2_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 128 || head_dim == 256, "asym2 requires head_dim=128 or 256");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + head_dim / 4;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_bpp = n_kv_heads * (head_dim / 32) * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, k_elems, v_elems)?;
+        replicate_givens_to_all_devices(gpus, head_dim / 2, 42)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: true, quant_fwht: false, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_fwht4_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 128 || head_dim == 256, "fwht4 requires head_dim=128 or 256");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + head_dim / 2;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_bpp = n_kv_heads * (head_dim / 32) * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, k_elems, v_elems)?;
+        replicate_fwht_signs_to_all_devices(gpus, 128)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: true, quant_asym3: false, quant_asym2: false, quant_fwht: true, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_fwht3_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 256, "fwht3 currently requires head_dim=256 (Qwen 3.5)");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + (head_dim * 3) / 8;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_bpp = n_kv_heads * (head_dim / 32) * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, k_elems, v_elems)?;
+        replicate_fwht_signs_to_all_devices(gpus, 256)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: true, quant_asym2: false, quant_fwht: true, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
+
+    pub fn new_gpu_fwht2_capped_multi_filtered(
+        gpus: &mut Gpus, is_kv_layer: &[bool], n_kv_heads: usize, head_dim: usize,
+        max_seq_len: usize, physical_cap: usize,
+    ) -> HipResult<Self> {
+        assert!(head_dim == 128 || head_dim == 256, "fwht2 requires head_dim=128 or 256");
+        assert!(head_dim % 32 == 0);
+        assert!(physical_cap > 0 && physical_cap <= max_seq_len);
+        let kv_dim = n_kv_heads * head_dim;
+        let k_bph = 4 + head_dim / 4;
+        let k_elems = (physical_cap * n_kv_heads * k_bph + 3) / 4;
+        let v_bpp = n_kv_heads * (head_dim / 32) * 34;
+        let v_elems = (physical_cap * v_bpp + 3) / 4;
+        let (k_gpu, v_gpu) = alloc_kv_per_layer_multi_filtered(gpus, is_kv_layer, k_elems, v_elems)?;
+        replicate_fwht_signs_to_all_devices(gpus, 128)?;
+        Ok(Self { k_gpu, v_gpu, k_scales: vec![], v_scales: vec![], kv_dim, max_seq: max_seq_len, physical_cap, n_kv_heads, head_dim, quantized: true, quant_q8: false, quant_int8: false, quant_hfq4: false, quant_asym4: false, quant_asym3: false, quant_asym2: true, quant_fwht: true, boundary_layers: 0, givens_cos: None, givens_sin: None, layer_is_boundary: vec![], compact_offset: 0 })
+    }
 }
 
 // ── Stage 5 helpers: per-device KV alloc + givens replication ────────
@@ -4537,6 +4682,34 @@ fn alloc_kv_per_layer_multi(
         let g = &mut gpus.devices[dev_idx];
         k_gpu.push(g.zeros(&[k_elems], DType::F32)?);
         v_gpu.push(g.zeros(&[v_elems], DType::F32)?);
+    }
+    Ok((k_gpu, v_gpu))
+}
+
+/// Filtered variant of [`alloc_kv_per_layer_multi`]: allocates a full KV slot
+/// only for layers where `is_kv_layer[i]` (the FullAttention layers of a hybrid
+/// Qwen3.5/3.6 stack), and a 1-element placeholder on the layer's assigned
+/// device otherwise. Placeholders are never read/written; absolute per-layer
+/// indexing (`k_gpu[layer_idx]`) and `device_for_layer` assignment stay valid.
+fn alloc_kv_per_layer_multi_filtered(
+    gpus: &mut Gpus,
+    is_kv_layer: &[bool],
+    k_elems: usize,
+    v_elems: usize,
+) -> HipResult<(Vec<GpuTensor>, Vec<GpuTensor>)> {
+    let n_layers = is_kv_layer.len();
+    let mut k_gpu = Vec::with_capacity(n_layers);
+    let mut v_gpu = Vec::with_capacity(n_layers);
+    for i in 0..n_layers {
+        let dev_idx = gpus.device_for_layer(i);
+        let g = &mut gpus.devices[dev_idx];
+        if is_kv_layer[i] {
+            k_gpu.push(g.zeros(&[k_elems], DType::F32)?);
+            v_gpu.push(g.zeros(&[v_elems], DType::F32)?);
+        } else {
+            k_gpu.push(g.zeros(&[1], DType::F32)?);
+            v_gpu.push(g.zeros(&[1], DType::F32)?);
+        }
     }
     Ok((k_gpu, v_gpu))
 }

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -388,6 +388,21 @@ pub struct ToolCall {
     pub arguments: serde_json::Value,
 }
 
+/// Remove HF `{% generation %}` / `{% endgeneration %}` tags (with optional
+/// whitespace-control dashes and the line they sit on) from a chat template.
+/// These mark the assistant-token span for training-data masking and emit
+/// nothing, so dropping the markers keeps inference rendering byte-identical —
+/// while letting minijinja (which has no `generation` block tag) parse the
+/// template instead of erroring. No-op for templates without them.
+fn strip_generation_tags(template: &str) -> String {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"[ \t]*\{%-?\s*(?:end)?generation\s*-?%\}\n?").unwrap()
+    });
+    re.replace_all(template, "").into_owned()
+}
+
 impl<'a> JinjaChatFrame<'a> {
     /// Render the template and tokenize the result. Returns `Err` on
     /// any template-side failure so the caller can fall back to
@@ -466,7 +481,16 @@ impl<'a> JinjaChatFrame<'a> {
             Err(Error::new(ErrorKind::InvalidOperation, msg))
         });
 
-        env.add_template("chat", self.template)
+        // Strip HF `{% generation %}` / `{% endgeneration %}` training-mask
+        // tags (and their whitespace-control `{%- … -%}` variants). minijinja
+        // has no `generation` block tag, so a template that uses them (e.g.
+        // LFM2.5) fails to parse and the caller silently falls back to Plain
+        // framing. These tags only delimit the assistant-token span for
+        // training-data masking — they emit nothing — so removing the markers
+        // (including their own line) leaves the rendered output byte-identical
+        // for inference. No-op for templates that don't use them (Qwen/MiniMax).
+        let sanitized = strip_generation_tags(self.template);
+        env.add_template_owned("chat", sanitized)
             .map_err(|e| format!("template parse: {e}"))?;
         let tmpl = env.get_template("chat")
             .map_err(|e| format!("template lookup: {e}"))?;
@@ -676,6 +700,49 @@ mod tests {
         expected.extend_from_slice(&t.encode("assistant"));
         expected.extend_from_slice(&t.encode("\n"));
         assert_eq!(got, expected, "Plain assistant prefix layout mismatch");
+    }
+
+    #[test]
+    fn strip_generation_tags_removes_markers_keeps_body() {
+        // HF training-mask tags (and their whitespace-control variants) are
+        // dropped; the body between them and everything else is untouched.
+        let tpl = "a\n{%- generation -%}\nBODY\n{%- endgeneration -%}\nb\n{% generation %}X{% endgeneration %}c";
+        let got = strip_generation_tags(tpl);
+        assert!(!got.contains("generation"), "tags not stripped: {got:?}");
+        assert!(got.contains("BODY"), "inner body dropped: {got:?}");
+        assert!(got.contains('X') && got.contains('c'), "non-dashed body dropped: {got:?}");
+        // A template with no generation tags is returned unchanged.
+        let plain = "{{ bos_token }}{%- for m in messages -%}{{ m.role }}{%- endfor -%}";
+        assert_eq!(strip_generation_tags(plain), plain);
+    }
+
+    #[test]
+    fn jinja_render_tolerates_generation_tags() {
+        // A minimal template that uses `{% generation %}` around the assistant
+        // body — minijinja has no such tag, so without the strip this fails to
+        // parse. With the strip it renders the assistant body normally.
+        let t = make_tokenizer();
+        let template = "{%- for message in messages -%}\
+            {{- '<|im_start|>' + message.role + '\\n' -}}\
+            {%- if message.role == 'assistant' -%}{%- generation -%}{{- message.content -}}{%- endgeneration -%}\
+            {%- else -%}{{- message.content -}}{%- endif -%}\
+            {{- '<|im_end|>\\n' -}}\
+            {%- endfor -%}";
+        let frame = JinjaChatFrame {
+            tokenizer: &t,
+            template,
+            system: None,
+            user: "hi",
+            enable_thinking: false,
+            bos_token: Some("<|im_start|>"),
+        };
+        let msgs = vec![
+            Message { role: Role::User, content: "hi".into(), tool_calls: vec![], tool_call_id: None },
+            Message { role: Role::Assistant, content: "yo".into(), tool_calls: vec![], tool_call_id: None },
+        ];
+        let rendered = frame.render_messages(&msgs, None, None)
+            .expect("template with generation tags must render after strip");
+        assert_eq!(rendered, "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\nyo<|im_end|>\n");
     }
 
     #[test]

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -480,6 +480,22 @@ impl<'a> JinjaChatFrame<'a> {
         env.add_function("raise_exception", |msg: String| -> Result<Value, Error> {
             Err(Error::new(ErrorKind::InvalidOperation, msg))
         });
+        // Some HF templates call `tojson(ensure_ascii=False)` (MiniMax-M2's tool
+        // block) or `tojson(indent=…)`. minijinja's builtin `tojson` rejects
+        // unknown kwargs, so the whole template fails to render and we silently
+        // fall back to the Plain frame — the model then never sees its native
+        // tool format (observed e2e on MiniMax-M2: template render failed on
+        // `ensure_ascii`, Plain fallback, model emitted a Qwen-ish `<tool_call>`
+        // instead of `<minimax:tool_call>`). Override `tojson` with a serde_json
+        // serializer that accepts + ignores those kwargs; serde_json emits raw
+        // UTF-8 (== ensure_ascii=False), which is what chat templates want.
+        env.add_filter("tojson", |value: Value, kwargs: minijinja::value::Kwargs| -> Result<Value, Error> {
+            let _ = kwargs.get::<Option<bool>>("ensure_ascii");
+            let _ = kwargs.get::<Option<i64>>("indent");
+            let s = serde_json::to_string(&value)
+                .map_err(|e| Error::new(ErrorKind::InvalidOperation, format!("tojson: {e}")))?;
+            Ok(Value::from_safe_string(s))
+        });
 
         // Strip HF `{% generation %}` / `{% endgeneration %}` training-mask
         // tags (and their whitespace-control `{%- … -%}` variants). minijinja
@@ -743,6 +759,29 @@ mod tests {
         let rendered = frame.render_messages(&msgs, None, None)
             .expect("template with generation tags must render after strip");
         assert_eq!(rendered, "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\nyo<|im_end|>\n");
+    }
+
+    #[test]
+    fn jinja_tojson_accepts_ensure_ascii_kwarg() {
+        // MiniMax-M2's template calls `tojson(ensure_ascii=False)`; minijinja's
+        // builtin rejects the kwarg → render fails → silent Plain fallback (the
+        // model then never emits its native tool format). Our override must
+        // accept the kwarg and emit raw JSON.
+        let t = make_tokenizer();
+        let template = "{%- for m in messages -%}{{- m.content -}}{%- endfor -%}{{- tools | tojson(ensure_ascii=False) -}}";
+        let frame = JinjaChatFrame {
+            tokenizer: &t,
+            template,
+            system: None,
+            user: "hi",
+            enable_thinking: false,
+            bos_token: Some(""),
+        };
+        let msgs = vec![Message { role: Role::User, content: "hi".into(), tool_calls: vec![], tool_call_id: None }];
+        let tools = vec![serde_json::json!({"type": "function", "function": {"name": "get_weather"}})];
+        let rendered = frame.render_messages(&msgs, Some(&tools), None)
+            .expect("tojson(ensure_ascii=False) must render, not fall back");
+        assert!(rendered.contains("\"get_weather\""), "tool json missing: {rendered}");
     }
 
     #[test]

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -460,12 +460,21 @@ impl<'a> JinjaChatFrame<'a> {
         use minijinja::{Environment, Error, ErrorKind, Value};
         use minijinja_contrib::pycompat::unknown_method_callback;
 
+        // Chainable-undefined (NOT Strict): chat templates are authored for
+        // Jinja2's lenient semantics and routinely PROBE optional fields —
+        // `system_message.current_date`, `.current_location`, `tools`,
+        // `documents`, etc. Under Strict, probing a key a caller didn't set
+        // raises, and the whole render fails → silent Plain fallback. That's
+        // exactly what broke MiniMax-M2 under an agent (Hermes) that sends a
+        // system message without `current_date`: `{% if system_message and
+        // system_message.current_date %}` errored at template line 37. Chainable
+        // matches Jinja2 (missing keys → falsy/undefined, chained access on
+        // undefined stays undefined) while still surfacing hard render errors
+        // (raise_exception, syntax). The required context vars (messages, tools,
+        // add_generation_prompt, bos_token) are always provided below, so the
+        // PR #175 "missing required var" concern doesn't regress.
         let mut env = Environment::new();
-        // Strict-undefined: a missing context variable raises Err instead of
-        // silently rendering empty/partial output. Without this, malformed
-        // prompts could propagate to the model unnoticed (Codex review on
-        // PR #175 flagged this; we apply it here in the same port).
-        env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Chainable);
         // Make Python-style str/list/dict methods (`.startswith`,
         // `.split`, `.rstrip`, `.lstrip`, `|items`, etc.) work on
         // ordinary Jinja values. Required by the Qwen3 family
@@ -782,6 +791,30 @@ mod tests {
         let rendered = frame.render_messages(&msgs, Some(&tools), None)
             .expect("tojson(ensure_ascii=False) must render, not fall back");
         assert!(rendered.contains("\"get_weather\""), "tool json missing: {rendered}");
+    }
+
+    #[test]
+    fn jinja_chainable_tolerates_missing_optional_field() {
+        // Chat templates probe optional message fields (e.g. MiniMax-M2's
+        // `system_message.current_date`). Under Strict-undefined that raised and
+        // forced a Plain fallback (broke MiniMax under Hermes); Chainable treats a
+        // missing key as falsy like Jinja2, so the probe is a no-op.
+        let t = make_tokenizer();
+        let template = "{%- for m in messages -%}\
+            {%- if m.current_date -%}D:{{ m.current_date }}{%- endif -%}\
+            {{- m.content -}}\
+            {%- endfor -%}";
+        let frame = JinjaChatFrame {
+            tokenizer: &t, template, system: None, user: "hi",
+            enable_thinking: false, bos_token: Some(""),
+        };
+        let msgs = vec![
+            Message { role: Role::System, content: "S".into(), tool_calls: vec![], tool_call_id: None },
+            Message { role: Role::User, content: "U".into(), tool_calls: vec![], tool_call_id: None },
+        ];
+        let rendered = frame.render_messages(&msgs, None, None)
+            .expect("probing a missing optional message field must not raise");
+        assert_eq!(rendered, "SU");
     }
 
     #[test]

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -1391,9 +1391,21 @@ pub fn strip_trailing_line_ws(s: &str) -> String {
 /// disabled; `Cow::Owned` only on actual rewrite. Each step in the pipeline
 /// is itself a no-op fast-path when its trigger pattern is absent.
 pub fn maybe_normalize_prompt(s: &str) -> std::borrow::Cow<'_, str> {
+    // Default ON. Explicit "0" / "false" / "off" opts out (parsed once in
+    // RuntimeConfig::from_env). Delegates to the flag-parameterized core so the
+    // pipeline is unit-testable without the memoized `config::get()` singleton.
+    normalize_prompt_with(s, crate::config::get().normalize_prompt)
+}
+
+/// Core prompt-normalization pipeline, parameterized on the enable flag.
+/// `maybe_normalize_prompt` is the production entry point; tests call this
+/// directly with an explicit flag. (The global `config::get()` is a memoized
+/// `OnceLock`, so toggling `HIPFIRE_NORMALIZE_PROMPT` per-call can't drive it
+/// in a shared test process — that mismatch is what silently broke the
+/// opt-out tests until CI surfaced it.)
+fn normalize_prompt_with(s: &str, enabled: bool) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;
-    // Default ON. Explicit "0" / "false" / "off" / "no" opts out.
-    if !crate::config::get().normalize_prompt {
+    if !enabled {
         return Cow::Borrowed(s);
     }
 
@@ -1833,6 +1845,13 @@ mod sp_tests {
 mod prompt_norm_tests {
     use super::*;
 
+    // The flag-routing tests below call `normalize_prompt_with(s, enabled)`
+    // directly instead of toggling `HIPFIRE_NORMALIZE_PROMPT` and going through
+    // `maybe_normalize_prompt`. The env var is consumed once by the memoized
+    // `config::get()` singleton, so per-call toggling can't drive it in a
+    // shared test process — testing the parameterized core keeps these
+    // deterministic and parallel-safe.
+
     #[test]
     fn collapse_three_to_two() {
         assert_eq!(collapse_newline_runs("a\n\n\nb"), "a\n\nb");
@@ -1887,31 +1906,28 @@ mod prompt_norm_tests {
     }
 
     #[test]
-    fn default_on_collapses_when_env_unset() {
-        // Default flipped to ON 2026-04-26 — env unset → still collapses.
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
+    fn enabled_collapses_newline_runs() {
+        // Enabled (the production default) → `\n{3,}` collapses to `\n\n`.
         let s = "a\n\n\nb";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, true);
         assert!(matches!(out, std::borrow::Cow::Owned(_)));
         assert_eq!(out.as_ref(), "a\n\nb");
     }
 
     #[test]
-    fn explicit_zero_opts_out() {
-        std::env::set_var("HIPFIRE_NORMALIZE_PROMPT", "0");
+    fn disabled_passes_through_borrowed() {
+        // Opt-out (HIPFIRE_NORMALIZE_PROMPT=0 → enabled=false) → input untouched.
         let s = "a\n\n\nb";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, false);
         assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
         assert_eq!(out.as_ref(), "a\n\n\nb");
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
     }
 
     #[test]
     fn cow_borrowed_when_no_runs() {
-        // Even with default-ON, no `\n{3,}` runs means no rewrite needed.
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
+        // Even enabled, no `\n{3,}` runs means no rewrite needed → Borrowed.
         let s = "a\n\nb"; // already single-blank
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, true);
         assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
         assert_eq!(out.as_ref(), "a\n\nb");
     }
@@ -2093,9 +2109,8 @@ mod prompt_norm_tests {
     #[test]
     fn pipeline_crlf_and_trailing_ws() {
         // Windows-pasted snippet with trailing whitespace.
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
         let s = "def foo():   \r\n    return 1   \r\n";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, true);
         assert_eq!(out.as_ref(), "def foo():\n    return 1\n");
     }
 
@@ -2104,38 +2119,34 @@ mod prompt_norm_tests {
         // Indented blank line between top-level defs:
         //   "a\n    \n\nb" — line 2 is whitespace-only, lines 2-3 form a `\n\n\n`
         //   run after stripping. Collapse should reduce to `\n\n`.
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
         let s = "a\n    \n\nb";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, true);
         assert_eq!(out.as_ref(), "a\n\nb");
     }
 
     #[test]
     fn pipeline_nbsp_in_prose() {
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
         let s = "Use\u{00A0}foo()\u{00A0}for\u{00A0}this.";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, true);
         assert_eq!(out.as_ref(), "Use foo() for this.");
     }
 
     #[test]
     fn pipeline_clean_input_is_borrowed() {
         // No CRLF, no NBSP, no trailing ws, no \n{3,} — must stay Borrowed.
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
         let s = "Plain prompt.\nSecond line.\n\nThird paragraph.\n";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, true);
         assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
         assert_eq!(out.as_ref(), s);
     }
 
     #[test]
     fn pipeline_explicit_opt_out_skips_all_rules() {
-        // Opt-out must skip CRLF/NBSP/trailing-ws too, not just newline collapse.
-        std::env::set_var("HIPFIRE_NORMALIZE_PROMPT", "0");
+        // Opt-out (enabled=false) must skip CRLF/NBSP/trailing-ws too, not just
+        // newline collapse.
         let s = "a\r\nb\u{00A0}c   \nd\n\n\ne";
-        let out = maybe_normalize_prompt(s);
+        let out = normalize_prompt_with(s, false);
         assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
         assert_eq!(out.as_ref(), s);
-        std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT");
     }
 }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -14938,6 +14938,66 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         result
     }
 
+    /// HFQ6G256 counterpart to `gemv_hfq4g256_moe_gate_up_k8_indexed_batched`.
+    /// N-batched indexed MoE gate_up GEMV for 6-bit (200 B/group) routed
+    /// experts. Same kernarg + grid (M, K_TOP, N) + gate/up output split as
+    /// the HFQ4 sibling; only the per-group dequant differs (handled inside
+    /// the kernel). Wave32 (RDNA) only — no wave64 variant.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemv_hfq6g256_moe_gate_up_k8_indexed_batched(
+        &mut self,
+        expert_ptrs: &GpuTensor,
+        topk_indices: &GpuTensor,
+        x: &GpuTensor,
+        y_gate: &GpuTensor,
+        y_up:   &GpuTensor,
+        m: usize, k: usize, k_top: usize, batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemv_hfq6g256_moe_gate_up_indexed_batched",
+            kernels::GEMV_HFQ6G256_MOE_GATE_UP_INDEXED_BATCHED_SRC,
+            "gemv_hfq6g256_moe_gate_up_k8_indexed_batched",
+        )?;
+        let pp = expert_ptrs.buf.as_ptr();
+        let ip = topk_indices.buf.as_ptr();
+        let xp = x.buf.as_ptr();
+        let ygp = y_gate.buf.as_ptr();
+        let yup = y_up.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let kt_val = k_top as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &pp as *const _ as *mut c_void,
+            &ip as *const _ as *mut c_void,
+            &xp as *const _ as *mut c_void,
+            &ygp as *const _ as *mut c_void,
+            &yup as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &kt_val as *const _ as *mut c_void,
+        ];
+        // 200 vs 136 B/group: scale the HFQ4 byte estimate by 200/136.
+        let hfq4_bytes = crate::profile::gemv_hfq4g256_bytes(m, k);
+        let bytes = batch_size * k_top * (hfq4_bytes * 200 / 136 + m * 4);
+        let timer = crate::profile::begin_timer(
+            &self.hip, "gemv", "gemv_hfq6g256_moe_gate_up_k8_indexed_batched", bytes,
+        );
+        let result = self.launch_maybe_blob(
+            "gemv_hfq6g256_moe_gate_up_k8_indexed_batched",
+            [m as u32, k_top as u32, batch_size as u32], [32, 1, 1], 0, &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(pp); b.push_ptr(ip); b.push_ptr(xp);
+                b.push_ptr(ygp); b.push_ptr(yup);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(kt_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ6G256 counterpart to `gemv_hfq4g256_moe_down_k8_indexed_batched_expanded`.
     /// Atomic-free expand-then-combine for the MoE down step. Pairs with
     /// `moe_down_combine_k8_batched` (dtype-independent — operates on the

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -25271,9 +25271,22 @@ self.flags.rocblas_min_batch.unwrap_or(4)
             &mut nkv as *mut _ as *mut c_void, &mut hd as *mut _ as *mut c_void,
             &mut ms as *mut _ as *mut c_void, &mut sc as *mut _ as *mut c_void,
         ];
-        let block_size = (seq_len_hint.max(head_dim) as u32).next_power_of_two().min(256);
+        // hipGraph capture: `block_size` and `shared_mem` are launch-time host
+        // scalars baked into the captured node. They are sized by `seq_len_hint`
+        // (= current position + 1) on the direct path, which would lock a
+        // captured graph to its capture position and under-allocate scores[] on
+        // replay at a later position. Under capture, size both to `max_seq` so
+        // ONE captured graph replays correctly at EVERY later position: the
+        // kernel recomputes `seq_len = pos_buf[0]+1` from the DEVICE pos buffer
+        // (updated direct before each replay) and self-adjusts its internal
+        // scores[]/q_sh offsets — only the *allocated* shared-mem must be large
+        // enough, and `max_seq` always is. block_size strides safely at any
+        // nthreads, so the larger capture value stays correct. Mirrors the
+        // `if self.capture_mode { max_tiles }` pattern used elsewhere here.
+        let sizing_seq = if self.capture_mode { max_seq } else { seq_len_hint };
+        let block_size = (sizing_seq.max(head_dim) as u32).next_power_of_two().min(256);
         // Extra shared mem for Q head vector preloaded into shared memory
-        let shared_mem = ((seq_len_hint + block_size as usize + head_dim) * 4) as u32;
+        let shared_mem = ((sizing_seq + block_size as usize + head_dim) * 4) as u32;
         let bytes = crate::profile::attention_q8_0_kv_bytes(n_heads, n_kv_heads, head_dim, seq_len_hint);
         let timer = crate::profile::begin_timer(&self.hip, "attention", "attention_q8_0_kv", bytes);
         let result = unsafe { self.hip.launch_kernel(func, [n_heads as u32, 1, 1], [block_size, 1, 1], shared_mem, self.stream_ref(), &mut params) };

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -27176,6 +27176,59 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         unsafe { self.hip.launch_kernel(func, [grid, 1, 1], [block, 1, 1], 0, self.stream_ref(), &mut params) }
     }
 
+    /// LFM2 LIV double-gated short-conv, single-token decode. Reads the in_proj
+    /// output `bcx` [batch, 3*channels] (B | C_gate | x layout), applies the
+    /// B*x pre-gate, runs the depthwise causal conv over the rolling `state`
+    /// [batch, channels, K-1] history, applies the C_gate post-gate into
+    /// `out_y` [batch, channels], and advances `state` in place. kernel_size K
+    /// is a runtime arg (LFM2 K=3); conv_bias is always false.
+    pub fn conv1d_gated_decode_f32(
+        &mut self,
+        bcx: &GpuTensor,
+        state: &GpuTensor,
+        weight: &GpuTensor,
+        out_y: &GpuTensor,
+        batch: usize,
+        channels: usize,
+        kernel_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "conv1d_gated_decode",
+            kernels::CONV1D_GATED_DECODE_SRC,
+            "conv1d_gated_decode_f32",
+        )?;
+        let func = &self.functions["conv1d_gated_decode_f32"];
+        let mut bp = bcx.buf.as_ptr();
+        let mut sp = state.buf.as_ptr();
+        let mut wp = weight.buf.as_ptr();
+        let mut oyp = out_y.buf.as_ptr();
+        let mut bb = batch as i32;
+        let mut cc = channels as i32;
+        let mut kk = kernel_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut bp as *mut _ as *mut c_void,
+            &mut sp as *mut _ as *mut c_void,
+            &mut wp as *mut _ as *mut c_void,
+            &mut oyp as *mut _ as *mut c_void,
+            &mut bb as *mut _ as *mut c_void,
+            &mut cc as *mut _ as *mut c_void,
+            &mut kk as *mut _ as *mut c_void,
+        ];
+        let block = 256u32;
+        let grid = (((batch * channels) as u32) + block - 1) / block;
+        unsafe {
+            self.hip.launch_kernel(
+                func,
+                [grid, 1, 1],
+                [block, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        }
+    }
+
     /// Gated output norm: rmsnorm(x) * silu(z). Fused kernel.
     #[cfg(feature = "deltanet")]
     pub fn gated_norm_f32(

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -409,6 +409,11 @@ pub struct Gpu {
     /// graph_destroy + re-capture every oscillation, which was wiping out the
     /// hipGraph replay gain entirely.
     pub verify_graph_cache: HashMap<usize, (hip_bridge::Graph, hip_bridge::GraphExec, Vec<Vec<u8>>)>,
+    /// Subset of `verify_graph_cache` whose captured region also includes the
+    /// DFlash verify lm_head + argmax tail. Forward-only and extended verify
+    /// graphs share the same per-B cache, so callers need this side metadata
+    /// before deciding whether to enqueue lm_head outside the graph.
+    pub verify_graph_lmhead_argmax: HashSet<usize>,
     /// Set of B values that have completed the once-per-B JIT/scratch warmup.
     /// Capture can safely begin only after warmup — see graph_verify_warmup doc.
     pub verify_warmed_up: HashSet<usize>,
@@ -644,6 +649,7 @@ impl Gpu {
             ar_forward_kernel_dirty: true,
             ar_forward_replay_enabled: false,
             verify_graph_cache: HashMap::new(),
+            verify_graph_lmhead_argmax: HashSet::new(),
             verify_warmed_up: HashSet::new(),
             verify_capturing_b: None,
             replay_graph_cache: HashMap::new(),
@@ -903,6 +909,16 @@ impl Gpu {
         self.verify_graph_cache.contains_key(&b)
     }
 
+    pub fn verify_graph_has_lmhead_argmax(&self, b: usize) -> bool {
+        // bind_thread: skip — pure state query
+        self.verify_graph_lmhead_argmax.contains(&b)
+    }
+
+    pub fn verify_mark_graph_lmhead_argmax(&mut self, b: usize) {
+        // bind_thread: skip — pure state update
+        self.verify_graph_lmhead_argmax.insert(b);
+    }
+
     pub fn verify_needs_warmup(&self, b: usize) -> bool {
         // bind_thread: skip — pure state query
         !self.verify_warmed_up.contains(&b)
@@ -968,6 +984,7 @@ impl Gpu {
             let _ = self.hip.graph_exec_destroy(exec);
             let _ = self.hip.graph_destroy(graph);
         }
+        self.verify_graph_lmhead_argmax.clear();
         self.verify_warmed_up.clear();
         self.verify_capturing_b = None;
     }
@@ -13565,6 +13582,66 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         result
     }
 
+    /// gfx12 lm_head sibling of `gemm_hfq4g256_residual_wmma_gfx12`.
+    /// Uses the same WMMA tile mapping but overwrites Y instead of reading
+    /// and adding to it, so lm_head callers can skip a full-vocab zero-fill.
+    pub fn gemm_hfq4g256_lmhead_wmma_gfx12(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "gemm_hfq4g256_lmhead_wmma_gfx12",
+            kernels::GEMM_HFQ4G256_LMHEAD_WMMA_GFX12_SRC,
+            "gemm_hfq4g256_lmhead_wmma_gfx12",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut y_ptr = y.buf.as_ptr();
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+
+        let row_tiles = (m + 15) / 16;
+        let batch_tiles = (batch_size + 15) / 16;
+
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_lmhead_wmma_gfx12", bytes);
+        let result = self.launch_maybe_blob(
+            "gemm_hfq4g256_lmhead_wmma_gfx12",
+            [row_tiles as u32, batch_tiles as u32, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(y_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        );
+        if let Some(t) = timer { t.finish(&self.hip); }
+        result
+    }
+
     /// HFQ4-G256 GEMV with fused residual add: y[row] += A[row] · x.
     /// Same math as `gemv_hfq4g256` but the final write accumulates into `y`
     /// instead of overwriting. Used for wo / w_down projections where the
@@ -19192,6 +19269,8 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// WMMA lm_head fast path for DFlash. Computes y = A @ x at batch>1 via
     /// the residual-WMMA kernel on pre-zeroed y — 8-10× faster than the
     /// scalar `gemm_hfq4g256` on 9B lm_head (batch=16, vocab=248K, k=2560).
+    /// HIPFIRE_LM_HEAD_OVERWRITE=1 opts into a gfx12 overwrite sibling that
+    /// skips the zero-fill; measured as a small win but not enough to default.
     ///
     /// NOT numerically identical to `gemm_hfq4g256`. Uses FP16 tensor cores
     /// with the accumulators in FP32 the residual kernel ships. On the
@@ -19227,22 +19306,27 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         // ~26.68% of composition cycle wall in this scalar path).
         let arch = self.arch.as_str();
         let wmma_eligible = batch_size > 1
-            && self.arch_caps.has_wmma_w32()
+            && (self.arch_caps.has_wmma_w32() || self.arch_caps.has_wmma_w32_gfx12())
             && !self.flags.fp16_disabled
             && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {
             self.fp16_x_source_ptr = std::ptr::null_mut();
-            match self.active_stream.as_ref() {
-                Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
-                None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
-            }
-            return if arch.starts_with("gfx12") {
-                self.gemm_hfq4g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size)
+            if arch.starts_with("gfx12") && self.flags.lm_head_overwrite {
+                self.gemm_hfq4g256_lmhead_wmma_gfx12(a_raw, x, y, m, k, batch_size)
             } else {
-                self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size)
-            };
+                match self.active_stream.as_ref() {
+                    Some(stream) => self.hip.memset_async(&y.buf, 0, batch_size * m * 4, stream)?,
+                    None => self.hip.memset(&y.buf, 0, batch_size * m * 4)?,
+                }
+                if arch.starts_with("gfx12") {
+                    self.gemm_hfq4g256_residual_wmma_gfx12(a_raw, x, y, m, k, batch_size)
+                } else {
+                    self.gemm_hfq4g256_residual_wmma(a_raw, x, y, m, k, batch_size)
+                }
+            }
+        } else {
+            self.gemm_hfq4g256(a_raw, x, y, m, k, batch_size)
         }
-        self.gemm_hfq4g256(a_raw, x, y, m, k, batch_size)
     }
 
     /// HFQ6-G256 sister of `gemm_hfq4g256_batched_lmhead`. Phase A.4
@@ -22349,6 +22433,118 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         )
     }
 
+    /// GPU-side single-row argmax that writes directly into an MTP token
+    /// chain. If `vocab_map` is present, the argmax index is treated as a
+    /// compressed-vocab row and remapped to the full-vocab token id before
+    /// storing `token_chain[dst_slot]`.
+    pub fn argmax_token_chain_f32(
+        &mut self,
+        data: &GpuTensor,
+        argmax_out: &GpuTensor,
+        token_chain: &GpuTensor,
+        vocab_map: Option<&GpuTensor>,
+        n: usize,
+        dst_slot: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "argmax_token_chain",
+            kernels::ARGMAX_TOKEN_CHAIN_SRC,
+            "argmax_token_chain_f32",
+        )?;
+
+        let mut dp = data.buf.as_ptr();
+        let mut ap = argmax_out.buf.as_ptr();
+        let mut cp = token_chain.buf.as_ptr();
+        let mut vp = vocab_map
+            .map(|t| t.buf.as_ptr())
+            .unwrap_or(std::ptr::null_mut::<c_void>());
+        let mut nn = n as i32;
+        let mut ds = dst_slot as i32;
+        let mut use_map = i32::from(vocab_map.is_some());
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut dp as *mut _ as *mut c_void,
+            &mut ap as *mut _ as *mut c_void,
+            &mut cp as *mut _ as *mut c_void,
+            &mut vp as *mut _ as *mut c_void,
+            &mut nn as *mut _ as *mut c_void,
+            &mut ds as *mut _ as *mut c_void,
+            &mut use_map as *mut _ as *mut c_void,
+        ];
+
+        let block_size = 256u32;
+        let shared = block_size * 8; // f32 + i32 per thread
+        self.launch_maybe_blob(
+            "argmax_token_chain_f32",
+            [1, 1, 1],
+            [block_size, 1, 1],
+            shared,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(dp);
+                b.push_ptr(ap);
+                b.push_ptr(cp);
+                b.push_ptr(vp);
+                b.push_i32(nn);
+                b.push_i32(ds);
+                b.push_i32(use_map);
+                b
+            },
+        )
+    }
+
+    /// Device-side greedy accept prefix scan over verify argmaxes and MTP
+    /// candidates. `result[0]` is accept_count; `result[1]` is the bonus
+    /// token, or -1 if an accepted candidate was EOS and no bonus is present.
+    pub fn greedy_accept_from_argmax_i32(
+        &mut self,
+        argmax_per_pos: &GpuTensor,
+        candidates: &GpuTensor,
+        result: &GpuTensor,
+        drafts_generated: usize,
+        eos_token_id: u32,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "greedy_accept",
+            kernels::GREEDY_ACCEPT_SRC,
+            "greedy_accept_from_argmax_i32",
+        )?;
+
+        let mut ap = argmax_per_pos.buf.as_ptr();
+        let mut cp = candidates.buf.as_ptr();
+        let mut rp = result.buf.as_ptr();
+        let mut dg = drafts_generated as i32;
+        let mut eos = eos_token_id as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut ap as *mut _ as *mut c_void,
+            &mut cp as *mut _ as *mut c_void,
+            &mut rp as *mut _ as *mut c_void,
+            &mut dg as *mut _ as *mut c_void,
+            &mut eos as *mut _ as *mut c_void,
+        ];
+
+        self.launch_maybe_blob(
+            "greedy_accept_from_argmax_i32",
+            [1, 1, 1],
+            [1, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ap);
+                b.push_ptr(cp);
+                b.push_ptr(rp);
+                b.push_i32(dg);
+                b.push_i32(eos);
+                b
+            },
+        )
+    }
+
     /// GPU-side argmax: returns index of max value. Avoids downloading full logits.
     pub fn argmax_f32(&mut self, data: &GpuTensor, n: usize) -> HipResult<u32> {
         self.bind_thread()?;
@@ -22564,6 +22760,40 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         let block = 256u32;
         let grid = ((n as u32) + block - 1) / block;
         unsafe { self.hip.launch_kernel(func, [grid, 1, 1], [block, 1, 1], 0, None, &mut params) }
+    }
+
+    /// c = a + b (element-wise), graph-capture-safe launch path. Keep the
+    /// legacy `add_f32` path unchanged for non-captured callers; use this in
+    /// subgraphs where stack-backed kernelParams would dangle on replay.
+    pub fn add_f32_graph_safe(&mut self, a: &GpuTensor, b: &GpuTensor, c: &GpuTensor) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel("add", kernels::ADD_SRC, "add_f32")?;
+
+        let n = a.numel() as i32;
+        let mut a_ptr = a.buf.as_ptr();
+        let mut b_ptr = b.buf.as_ptr();
+        let mut c_ptr = c.buf.as_ptr();
+        let mut n_val = n;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut b_ptr as *mut _ as *mut c_void,
+            &mut c_ptr as *mut _ as *mut c_void,
+            &mut n_val as *mut _ as *mut c_void,
+        ];
+
+        let block = 256u32;
+        let grid = ((n as u32) + block - 1) / block;
+        self.launch_maybe_blob(
+            "add_f32",
+            [grid, 1, 1], [block, 1, 1], 0, &mut params,
+            || {
+                let mut bb = hip_bridge::KernargBlob::new();
+                bb.push_ptr(a_ptr); bb.push_ptr(b_ptr); bb.push_ptr(c_ptr);
+                bb.push_i32(n_val);
+                bb
+            },
+        )
     }
 
     /// a += b (in-place element-wise add)
@@ -25193,7 +25423,6 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel("attention_q8_0_kv", kernels::ATTENTION_Q8_0_KV_SRC, "attention_q8_0_kv")?;
-        let func = &self.functions["attention_q8_0_kv"];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
         let mut q_ptr = q.buf.as_ptr(); let mut k_ptr = k_cache.buf.as_ptr();
         let mut v_ptr = v_cache.buf.as_ptr(); let mut out_ptr = out.buf.as_ptr();
@@ -25212,7 +25441,27 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         let shared_mem = ((seq_len_hint + block_size as usize + head_dim) * 4) as u32;
         let bytes = crate::profile::attention_q8_0_kv_bytes(n_heads, n_kv_heads, head_dim, seq_len_hint);
         let timer = crate::profile::begin_timer(&self.hip, "attention", "attention_q8_0_kv", bytes);
-        let result = unsafe { self.hip.launch_kernel(func, [n_heads as u32, 1, 1], [block_size, 1, 1], shared_mem, self.stream_ref(), &mut params) };
+        let result = self.launch_maybe_blob(
+            "attention_q8_0_kv",
+            [n_heads as u32, 1, 1],
+            [block_size, 1, 1],
+            shared_mem,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(q_ptr);
+                b.push_ptr(k_ptr);
+                b.push_ptr(v_ptr);
+                b.push_ptr(out_ptr);
+                b.push_ptr(pos_ptr);
+                b.push_i32(nh);
+                b.push_i32(nkv);
+                b.push_i32(hd);
+                b.push_i32(ms);
+                b.push_f32(sc);
+                b
+            },
+        );
         if let Some(t) = timer { t.finish(&self.hip); }
         result
     }

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -44,6 +44,7 @@ pub struct FeatureFlags {
     pub fp16_layer_max: Option<usize>,
     pub wo_mmq: bool,
     pub lm_head_wmma_disabled: bool,
+    pub lm_head_overwrite: bool,
 
     // ── MMQ screening ─────────────────────────────────────────────
     pub mmq_screen: bool,
@@ -160,6 +161,7 @@ impl FeatureFlags {
             fp16_layer_max: parse_usize("HIPFIRE_FP16_LAYER_MAX"),
             wo_mmq: std::env::var("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1"),
             lm_head_wmma_disabled: std::env::var("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0"),
+            lm_head_overwrite: std::env::var("HIPFIRE_LM_HEAD_OVERWRITE").as_deref() == Ok("1"),
 
             // MMQ screening
             mmq_screen: std::env::var("HIPFIRE_MMQ_SCREEN")
@@ -311,6 +313,7 @@ impl FeatureFlags {
             fp16_layer_max: None,
             wo_mmq: false,
             lm_head_wmma_disabled: false,
+            lm_head_overwrite: false,
             mmq_screen: false,
             mmq_screen_threshold: if is_gfx906 { 0.50 } else { 0.10 },
             mmq_diag_quantize_only: false,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -961,6 +961,14 @@ pub const GIVENS_ROTATE_TO_SRC: &str =
 pub const GEMV_HFQ6G256_MOE_GATE_UP_INDEXED_SRC: &str =
     include_str!("../../../kernels/src/gemv_hfq6g256_moe_gate_up_indexed.hip");
 
+/// N-batched indexed MoE gate_up GEMV for HFQ6G256-layout routed experts.
+/// HFQ6G256 counterpart to `GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_BATCHED_SRC`;
+/// same kernarg signature + grid (M, K_TOP, N) + gate/up output split, only
+/// the per-group dequant differs (200 B/group, 6-bit). Pairs with the HFQ6
+/// expanded down kernel for the batched LFM2.5-MoE decode path.
+pub const GEMV_HFQ6G256_MOE_GATE_UP_INDEXED_BATCHED_SRC: &str =
+    include_str!("../../../kernels/src/gemv_hfq6g256_moe_gate_up_k8_indexed_batched.hip");
+
 /// HFQ6G256 counterpart to the atomic-free expanded batched MoE down kernel.
 /// Same expand-then-combine pattern; pairs with `MOE_DOWN_COMBINE_K8_BATCHED_SRC`
 /// (combine is dtype-independent — operates on the f32 expanded buffer).

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1257,6 +1257,7 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_SRC: &str = include_str!("../../../
 // the residual-GEMM gap on 9B prefill (42% of decode-batch GEMM time was
 // stuck on the dot2 fp16 fallback before this).
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma.gfx12.hip");
+pub const GEMM_HFQ4G256_LMHEAD_WMMA_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip");
 // Q8_1 MMQ prefill variant — opt-in via HIPFIRE_MMQ=1, gated to RDNA3/3.5.
 // Pre-quantizes activations to Q8_1 + uses i8 WMMA over 128×128 tiles. Targets
 // the Strix Halo prefill gap vs llama.cpp (#60); also wins ~+20% on gfx1100
@@ -2475,6 +2476,14 @@ pub const ARGMAX_SRC: &str = include_str!("../../../kernels/src/argmax.hip");
 /// Batched argmax: one block per row, writes B indices with one kernel launch.
 /// Used by DFlash verify to collapse the B × [vocab] logit download to B × 4 bytes.
 pub const ARGMAX_BATCHED_SRC: &str = include_str!("../../../kernels/src/argmax_batched.hip");
+
+/// Single-row argmax that writes the selected token into an on-device MTP
+/// token chain, optionally remapping through a compressed-vocab sidecar.
+pub const ARGMAX_TOKEN_CHAIN_SRC: &str = include_str!("../../../kernels/src/argmax_token_chain.hip");
+
+/// Device-side greedy MTP accept prefix scan over verify argmaxes and draft
+/// candidates. Writes compact `[accept_count, bonus_or_minus_one]` result.
+pub const GREEDY_ACCEPT_SRC: &str = include_str!("../../../kernels/src/greedy_accept.hip");
 
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2271,6 +2271,13 @@ pub const ROPE_PARTIAL_HALFSPLIT_BATCHED_SRC: &str = include_str!("../../../kern
 #[cfg(feature = "deltanet")]
 pub const CONV1D_DECODE_SRC: &str = include_str!("../../../kernels/src/conv1d_decode.hip");
 
+/// LFM2 LIV double-gated short-conv, single-token decode (runtime kernel_size).
+/// Fuses the B*x pre-gate, depthwise causal conv, C*conv_out post-gate, and the
+/// rolling conv-state ring-buffer advance into one launch. conv_bias is always
+/// false for LFM2. See kernels/src/conv1d_gated_decode.hip.
+pub const CONV1D_GATED_DECODE_SRC: &str =
+    include_str!("../../../kernels/src/conv1d_gated_decode.hip");
+
 
 /// Gated output norm: rmsnorm(x) * silu(z). Fused single kernel.
 /// x and z are [n_heads × head_dim]. weight is [head_dim] (shared across heads).

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -1,0 +1,199 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 Kaden Schutt
+hipfire — see LICENSE and NOTICE in the project root.
+-->
+# LFM2.5-8B-A1B port design + validation (arch_id 11)
+
+Ground-truth architecture analysis and validation record for porting
+LiquidAI/LFM2.5-8B-A1B (model_type `lfm2_moe`) to hipfire on gfx1201 (RDNA4),
+mirroring the MiniMax-M2 (arch_id 10) arch-port method
+(`docs/methodology/arch-port-validation.md`).
+
+Source of truth: `transformers` 5.8.0 `models/lfm2_moe/{modeling,configuration}
+_lfm2_moe.py` + the real checkpoint `config.json` / safetensors (read 2026-05-29).
+
+## Feasibility verdict — GREEN (no greenfield operator)
+
+The task's worst-case assumption (no conv kernel, no top-4 MoE) did not hold:
+- **Conv (LIV short-conv):** hipfire already has depthwise causal conv1d decode
+  kernels + a rolling conv-state cache (qwen35 DeltaNet's `DnState.conv_states`),
+  but they are compile-time K=4 and SiLU/QKV-fused. LFM2 needs K=3 and a plain
+  double-gate (B·x / C·conv_out), so I authored ONE small new kernel:
+  `kernels/src/conv1d_gated_decode.hip` (runtime K, fused gates + ring-buffer
+  advance, one launch, ungated by `deltanet`).
+- **MoE top-4:** the indexed-MoE GEMV `_k8` family takes `k_top` as a RUNTIME
+  arg (the `_k8` is a naming convention, not a compiled trip count). top-4 works
+  by passing `k_top=4` to the batched variants + `deepseek4_moe_topk_bias_aware`
+  (MAX_K_TOP=32, bias for selection only). NO new MoE kernel needed.
+
+## Config (real checkpoint)
+
+| field | value | notes |
+|---|---|---|
+| model_type | `lfm2_moe` | classes Lfm2MoeForCausalLM / Lfm2MoeConfig |
+| vocab_size | 128000 | tie_word_embeddings=true (no lm_head tensor) |
+| hidden_size | 2048 | |
+| num_hidden_layers | 24 | 18 conv + 6 full_attention (per `layer_types`) |
+| layer_types | attn at L 2,6,10,14,18,21; conv elsewhere | literal 24-entry list |
+| num_attention_heads / kv | 32 / 8 | GQA 4:1 |
+| head_dim | 64 | q_dim 2048, kv_dim 512 |
+| conv_L_cache | 3 | depthwise causal short-conv kernel size K |
+| conv_bias | false | |
+| intermediate_size | 7168 | DENSE MLP dim (first num_dense_layers) |
+| moe_intermediate_size | 1792 | expert FFN dim (= 7·256 ✓ G256) |
+| num_experts / per_tok | 32 / 4 | TOP-4 |
+| num_dense_layers | 2 | L0,L1 dense SwiGLU; L2..23 MoE |
+| norm_topk_prob / use_expert_bias | true / true | renorm gathered weights; aux-free bias |
+| routed_scaling_factor | 1.0 | |
+| rope_theta | 5e6 | full-dim rotate_half (`rope_f32`), no partial |
+| norm_eps | 1e-5 | standard RMSNorm (weight·x̂, NO +1) |
+| dtype | bfloat16 | |
+
+## Module forward (ground truth → hipfire mapping)
+
+Pre-norm decoder layer; mixer = conv OR attention, FFN = dense OR MoE:
+```
+tmp = operator_norm(h)
+if conv:  h += out_proj( C_gate ⊙ depthwise_causal_conv( B_gate ⊙ x ) )   # in_proj→conv→out_proj
+if attn:  h += out_proj( attn( qk_norm(q/k)+RoPE, v ) )                    # GQA, Q8 KV
+ffn = ffn_norm(h)
+if dense: h += w2( silu(w1·ffn) ⊙ (w3·ffn) )                              # SwiGLU
+if moe:   h += Σ_k w_k · expert_{sel_k}(ffn)                              # sigmoid+bias top-4
+logits = lm_head( embedding_norm(h) )   # lm_head tied to embed_tokens
+```
+- **conv** → `gpu.conv1d_gated_decode_f32` (NEW): in_proj [3H,H] → B|C|x, B·x
+  pre-gate, depthwise causal conv (K=3) over rolling state, C·conv_out post-gate,
+  out_proj [H,H]. conv_bias=false. State = one [H,K-1] ring buffer per conv layer.
+- **attention** → per-HEAD QK-norm (`rmsnorm_batched(n_heads, head_dim)`,
+  weight [head_dim]) + full-dim rotate_half (`rope_f32`, θ=5e6) + Q8 GQA flash.
+- **MoE** → `weight_gemv`(router Q8) → `sigmoid_f32` →
+  `deepseek4_moe_topk_bias_aware_f32(k_top=4, route_scale=1.0)` → FWHT-rotated
+  MQ4 experts via batched indexed `gemv_hfq4g256_moe_{gate_up,down}` + combine.
+- **dense** → Q8 SwiGLU (w1 gate, w3 up, `silu_mul_f32`, w2 down + residual).
+
+### RAW HF weight names (loader looks up verbatim; no rename)
+`model.embed_tokens.weight` (tied lm_head), `model.embedding_norm.weight` (final),
+per layer `operator_norm` / `ffn_norm`; conv: `conv.in_proj`/`conv.out_proj`/
+`conv.conv.weight`[H,1,K]; attn: `self_attn.{q,k,v,out}_proj` + `q_layernorm`/
+`k_layernorm`[head_dim]; dense: `feed_forward.{w1,w2,w3}`; MoE:
+`feed_forward.gate` + `feed_forward.expert_bias`[32] + `feed_forward.experts.{e}.
+{w1,w2,w3}` (SPLIT per-expert — no packed-3D re-split, unlike minimax).
+
+## Quantizer (crates/hipfire-quantize/src/main.rs)
+`"lfm2_moe" => 11`; `is_lfm2moe` ingest (bf16 source): routed experts → MQ4G256
+(FWHT 4-bit), `expert_bias` → F32, everything else (conv in/out_proj, attn
+q/k/v/out, dense w1/w2/w3, router gate, all norms, depthwise conv filter, tied
+embed) → Q8. Opt-in `HIPFIRE_LFM2_PROJ_MQ4=1` additionally 4-bits the dense
+projections (see PERF TUNING). Group-size 256 divisibility all clean (hidden
+2048=8·256, moe_inter 1792=7·256, dense_inter 7168=28·256).
+
+## VALIDATION — tiny-oracle cosine PASS ✅
+
+Tiny oracle (`scripts/gen_tiny_lfm2moe.py`): 5 layers
+`["conv","full_attention","conv","full_attention","conv"]`, num_dense_layers=2
+(so L0–1 dense, L2–4 MoE) — exercises conv + attention + dense + MoE + the
+dense→MoE transition. hidden 256, head_dim 64 (REAL), 8 experts top-4 (matches
+the indexed-GEMV k_top path), conv K=3. Experts MQ4G256, all else Q8.
+
+Per-layer cosine, hipfire `decode_step` vs HF `Lfm2MoeForCausalLM` oracle:
+
+| layer | mixer/ffn  | mean_cos | min_cos  |
+|-------|------------|----------|----------|
+| 0     | conv/dense | 0.999961 | 0.999948 |
+| 1     | attn/dense | 0.999854 | 0.999798 |
+| 2     | conv/MoE   | 0.999583 | 0.999479 |
+| 3     | attn/MoE   | 0.999450 | 0.999310 |
+| 4     | conv/MoE   | 0.999311 | 0.999102 |
+
+All ≥0.999 mean (4-bit expert target ≥0.99). Monotone drift = quant-noise
+accumulation, not a structural bug. Validates the NEW conv kernel + conv-state
+cache, per-head QK-norm, full-dim RoPE, sigmoid+bias top-4 MoE, dense SwiGLU, and
+the per-layer hybrid dispatch — all on a tiny model, no GPU-hours. The earlier
+pre-fix NaN was the expert format mismatch (Q8 bytes fed to the MQ4 kernel),
+fixed by the `is_lfm2moe` ingest routing experts → MQ4G256.
+
+Reproduce:
+```
+python3 scripts/gen_tiny_lfm2moe.py --out /tmp/tiny
+./target/release/hipfire-quantize --input /tmp/tiny/hf --output /tmp/tiny/tiny.hfq
+cargo build -p hipfire-arch-lfm2moe --example dump_lfm2moe_hidden_states --features deltanet
+./target/debug/examples/dump_lfm2moe_hidden_states \
+    --model /tmp/tiny/tiny.hfq --tokens /tmp/tiny/tokens.json --out /tmp/tiny/hipfire.hfhs
+python3 scripts/compare_hidden_states.py --hf /tmp/tiny/oracle.hfhs --hipfire /tmp/tiny/hipfire.hfhs
+```
+
+## REAL-MODEL COHERENCE — daemon PASS ✅
+
+Quantized the real bf16 checkpoint (2302 tensors) →
+`~/.hipfire/models/lfm2.5-8b-a1b.mq4` (4.90 GB; experts MQ4G256, all else Q8).
+Registered arch_id 11 in the daemon (LoadedModel lfm2moe_* fields, arch_id==11
+load branch, `generate_lfm2moe`, Cargo `arch-lfm2moe`); builds clean under
+default / {arch-lfm2moe,deltanet} / {arch-minimax,deltanet}.
+
+Verified through the daemon JSONL path (captured bytes, `prompt` field, temp 0;
+also formal `scripts/coherence-gate.sh` lfm2 rows → no hard errors,
+report /tmp/coherence-20260529-102029.md):
+- "What is the capital of France?" → "Paris is the capital of France."
+- "…train 60 km in 45 minutes, speed?" → "…= 80 km/h. The train's speed is 80 km/h."
+- (earlier battery) "capital of Japan?" → Tokyo; "nth Fibonacci" → working code.
+
+Healthy uniq-word ratios (0.71–0.82), correct facts, no attractor/loop/special-
+token leak.
+
+**CAVEAT — chat framing required:** the raw `infer_lfm2moe` example (bare
+completion prompt, no chat frame, greedy) degenerates into a token loop — expected
+for a *completion* prompt fed to an *instruct/thinking* model, NOT an arch bug
+(cosine ≥0.999 already proves the forward). The daemon's ChatFrame wraps the turn
+correctly. Use chat framing for this model.
+
+## PERF TUNING (gfx1201)
+
+Warm decode baseline (fresh process, `HIPFIRE_DPM_WARMUP_SECS=10`, matched full
+256-tok runs via `infer_lfm2moe`, byte-identical prompt):
+**241.5 tok/s** (Q8 projections — validated default; 9 runs, 241.3–241.9, ±0.1%).
+
+### proj-MQ4 (`HIPFIRE_LFM2_PROJ_MQ4=1`) — real +7.2% decode, opt-in (quality cost)
+
+Decode is weight-bandwidth-bound. The always-on dense projections (conv
+in/out_proj, attn q/k/v/out_proj, dense MLP w1/w2/w3 — experts already MQ4) are
+read in full every token; 4-bit-ing them cuts per-token bytes. The quantizer flag
+routes those 2D linears to MQ4G256 (weight_gemv's MQ4G256 arm FWHT-rotates x
+internally — forward unchanged).
+
+Matched measurement (same binary, byte-identical prompt, full 256-tok, fresh
+process, gfx1201):
+- Q8-proj default: **241.5 tok/s** (9 runs, 241.3–241.9)
+- proj-MQ4:        **258.8 tok/s** (6 runs, 258.4–259.1)  → **+7.2%**, reproducible
+- coherence: PASS (Paris / 80 km/h, no attractor/leak)
+- tiny-oracle cosine: **0.94** worst min_cos — genuine 4-bit projection quant
+  noise, exaggerated by the tiny model's narrow (256/768) projections vs the real
+  2048/6144/7168-wide ones; the real model stays coherent.
+
++7.2% crosses the ±5% rule, is reproducible, coherence established → valid gain.
+**Opt-in, not default** purely because of the unquantified quality cost: a
+quality-reducing quant must clear a KLD-vs-Q8 check before becoming default.
+Validated default stays Q8-proj (cosine ≥0.999, 241 tok/s); fast variant ships as
+`~/.hipfire/models/lfm2.5-8b-a1b.mq4p` (4.66 GB).
+
+> **Measurement-integrity note (cost: 3 tries, 2 wrong numbers).** An early
+> "+18% / 285 tok/s" was a real artifact — EOS-truncated ~110-tok runs report a
+> higher *instantaneous* tok/s than full 256-tok runs. A follow-up "WASH /
+> 240.8 / −0.2%" was a fabricated figure written before the matched data
+> returned. Both wrong, both corrected. The +7.2% above is the only result from
+> matched full-256-tok logs. **Rule reaffirmed: no tok/s claim without a matched
+> full-length run you can point to; EOS-truncated runs are invalid for tok/s.**
+
+### Further levers (untried; cut launch COUNT, not just bytes — see NEXT-STEPS)
+compile-time-K3 conv (drop the runtime-K loop / a launch), conv-gate/proj fusion,
+MoE down+combine fusion, MQ6-proj middle-ground, prefill batching. Re-validate
+cosine + coherence after each.
+
+## Open items
+1. KLD/PPL of proj-MQ4 (and any future quant) vs the Q8 model on a calibration
+   set, to decide whether proj-MQ4 (or a mixed mq4/mq6) can become default.
+2. Prefill is per-token `decode_step` (correctness-first); a batched prefill
+   kernel set would speed long-context ingestion (needs batched conv1d scan +
+   batched attn/MoE).
+3. Spec-decode / DFlash: the conv-state tree/snapshot pattern exists in qwen35
+   (`conv1d_silu_split_tree`, speculative.rs) if ever needed; out of scope here.

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -216,15 +216,47 @@ earlier *assumptions* that turned out wrong:
   projections), then the two MoE 4-bit expert GEMVs (gate_up 17.7% + down 12.4%
   = 30%). Decode is **weight-bandwidth-bound on the dense projections.**
 
-**Consequence: HIP graph capture is NOT the big lever** it was assumed to be — it
-only attacks the ~27% launch-idle, and qwen35 already disabled AR-forward graph
-capture (`qwen35.rs` `use_graph=false`) over a ROCm kernarg-bake attractor bug.
-The bandwidth axis (4-bit-ing the hot `gemv_q8_0` projections) is where the real
-decode time is — which is exactly the proj-quant lever below.
+**Consequence (SUPERSEDED — see "Bandwidth ceiling measured" below):** an earlier
+draft here claimed "HIP graph capture is NOT the big lever" on the reasoning that
+decode is bandwidth-bound and graph capture only attacks the ~27% launch-idle.
+**That conclusion was wrong** — the direct bandwidth measurement below shows
+decode uses only ~47% of the card's real bandwidth, so it is NOT saturating the
+bus; the launch/occupancy axis (graph capture + fusion) IS the lever after all.
 
 Other launch-COUNT levers (rmsnorm→gemv fusion, MoE down+combine fusion, batched
-prefill) remain available but target the smaller idle fraction, not the 80% the
-GEMVs occupy.
+prefill) target that same ~47%-utilization gap.
+
+### Bandwidth ceiling MEASURED (gfx1201, 2026-05-30): 632 GB/s, decode uses ~47%
+
+Motivated by a real-world report that an RTX 3090 outperforms the R9700 on this
+model. Investigated directly rather than by assumption:
+
+- **R9700 real sustained bandwidth** (hand-rolled HIP microbench, large-buffer
+  grid-stride read; rocprof HW counters are broken on navi4x so this is the only
+  way): **632 GB/s READ** (stable across 2 GB and 4 GB buffers — not cache),
+  ~565 GB/s copy. The DPM mclk table tops out at 1258 MHz.
+- **LFM2 decode (mq4)** = 241 tok/s ≈ **311 GB/s achieved = ~47% of the 632
+  ceiling.** Decode is bandwidth-*sensitive* but NOT bandwidth-*saturated*.
+- **DPM pin test (FALSIFIED a hypothesis):** forcing
+  `power_dpm_force_performance_level=high` (mclk pinned to the 1258 MHz top)
+  gave **224 tok/s — SLOWER than auto's 241.** So mid-decode DPM down-clocking is
+  NOT the bottleneck; the auto governor is already at the better operating point.
+  (Restored to `auto` after.)
+- **Bandwidth sensitivity ladder** (tok/s rises monotonically as bytes/token
+  falls): mq6e (most bytes) 203 < mq4 241 < mq4p (fewest) 259.
+
+**Conclusion:** decode only reaches ~47% of bandwidth because it is
+latency/occupancy-bound per launch — 377 tiny kernels/token with ~27%
+inter-kernel idle, so the bus is never kept busy. The "3090 beats R9700" gap is
+roughly half hardware (GDDR6X ~936 GB/s vs our measured 632) and half our own
+software leaving bandwidth on the floor. The real lever to close it is the
+**launch/occupancy axis** — HIP graph capture (amortize the 377 launches/token)
++ kernel fusion — NOT bandwidth (HW-capped) and NOT DPM (pinning hurt). Lifting
+utilization 47%→~70% would be ~+50% tok/s (241→~360), which would flip the
+comparison. Caveat: qwen35 has AR-forward graph capture disabled
+(`use_graph=false`) on an older ROCm over a kernarg-bake attractor; we are on
+gfx1201 + custom ROCm, so it is worth re-testing here (with coherence-gating) —
+that is the recommended next perf task.
 
 ### Projection-quant bandwidth sweep (KLD, gfx1201, 2026-05-30) — SETTLED
 

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -245,18 +245,32 @@ model. Investigated directly rather than by assumption:
 - **Bandwidth sensitivity ladder** (tok/s rises monotonically as bytes/token
   falls): mq6e (most bytes) 203 < mq4 241 < mq4p (fewest) 259.
 
-**Conclusion:** decode only reaches ~47% of bandwidth because it is
-latency/occupancy-bound per launch — 377 tiny kernels/token with ~27%
-inter-kernel idle, so the bus is never kept busy. The "3090 beats R9700" gap is
-roughly half hardware (GDDR6X ~936 GB/s vs our measured 632) and half our own
-software leaving bandwidth on the floor. The real lever to close it is the
-**launch/occupancy axis** — HIP graph capture (amortize the 377 launches/token)
-+ kernel fusion — NOT bandwidth (HW-capped) and NOT DPM (pinning hurt). Lifting
-utilization 47%→~70% would be ~+50% tok/s (241→~360), which would flip the
-comparison. Caveat: qwen35 has AR-forward graph capture disabled
-(`use_graph=false`) on an older ROCm over a kernarg-bake attractor; we are on
-gfx1201 + custom ROCm, so it is worth re-testing here (with coherence-gating) —
-that is the recommended next perf task.
+**Conclusion:** decode only reaches ~47% of bandwidth because the GEMV kernels
+are occupancy/latency-bound — not enough in-flight memory requests to saturate
+the bus. The "3090 beats R9700" gap is roughly half hardware (GDDR6X ~936 GB/s
+vs our measured 632) and half our own software leaving bandwidth on the floor.
+
+### Graph capture MEASURED (gfx1201, 2026-05-30): +3.4%, NOT the projected +50%
+
+I first guessed HIP graph capture would recover the ~27% inter-kernel idle for
+~+50% tok/s. **That guess was wrong** — measured result is **+3.4%** (240.3 →
+248.5 tok/s, matched). Implemented + validated (opt-in `HIPFIRE_LFM2_GRAPH=1`,
+commit 0de1e122): correct on gfx1201 — tiny-oracle cosine ≥0.999, byte-identical
+logits parity (cos=1.0, 0/8 argmax mismatch), greedy token-ids match on/off,
+coherence verdict OK; the qwen35 ROCm kernarg-snapshot attractor that forced
+`use_graph=false` there does NOT reproduce on gfx1201. But the gain is small.
+
+**Why the guess was wrong, and what it reveals:** the ~27% trace "idle" mostly
+*overlaps* kernel execution rather than being recoverable wall-time, so
+amortizing the 377 launches/token only buys a few percent. Crucially, graph
+capture recovering ~none of the 53% un-utilized bandwidth PROVES the
+un-utilization is **not** launch-gap-driven — it's the GEMV kernels themselves
+being occupancy/latency-bound. So the real remaining software lever is **GEMV
+occupancy** (VGPR pressure / `__launch_bounds__` / waves-in-flight on the hot
+`gemv_q8_0` + the indexed MoE expert GEMVs), NOT launch count or fusion. That is
+the recommended next perf task — kernel-level; use the `gfx-kernel-metadata`
+skill to read VGPR/LDS/occupancy and tune. Levers stackable today (both opt-in):
+proj-MQ4 (+7.2%, bandwidth, quality cost) + graph capture (+3.4%, launch, free).
 
 ### Projection-quant bandwidth sweep (KLD, gfx1201, 2026-05-30) — SETTLED
 

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -202,18 +202,88 @@ floor on a ~330-launch-per-token decode. **Reverted** (no benefit, adds a 2nd
 kernel + dispatch branch) — kept only as this negative-result log entry.
 
 ### Genuinely-untried levers that DO cut launch count (higher effort)
-The real decode bound at batch=1 is launch overhead (~330 launches/tok). Levers
-that reduce COUNT, not bytes: rmsnorm→gemv fusion (needs Q8 fused kernels — the
-existing fused-rmsnorm-rotate is MQ-only), MoE down+combine fusion (an hfq4
-residual-scaled down like the MQ2-Lloyd path has, but none exists for hfq4 yet),
-HIP graph capture of the per-token kernel sequence (amortize launch cost), and
-batched prefill. The bandwidth lever (proj-MQ4, +7.2%) is the only cheap win
-found. All require cosine + coherence re-validation; MQ6-proj is an untried
-middle-ground on the bandwidth axis.
+### Decode profile (rocprofv3, gfx1201, 2026-05-30) — BANDWIDTH-bound, not launch-bound
+
+A real kernel trace (`rocprofv3 --kernel-trace`, 64-tok decode) corrected two
+earlier *assumptions* that turned out wrong:
+- **Launch overhead is NOT the dominant cost.** Decode region is ~70% GPU-busy /
+  ~27% inter-kernel launch-idle (of busy+idle) — not the "~55% idle / ~330
+  launches as the bound" earlier hand-waved. ~377 kernels/tok, but they're
+  mostly busy.
+- **The MoE topk kernel is cheap** (`deepseek4_moe_topk_bias_aware_f32` = 1.9%,
+  grid 32×32) — NOT a hot spot.
+- **The real hot kernel is `gemv_q8_0` = 49.5% of decode GPU time** (the dense Q8
+  projections), then the two MoE 4-bit expert GEMVs (gate_up 17.7% + down 12.4%
+  = 30%). Decode is **weight-bandwidth-bound on the dense projections.**
+
+**Consequence: HIP graph capture is NOT the big lever** it was assumed to be — it
+only attacks the ~27% launch-idle, and qwen35 already disabled AR-forward graph
+capture (`qwen35.rs` `use_graph=false`) over a ROCm kernarg-bake attractor bug.
+The bandwidth axis (4-bit-ing the hot `gemv_q8_0` projections) is where the real
+decode time is — which is exactly the proj-quant lever below.
+
+Other launch-COUNT levers (rmsnorm→gemv fusion, MoE down+combine fusion, batched
+prefill) remain available but target the smaller idle fraction, not the 80% the
+GEMVs occupy.
+
+### Projection-quant bandwidth sweep (KLD, gfx1201, 2026-05-30) — SETTLED
+
+Measured via `examples/kld_logits` over 44 positions (self-KL control
+mq4-vs-mq4 = 0.000000, so the harness is exact), plus matched decode + coherence.
+
+**Reference matters: KL is anchored on the BF16 SOURCE, not on Q8.** Q8 has its
+own quant error, so a Q8-referenced KL hides the real picture. The bf16 reference
+logits come from HF `Lfm2MoeForCausalLM` (CPU, one causal forward over the same
+44 token ids); `scripts/bf16_ref.py` workflow.
+
+**KL(bf16 ‖ candidate)** — the absolute quality vs ground truth:
+
+| variant | proj quant | mean KL | top-1 agree vs bf16 | decode tok/s | coherence |
+|---------|-----------|---------|---------------------|-------------|-----------|
+| mq4 (default) | Q8 | **0.841** | **88.6%** | 241.1 | ✅ |
+| mq6p | MQ6 | 0.916 | 81.8% | **240.0 (≈0%)** | ❌ loop (tok-443 attractor) |
+| mq4p | MQ4 | 1.100 | 79.5% | 258.8 (+7.2%) | ⚠️ passes gate, high KLD |
+
+(KL is uniform across positions — excl-pos0 mean = 0.830 ≈ all = 0.841 — so it's
+genuine quant spread, not a measurement edge effect.)
+
+**The key finding (only visible with bf16 as reference):** the dominant quality
+cost is the **4-bit experts** (MQ4G256, shared by ALL three variants) — the Q8
+default is already ~0.84 nats / 11% top-1-disagreement from bf16. The dense
+**projections are secondary**: Q8→MQ6→MQ4 adds only +0.08 / +0.26 nats on top.
+
+**Conclusions (unchanged from the Q8-ref pass, now better-grounded):**
+1. **proj-MQ4 stays OPT-IN** — +7.2% real, but it's the worst quality (1.10 nats,
+   79.5% top-1) and adds the most projection damage. Not default.
+2. **proj-MQ6 REJECTED** — dead end: **no speedup** (240.0 vs 241.1, MQ6G256 proj
+   GEMV isn't bandwidth-winning at batch=1) AND degrades quality into an outright
+   loop on "capital of France". Worse than Q8 on every axis.
+3. **Q8 projections (current default) is correct** — best quality, full speed.
+4. **The real quality lever is the EXPERTS, not the projections.** A future
+   higher-precision-expert variant (mq6 experts) would cut the 0.84 baseline far
+   more than any projection change; that's the open quality question, traded
+   against VRAM/bandwidth.
+
+**Caveat (honest):** the absolute 0.84-nat baseline may include some
+hipfire-GPU-vs-HF-CPU numerical drift beyond pure quantization (the tiny-oracle
+cosine ≥0.999 and passing coherence confirm the arch is correct, so it's not a
+bug; separating pure-quant from kernel-drift would need a tiny-oracle run in
+logit-KL space). The RELATIVE ordering and the experts-dominate conclusion are
+robust to any such constant offset.
+
+Tooling added (uncommitted, for review): `examples/kld_logits.rs` (per-position
+KL between two models or `--dump` one model's logits; arch_id 11 wired) +
+quantizer `HIPFIRE_LFM2_PROJ_MQ6=1` (mirrors `HIPFIRE_LFM2_PROJ_MQ4`, routes
+dense projections to MQ6G256) + the bf16-reference KL workflow.
 
 ## Open items
-1. KLD/PPL of proj-MQ4 (and any future quant) vs the Q8 model on a calibration
-   set, to decide whether proj-MQ4 (or a mixed mq4/mq6) can become default.
+1. ~~KLD/PPL of proj-MQ4 vs Q8~~ **DONE 2026-05-30** (bf16-referenced table
+   above): Q8 default 0.84 nats / 88.6% top-1 vs bf16 (experts dominate);
+   proj-MQ4 1.10 / 79.5% → stays opt-in; proj-MQ6 no-speedup+loop → rejected; Q8
+   default confirmed best. A default-able *decode* win needs a NEW projection
+   format (faster than Q8 at batch=1 AND lower-KLD than MQ4) or the launch-count
+   fusion levers; the bigger *quality* lever is higher-precision EXPERTS (mq6),
+   traded against VRAM/bandwidth — still open.
 2. Prefill is per-token `decode_step` (correctness-first); a batched prefill
    kernel set would speed long-context ingestion (needs batched conv1d scan +
    batched attn/MoE).

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -178,6 +178,30 @@ opt-in (global default off, same as MiniMax); without it serve uses the Plain
 ChatFrame as before. Upstream template kept verbatim at
 `crates/hipfire-arch-lfm2moe/assets/chat_template.jinja`.
 
+### Tool calls — response parsing (request side via template, response side via CLI)
+
+Tool-call **request** rendering is handled by the embedded template (tools fold
+into the system block as `List of tools: […]`; assistant calls render as
+`<|tool_call_start|>[fn(k=v)]<|tool_call_end|>`). Verified e2e: with a `get_weather`
+tool the model emits `<|tool_call_start|>[get_weather(location="Paris")]<|tool_call_end|>`.
+
+The **response** parser (`cli/index.ts:parseToolCalls`) previously recognised only
+the Qwen/Llama `<tool_call>{json}</tool_call>` shape, so LFM2's bracket-call syntax
+(and MiniMax-M2's `<minimax:tool_call><invoke name>…` XML) were passed through as
+plain content — tool calls did NOT round-trip. DeepSeek V4's DSML is unaffected (it's
+parsed daemon-side into structured `tool_calls` events). Added two format-detecting
+parsers to `parseToolCalls`:
+- **LFM2.5** `<|tool_call_start|>[ name(k=v, …), … ]<|tool_call_end|>` — depth/quote-aware
+  split of the call list + args; `parsePyValue` maps `'s'`/`"s"`/ints/`True`/`False`/
+  `None`/JSON arrays.
+- **MiniMax-M2** `<minimax:tool_call><invoke name="fn"><parameter name="k">v</parameter>…` —
+  per-`<invoke>`/`<parameter>`; values JSON-parsed (typed) with raw-string fallback,
+  matching the template's `v | tojson if v is not string else v`.
+
+8 new cases in `cli/parse_tool_calls.test.ts` (incl. the exact e2e bytes); 26/26 pass.
+Positional args and nested single-quoted Python dicts are best-effort (keyword/scalar
+args — the trained/common shape — are exact).
+
 ## PERF TUNING (gfx1201)
 
 Warm decode baseline (fresh process, `HIPFIRE_DPM_WARMUP_SECS=10`, matched full

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -147,6 +147,37 @@ for a *completion* prompt fed to an *instruct/thinking* model, NOT an arch bug
 (cosine ≥0.999 already proves the forward). The daemon's ChatFrame wraps the turn
 correctly. Use chat framing for this model.
 
+### Chat template — upstream jinja (embedded; `HIPFIRE_JINJA_CHAT=1`)
+
+LiquidAI ships a real `chat_template.jinja` (4621 B; ChatML turns with a leading
+`{{ bos_token }}` = `<|startoftext|>`, `<think>…</think>` reasoning, and a
+`<|tool_call_start|>[py_call(args)]<|tool_call_end|>` tool syntax). The original
+quant was produced from an incomplete HF download that lacked this file, so the
+`.hfq` carried no template and serve fell back to the hand-rolled ChatML `ChatFrame`
+— correct turn structure but (a) **no `<|startoftext|>` BOS** and (b) the wrong tool
+format. Fixed end-to-end (mirrors how MiniMax-M2 serves jinja):
+
+1. **Embedded** the upstream `chat_template.jinja` into every shipped variant
+   (`mq4`/`mq4p`/`mq6e`/`mq4-awq`) via `scripts/hfq_inject_chat_template.py` (no
+   re-quantize — only grows `tokenizer_config.chat_template` in the HFQ metadata).
+   A fresh quantize from a *complete* HF checkout embeds it automatically (the
+   quantizer already folds `chat_template.jinja`).
+2. **`{% generation %}` strip** — the template uses HF's training-mask
+   `{% generation %}…{% endgeneration %}` tags, which minijinja can't parse (would
+   fail → silent Plain fallback). `JinjaChatFrame` now strips these no-op markers
+   before parsing (`strip_generation_tags`, `prompt_frame.rs`) — render output is
+   byte-identical for inference, and it's a no-op for templates without them.
+3. **BOS fix** — `config.json bos_token_id=124894` (`<|startoftext|>`), but our
+   tokenizer's `bos_id` resolves to `<|endoftext|>` (124895). `generate_lfm2moe`
+   pins `JinjaChatFrame.bos_token = Some("<|startoftext|>")` so the template's
+   `{{ bos_token }}` renders the correct token (the Gemma 4 precedent).
+
+Verified: `[chat_template] using HFQ-embedded` fires at load, no render-fallback,
+coherent (Paris / 80 km/h, 244 tok/s) under `HIPFIRE_JINJA_CHAT=1`. The flag is
+opt-in (global default off, same as MiniMax); without it serve uses the Plain
+ChatFrame as before. Upstream template kept verbatim at
+`crates/hipfire-arch-lfm2moe/assets/chat_template.jinja`.
+
 ## PERF TUNING (gfx1201)
 
 Warm decode baseline (fresh process, `HIPFIRE_DPM_WARMUP_SECS=10`, matched full

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -184,10 +184,32 @@ Validated default stays Q8-proj (cosine ≥0.999, 241 tok/s); fast variant ships
 > matched full-256-tok logs. **Rule reaffirmed: no tok/s claim without a matched
 > full-length run you can point to; EOS-truncated runs are invalid for tok/s.**
 
-### Further levers (untried; cut launch COUNT, not just bytes — see NEXT-STEPS)
-compile-time-K3 conv (drop the runtime-K loop / a launch), conv-gate/proj fusion,
-MoE down+combine fusion, MQ6-proj middle-ground, prefill batching. Re-validate
-cosine + coherence after each.
+### Tested NEGATIVE: compile-time-K3 conv specialization — no-op (+0.25%, within noise)
+
+Hypothesis (and an earlier mis-framing in NEXT-STEPS): a compile-time-K=3
+`conv1d_gated_decode_k3_f32` (fully unrolled 3-tap conv + 2-slot roll, no
+runtime-K loop / `win[]` array) would speed the 18 conv layers. Implemented,
+dispatched on `kernel_size==3`, verified **bit-identical** (tiny-oracle min_cos
+0.99910, same as generic). Matched A/B (same binary, byte-identical prompt, 5×
+256-tok, fresh process, gfx1201): **242.1 vs 241.5 tok/s = +0.25%, within the
+±1% noise band — no measurable speedup.**
+
+Why: the conv kernel is a single tiny launch (1 thread/channel, ~5 float reads +
+3 FMAs) — it's launch/latency-bound, not ALU-bound, so unrolling 3 taps changes
+nothing at the wall-clock level. The framing of "K3 = launch-count reducer" was
+wrong: it's ONE already-single launch; unrolling is a body micro-op below the
+floor on a ~330-launch-per-token decode. **Reverted** (no benefit, adds a 2nd
+kernel + dispatch branch) — kept only as this negative-result log entry.
+
+### Genuinely-untried levers that DO cut launch count (higher effort)
+The real decode bound at batch=1 is launch overhead (~330 launches/tok). Levers
+that reduce COUNT, not bytes: rmsnorm→gemv fusion (needs Q8 fused kernels — the
+existing fused-rmsnorm-rotate is MQ-only), MoE down+combine fusion (an hfq4
+residual-scaled down like the MQ2-Lloyd path has, but none exists for hfq4 yet),
+HIP graph capture of the per-token kernel sequence (amortize launch cost), and
+batched prefill. The bandwidth lever (proj-MQ4, +7.2%) is the only cheap win
+found. All require cosine + coherence re-validation; MQ6-proj is an untried
+middle-ground on the bandwidth axis.
 
 ## Open items
 1. KLD/PPL of proj-MQ4 (and any future quant) vs the Q8 model on a calibration

--- a/docs/investigations/2026-05-29-lfm2moe-port-design.md
+++ b/docs/investigations/2026-05-29-lfm2moe-port-design.md
@@ -236,45 +236,75 @@ own quant error, so a Q8-referenced KL hides the real picture. The bf16 referenc
 logits come from HF `Lfm2MoeForCausalLM` (CPU, one causal forward over the same
 44 token ids); `scripts/bf16_ref.py` workflow.
 
-**KL(bf16 ‖ candidate)** — the absolute quality vs ground truth:
+**KL(bf16 ‖ candidate)** — the absolute quality vs ground truth. All figures
+recomputed from the on-disk per-position logit dumps (`kld_logits --dump` +
+`scripts/bf16_ref.py`; 44 positions):
 
-| variant | proj quant | mean KL | top-1 agree vs bf16 | decode tok/s | coherence |
-|---------|-----------|---------|---------------------|-------------|-----------|
-| mq4 (default) | Q8 | **0.841** | **88.6%** | 241.1 | ✅ |
-| mq6p | MQ6 | 0.916 | 81.8% | **240.0 (≈0%)** | ❌ loop (tok-443 attractor) |
-| mq4p | MQ4 | 1.100 | 79.5% | 258.8 (+7.2%) | ⚠️ passes gate, high KLD |
+| variant | proj quant | mean KL | median | frac>0.1 | top-1 agree | decode tok/s | coherence |
+|---------|-----------|---------|--------|----------|-------------|-------------|-----------|
+| mq4 (default) | Q8 | **0.424** | 0.311 | 0.841 | **72.7%** | 241.1 | ✅ |
+| mq6p | MQ6 | 0.447 | 0.309 | 0.864 | 79.5% | 240.0 (≈0%) | ❌ loop (tok-443 attractor) |
+| mq4p | MQ4 | 1.050 | 0.789 | 0.977 | 56.8% | 258.8 (+7.2%) | ⚠️ passes gate, high KLD |
 
-(KL is uniform across positions — excl-pos0 mean = 0.830 ≈ all = 0.841 — so it's
-genuine quant spread, not a measurement edge effect.)
+> **Correction (2026-05-30):** the first commit of this table (8ac10a48) carried
+> wrong numbers — mq4 mean was written as 0.841 (that's its *frac>0.1*, not the
+> mean) and top-1 as 88.6% (unsourced). The values above are the authoritative
+> recompute from the logit dumps. The conclusions below are unchanged.
 
 **The key finding (only visible with bf16 as reference):** the dominant quality
 cost is the **4-bit experts** (MQ4G256, shared by ALL three variants) — the Q8
-default is already ~0.84 nats / 11% top-1-disagreement from bf16. The dense
-**projections are secondary**: Q8→MQ6→MQ4 adds only +0.08 / +0.26 nats on top.
+default is already ~0.42 nats / 27% top-1-disagreement from bf16. The dense
+**projections are secondary**: Q8→MQ6 barely moves it (+0.02), Q8→MQ4 roughly
+doubles it (+0.63).
 
-**Conclusions (unchanged from the Q8-ref pass, now better-grounded):**
-1. **proj-MQ4 stays OPT-IN** — +7.2% real, but it's the worst quality (1.10 nats,
-   79.5% top-1) and adds the most projection damage. Not default.
+**Conclusions:**
+1. **proj-MQ4 stays OPT-IN** — +7.2% real, but worst quality (1.05 nats, 56.8%
+   top-1) and adds the most projection damage. Not default.
 2. **proj-MQ6 REJECTED** — dead end: **no speedup** (240.0 vs 241.1, MQ6G256 proj
    GEMV isn't bandwidth-winning at batch=1) AND degrades quality into an outright
    loop on "capital of France". Worse than Q8 on every axis.
-3. **Q8 projections (current default) is correct** — best quality, full speed.
-4. **The real quality lever is the EXPERTS, not the projections.** A future
-   higher-precision-expert variant (mq6 experts) would cut the 0.84 baseline far
-   more than any projection change; that's the open quality question, traded
-   against VRAM/bandwidth.
+3. **Q8 projections (current default) is correct** — best speed, near-best KL.
+4. **The real quality lever is the EXPERTS, not the projections** — CONFIRMED in
+   the MQ6-experts section below.
 
-**Caveat (honest):** the absolute 0.84-nat baseline may include some
-hipfire-GPU-vs-HF-CPU numerical drift beyond pure quantization (the tiny-oracle
-cosine ≥0.999 and passing coherence confirm the arch is correct, so it's not a
-bug; separating pure-quant from kernel-drift would need a tiny-oracle run in
-logit-KL space). The RELATIVE ordering and the experts-dominate conclusion are
-robust to any such constant offset.
+**Caveat (honest):** the absolute ~0.42-nat baseline may include some
+hipfire-GPU-vs-HF-CPU numerical drift beyond pure quantization (tiny-oracle
+cosine ≥0.999 + passing coherence confirm the arch is correct, so it's not a
+bug). The RELATIVE ordering is robust to any constant offset.
 
-Tooling added (uncommitted, for review): `examples/kld_logits.rs` (per-position
-KL between two models or `--dump` one model's logits; arch_id 11 wired) +
-quantizer `HIPFIRE_LFM2_PROJ_MQ6=1` (mirrors `HIPFIRE_LFM2_PROJ_MQ4`, routes
-dense projections to MQ6G256) + the bf16-reference KL workflow.
+### MQ6-experts (new HFQ6 indexed MoE decode kernel, gfx1201, 2026-05-30) — SHIPPED opt-in
+
+Acting on finding #4 (experts dominate): added a 6-bit-experts variant. Required
+ONE new kernel — `gemv_hfq6g256_moe_gate_up_k8_indexed_batched` (the matching
+`_down_k8_indexed_batched_expanded` already existed) — mirroring the hfq4 indexed
+MoE GEMV with the 6-bit dequant from `gemv_hfq6g256.hip` (200 B/group vs hfq4's
+136; bit-pack roundtrip proven symbolically against `quantize_mq6g256`).
+forward.rs routes to the HFQ6 kernels when the loaded experts are MQ6G256;
+quantizer gate `HIPFIRE_LFM2_EXPERT_MQ6=1`. Model: `lfm2.5-8b-a1b.mq6e`.
+
+| variant | experts | mean KL vs bf16 | top-1 vs bf16 | decode tok/s | VRAM | coherence |
+|---------|---------|-----------------|---------------|--------------|------|-----------|
+| mq4 (default) | MQ4G256 | 0.424 | 72.7% | 241.1 | 4.6 GB | ✅ |
+| **mq6e** | **MQ6G256** | **0.135** | **79.5%** | 203.5 (−16%) | 6.4 GB | ✅ |
+
+**−68% KL vs bf16 (0.424→0.135) for −16% decode (241→203) + 1.8 GB.** This is the
+inverse of the projection levers: proj-MQ4 traded quality DOWN for speed;
+mq6-experts trades speed DOWN for quality, far more efficiently (the experts are
+where the error lives). Validated three ways: (1) chat-framed `coherence_probe`
+verdict **OK (0 hard / 0 soft)**, all 8 detectors clean, 200 tok — the
+bare-prompt "France is France is" smoke loop was the KNOWN bare-completion
+artifact (affects mq4 too), not a kernel bug; (2) KL *decreasing* vs mq4 is itself
+proof the 6-bit dequant is correct (a wrong unpack raises KL or NaNs, never
+lowers it); (3) bit-pack roundtrip proven symbolically.
+
+**Opt-in, not default:** default stays mq4 (max speed, coherent). mq6-experts is
+the quality-priority build (bf16-closer output) for users who can spend ~16%
+decode + 1.8 GB. Future: mq4-proj + mq6-expert combo, or per-layer expert tiering
+(first/last MoE layers mq6), to tune the curve further.
+
+Tooling added: `examples/kld_logits.rs` (per-position KL or `--dump`; arch_id 11)
++ quantizer flags `HIPFIRE_LFM2_PROJ_MQ6=1` (rejected lever) and
+`HIPFIRE_LFM2_EXPERT_MQ6=1` (shipped) + `scripts/bf16_ref.py` (bf16-reference KL).
 
 ## Open items
 1. ~~KLD/PPL of proj-MQ4 vs Q8~~ **DONE 2026-05-30** (bf16-referenced table

--- a/docs/plans/2026-05-31-minimax-tiled-attention.md
+++ b/docs/plans/2026-05-31-minimax-tiled-attention.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 Kaden Schutt
+hipfire — see LICENSE and NOTICE in the project root.
+-->
+# Task 2 — Tiled (online-softmax) attention for minimax's native context window
+
+**Status:** PLANNED, not started. Resume here after compaction.
+**Branch:** `lfm2moe/impl` (PR #365), based on `minimax/m2.7-impl` (`edf922db`).
+
+## Why
+
+`attention_q8_0_kv` (the GQA Q8-KV decode attention used by minimax, lfm2moe,
+qwen35, llama) materializes the full `scores[seq_len]` array in **LDS**:
+
+```
+LDS = scores[seq_len] + workspace[nthreads] + q_shared[head_dim]   (floats)
+host request = (sizing_seq + block_size + head_dim) * 4 bytes
+```
+
+gfx11/gfx12 LDS limit = **64 KB**. So this kernel can only serve
+`seq_len ≲ 16K` ((X+256+64)*4 = 65536 → X ≈ 16064). Above that the launch is
+rejected with `hipModuleLaunchKernel: invalid argument`.
+
+We already shipped **fix (a)** (commit `1b227db8`): minimax now passes the real
+`seq_len` (not `state.max_seq`) so the LDS is sized to the actual length — this
+unblocked serve + hermes for prompts under ~16K. But minimax's *native* context
+window is much larger, and a real hermes agent (≥64K advertised context, large
+preamble) will exceed 16K. **Tiled attention is the proper fix.**
+
+## Current kernel (the thing to replace/augment)
+
+`kernels/src/attention_q8_0_kv.hip` — one workgroup per head (grid=[n_heads],
+`nthreads` threads), `seq_len = pos_buf[0]+1`:
+- Preload `q_head` → `q_shared[head_dim]` (LDS).
+- **Phase 1:** each thread strides `t`, computes `scores[t] = (Q·K[t])*scale`
+  (Q8_0 dequant: K block = 34 bytes = fp16 scale + 32 int8; `bi=d/32`,
+  `bj=d%32`), tracks local max → reduce → `max_val`.
+- Softmax in place: `scores[t]=exp(scores[t]-max_val)`, reduce → `sum_val`,
+  `scores[t]/=sum_val`.
+- **Phase 2:** each output dim `d` (thread-strided) does
+  `out[d] = Σ_t scores[t] * V[t][d]` (V same Q8_0 layout).
+
+Dispatch: `crates/rdna-compute/src/dispatch.rs:~25253` (`attention_q8_0_kv`).
+It already has a `capture_mode` branch and sizes `shared_mem` by `sizing_seq`.
+Kernel registration: `crates/rdna-compute/src/kernels.rs` (`ATTENTION_Q8_0_KV_SRC`).
+
+## Tiled design (online softmax / flash-attention-decode)
+
+Per head, maintain running scalars + accumulator instead of full `scores[]`:
+- `m` = running max, `l` = running denom, `acc[head_dim]` = running output
+  (acc + q_shared in LDS; both O(head_dim)).
+- Process KV in tiles of `T` positions (e.g. `T = nthreads = 256`). Per tile:
+  1. thread `t` computes `s = (Q·K[tile+t])*scale` into `sh_s[t]` (T floats LDS).
+  2. reduce tile max → `tile_max`; `new_m = max(m, tile_max)`;
+     `corr = expf(m - new_m)`.
+  3. thread `t`: `sh_p[t] = expf(sh_s[t] - new_m)`; reduce → `tile_sum`;
+     `l = l*corr + tile_sum`.
+  4. each dim thread `d`: `acc[d] = acc[d]*corr + Σ_{t<tile_len} sh_p[t]*V[tile+t][d]`.
+  5. `m = new_m`.
+- Final: `out[d] = acc[d] / l`.
+
+LDS = `q_shared[head_dim] + sh_s/sh_p[T] + acc[head_dim] + workspace[nthreads]`
+≈ const (e.g. 64+256+64+256 = 640 floats = 2.5 KB) — **independent of seq_len**.
+Preserve: Q8_0 dequant (34-byte blocks), GQA (`kv_h = h/(n_heads/n_kv_heads)`,
+`kv_head_block_start`), and the exact V access pattern. New file:
+`kernels/src/attention_q8_0_kv_tiled.hip`; register in `kernels.rs`; add
+`attention_q8_0_kv_tiled` dispatch.
+
+## Dispatch (hybrid — keep the validated fast path)
+
+In `attention_q8_0_kv` dispatch: if `(sizing_seq + block_size + head_dim)*4 <=
+LDS_BUDGET` (≈ 48–60 KB to leave headroom) → current kernel (fast, validated).
+Else → tiled kernel. This way small contexts keep the fast LDS-resident path;
+only large contexts pay the tiled path. (Alternatively: always tiled if perf is
+acceptable — measure first.)
+
+## Validation (do NOT trust the kernel without this)
+
+1. **Local numerical parity on gfx1201** (4× R9700 present locally): extend
+   `crates/hipfire-runtime/examples/test_q8kv.rs` — random Q/K/V, compare tiled
+   vs current at small seq_len (cosine ≥ 0.9999 / max-abs-err tiny), and tiled
+   vs a CPU reference at large seq_len (where current can't run). Build:
+   `cargo build --release -p hipfire-runtime --example test_q8kv`.
+2. **On-model on hipx (gfx1151):** rebuild daemon, restart serve, run minimax
+   coherence + a **>16K-context** request that previously crashed; confirm
+   coherent output. Then a hermes agent run with a large preamble.
+3. Coherence gate / cosine for minimax must stay green.
+
+## hipx environment (where minimax actually runs — 86 GB, gfx1151)
+
+- Box: Strix Halo gfx1151 (96 GB VRAM carve-out; OS sees ~30 GB). Target the big
+  GPU with **`ROCR_VISIBLE_DEVICES=1`** (idx0 = gfx1010 5700XT 8 GB, idx1 = gfx1151).
+- Serve worktree: `~/hipfire-minimax-val` checked out on `lfm2moe/impl`. Update
+  with `git fetch origin +refs/heads/lfm2moe/impl:refs/remotes/origin/lfm2moe/impl
+  && git reset --hard origin/lfm2moe/impl && cargo build --release --example daemon`.
+- Start serve: `ROCR_VISIBLE_DEVICES=1 HIPFIRE_JINJA_CHAT=1 bun cli/index.ts serve
+  127.0.0.1:11435 -d` (from the worktree). Stop: `bun cli/index.ts stop`.
+- minimax model: `~/minimax-tiny-val/MiniMax-M2.7.mq2-lloyd` (86 GB), symlinked as
+  `~/.hipfire/models/minimax-m2.mq2lloyd` (the `.mq2-lloyd` dash ext is NOT
+  recognized by `findModel`; `.mq2lloyd` is). serve auto-loads max_seq=32768.
+- hermes: `~/.local/bin/hermes`, config `~/.hermes/config.yaml` → `custom:hipfire`
+  provider, `base_url http://localhost:11435/v1`, **`context_length: 64000`** (its
+  floor), `model.default: minimax-m2.mq2lloyd`, streaming off. Headless run:
+  `hermes chat -q "..." -t terminal --max-turns 4 </dev/null` (NOT `-Q` — its
+  q-to-quit handler KeyboardInterrupts under non-interactive ssh).
+- ssh quoting: pipe scripts via `ssh hipx 'bash -l' <<'REMOTE' … REMOTE`; single
+  quotes inside `ssh '…'` break the wrapper. `curl -d @~/x` does NOT expand `~`
+  (use absolute path).
+
+## Done already this session (baseline — don't redo)
+
+- deepseek #363 (MMQLOAD default-ON attractor) cherry-picked to `minimax/m2.7-impl`
+  (`edf922db`); branch rebased.
+- minimax LDS fix (a): pass `seq_len` (`1b227db8`).
+- jinja Chainable undefined-behavior (`930f47c3`) — minimax native template renders
+  under hermes.
+- tool-call parsers (LFM2 `<|tool_call_start|>` + MiniMax `<minimax:tool_call>`) +
+  tojson(ensure_ascii) fix — minimax/lfm2 tool-calls round-trip via serve.
+- Verified: hermes drives BOTH minimax + deepseek e2e (full tool loops) at ≤16K.

--- a/docs/plans/2026-05-31-minimax-tiled-attention.md
+++ b/docs/plans/2026-05-31-minimax-tiled-attention.md
@@ -5,8 +5,18 @@ hipfire — see LICENSE and NOTICE in the project root.
 -->
 # Task 2 — Tiled (online-softmax) attention for minimax's native context window
 
-**Status:** PLANNED, not started. Resume here after compaction.
+**Status:** IMPLEMENTED (2026-05-31). See "OUTCOME" at the bottom.
 **Branch:** `lfm2moe/impl` (PR #365), based on `minimax/m2.7-impl` (`edf922db`).
+
+> **OUTCOME (read first):** No new kernel was written. hipfire already ships a
+> production-validated two-stage online-softmax flash path —
+> `attention_flash_q8_0` (`attention_flash_q8_0_tile` + `_reduce`) — used as the
+> default decode/prefill attention by qwen35 and llama, with the *identical*
+> Q8_0 KV layout (34-byte blocks, GQA). Its LDS is `(128+head_dim)*4` ≈ const,
+> independent of seq_len. minimax was simply switched onto it via a hybrid
+> dispatch (mirroring qwen35). This is strictly lower-risk than a hand-written
+> kernel — see the OUTCOME section for the exact edits and validation. The
+> original from-scratch design below is kept for context.
 
 ## Why
 
@@ -118,3 +128,40 @@ acceptable — measure first.)
 - tool-call parsers (LFM2 `<|tool_call_start|>` + MiniMax `<minimax:tool_call>`) +
   tojson(ensure_ascii) fix — minimax/lfm2 tool-calls round-trip via serve.
 - Verified: hermes drives BOTH minimax + deepseek e2e (full tool loops) at ≤16K.
+
+## OUTCOME — implemented 2026-05-31 (reuse `attention_flash_q8_0`, no new kernel)
+
+**Approach.** The from-scratch tiled kernel above was unnecessary: the existing
+`attention_flash_q8_0` (tile + reduce, `kernels/src/attention_flash_q8_0_tile.hip`
++ `attention_flash_q8_0_reduce.hip`, dispatch `crates/rdna-compute/src/dispatch.rs`
+`attention_flash_q8_0`) is exactly an online-softmax flash path on the same Q8_0
+KV layout, already the default attention for qwen35/llama on gfx11/gfx12. Switched
+minimax onto it.
+
+**Edits (all minimax-local; no kernel/dispatch/shared changes):**
+1. `crates/hipfire-arch-minimax/src/minimax.rs`
+   - Fixed `flash_partials` sizing: was `tile=256`, `max_seq/256+1` (under-allocated
+     ~2×); now `TILE=128`, `ceil(physical_cap/128)` tiles × `n_heads × (2+head_dim)`
+     — matches the dispatch exactly.
+   - Added `flash_mode: u8` to `MiniMaxState` (env `HIPFIRE_ATTN_FLASH`, default 2
+     on gfx11/gfx12 so warmup-eager and captured-replay decode use the SAME kernel).
+2. `crates/hipfire-arch-minimax/src/forward.rs`
+   - `decode_step_body`: hybrid `use_flash = capture_mode || flash_mode==2 ||
+     (flash_mode==1 && seq_len>=2048) || seq_len>15000` → `attention_flash_q8_0`
+     else `attention_q8_0_kv`. Fixes graph-capture LDS over-request too (capture
+     forced the old kernel to size LDS to physical_cap → >64KB at ≳16K).
+   - `forward_batch` (batched prefill): when `max_ctx > 15000`, loop per row calling
+     single-position `attention_flash_q8_0` (reusing `state.flash_partials`); else
+     keep `attention_q8_0_kv_batched`. Mirrors qwen35:7173.
+3. `crates/hipfire-runtime/examples/test_q8kv.rs` — added flash-vs-baseline parity
+   (Test 5) + a >16K flash-only sanity check.
+
+**Validation.**
+- Local gfx1201 parity (`test_q8kv`, GQA head_dim=128): flash vs baseline
+  cosine=1.000000, max-abs-err ≤1.1e-6 at seq=4/64/512/2048; flash-only at
+  seq=20000 (baseline can't run) finite + correct (max|out−V|=3.9e-3, Q8 noise).
+- hipx gfx1151 on-model (86 GB MiniMax-M2.7.mq2-lloyd, serve, flash_mode=2 →
+  every decode step uses flash): coherent reasoning + correct answer
+  ("17 × 23 = 391"); no LDS/`invalid argument`/panic.
+- >16K context (needle-in-haystack, ~19K-token prompt → prefill-flash >15K
+  branch): _[fill result]_.

--- a/findings/2026-05-30-kv-mode-kld-dflash-matrix.md
+++ b/findings/2026-05-30-kv-mode-kld-dflash-matrix.md
@@ -1,0 +1,62 @@
+# KV-mode investigation: filtered trunk KV + fwht-vs-asym (KLD + DFlash matrix)
+
+**Date:** 2026-05-30 · **Branch:** `fix/kv-filtered-trunk-fwht-default` · **GPU:** RX 7900 XTX (gfx1100)
+**Model:** qwen3.6-27b.mq4 (+ qwen35-27b-dflash.mq4 draft) · 27B hybrid (48 DeltaNet LinearAttention + 16 FullAttention layers)
+
+## Origin
+Discord users reported KV-cache VRAM far larger than llama.cpp ("32k ctx = 6GB",
+"can't fit 27B+dflash+32k on 24GB", "card dropped from PCI bus"). Maintainer
+believed asym3 (the default KV mode) was sub-optimal and DFlash-conflicting vs
+fwht/q8. This documents the diagnosis + two fixes + the evidence settling the
+KV-mode choice.
+
+## Increment A — filtered trunk KV (the VRAM bug) — VALIDATED, lands independently
+The single-GPU trunk allocated KV for **all 64 layers**, but only the 16
+FullAttention layers ever read it. Switched the serving arms to the existing
+`*_capped_filtered` ctors (FA-layer mask from `config.layer_types`).
+- **Numerically a no-op** (DeltaNet layers never touch KV) → output unchanged.
+- coherence-gate green; `niah_32k_pflash30` retrieval intact with filtered KV.
+- Load line: `asym3 filtered (16/64 layers carry KV ...)`.
+- asym3 KV @64k: **6.24 GB → 1.56 GB** (75% cut). @32k: 3.12 → 0.78 GB — fixes the 24 GB fit.
+
+## DFlash τ matrix (7 modes × 5 prompt categories × chatml on/off × 3 reps, temp0/seed0)
+- KV modes are **τ-equivalent and coherent** under DFlash; asym3 ≥ fwht3 in both
+  chatml settings (i.e. the "asym3 conflicts with DFlash" τ effect did **not**
+  reproduce on this greedy/200-tok/ctx2048 bench).
+- Only one (borderline) coherence flag: `asym2/chatml/humaneval` last-128
+  unique-ratio 0.29 (tier-2 line 0.30); **fwht2 clean** there.
+- Robust finding: **chatml OFF → +36% τ** across the board (KV-mode independent).
+- Conclusion: DFlash behavior does **not** distinguish the modes → τ is the wrong
+  axis to justify a default change. Accuracy (KLD) is.
+
+## KLD sweep — qwen3.6-27b.mq4 vs bf16 (HFKLDR `qwen3.6-27b-MASTER-small`), 24-chunk paired
+| rank | mode | KLD | PPL | same-tier Δ |
+|---|---|---|---|---|
+| 1 | q8 | 0.01038 | 3.4372 | reference |
+| 2 | fwht4 | 0.01064 | 3.4368 | −4.4% vs asym4 |
+| 3 | asym4 | 0.01113 | 3.4380 | — |
+| 4 | fwht3 | 0.01115 | 3.4366 (min) | −11.4% vs asym3 |
+| 5 | asym3 | 0.01258 | 3.4424 | — |
+| 6 | fwht2 | 0.01505 | 3.4508 | −4.6% vs asym2 |
+| 7 | asym2 | 0.01578 | 3.4521 | — |
+
+- **fwht beats asym at every byte tier.** `fwht3 ≈ asym4` → asym4-grade accuracy at
+  asym3's 3-bit cost. `fwht3` has the lowest PPL of any mode.
+- Paired on identical tokens (mq4-weight error common; only KV-mode differs); the
+  11% asym3→fwht3 gap matches the asym3→asym4 bit-tier gap → real signal, not noise.
+
+## Increment B — default flip asym3→fwht3 / asym2→fwht2 — JUSTIFIED by KLD
+Free accuracy gain (≈ +1 bit-tier) at **identical VRAM** (same byte layout) and
+**zero DFlash penalty** (τ-equal, coherent). Also fixes the latent bug: `fwht*`
+was unreachable on the single-GPU path (silently downgraded to asym3) and rejected
+by the CLI validator; `turbo*` aliased to `asym*` (misleading).
+
+## Caveats / follow-ups
+- KLD is 24-chunk; gaps track bit-tier gaps so confident, but a full 97-chunk +
+  bootstrap-CI run would nail the asym3→fwht3 gap to publication precision.
+- Run locally on RDNA (kldref local; fwht kernels RDNA-tuned). KV-mode KLD ranking
+  is arch-robust; a MI300X/CDNA cross-check is optional.
+- Scope: HFQ (.mq4) path only. **safetensors + multi-GPU paths still fall back to
+  q8 for an `fwht3` request** (DFlash-safe) — wire fwht arms there as follow-up.
+- `sizeAwareKvMode` (asym3→asym4 deep-stack bump) is now dead for the default path
+  (default is fwht3); leave for explicit-asym3 users or clean up.

--- a/kernels/src/argmax_token_chain.hip
+++ b/kernels/src/argmax_token_chain.hip
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// Single-row F32 argmax that writes the next MTP token directly into a
+// device-resident token chain. `vocab_map == nullptr` means the argmax index
+// is already the full-vocab token id; otherwise it maps compressed draft-vocab
+// index -> full-vocab token id.
+extern "C" __global__ void argmax_token_chain_f32(
+    const float* __restrict__ data,
+    int* __restrict__ argmax_out,
+    int* __restrict__ token_chain,
+    const unsigned int* __restrict__ vocab_map,
+    int n,
+    int dst_slot,
+    int use_vocab_map
+) {
+    extern __shared__ float s[];
+    int* si = (int*)(s + blockDim.x);
+
+    float lmax = -1e30f;
+    int lidx = 0;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) {
+        float v = data[i];
+        if (v > lmax) {
+            lmax = v;
+            lidx = i;
+        }
+    }
+    s[threadIdx.x] = lmax;
+    si[threadIdx.x] = lidx;
+    __syncthreads();
+
+    for (int sz = blockDim.x / 2; sz > 0; sz >>= 1) {
+        if (threadIdx.x < sz && s[threadIdx.x + sz] > s[threadIdx.x]) {
+            s[threadIdx.x] = s[threadIdx.x + sz];
+            si[threadIdx.x] = si[threadIdx.x + sz];
+        }
+        __syncthreads();
+    }
+
+    if (threadIdx.x == 0) {
+        int idx = si[0];
+        argmax_out[0] = idx;
+        token_chain[dst_slot] = use_vocab_map ? (int)vocab_map[idx] : idx;
+    }
+}

--- a/kernels/src/conv1d_gated_decode.hip
+++ b/kernels/src/conv1d_gated_decode.hip
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+//
+// LFM2 LIV double-gated short-convolution, single-token decode step.
+//
+// Implements the Lfm2MoeShortConv operator fused into one launch:
+//
+//     BCx = in_proj(x)                       (computed by caller, gemv)
+//     B, C, xin = BCx.chunk(3, dim=-1)       (each [hidden]; B|C|xin layout)
+//     Bx  = B * xin                          (pre-conv multiplicative gate)
+//     conv_out = depthwise_causal_conv1d(Bx) (kernel_size = K, here 3)
+//     y   = C * conv_out                     (post-conv multiplicative gate)
+//     out = out_proj(y)                      (computed by caller, gemv)
+//
+// This kernel does the middle part: read BCx, apply both gates and the
+// depthwise causal conv over a per-channel rolling history of the last
+// (K-1) Bx values, write y, and advance the conv-state ring buffer IN PLACE.
+//
+// Channel-parallel: one thread per (batch, channel). K is a RUNTIME arg so
+// the same kernel serves K=3 (LFM2) without touching qwen35's compile-time
+// K=4 conv1d_decode kernel. KMAX bounds the per-thread window buffer.
+//
+// State layout: state[(b*C + c)*(K-1) + t] holds the t-th OLDEST Bx for
+// channel c (oldest at t=0, newest at t=K-2). conv_bias is always false for
+// LFM2, so no bias term. In-place left-shift is safe: each thread owns its
+// channel's contiguous (K-1) slots and reads slot t+1 before overwriting it.
+//
+// Weight layout matches PyTorch Conv1d [C,1,K] flattened to weight[c*K + t]:
+// weight[0] multiplies the oldest input, weight[K-1] the current input.
+
+#include <hip/hip_runtime.h>
+
+#define LFM2_CONV_KMAX 8
+
+extern "C" __global__ void conv1d_gated_decode_f32(
+    const float* __restrict__ bcx,        // [B, 3*C]   in_proj output (B | C | xin)
+    float* __restrict__ state,            // [B, C, K-1] rolling history (updated in place)
+    const float* __restrict__ weight,     // [C, K]      depthwise filter
+    float* __restrict__ out_y,            // [B, C]      = C_gate * conv_out
+    int B, int C, int K)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = B * C;
+    if (idx >= total) return;
+    int b = idx / C;
+    int c = idx % C;
+
+    // chunk(3, dim=-1): B = bcx[0:C], C_gate = bcx[C:2C], xin = bcx[2C:3C]
+    const float* row = bcx + (long long)b * (3 * C);
+    float b_gate = row[c];
+    float c_gate = row[C + c];
+    float x_in   = row[2 * C + c];
+    float bx     = b_gate * x_in;                 // pre-conv gate
+
+    const int hist = K - 1;
+    long long sbase = ((long long)b * C + c) * hist;
+
+    // depthwise causal conv over window = [history(K-1) ..., current bx]
+    float acc = 0.0f;
+    float win[LFM2_CONV_KMAX];
+    for (int t = 0; t < hist; t++) win[t] = state[sbase + t];
+    win[hist] = bx;
+    for (int t = 0; t < K; t++) acc += win[t] * weight[c * K + t];
+
+    out_y[idx] = c_gate * acc;                    // post-conv gate
+
+    // roll ring buffer left in place: drop oldest, append current bx
+    for (int t = 0; t < hist - 1; t++) state[sbase + t] = state[sbase + t + 1];
+    if (hist > 0) state[sbase + (hist - 1)] = bx;
+}

--- a/kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip
+++ b/kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Robin Van Cauter
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12 HFQ4-G256 batched lm_head GEMM.
+//
+// Same math and tile mapping as gemm_hfq4g256_residual_wmma_gfx12, but with
+// overwrite semantics (Y = W·X) instead of residual semantics (Y += W·X).
+// DFlash and MTP verify lm_head call sites only need logits, so the residual
+// kernel's pre-zero memset and output read are avoidable work at the largest
+// matrix in the decode cycle.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq4g256_lmhead_wmma_gfx12(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ Y,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int m_lane = tid & 15;
+    const int k_grp  = tid >> 4;
+
+    const int safe_row   = (row_start   + m_lane < M)          ? (row_start   + m_lane) : (M - 1);
+    const int safe_batch = (batch_start + m_lane < batch_size) ? (batch_start + m_lane) : 0;
+
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 136;
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 136;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg = x_base + g * 256;
+
+        #define DQ8(pk) \
+            a_reg[0] = sc_h * (_Float16)(float)(((pk) >>  0) & 0xFu) + zp_h; \
+            a_reg[1] = sc_h * (_Float16)(float)(((pk) >>  4) & 0xFu) + zp_h; \
+            a_reg[2] = sc_h * (_Float16)(float)(((pk) >>  8) & 0xFu) + zp_h; \
+            a_reg[3] = sc_h * (_Float16)(float)(((pk) >> 12) & 0xFu) + zp_h; \
+            a_reg[4] = sc_h * (_Float16)(float)(((pk) >> 16) & 0xFu) + zp_h; \
+            a_reg[5] = sc_h * (_Float16)(float)(((pk) >> 20) & 0xFu) + zp_h; \
+            a_reg[6] = sc_h * (_Float16)(float)(((pk) >> 24) & 0xFu) + zp_h; \
+            a_reg[7] = sc_h * (_Float16)(float)(((pk) >> 28) & 0xFu) + zp_h
+
+        for (int kt = 0; kt < 16; kt += 4) {
+            const int k_off_a = (kt + 0) * 16;
+            const int k_off_b = (kt + 1) * 16;
+            const int k_off_c = (kt + 2) * 16;
+            const int k_off_d = (kt + 3) * 16;
+
+            unsigned int pka = *(const unsigned int*)(gp + 8 + k_off_a / 2 + k_grp * 4);
+            unsigned int pkb = *(const unsigned int*)(gp + 8 + k_off_b / 2 + k_grp * 4);
+            unsigned int pkc = *(const unsigned int*)(gp + 8 + k_off_c / 2 + k_grp * 4);
+            unsigned int pkd = *(const unsigned int*)(gp + 8 + k_off_d / 2 + k_grp * 4);
+
+            half8_t b_a = *(const half8_t*)(xg + k_off_a + k_grp * 8);
+            half8_t b_b = *(const half8_t*)(xg + k_off_b + k_grp * 8);
+            half8_t b_c = *(const half8_t*)(xg + k_off_c + k_grp * 8);
+            half8_t b_d = *(const half8_t*)(xg + k_off_d + k_grp * 8);
+
+            half8_t a_reg;
+            DQ8(pka);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_a, acc);
+            DQ8(pkb);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_b, acc);
+            DQ8(pkc);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_c, acc);
+            DQ8(pkd);
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_d, acc);
+        }
+        #undef DQ8
+    }
+
+    const int out_col = batch_start + m_lane;
+    if (out_col < batch_size) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 8 * k_grp + j;
+            if (out_row < M)
+                Y[(long long)out_col * M + out_row] = acc[j];
+        }
+    }
+}

--- a/kernels/src/gemv_hfq6g256_moe_gate_up_k8_indexed_batched.hip
+++ b/kernels/src/gemv_hfq6g256_moe_gate_up_k8_indexed_batched.hip
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// HFQ6G256 counterpart of `gemv_hfq4g256_moe_gate_up_k8_indexed_batched`
+// (kernels/src/gemv_hfq4g256_moe_gate_up_indexed_batched.hip).
+//
+// Batched N-token indexed MoE gate_up GEMV. Identical kernarg signature,
+// expert indexing (expert_ptrs[topk_indices[bid*K_TOP + krank]]), grid
+// mapping (M, K_TOP, N), group-size-256 loop, gate/up output split
+// (M = 2*MI: first half → y_gate, second half → y_up), batch handling,
+// and wave32 reduction. The ONLY difference is the per-group weight
+// dequant: 4-bit (136 B/group) → 6-bit (200 B/group).
+//
+// 6-bit dequant copied verbatim from kernels/src/gemv_hfq6g256.hip
+// (lines 24-60: 4 B fp32 scale + 4 B fp32 zero + 192 B of 6-bit packed
+// quants for 256 weights; 8 weights/thread = 6 bytes/thread). 256*6/8 = 192,
+// + 8 B header = 200 B/group.
+//
+// Note: weights post-PR-199 are typically MQ6G256 (FWHT-rotated). HFQ6G256
+// (non-rotated) shares the same byte layout — the kernel is rotation-
+// agnostic, the caller decides whether to pass FWHT(x) or x_norm via the
+// `x` parameter (same contract as the HFQ4 sibling).
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void gemv_hfq6g256_moe_gate_up_k8_indexed_batched(
+    const unsigned long long* __restrict__ expert_ptrs, // [n_exp]
+    const int* __restrict__ topk_indices,                // [N × K_TOP]
+    const float* __restrict__ x,                         // [N × K]
+    float* __restrict__ y_gate,                          // [N × K_TOP × MI]
+    float* __restrict__ y_up,                            // [N × K_TOP × MI]
+    int M, int K, int K_TOP
+) {
+    const int row = blockIdx.x;
+    if (row >= M) return;
+    const int krank = blockIdx.y;
+    const int bid = blockIdx.z;
+    const int tid = threadIdx.x;
+
+    // Per-token slices into routing + input.
+    const int expert_id = topk_indices[bid * K_TOP + krank];
+    const char* __restrict__ A =
+        reinterpret_cast<const char*>(expert_ptrs[expert_id]);
+    const float* __restrict__ x_row = x + (long long)bid * K;
+
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gptr = row_ptr + g * 200;
+        float scale = __builtin_bit_cast(float, *(const unsigned int*)(gptr));
+        float zero  = __builtin_bit_cast(float, *(const unsigned int*)(gptr + 4));
+        const unsigned char* data = (const unsigned char*)(gptr + 8);
+
+        // 256 weights / 32 threads = 8 weights per thread
+        // 4 weights per 3 bytes → 8 weights = 6 bytes per thread
+        int base_idx = g * 256 + tid * 8;
+        int byte_off = tid * 6;
+
+        unsigned char b0 = data[byte_off];
+        unsigned char b1 = data[byte_off + 1];
+        unsigned char b2 = data[byte_off + 2];
+        unsigned char b3 = data[byte_off + 3];
+        unsigned char b4 = data[byte_off + 4];
+        unsigned char b5 = data[byte_off + 5];
+
+        // 4 weights from first 3 bytes
+        int q0 = b0 & 63;
+        int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        int q2 = (b1 >> 4) | ((b2 & 3) << 4);
+        int q3 = b2 >> 2;
+        // 4 weights from next 3 bytes
+        int q4 = b3 & 63;
+        int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        int q6 = (b4 >> 4) | ((b5 & 3) << 4);
+        int q7 = b5 >> 2;
+
+        acc += (scale * (float)q0 + zero) * x_row[base_idx]
+             + (scale * (float)q1 + zero) * x_row[base_idx + 1]
+             + (scale * (float)q2 + zero) * x_row[base_idx + 2]
+             + (scale * (float)q3 + zero) * x_row[base_idx + 3]
+             + (scale * (float)q4 + zero) * x_row[base_idx + 4]
+             + (scale * (float)q5 + zero) * x_row[base_idx + 5]
+             + (scale * (float)q6 + zero) * x_row[base_idx + 6]
+             + (scale * (float)q7 + zero) * x_row[base_idx + 7];
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    if (tid == 0) {
+        // Output layout matches gemv_hfq4g256_moe_gate_up_k8_indexed_batched:
+        // M = 2 * MI, first half is gate, second half is up.
+        const int mi = M >> 1;
+        const long long base_out = (long long)bid * K_TOP * mi + (long long)krank * mi;
+        if (row < mi) {
+            y_gate[base_out + row] = acc;
+        } else {
+            y_up[base_out + (row - mi)] = acc;
+        }
+    }
+}

--- a/kernels/src/greedy_accept.hip
+++ b/kernels/src/greedy_accept.hip
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// Greedy speculative-accept prefix scan over device-resident verify argmaxes
+// and MTP candidate tokens.
+//
+// result[0] = number of draft candidates accepted
+// result[1] = bonus token id, or -1 when an accepted candidate was EOS and no
+//             bonus should be committed
+extern "C" __global__ void greedy_accept_from_argmax_i32(
+    const int* __restrict__ argmax_per_pos,
+    const int* __restrict__ candidates,
+    int* __restrict__ result,
+    int drafts_generated,
+    int eos_token_id
+) {
+    if (blockIdx.x != 0 || threadIdx.x != 0) {
+        return;
+    }
+
+    int accept_count = 0;
+    for (int k = 0; k < drafts_generated; ++k) {
+        int candidate = candidates[k];
+        if (argmax_per_pos[k] != candidate) {
+            result[0] = accept_count;
+            result[1] = argmax_per_pos[k];
+            return;
+        }
+
+        ++accept_count;
+        if (candidate == eos_token_id) {
+            result[0] = accept_count;
+            result[1] = -1;
+            return;
+        }
+    }
+
+    result[0] = accept_count;
+    result[1] = argmax_per_pos[drafts_generated];
+}

--- a/scripts/coherence-gate.sh
+++ b/scripts/coherence-gate.sh
@@ -100,6 +100,12 @@ SHORT_TESTS=(
     # drift between bit-widths is comparable.
     "qwen3.5-9b.mq3|reason-mq3|A farmer has 17 sheep. All but 9 die. How many are left? Show brief reasoning then state the final number.|300"
     "qwen3.5-27b.mq3|cap-mq3-27b|What is the capital of France? Answer in one short sentence.|80"
+    # LFM2.5-8B-A1B (arch_id 11, hipfire-arch-lfm2moe): hybrid 18 short-conv + 6
+    # GQA-attn mixers, 2 dense SwiGLU + 22 top-4 MoE FFN layers. Exercises the
+    # NEW conv1d_gated_decode kernel + per-head QK-norm + full-dim RoPE +
+    # sigmoid-bias top-4 MoE GEMV path. Skipped if the model file is absent.
+    "lfm2.5-8b-a1b.mq4|lfm2-cap|What is the capital of France? Answer in one short sentence.|80"
+    "lfm2.5-8b-a1b.mq4|lfm2-reason|If a train travels 60 km in 45 minutes, what is its speed in km/h?|160"
     # MQ3-Lloyd coverage (PR #115 — research-gated format, --allow-mq3-lloyd
     # at quantize time only; no runtime gate). 4B + 9B exercise the K4 +
     # fp32-LDS-codebook gfx1100 kernel + tail-rotation logic. Runs anywhere

--- a/scripts/gen_tiny_lfm2moe.py
+++ b/scripts/gen_tiny_lfm2moe.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+#
+# Tiny dimension-faithful LFM2.5-MoE (arch_id 11) oracle generator.
+#
+# Builds a small random-weight Lfm2MoeForCausalLM that EXERCISES ALL PATHS:
+#   * conv mixer (LIV short-conv, K=3) AND attention mixer (GQA + qk-norm)
+#   * dense SwiGLU MLP (the first num_dense_layers) AND sparse top-4 MoE
+# then dumps per-layer POST-residual hidden states in the shared HFHS format
+# for comparison against the hipfire decode_step (see
+# docs/methodology/arch-port-validation.md and compare_hidden_states.py).
+#
+# Pitfalls baked in (per the methodology checklist):
+#   * REAL head_dim (64) and REAL conv kernel size (conv_L_cache=3); we shrink
+#     the *number* of heads/layers, not head_dim.
+#   * num_experts_per_tok = 4 to match the hipfire indexed-MoE GEMV K_TOP=4.
+#   * every quantized 2D weight has k % 256 == 0 (hidden=256, moe_inter=256,
+#     dense inter=256, 3*hidden=768).
+#   * weights persisted as bf16 (matching the real checkpoint dtype) and the
+#     reference forward is run from the RELOADED bf16 values upcast to f32, so
+#     the cosine isolates hipfire quant error, not bf16 rounding.
+#
+# Usage:
+#   python3 scripts/gen_tiny_lfm2moe.py --out /tmp/tiny_lfm2moe
+# Produces:
+#   <out>/hf/            tiny HF checkpoint (bf16 safetensors + config.json)
+#   <out>/oracle.hfhs    per-layer hidden states (HFHS)
+#   <out>/tokens.json    the fixed input token ids
+import argparse, json, os, struct, sys
+
+import torch
+from transformers import Lfm2MoeConfig, Lfm2MoeForCausalLM
+
+# ----- fixed tiny input -----
+TOKENS = [1, 5, 9, 3, 7, 2, 8, 4]  # within tiny vocab; 8 positions
+
+
+def build_tiny_config() -> Lfm2MoeConfig:
+    # 5 layers: cover conv+dense, attn+dense, conv+moe, attn+moe, conv+moe.
+    # num_dense_layers=2 -> layers 0,1 dense; 2,3,4 MoE.
+    layer_types = ["conv", "full_attention", "conv", "full_attention", "conv"]
+    return Lfm2MoeConfig(
+        vocab_size=512,
+        hidden_size=256,
+        num_hidden_layers=len(layer_types),
+        num_attention_heads=4,        # 4 * head_dim(64) = 256
+        num_key_value_heads=2,        # GQA 2:1
+        head_dim=64,                  # REAL head_dim
+        max_position_embeddings=1024,
+        norm_eps=1e-5,
+        rope_theta=1_000_000.0,
+        # conv (LIV short-conv)
+        conv_L_cache=3,               # REAL kernel size
+        conv_bias=False,
+        # dense MLP dim -> force 256 (k % 256 == 0); disable auto-adjust
+        intermediate_size=256,
+        block_ff_dim=256,
+        block_multiple_of=256,
+        block_ffn_dim_multiplier=1.0,
+        block_auto_adjust_ff_dim=False,
+        # MoE
+        moe_intermediate_size=256,    # k % 256 == 0
+        num_experts=8,                # > num_experts_per_tok
+        num_experts_per_tok=4,        # match indexed-MoE K_TOP=4
+        num_dense_layers=2,
+        norm_topk_prob=True,
+        use_expert_bias=True,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        hidden_act="silu",
+        tie_word_embeddings=True,
+        layer_types=layer_types,
+        bos_token_id=1,
+        eos_token_id=2,
+        pad_token_id=0,
+        torch_dtype="bfloat16",
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="/tmp/tiny_lfm2moe")
+    ap.add_argument("--seed", type=int, default=1234)
+    args = ap.parse_args()
+
+    torch.manual_seed(args.seed)
+    cfg = build_tiny_config()
+    print("tiny config:", json.dumps({
+        "layer_types": cfg.layer_types,
+        "num_dense_layers": cfg.num_dense_layers,
+        "hidden_size": cfg.hidden_size,
+        "head_dim": cfg.head_dim,
+        "num_experts": cfg.num_experts,
+        "num_experts_per_tok": cfg.num_experts_per_tok,
+        "conv_L_cache": cfg.conv_L_cache,
+        "intermediate_size": cfg.intermediate_size,
+        "moe_intermediate_size": cfg.moe_intermediate_size,
+    }, indent=1))
+
+    model = Lfm2MoeForCausalLM(cfg)
+    model.eval()
+
+    # Give expert_bias and norms non-degenerate values so routing & norms
+    # actually do something (default init may leave bias at 0 / norms at 1).
+    with torch.no_grad():
+        for name, p in model.named_parameters():
+            if name.endswith("expert_bias"):
+                p.copy_(torch.randn_like(p) * 0.1)
+            elif name.endswith("_norm.weight") or name.endswith("norm.weight") \
+                    or name.endswith("layernorm.weight"):
+                # perturb RMSNorm weights away from 1.0 to catch +1/Gemma bugs
+                p.copy_(1.0 + torch.randn_like(p) * 0.05)
+
+    hf_dir = os.path.join(args.out, "hf")
+    os.makedirs(hf_dir, exist_ok=True)
+
+    # Persist as bf16 (real checkpoint dtype), then reload upcast to f32 so the
+    # reference forward uses exactly the bf16-rounded values.
+    model.to(torch.bfloat16).save_pretrained(hf_dir, safe_serialization=True)
+    cfg.save_pretrained(hf_dir)
+    ref = Lfm2MoeForCausalLM.from_pretrained(hf_dir, torch_dtype=torch.float32)
+    ref.eval()
+
+    # Print expert/param shapes for divisibility sanity.
+    for n, p in ref.named_parameters():
+        if any(s in n for s in ("layers.0.", "layers.2.")) and "weight" in n:
+            print(f"  param {n}: {tuple(p.shape)}")
+
+    # ----- per-layer post-residual capture via forward hooks -----
+    captures = {}
+
+    def mk_hook(i):
+        def hook(_mod, _inp, out):
+            hs = out[0] if isinstance(out, tuple) else out
+            captures[i] = hs.detach().float()[0].cpu()  # [seq, hidden]
+        return hook
+
+    handles = [layer.register_forward_hook(mk_hook(i))
+               for i, layer in enumerate(ref.model.layers)]
+
+    ids = torch.tensor([TOKENS], dtype=torch.long)
+    with torch.no_grad():
+        ref(input_ids=ids, use_cache=False)
+    for h in handles:
+        h.remove()
+
+    n_layers = cfg.num_hidden_layers
+    n_pos = len(TOKENS)
+    hidden = cfg.hidden_size
+    # ----- write HFHS -----
+    # magic "HFHS\0\0\0\0", <IIII> n_layers,n_pos,hidden,reserved,
+    # then n_layers x [n_pos, hidden] f32 row-major.
+    out_path = os.path.join(args.out, "oracle.hfhs")
+    with open(out_path, "wb") as f:
+        f.write(b"HFHS\x00\x00\x00\x00")
+        f.write(struct.pack("<IIII", n_layers, n_pos, hidden, 0))
+        for i in range(n_layers):
+            arr = captures[i].contiguous().numpy().astype("float32")
+            assert arr.shape == (n_pos, hidden), (i, arr.shape)
+            f.write(arr.tobytes())
+    with open(os.path.join(args.out, "tokens.json"), "w") as f:
+        json.dump(TOKENS, f)
+
+    print(f"wrote {out_path}  ({n_layers} layers x {n_pos} pos x {hidden} hidden)")
+    print(f"wrote tiny HF checkpoint to {hf_dir}")
+    print("RMS of last-layer hidden:", float(captures[n_layers - 1].pow(2).mean().sqrt()))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## LFM2.5-8B-A1B port (arch_id 11)

Ports **LiquidAI/LFM2.5-8B-A1B** (`model_type = lfm2_moe`) to hipfire and validates it
end-to-end on gfx1201 (R9700, RDNA4). Hybrid architecture: 18 double-gated LIV
short-conv mixers interleaved with 6 GQA+QK-norm attention layers, feeding a
DeepSeek-style sigmoid-bias **top-4 MoE** FFN (32 experts) — or dense SwiGLU on the
first 2 layers. Mirrors the MiniMax-M2 (arch_id 10) arch-port method.

> **Stacked on #362.** Base is `minimax/m2.7-impl` (the MiniMax-M2 port), since this work
> was built on top of it and shares the arch-port scaffolding (quantizer arch-map, daemon
> registration pattern, indexed-MoE GEMV family). The diff here is **only the 13 lfm2moe
> commits**; GitHub will auto-retarget this PR to `master` once #362 merges. **Draft** —
> opened for visibility/review of the LFM2.5 port and its perf/KLD characterization.

### What's new
- **`crates/hipfire-arch-lfm2moe`** — config / loader / `decode_step` forward + examples
  (`dump_lfm2moe_hidden_states`, `infer_lfm2moe`, `kld_logits`, `graph_parity_lfm2moe`).
- **`kernels/src/conv1d_gated_decode.hip`** — the one genuinely-new operator: the LIV
  double-gated short-conv decode op (B·x pre-gate → depthwise causal conv runtime-K →
  C·conv_out post-gate → rolling conv-state advance), fused in a single launch. MoE top-4
  reuses the existing indexed-GEMV `_k8` family (`k_top` is a runtime arg — no new MoE kernel).
- **Quantizer** — `lfm2_moe => 11`, `is_lfm2moe` ingest (bf16 → experts MQ4G256,
  `expert_bias` F32, everything else Q8). Opt-in flags for the quality/perf levers below.
- **Daemon** — arch_id 11 registered end-to-end (`LoadedModel` slots, load branch,
  `generate_lfm2moe`, `arch-lfm2moe` Cargo feature) + 2 coherence-gate rows.

### Validation
- **Tiny-oracle per-layer cosine** vs HF `Lfm2MoeForCausalLM`: 0.99996 → 0.99931 (≥0.999
  through all 5 layers; exercises conv + attn + dense + MoE + the dense→MoE transition).
- **Real-model coherence** through the daemon (chat-framed, greedy): "capital of France" →
  *"Paris is the capital of France."*; train-speed → *"80 km/h"*; clean `<think>` blocks,
  no attractor / loop / special-token leak. Scoped coherence-gate run: both lfm2 rows **OK**.

### Perf (gfx1201, matched full-256-tok, fresh process, byte-identical prompt)
| build | tok/s | Δ | notes |
|---|---|---|---|
| **mq4 (default)** | 241.5 | — | validated default, experts MQ4G256 / rest Q8, 4.9 GB |
| proj-MQ4 (`HIPFIRE_LFM2_PROJ_MQ4=1`) | 258.8 | **+7.2%** | opt-in; 4-bits dense projections, quality cost |
| graph capture (`HIPFIRE_LFM2_GRAPH=1`) | — | **+3.4%** | opt-in, free; correct on gfx1201 (cos=1.0 parity) |
| mq6e experts (`HIPFIRE_LFM2_EXPERT_MQ6=1`) | 203.5 | **−16%** | quality build (see KLD), 6.4 GB |

Decode is bandwidth-*sensitive* but **not** bandwidth-*saturated*: measured ~311 GB/s
achieved = ~47% of the card's 632 GB/s ceiling. The GEMV kernels are occupancy/latency-bound
(`gemv_q8_0` = 49.5% of decode GPU time) — that's the flagged next lever, not launch count
(graph capture recovering ~none of the 53% idle bandwidth proves it). Tested-negative and
**reverted**: compile-time-K3 conv specialization (+0.25%, within noise — the conv is one
tiny latency-bound launch); proj-MQ6 (no speedup + degrades into a loop).

### Quality — KL(bf16 ‖ candidate), bf16-referenced, 44 positions
| variant | experts | proj | mean KL | top-1 agree | tok/s | coherence |
|---|---|---|---|---|---|---|
| mq4 (default) | MQ4G256 | Q8 | 0.424 | 72.7% | 241 | ✅ |
| **mq6e** | **MQ6G256** | Q8 | **0.135** (−68%) | 79.5% | 203 (−16%) | ✅ |
| mq4-awq | MQ4G256+AWQ | Q8 | 0.398 (−6.1%) | — | 241 | ✅ |
| proj-MQ4 | MQ4G256 | MQ4 | 1.050 | 56.8% | 259 | ⚠️ passes gate, high KL |

**Key finding (only visible with bf16 as the reference, not Q8):** the dominant quality cost
is the **4-bit experts**, not the dense projections. So the quality lever is higher-precision
experts (mq6e: −68% KL for −16% decode + 1.8 GB), and AWQ-on-experts shaves a further −6.1%
KL at zero perf cost — while the projection levers (proj-MQ4) only trade quality *down* for
speed. Default stays mq4 (max speed, coherent); mq6e / awq ship as opt-in quality builds.

### Open items (tracked in `crates/hipfire-arch-lfm2moe/NEXT-STEPS.md`)
1. **GEMV occupancy** — VGPR/launch-bounds/waves on `gemv_q8_0` + indexed MoE GEMVs (the
   real remaining decode lever; the multi-row wo GEMV that landed via the minimax base is a
   reference shape).
2. **Batched prefill** — currently per-token `decode_step`; a batched conv-scan + attn/MoE set
   would speed long-context ingestion.

### Test plan
- `cargo build --release --workspace --all-targets --locked` ✅
- `cargo test --lib --workspace --locked` — all pass **except** 2–4 flaky
  `tokenizer::prompt_norm_tests` that `set_var`/`remove_var("HIPFIRE_NORMALIZE_PROMPT")`
  on a process-global and race under cargo's parallel runner (the failing set varies
  run-to-run). `tokenizer.rs` is **byte-identical to the base branch** — these are
  **pre-existing on `minimax/m2.7-impl` (#362), not introduced here**, and none of the 13
  lfm2moe commits touch that file. Should be fixed in #362 / a separate PR (env-var test
  isolation), not this one.
- daemon example builds with default features (`arch-lfm2moe` on) ✅
- scoped `coherence-gate.sh` (lfm2 rows) ✅ — both OK, ~244 tok/s, clean output
- tiny-oracle reproduction documented in `docs/investigations/2026-05-29-lfm2moe-port-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
