### PR TITLE
fix: keep CLI update payload in sync

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,10 +8,9 @@
 //   hipfire sidecar-gen <model>       → generate TriAttention calibration sidecar
 
 import { spawn } from "bun";
-import { existsSync, readdirSync, statSync, unlinkSync, mkdirSync } from "fs";
+import { existsSync, readdirSync, statSync, unlinkSync, mkdirSync, copyFileSync, cpSync, rmSync, renameSync } from "fs";
 import { join, resolve, basename, dirname } from "path";
 import { homedir } from "os";
-import { stripVisibleThinking } from "./chat_pure.ts";
 
 const HIPFIRE_DIR = join(homedir(), ".hipfire");
 const MODELS_DIR = join(HIPFIRE_DIR, "models");
@@ -5136,6 +5135,63 @@ function findDep(binary: string, extraDirs: string[]): string | null {
   return null;
 }
 
+function stripVisibleThinking(content: string, preserveThinking: boolean = false): string {
+  if (preserveThinking) return content.replace(/<\|im_end\|>/g, "").trim();
+  return content
+    .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+    .replace(/<think>[\s\S]*$/, "")
+    .replace(/^\s*<\/think>\s*/, "")
+    .replace(/<\|im_end\|>/g, "")
+    .trim();
+}
+
+function pruneCliRuntimePayload(cliDir: string): void {
+  for (const name of ["node_modules", ".gitignore", "tsconfig.json", "README.md", "bun.lock"]) {
+    rmSync(join(cliDir, name), { recursive: true, force: true });
+  }
+  for (const name of readdirSync(cliDir)) {
+    if (/\.test\.ts$/.test(name) || /^test_.*\.ts$/.test(name) || /^bench_.*\.ts$/.test(name)) {
+      unlinkSync(join(cliDir, name));
+    }
+  }
+}
+
+function syncCliRuntimePayload(repoDir: string): void {
+  const cliSrcDir = join(repoDir, "cli");
+  const cliDstDir = join(HIPFIRE_DIR, "cli");
+  const required = ["registry.json", "index.ts"];
+  for (const file of required) {
+    if (!existsSync(join(cliSrcDir, file))) {
+      console.error(`\nUpdate aborted: cli/${file} missing in repo checkout at`);
+      console.error(`  ${repoDir}`);
+      console.error("Repo may be on a pre-migration commit or in a dirty state. Verify with:");
+      console.error(`  git -C ${repoDir} status && git -C ${repoDir} log -1 --stat`);
+      process.exit(1);
+    }
+  }
+
+  mkdirSync(HIPFIRE_DIR, { recursive: true });
+  const stamp = `${process.pid}-${Date.now()}`;
+  const tmpDir = join(HIPFIRE_DIR, `.cli-update-${stamp}`);
+  const backupDir = join(HIPFIRE_DIR, `.cli-prev-${stamp}`);
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(backupDir, { recursive: true, force: true });
+
+  try {
+    cpSync(cliSrcDir, tmpDir, { recursive: true, force: true });
+    pruneCliRuntimePayload(tmpDir);
+    if (existsSync(cliDstDir)) renameSync(cliDstDir, backupDir);
+    renameSync(tmpDir, cliDstDir);
+    rmSync(backupDir, { recursive: true, force: true });
+  } catch (err) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (!existsSync(cliDstDir) && existsSync(backupDir)) {
+      renameSync(backupDir, cliDstDir);
+    }
+    throw err;
+  }
+}
+
 // ─── Main ───────────────────────────────────────────────
 
 const [cmd, ...rest] = process.argv.slice(2);
@@ -5562,26 +5618,14 @@ switch (cmd) {
     // config commands keep working. Previously the copy happened after the
     // cargo build, so a build failure left the CLI frozen at its install-time
     // version — users saw "unknown model" for entries added post-install.
-    const { copyFileSync } = await import("fs");
     const exe = process.platform === "win32" ? ".exe" : "";
     const binDir = join(HIPFIRE_DIR, "bin");
-    // Order: registry.json BEFORE index.ts. The new index.ts imports the JSON
-    // at startup; if we copied index.ts first and the JSON copy then failed
-    // (missing in repoDir, IO error, partial git pull), the install would be
-    // stranded — new TS that can't resolve its own data file. Copying JSON
-    // first means a partial failure leaves the CLI in a recoverable state:
-    // either old TS + old JSON, or old TS + new JSON (still loads OK).
-    const registrySrc = join(repoDir, "cli/registry.json");
-    const indexSrc    = join(repoDir, "cli/index.ts");
-    if (!existsSync(registrySrc) || !existsSync(indexSrc)) {
-      console.error("\nUpdate aborted: cli/registry.json or cli/index.ts missing in repo checkout at");
-      console.error(`  ${repoDir}`);
-      console.error("Repo may be on a pre-migration commit or in a dirty state. Verify with:");
-      console.error(`  git -C ${repoDir} status && git -C ${repoDir} log -1 --stat`);
-      process.exit(1);
-    }
-    copyFileSync(registrySrc, join(HIPFIRE_DIR, "cli/registry.json"));
-    copyFileSync(indexSrc,    join(HIPFIRE_DIR, "cli/index.ts"));
+    // Keep index.ts and its sibling runtime modules in lockstep. This mirrors
+    // scripts/install.{sh,ps1}: copy the whole cli/ tree, prune dev/test files,
+    // then swap the staged payload into place. A legacy updater can still copy
+    // only this new index.ts once; keeping index.ts startup-self-contained lets
+    // the user run `hipfire update` again to repair the full payload.
+    syncCliRuntimePayload(repoDir);
     console.error("  CLI updated ✓");
     // Rebuild
     console.error("Rebuilding daemon (this may take a few minutes)...");

--- a/scripts/tests/test-update-cli-payload.sh
+++ b/scripts/tests/test-update-cli-payload.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire - see LICENSE and NOTICE in the project root.
+
+# Regression test for issue #376:
+# `hipfire update` copied only cli/index.ts + cli/registry.json, so after
+# index.ts gained helper imports (`./chat_pure.ts`, `./chat.ts`) installed
+# CLIs could be stranded with a new entrypoint and missing sibling modules.
+
+set -euo pipefail
+
+TEST_NAME="update-cli-payload"
+
+fail() { echo "FAIL [$TEST_NAME]: $*" >&2; exit 1; }
+pass() { echo "PASS [$TEST_NAME]: $*"; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+[ -n "$REPO_ROOT" ] || fail "not in a git checkout"
+
+CLI="$REPO_ROOT/cli/index.ts"
+[ -f "$CLI" ] || fail "cli/index.ts not found at $CLI"
+
+# Bootstrap safety: an older installed updater may copy only the new index.ts.
+# The new entrypoint must still start so the user can run `hipfire update`
+# again and let the fixed updater copy the rest of cli/.
+if grep -E '^import .*"\./(chat|chat_pure)\.ts";' "$CLI" >/dev/null; then
+    fail "cli/index.ts has a startup import of chat/chat_pure; legacy index-only updates can strand the CLI"
+fi
+
+# Future safety: the fixed updater must copy the whole runtime CLI tree, then
+# prune dev-only files, matching scripts/install.{sh,ps1}.
+grep -q 'function syncCliRuntimePayload' "$CLI" \
+    || fail "cli/index.ts is missing syncCliRuntimePayload()"
+grep -q 'cpSync(cliSrcDir, tmpDir, { recursive: true' "$CLI" \
+    || fail "hipfire update does not recursively copy cli/"
+grep -q 'pruneCliRuntimePayload' "$CLI" \
+    || fail "hipfire update does not prune dev/test CLI artifacts after copy"
+
+# Forbidden: this is the exact stale-copy pattern that caused #376.
+if grep -q 'copyFileSync(indexSrc,.*cli/index\.ts' "$CLI"; then
+    fail "hipfire update still copies only cli/index.ts instead of the CLI payload"
+fi
+
+pass "update keeps CLI payload dependencies together"


### PR DESCRIPTION
## Summary

Fixes #376.

`hipfire update` copied only `cli/index.ts` and `cli/registry.json`, while fresh installs already copy the whole `cli/` tree. Once `index.ts` gained sibling module dependencies like `chat_pure.ts` and `chat.ts`, an update could strand users with a new entrypoint and missing runtime modules.

This PR:
- makes `cli/index.ts` startup-self-contained by removing the top-level `chat_pure.ts` import
- changes `hipfire update` to stage-copy the whole `cli/` tree, prune dev/test artifacts, and then swap it into `~/.hipfire/cli`
- adds a regression script for the update payload contract

## Validation

- `bash scripts/tests/test-update-cli-payload.sh`
- `bash scripts/tests/test-update-dirty-tree.sh`
- `bun test cli`
- temp legacy install smoke: started with only `index.ts` + `registry.json`, ran `hipfire update` with fake build tools, verified `chat.ts`/`chat_pure.ts` were copied, test artifacts were pruned, and the updated CLI started with `list --remote`