### PR TITLE
Fix-forward lint advisory CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ name: CI
 # Required vs advisory: `build` and `test` are the load-bearing
 # "is it broken" gates and are intended to be required status checks on
 # master. `fmt` and `clippy` start advisory (not required) because this
-# repo predates CI and likely carries lint/format debt; promote them to
-# required after a cleanup pass (flip clippy to `-D warnings`).
+# repo predates CI and carries lint/format debt. rustfmt is enforced on
+# changed Rust files only until the historical workspace-wide churn is paid
+# down; promote the full gate after that cleanup pass.
 
 on:
   pull_request:
@@ -69,10 +70,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo fmt --all --check
+      - run: bash scripts/ci-rustfmt-changed.sh
 
   clippy:
     name: clippy (advisory)

--- a/cli/chat_pure.test.ts
+++ b/cli/chat_pure.test.ts
@@ -23,6 +23,7 @@ import {
   historyUp,
   historyDown,
   historySubmit,
+  stripVisibleThinking,
 } from "./chat_pure.ts";
 
 // ─── graphemes ──────────────────────────────────────────────────────────────
@@ -102,6 +103,14 @@ describe("sanitizePaste", () => {
 
   test("preserves Unicode (multi-byte chars are >= 0x20)", () => {
     expect(sanitizePaste("hello 你好 😀")).toBe("hello 你好 😀");
+  });
+});
+
+// ─── Visible thinking cleanup ───────────────────────────────────────────────
+
+describe("stripVisibleThinking", () => {
+  test("strips leading orphan think closer before visible answer", () => {
+    expect(stripVisibleThinking("</think>\n\n```python\ndef add(): pass")).toBe("```python\ndef add(): pass");
   });
 });
 

--- a/cli/chat_pure.ts
+++ b/cli/chat_pure.ts
@@ -126,6 +126,16 @@ export function stripAnsi(s: string): string {
     .replace(SGR_RE, "");
 }
 
+export function stripVisibleThinking(content: string, preserveThinking: boolean = false): string {
+  if (preserveThinking) return content.replace(/<\|im_end\|>/g, "").trim();
+  return content
+    .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+    .replace(/<think>[\s\S]*$/, "")
+    .replace(/^\s*<\/think>\s*/, "")
+    .replace(/<\|im_end\|>/g, "")
+    .trim();
+}
+
 // ─── Markdown rendering ─────────────────────────────────────────────────────
 
 // Phase 1 markdown: fenced code blocks, inline code, bold, italic. ANSI SGR

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -11,6 +11,7 @@ import { spawn } from "bun";
 import { existsSync, readdirSync, statSync, unlinkSync, mkdirSync } from "fs";
 import { join, resolve, basename, dirname } from "path";
 import { homedir } from "os";
+import { stripVisibleThinking } from "./chat_pure.ts";
 
 const HIPFIRE_DIR = join(homedir(), ".hipfire");
 const MODELS_DIR = join(HIPFIRE_DIR, "models");
@@ -3058,13 +3059,7 @@ async function serve(port: number, host: string) {
         // representation including reasoning. <|im_end|> stripping always
         // applies (it would break clients that re-encode message history).
         const strippedContent = content;
-        if (preserveThinking) {
-          content = content.replace(/<\|im_end\|>/g, "").trim();
-        } else {
-          content = content.replace(/<think>[\s\S]*?<\/think>\s*/g, "")
-            .replace(/<think>[\s\S]*$/, "") // unclosed think block
-            .replace(/<\|im_end\|>/g, "").trim();
-        }
+        content = stripVisibleThinking(content, preserveThinking);
 
         // Diagnostic: detect empty-after-unclosed-think-strip.
         let thinkWarning: string | null = null;

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -37,9 +37,15 @@ pub mod launch_counters {
                     COUNT.with(|c| c.set(c.get() + 1));
                     BYTES.with(|c| c.set(c.get() + bytes));
                 }
-                pub fn time_ns() -> u64 { TIME_NS.with(|c| c.get()) }
-                pub fn count() -> u64 { COUNT.with(|c| c.get()) }
-                pub fn bytes() -> u64 { BYTES.with(|c| c.get()) }
+                pub fn time_ns() -> u64 {
+                    TIME_NS.with(|c| c.get())
+                }
+                pub fn count() -> u64 {
+                    COUNT.with(|c| c.get())
+                }
+                pub fn bytes() -> u64 {
+                    BYTES.with(|c| c.get())
+                }
                 pub fn reset() {
                     TIME_NS.with(|c| c.set(0));
                     COUNT.with(|c| c.set(0));
@@ -77,8 +83,12 @@ pub mod launch_counters {
         graph_launch::reset();
     }
 
-    pub fn time_ns() -> u64 { TIME_NS.with(|c| c.get()) }
-    pub fn count() -> u64 { COUNT.with(|c| c.get()) }
+    pub fn time_ns() -> u64 {
+        TIME_NS.with(|c| c.get())
+    }
+    pub fn count() -> u64 {
+        COUNT.with(|c| c.get())
+    }
 
     // Per-API counters
     counter!(launch_kernel);
@@ -146,12 +156,10 @@ pub struct HipRuntime {
     // Multi-device / peer access
     fn_device_can_access_peer: unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32,
     fn_device_enable_peer_access: unsafe extern "C" fn(c_int, c_uint) -> u32,
-    fn_memcpy_peer:
-        unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize) -> u32,
+    fn_memcpy_peer: unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize) -> u32,
     fn_memcpy_peer_async:
         unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize, HipStream) -> u32,
-    fn_pointer_get_attributes:
-        unsafe extern "C" fn(*mut HipPointerAttribute, *const c_void) -> u32,
+    fn_pointer_get_attributes: unsafe extern "C" fn(*mut HipPointerAttribute, *const c_void) -> u32,
 
     // Memory
     fn_malloc: unsafe extern "C" fn(*mut *mut c_void, usize) -> u32,
@@ -170,8 +178,7 @@ pub struct HipRuntime {
     // Modules & kernels
     fn_module_load: unsafe extern "C" fn(*mut HipModule, *const c_char) -> u32,
     fn_module_load_data: unsafe extern "C" fn(*mut HipModule, *const c_void) -> u32,
-    fn_module_get_function:
-        unsafe extern "C" fn(*mut HipFunction, HipModule, *const c_char) -> u32,
+    fn_module_get_function: unsafe extern "C" fn(*mut HipFunction, HipModule, *const c_char) -> u32,
     fn_module_launch_kernel: unsafe extern "C" fn(
         HipFunction,
         c_uint,
@@ -199,19 +206,15 @@ pub struct HipRuntime {
     fn_get_last_error: unsafe extern "C" fn() -> u32,
 
     // Graph capture & replay
-    fn_stream_begin_capture:
-        unsafe extern "C" fn(HipStream, c_uint) -> u32,
-    fn_stream_end_capture:
-        unsafe extern "C" fn(HipStream, *mut HipGraph) -> u32,
+    fn_stream_begin_capture: unsafe extern "C" fn(HipStream, c_uint) -> u32,
+    fn_stream_end_capture: unsafe extern "C" fn(HipStream, *mut HipGraph) -> u32,
     fn_graph_instantiate:
         unsafe extern "C" fn(*mut HipGraphExec, HipGraph, *mut HipGraph, *mut c_void, usize) -> u32,
-    fn_graph_launch:
-        unsafe extern "C" fn(HipGraphExec, HipStream) -> u32,
+    fn_graph_launch: unsafe extern "C" fn(HipGraphExec, HipStream) -> u32,
     fn_graph_exec_destroy: unsafe extern "C" fn(HipGraphExec) -> u32,
     fn_graph_destroy: unsafe extern "C" fn(HipGraph) -> u32,
     // Stream memory ops (HIP 7.2+)
-    fn_stream_write_value32:
-        unsafe extern "C" fn(HipStream, *mut c_void, u32, c_uint) -> u32,
+    fn_stream_write_value32: unsafe extern "C" fn(HipStream, *mut c_void, u32, c_uint) -> u32,
     fn_device_synchronize: unsafe extern "C" fn() -> u32,
     fn_get_device_properties: unsafe extern "C" fn(*mut u8, c_int) -> u32,
     fn_get_device_attribute: unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32,
@@ -293,53 +296,230 @@ impl HipRuntime {
         let runtime = unsafe {
             Self {
                 fn_init: load_fn!(lib, "hipInit", unsafe extern "C" fn(c_uint) -> u32),
-                fn_runtime_get_version: load_fn!(lib, "hipRuntimeGetVersion", unsafe extern "C" fn(*mut c_int) -> u32),
-                fn_get_device_count: load_fn!(lib, "hipGetDeviceCount", unsafe extern "C" fn(*mut c_int) -> u32),
+                fn_runtime_get_version: load_fn!(
+                    lib,
+                    "hipRuntimeGetVersion",
+                    unsafe extern "C" fn(*mut c_int) -> u32
+                ),
+                fn_get_device_count: load_fn!(
+                    lib,
+                    "hipGetDeviceCount",
+                    unsafe extern "C" fn(*mut c_int) -> u32
+                ),
                 fn_set_device: load_fn!(lib, "hipSetDevice", unsafe extern "C" fn(c_int) -> u32),
-                fn_get_device: load_fn!(lib, "hipGetDevice", unsafe extern "C" fn(*mut c_int) -> u32),
-                fn_device_can_access_peer: load_fn!(lib, "hipDeviceCanAccessPeer",
-                    unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32),
-                fn_device_enable_peer_access: load_fn!(lib, "hipDeviceEnablePeerAccess",
-                    unsafe extern "C" fn(c_int, c_uint) -> u32),
-                fn_memcpy_peer: load_fn!(lib, "hipMemcpyPeer",
-                    unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize) -> u32),
-                fn_memcpy_peer_async: load_fn!(lib, "hipMemcpyPeerAsync",
-                    unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize, HipStream) -> u32),
-                fn_pointer_get_attributes: load_fn!(lib, "hipPointerGetAttributes",
-                    unsafe extern "C" fn(*mut HipPointerAttribute, *const c_void) -> u32),
-                fn_malloc: load_fn!(lib, "hipMalloc", unsafe extern "C" fn(*mut *mut c_void, usize) -> u32),
+                fn_get_device: load_fn!(
+                    lib,
+                    "hipGetDevice",
+                    unsafe extern "C" fn(*mut c_int) -> u32
+                ),
+                fn_device_can_access_peer: load_fn!(
+                    lib,
+                    "hipDeviceCanAccessPeer",
+                    unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32
+                ),
+                fn_device_enable_peer_access: load_fn!(
+                    lib,
+                    "hipDeviceEnablePeerAccess",
+                    unsafe extern "C" fn(c_int, c_uint) -> u32
+                ),
+                fn_memcpy_peer: load_fn!(
+                    lib,
+                    "hipMemcpyPeer",
+                    unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize) -> u32
+                ),
+                fn_memcpy_peer_async: load_fn!(
+                    lib,
+                    "hipMemcpyPeerAsync",
+                    unsafe extern "C" fn(
+                        *mut c_void,
+                        c_int,
+                        *const c_void,
+                        c_int,
+                        usize,
+                        HipStream,
+                    ) -> u32
+                ),
+                fn_pointer_get_attributes: load_fn!(
+                    lib,
+                    "hipPointerGetAttributes",
+                    unsafe extern "C" fn(*mut HipPointerAttribute, *const c_void) -> u32
+                ),
+                fn_malloc: load_fn!(
+                    lib,
+                    "hipMalloc",
+                    unsafe extern "C" fn(*mut *mut c_void, usize) -> u32
+                ),
                 fn_free: load_fn!(lib, "hipFree", unsafe extern "C" fn(*mut c_void) -> u32),
-                fn_memcpy: load_fn!(lib, "hipMemcpy", unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_uint) -> u32),
-                fn_memcpy_async: load_fn!(lib, "hipMemcpyAsync", unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_uint, HipStream) -> u32),
-                fn_memset: load_fn!(lib, "hipMemset", unsafe extern "C" fn(*mut c_void, c_int, usize) -> u32),
-                fn_memset_async: load_fn!(lib, "hipMemsetAsync", unsafe extern "C" fn(*mut c_void, c_int, usize, HipStream) -> u32),
-                fn_stream_create: load_fn!(lib, "hipStreamCreate", unsafe extern "C" fn(*mut HipStream) -> u32),
-                fn_stream_synchronize: load_fn!(lib, "hipStreamSynchronize", unsafe extern "C" fn(HipStream) -> u32),
-                fn_stream_destroy: load_fn!(lib, "hipStreamDestroy", unsafe extern "C" fn(HipStream) -> u32),
-                fn_module_load: load_fn!(lib, "hipModuleLoad", unsafe extern "C" fn(*mut HipModule, *const c_char) -> u32),
-                fn_module_load_data: load_fn!(lib, "hipModuleLoadData", unsafe extern "C" fn(*mut HipModule, *const c_void) -> u32),
-                fn_module_get_function: load_fn!(lib, "hipModuleGetFunction", unsafe extern "C" fn(*mut HipFunction, HipModule, *const c_char) -> u32),
-                fn_module_launch_kernel: load_fn!(lib, "hipModuleLaunchKernel", unsafe extern "C" fn(HipFunction, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, HipStream, *mut *mut c_void, *mut *mut c_void) -> u32),
-                fn_event_create: load_fn!(lib, "hipEventCreate", unsafe extern "C" fn(*mut HipEvent) -> u32),
-                fn_event_record: load_fn!(lib, "hipEventRecord", unsafe extern "C" fn(HipEvent, HipStream) -> u32),
-                fn_event_synchronize: load_fn!(lib, "hipEventSynchronize", unsafe extern "C" fn(HipEvent) -> u32),
-                fn_event_elapsed_time: load_fn!(lib, "hipEventElapsedTime", unsafe extern "C" fn(*mut f32, HipEvent, HipEvent) -> u32),
-                fn_event_destroy: load_fn!(lib, "hipEventDestroy", unsafe extern "C" fn(HipEvent) -> u32),
-                fn_stream_wait_event: load_fn!(lib, "hipStreamWaitEvent", unsafe extern "C" fn(HipStream, HipEvent, c_uint) -> u32),
-                fn_get_error_string: load_fn!(lib, "hipGetErrorString", unsafe extern "C" fn(u32) -> *const i8),
+                fn_memcpy: load_fn!(
+                    lib,
+                    "hipMemcpy",
+                    unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_uint) -> u32
+                ),
+                fn_memcpy_async: load_fn!(
+                    lib,
+                    "hipMemcpyAsync",
+                    unsafe extern "C" fn(
+                        *mut c_void,
+                        *const c_void,
+                        usize,
+                        c_uint,
+                        HipStream,
+                    ) -> u32
+                ),
+                fn_memset: load_fn!(
+                    lib,
+                    "hipMemset",
+                    unsafe extern "C" fn(*mut c_void, c_int, usize) -> u32
+                ),
+                fn_memset_async: load_fn!(
+                    lib,
+                    "hipMemsetAsync",
+                    unsafe extern "C" fn(*mut c_void, c_int, usize, HipStream) -> u32
+                ),
+                fn_stream_create: load_fn!(
+                    lib,
+                    "hipStreamCreate",
+                    unsafe extern "C" fn(*mut HipStream) -> u32
+                ),
+                fn_stream_synchronize: load_fn!(
+                    lib,
+                    "hipStreamSynchronize",
+                    unsafe extern "C" fn(HipStream) -> u32
+                ),
+                fn_stream_destroy: load_fn!(
+                    lib,
+                    "hipStreamDestroy",
+                    unsafe extern "C" fn(HipStream) -> u32
+                ),
+                fn_module_load: load_fn!(
+                    lib,
+                    "hipModuleLoad",
+                    unsafe extern "C" fn(*mut HipModule, *const c_char) -> u32
+                ),
+                fn_module_load_data: load_fn!(
+                    lib,
+                    "hipModuleLoadData",
+                    unsafe extern "C" fn(*mut HipModule, *const c_void) -> u32
+                ),
+                fn_module_get_function: load_fn!(
+                    lib,
+                    "hipModuleGetFunction",
+                    unsafe extern "C" fn(*mut HipFunction, HipModule, *const c_char) -> u32
+                ),
+                fn_module_launch_kernel: load_fn!(
+                    lib,
+                    "hipModuleLaunchKernel",
+                    unsafe extern "C" fn(
+                        HipFunction,
+                        c_uint,
+                        c_uint,
+                        c_uint,
+                        c_uint,
+                        c_uint,
+                        c_uint,
+                        c_uint,
+                        HipStream,
+                        *mut *mut c_void,
+                        *mut *mut c_void,
+                    ) -> u32
+                ),
+                fn_event_create: load_fn!(
+                    lib,
+                    "hipEventCreate",
+                    unsafe extern "C" fn(*mut HipEvent) -> u32
+                ),
+                fn_event_record: load_fn!(
+                    lib,
+                    "hipEventRecord",
+                    unsafe extern "C" fn(HipEvent, HipStream) -> u32
+                ),
+                fn_event_synchronize: load_fn!(
+                    lib,
+                    "hipEventSynchronize",
+                    unsafe extern "C" fn(HipEvent) -> u32
+                ),
+                fn_event_elapsed_time: load_fn!(
+                    lib,
+                    "hipEventElapsedTime",
+                    unsafe extern "C" fn(*mut f32, HipEvent, HipEvent) -> u32
+                ),
+                fn_event_destroy: load_fn!(
+                    lib,
+                    "hipEventDestroy",
+                    unsafe extern "C" fn(HipEvent) -> u32
+                ),
+                fn_stream_wait_event: load_fn!(
+                    lib,
+                    "hipStreamWaitEvent",
+                    unsafe extern "C" fn(HipStream, HipEvent, c_uint) -> u32
+                ),
+                fn_get_error_string: load_fn!(
+                    lib,
+                    "hipGetErrorString",
+                    unsafe extern "C" fn(u32) -> *const i8
+                ),
                 fn_get_last_error: load_fn!(lib, "hipGetLastError", unsafe extern "C" fn() -> u32),
-                fn_stream_begin_capture: load_fn!(lib, "hipStreamBeginCapture", unsafe extern "C" fn(HipStream, c_uint) -> u32),
-                fn_stream_end_capture: load_fn!(lib, "hipStreamEndCapture", unsafe extern "C" fn(HipStream, *mut HipGraph) -> u32),
-                fn_graph_instantiate: load_fn!(lib, "hipGraphInstantiate", unsafe extern "C" fn(*mut HipGraphExec, HipGraph, *mut HipGraph, *mut c_void, usize) -> u32),
-                fn_graph_launch: load_fn!(lib, "hipGraphLaunch", unsafe extern "C" fn(HipGraphExec, HipStream) -> u32),
-                fn_graph_exec_destroy: load_fn!(lib, "hipGraphExecDestroy", unsafe extern "C" fn(HipGraphExec) -> u32),
-                fn_graph_destroy: load_fn!(lib, "hipGraphDestroy", unsafe extern "C" fn(HipGraph) -> u32),
-                fn_stream_write_value32: load_fn!(lib, "hipStreamWriteValue32",
-                    unsafe extern "C" fn(HipStream, *mut c_void, u32, c_uint) -> u32),
-                fn_device_synchronize: load_fn!(lib, "hipDeviceSynchronize", unsafe extern "C" fn() -> u32),
-                fn_get_device_properties: load_fn!(lib, "hipGetDeviceProperties", unsafe extern "C" fn(*mut u8, c_int) -> u32),
-                fn_get_device_attribute: load_fn!(lib, "hipDeviceGetAttribute", unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32),
-                fn_mem_get_info: load_fn!(lib, "hipMemGetInfo", unsafe extern "C" fn(*mut usize, *mut usize) -> u32),
+                fn_stream_begin_capture: load_fn!(
+                    lib,
+                    "hipStreamBeginCapture",
+                    unsafe extern "C" fn(HipStream, c_uint) -> u32
+                ),
+                fn_stream_end_capture: load_fn!(
+                    lib,
+                    "hipStreamEndCapture",
+                    unsafe extern "C" fn(HipStream, *mut HipGraph) -> u32
+                ),
+                fn_graph_instantiate: load_fn!(
+                    lib,
+                    "hipGraphInstantiate",
+                    unsafe extern "C" fn(
+                        *mut HipGraphExec,
+                        HipGraph,
+                        *mut HipGraph,
+                        *mut c_void,
+                        usize,
+                    ) -> u32
+                ),
+                fn_graph_launch: load_fn!(
+                    lib,
+                    "hipGraphLaunch",
+                    unsafe extern "C" fn(HipGraphExec, HipStream) -> u32
+                ),
+                fn_graph_exec_destroy: load_fn!(
+                    lib,
+                    "hipGraphExecDestroy",
+                    unsafe extern "C" fn(HipGraphExec) -> u32
+                ),
+                fn_graph_destroy: load_fn!(
+                    lib,
+                    "hipGraphDestroy",
+                    unsafe extern "C" fn(HipGraph) -> u32
+                ),
+                fn_stream_write_value32: load_fn!(
+                    lib,
+                    "hipStreamWriteValue32",
+                    unsafe extern "C" fn(HipStream, *mut c_void, u32, c_uint) -> u32
+                ),
+                fn_device_synchronize: load_fn!(
+                    lib,
+                    "hipDeviceSynchronize",
+                    unsafe extern "C" fn() -> u32
+                ),
+                fn_get_device_properties: load_fn!(
+                    lib,
+                    "hipGetDeviceProperties",
+                    unsafe extern "C" fn(*mut u8, c_int) -> u32
+                ),
+                fn_get_device_attribute: load_fn!(
+                    lib,
+                    "hipDeviceGetAttribute",
+                    unsafe extern "C" fn(*mut c_int, c_int, c_int) -> u32
+                ),
+                fn_mem_get_info: load_fn!(
+                    lib,
+                    "hipMemGetInfo",
+                    unsafe extern "C" fn(*mut usize, *mut usize) -> u32
+                ),
                 _lib: lib,
             }
         };
@@ -434,8 +614,16 @@ impl HipRuntime {
         src_device: i32,
         size: usize,
     ) -> HipResult<()> {
-        assert!(size <= dst.size(), "size ({size}) exceeds dst ({})", dst.size());
-        assert!(size <= src.size(), "size ({size}) exceeds src ({})", src.size());
+        assert!(
+            size <= dst.size(),
+            "size ({size}) exceeds dst ({})",
+            dst.size()
+        );
+        assert!(
+            size <= src.size(),
+            "size ({size}) exceeds src ({})",
+            src.size()
+        );
         let code = unsafe {
             (self.fn_memcpy_peer)(
                 dst.as_ptr(),
@@ -458,8 +646,16 @@ impl HipRuntime {
         size: usize,
         stream: &Stream,
     ) -> HipResult<()> {
-        assert!(size <= dst.size(), "size ({size}) exceeds dst ({})", dst.size());
-        assert!(size <= src.size(), "size ({size}) exceeds src ({})", src.size());
+        assert!(
+            size <= dst.size(),
+            "size ({size}) exceeds dst ({})",
+            dst.size()
+        );
+        assert!(
+            size <= src.size(),
+            "size ({size}) exceeds src ({})",
+            src.size()
+        );
         let code = unsafe {
             (self.fn_memcpy_peer_async)(
                 dst.as_ptr(),
@@ -493,7 +689,6 @@ impl HipRuntime {
     /// Caller must ensure the buffer is not in use by any pending GPU operations.
     pub fn free(&self, buf: DeviceBuffer) -> HipResult<()> {
         let code = unsafe { (self.fn_free)(buf.ptr) };
-        std::mem::forget(buf); // prevent double-free
         self.check(code, "hipFree")
     }
 
@@ -557,12 +752,7 @@ impl HipRuntime {
         let src_ptr = unsafe { (src.ptr as *const u8).add(src_offset) as *const c_void };
         let t = std::time::Instant::now();
         let code = unsafe {
-            (self.fn_memcpy)(
-                dst.ptr,
-                src_ptr,
-                size,
-                MemcpyKind::DeviceToDevice as c_uint,
-            )
+            (self.fn_memcpy)(dst.ptr, src_ptr, size, MemcpyKind::DeviceToDevice as c_uint)
         };
         crate::ffi::launch_counters::memcpy_dtod::record(t.elapsed().as_nanos() as u64);
         self.check(code, "hipMemcpy D2D offset")
@@ -609,11 +799,16 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memcpy_dtoh::record_bytes(elapsed, dst.len() as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump = *DUMP.get_or_init(|| {
-            std::env::var("HIPFIRE_DTOH_DUMP").ok().as_deref() == Some("1")
-        });
+        let dump =
+            *DUMP.get_or_init(|| std::env::var("HIPFIRE_DTOH_DUMP").ok().as_deref() == Some("1"));
         if dump {
-            eprintln!("dtoh bytes={} us={} at {}:{}", dst.len(), elapsed / 1000, loc.file(), loc.line());
+            eprintln!(
+                "dtoh bytes={} us={} at {}:{}",
+                dst.len(),
+                elapsed / 1000,
+                loc.file(),
+                loc.line()
+            );
         }
         self.check(code, "hipMemcpy D2H")
     }
@@ -630,7 +825,9 @@ impl HipRuntime {
         assert!(
             src_offset + dst.len() <= src.size,
             "src_offset ({}) + dst len ({}) exceeds device buffer ({})",
-            src_offset, dst.len(), src.size
+            src_offset,
+            dst.len(),
+            src.size
         );
         let src_ptr = unsafe { (src.ptr as *const u8).add(src_offset) as *const c_void };
         let loc = std::panic::Location::caller();
@@ -646,11 +843,16 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memcpy_dtoh::record_bytes(elapsed, dst.len() as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump = *DUMP.get_or_init(|| {
-            std::env::var("HIPFIRE_DTOH_DUMP").ok().as_deref() == Some("1")
-        });
+        let dump =
+            *DUMP.get_or_init(|| std::env::var("HIPFIRE_DTOH_DUMP").ok().as_deref() == Some("1"));
         if dump {
-            eprintln!("dtoh_at bytes={} us={} at {}:{}", dst.len(), elapsed / 1000, loc.file(), loc.line());
+            eprintln!(
+                "dtoh_at bytes={} us={} at {}:{}",
+                dst.len(),
+                elapsed / 1000,
+                loc.file(),
+                loc.line()
+            );
         }
         self.check(code, "hipMemcpy D2H at offset")
     }
@@ -684,11 +886,16 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memset::record_bytes(elapsed, size as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump = *DUMP.get_or_init(|| {
-            std::env::var("HIPFIRE_MEMSET_DUMP").ok().as_deref() == Some("1")
-        });
+        let dump =
+            *DUMP.get_or_init(|| std::env::var("HIPFIRE_MEMSET_DUMP").ok().as_deref() == Some("1"));
         if dump {
-            eprintln!("memset bytes={} us={} at {}:{}", size, elapsed / 1000, loc.file(), loc.line());
+            eprintln!(
+                "memset bytes={} us={} at {}:{}",
+                size,
+                elapsed / 1000,
+                loc.file(),
+                loc.line()
+            );
         }
         self.check(code, "hipMemset")
     }
@@ -710,11 +917,16 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memset::record_bytes(elapsed, size as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump = *DUMP.get_or_init(|| {
-            std::env::var("HIPFIRE_MEMSET_DUMP").ok().as_deref() == Some("1")
-        });
+        let dump =
+            *DUMP.get_or_init(|| std::env::var("HIPFIRE_MEMSET_DUMP").ok().as_deref() == Some("1"));
         if dump {
-            eprintln!("memset_async bytes={} us={} at {}:{}", size, elapsed / 1000, loc.file(), loc.line());
+            eprintln!(
+                "memset_async bytes={} us={} at {}:{}",
+                size,
+                elapsed / 1000,
+                loc.file(),
+                loc.line()
+            );
         }
         self.check(code, "hipMemsetAsync")
     }
@@ -737,7 +949,6 @@ impl HipRuntime {
 
     pub fn stream_destroy(&self, stream: Stream) -> HipResult<()> {
         let code = unsafe { (self.fn_stream_destroy)(stream.0) };
-        std::mem::forget(stream);
         self.check(code, "hipStreamDestroy")
     }
 
@@ -764,8 +975,7 @@ impl HipRuntime {
         let c_name = CString::new(name)
             .map_err(|_| HipError::new(1, "invalid kernel name for module_get_function"))?;
         let mut func: HipFunction = ptr::null_mut();
-        let code =
-            unsafe { (self.fn_module_get_function)(&mut func, module.0, c_name.as_ptr()) };
+        let code = unsafe { (self.fn_module_get_function)(&mut func, module.0, c_name.as_ptr()) };
         self.check(code, "hipModuleGetFunction")?;
         Ok(Function(func))
     }
@@ -844,11 +1054,11 @@ impl HipRuntime {
         let blob_ptr: *mut c_void = kernarg_blob.as_mut_ptr() as *mut c_void;
         let size_ptr: *mut c_void = (&mut blob_size as *mut usize) as *mut c_void;
         let mut extra: [*mut c_void; 5] = [
-            0x01 as *mut c_void,       // HIP_LAUNCH_PARAM_BUFFER_POINTER
-            blob_ptr,                  // → persistent kernarg blob
-            0x02 as *mut c_void,       // HIP_LAUNCH_PARAM_BUFFER_SIZE
-            size_ptr,                  // → &blob_size (must live across the call)
-            0x03 as *mut c_void,       // HIP_LAUNCH_PARAM_END
+            0x01 as *mut c_void, // HIP_LAUNCH_PARAM_BUFFER_POINTER
+            blob_ptr,            // → persistent kernarg blob
+            0x02 as *mut c_void, // HIP_LAUNCH_PARAM_BUFFER_SIZE
+            size_ptr,            // → &blob_size (must live across the call)
+            0x03 as *mut c_void, // HIP_LAUNCH_PARAM_END
         ];
 
         let stream_raw = stream.map_or(ptr::null_mut(), |s| s.0);
@@ -863,7 +1073,7 @@ impl HipRuntime {
             block[2],
             shared_mem,
             stream_raw,
-            ptr::null_mut(),           // kernelParams = null (we use extra)
+            ptr::null_mut(), // kernelParams = null (we use extra)
             extra.as_mut_ptr(),
         );
         crate::ffi::launch_counters::record(t.elapsed().as_nanos() as u64);
@@ -901,7 +1111,6 @@ impl HipRuntime {
 
     pub fn event_destroy(&self, event: Event) -> HipResult<()> {
         let code = unsafe { (self.fn_event_destroy)(event.0) };
-        std::mem::forget(event);
         self.check(code, "hipEventDestroy")
     }
 
@@ -975,7 +1184,9 @@ impl HipRuntime {
         let src_ptr = unsafe { (src.ptr as *const u8).add(src_offset) as *const c_void };
         let code = unsafe {
             (self.fn_memcpy_async)(
-                dst_ptr, src_ptr, size,
+                dst_ptr,
+                src_ptr,
+                size,
                 MemcpyKind::DeviceToDevice as c_uint,
                 stream.0,
             )
@@ -1020,13 +1231,11 @@ impl HipRuntime {
 
     pub fn graph_exec_destroy(&self, exec: GraphExec) -> HipResult<()> {
         let code = unsafe { (self.fn_graph_exec_destroy)(exec.0) };
-        std::mem::forget(exec);
         self.check(code, "hipGraphExecDestroy")
     }
 
     pub fn graph_destroy(&self, graph: Graph) -> HipResult<()> {
         let code = unsafe { (self.fn_graph_destroy)(graph.0) };
-        std::mem::forget(graph);
         self.check(code, "hipGraphDestroy")
     }
 
@@ -1034,7 +1243,13 @@ impl HipRuntime {
     /// The write is ordered with respect to other operations on the stream.
     /// Graph-safe: can be used before hipGraphLaunch to update device state
     /// that captured kernels will read (e.g., position buffers).
-    pub fn stream_write_value32(&self, stream: &Stream, ptr: &DeviceBuffer, value: u32, flags: u32) -> HipResult<()> {
+    pub fn stream_write_value32(
+        &self,
+        stream: &Stream,
+        ptr: &DeviceBuffer,
+        value: u32,
+        flags: u32,
+    ) -> HipResult<()> {
         let code = unsafe { (self.fn_stream_write_value32)(stream.0, ptr.as_ptr(), value, flags) };
         self.check(code, "hipStreamWriteValue32")
     }
@@ -1058,7 +1273,9 @@ impl HipRuntime {
         let s = String::from_utf8_lossy(&buf);
         if let Some(pos) = s.find("gfx") {
             let arch_str = &s[pos..];
-            let end = arch_str.find(|c: char| c == '\0' || c == ':' || c == ' ').unwrap_or(arch_str.len());
+            let end = arch_str
+                .find(|c: char| c == '\0' || c == ':' || c == ' ')
+                .unwrap_or(arch_str.len());
             Ok(arch_str[..end].to_string())
         } else {
             // Fallback: read as null-terminated string from known offsets
@@ -1079,7 +1296,9 @@ impl HipRuntime {
     /// when sysfs/KFD is unavailable (Windows, restricted containers).
     pub fn get_device_attribute(&self, attr_id: i32, device_id: i32) -> HipResult<i32> {
         let mut value: c_int = 0;
-        let code = unsafe { (self.fn_get_device_attribute)(&mut value, attr_id as c_int, device_id as c_int) };
+        let code = unsafe {
+            (self.fn_get_device_attribute)(&mut value, attr_id as c_int, device_id as c_int)
+        };
         self.check(code, "hipDeviceGetAttribute")?;
         Ok(value as i32)
     }
@@ -1098,6 +1317,11 @@ impl HipRuntime {
 
 /// GPU stream handle.
 pub struct Stream(HipStream);
+impl Stream {
+    pub fn as_raw(&self) -> *mut c_void {
+        self.0
+    }
+}
 unsafe impl Send for Stream {}
 
 /// Loaded GPU module (compiled kernels).

--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -6,17 +6,17 @@
 //! hip-bridge: Safe Rust FFI to AMD HIP runtime via dlopen.
 //! Modeled after rustane's ane-bridge — no link-time dependency on libamdhip64.
 
-mod ffi;
 mod error;
+mod ffi;
 mod kernarg;
 mod rocblas;
 
 pub use error::{
-    HipError, HipResult, HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED,
-    HIP_ERROR_PEER_ACCESS_NOT_ENABLED, HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
+    HipError, HipResult, HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED, HIP_ERROR_PEER_ACCESS_NOT_ENABLED,
+    HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
 };
-pub use ffi::{Event, Function, Graph, GraphExec, HipPointerAttribute, HipRuntime, Module, Stream};
 pub use ffi::launch_counters;
+pub use ffi::{Event, Function, Graph, GraphExec, HipPointerAttribute, HipRuntime, Module, Stream};
 pub use kernarg::KernargBlob;
 pub use rocblas::{Rocblas, RocblasDatatype, RocblasError, RocblasOperation, RocblasResult};
 
@@ -75,6 +75,11 @@ impl DeviceBuffer {
     /// Create a non-owning DeviceBuffer from a raw pointer and size.
     /// The caller must ensure the pointer is valid GPU memory.
     /// The resulting buffer must NOT be freed (it doesn't own the memory).
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to at least `size` bytes of valid GPU-accessible
+    /// memory for the lifetime of the returned non-owning wrapper.
     pub unsafe fn from_raw(ptr: *mut std::ffi::c_void, size: usize) -> DeviceBuffer {
         DeviceBuffer { ptr, size }
     }
@@ -85,7 +90,10 @@ impl DeviceBuffer {
     /// # Safety
     /// Caller must ensure the alias doesn't outlive the original.
     pub unsafe fn alias(&self) -> DeviceBuffer {
-        DeviceBuffer { ptr: self.ptr, size: self.size }
+        DeviceBuffer {
+            ptr: self.ptr,
+            size: self.size,
+        }
     }
 }
 

--- a/crates/hip-bridge/src/rocblas.rs
+++ b/crates/hip-bridge/src/rocblas.rs
@@ -13,6 +13,7 @@
 //! Loaded lazily via `libloading`; absence of librocblas is a recoverable
 //! runtime error so the engine still builds + runs without it.
 
+use crate::Stream;
 use libloading::{Library, Symbol};
 use std::ffi::{c_int, c_void};
 use std::os::raw::c_uint;
@@ -70,22 +71,33 @@ pub struct Rocblas {
     _lib: Library,
     handle: RocblasHandle,
 
-    fn_create_handle: unsafe extern "C" fn(*mut RocblasHandle) -> u32,
     fn_destroy_handle: unsafe extern "C" fn(RocblasHandle) -> u32,
     fn_set_stream: unsafe extern "C" fn(RocblasHandle, *mut c_void) -> u32,
     fn_gemm_ex: unsafe extern "C" fn(
         RocblasHandle,
-        c_uint, c_uint,              // transA, transB
-        c_int, c_int, c_int,         // m, n, k
-        *const c_void,               // alpha (pointer to scalar of compute_type)
-        *const c_void, c_uint, c_int,// A, a_type, lda
-        *const c_void, c_uint, c_int,// B, b_type, ldb
-        *const c_void,               // beta
-        *const c_void, c_uint, c_int,// C, c_type, ldc
-        *mut c_void,   c_uint, c_int,// D, d_type, ldd
-        c_uint,                      // compute_type
-        c_uint,                      // algo
-        i32, u32,                    // solution_index, flags
+        c_uint,
+        c_uint, // transA, transB
+        c_int,
+        c_int,
+        c_int,         // m, n, k
+        *const c_void, // alpha (pointer to scalar of compute_type)
+        *const c_void,
+        c_uint,
+        c_int, // A, a_type, lda
+        *const c_void,
+        c_uint,
+        c_int,         // B, b_type, ldb
+        *const c_void, // beta
+        *const c_void,
+        c_uint,
+        c_int, // C, c_type, ldc
+        *mut c_void,
+        c_uint,
+        c_int,  // D, d_type, ldd
+        c_uint, // compute_type
+        c_uint, // algo
+        i32,
+        u32, // solution_index, flags
     ) -> u32,
 }
 
@@ -104,21 +116,24 @@ impl Rocblas {
             "/opt/rocm/lib/librocblas.so.6",
             "/opt/rocm/lib/librocblas.so.5",
         ];
-        let lib = candidates.iter().find_map(|name| {
-            unsafe { Library::new(name).ok() }
-        }).ok_or_else(|| RocblasError {
-            status: 0,
-            context: "dlopen librocblas.so (tried several names) failed".into(),
-        })?;
+        let lib = candidates
+            .iter()
+            .find_map(|name| unsafe { Library::new(name).ok() })
+            .ok_or_else(|| RocblasError {
+                status: 0,
+                context: "dlopen librocblas.so (tried several names) failed".into(),
+            })?;
 
         unsafe {
-            let fn_create_handle: Symbol<unsafe extern "C" fn(*mut RocblasHandle) -> u32> =
-                lib.get(b"rocblas_create_handle").map_err(|e| RocblasError {
+            let fn_create_handle: Symbol<unsafe extern "C" fn(*mut RocblasHandle) -> u32> = lib
+                .get(b"rocblas_create_handle")
+                .map_err(|e| RocblasError {
                     status: 0,
                     context: format!("resolve rocblas_create_handle: {e}"),
                 })?;
-            let fn_destroy_handle: Symbol<unsafe extern "C" fn(RocblasHandle) -> u32> =
-                lib.get(b"rocblas_destroy_handle").map_err(|e| RocblasError {
+            let fn_destroy_handle: Symbol<unsafe extern "C" fn(RocblasHandle) -> u32> = lib
+                .get(b"rocblas_destroy_handle")
+                .map_err(|e| RocblasError {
                     status: 0,
                     context: format!("resolve rocblas_destroy_handle: {e}"),
                 })?;
@@ -127,20 +142,34 @@ impl Rocblas {
                     status: 0,
                     context: format!("resolve rocblas_set_stream: {e}"),
                 })?;
-            let fn_gemm_ex: Symbol<unsafe extern "C" fn(
-                RocblasHandle,
-                c_uint, c_uint,
-                c_int, c_int, c_int,
-                *const c_void,
-                *const c_void, c_uint, c_int,
-                *const c_void, c_uint, c_int,
-                *const c_void,
-                *const c_void, c_uint, c_int,
-                *mut c_void,   c_uint, c_int,
-                c_uint,
-                c_uint,
-                i32, u32,
-            ) -> u32> = lib.get(b"rocblas_gemm_ex").map_err(|e| RocblasError {
+            let fn_gemm_ex: Symbol<
+                unsafe extern "C" fn(
+                    RocblasHandle,
+                    c_uint,
+                    c_uint,
+                    c_int,
+                    c_int,
+                    c_int,
+                    *const c_void,
+                    *const c_void,
+                    c_uint,
+                    c_int,
+                    *const c_void,
+                    c_uint,
+                    c_int,
+                    *const c_void,
+                    *const c_void,
+                    c_uint,
+                    c_int,
+                    *mut c_void,
+                    c_uint,
+                    c_int,
+                    c_uint,
+                    c_uint,
+                    i32,
+                    u32,
+                ) -> u32,
+            > = lib.get(b"rocblas_gemm_ex").map_err(|e| RocblasError {
                 status: 0,
                 context: format!("resolve rocblas_gemm_ex: {e}"),
             })?;
@@ -162,7 +191,6 @@ impl Rocblas {
             Ok(Self {
                 _lib: lib,
                 handle,
-                fn_create_handle,
                 fn_destroy_handle,
                 fn_set_stream,
                 fn_gemm_ex,
@@ -171,11 +199,15 @@ impl Rocblas {
     }
 
     /// Bind this rocBLAS handle to a HIP stream so calls execute on it.
-    /// Passing null stream (default stream) is also valid.
-    pub fn set_stream(&self, stream_handle: *mut c_void) -> RocblasResult<()> {
-        let st = unsafe { (self.fn_set_stream)(self.handle, stream_handle) };
-        if st == ROCBLAS_STATUS_SUCCESS { Ok(()) } else {
-            Err(RocblasError { status: st, context: "rocblas_set_stream".into() })
+    pub fn set_stream(&self, stream: &Stream) -> RocblasResult<()> {
+        let st = unsafe { (self.fn_set_stream)(self.handle, stream.as_raw()) };
+        if st == ROCBLAS_STATUS_SUCCESS {
+            Ok(())
+        } else {
+            Err(RocblasError {
+                status: st,
+                context: "rocblas_set_stream".into(),
+            })
         }
     }
 
@@ -188,35 +220,69 @@ impl Rocblas {
     /// Note: rocBLAS is column-major. Our engine stores matrices row-major,
     /// so callers flip the operation (A_row · B_row == (B_col^T · A_col^T)^T)
     /// and swap (m, n) / (a, b) / (lda, ldb) / transA, transB when dispatching.
+    ///
+    /// # Safety
+    ///
+    /// All matrix pointers and scalar pointers must be valid for the rocBLAS
+    /// call, point to GPU memory where rocBLAS expects it, and describe buffers
+    /// large enough for the dimensions and leading dimensions passed here.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn gemm_ex(
         &self,
-        trans_a: RocblasOperation, trans_b: RocblasOperation,
-        m: i32, n: i32, k: i32,
+        trans_a: RocblasOperation,
+        trans_b: RocblasOperation,
+        m: i32,
+        n: i32,
+        k: i32,
         alpha: *const c_void,
-        a: *const c_void, a_type: RocblasDatatype, lda: i32,
-        b: *const c_void, b_type: RocblasDatatype, ldb: i32,
+        a: *const c_void,
+        a_type: RocblasDatatype,
+        lda: i32,
+        b: *const c_void,
+        b_type: RocblasDatatype,
+        ldb: i32,
         beta: *const c_void,
-        c: *const c_void, c_type: RocblasDatatype, ldc: i32,
-        d: *mut c_void,   d_type: RocblasDatatype, ldd: i32,
+        c: *const c_void,
+        c_type: RocblasDatatype,
+        ldc: i32,
+        d: *mut c_void,
+        d_type: RocblasDatatype,
+        ldd: i32,
         compute_type: RocblasDatatype,
     ) -> RocblasResult<()> {
         let st = (self.fn_gemm_ex)(
             self.handle,
-            trans_a as c_uint, trans_b as c_uint,
-            m, n, k,
+            trans_a as c_uint,
+            trans_b as c_uint,
+            m,
+            n,
+            k,
             alpha,
-            a, a_type as c_uint, lda,
-            b, b_type as c_uint, ldb,
+            a,
+            a_type as c_uint,
+            lda,
+            b,
+            b_type as c_uint,
+            ldb,
             beta,
-            c, c_type as c_uint, ldc,
-            d, d_type as c_uint, ldd,
+            c,
+            c_type as c_uint,
+            ldc,
+            d,
+            d_type as c_uint,
+            ldd,
             compute_type as c_uint,
             RocblasGemmAlgo::Standard as c_uint,
-            0, 0,
+            0,
+            0,
         );
-        if st == ROCBLAS_STATUS_SUCCESS { Ok(()) } else {
-            Err(RocblasError { status: st, context: "rocblas_gemm_ex".into() })
+        if st == ROCBLAS_STATUS_SUCCESS {
+            Ok(())
+        } else {
+            Err(RocblasError {
+                status: st,
+                context: "rocblas_gemm_ex".into(),
+            })
         }
     }
 }

--- a/crates/hipfire-arch-qwen35-vl/src/image.rs
+++ b/crates/hipfire-arch-qwen35-vl/src/image.rs
@@ -23,10 +23,16 @@ const MAX_DIMENSION_PIXELS: usize = 4_000_000;
 /// row/column. Passing any other factor (e.g. the legacy `28` from Qwen2-VL
 /// when patch_size=16) yields odd patch grids on small images and a
 /// merger/LM token-count mismatch downstream.
-pub fn smart_resize(height: usize, width: usize, factor: usize, min_pixels: usize, max_pixels: usize) -> (usize, usize) {
+pub fn smart_resize(
+    height: usize,
+    width: usize,
+    factor: usize,
+    min_pixels: usize,
+    max_pixels: usize,
+) -> (usize, usize) {
     let h_bar = ((height as f64 / factor as f64).round() as usize) * factor;
     let w_bar = ((width as f64 / factor as f64).round() as usize) * factor;
-    
+
     if h_bar * w_bar > max_pixels {
         let beta = ((height * width) as f64 / max_pixels as f64).sqrt();
         let h_bar = factor.max(((height as f64 / beta / factor as f64).floor() as usize) * factor);
@@ -89,8 +95,8 @@ fn preprocess_dynamic_image(
         for x in 0..w {
             let pixel = rgb.get_pixel(x as u32, y as u32);
             let idx = y * w + x;
-            out[idx] = pixel[0] as f32 / 127.5 - 1.0;             // channel 0 = R
-            out[plane + idx] = pixel[1] as f32 / 127.5 - 1.0;     // channel 1 = G
+            out[idx] = pixel[0] as f32 / 127.5 - 1.0; // channel 0 = R
+            out[plane + idx] = pixel[1] as f32 / 127.5 - 1.0; // channel 1 = G
             out[2 * plane + idx] = pixel[2] as f32 / 127.5 - 1.0; // channel 2 = B
         }
     }
@@ -108,9 +114,13 @@ pub fn load_and_preprocess(
     patch_size: usize,
     spatial_merge_size: usize,
 ) -> Result<(Vec<f32>, usize, usize), String> {
-    let img = image::open(path)
-        .map_err(|e| format!("failed to open image {}: {e}", path.display()))?;
-    Ok(preprocess_dynamic_image(img, patch_size, spatial_merge_size))
+    let img =
+        image::open(path).map_err(|e| format!("failed to open image {}: {e}", path.display()))?;
+    Ok(preprocess_dynamic_image(
+        img,
+        patch_size,
+        spatial_merge_size,
+    ))
 }
 
 /// Load an image from raw bytes (PNG or JPEG), smart-resize, normalize.
@@ -131,9 +141,7 @@ pub fn load_and_preprocess_from_bytes(
         .with_guessed_format()
         .map_err(|e| format!("failed to read image: {e}"))?;
 
-    let (orig_w, orig_h) = reader
-        .into_dimensions()
-        .map_err(map_image_err)?;
+    let (orig_w, orig_h) = reader.into_dimensions().map_err(map_image_err)?;
     let (orig_w, orig_h) = (orig_w as usize, orig_h as usize);
     if orig_w * orig_h > MAX_DIMENSION_PIXELS {
         return Err(format!(
@@ -142,7 +150,11 @@ pub fn load_and_preprocess_from_bytes(
     }
 
     let img = image::load_from_memory(data).map_err(map_image_err)?;
-    Ok(preprocess_dynamic_image(img, patch_size, spatial_merge_size))
+    Ok(preprocess_dynamic_image(
+        img,
+        patch_size,
+        spatial_merge_size,
+    ))
 }
 
 fn map_image_err(e: image::ImageError) -> String {
@@ -198,9 +210,7 @@ pub fn extract_patches(
     let mut patches = vec![0.0f32; n_patches * patch_elems];
 
     assert!(
-        spatial_merge_size >= 1
-            && ph % spatial_merge_size == 0
-            && pw % spatial_merge_size == 0,
+        spatial_merge_size >= 1 && ph % spatial_merge_size == 0 && pw % spatial_merge_size == 0,
         "patch grid {ph}x{pw} not divisible by spatial_merge_size={spatial_merge_size} — \
          smart_resize should guarantee this",
     );
@@ -213,7 +223,8 @@ pub fn extract_patches(
             let sy = py % spatial_merge_size;
             let sx = px % spatial_merge_size;
             // SMS×SMS-block-grouped row-major: ((gy, gx), (sy, sx)) flattened.
-            let patch_out_idx = ((gy * gw + gx) * spatial_merge_size + sy) * spatial_merge_size + sx;
+            let patch_out_idx =
+                ((gy * gw + gx) * spatial_merge_size + sy) * spatial_merge_size + sx;
             let out_base = patch_out_idx * patch_elems;
 
             for c in 0..channels {
@@ -271,7 +282,9 @@ mod tests {
     #[test]
     fn extract_patches_locks_layout_and_order_4x4() {
         let chw = synthetic_chw(3, 4, 4);
-        let patches = extract_patches(&chw, 3, 4, 4, /*patch_size=*/2, /*T=*/2, /*SMS=*/2);
+        let patches = extract_patches(
+            &chw, 3, 4, 4, /*patch_size=*/ 2, /*T=*/ 2, /*SMS=*/ 2,
+        );
         // Per-patch element count: T * C * ph * pw = 2 * 3 * 2 * 2 = 24.
         // Total: 4 patches × 24 = 96.
         assert_eq!(patches.len(), 96);
@@ -281,19 +294,28 @@ mod tests {
         //   patch_out_idx 1 → out_base = 1 * 24 = 24
         // Per-patch layout (C, T, ph, pw): for c=0, t=0, dy=0, dx=0 the source
         // pixel is at (py*ps+dy, px*ps+dx) = (0, 2) so value = 0*10000 + 0*100 + 2 = 2.
-        let v = patches[24 + 0 * 8 + 0 * 4 + 0 * 2 + 0];
-        assert_eq!(v, 2.0, "patch_out_idx=1, c=0,t=0,dy=0,dx=0 should hold (0,2)=2");
+        let v = patches[24];
+        assert_eq!(
+            v, 2.0,
+            "patch_out_idx=1, c=0,t=0,dy=0,dx=0 should hold (0,2)=2"
+        );
         // Same patch, c=2 (B), t=1, dy=1, dx=1:
         //   src = (0*4 + 1) = y=1, x=2*2+1=3, c=2 → 2*10000 + 1*100 + 3 = 20103.
         //   dst offset within patch = 2 * 8 + 1 * 4 + 1 * 2 + 1 = 23.
         let v = patches[24 + 23];
-        assert_eq!(v, 20103.0, "patch_out_idx=1, c=2,t=1,dy=1,dx=1 should hold (2,1,3)");
+        assert_eq!(
+            v, 20103.0,
+            "patch_out_idx=1, c=2,t=1,dy=1,dx=1 should hold (2,1,3)"
+        );
 
         // Patch (py=1, px=0) — bottom-left. out_idx = sy=1, sx=0 = 2.
         // Per-patch c=1, t=0, dy=0, dx=0: src = (y=2, x=0, c=1) → 10000 + 200 + 0 = 10200.
         // dst offset = 1*8 + 0*4 + 0*2 + 0 = 8.
         let v = patches[2 * 24 + 8];
-        assert_eq!(v, 10200.0, "patch_out_idx=2, c=1,t=0,dy=0,dx=0 should hold (1,2,0)");
+        assert_eq!(
+            v, 10200.0,
+            "patch_out_idx=2, c=1,t=0,dy=0,dx=0 should hold (1,2,0)"
+        );
     }
 
     /// 4×6 image, patch_size=2, SMS=2: ph=2, pw=3 — non-square. ph%SMS=0,
@@ -302,7 +324,9 @@ mod tests {
     #[should_panic(expected = "not divisible by spatial_merge_size")]
     fn extract_patches_rejects_indivisible_grid() {
         let chw = synthetic_chw(3, 4, 6);
-        let _ = extract_patches(&chw, 3, 4, 6, /*patch_size=*/2, /*T=*/2, /*SMS=*/2);
+        let _ = extract_patches(
+            &chw, 3, 4, 6, /*patch_size=*/ 2, /*T=*/ 2, /*SMS=*/ 2,
+        );
     }
 
     /// SMS=4 on a 8×8 image: ph=pw=4, divisible. Spot-check the 4x4-grouping
@@ -311,7 +335,9 @@ mod tests {
     #[test]
     fn extract_patches_supports_sms_4() {
         let chw = synthetic_chw(3, 8, 8);
-        let patches = extract_patches(&chw, 3, 8, 8, /*patch_size=*/2, /*T=*/1, /*SMS=*/4);
+        let patches = extract_patches(
+            &chw, 3, 8, 8, /*patch_size=*/ 2, /*T=*/ 1, /*SMS=*/ 4,
+        );
         // ph=pw=4, n=16 patches, patch_elems = 1*3*2*2 = 12.
         assert_eq!(patches.len(), 16 * 12);
         // With SMS=4 the entire 4×4 grid is ONE merge block (mh=mw=1).

--- a/crates/hsa-bridge/examples/hsa_vs_hip_launch.rs
+++ b/crates/hsa-bridge/examples/hsa_vs_hip_launch.rs
@@ -30,6 +30,16 @@ __global__ void vector_add(const float* a, const float* b, float* c, int n) {
 }
 "#;
 
+const HSA_WAIT_TIMEOUT_NS: u64 = 5_000_000_000;
+
+fn wait_for_completion(signal: &HsaSignal, context: &str) {
+    let observed = signal.wait_lt_active(1, HSA_WAIT_TIMEOUT_NS);
+    assert!(
+        observed < 1,
+        "{context}: HSA completion signal timed out with value {observed}"
+    );
+}
+
 fn main() {
     let iters: u32 = std::env::args()
         .nth(1)
@@ -99,20 +109,32 @@ fn main() {
 
     // ─── 4. Set up HSA path ──────────────────────────────────────────────
     let queue = agent.create_queue(1024).expect("create_queue");
-    eprintln!("[hsa] queue size={} doorbell=0x{:x}", queue.size(), queue.doorbell());
+    eprintln!(
+        "[hsa] queue size={} doorbell=0x{:x}",
+        queue.size(),
+        queue.doorbell()
+    );
 
     // Kernarg pool lives on the CPU agent (host-pinned, GPU-readable).
     let cpu_agent = hsa.find_cpu_agent().expect("find_cpu_agent");
     let kernarg_pool = cpu_agent.find_kernarg_pool().expect("kernarg pool");
-    let device_pool = agent.find_coarse_grained_pool().expect("device pool (coarse)");
+    let device_pool = agent
+        .find_coarse_grained_pool()
+        .expect("device pool (coarse)");
 
     let hsa_a = device_pool.allocate(nbytes).unwrap();
     let hsa_b = device_pool.allocate(nbytes).unwrap();
     let hsa_c = device_pool.allocate(nbytes).unwrap();
     // Coarse-grained device memory is GPU-only by default; allow CPU writes too.
-    device_pool.allow_access(&[&cpu_agent, &agent], hsa_a).unwrap();
-    device_pool.allow_access(&[&cpu_agent, &agent], hsa_b).unwrap();
-    device_pool.allow_access(&[&cpu_agent, &agent], hsa_c).unwrap();
+    device_pool
+        .allow_access(&[&cpu_agent, &agent], hsa_a)
+        .unwrap();
+    device_pool
+        .allow_access(&[&cpu_agent, &agent], hsa_b)
+        .unwrap();
+    device_pool
+        .allow_access(&[&cpu_agent, &agent], hsa_c)
+        .unwrap();
     unsafe {
         std::ptr::copy_nonoverlapping(a_data.as_ptr() as *const u8, hsa_a, nbytes);
         std::ptr::copy_nonoverlapping(b_data.as_ptr() as *const u8, hsa_b, nbytes);
@@ -133,7 +155,9 @@ fn main() {
     // (KERNARG_INIT flag, fine-grained system memory). Explicitly allow the GPU
     // to read it — without this we get a GPU page fault on the kernarg load.
     let kernarg = kernarg_pool.allocate(kernel.kernarg_size as usize).unwrap();
-    kernarg_pool.allow_access(&[&cpu_agent, &agent], kernarg).unwrap();
+    kernarg_pool
+        .allow_access(&[&cpu_agent, &agent], kernarg)
+        .unwrap();
     eprintln!(
         "[hsa] addrs: a=0x{:x} b=0x{:x} c=0x{:x} kernarg=0x{:x}",
         hsa_a as usize, hsa_b as usize, hsa_c as usize, kernarg as usize,
@@ -184,18 +208,20 @@ fn main() {
         signal.store_relaxed(1);
         let idx = queue.load_write_index_relaxed();
         let slot = queue.packet_slot(idx);
-        build_dispatch_packet(
-            slot,
-            &kernel,
-            [groups, 1, 1],
-            [256, 1, 1],
-            kernarg,
-            signal.raw_handle(),
-        );
-        publish_dispatch_packet(slot, header);
+        unsafe {
+            build_dispatch_packet(
+                slot,
+                &kernel,
+                [groups, 1, 1],
+                [256, 1, 1],
+                kernarg,
+                signal.raw_handle(),
+            );
+            publish_dispatch_packet(slot, header);
+        }
         queue.store_write_index_release(idx + 1);
         queue.ring_doorbell(idx);
-        signal.wait_lt_active(1, u64::MAX);
+        wait_for_completion(&signal, "HSA warm-up");
     }
 
     // ─── 6. Verify both paths produce the same result ────────────────────
@@ -223,14 +249,8 @@ fn main() {
         n
     );
     if hip_bad != 0 || hsa_bad != 0 {
-        eprintln!(
-            "  HIP first 4: {:?}",
-            &hip_floats[..4]
-        );
-        eprintln!(
-            "  HSA first 4: {:?}",
-            &hsa_floats[..4]
-        );
+        eprintln!("  HIP first 4: {:?}", &hip_floats[..4]);
+        eprintln!("  HSA first 4: {:?}", &hsa_floats[..4]);
         std::process::exit(1);
     }
 
@@ -260,18 +280,20 @@ fn main() {
         signal.store_relaxed(1);
         let idx = queue.load_write_index_relaxed();
         let slot = queue.packet_slot(idx);
-        build_dispatch_packet(
-            slot,
-            &kernel,
-            [groups, 1, 1],
-            [256, 1, 1],
-            kernarg,
-            signal.raw_handle(),
-        );
-        publish_dispatch_packet(slot, header);
+        unsafe {
+            build_dispatch_packet(
+                slot,
+                &kernel,
+                [groups, 1, 1],
+                [256, 1, 1],
+                kernarg,
+                signal.raw_handle(),
+            );
+            publish_dispatch_packet(slot, header);
+        }
         queue.store_write_index_release(idx + 1);
         queue.ring_doorbell(idx);
-        signal.wait_lt_active(1, u64::MAX);
+        wait_for_completion(&signal, "HSA latency iteration");
         hsa_lat.push(t.elapsed());
     }
 
@@ -332,20 +354,26 @@ fn main() {
             for i in 0..burst {
                 let idx = base_idx + i as u64;
                 let slot = queue.packet_slot(idx);
-                let completion = if i == burst - 1 { signal.raw_handle() } else { 0 };
-                build_dispatch_packet(
-                    slot,
-                    &kernel,
-                    [groups, 1, 1],
-                    [256, 1, 1],
-                    kernarg,
-                    completion,
-                );
-                publish_dispatch_packet(slot, header);
+                let completion = if i == burst - 1 {
+                    signal.raw_handle()
+                } else {
+                    0
+                };
+                unsafe {
+                    build_dispatch_packet(
+                        slot,
+                        &kernel,
+                        [groups, 1, 1],
+                        [256, 1, 1],
+                        kernarg,
+                        completion,
+                    );
+                    publish_dispatch_packet(slot, header);
+                }
             }
             queue.store_write_index_release(base_idx + burst as u64);
             queue.ring_doorbell(base_idx + burst as u64 - 1);
-            signal.wait_lt_active(1, u64::MAX);
+            wait_for_completion(&signal, "HSA burst iteration");
             burst_lat.push(t.elapsed());
         }
         burst_lat.sort();
@@ -365,17 +393,26 @@ fn main() {
     let hsa_med = median_us(&hsa_lat);
     eprintln!("\n[summary]");
     eprintln!("  HIP single dispatch:  {hip_med:6.2} µs");
-    eprintln!("  HSA single dispatch:  {hsa_med:6.2} µs   ({:.2}x vs HIP)", hip_med / hsa_med);
+    eprintln!(
+        "  HSA single dispatch:  {hsa_med:6.2} µs   ({:.2}x vs HIP)",
+        hip_med / hsa_med
+    );
     if let Some(&(_, hip_best)) = hip_burst_results
         .iter()
         .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
     {
-        eprintln!("  HIP burst (best):     {hip_best:6.2} µs   ({:.2}x vs HIP single)", hip_med / hip_best);
+        eprintln!(
+            "  HIP burst (best):     {hip_best:6.2} µs   ({:.2}x vs HIP single)",
+            hip_med / hip_best
+        );
         if let Some(&(_, hsa_best)) = burst_results
             .iter()
             .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
         {
-            eprintln!("  HSA burst (best):     {hsa_best:6.2} µs   ({:.2}x vs HIP burst)", hip_best / hsa_best);
+            eprintln!(
+                "  HSA burst (best):     {hsa_best:6.2} µs   ({:.2}x vs HIP burst)",
+                hip_best / hsa_best
+            );
         }
     }
 }

--- a/crates/hsa-bridge/src/lib.rs
+++ b/crates/hsa-bridge/src/lib.rs
@@ -43,10 +43,7 @@ impl HsaRuntime {
 
     /// Enumerate agents and return the first GPU whose name contains `gfx_arch`.
     /// Pass `None` to get the first GPU agent regardless of arch.
-    pub fn find_gpu_agent(
-        self: &Arc<Self>,
-        gfx_arch: Option<&str>,
-    ) -> HsaResult<HsaAgent> {
+    pub fn find_gpu_agent(self: &Arc<Self>, gfx_arch: Option<&str>) -> HsaResult<HsaAgent> {
         self.find_agent(HSA_DEVICE_TYPE_GPU, gfx_arch)
     }
 
@@ -67,10 +64,7 @@ impl HsaRuntime {
             found: HsaAgentHandle,
         }
 
-        unsafe extern "C" fn visit(
-            agent: HsaAgentHandle,
-            data: *mut c_void,
-        ) -> HsaStatus {
+        unsafe extern "C" fn visit(agent: HsaAgentHandle, data: *mut c_void) -> HsaStatus {
             let ctx = &mut *(data as *mut Ctx);
             let rt = &*ctx.runtime;
             let mut dev_type: u32 = 0;
@@ -157,8 +151,7 @@ impl HsaAgent {
         };
         error::check(st, "agent_get_info(NAME)")?;
         let end = buf.iter().position(|&c| c == 0).unwrap_or(64);
-        let bytes: &[u8] =
-            unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, end) };
+        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, end) };
         Ok(std::str::from_utf8(bytes).unwrap_or("").to_string())
     }
 
@@ -208,10 +201,7 @@ impl HsaAgent {
             found: HsaMemoryPoolHandle,
         }
 
-        unsafe extern "C" fn visit(
-            pool: HsaMemoryPoolHandle,
-            data: *mut c_void,
-        ) -> HsaStatus {
+        unsafe extern "C" fn visit(pool: HsaMemoryPoolHandle, data: *mut c_void) -> HsaStatus {
             let ctx = &mut *(data as *mut Ctx);
             let rt = &*ctx.runtime;
             let mut segment: u32 = 0;
@@ -242,9 +232,7 @@ impl HsaAgent {
                 return HSA_STATUS_SUCCESS;
             }
             let matches = match ctx.kind {
-                PoolKind::Kernarg => {
-                    flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT != 0
-                }
+                PoolKind::Kernarg => flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT != 0,
                 PoolKind::FineGrained => {
                     flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED != 0
                         && flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT == 0
@@ -275,7 +263,10 @@ impl HsaAgent {
         if ctx.found == 0 {
             return Err(HsaError::new(
                 st,
-                &format!("find_pool({:?}) did not match any pool on this agent", ctx.kind),
+                &format!(
+                    "find_pool({:?}) did not match any pool on this agent",
+                    ctx.kind
+                ),
             ));
         }
         Ok(HsaMemoryPool {
@@ -365,9 +356,7 @@ unsafe impl Sync for HsaSignal {}
 impl HsaSignal {
     pub fn create(runtime: &Arc<HsaRuntime>, initial: i64) -> HsaResult<Self> {
         let mut handle: HsaSignalHandle = 0;
-        let st = unsafe {
-            (runtime.lib.fn_signal_create)(initial, 0, ptr::null(), &mut handle)
-        };
+        let st = unsafe { (runtime.lib.fn_signal_create)(initial, 0, ptr::null(), &mut handle) };
         error::check(st, "hsa_signal_create")?;
         Ok(Self {
             runtime: runtime.clone(),
@@ -490,23 +479,21 @@ pub struct HsaExecutable {
 impl HsaExecutable {
     /// Parse a `.hsaco` code object from memory and bind it to `agent`.
     /// Must call `freeze()` before using kernels.
-    pub fn from_code_object(
-        agent: &HsaAgent,
-        hsaco_bytes: &[u8],
-    ) -> HsaResult<Self> {
+    pub fn from_code_object(agent: &HsaAgent, hsaco_bytes: &[u8]) -> HsaResult<Self> {
         let runtime = agent.runtime.clone();
 
         // Unwrap Clang offload bundle if present.
-        let bytes: &[u8] = if hsaco_bytes.len() > 24 && &hsaco_bytes[0..24] == b"__CLANG_OFFLOAD_BUNDLE__" {
-            const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
-            if let Some(pos) = hsaco_bytes.windows(4).position(|w| w == ELF_MAGIC) {
-                &hsaco_bytes[pos..]
+        let bytes: &[u8] =
+            if hsaco_bytes.len() > 24 && &hsaco_bytes[0..24] == b"__CLANG_OFFLOAD_BUNDLE__" {
+                const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
+                if let Some(pos) = hsaco_bytes.windows(4).position(|w| w == ELF_MAGIC) {
+                    &hsaco_bytes[pos..]
+                } else {
+                    return Err(HsaError::new(0, "clang offload bundle contains no ELF"));
+                }
             } else {
-                return Err(HsaError::new(0, "clang offload bundle contains no ELF"));
-            }
-        } else {
-            hsaco_bytes
-        };
+                hsaco_bytes
+            };
 
         // Create the code object reader.
         let mut reader: HsaCodeObjectReaderHandle = 0;
@@ -564,9 +551,7 @@ impl HsaExecutable {
 
     /// Finalize the executable — required before kernel lookup.
     pub fn freeze(&mut self) -> HsaResult<()> {
-        let st = unsafe {
-            (self.runtime.lib.fn_executable_freeze)(self.handle, ptr::null())
-        };
+        let st = unsafe { (self.runtime.lib.fn_executable_freeze)(self.handle, ptr::null()) };
         error::check(st, "hsa_executable_freeze")?;
         self.frozen = true;
         Ok(())
@@ -577,7 +562,10 @@ impl HsaExecutable {
     /// function appends it if missing (matches standard hipcc output).
     pub fn kernel(&self, agent: &HsaAgent, name: &str) -> HsaResult<HsaKernel> {
         if !self.frozen {
-            return Err(HsaError::new(0, "executable must be frozen before kernel lookup"));
+            return Err(HsaError::new(
+                0,
+                "executable must be frozen before kernel lookup",
+            ));
         }
         let full_name = if name.ends_with(".kd") {
             name.to_string()
@@ -684,8 +672,14 @@ pub fn dispatch_packet_header() -> u16 {
 ///
 /// Sets completion_signal to 0 by default; caller can overwrite it after
 /// this returns.
+///
+/// # Safety
+///
+/// `slot` must be valid and uniquely writable for one
+/// `HsaKernelDispatchPacket`. The caller is responsible for publishing the
+/// packet header after all fields are written.
 #[inline]
-pub fn build_dispatch_packet(
+pub unsafe fn build_dispatch_packet(
     slot: *mut HsaKernelDispatchPacket,
     kernel: &HsaKernel,
     grid: [u32; 3],
@@ -700,31 +694,35 @@ pub fn build_dispatch_packet(
     } else {
         1
     };
-    unsafe {
-        let p = &mut *slot;
-        // Header is written LAST with release ordering; leave it whatever it is
-        // for now (the HSA runtime pre-fills HSA_PACKET_TYPE_INVALID).
-        p.setup = ndims;
-        p.workgroup_size_x = block[0] as u16;
-        p.workgroup_size_y = block[1] as u16;
-        p.workgroup_size_z = block[2] as u16;
-        p.reserved0 = 0;
-        p.grid_size_x = grid[0].saturating_mul(block[0]);
-        p.grid_size_y = grid[1].saturating_mul(block[1]);
-        p.grid_size_z = grid[2].saturating_mul(block[2]);
-        p.private_segment_size = kernel.private_segment_size;
-        p.group_segment_size = kernel.group_segment_size;
-        p.kernel_object = kernel.kernel_object;
-        p.kernarg_address = kernarg_ptr as *mut c_void;
-        p.reserved2 = 0;
-        p.completion_signal = completion_signal;
-    }
+    let p = unsafe { &mut *slot };
+    // Header is written LAST with release ordering; leave it whatever it is
+    // for now (the HSA runtime pre-fills HSA_PACKET_TYPE_INVALID).
+    p.setup = ndims;
+    p.workgroup_size_x = block[0] as u16;
+    p.workgroup_size_y = block[1] as u16;
+    p.workgroup_size_z = block[2] as u16;
+    p.reserved0 = 0;
+    p.grid_size_x = grid[0].saturating_mul(block[0]);
+    p.grid_size_y = grid[1].saturating_mul(block[1]);
+    p.grid_size_z = grid[2].saturating_mul(block[2]);
+    p.private_segment_size = kernel.private_segment_size;
+    p.group_segment_size = kernel.group_segment_size;
+    p.kernel_object = kernel.kernel_object;
+    p.kernarg_address = kernarg_ptr as *mut c_void;
+    p.reserved2 = 0;
+    p.completion_signal = completion_signal;
 }
 
 /// Atomic release-store of the header word. Must be called after the rest
 /// of the packet is filled in. Makes the packet visible to the AQL engine.
+///
+/// # Safety
+///
+/// `slot` must point to a valid AQL packet whose non-header fields are fully
+/// initialized. Publishing the header makes the packet visible to the queue's
+/// AQL engine, so callers must not mutate it after this call.
 #[inline]
-pub fn publish_dispatch_packet(slot: *mut HsaKernelDispatchPacket, header: u16) {
+pub unsafe fn publish_dispatch_packet(slot: *mut HsaKernelDispatchPacket, header: u16) {
     use std::sync::atomic::{fence, AtomicU16, Ordering};
     unsafe {
         fence(Ordering::Release);

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -81,8 +81,6 @@ pub(crate) const FP8_WMMA_MIN_BATCH: usize = 1024;
 /// than uniformly applying FP8 everywhere.
 pub(crate) const FP8_GEMV_MIN_M: usize = 4096;
 
-
-
 /// Tensor stored on the GPU. Tracks shape and element type.
 pub struct GpuTensor {
     pub buf: DeviceBuffer,
@@ -117,42 +115,42 @@ impl GpuTensor {
 pub enum DType {
     F32,
     F16,
-    Q4K,  // 144 bytes per 256 elements
-    Q6K,  // 210 bytes per 256 elements
-    Q8_0,      // 34 bytes per 32 elements
-    Q4F16G64,  // 36 bytes per 64 elements (RDNA-native FP16 dequant)
-    Q4F16G32,  // 20 bytes per 32 elements (RDNA-native FP16 dequant)
-    Q8HFQ,     // split-metadata: scales contiguous then values contiguous, 128B-aligned rows
-    HFQ4G256,  // 136 bytes per 256 elements (flat 4-bit, f32 scale+zero, 18 VGPRs)
-    HFQ4G128,  // 72 bytes per 128 elements (flat 4-bit, f32 scale+zero, 14 VGPRs)
-    PARO4G128, // ParoQuant: native G128 W4 plus pairwise activation rotation metadata
-    PARO4G128T, // ParoQuant: engine-tiled qweight [M/8, K] for coalesced GEMV reads
-    HFQ3G256,  // 104 bytes per 256 elements (flat 3-bit, f32 scale+zero)
-    HFQ3G128,  // 56 bytes per 128 elements (flat 3-bit, f32 scale+zero)
-    MQ4G256,   // MagnumQuant: FWHT-rotated HFQ4-G256 (136 bytes/group, same as HFQ4G256)
-    MQ4G128,   // MagnumQuant: FWHT-128-rotated INT4 (72 bytes/group, same layout as HFQ4G128)
-    MQ8G256,   // MagnumQuant: FWHT-rotated symmetric INT8, dp4a target (258 bytes/group)
-    MQ6G256,   // MagnumQuant: FWHT-rotated HFQ6-G256 (200 bytes/group, same as HFQ6G256)
-    MQ3G256,   // MagnumQuant: FWHT-rotated HFQ3-G256 (104 bytes/group, same as HFQ3G256)
-    MQ2G256,   // MagnumQuant: FWHT-rotated HFQ2-G256 (72 bytes/group, same as HFQ2G256)
+    Q4K,          // 144 bytes per 256 elements
+    Q6K,          // 210 bytes per 256 elements
+    Q8_0,         // 34 bytes per 32 elements
+    Q4F16G64,     // 36 bytes per 64 elements (RDNA-native FP16 dequant)
+    Q4F16G32,     // 20 bytes per 32 elements (RDNA-native FP16 dequant)
+    Q8HFQ,        // split-metadata: scales contiguous then values contiguous, 128B-aligned rows
+    HFQ4G256,     // 136 bytes per 256 elements (flat 4-bit, f32 scale+zero, 18 VGPRs)
+    HFQ4G128,     // 72 bytes per 128 elements (flat 4-bit, f32 scale+zero, 14 VGPRs)
+    PARO4G128,    // ParoQuant: native G128 W4 plus pairwise activation rotation metadata
+    PARO4G128T,   // ParoQuant: engine-tiled qweight [M/8, K] for coalesced GEMV reads
+    HFQ3G256,     // 104 bytes per 256 elements (flat 3-bit, f32 scale+zero)
+    HFQ3G128,     // 56 bytes per 128 elements (flat 3-bit, f32 scale+zero)
+    MQ4G256,      // MagnumQuant: FWHT-rotated HFQ4-G256 (136 bytes/group, same as HFQ4G256)
+    MQ4G128,      // MagnumQuant: FWHT-128-rotated INT4 (72 bytes/group, same layout as HFQ4G128)
+    MQ8G256,      // MagnumQuant: FWHT-rotated symmetric INT8, dp4a target (258 bytes/group)
+    MQ6G256,      // MagnumQuant: FWHT-rotated HFQ6-G256 (200 bytes/group, same as HFQ6G256)
+    MQ3G256,      // MagnumQuant: FWHT-rotated HFQ3-G256 (104 bytes/group, same as HFQ3G256)
+    MQ2G256,      // MagnumQuant: FWHT-rotated HFQ2-G256 (72 bytes/group, same as HFQ2G256)
     MQ2G256Lloyd, // MagnumQuant 2-bit + Lloyd-Max 4-entry fp16 codebook (72 bytes/group)
     MQ3G256Lloyd, // MagnumQuant 3-bit + Lloyd-Max 8-entry fp16 codebook (112 bytes/group)
     MQ4G256Lloyd, // MagnumQuant 4-bit + Lloyd-Max 16-entry fp16 codebook (160 bytes/group)
-    HFP4G32,   // HFP4: E2M1 element + UE8M0 g32 block scale + FP16 row scale.
-               // Per-row header 16 B; per-block payload 17 B (UE8M0 + 16 packed nibbles).
-               // See docs/quant-formats/hfp4.md.
-    MFP4G32,   // MFP4: HFP4G32 + offline FWHT (drop-in MQ4 replacement). Same byte layout
-               // as HFP4G32; format_flags bit 0 + bits 2-3 = 01 stamps the rotation kind.
-               // Runtime applies the matching FWHT to x via mq_rotate_x; the kernel itself
-               // is shared with HFP4G32.
-    HFQ2G256,  // 72 bytes per 256 elements (flat 2-bit, f32 scale+zero, ~19 VGPRs)
-    HFQ2G128,  // 40 bytes per 128 elements (flat 2-bit, f32 scale+zero)
-    HFQ6G256,  // 200 bytes per 256 elements (6-bit, f32 scale+zero)
+    HFP4G32,      // HFP4: E2M1 element + UE8M0 g32 block scale + FP16 row scale.
+    // Per-row header 16 B; per-block payload 17 B (UE8M0 + 16 packed nibbles).
+    // See docs/quant-formats/hfp4.md.
+    MFP4G32, // MFP4: HFP4G32 + offline FWHT (drop-in MQ4 replacement). Same byte layout
+    // as HFP4G32; format_flags bit 0 + bits 2-3 = 01 stamps the rotation kind.
+    // Runtime applies the matching FWHT to x via mq_rotate_x; the kernel itself
+    // is shared with HFP4G32.
+    HFQ2G256,   // 72 bytes per 256 elements (flat 2-bit, f32 scale+zero, ~19 VGPRs)
+    HFQ2G128,   // 40 bytes per 128 elements (flat 2-bit, f32 scale+zero)
+    HFQ6G256,   // 200 bytes per 256 elements (6-bit, f32 scale+zero)
     ParoQ4G128, // ParoQuant: AWQ-packed INT4 G128 repacked to HFQ4G128 layout at load.
-                // Weights are standard HFQ4G128 (72 bytes/group); the ParoQuant distinction
-                // is that weight_gemv applies Givens rotation to activations before GEMV.
-                // Rotation metadata (pairs, theta, channel_scales) lives on WeightTensor::paro.
-    Raw,       // raw bytes, no element interpretation
+    // Weights are standard HFQ4G128 (72 bytes/group); the ParoQuant distinction
+    // is that weight_gemv applies Givens rotation to activations before GEMV.
+    // Rotation metadata (pairs, theta, channel_scales) lives on WeightTensor::paro.
+    Raw, // raw bytes, no element interpretation
 }
 
 impl DType {
@@ -160,7 +158,34 @@ impl DType {
         match self {
             DType::F32 => 4,
             DType::F16 => 2,
-            DType::Q4K | DType::Q6K | DType::Q8_0 | DType::Q4F16G64 | DType::Q4F16G32 | DType::Q8HFQ | DType::HFQ4G256 | DType::HFQ4G128 | DType::PARO4G128 | DType::PARO4G128T | DType::HFQ3G256 | DType::HFQ3G128 | DType::HFQ2G256 | DType::HFQ2G128 | DType::HFQ6G256 | DType::MQ4G256 | DType::MQ4G128 | DType::MQ6G256 | DType::MQ8G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ2G256Lloyd | DType::MQ3G256Lloyd | DType::MQ4G256Lloyd | DType::HFP4G32 | DType::MFP4G32 | DType::ParoQ4G128 | DType::Raw => 1, // byte-level
+            DType::Q4K
+            | DType::Q6K
+            | DType::Q8_0
+            | DType::Q4F16G64
+            | DType::Q4F16G32
+            | DType::Q8HFQ
+            | DType::HFQ4G256
+            | DType::HFQ4G128
+            | DType::PARO4G128
+            | DType::PARO4G128T
+            | DType::HFQ3G256
+            | DType::HFQ3G128
+            | DType::HFQ2G256
+            | DType::HFQ2G128
+            | DType::HFQ6G256
+            | DType::MQ4G256
+            | DType::MQ4G128
+            | DType::MQ6G256
+            | DType::MQ8G256
+            | DType::MQ3G256
+            | DType::MQ2G256
+            | DType::MQ2G256Lloyd
+            | DType::MQ3G256Lloyd
+            | DType::MQ4G256Lloyd
+            | DType::HFP4G32
+            | DType::MFP4G32
+            | DType::ParoQ4G128
+            | DType::Raw => 1, // byte-level
         }
     }
 
@@ -317,10 +342,16 @@ pub struct Gpu {
 /// device-side init (`ensure_mq_signs` / `ensure_mq_signs_128`).
 pub fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     let mut state = seed;
-    (0..n).map(|_| {
-        state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
-        if (state >> 16) & 1 == 1 { 1.0f32 } else { -1.0f32 }
-    }).collect()
+    (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
+            if (state >> 16) & 1 == 1 {
+                1.0f32
+            } else {
+                -1.0f32
+            }
+        })
+        .collect()
 }
 
 impl Gpu {
@@ -369,7 +400,8 @@ impl Gpu {
         while t0.elapsed().as_secs_f32() < secs {
             // Rotate the fill byte so the driver/card can't short-circuit
             // repeated identical writes via any dedup or cache-match path.
-            self.hip.memset(&scratch, (n & 0xFF) as i32, SCRATCH_BYTES)?;
+            self.hip
+                .memset(&scratch, (n & 0xFF) as i32, SCRATCH_BYTES)?;
             self.hip.device_synchronize()?;
             n = n.wrapping_add(1);
         }
@@ -416,16 +448,28 @@ impl Gpu {
         // Check HIP runtime version matches GPU arch requirements
         let (hip_major, hip_minor) = hip.runtime_version().unwrap_or((0, 0));
         let (min_major, min_minor) = match arch.as_str() {
-            "gfx1200" | "gfx1201" => (6, 4), // RDNA4 needs ROCm 6.4+
+            "gfx1200" | "gfx1201" => (6, 4),             // RDNA4 needs ROCm 6.4+
             "gfx1150" | "gfx1151" | "gfx1152" => (7, 2), // RDNA3.5 (Strix) needs ROCm 7.2+
             "gfx1100" | "gfx1101" | "gfx1102" => (5, 5), // RDNA3 needs ROCm 5.5+
             _ => (5, 0),
         };
-        if hip_major > 0 && (hip_major < min_major || (hip_major == min_major && hip_minor < min_minor)) {
-            eprintln!("WARNING: HIP runtime {}.{} may not support {}. Minimum: {}.{}", hip_major, hip_minor, arch, min_major, min_minor);
+        if hip_major > 0
+            && (hip_major < min_major || (hip_major == min_major && hip_minor < min_minor))
+        {
+            eprintln!(
+                "WARNING: HIP runtime {}.{} may not support {}. Minimum: {}.{}",
+                hip_major, hip_minor, arch, min_major, min_minor
+            );
             eprintln!("  Update your HIP runtime or kernels may fail to load.");
         }
-        eprintln!("GPU dev {}: {} ({:.1} GB VRAM, HIP {}.{})", id, arch, vram_total as f64 / 1e9, hip_major, hip_minor);
+        eprintln!(
+            "GPU dev {}: {} ({:.1} GB VRAM, HIP {}.{})",
+            id,
+            arch,
+            vram_total as f64 / 1e9,
+            hip_major,
+            hip_minor
+        );
 
         let flags = Arc::new(FeatureFlags::from_env(&arch));
         let arch_caps = crate::arch_caps::ArchCaps::new(&arch, flags.clone());
@@ -515,24 +559,34 @@ impl Gpu {
     /// Callers always fall back to the non-rocBLAS path.
     pub fn try_init_rocblas(&mut self) {
         self.bind_thread_or_warn();
-        if self.rocblas.is_some() { return; }
+        if self.rocblas.is_some() {
+            return;
+        }
         let cdna3 = self.arch_caps.is_cdna3();
         let all_archs = self.flags.rocblas_all_archs;
-        if !cdna3 && !all_archs { return; }
+        if !cdna3 && !all_archs {
+            return;
+        }
         match Rocblas::load() {
             Ok(rb) => {
                 // Bind to the active stream if present; otherwise rocBLAS uses
                 // the default (null) stream, which still works — just bigger
                 // host-side sync cost.
                 if let Some(stream) = self.active_stream.as_ref() {
-                    let raw = stream as *const _ as *mut c_void;
-                    let _ = rb.set_stream(raw);
+                    if let Err(e) = rb.set_stream(stream) {
+                        eprintln!(
+                            "[rocblas] failed to bind active stream ({e}); using default stream"
+                        );
+                    }
                 }
                 eprintln!("[rocblas] loaded for {}", self.arch);
                 self.rocblas = Some(rb);
             }
             Err(e) => {
-                eprintln!("[rocblas] not available ({}); falling back to hand-rolled GEMMs", e);
+                eprintln!(
+                    "[rocblas] not available ({}); falling back to hand-rolled GEMMs",
+                    e
+                );
             }
         }
     }
@@ -549,10 +603,14 @@ impl Gpu {
         &mut self,
         w_mq4: &DeviceBuffer,
         w_fp16: &DeviceBuffer,
-        m: usize, k: usize,
+        m: usize,
+        k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        assert!(k % 256 == 0, "hfq4g256 dequant: K must be multiple of 256 (got {k})");
+        assert!(
+            k % 256 == 0,
+            "hfq4g256 dequant: K must be multiple of 256 (got {k})"
+        );
         self.ensure_kernel(
             "hfq4g256_dequantize_to_f16",
             kernels::HFQ4G256_DEQUANTIZE_TO_F16_SRC,
@@ -571,8 +629,14 @@ impl Gpu {
         ];
         let groups = (k / 256) as u32;
         unsafe {
-            self.hip.launch_kernel(func, [m as u32, groups, 1], [128, 1, 1], 0,
-                self.stream_ref(), &mut params)
+            self.hip.launch_kernel(
+                func,
+                [m as u32, groups, 1],
+                [128, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
         }
     }
 
@@ -592,9 +656,11 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         if let Some(stream) = self.active_stream.as_ref() {
-            self.hip.memcpy_dtod_async_at(dst, dst_offset, src, src_offset, size, stream)
+            self.hip
+                .memcpy_dtod_async_at(dst, dst_offset, src, src_offset, size, stream)
         } else {
-            self.hip.memcpy_dtod_at(dst, dst_offset, src, src_offset, size)
+            self.hip
+                .memcpy_dtod_at(dst, dst_offset, src, src_offset, size)
         }
     }
 
@@ -616,14 +682,12 @@ impl Gpu {
     /// dependency with the capturing stream. This method routes to
     /// `memcpy_htod_async` on the active (capturing) stream when in capture
     /// mode, falling back to sync `memcpy_htod` otherwise.
-    pub fn memcpy_htod_auto(
-        &self,
-        dst: &hip_bridge::DeviceBuffer,
-        src: &[u8],
-    ) -> HipResult<()> {
+    pub fn memcpy_htod_auto(&self, dst: &hip_bridge::DeviceBuffer, src: &[u8]) -> HipResult<()> {
         self.bind_thread()?;
         if self.graphs.capture_mode {
-            let stream = self.active_stream.as_ref()
+            let stream = self
+                .active_stream
+                .as_ref()
                 .expect("capture mode requires an active stream");
             self.hip.memcpy_htod_async(dst, src, stream)
         } else {
@@ -693,15 +757,24 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         let func = self.functions.get(func_name).ok_or_else(|| {
-            hip_bridge::HipError::new(0, &format!("launch_kernel_blob: function '{func_name}' not loaded"))
+            hip_bridge::HipError::new(
+                0,
+                &format!("launch_kernel_blob: function '{func_name}' not loaded"),
+            )
         })?;
         unsafe {
-            self.hip.launch_kernel_blob(func, grid, block, shared_mem, self.stream_ref(), kernargs)
+            self.hip
+                .launch_kernel_blob(func, grid, block, shared_mem, self.stream_ref(), kernargs)
         }
     }
 
     /// Compile and load a kernel, caching the result.
-    pub(crate) fn ensure_kernel(&mut self, module_name: &str, source: &str, func_name: &str) -> HipResult<()> {
+    pub(crate) fn ensure_kernel(
+        &mut self,
+        module_name: &str,
+        source: &str,
+        func_name: &str,
+    ) -> HipResult<()> {
         crate::scratch::compile_and_load_kernel(
             &mut self.compiler,
             &self.hip,
@@ -716,7 +789,11 @@ impl Gpu {
     /// Ensure the FP16 X scratch contains the conversion of `x`. Skips the
     /// convert kernel if `x.buf.as_ptr()` matches the last converted source.
     /// Returns the FP16 device pointer.
-    pub(crate) fn ensure_fp16_x(&mut self, x: &GpuTensor, n_elems: usize) -> HipResult<*mut c_void> {
+    pub(crate) fn ensure_fp16_x(
+        &mut self,
+        x: &GpuTensor,
+        n_elems: usize,
+    ) -> HipResult<*mut c_void> {
         self.scratch.ensure_fp16_x(
             &self.hip,
             &mut self.compiler,
@@ -734,7 +811,11 @@ impl Gpu {
     /// Convert F32 to F16 without caching. Used when the same x tensor
     /// pointer is reused with different contents across layers, where
     /// pointer-keyed caching would read stale FP16.
-    pub(crate) fn convert_fp16_x_uncached(&mut self, x: &GpuTensor, n_elems: usize) -> HipResult<*mut c_void> {
+    pub(crate) fn convert_fp16_x_uncached(
+        &mut self,
+        x: &GpuTensor,
+        n_elems: usize,
+    ) -> HipResult<*mut c_void> {
         self.scratch.convert_fp16_x_uncached(
             &self.hip,
             &mut self.compiler,
@@ -771,7 +852,12 @@ impl Gpu {
     /// Ensure prefill activations are quantized into a llama.cpp-style
     /// `block_q8_1_mmq` layout. The scratch is ordered by [K/128 block, batch]
     /// so a 128-column batch tile is contiguous for each K tile.
-    pub fn ensure_q8_1_mmq_x(&mut self, x: &GpuTensor, batch_size: usize, k: usize) -> HipResult<*mut c_void> {
+    pub fn ensure_q8_1_mmq_x(
+        &mut self,
+        x: &GpuTensor,
+        batch_size: usize,
+        k: usize,
+    ) -> HipResult<*mut c_void> {
         // bind_thread: skip — delegated to scratch.rs
         self.scratch.ensure_q8_1_mmq_x(
             &self.hip,
@@ -808,11 +894,15 @@ impl Gpu {
 
         // Generate synthetic activations on CPU
         let mut state = 0xDEAD_BEEF_CAFE_BABEu64;
-        let x_data: Vec<f32> = (0..screen_batch * k).map(|_| {
-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-            let t = (state >> 33) as f32 / (u32::MAX as f32);
-            t * 4.0 - 2.0
-        }).collect();
+        let x_data: Vec<f32> = (0..screen_batch * k)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let t = (state >> 33) as f32 / (u32::MAX as f32);
+                t * 4.0 - 2.0
+            })
+            .collect();
 
         let result = (|| -> HipResult<bool> {
             let x_gpu = self.upload_f32(&x_data, &[screen_batch * k])?;
@@ -824,7 +914,14 @@ impl Gpu {
 
             // Reference path: use FP16 wave64 on gfx906, WMMA otherwise
             if self.arch_caps.is_gfx906() {
-                self.gemm_hfq4g256_residual_fp16_wave64(a_raw, &x_gpu, &y_wmma, m, k, screen_batch)?;
+                self.gemm_hfq4g256_residual_fp16_wave64(
+                    a_raw,
+                    &x_gpu,
+                    &y_wmma,
+                    m,
+                    k,
+                    screen_batch,
+                )?;
             } else {
                 self.gemm_hfq4g256_residual_wmma(a_raw, &x_gpu, &y_wmma, m, k, screen_batch)?;
             }
@@ -855,7 +952,9 @@ impl Gpu {
                 for b in 0..screen_batch {
                     let idx = b * m + r;
                     let err = (ref_out[idx] - mmq_out[idx]).abs();
-                    if err > row_max { row_max = err; }
+                    if err > row_max {
+                        row_max = err;
+                    }
                 }
                 if row_max > worst_err {
                     worst_err = row_max;
@@ -895,9 +994,12 @@ impl Gpu {
     pub(crate) fn ensure_fp16_shadow(
         &mut self,
         w_mq4: &GpuTensor,
-        m: usize, k: usize,
+        m: usize,
+        k: usize,
     ) -> HipResult<Option<*mut c_void>> {
-        if self.rocblas.is_none() { return Ok(None); }
+        if self.rocblas.is_none() {
+            return Ok(None);
+        }
         let key = w_mq4.buf.as_ptr() as usize;
         if let Some(shadow) = self.fp16_shadow_cache.get(&key) {
             return Ok(Some(shadow.buf.as_ptr()));
@@ -918,10 +1020,10 @@ impl Gpu {
     /// a useful smoke-path in the absence of an MI300.
     pub(crate) fn rocblas_arch_eligible(&self) -> bool {
         static CACHE: OnceLock<bool> = OnceLock::new();
-        let all_archs = *CACHE.get_or_init(|| {
-            self.flags.rocblas_all_archs
-        });
-        if all_archs { return self.rocblas.is_some(); }
+        let all_archs = *CACHE.get_or_init(|| self.flags.rocblas_all_archs);
+        if all_archs {
+            return self.rocblas.is_some();
+        }
         self.arch_caps.is_cdna3()
     }
 
@@ -938,7 +1040,7 @@ impl Gpu {
             if self.flags.rocblas_off {
                 return usize::MAX;
             }
-self.flags.rocblas_min_batch.unwrap_or(4)
+            self.flags.rocblas_min_batch.unwrap_or(4)
         })
     }
 
@@ -948,7 +1050,8 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     pub fn precompile_kernels(&mut self, specs: &[(&str, &str, &str)]) -> HipResult<()> {
         self.bind_thread()?;
         // Collect (name, source) pairs for the compiler batch, skipping already-loaded
-        let batch: Vec<(&str, &str)> = specs.iter()
+        let batch: Vec<(&str, &str)> = specs
+            .iter()
             .filter(|(_, _, func)| !self.functions.contains_key(*func))
             .map(|(module, source, _)| (*module, *source))
             .collect();
@@ -995,9 +1098,8 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     pub fn upload_f32(&mut self, data: &[f32], shape: &[usize]) -> HipResult<GpuTensor> {
         self.bind_thread()?;
         let tensor = self.alloc_tensor(shape, DType::F32)?;
-        let bytes = unsafe {
-            std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
-        };
+        let bytes =
+            unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
         self.hip.memcpy_htod(&tensor.buf, bytes)?;
         Ok(tensor)
     }
@@ -1006,9 +1108,8 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         self.bind_thread()?;
         let numel = tensor.numel();
         let mut data = vec![0.0f32; numel];
-        let bytes = unsafe {
-            std::slice::from_raw_parts_mut(data.as_mut_ptr() as *mut u8, numel * 4)
-        };
+        let bytes =
+            unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr() as *mut u8, numel * 4) };
         self.hip.memcpy_dtoh(bytes, &tensor.buf)?;
         Ok(data)
     }
@@ -1017,7 +1118,9 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         self.bind_thread()?;
         let tensor = self.alloc_tensor(shape, dtype)?;
         match self.active_stream.as_ref() {
-            Some(stream) => self.hip.memset_async(&tensor.buf, 0, tensor.byte_size(), stream)?,
+            Some(stream) => self
+                .hip
+                .memset_async(&tensor.buf, 0, tensor.byte_size(), stream)?,
             None => self.hip.memset(&tensor.buf, 0, tensor.byte_size())?,
         }
         Ok(tensor)
@@ -1085,8 +1188,10 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     pub fn invalidate_graph_state(&mut self) {
         self.bind_thread_or_warn();
         self.graphs.graph_destroy(&self.hip, self.device_id);
-        self.graphs.verify_graph_destroy_all(&self.hip, self.device_id);
-        self.graphs.replay_graph_destroy_all(&self.hip, self.device_id);
+        self.graphs
+            .verify_graph_destroy_all(&self.hip, self.device_id);
+        self.graphs
+            .replay_graph_destroy_all(&self.hip, self.device_id);
     }
 
     // ── Kernel operations ───────────────────────────────────────
@@ -1138,8 +1243,16 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// copies, which was a footgun.
     pub fn copy_d2d(&self, src: &GpuTensor, dst: &GpuTensor, n_bytes: usize) -> HipResult<()> {
         // bind_thread: skip — delegates to memcpy_dtod_auto which binds
-        debug_assert!(n_bytes <= src.buf.size(), "copy_d2d: n_bytes ({n_bytes}) exceeds src.buf.size ({})", src.buf.size());
-        debug_assert!(n_bytes <= dst.buf.size(), "copy_d2d: n_bytes ({n_bytes}) exceeds dst.buf.size ({})", dst.buf.size());
+        debug_assert!(
+            n_bytes <= src.buf.size(),
+            "copy_d2d: n_bytes ({n_bytes}) exceeds src.buf.size ({})",
+            src.buf.size()
+        );
+        debug_assert!(
+            n_bytes <= dst.buf.size(),
+            "copy_d2d: n_bytes ({n_bytes}) exceeds dst.buf.size ({})",
+            dst.buf.size()
+        );
         self.memcpy_dtod_auto(&dst.buf, &src.buf, n_bytes)
     }
 
@@ -1238,7 +1351,6 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// distinct rotations, so this batches four rotates and four pack4 GEMVs
     /// into two launches.
     #[allow(clippy::too_many_arguments)]
-
     // ═══════════════════════════════════════════════════════════════════════════
     // Batch precompilation — compile all kernels a model needs in parallel
     // ═══════════════════════════════════════════════════════════════════════════
@@ -1246,7 +1358,12 @@ self.flags.rocblas_min_batch.unwrap_or(4)
     /// Pre-compile all kernels needed for Qwen3.5 inference with a given
     /// weight quantization and KV cache type. Runs hipcc in parallel.
     #[cfg(feature = "deltanet")]
-    pub fn precompile_qwen35(&mut self, weight_quant: &str, kv_type: &str, head_dim: usize) -> HipResult<()> {
+    pub fn precompile_qwen35(
+        &mut self,
+        weight_quant: &str,
+        kv_type: &str,
+        head_dim: usize,
+    ) -> HipResult<()> {
         self.bind_thread()?;
         // asym kernels #include "turbo_common.h" + "givens_common.h"; the
         // runtime dispatch path (see ensure_givens4_kernel) prepends the
@@ -1256,33 +1373,59 @@ self.flags.rocblas_min_batch.unwrap_or(4)
             let stripped = body
                 .replace("#include \"turbo_common.h\"", "")
                 .replace("#include \"givens_common.h\"", "");
-            format!("{}\n{}\n{}", kernels::TURBO_COMMON_H, kernels::GIVENS_COMMON_SRC, stripped)
+            format!(
+                "{}\n{}\n{}",
+                kernels::TURBO_COMMON_H,
+                kernels::GIVENS_COMMON_SRC,
+                stripped
+            )
         };
 
         // Common kernels for all Qwen3.5 models (DeltaNet + FullAttn shared ops)
         let mut specs: Vec<(&str, String)> = vec![
-            ("rmsnorm",                  kernels::RMSNORM_SRC.to_string()),
-            ("add_inplace",              kernels::ADD_INPLACE_SRC.to_string()),
-            ("mul",                      kernels::MUL_SRC.to_string()),
-            ("silu_mul",                 kernels::SILU_MUL_SRC.to_string()),
-            ("sigmoid",                  kernels::SIGMOID_SRC.to_string()),
-            ("alpha_gate",               kernels::ALPHA_GATE_SRC.to_string()),
-            ("conv1d_silu",              kernels::CONV1D_SILU_SRC.to_string()),
-            ("l2_norm",                  kernels::L2_NORM_SRC.to_string()),
-            ("fused_qk_l2_norm_scale",   kernels::FUSED_QK_L2_NORM_SCALE_SRC.to_string()),
-            ("fused_sigmoid_alpha_gate", kernels::FUSED_SIGMOID_ALPHA_GATE_SRC.to_string()),
-            ("conv1d_silu_split",        kernels::CONV1D_SILU_SPLIT_SRC.to_string()),
-            ("conv1d_silu_split_tree",   kernels::CONV1D_SILU_SPLIT_TREE_SRC.to_string()),
-            ("gated_delta_net_q8_tree",  kernels::GATED_DELTA_NET_Q8_TREE_SRC.to_string()),
-            ("sigmoid_mul",              kernels::SIGMOID_MUL_SRC.to_string()),
-            ("topk_logits",              kernels::TOPK_LOGITS_SRC.to_string()),
-            ("scale_f32",                kernels::SCALE_F32_SRC.to_string()),
-            ("gated_norm",               kernels::GATED_NORM_SRC.to_string()),
-            ("rope_partial_interleaved", kernels::ROPE_PARTIAL_INTERLEAVED_SRC.to_string()),
+            ("rmsnorm", kernels::RMSNORM_SRC.to_string()),
+            ("add_inplace", kernels::ADD_INPLACE_SRC.to_string()),
+            ("mul", kernels::MUL_SRC.to_string()),
+            ("silu_mul", kernels::SILU_MUL_SRC.to_string()),
+            ("sigmoid", kernels::SIGMOID_SRC.to_string()),
+            ("alpha_gate", kernels::ALPHA_GATE_SRC.to_string()),
+            ("conv1d_silu", kernels::CONV1D_SILU_SRC.to_string()),
+            ("l2_norm", kernels::L2_NORM_SRC.to_string()),
+            (
+                "fused_qk_l2_norm_scale",
+                kernels::FUSED_QK_L2_NORM_SCALE_SRC.to_string(),
+            ),
+            (
+                "fused_sigmoid_alpha_gate",
+                kernels::FUSED_SIGMOID_ALPHA_GATE_SRC.to_string(),
+            ),
+            (
+                "conv1d_silu_split",
+                kernels::CONV1D_SILU_SPLIT_SRC.to_string(),
+            ),
+            (
+                "conv1d_silu_split_tree",
+                kernels::CONV1D_SILU_SPLIT_TREE_SRC.to_string(),
+            ),
+            (
+                "gated_delta_net_q8_tree",
+                kernels::GATED_DELTA_NET_Q8_TREE_SRC.to_string(),
+            ),
+            ("sigmoid_mul", kernels::SIGMOID_MUL_SRC.to_string()),
+            ("topk_logits", kernels::TOPK_LOGITS_SRC.to_string()),
+            ("scale_f32", kernels::SCALE_F32_SRC.to_string()),
+            ("gated_norm", kernels::GATED_NORM_SRC.to_string()),
+            (
+                "rope_partial_interleaved",
+                kernels::ROPE_PARTIAL_INTERLEAVED_SRC.to_string(),
+            ),
             // FullAttn: Q+gate deinterleave split
-            ("deinterleave",             kernels::DEINTERLEAVE_SRC.to_string()),
+            ("deinterleave", kernels::DEINTERLEAVE_SRC.to_string()),
             // DeltaNet: Q/K repeat-interleave for asymmetric MQA (replaces 64+ memcpy_dtod calls per layer on 4B/9B)
-            ("repeat_interleave_qk",     kernels::REPEAT_INTERLEAVE_QK_SRC.to_string()),
+            (
+                "repeat_interleave_qk",
+                kernels::REPEAT_INTERLEAVE_QK_SRC.to_string(),
+            ),
         ];
 
         // Weight-format-specific GEMV
@@ -1300,105 +1443,172 @@ self.flags.rocblas_min_batch.unwrap_or(4)
                 specs.push(("gemv_hfq6g256", kernels::GEMV_HFQ6G256_SRC.to_string()));
             }
             "hfq4" => {
-                let (src, module) = kernels::gemv_hfq4g256_for_arch(&self.arch_caps, self.flags.rdna2_variant);
+                let (src, module) =
+                    kernels::gemv_hfq4g256_for_arch(&self.arch_caps, self.flags.rdna2_variant);
                 specs.push((module, src.to_string()));
-                specs.push(("gemv_hfq4g256_wide", kernels::GEMV_HFQ4G256_WIDE_SRC.to_string()));
+                specs.push((
+                    "gemv_hfq4g256_wide",
+                    kernels::GEMV_HFQ4G256_WIDE_SRC.to_string(),
+                ));
                 // Multi-projection fused kernels (LA 4-way, FA 3-way, FFN
                 // gate+up). Cross-arch — same 4-accumulator inner loop as
                 // gemv_hfq4g256.hip; precompile on every arch that uses
                 // the HFQ4 weight path.
-                specs.push(("fused_qkvza_hfq4g256",
-                            kernels::FUSED_QKVZA_HFQ4G256_SRC.to_string()));
-                specs.push(("fused_qkv_hfq4g256",
-                            kernels::FUSED_QKV_HFQ4G256_SRC.to_string()));
-                specs.push(("fused_gate_up_hfq4g256",
-                            kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string()));
+                specs.push((
+                    "fused_qkvza_hfq4g256",
+                    kernels::FUSED_QKVZA_HFQ4G256_SRC.to_string(),
+                ));
+                specs.push((
+                    "fused_qkv_hfq4g256",
+                    kernels::FUSED_QKV_HFQ4G256_SRC.to_string(),
+                ));
+                specs.push((
+                    "fused_gate_up_hfq4g256",
+                    kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string(),
+                ));
                 // gfx906/gfx908/gfx94x wave64-native variants — cut
                 // wavefront pressure in half on the hottest kernels. Wave32
                 // block=[32,1,1] kernels otherwise waste the upper 32 lanes
                 // of every wave slot on these wave64-native arches.
                 if self.arch_caps.is_wave64_native() {
                     // Single-token (draft / single-layer paths).
-                    specs.push(("fused_qkvza_hfq4g256_wave64",
-                                kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("fused_qkv_hfq4g256_wave64",
-                                kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("fused_gate_up_hfq4g256_wave64",
-                                kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_gate_up_indexed_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_down_indexed_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_WAVE64_SRC.to_string()));
+                    specs.push((
+                        "fused_qkvza_hfq4g256_wave64",
+                        kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "fused_qkv_hfq4g256_wave64",
+                        kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "fused_gate_up_hfq4g256_wave64",
+                        kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_gate_up_indexed_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_down_indexed_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_WAVE64_SRC.to_string(),
+                    ));
                     // Batched (DFlash verify path — hottest).
-                    specs.push(("gemm_qkvza_hfq4g256_wave64",
-                                kernels::GEMM_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemm_qkv_hfq4g256_wave64",
-                                kernels::GEMM_QKV_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemm_hfq4g256_wave64",
-                                kernels::GEMM_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemm_hfq4g256_residual_wave64",
-                                kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_gate_up_indexed_batched_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_BATCHED_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_down_indexed_batched_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_BATCHED_WAVE64_SRC.to_string()));
+                    specs.push((
+                        "gemm_qkvza_hfq4g256_wave64",
+                        kernels::GEMM_QKVZA_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemm_qkv_hfq4g256_wave64",
+                        kernels::GEMM_QKV_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemm_hfq4g256_wave64",
+                        kernels::GEMM_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemm_hfq4g256_residual_wave64",
+                        kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_BATCHED_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_down_indexed_batched_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_BATCHED_WAVE64_SRC.to_string(),
+                    ));
                 }
                 // gfx1100 multi-row GEMV is opt-in via HIPFIRE_GEMV_ROWS={2,4,8}.
                 // Empirically slower than the single-row kernel on gfx1100 at all
                 // tested matrix sizes (see commit log / multi-row kernel header),
                 // so we only precompile when the env var explicitly requests it.
-                if self.arch_caps.is_rdna3_dgpu()
-                    && self.flags.gemv_rows.unwrap_or(1) > 1
-                {
-                    specs.push(("gemv_hfq4g256_multirow_rdna3",
-                                kernels::GEMV_HFQ4G256_MULTIROW_GFX1100_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_residual_multirow_rdna3",
-                                kernels::GEMV_HFQ4G256_RESIDUAL_MULTIROW_GFX1100_SRC.to_string()));
+                if self.arch_caps.is_rdna3_dgpu() && self.flags.gemv_rows.unwrap_or(1) > 1 {
+                    specs.push((
+                        "gemv_hfq4g256_multirow_rdna3",
+                        kernels::GEMV_HFQ4G256_MULTIROW_GFX1100_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_residual_multirow_rdna3",
+                        kernels::GEMV_HFQ4G256_RESIDUAL_MULTIROW_GFX1100_SRC.to_string(),
+                    ));
                 }
             }
             "mq4" => {
                 // MQ4 = FWHT-rotated HFQ4-G256 — default format for current registry.
                 // Shares the HFQ4 fused kernels (same blob, different dispatch key)
                 // plus MQ-specific rotation kernels.
-                let (src, module) = kernels::gemv_hfq4g256_for_arch(&self.arch_caps, self.flags.rdna2_variant);
+                let (src, module) =
+                    kernels::gemv_hfq4g256_for_arch(&self.arch_caps, self.flags.rdna2_variant);
                 specs.push((module, src.to_string()));
                 specs.push(("gemv_mq4g256", kernels::GEMV_MQ4G256_SRC.to_string()));
-                specs.push(("fused_qkvza_hfq4g256",
-                            kernels::FUSED_QKVZA_HFQ4G256_SRC.to_string()));
-                specs.push(("fused_qkv_hfq4g256",
-                            kernels::FUSED_QKV_HFQ4G256_SRC.to_string()));
-                specs.push(("fused_gate_up_hfq4g256",
-                            kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string()));
-                specs.push(("fused_rmsnorm_mq_rotate",
-                            kernels::FUSED_RMSNORM_MQ_ROTATE_SRC.to_string()));
-                specs.push(("fused_silu_mul_mq_rotate",
-                            kernels::FUSED_SILU_MUL_MQ_ROTATE_SRC.to_string()));
+                specs.push((
+                    "fused_qkvza_hfq4g256",
+                    kernels::FUSED_QKVZA_HFQ4G256_SRC.to_string(),
+                ));
+                specs.push((
+                    "fused_qkv_hfq4g256",
+                    kernels::FUSED_QKV_HFQ4G256_SRC.to_string(),
+                ));
+                specs.push((
+                    "fused_gate_up_hfq4g256",
+                    kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string(),
+                ));
+                specs.push((
+                    "fused_rmsnorm_mq_rotate",
+                    kernels::FUSED_RMSNORM_MQ_ROTATE_SRC.to_string(),
+                ));
+                specs.push((
+                    "fused_silu_mul_mq_rotate",
+                    kernels::FUSED_SILU_MUL_MQ_ROTATE_SRC.to_string(),
+                ));
                 // gfx906/gfx908/gfx94x wave64 variants — see hfq4 branch for rationale.
                 if self.arch_caps.is_wave64_native() {
                     // Single-token (draft / single-layer paths).
-                    specs.push(("fused_qkvza_hfq4g256_wave64",
-                                kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("fused_qkv_hfq4g256_wave64",
-                                kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("fused_gate_up_hfq4g256_wave64",
-                                kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_gate_up_indexed_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_down_indexed_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_WAVE64_SRC.to_string()));
+                    specs.push((
+                        "fused_qkvza_hfq4g256_wave64",
+                        kernels::FUSED_QKVZA_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "fused_qkv_hfq4g256_wave64",
+                        kernels::FUSED_QKV_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "fused_gate_up_hfq4g256_wave64",
+                        kernels::FUSED_GATE_UP_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_gate_up_indexed_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_down_indexed_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_WAVE64_SRC.to_string(),
+                    ));
                     // Batched (DFlash verify path — hottest).
-                    specs.push(("gemm_qkvza_hfq4g256_wave64",
-                                kernels::GEMM_QKVZA_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemm_qkv_hfq4g256_wave64",
-                                kernels::GEMM_QKV_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemm_hfq4g256_wave64",
-                                kernels::GEMM_HFQ4G256_WAVE64_SRC.to_string()));
-                    specs.push(("gemm_hfq4g256_residual_wave64",
-                                kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_gate_up_indexed_batched_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_BATCHED_WAVE64_SRC.to_string()));
-                    specs.push(("gemv_hfq4g256_moe_down_indexed_batched_wave64",
-                                kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_BATCHED_WAVE64_SRC.to_string()));
+                    specs.push((
+                        "gemm_qkvza_hfq4g256_wave64",
+                        kernels::GEMM_QKVZA_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemm_qkv_hfq4g256_wave64",
+                        kernels::GEMM_QKV_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemm_hfq4g256_wave64",
+                        kernels::GEMM_HFQ4G256_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemm_hfq4g256_residual_wave64",
+                        kernels::GEMM_HFQ4G256_RESIDUAL_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_BATCHED_WAVE64_SRC.to_string(),
+                    ));
+                    specs.push((
+                        "gemv_hfq4g256_moe_down_indexed_batched_wave64",
+                        kernels::GEMV_HFQ4G256_MOE_DOWN_INDEXED_BATCHED_WAVE64_SRC.to_string(),
+                    ));
                 }
             }
             "q8" => {
@@ -1409,108 +1619,198 @@ self.flags.rocblas_min_batch.unwrap_or(4)
 
         // Embedding kernels — Q8_0 is most common, also cover HFQ4G256/G128 variants
         specs.push(("embedding_q8", kernels::EMBEDDING_Q8_SRC.to_string()));
-        specs.push(("embedding_hfq4g256", kernels::EMBEDDING_HFQ4G256_SRC.to_string()));
-        specs.push(("embedding_hfq4g128", kernels::EMBEDDING_HFQ4G128_SRC.to_string()));
-        specs.push(("embedding_hfq4g256_batched", kernels::EMBEDDING_HFQ4G256_BATCHED_SRC.to_string()));
-        specs.push(("embedding_q8_batched", kernels::EMBEDDING_Q8_BATCHED_SRC.to_string()));
+        specs.push((
+            "embedding_hfq4g256",
+            kernels::EMBEDDING_HFQ4G256_SRC.to_string(),
+        ));
+        specs.push((
+            "embedding_hfq4g128",
+            kernels::EMBEDDING_HFQ4G128_SRC.to_string(),
+        ));
+        specs.push((
+            "embedding_hfq4g256_batched",
+            kernels::EMBEDDING_HFQ4G256_BATCHED_SRC.to_string(),
+        ));
+        specs.push((
+            "embedding_q8_batched",
+            kernels::EMBEDDING_Q8_BATCHED_SRC.to_string(),
+        ));
 
         // DeltaNet kernels
-        specs.push(("gated_delta_net_q8", kernels::GATED_DELTA_NET_Q8_SRC.to_string()));
+        specs.push((
+            "gated_delta_net_q8",
+            kernels::GATED_DELTA_NET_Q8_SRC.to_string(),
+        ));
 
         // KV cache kernels. asym3 is the current default — always ships flash.
         // q8 is the compat path with its own flash tile+reduce for long context.
         match kv_type {
             "asym4" => {
-                specs.push(("kv_cache_write_asym_k_givens4",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS4_SRC)));
-                specs.push(("kv_cache_write_asym_k_givens4_batched",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS4_BATCHED_SRC)));
-                specs.push(("attention_flash_asym4_tile",
-                            assemble_asym(kernels::ATTENTION_FLASH_ASYM4_TILE_SRC)));
-                specs.push(("attention_flash_asym4_tile_batched",
-                            assemble_asym(kernels::ATTENTION_FLASH_ASYM4_TILE_BATCHED_SRC)));
-                specs.push(("attention_flash_asym_reduce_batched",
-                            kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_asym_k_givens4",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS4_SRC),
+                ));
+                specs.push((
+                    "kv_cache_write_asym_k_givens4_batched",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS4_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym4_tile",
+                    assemble_asym(kernels::ATTENTION_FLASH_ASYM4_TILE_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym4_tile_batched",
+                    assemble_asym(kernels::ATTENTION_FLASH_ASYM4_TILE_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym_reduce_batched",
+                    kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string(),
+                ));
             }
             "fwht4" => {
                 // Same byte layout as asym4 — just different K-rotation primitive.
-                specs.push(("kv_cache_write_asym_k_fwht4",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT4_SRC)));
-                specs.push(("kv_cache_write_asym_k_fwht4_batched",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT4_BATCHED_SRC)));
-                specs.push(("attention_flash_fwht4_tile",
-                            assemble_asym(kernels::ATTENTION_FLASH_FWHT4_TILE_SRC)));
-                specs.push(("attention_flash_fwht4_tile_batched",
-                            assemble_asym(kernels::ATTENTION_FLASH_FWHT4_TILE_BATCHED_SRC)));
-                specs.push(("attention_flash_asym_reduce_batched",
-                            kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_asym_k_fwht4",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT4_SRC),
+                ));
+                specs.push((
+                    "kv_cache_write_asym_k_fwht4_batched",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT4_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_fwht4_tile",
+                    assemble_asym(kernels::ATTENTION_FLASH_FWHT4_TILE_SRC),
+                ));
+                specs.push((
+                    "attention_flash_fwht4_tile_batched",
+                    assemble_asym(kernels::ATTENTION_FLASH_FWHT4_TILE_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym_reduce_batched",
+                    kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string(),
+                ));
             }
             "fwht3" => {
                 // Same byte layout as asym3 (single-pass 256-element), FWHT rotation.
-                specs.push(("kv_cache_write_asym_k_fwht3",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT3_SRC)));
-                specs.push(("kv_cache_write_asym_k_fwht3_batched",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT3_BATCHED_SRC)));
-                specs.push(("attention_flash_fwht3_tile",
-                            assemble_asym(kernels::ATTENTION_FLASH_FWHT3_TILE_SRC)));
-                specs.push(("attention_flash_fwht3_tile_batched",
-                            assemble_asym(kernels::ATTENTION_FLASH_FWHT3_TILE_BATCHED_SRC)));
-                specs.push(("attention_flash_asym_reduce_batched",
-                            kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_asym_k_fwht3",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT3_SRC),
+                ));
+                specs.push((
+                    "kv_cache_write_asym_k_fwht3_batched",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT3_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_fwht3_tile",
+                    assemble_asym(kernels::ATTENTION_FLASH_FWHT3_TILE_SRC),
+                ));
+                specs.push((
+                    "attention_flash_fwht3_tile_batched",
+                    assemble_asym(kernels::ATTENTION_FLASH_FWHT3_TILE_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym_reduce_batched",
+                    kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string(),
+                ));
             }
             "fwht2" => {
                 // Same byte layout as asym2, FWHT rotation. 2-pass over 128.
-                specs.push(("kv_cache_write_asym_k_fwht2",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT2_SRC)));
-                specs.push(("kv_cache_write_asym_k_fwht2_batched",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT2_BATCHED_SRC)));
-                specs.push(("attention_flash_fwht2_tile",
-                            assemble_asym(kernels::ATTENTION_FLASH_FWHT2_TILE_SRC)));
-                specs.push(("attention_flash_fwht2_tile_batched",
-                            assemble_asym(kernels::ATTENTION_FLASH_FWHT2_TILE_BATCHED_SRC)));
-                specs.push(("attention_flash_asym_reduce_batched",
-                            kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_asym_k_fwht2",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT2_SRC),
+                ));
+                specs.push((
+                    "kv_cache_write_asym_k_fwht2_batched",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_FWHT2_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_fwht2_tile",
+                    assemble_asym(kernels::ATTENTION_FLASH_FWHT2_TILE_SRC),
+                ));
+                specs.push((
+                    "attention_flash_fwht2_tile_batched",
+                    assemble_asym(kernels::ATTENTION_FLASH_FWHT2_TILE_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym_reduce_batched",
+                    kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string(),
+                ));
             }
             "asym3" => {
-                specs.push(("kv_cache_write_asym_k_givens3",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC)));
-                specs.push(("kv_cache_write_asym_k_givens3_batched",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_BATCHED_SRC)));
-                specs.push(("attention_flash_asym3_tile",
-                            assemble_asym(kernels::ATTENTION_FLASH_ASYM3_TILE_SRC)));
-                specs.push(("attention_flash_asym3_tile_batched",
-                            assemble_asym(kernels::ATTENTION_FLASH_ASYM3_TILE_BATCHED_SRC)));
-                specs.push(("attention_flash_asym_reduce_batched",
-                            kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_asym_k_givens3",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC),
+                ));
+                specs.push((
+                    "kv_cache_write_asym_k_givens3_batched",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym3_tile",
+                    assemble_asym(kernels::ATTENTION_FLASH_ASYM3_TILE_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym3_tile_batched",
+                    assemble_asym(kernels::ATTENTION_FLASH_ASYM3_TILE_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym_reduce_batched",
+                    kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string(),
+                ));
             }
             "asym2" => {
-                specs.push(("kv_cache_write_asym_k_givens2",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS2_SRC)));
-                specs.push(("kv_cache_write_asym_k_givens2_batched",
-                            assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS2_BATCHED_SRC)));
-                specs.push(("attention_flash_asym2_tile",
-                            assemble_asym(kernels::ATTENTION_FLASH_ASYM2_TILE_SRC)));
-                specs.push(("attention_flash_asym2_tile_batched",
-                            assemble_asym(kernels::ATTENTION_FLASH_ASYM2_TILE_BATCHED_SRC)));
-                specs.push(("attention_flash_asym_reduce_batched",
-                            kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_asym_k_givens2",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS2_SRC),
+                ));
+                specs.push((
+                    "kv_cache_write_asym_k_givens2_batched",
+                    assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS2_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym2_tile",
+                    assemble_asym(kernels::ATTENTION_FLASH_ASYM2_TILE_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym2_tile_batched",
+                    assemble_asym(kernels::ATTENTION_FLASH_ASYM2_TILE_BATCHED_SRC),
+                ));
+                specs.push((
+                    "attention_flash_asym_reduce_batched",
+                    kernels::ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC.to_string(),
+                ));
             }
             "q8" | _ => {
-                specs.push(("kv_cache_write_q8_0", kernels::KV_CACHE_WRITE_Q8_0_SRC.to_string()));
-                specs.push(("attention_q8_0_kv",   kernels::ATTENTION_Q8_0_KV_SRC.to_string()));
-                specs.push(("attention_q8_0_kv_batched",
-                            kernels::ATTENTION_Q8_0_KV_BATCHED_SRC.to_string()));
-                specs.push(("kv_cache_write_q8_0_batched",
-                            kernels::KV_CACHE_WRITE_Q8_0_BATCHED_SRC.to_string()));
-                specs.push(("attention_flash_q8_0_tile",
-                            kernels::ATTENTION_FLASH_Q8_0_TILE_SRC.to_string()));
-                specs.push(("attention_flash_q8_0_reduce",
-                            kernels::ATTENTION_FLASH_Q8_0_REDUCE_SRC.to_string()));
+                specs.push((
+                    "kv_cache_write_q8_0",
+                    kernels::KV_CACHE_WRITE_Q8_0_SRC.to_string(),
+                ));
+                specs.push((
+                    "attention_q8_0_kv",
+                    kernels::ATTENTION_Q8_0_KV_SRC.to_string(),
+                ));
+                specs.push((
+                    "attention_q8_0_kv_batched",
+                    kernels::ATTENTION_Q8_0_KV_BATCHED_SRC.to_string(),
+                ));
+                specs.push((
+                    "kv_cache_write_q8_0_batched",
+                    kernels::KV_CACHE_WRITE_Q8_0_BATCHED_SRC.to_string(),
+                ));
+                specs.push((
+                    "attention_flash_q8_0_tile",
+                    kernels::ATTENTION_FLASH_Q8_0_TILE_SRC.to_string(),
+                ));
+                specs.push((
+                    "attention_flash_q8_0_reduce",
+                    kernels::ATTENTION_FLASH_Q8_0_REDUCE_SRC.to_string(),
+                ));
             }
         }
 
         // Convert to (&str, &str) for the batch API
-        let batch: Vec<(&str, &str)> = specs.iter()
+        let batch: Vec<(&str, &str)> = specs
+            .iter()
             .map(|(name, src)| (*name, src.as_str()))
             .collect();
         self.compiler.compile_batch(&batch)?;
@@ -1534,7 +1834,7 @@ self.flags.rocblas_min_batch.unwrap_or(4)
                 "conv1d_silu_split_tree" => vec!["conv1d_silu_split_tree_f32"],
                 "gated_delta_net_q8_tree" => vec!["gated_delta_net_q8_tree"],
                 "sigmoid_mul" => vec!["sigmoid_mul_f32"],
-                "topk_logits"  => vec!["topk_logits_f32"],
+                "topk_logits" => vec!["topk_logits_f32"],
                 "scale_f32" => vec!["scale_f32"],
                 "gated_norm" => vec!["gated_norm_f32"],
                 "rope_partial_interleaved" => vec!["rope_partial_interleaved_f32"],
@@ -1558,18 +1858,18 @@ self.flags.rocblas_min_batch.unwrap_or(4)
                     "gemv_hfq4g256_residual_multirow_r4",
                     "gemv_hfq4g256_residual_multirow_r8",
                 ],
-                "gemv_hfq4g256_moe_gate_up_indexed_wave64" => vec![
-                    "gemv_hfq4g256_moe_gate_up_k8_indexed_wave64",
-                ],
-                "gemv_hfq4g256_moe_down_indexed_wave64" => vec![
-                    "gemv_hfq4g256_moe_down_residual_scaled_k8_indexed_wave64",
-                ],
-                "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64" => vec![
-                    "gemv_hfq4g256_moe_gate_up_k8_indexed_batched_wave64",
-                ],
-                "gemv_hfq4g256_moe_down_indexed_batched_wave64" => vec![
-                    "gemv_hfq4g256_moe_down_residual_scaled_k8_indexed_batched_wave64",
-                ],
+                "gemv_hfq4g256_moe_gate_up_indexed_wave64" => {
+                    vec!["gemv_hfq4g256_moe_gate_up_k8_indexed_wave64"]
+                }
+                "gemv_hfq4g256_moe_down_indexed_wave64" => {
+                    vec!["gemv_hfq4g256_moe_down_residual_scaled_k8_indexed_wave64"]
+                }
+                "gemv_hfq4g256_moe_gate_up_indexed_batched_wave64" => {
+                    vec!["gemv_hfq4g256_moe_gate_up_k8_indexed_batched_wave64"]
+                }
+                "gemv_hfq4g256_moe_down_indexed_batched_wave64" => {
+                    vec!["gemv_hfq4g256_moe_down_residual_scaled_k8_indexed_batched_wave64"]
+                }
                 other => vec![other],
             };
             // Compile and ensure the module is loaded once.
@@ -1592,17 +1892,25 @@ self.flags.rocblas_min_batch.unwrap_or(4)
         Ok(())
     }
 
-
     // ═══════════════════════════════════════════════════════════════════════════
     // Kernel profiler
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// Profile all compiled kernels: hardware caps + ISA metadata + occupancy.
-    pub fn profile(&self) -> (crate::profiler::GpuCapability, Vec<crate::profiler::KernelProfile>) {
+    pub fn profile(
+        &self,
+    ) -> (
+        crate::profiler::GpuCapability,
+        Vec<crate::profiler::KernelProfile>,
+    ) {
         self.bind_thread_or_warn();
         let vram = self.hip.get_vram_info().map(|(_, t)| t as u64).unwrap_or(0);
-        let cu_hint = self.hip
-            .get_device_attribute(crate::profiler::HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, 0)
+        let cu_hint = self
+            .hip
+            .get_device_attribute(
+                crate::profiler::HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+                0,
+            )
             .ok()
             .filter(|&v| v > 0)
             .map(|v| crate::profiler::hip_mp_count_to_cu_count(&self.arch, v as u32))
@@ -1638,12 +1946,20 @@ mod tests {
         let s2 = gen_fwht_signs(1043, 128);
         assert_eq!(s1.len(), 128);
         assert_eq!(s2.len(), 128);
-        for x in &s1 { assert!(*x == 1.0 || *x == -1.0, "signs1 contains {x}"); }
-        for x in &s2 { assert!(*x == 1.0 || *x == -1.0, "signs2 contains {x}"); }
+        for x in &s1 {
+            assert!(*x == 1.0 || *x == -1.0, "signs1 contains {x}");
+        }
+        for x in &s2 {
+            assert!(*x == 1.0 || *x == -1.0, "signs2 contains {x}");
+        }
         // Reproducibility
         assert_eq!(gen_fwht_signs(43, 128), s1);
         assert_eq!(gen_fwht_signs(1043, 128), s2);
         // Distinct from G256 seeds
-        assert_ne!(gen_fwht_signs(42, 128), s1, "seed 43 should differ from seed 42");
+        assert_ne!(
+            gen_fwht_signs(42, 128),
+            s1,
+            "seed 43 should differ from seed 42"
+        );
     }
 }

--- a/scripts/ci-rustfmt-changed.sh
+++ b/scripts/ci-rustfmt-changed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The repository still has historical rustfmt debt. Keep PR/push lint useful by
+# enforcing rustfmt on the Rust files changed by this branch or push, without
+# turning untouched legacy formatting into a permanent red check.
+
+if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
+  mapfile -t files < <(git diff --name-only --diff-filter=ACMRT -- '*.rs' | sort)
+elif [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+  base_ref="${GITHUB_BASE_REF:?GITHUB_BASE_REF is required for pull_request events}"
+  git fetch --no-tags origin "${base_ref}:refs/remotes/origin/${base_ref}"
+  range="origin/${base_ref}...HEAD"
+  mapfile -t files < <(git diff --name-only --diff-filter=ACMRT "${range}" -- '*.rs' | sort)
+elif [[ -n "${GITHUB_EVENT_BEFORE:-}" && "${GITHUB_EVENT_BEFORE}" != "0000000000000000000000000000000000000000" ]]; then
+  range="${GITHUB_EVENT_BEFORE}...HEAD"
+  mapfile -t files < <(git diff --name-only --diff-filter=ACMRT "${range}" -- '*.rs' | sort)
+else
+  base_ref="${BASE_REF:-origin/master}"
+  git fetch --no-tags origin "master:refs/remotes/origin/master"
+  range="${base_ref}...HEAD"
+  mapfile -t files < <(git diff --name-only --diff-filter=ACMRT "${range}" -- '*.rs' | sort)
+fi
+
+if [[ "${#files[@]}" -eq 0 ]]; then
+  echo "No changed Rust files to rustfmt-check."
+  exit 0
+fi
+
+printf 'rustfmt-checking %d changed Rust files:\n' "${#files[@]}"
+printf '  %s\n' "${files[@]}"
+rustfmt --edition 2021 --check --config skip_children=true "${files[@]}"


### PR DESCRIPTION
## Summary

Fix-forward a bounded slice of the cleanup direction from #303 while avoiding the repo-wide rustfmt churn that made the original branch hard to land.

- Replace the rustfmt advisory with `scripts/ci-rustfmt-changed.sh`, which checks only changed Rust files and uses `skip_children=true` so unchanged child modules do not turn the check red.
- Carry forward the low-level safety cleanup spirit from #303: bind rocBLAS to the real `Stream` handle, document raw-buffer safety contracts, make HSA dispatch-packet construction/publication unsafe at the public boundary, and remove misleading no-op `mem::forget` calls.
- Clear the current clippy deny blockers while leaving legacy non-fatal warnings as advisory output.
- Fix a serve non-stream cleanup bug caught by smoke testing: `enable_thinking:false` no longer leaks a leading orphan `</think>` into `message.content`.
- Address advisory review follow-up: finite HSA bench wait timeout, removal of the dead stored `rocblas_create_handle` pointer, and visible logging for rocBLAS stream-bind fallback.

## Credit

This is a bounded fix-forward of cleanup work originally opened by @xynexus in #303. It preserves the low-risk safety/lint cleanup direction while intentionally dropping the repo-wide churn and stale/conflicting pieces from that branch.

## Validation

- `bash scripts/ci-rustfmt-changed.sh`
- `git diff --check`
- `cargo check -p hsa-bridge --example hsa_vs_hip_launch`
- `cargo check -p hip-bridge`
- `cargo check -p rdna-compute`
- `cargo clippy --workspace --all-targets --locked`
- `bun test cli/chat_pure.test.ts cli/parse_tool_calls.test.ts`
- prior gfx1100: `dflash_spec_demo` Qwen3.5 9B AR smoke (`--ar-baseline`) emitted coherent Python code and completed 32 tokens.
- prior gfx1100: `dflash_spec_demo` Qwen3.5 9B DFlash smoke emitted coherent Python code and completed with `τ=5.167`.
- prior gfx1100: daemon JSONL Qwen3.5 9B AR smoke loaded, streamed 32 tokens, emitted `done`, and unloaded.
- prior gfx1100: daemon JSONL Qwen3.5 9B DFlash smoke loaded the draft, streamed 32 tokens, emitted `done`, and unloaded.
- prior gfx1100: `hipfire serve` `/v1/chat/completions` non-stream smoke returned coherent code content without leaking leading `</think>` after the fix.
- prior gfx1100: `hipfire serve` `/v1/chat/completions` streaming smoke returned SSE chunks and `[DONE]`.

Notes: this intentionally does not run `cargo fmt --all --check`; that is the legacy workspace-wide debt this PR keeps out of advisory CI until the cleanup is split into smaller pieces.