### PR TITLE
[codex] Port dots.ocr WMMA paths to gfx12

### DIFF
--- a/crates/hipfire-arch-dots-ocr/src/dots_ocr.rs
+++ b/crates/hipfire-arch-dots-ocr/src/dots_ocr.rs
@@ -724,10 +724,10 @@ pub(crate) fn linear_f16(
     // whole buffer as ONE row of length `n * out_dim` and reads the
     // norm-weight (length out_dim) out of bounds -> sticky HIP fault.
     let y = gpu.alloc_tensor(&[n, out_dim], DType::F32)?;
-    // gfx1100+ (RDNA3 / RDNA3.5) — use the fused-transpose WMMA variant.
+    // gfx11/gfx12 — use the fused-transpose WMMA variant.
     // It writes row-major `[n, out_dim]` directly, dropping the separate
     // transpose_f32 kernel that the older `gemm_f16_wmma` path required.
-    if gpu.arch_caps.has_wmma_w32() {
+    if gpu.arch_caps.has_wmma_w32() || gpu.arch_caps.has_wmma_w32_gfx12() {
         gpu.gemm_f16_wmma_mb8(w, x, &y, out_dim, in_dim, n)?;
     } else {
         let yt = gpu.alloc_tensor(&[out_dim * n], DType::F32)?;
@@ -758,7 +758,7 @@ pub(crate) fn linear_f16_no_bias(
     let y = gpu.alloc_tensor(&[n, out_dim], DType::F32)?;
     // See [`linear_f16`] for the fused-transpose WMMA rationale and the
     // 2-D output-shape requirement.
-    if gpu.arch_caps.has_wmma_w32() {
+    if gpu.arch_caps.has_wmma_w32() || gpu.arch_caps.has_wmma_w32_gfx12() {
         gpu.gemm_f16_wmma_mb8(w, x, &y, out_dim, in_dim, n)?;
     } else {
         let yt = gpu.alloc_tensor(&[out_dim * n], DType::F32)?;
@@ -882,13 +882,21 @@ pub fn vision_forward(
 
     let t0 = std::time::Instant::now();
     let use_wmma = gpu.arch_caps.has_wmma_w32();
+    let use_gfx12_wmma = gpu.arch_caps.has_wmma_w32_gfx12();
+    let use_dots_v5_wmma = use_wmma || use_gfx12_wmma;
     eprintln!(
         "  vision forward (dots-ocr GPU): {n_patches} patches, {grid_h}×{grid_w} grid, {} blocks",
         cfg.num_hidden_layers,
     );
     eprintln!(
         "  vision kernels: {}",
-        if use_wmma { "rdna3-wmma" } else { "scalar-fallback" },
+        if use_wmma {
+            "rdna3-wmma"
+        } else if use_gfx12_wmma {
+            "rdna4-wmma"
+        } else {
+            "scalar-fallback"
+        },
     );
 
     // HIPFIRE_DOTS_OCR_DUMP_DIR=<path>: dump full per-stage tensor
@@ -1110,7 +1118,7 @@ pub fn vision_forward(
         // For dots.ocr (head_dim=128) use the v5 M=64/V_tile=32 f16-K/V
         // O-register-resident path. V_tile=32 keeps LDS small enough for
         // 2 WG/CU at the smoke-image shape.
-        if use_wmma && head_dim == 128 && n_patches >= 64 {
+        if use_dots_v5_wmma && head_dim == 128 && n_patches >= 64 {
             let k_f16 = gpu.alloc_tensor(&[n_patches, h], DType::F16)?;
             let v_f16 = gpu.alloc_tensor(&[n_patches, h], DType::F16)?;
             gpu.cast_f32_to_f16(&k_buf, &k_f16)?;

--- a/crates/rdna-compute/examples/bench_attention_vision.rs
+++ b/crates/rdna-compute/examples/bench_attention_vision.rs
@@ -63,6 +63,31 @@ fn main() {
     gpu.cast_f32_to_f16(&d_k, &d_k_f16).unwrap();
     gpu.cast_f32_to_f16(&d_v, &d_v_f16).unwrap();
 
+    if gpu.arch_caps.has_wmma_w32_gfx12() {
+        eprintln!("gfx12: running production dots.ocr v5 path; older gfx11 experiment variants are skipped");
+        gpu.attention_dflash_wmma_m64_n32_f16kv_v5_f32(
+            &d_q, &d_k_f16, &d_v_f16, &d_out, b, l, n_heads, n_kv_heads, hd,
+        ).unwrap();
+        gpu.hip.device_synchronize().unwrap();
+
+        let t = std::time::Instant::now();
+        for _ in 0..iters {
+            gpu.attention_dflash_wmma_m64_n32_f16kv_v5_f32(
+                &d_q, &d_k_f16, &d_v_f16, &d_out, b, l, n_heads, n_kv_heads, hd,
+            ).unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        eprintln!("M=64 N=32  v5 gfx12 (V_tile=32): {:.1} ms / iter ({iters} iters)", t.elapsed().as_secs_f32() * 1000.0 / iters as f32);
+
+        gpu.free_tensor(d_q).unwrap();
+        gpu.free_tensor(d_k).unwrap();
+        gpu.free_tensor(d_v).unwrap();
+        gpu.free_tensor(d_k_f16).unwrap();
+        gpu.free_tensor(d_v_f16).unwrap();
+        gpu.free_tensor(d_out).unwrap();
+        return;
+    }
+
     // Warm-up.
     gpu.attention_dflash_wmma_f32(&d_q, &d_k, &d_v, &d_out, b, l, n_heads, n_kv_heads, hd).unwrap();
     gpu.attention_dflash_wmma_m32_f32(&d_q, &d_k, &d_v, &d_out, b, l, n_heads, n_kv_heads, hd).unwrap();

--- a/crates/rdna-compute/examples/test_dots_ocr_wmma_gfx12.rs
+++ b/crates/rdna-compute/examples/test_dots_ocr_wmma_gfx12.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire - see LICENSE and NOTICE in the project root.
+
+//! Focused channel test for the dots.ocr vision WMMA fast paths.
+//!
+//! This covers the two production kernels dots.ocr needs before gfx12 can
+//! safely leave the scalar vision fallback:
+//! - `gemm_f16_wmma_mb8`: fused-transpose F16 vision linear
+//! - `attention_dflash_wmma_m64_n32_f16kv_v5_f32`: large vision attention
+
+use rdna_compute::{DType, Gpu};
+
+fn lcg_data(seed: u32, n: usize) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s = s.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+            let u = (s >> 16) & 0x7fff;
+            (u as f32 / 32_768.0 - 0.5) * 0.2
+        })
+        .collect()
+}
+
+fn max_abs(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+fn assert_close(name: &str, got: &[f32], expected: &[f32], tol: f32) {
+    let diff = max_abs(got, expected);
+    println!("{name}: max_abs_diff={diff:.3e} tol={tol:.3e}");
+    assert!(
+        diff < tol,
+        "{name}: max_abs_diff={diff:.3e} exceeds tol={tol:.3e}"
+    );
+}
+
+fn test_gemm_f16_wmma_mb8(gpu: &mut Gpu) {
+    let m = 37usize;
+    let k = 64usize;
+    let n = 130usize;
+
+    let w_f32 = lcg_data(0x1111_2222, m * k);
+    let x_f32 = lcg_data(0x3333_4444, n * k);
+
+    let w_src = gpu.upload_f32(&w_f32, &[m * k]).unwrap();
+    let w_f16 = gpu.alloc_tensor(&[m * k], DType::F16).unwrap();
+    gpu.cast_f32_to_f16(&w_src, &w_f16).unwrap();
+    let x = gpu.upload_f32(&x_f32, &[n * k]).unwrap();
+
+    let y_ref_t = gpu.zeros(&[m * n], DType::F32).unwrap();
+    let y_ref = gpu.zeros(&[n, m], DType::F32).unwrap();
+    gpu.gemm_f16(&w_f16, &x, &y_ref_t, m, k, n).unwrap();
+    gpu.transpose_f32(&y_ref_t, &y_ref, m, n).unwrap();
+
+    let y_wmma = gpu.zeros(&[n, m], DType::F32).unwrap();
+    gpu.gemm_f16_wmma_mb8(&w_f16, &x, &y_wmma, m, k, n).unwrap();
+    gpu.hip.device_synchronize().unwrap();
+
+    let ref_host = gpu.download_f32(&y_ref).unwrap();
+    let wmma_host = gpu.download_f32(&y_wmma).unwrap();
+    assert_close("gemm_f16_wmma_mb8", &wmma_host, &ref_host, 5.0e-3);
+}
+
+fn test_attention_v5(gpu: &mut Gpu) {
+    let b = 65usize;
+    let l = 96usize;
+    let n_heads = 2usize;
+    let n_kv_heads = 2usize;
+    let hd = 128usize;
+
+    let q = lcg_data(0xa5a5_a5a5, b * n_heads * hd);
+    let k = lcg_data(0xc3c3_c3c3, l * n_kv_heads * hd);
+    let v = lcg_data(0x9696_9696, l * n_kv_heads * hd);
+
+    let d_q = gpu.upload_f32(&q, &[b * n_heads * hd]).unwrap();
+    let d_k = gpu.upload_f32(&k, &[l * n_kv_heads * hd]).unwrap();
+    let d_v = gpu.upload_f32(&v, &[l * n_kv_heads * hd]).unwrap();
+
+    let out_scalar = gpu.zeros(&[b * n_heads * hd], DType::F32).unwrap();
+    gpu.attention_dflash_f32(&d_q, &d_k, &d_v, &out_scalar, b, l, n_heads, n_kv_heads, hd)
+        .unwrap();
+
+    let d_k_f16 = gpu.alloc_tensor(&[l * n_kv_heads * hd], DType::F16).unwrap();
+    let d_v_f16 = gpu.alloc_tensor(&[l * n_kv_heads * hd], DType::F16).unwrap();
+    gpu.cast_f32_to_f16(&d_k, &d_k_f16).unwrap();
+    gpu.cast_f32_to_f16(&d_v, &d_v_f16).unwrap();
+
+    let out_wmma = gpu.zeros(&[b * n_heads * hd], DType::F32).unwrap();
+    gpu.attention_dflash_wmma_m64_n32_f16kv_v5_f32(
+        &d_q,
+        &d_k_f16,
+        &d_v_f16,
+        &out_wmma,
+        b,
+        l,
+        n_heads,
+        n_kv_heads,
+        hd,
+    )
+    .unwrap();
+    gpu.hip.device_synchronize().unwrap();
+
+    let scalar_host = gpu.download_f32(&out_scalar).unwrap();
+    let wmma_host = gpu.download_f32(&out_wmma).unwrap();
+    assert_close("attention_dflash_wmma_m64_n32_f16kv_v5_f32", &wmma_host, &scalar_host, 5.0e-3);
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    println!("GPU initialized: {}", gpu.arch);
+
+    if !(gpu.arch_caps.has_wmma_w32() || gpu.arch_caps.has_wmma_w32_gfx12()) {
+        println!("SKIP dots.ocr WMMA channel test: {} lacks wave32 WMMA", gpu.arch);
+        return;
+    }
+
+    test_gemm_f16_wmma_mb8(&mut gpu);
+    test_attention_v5(&mut gpu);
+    println!("PASS dots.ocr WMMA channel test");
+}

--- a/crates/rdna-compute/src/attention.rs
+++ b/crates/rdna-compute/src/attention.rs
@@ -4102,7 +4102,19 @@ impl Gpu {
             n_heads % n_kv_heads == 0,
             "attention_dflash_wmma_m64_n32_f16kv_v5_f32: n_heads={n_heads} must be divisible by n_kv_heads={n_kv_heads}",
         );
-        if !self.arch_caps.has_wmma_w32() {
+        let (kernel_name, kernel_src, symbol) = if self.arch_caps.has_wmma_w32_gfx12() {
+            (
+                "attention_dflash_wmma_m64_n32_f16kv_v5_f32_gfx12",
+                kernels::ATTENTION_DFLASH_WMMA_M64_N32_F16KV_V5_GFX12_SRC,
+                "attention_dflash_wmma_m64_n32_f16kv_v5_f32_gfx12",
+            )
+        } else if self.arch_caps.has_wmma_w32() {
+            (
+                "attention_dflash_wmma_m64_n32_f16kv_v5_f32",
+                kernels::ATTENTION_DFLASH_WMMA_M64_N32_F16KV_V5_SRC,
+                "attention_dflash_wmma_m64_n32_f16kv_v5_f32",
+            )
+        } else {
             return Err(hip_bridge::HipError::new(
                 0,
                 &format!(
@@ -4111,13 +4123,9 @@ impl Gpu {
                     self.arch
                 ),
             ));
-        }
-        self.ensure_kernel(
-            "attention_dflash_wmma_m64_n32_f16kv_v5_f32",
-            kernels::ATTENTION_DFLASH_WMMA_M64_N32_F16KV_V5_SRC,
-            "attention_dflash_wmma_m64_n32_f16kv_v5_f32",
-        )?;
-        let func = &self.functions["attention_dflash_wmma_m64_n32_f16kv_v5_f32"];
+        };
+        self.ensure_kernel(kernel_name, kernel_src, symbol)?;
+        let func = &self.functions[kernel_name];
         let scale = 1.0f32 / (head_dim as f32).sqrt();
 
         let v_tile = 32usize;

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -14922,8 +14922,26 @@ impl Gpu {
         m: usize, k: usize, n: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        self.ensure_kernel("gemm_f16_wmma_mb8", kernels::GEMM_F16_WMMA_MB8_SRC, "gemm_f16_wmma_mb8")?;
-        let func = &self.functions["gemm_f16_wmma_mb8"];
+        let (kernel_name, kernel_src, symbol) = if self.arch_caps.has_wmma_w32_gfx12() {
+            (
+                "gemm_f16_wmma_mb8_gfx12",
+                kernels::GEMM_F16_WMMA_MB8_GFX12_SRC,
+                "gemm_f16_wmma_mb8_gfx12",
+            )
+        } else if self.arch_caps.has_wmma_w32() {
+            (
+                "gemm_f16_wmma_mb8",
+                kernels::GEMM_F16_WMMA_MB8_SRC,
+                "gemm_f16_wmma_mb8",
+            )
+        } else {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("gemm_f16_wmma_mb8 requires wave32 WMMA; arch={} does not support it.", self.arch),
+            ));
+        };
+        self.ensure_kernel(kernel_name, kernel_src, symbol)?;
+        let func = &self.functions[kernel_name];
         let mut wp = w.buf.as_ptr();
         let mut xp = x.buf.as_ptr();
         let mut yp = y.buf.as_ptr();

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2251,6 +2251,8 @@ pub const ATTENTION_DFLASH_WMMA_M64_N128_F16KV_V3_SRC: &str = include_str!("../.
 /// v_chunks per K-tile, keeping LDS at 25.6 KB (2 WG/CU occupancy).
 /// Grid=[n_heads, ceil(B/64)], block=[128] (4 waves).
 pub const ATTENTION_DFLASH_WMMA_M64_N32_F16KV_V5_SRC: &str = include_str!("../../../kernels/src/attention_dflash_wmma_m64_n32_f16kv_v5_f32.hip");
+/// gfx12/RDNA4 sibling of the dots.ocr v5 vision attention kernel.
+pub const ATTENTION_DFLASH_WMMA_M64_N32_F16KV_V5_GFX12_SRC: &str = include_str!("../../../kernels/src/attention_dflash_wmma_m64_n32_f16kv_v5_f32.gfx12.hip");
 
 /// Causal variant of v3 (M=64, N=128, f16 K/V). Adds causal mask:
 /// S[q, k] = -inf when k > q. Skips entirely-masked tiles. Grid
@@ -2549,6 +2551,8 @@ pub const GEMM_F16_WMMA_SRC: &str = include_str!("../../../kernels/src/gemm_f16_
 pub const GEMM_F16_WMMA_MB4_SRC: &str = include_str!("../../../kernels/src/gemm_f16_wmma_mb4.hip");
 /// MB=8: 8 N-subtiles per block (128 N-cols). Grid=[ceil(M/16), ceil(N/128)], block=[32].
 pub const GEMM_F16_WMMA_MB8_SRC: &str = include_str!("../../../kernels/src/gemm_f16_wmma_mb8.hip");
+/// gfx12/RDNA4 sibling of the MB=8 fused-transpose F16 WMMA GEMM.
+pub const GEMM_F16_WMMA_MB8_GFX12_SRC: &str = include_str!("../../../kernels/src/gemm_f16_wmma_mb8.gfx12.hip");
 /// Tiled F16 GEMM with shared memory (no WMMA dependency, works on all RDNA).
 /// ~5-10x faster than naive gemm_f16 via LDS data reuse. Tile size 64K.
 pub const GEMM_F16_TILED_SRC: &str = include_str!("../../../kernels/src/gemm_f16_tiled.hip");

--- a/kernels/src/attention_dflash_wmma_m64_n32_f16kv_v5_f32.gfx12.hip
+++ b/kernels/src/attention_dflash_wmma_m64_n32_f16kv_v5_f32.gfx12.hip
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Kevin Read
+// Copyright (c) 2026 Kaden Schutt
+// hipfire - see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// gfx12/RDNA4 sister of attention_dflash_wmma_m64_n32_f16kv_v5_f32.hip.
+// The algorithm is the same v5 dots.ocr winner, but gfx12 WMMA uses half8_t
+// operands and `_w32_gfx12`; each lane group owns one half of the K tile.
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+constexpr int S_LDS_STRIDE = 130;
+constexpr int V_tile = 32;
+
+extern "C" __global__ void __launch_bounds__(128, 2)
+attention_dflash_wmma_m64_n32_f16kv_v5_f32_gfx12(
+    const float* __restrict__ q,
+    const _Float16* __restrict__ k,
+    const _Float16* __restrict__ v,
+    float* __restrict__ out,
+    int B, int L, int n_heads, int n_kv_heads, int head_dim,
+    float scale
+) {
+    const int head = blockIdx.x;
+    const int qt = blockIdx.y;
+    const int q_start = qt * 64;
+    const int tid = threadIdx.x;
+
+    if (head >= n_heads || q_start >= B) return;
+    if (head_dim != 128) return;
+
+    const int rep = n_heads / n_kv_heads;
+    const int kv_head = head / rep;
+    const int q_stride = n_heads * head_dim;
+    const int kv_stride = n_kv_heads * head_dim;
+
+    const int wave = tid >> 5;
+    const int lane = tid & 31;
+    const int half = lane & 15;
+    const int half_id = lane >> 4;
+    const int my_row_base = wave * 16;
+
+    constexpr int d_chunks = 8;
+    constexpr int n_chunks = 8;
+    constexpr int n_tile = 128;
+    constexpr int m_tile = 64;
+
+    extern __shared__ float sdata[];
+    _Float16* V_lds = (_Float16*)sdata;
+    _Float16* S_lds = (_Float16*)(V_lds + V_tile * head_dim);
+    float* m_lds = (float*)(S_lds + m_tile * S_LDS_STRIDE);
+    float* l_lds = m_lds + m_tile;
+    float* alpha_lds = l_lds + m_tile;
+
+    half8_t Q_frags[8];
+    {
+        int gq = q_start + my_row_base + half;
+        const float* q_row = (gq < B) ? (q + gq * q_stride + head * head_dim) : nullptr;
+        #pragma unroll
+        for (int dc = 0; dc < d_chunks; ++dc) {
+            int d0 = dc * 16 + half_id * 8;
+            if (q_row) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) Q_frags[dc][j] = (_Float16)q_row[d0 + j];
+            } else {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) Q_frags[dc][j] = (_Float16)0.0f;
+            }
+        }
+    }
+
+    float8_t O_frags[8];
+    #pragma unroll
+    for (int dc = 0; dc < d_chunks; ++dc) {
+        O_frags[dc] = (float8_t){0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    }
+    if (lane < 16) {
+        m_lds[my_row_base + lane] = -INFINITY;
+        l_lds[my_row_base + lane] = 0.0f;
+    }
+    __syncthreads();
+
+    for (int kt_start = 0; kt_start < L; kt_start += n_tile) {
+        float8_t s_acc[8];
+        #pragma unroll
+        for (int c = 0; c < n_chunks; ++c) {
+            s_acc[c] = (float8_t){0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+        }
+
+        #pragma unroll
+        for (int kc = 0; kc < n_chunks; ++kc) {
+            int my_k = kt_start + kc * 16 + half;
+            bool k_valid = my_k < L;
+            const _Float16* my_k_row = k_valid
+                ? (k + my_k * kv_stride + kv_head * head_dim)
+                : nullptr;
+
+            #pragma unroll 4
+            for (int dc = 0; dc < d_chunks; ++dc) {
+                int d0 = dc * 16 + half_id * 8;
+                half8_t a_reg = Q_frags[dc];
+
+                half8_t b_reg;
+                if (k_valid) {
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) b_reg[j] = my_k_row[d0 + j];
+                } else {
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) b_reg[j] = (_Float16)0.0f;
+                }
+                s_acc[kc] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_reg, s_acc[kc]);
+            }
+        }
+
+        #pragma unroll
+        for (int c = 0; c < n_chunks; ++c) {
+            int s_col = c * 16 + half;
+            bool col_valid = (kt_start + s_col) < L;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) {
+                int s_row = my_row_base + 8 * half_id + j;
+                float s_val_f32 = s_acc[c][j] * scale;
+                if (!col_valid) s_val_f32 = -INFINITY;
+                S_lds[s_row * S_LDS_STRIDE + s_col] = (_Float16)s_val_f32;
+            }
+        }
+
+        #pragma unroll 1
+        for (int r_local = 0; r_local < 16; ++r_local) {
+            int row = my_row_base + r_local;
+            _Float16* s_row = S_lds + row * S_LDS_STRIDE;
+
+            float local_max = -INFINITY;
+            #pragma unroll
+            for (int kk = 0; kk < 4; ++kk) {
+                int idx = lane + kk * 32;
+                local_max = fmaxf(local_max, (float)s_row[idx]);
+            }
+            local_max = fmaxf(local_max, __shfl_xor(local_max, 1));
+            local_max = fmaxf(local_max, __shfl_xor(local_max, 2));
+            local_max = fmaxf(local_max, __shfl_xor(local_max, 4));
+            local_max = fmaxf(local_max, __shfl_xor(local_max, 8));
+            local_max = fmaxf(local_max, __shfl_xor(local_max, 16));
+            float tm = local_max;
+
+            float m_old = m_lds[row];
+            float m_new = fmaxf(m_old, tm);
+            float alpha = expf(m_old - m_new);
+
+            float local_sum = 0.0f;
+            #pragma unroll
+            for (int kk = 0; kk < 4; ++kk) {
+                int idx = lane + kk * 32;
+                float e = expf((float)s_row[idx] - m_new);
+                s_row[idx] = (_Float16)e;
+                local_sum += e;
+            }
+            local_sum += __shfl_xor(local_sum, 1);
+            local_sum += __shfl_xor(local_sum, 2);
+            local_sum += __shfl_xor(local_sum, 4);
+            local_sum += __shfl_xor(local_sum, 8);
+            local_sum += __shfl_xor(local_sum, 16);
+
+            if (lane == 0) {
+                l_lds[row] = alpha * l_lds[row] + local_sum;
+                m_lds[row] = m_new;
+                alpha_lds[row] = alpha;
+            }
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int dc = 0; dc < d_chunks; ++dc) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) {
+                int o_row = my_row_base + 8 * half_id + j;
+                O_frags[dc][j] *= alpha_lds[o_row];
+            }
+        }
+
+        #pragma unroll
+        for (int v_chunk = 0; v_chunk < 4; ++v_chunk) {
+            int v_start = v_chunk * V_tile;
+
+            for (int kr_local = 0; kr_local < 8; ++kr_local) {
+                int kr = wave * 8 + kr_local;
+                int gk = kt_start + v_start + kr;
+                bool valid = gk < L;
+                const _Float16* v_row = valid
+                    ? (v + gk * kv_stride + kv_head * head_dim)
+                    : nullptr;
+                for (int d_base = 0; d_base < head_dim; d_base += 32) {
+                    int d = d_base + lane;
+                    _Float16 vv = v_row ? v_row[d] : (_Float16)0.0f;
+                    V_lds[kr * head_dim + d] = vv;
+                }
+            }
+            __syncthreads();
+
+            #pragma unroll
+            for (int c = 0; c < n_chunks; ++c) {
+                int s_col_base = c * 16;
+
+                if (s_col_base >= v_start && s_col_base < v_start + V_tile) {
+                    int s_col_local = s_col_base - v_start;
+
+                    half8_t a_reg_sm;
+                    {
+                        const _Float16* sm_row =
+                            S_lds + (my_row_base + half) * S_LDS_STRIDE + s_col_base + half_id * 8;
+                        #pragma unroll
+                        for (int j = 0; j < 8; ++j) a_reg_sm[j] = sm_row[j];
+                    }
+
+                    #pragma unroll 4
+                    for (int dc = 0; dc < d_chunks; ++dc) {
+                        int d0 = dc * 16;
+
+                        half8_t b_reg;
+                        int my_d = d0 + half;
+                        #pragma unroll
+                        for (int j = 0; j < 8; ++j) {
+                            b_reg[j] = V_lds[(s_col_local + half_id * 8 + j) * head_dim + my_d];
+                        }
+
+                        O_frags[dc] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(
+                            a_reg_sm, b_reg, O_frags[dc]);
+                    }
+                }
+            }
+
+            __syncthreads();
+        }
+    }
+
+    #pragma unroll
+    for (int dc = 0; dc < d_chunks; ++dc) {
+        int o_col = dc * 16 + half;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            int o_row = my_row_base + 8 * half_id + j;
+            int gq = q_start + o_row;
+            if (gq < B) {
+                float l_sum = l_lds[o_row];
+                float inv_l = (l_sum > 0.0f) ? (1.0f / l_sum) : 0.0f;
+                out[gq * q_stride + head * head_dim + o_col] = O_frags[dc][j] * inv_l;
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_f16_wmma_mb8.gfx12.hip
+++ b/kernels/src/gemm_f16_wmma_mb8.gfx12.hip
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Kevin Read
+// Copyright (c) 2026 Kaden Schutt
+// hipfire - see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// gfx12/RDNA4 sister of gemm_f16_wmma_mb8.hip.
+//
+// gfx12 WMMA differs from gfx11 in two load-bearing ways:
+// - half8_t operands and the _w32_gfx12 builtin
+// - output rows map contiguously per lane group:
+//     acc[j] = C[8 * (tid >> 4) + j][tid & 15]
+
+typedef _Float16 __attribute__((ext_vector_type(8))) half8_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+#define NB 8
+
+__launch_bounds__(32, 8)
+extern "C" __global__ void gemm_f16_wmma_mb8_gfx12(
+    const _Float16* __restrict__ W,   // [M, K] row-major F16 (weights)
+    const float*    __restrict__ X,   // [N, K] row-major F32 (input)
+    float*          __restrict__ Y,   // [N, M] row-major F32 (transposed output)
+    int M, int K, int N
+) {
+    const int row_start = blockIdx.x * 16;
+    const int col_start = blockIdx.y * (16 * NB);
+    const int tid = threadIdx.x;
+    const int lane_m = tid & 15;
+    const int k_grp = tid >> 4;
+
+    if (row_start >= M || col_start >= N) return;
+
+    const int my_a_row = row_start + lane_m;
+    const bool a_in_bounds = my_a_row < M;
+
+    float8_t acc[NB];
+    #pragma unroll
+    for (int nb = 0; nb < NB; nb++) {
+        acc[nb] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    }
+
+    for (int k0 = 0; k0 < K; k0 += 16) {
+        half8_t a_reg;
+        if (a_in_bounds) {
+            const _Float16* src = W + (long long)my_a_row * K + k0;
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                const int kk = k0 + k_grp * 8 + j;
+                a_reg[j] = kk < K ? src[k_grp * 8 + j] : (_Float16)0.0f;
+            }
+        } else {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) a_reg[j] = (_Float16)0.0f;
+        }
+
+        #pragma unroll
+        for (int nb = 0; nb < NB; nb++) {
+            const int my_b_row = col_start + nb * 16 + lane_m;
+            half8_t b_reg;
+            if (my_b_row < N) {
+                const float* src = X + (long long)my_b_row * K + k0;
+                #pragma unroll
+                for (int j = 0; j < 8; j++) {
+                    const int kk = k0 + k_grp * 8 + j;
+                    b_reg[j] = kk < K ? (_Float16)src[k_grp * 8 + j] : (_Float16)0.0f;
+                }
+            } else {
+                #pragma unroll
+                for (int j = 0; j < 8; j++) b_reg[j] = (_Float16)0.0f;
+            }
+            acc[nb] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a_reg, b_reg, acc[nb]);
+        }
+    }
+
+    #pragma unroll
+    for (int nb = 0; nb < NB; nb++) {
+        const int out_col = col_start + nb * 16 + lane_m;
+        if (out_col < N) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                const int out_row = row_start + 8 * k_grp + j;
+                if (out_row < M) {
+                    Y[(long long)out_col * M + out_row] = acc[nb][j];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds gfx12 sibling kernels for dots.ocr fused f16 GEMM and production v5 DFlash vision attention.
- Routes shared GEMM/attention wrappers by arch caps so gfx11 keeps existing kernels and gfx12 uses `_w32_gfx12` WMMA.
- Enables dots.ocr vision on gfx12 as `rdna4-wmma`, while leaving older gfx11-only experiment variants gated off on gfx12.

## Validation
- `git diff --check`
- gfx11/k9lin: `cargo build --release --features deltanet -p rdna-compute --example test_dots_ocr_wmma_gfx12 --example bench_attention_vision -p hipfire-arch-dots-ocr`
- gfx11/k9lin: `HIP_VISIBLE_DEVICES=0 ./target/release/examples/test_dots_ocr_wmma_gfx12` (`gemm` max_abs_diff `1.948e-5`, attention max_abs_diff `6.038e-6`, tol `5e-3`)
- gfx11/k9lin: `cargo test -p hipfire-arch-dots-ocr --lib` (27 passed)
- gfx11/k9lin: `cargo test -p rdna-compute arch_caps --lib` (17 passed)
- gfx11/k9lin: `./scripts/speed-gate.sh --fast` (2 metrics passed)
- gfx12/hiptrx: `cargo build --release --features deltanet -p rdna-compute --example test_dots_ocr_wmma_gfx12 && HIP_VISIBLE_DEVICES=0 ./target/release/examples/test_dots_ocr_wmma_gfx12` (gfx1201 PASS)
- gfx12/hiptrx: bounded `ocr_e2e` smoke on `dots-ocr.q8.hfq` completed vision encoder, merger, prefill, and `max_tokens=0` generate path with `vision kernels: rdna4-wmma`