### PR TITLE
Vision pipeline cleanup (issue #326)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1705,7 +1705,7 @@ async function serve(port: number, host: string) {
         // prompt, which the model has no way to recover from. Issue #79.
         // Image parts are filtered out (no vision encoder in serve path);
         // matches the daemon's existing text-only behaviour.
-        const extractContent = (content: any): { text: string, images: string[], unsupportedImage: boolean, malformedImage: boolean } => {
+        const extractContent = (content: any): { text: string, images: string[], unsupportedImage: boolean, remoteImageUrl: boolean, malformedImage: boolean } => {
           // OpenAI assistant messages carrying only `tool_calls` send
           // `content: null`. Returning `String(null) === "null"` here
           // (the legacy fallback below) leaked the literal text `null`
@@ -1714,12 +1714,13 @@ async function serve(port: number, host: string) {
           // tool-call turn, which the model reads as "the assistant
           // previously said the word null", not as an empty turn.
           // Treat null/undefined as empty content.
-          if (content == null) return { text: "", images: [], unsupportedImage: false, malformedImage: false };
-          if (typeof content === "string") return { text: content, images: [], unsupportedImage: false, malformedImage: false };
+          if (content == null) return { text: "", images: [], unsupportedImage: false, remoteImageUrl: false, malformedImage: false };
+          if (typeof content === "string") return { text: content, images: [], unsupportedImage: false, remoteImageUrl: false, malformedImage: false };
           if (Array.isArray(content)) {
             const textParts: string[] = [];
             const images: string[] = [];
             let unsupportedImage = false;
+            let remoteImageUrl = false;
             let malformedImage = false;
             for (const p of content) {
               if (p?.type === "text") textParts.push(p.text ?? "");
@@ -1739,15 +1740,21 @@ async function serve(port: number, host: string) {
                       // dropping the part and proceeding as text-only.
                       unsupportedImage = true;
                     }
+                  } else {
+                    // Non-data: URLs (https://, http://, file://, etc.)
+                    // are not supported — hipfire does not fetch remote
+                    // images. Use a separate flag so the error message
+                    // distinguishes "bad format" from "unsupported transport".
+                    remoteImageUrl = true;
                   }
                 } else {
                   malformedImage = true;
                 }
               }
             }
-            return { text: textParts.join(""), images, unsupportedImage, malformedImage };
+            return { text: textParts.join(""), images, unsupportedImage, remoteImageUrl, malformedImage };
           }
-          return { text: String(content), images: [], unsupportedImage: false, malformedImage: false };
+          return { text: String(content), images: [], unsupportedImage: false, remoteImageUrl: false, malformedImage: false };
         };
 
         const extractText = (content: any): string => extractContent(content).text;
@@ -1907,6 +1914,9 @@ async function serve(port: number, host: string) {
             const content = extractContent(m.content);
             if (content.malformedImage) {
               return rejectImage("malformed image part — image_url.url is required");
+            }
+            if (content.remoteImageUrl) {
+              return rejectImage("remote image URLs are not supported — embed images as base64 data: URLs (supported formats: png, jpeg)");
             }
             if (content.unsupportedImage) {
               return rejectImage("unsupported image format — supported: png, jpeg");

--- a/crates/hipfire-arch-dots-ocr/src/image.rs
+++ b/crates/hipfire-arch-dots-ocr/src/image.rs
@@ -280,8 +280,16 @@ pub fn extract_patches(chw: &[f32], h: usize, w: usize) -> Vec<f32> {
         3 * h * w,
         chw.len()
     );
-    assert_eq!(h % PATCH_SIZE, 0, "h={h} must be a multiple of PATCH_SIZE={PATCH_SIZE}");
-    assert_eq!(w % PATCH_SIZE, 0, "w={w} must be a multiple of PATCH_SIZE={PATCH_SIZE}");
+    assert_eq!(
+        h % PATCH_SIZE,
+        0,
+        "h={h} must be a multiple of PATCH_SIZE={PATCH_SIZE}"
+    );
+    assert_eq!(
+        w % PATCH_SIZE,
+        0,
+        "w={w} must be a multiple of PATCH_SIZE={PATCH_SIZE}"
+    );
     let grid_h = h / PATCH_SIZE;
     let grid_w = w / PATCH_SIZE;
     assert_eq!(
@@ -446,7 +454,11 @@ fn composite_rgba_on_white(rgba: &image::RgbaImage) -> image::RgbImage {
         let a = pix[3] as u32;
         let inv_a = 255 - a;
         let blend = |c: u8| ((c as u32 * a + 255 * inv_a) / 255) as u8;
-        out.put_pixel(x, y, image::Rgb([blend(pix[0]), blend(pix[1]), blend(pix[2])]));
+        out.put_pixel(
+            x,
+            y,
+            image::Rgb([blend(pix[0]), blend(pix[1]), blend(pix[2])]),
+        );
     }
     out
 }
@@ -467,7 +479,11 @@ mod tests {
         assert_eq!(w % IMAGE_FACTOR, 0, "w={w} is not a 28-multiple");
         // 100×3000 = 300_000 pixels, way under MAX_PIXELS=11_289_600,
         // so smart_resize rounds to nearest 28-multiple.
-        assert!(h * w <= MAX_PIXELS, "{h}×{w} = {} exceeds MAX_PIXELS", h * w);
+        assert!(
+            h * w <= MAX_PIXELS,
+            "{h}×{w} = {} exceeds MAX_PIXELS",
+            h * w
+        );
         assert!(h * w >= MIN_PIXELS, "{h}×{w} = {} below MIN_PIXELS", h * w);
     }
 
@@ -475,8 +491,7 @@ mod tests {
     fn smart_resize_rejects_extreme_aspect_ratio() {
         // 1×500 → ratio = 500, well over MAX_RATIO=200. Must error,
         // not silently produce a 28×28 or similar degenerate dim.
-        let err = smart_resize(1, 500)
-            .expect_err("AR=500 must trip the MAX_RATIO=200 guard");
+        let err = smart_resize(1, 500).expect_err("AR=500 must trip the MAX_RATIO=200 guard");
         assert!(
             err.contains("aspect ratio") && err.contains("200"),
             "unexpected error message: {err}"
@@ -569,18 +584,22 @@ mod tests {
         // is its tag, since the synthetic input is per-pixel-constant
         // within a single patch).
         let expected = [
-            0.0,       // (outer 0,0, inner 0,0) → py=0, px=0
-            1.0,       // (outer 0,0, inner 0,1) → py=0, px=1
-            1000.0,    // (outer 0,0, inner 1,0) → py=1, px=0
-            1001.0,    // (outer 0,0, inner 1,1) → py=1, px=1
-            2.0,       // (outer 0,1, inner 0,0) → py=0, px=2
-            3.0,       // (outer 0,1, inner 0,1) → py=0, px=3
-            1002.0,    // (outer 0,1, inner 1,0) → py=1, px=2
-            1003.0,    // (outer 0,1, inner 1,1) → py=1, px=3
+            0.0,    // (outer 0,0, inner 0,0) → py=0, px=0
+            1.0,    // (outer 0,0, inner 0,1) → py=0, px=1
+            1000.0, // (outer 0,0, inner 1,0) → py=1, px=0
+            1001.0, // (outer 0,0, inner 1,1) → py=1, px=1
+            2.0,    // (outer 0,1, inner 0,0) → py=0, px=2
+            3.0,    // (outer 0,1, inner 0,1) → py=0, px=3
+            1002.0, // (outer 0,1, inner 1,0) → py=1, px=2
+            1003.0, // (outer 0,1, inner 1,1) → py=1, px=3
         ];
         for (i, &want) in expected.iter().enumerate() {
             let got = patches[i * patch_elems];
-            let raster_would_give = if i < 4 { i as f32 } else { 1000.0 + (i - 4) as f32 };
+            let raster_would_give = if i < 4 {
+                i as f32
+            } else {
+                1000.0 + (i - 4) as f32
+            };
             assert_eq!(
                 got, want,
                 "patch[{i}] first element: expected {want}, got {got} \
@@ -604,9 +623,8 @@ mod tests {
                 for x in 0..w {
                     // Pixel value = c * 10000 + y * 100 + x — unique
                     // per (c, y, x) so any reordering is detectable.
-                    chw[c * h * w + y * w + x] = (c as f32) * 10000.0
-                        + (y as f32) * 100.0
-                        + (x as f32);
+                    chw[c * h * w + y * w + x] =
+                        (c as f32) * 10000.0 + (y as f32) * 100.0 + (x as f32);
                 }
             }
         }
@@ -680,7 +698,10 @@ mod tests {
             resized_w: 84,
         };
         assert_eq!(p.n_patches(), 24);
-        assert_eq!(p.n_visual_tokens(), 24 / (SPATIAL_MERGE_SIZE * SPATIAL_MERGE_SIZE));
+        assert_eq!(
+            p.n_visual_tokens(),
+            24 / (SPATIAL_MERGE_SIZE * SPATIAL_MERGE_SIZE)
+        );
     }
 
     #[test]

--- a/crates/hipfire-arch-dots-ocr/src/image.rs
+++ b/crates/hipfire-arch-dots-ocr/src/image.rs
@@ -137,15 +137,21 @@ fn smart_resize_inner(
     let h_round = ((h / factor_f).round() as usize) * factor;
     let w_round = ((w / factor_f).round() as usize) * factor;
 
-    let (h_out, w_out) = if h_round * w_round > max_pixels {
+    // Use u64 for pixel-count comparisons to avoid usize overflow on
+    // 32-bit targets. (Defense-in-depth; callers gate dimensions.)
+    let hround_wround = (h_round as u64) * (w_round as u64);
+
+    let (h_out, w_out) = if hround_wround > max_pixels as u64 {
         // Down-scale: shrink by sqrt(h*w / max_pixels), then floor to factor.
-        let beta = (h * w / max_pixels as f64).sqrt();
+        let hw = h * w;
+        let beta = (hw / max_pixels as f64).sqrt();
         let h_scaled = factor.max(((h / beta / factor_f).floor() as usize) * factor);
         let w_scaled = factor.max(((w / beta / factor_f).floor() as usize) * factor);
         (h_scaled, w_scaled)
-    } else if h_round * w_round < min_pixels {
+    } else if hround_wround < min_pixels as u64 {
         // Up-scale: grow by sqrt(min_pixels / (h*w)), then ceil to factor.
-        let beta = (min_pixels as f64 / (h * w)).sqrt();
+        let hw = h * w;
+        let beta = (min_pixels as f64 / hw).sqrt();
         let h_scaled = factor.max(((h * beta / factor_f).ceil() as usize) * factor);
         let w_scaled = factor.max(((w * beta / factor_f).ceil() as usize) * factor);
         // Edge case from `dots_ocr/utils/image_utils.py:56-61`: the
@@ -156,8 +162,9 @@ fn smart_resize_inner(
         // dots.ocr's MIN=3136 / MAX=11_289_600 the ratio (~3600×) makes
         // this branch effectively unreachable, but we mirror the source
         // exactly to keep the byte-identity claim with HF.
-        if h_scaled * w_scaled > max_pixels {
-            let beta = ((h_scaled * w_scaled) as f64 / max_pixels as f64).sqrt();
+        let hs_ws = (h_scaled as u64) * (w_scaled as u64);
+        if hs_ws > max_pixels as u64 {
+            let beta = (hs_ws as f64 / max_pixels as f64).sqrt();
             let h_re = factor.max(((h_scaled as f64 / beta / factor_f).floor() as usize) * factor);
             let w_re = factor.max(((w_scaled as f64 / beta / factor_f).floor() as usize) * factor);
             (h_re, w_re)

--- a/crates/hipfire-arch-qwen35-vl/src/image.rs
+++ b/crates/hipfire-arch-qwen35-vl/src/image.rs
@@ -30,16 +30,23 @@ pub fn smart_resize(
     min_pixels: usize,
     max_pixels: usize,
 ) -> (usize, usize) {
+    // Use u64 for pixel-count arithmetic to avoid usize overflow on
+    // 32-bit targets where height * width could exceed 2^32-1.
+    // (Defense-in-depth; callers are already gated by
+    // MAX_DIMENSION_PIXELS, but the arithmetic should be correct
+    // regardless of pointer width.)
     let h_bar = ((height as f64 / factor as f64).round() as usize) * factor;
     let w_bar = ((width as f64 / factor as f64).round() as usize) * factor;
+    let hw = (height as u64) * (width as u64);
+    let hbar_wbar = (h_bar as u64) * (w_bar as u64);
 
-    if h_bar * w_bar > max_pixels {
-        let beta = ((height * width) as f64 / max_pixels as f64).sqrt();
+    if hbar_wbar > max_pixels as u64 {
+        let beta = (hw as f64 / max_pixels as f64).sqrt();
         let h_bar = factor.max(((height as f64 / beta / factor as f64).floor() as usize) * factor);
         let w_bar = factor.max(((width as f64 / beta / factor as f64).floor() as usize) * factor);
         (h_bar, w_bar)
-    } else if h_bar * w_bar < min_pixels {
-        let beta = (min_pixels as f64 / (height * width) as f64).sqrt();
+    } else if hbar_wbar < min_pixels as u64 {
+        let beta = (min_pixels as f64 / hw as f64).sqrt();
         let h_bar = factor.max(((height as f64 * beta / factor as f64).ceil() as usize) * factor);
         let w_bar = factor.max(((width as f64 * beta / factor as f64).ceil() as usize) * factor);
         (h_bar, w_bar)

--- a/crates/hipfire-arch-qwen35-vl/tests/channel_order.rs
+++ b/crates/hipfire-arch-qwen35-vl/tests/channel_order.rs
@@ -88,3 +88,82 @@ fn mixed_pixel_keeps_rgb_order() {
     assert!((channel_at_origin(&out, h, w, 1) - norm(200)).abs() < 1e-5, "G (200) in channel 1");
     assert!((channel_at_origin(&out, h, w, 2) - norm(50)).abs() < 1e-5, "B (50) in channel 2");
 }
+
+/// Write a 256×256 PNG with different colors in each quadrant, returning
+/// its path. 256×256 is a multiple of factor=32 (patch_size=16 ×
+/// spatial_merge_size=2) and above min_pixels=3136, so smart_resize
+/// keeps it at 256×256 unchanged.
+/// Each quadrant uses distinct per-channel values that form a
+/// unique "fingerprint" — so a spatial transpose (H↔V flip), a channel
+/// swap, or any combination will corrupt at least one fingerprint.
+fn write_quadrant_png(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "hipfire-channel-order-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0),
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join(format!("{name}.png"));
+    let mut img: ImageBuffer<Rgb<u8>, Vec<u8>> = ImageBuffer::new(256, 256);
+    // Quadrant colors chosen so each R,G,B triple is unique and no
+    // per-channel value appears in the same position across quadrants.
+    let colors = [
+        (200, 30, 100),  // top-left
+        (50, 180, 15),   // top-right
+        (10, 70, 240),   // bottom-left
+        (150, 5, 60),    // bottom-right
+    ];
+    for (y, row) in img.rows_mut().enumerate() {
+        for (x, pixel) in row.enumerate() {
+            let qi = if y < 128 { 0 } else { 2 } + if x < 128 { 0 } else { 1 };
+            let (r, g, b) = colors[qi];
+            *pixel = Rgb([r, g, b]);
+        }
+    }
+    img.save(&path).expect("write png");
+    path
+}
+
+#[test]
+fn quadrant_pixels_keep_rgb_spatial_order() {
+    // Verifies channel AND spatial ordering simultaneously: each quadrant
+    // of the input image has a unique (R,G,B) fingerprint, and we check
+    // that the correct fingerprint lands at the correct (y,x) position
+    // in each CHW channel plane.
+    let path = write_quadrant_png("quadrant");
+    let (out, h, w) = load_and_preprocess(&path, 16, 2).expect("load_and_preprocess failed");
+
+    // 256×256 with patch_size=16, spatial_merge=2 → factor=32.
+    // smart_resize keeps it at 256×256 (already a multiple of 32,
+    // and 65536 > min_pixels=3136).
+    assert_eq!(h, 256, "expected height 256, got {}", h);
+    assert_eq!(w, 256, "expected width 256, got {}", w);
+
+    // Check a pixel in each quadrant of the CHW output.
+    let colors = [
+        (200u8, 30u8, 100u8),  // TL
+        (50u8, 180u8, 15u8),   // TR
+        (10u8, 70u8, 240u8),   // BL
+        (150u8, 5u8, 60u8),    // BR
+    ];
+    let positions = [
+        (64, 64),    // TL interior
+        (64, 192),   // TR interior
+        (192, 64),   // BL interior
+        (192, 192),  // BR interior
+    ];
+    // Note: CHW layout is [C, H, W], so pixel at (y, x) in channel c is:
+    //   out[c * h * w + y * w + x]
+    for (qi, &(py, px)) in positions.iter().enumerate() {
+        let (r, g, b) = colors[qi];
+        let r_val = out[0 * h * w + py * w + px];
+        let g_val = out[1 * h * w + py * w + px];
+        let b_val = out[2 * h * w + py * w + px];
+        assert!((r_val - norm(r)).abs() < 1e-4, "Q{} ({},{}) R: expected {} got {}", qi, py, px, norm(r), r_val);
+        assert!((g_val - norm(g)).abs() < 1e-4, "Q{} ({},{}) G: expected {} got {}", qi, py, px, norm(g), g_val);
+        assert!((b_val - norm(b)).abs() < 1e-4, "Q{} ({},{}) B: expected {} got {}", qi, py, px, norm(b), b_val);
+    }
+}

--- a/crates/hipfire-arch-qwen35-vl/tests/channel_order.rs
+++ b/crates/hipfire-arch-qwen35-vl/tests/channel_order.rs
@@ -56,27 +56,54 @@ fn channel_at_origin(out: &[f32], h: usize, w: usize, channel: usize) -> f32 {
 fn pure_red_lands_in_channel_0() {
     let path = write_solid_png("red", 255, 0, 0);
     let (out, h, w) = load_and_preprocess(&path, 16, 2).expect("load_and_preprocess failed");
-    assert!((channel_at_origin(&out, h, w, 0) - norm(255)).abs() < 1e-5, "R in channel 0");
-    assert!((channel_at_origin(&out, h, w, 1) - norm(0)).abs() < 1e-5, "G in channel 1 (=0)");
-    assert!((channel_at_origin(&out, h, w, 2) - norm(0)).abs() < 1e-5, "B in channel 2 (=0)");
+    assert!(
+        (channel_at_origin(&out, h, w, 0) - norm(255)).abs() < 1e-5,
+        "R in channel 0"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 1) - norm(0)).abs() < 1e-5,
+        "G in channel 1 (=0)"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 2) - norm(0)).abs() < 1e-5,
+        "B in channel 2 (=0)"
+    );
 }
 
 #[test]
 fn pure_green_lands_in_channel_1() {
     let path = write_solid_png("green", 0, 255, 0);
     let (out, h, w) = load_and_preprocess(&path, 16, 2).expect("load_and_preprocess failed");
-    assert!((channel_at_origin(&out, h, w, 0) - norm(0)).abs() < 1e-5, "R in channel 0 (=0)");
-    assert!((channel_at_origin(&out, h, w, 1) - norm(255)).abs() < 1e-5, "G in channel 1");
-    assert!((channel_at_origin(&out, h, w, 2) - norm(0)).abs() < 1e-5, "B in channel 2 (=0)");
+    assert!(
+        (channel_at_origin(&out, h, w, 0) - norm(0)).abs() < 1e-5,
+        "R in channel 0 (=0)"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 1) - norm(255)).abs() < 1e-5,
+        "G in channel 1"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 2) - norm(0)).abs() < 1e-5,
+        "B in channel 2 (=0)"
+    );
 }
 
 #[test]
 fn pure_blue_lands_in_channel_2() {
     let path = write_solid_png("blue", 0, 0, 255);
     let (out, h, w) = load_and_preprocess(&path, 16, 2).expect("load_and_preprocess failed");
-    assert!((channel_at_origin(&out, h, w, 0) - norm(0)).abs() < 1e-5, "R in channel 0 (=0)");
-    assert!((channel_at_origin(&out, h, w, 1) - norm(0)).abs() < 1e-5, "G in channel 1 (=0)");
-    assert!((channel_at_origin(&out, h, w, 2) - norm(255)).abs() < 1e-5, "B in channel 2");
+    assert!(
+        (channel_at_origin(&out, h, w, 0) - norm(0)).abs() < 1e-5,
+        "R in channel 0 (=0)"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 1) - norm(0)).abs() < 1e-5,
+        "G in channel 1 (=0)"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 2) - norm(255)).abs() < 1e-5,
+        "B in channel 2"
+    );
 }
 
 #[test]
@@ -84,9 +111,18 @@ fn mixed_pixel_keeps_rgb_order() {
     // Distinctive per-channel values so any transposition shows up clearly.
     let path = write_solid_png("mixed", 10, 200, 50);
     let (out, h, w) = load_and_preprocess(&path, 16, 2).expect("load_and_preprocess failed");
-    assert!((channel_at_origin(&out, h, w, 0) - norm(10)).abs() < 1e-5, "R (10) in channel 0");
-    assert!((channel_at_origin(&out, h, w, 1) - norm(200)).abs() < 1e-5, "G (200) in channel 1");
-    assert!((channel_at_origin(&out, h, w, 2) - norm(50)).abs() < 1e-5, "B (50) in channel 2");
+    assert!(
+        (channel_at_origin(&out, h, w, 0) - norm(10)).abs() < 1e-5,
+        "R (10) in channel 0"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 1) - norm(200)).abs() < 1e-5,
+        "G (200) in channel 1"
+    );
+    assert!(
+        (channel_at_origin(&out, h, w, 2) - norm(50)).abs() < 1e-5,
+        "B (50) in channel 2"
+    );
 }
 
 /// Write a 256×256 PNG with different colors in each quadrant, returning
@@ -111,10 +147,10 @@ fn write_quadrant_png(name: &str) -> PathBuf {
     // Quadrant colors chosen so each R,G,B triple is unique and no
     // per-channel value appears in the same position across quadrants.
     let colors = [
-        (200, 30, 100),  // top-left
-        (50, 180, 15),   // top-right
-        (10, 70, 240),   // bottom-left
-        (150, 5, 60),    // bottom-right
+        (200, 30, 100), // top-left
+        (50, 180, 15),  // top-right
+        (10, 70, 240),  // bottom-left
+        (150, 5, 60),   // bottom-right
     ];
     for (y, row) in img.rows_mut().enumerate() {
         for (x, pixel) in row.enumerate() {
@@ -144,26 +180,52 @@ fn quadrant_pixels_keep_rgb_spatial_order() {
 
     // Check a pixel in each quadrant of the CHW output.
     let colors = [
-        (200u8, 30u8, 100u8),  // TL
-        (50u8, 180u8, 15u8),   // TR
-        (10u8, 70u8, 240u8),   // BL
-        (150u8, 5u8, 60u8),    // BR
+        (200u8, 30u8, 100u8), // TL
+        (50u8, 180u8, 15u8),  // TR
+        (10u8, 70u8, 240u8),  // BL
+        (150u8, 5u8, 60u8),   // BR
     ];
     let positions = [
-        (64, 64),    // TL interior
-        (64, 192),   // TR interior
-        (192, 64),   // BL interior
-        (192, 192),  // BR interior
+        (64, 64),   // TL interior
+        (64, 192),  // TR interior
+        (192, 64),  // BL interior
+        (192, 192), // BR interior
     ];
     // Note: CHW layout is [C, H, W], so pixel at (y, x) in channel c is:
     //   out[c * h * w + y * w + x]
     for (qi, &(py, px)) in positions.iter().enumerate() {
         let (r, g, b) = colors[qi];
-        let r_val = out[0 * h * w + py * w + px];
-        let g_val = out[1 * h * w + py * w + px];
-        let b_val = out[2 * h * w + py * w + px];
-        assert!((r_val - norm(r)).abs() < 1e-4, "Q{} ({},{}) R: expected {} got {}", qi, py, px, norm(r), r_val);
-        assert!((g_val - norm(g)).abs() < 1e-4, "Q{} ({},{}) G: expected {} got {}", qi, py, px, norm(g), g_val);
-        assert!((b_val - norm(b)).abs() < 1e-4, "Q{} ({},{}) B: expected {} got {}", qi, py, px, norm(b), b_val);
+        let pixel_offset = py * w + px;
+        let channel_stride = h * w;
+        let r_val = out[pixel_offset];
+        let g_val = out[channel_stride + pixel_offset];
+        let b_val = out[2 * channel_stride + pixel_offset];
+        assert!(
+            (r_val - norm(r)).abs() < 1e-4,
+            "Q{} ({},{}) R: expected {} got {}",
+            qi,
+            py,
+            px,
+            norm(r),
+            r_val
+        );
+        assert!(
+            (g_val - norm(g)).abs() < 1e-4,
+            "Q{} ({},{}) G: expected {} got {}",
+            qi,
+            py,
+            px,
+            norm(g),
+            g_val
+        );
+        assert!(
+            (b_val - norm(b)).abs() < 1e-4,
+            "Q{} ({},{}) B: expected {} got {}",
+            qi,
+            py,
+            px,
+            norm(b),
+            b_val
+        );
     }
 }

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -21,30 +21,30 @@
 //!   → {"type":"unload"}
 //!   ← {"type":"unloaded"}
 
+use base64::Engine;
+use hip_bridge::HipResult;
+use hipfire_arch_deepseek4 as deepseek4;
+use hipfire_arch_dots_ocr::dots_ocr;
+use hipfire_arch_llama::Llama;
+use hipfire_arch_qwen2::qwen2;
+use hipfire_arch_qwen35::qwen35;
+use hipfire_arch_qwen35::qwen35::{DeltaNetState, LayerType, Qwen35ScratchSet};
+use hipfire_arch_qwen35::speculative::{
+    self, DdtreeScratch, DeltaNetSnapshot, GdnTape, HiddenStateRingBuffer, VerifyScratch,
+};
+use hipfire_arch_qwen35_vl::image;
+use hipfire_arch_qwen35_vl::qwen35_vl;
 use hipfire_runtime::cask::CaskCtx;
 use hipfire_runtime::dflash::{DflashConfig, DflashScratch, DflashWeights};
 use hipfire_runtime::eos_filter::{EosFilter, EosFilterConfig, FilterAction};
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama;
 use hipfire_runtime::multi_gpu::Gpus;
-use hipfire_arch_deepseek4 as deepseek4;
-use hipfire_arch_llama::Llama;
-use hipfire_arch_qwen2::qwen2;
-use hipfire_arch_dots_ocr::dots_ocr;
-use hipfire_arch_qwen35::qwen35;
-use hipfire_arch_qwen35::qwen35::{DeltaNetState, LayerType, Qwen35ScratchSet};
-use hipfire_arch_qwen35_vl::qwen35_vl;
 use hipfire_runtime::sampler::{self, SamplerConfig};
-use hipfire_arch_qwen35::speculative::{
-    self, DdtreeScratch, DeltaNetSnapshot, GdnTape, HiddenStateRingBuffer, VerifyScratch,
-};
 use hipfire_runtime::triattn::{EvictionCtx, TriAttnCenters};
-use hipfire_arch_qwen35_vl::image;
-use base64::Engine;
-use hip_bridge::HipResult;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Mutex, OnceLock, mpsc};
+use std::sync::{mpsc, Mutex, OnceLock};
 use std::time::Instant;
 
 /// Abort-target request ID. Set asynchronously by the background
@@ -213,12 +213,17 @@ fn block_attractor_unclosed_cpu(
     window: usize,
     threshold: usize,
 ) {
-    if window == 0 || threshold == 0 || open_id == close_id { return; }
+    if window == 0 || threshold == 0 || open_id == close_id {
+        return;
+    }
     let start = history.len().saturating_sub(window);
     let mut depth: i32 = 0;
     for &t in &history[start..] {
-        if t == open_id { depth += 1; }
-        else if t == close_id && depth > 0 { depth -= 1; }
+        if t == open_id {
+            depth += 1;
+        } else if t == close_id && depth > 0 {
+            depth -= 1;
+        }
     }
     if depth >= threshold as i32 {
         if let Some(slot) = logits.get_mut(open_id as usize) {
@@ -271,7 +276,9 @@ struct AsstTurnCache {
 
 impl AsstTurnCache {
     fn new_from_env() -> Self {
-        let unbounded = std::env::var("HIPFIRE_PROMPT_CACHE_UNBOUNDED").ok().as_deref()
+        let unbounded = std::env::var("HIPFIRE_PROMPT_CACHE_UNBOUNDED")
+            .ok()
+            .as_deref()
             == Some("1");
         let cap = if unbounded {
             None
@@ -477,9 +484,7 @@ fn strip_think_for_fingerprint(s: &str) -> String {
 /// repair paths — we don't need round-tripping fidelity for malformed
 /// blocks since the fingerprint just needs to MATCH what the CLI sends
 /// back, and the CLI normalizes through the same parser.
-fn extract_tool_calls_from_text(
-    s: &str,
-) -> Vec<hipfire_runtime::prompt_frame::ToolCall> {
+fn extract_tool_calls_from_text(s: &str) -> Vec<hipfire_runtime::prompt_frame::ToolCall> {
     let mut out: Vec<hipfire_runtime::prompt_frame::ToolCall> = Vec::new();
     let mut search_pos = 0;
     while let Some(open_rel) = s[search_pos..].find("<tool_call>") {
@@ -587,10 +592,7 @@ fn extract_tool_call_name_fallback(s: &str) -> Option<String> {
         // boundary char. Skips false matches like the `name` substring
         // inside `firstname` / `lastname` / etc.
         let pre = if abs == 0 { b' ' } else { bytes[abs - 1] };
-        let pre_ok = matches!(
-            pre,
-            b'{' | b',' | b' ' | b'\n' | b'\t' | b'"' | b'\''
-        );
+        let pre_ok = matches!(pre, b'{' | b',' | b' ' | b'\n' | b'\t' | b'"' | b'\'');
         if !pre_ok {
             continue;
         }
@@ -793,11 +795,7 @@ fn write_canonical_json(v: &serde_json::Value, out: &mut String) {
 /// interpolation of error values — Rust's `Display` will pass through
 /// a `"` unchanged, and `Debug` actively wraps strings in escaped quotes,
 /// both of which break the surrounding JSON.
-fn emit_error_with_id(
-    stdout: &mut std::io::Stdout,
-    id: &str,
-    message: impl std::fmt::Display,
-) {
+fn emit_error_with_id(stdout: &mut std::io::Stdout, id: &str, message: impl std::fmt::Display) {
     let envelope = serde_json::json!({
         "type": "error",
         "id": id,
@@ -808,10 +806,7 @@ fn emit_error_with_id(
 }
 
 #[allow(dead_code)]
-fn emit_error_no_id(
-    stdout: &mut std::io::Stdout,
-    message: impl std::fmt::Display,
-) {
+fn emit_error_no_id(stdout: &mut std::io::Stdout, message: impl std::fmt::Display) {
     let envelope = serde_json::json!({
         "type": "error",
         "message": format!("{}", message),
@@ -879,9 +874,8 @@ fn emit_committed_event(
 ) {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    let on = *ENABLED.get_or_init(|| {
-        std::env::var("HIPFIRE_EMIT_TOKEN_IDS").ok().as_deref() == Some("1")
-    });
+    let on = *ENABLED
+        .get_or_init(|| std::env::var("HIPFIRE_EMIT_TOKEN_IDS").ok().as_deref() == Some("1"));
     if !on {
         return;
     }
@@ -908,12 +902,16 @@ fn gpu_block_attractor_token(
     window: usize,
     threshold: usize,
 ) {
-    if window == 0 || threshold == 0 { return; }
+    if window == 0 || threshold == 0 {
+        return;
+    }
     let start = history.len().saturating_sub(window);
     let count = history[start..].iter().filter(|&&t| t == tok_id).count();
     if count >= threshold {
         let bytes: [u8; 4] = f32::NEG_INFINITY.to_ne_bytes();
-        let _ = gpu.hip.memcpy_htod_offset(logits_buf, (tok_id as usize) * 4, &bytes);
+        let _ = gpu
+            .hip
+            .memcpy_htod_offset(logits_buf, (tok_id as usize) * 4, &bytes);
     }
 }
 
@@ -923,8 +921,7 @@ fn acquire_daemon_lock() -> std::fs::File {
     #[cfg(unix)]
     let home = std::env::var("HOME").expect("HOME environment variable not set");
     #[cfg(windows)]
-    let home = std::env::var("USERPROFILE")
-        .expect("USERPROFILE environment variable not set");
+    let home = std::env::var("USERPROFILE").expect("USERPROFILE environment variable not set");
 
     let hipfire_dir = std::path::PathBuf::from(home).join(".hipfire");
     std::fs::create_dir_all(&hipfire_dir).expect("failed to create ~/.hipfire");
@@ -1293,18 +1290,28 @@ fn main() {
         // compiler's writeback path fires. Without this, Gpu::init probes for
         // an existing dir and silently disables writeback if it's missing —
         // meaning fresh installs would compile but never cache cross-invocation.
-        if let Some(exe_dir) = std::env::current_exe().ok().and_then(|p| p.parent().map(|d| d.to_path_buf())) {
+        if let Some(exe_dir) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        {
             // Arch is unknown until Gpu::init; use a broad mkdir for the common arches
             // we support so the probe picks one up. The real arch check after init
             // will log the active dir.
-            for arch in ["gfx906", "gfx1010", "gfx1013", "gfx1030", "gfx1031", "gfx1100", "gfx1101", "gfx1102", "gfx1151", "gfx1152", "gfx1200", "gfx1201"] {
-                let _ = std::fs::create_dir_all(exe_dir.join("kernels").join("compiled").join(arch));
+            for arch in [
+                "gfx906", "gfx1010", "gfx1013", "gfx1030", "gfx1031", "gfx1100", "gfx1101",
+                "gfx1102", "gfx1151", "gfx1152", "gfx1200", "gfx1201",
+            ] {
+                let _ =
+                    std::fs::create_dir_all(exe_dir.join("kernels").join("compiled").join(arch));
             }
         }
         let mut gpu = match rdna_compute::Gpu::init() {
-        Ok(g) => g,
-        Err(e) => { report_gpu_init_failure(&e); std::process::exit(1); }
-    };
+            Ok(g) => g,
+            Err(e) => {
+                report_gpu_init_failure(&e);
+                std::process::exit(1);
+            }
+        };
         eprintln!("Pre-compiling kernels for {}...", gpu.arch);
         let mut errors = 0usize;
         for kv in &["asym3", "q8"] {
@@ -1331,7 +1338,10 @@ fn main() {
 
     let mut gpu = match rdna_compute::Gpu::init() {
         Ok(g) => g,
-        Err(e) => { report_gpu_init_failure(&e); std::process::exit(1); }
+        Err(e) => {
+            report_gpu_init_failure(&e);
+            std::process::exit(1);
+        }
     };
     let mut model: Option<LoadedModel> = None;
     // PFlash speculative-prefill state. None unless the load message
@@ -1367,7 +1377,9 @@ fn main() {
                 Ok(l) => l,
                 Err(_) => break,
             };
-            if line.trim().is_empty() { continue; }
+            if line.trim().is_empty() {
+                continue;
+            }
             match serde_json::from_str::<serde_json::Value>(&line) {
                 Ok(msg) => {
                     if msg.get("type").and_then(|v| v.as_str()) == Some("abort") {
@@ -1384,10 +1396,14 @@ fn main() {
                         }
                         continue;
                     }
-                    if msg_tx.send(DaemonMsg::Regular(msg)).is_err() { break; }
+                    if msg_tx.send(DaemonMsg::Regular(msg)).is_err() {
+                        break;
+                    }
                 }
                 Err(e) => {
-                    if msg_tx.send(DaemonMsg::ParseError(e.to_string())).is_err() { break; }
+                    if msg_tx.send(DaemonMsg::ParseError(e.to_string())).is_err() {
+                        break;
+                    }
                 }
             }
         }
@@ -1398,7 +1414,11 @@ fn main() {
         let msg = match daemon_msg {
             DaemonMsg::Regular(m) => m,
             DaemonMsg::ParseError(e) => {
-                let _ = writeln!(stdout, r#"{{"type":"error","message":"invalid JSON: {}"}}"#, e);
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"error","message":"invalid JSON: {}"}}"#,
+                    e
+                );
                 let _ = stdout.flush();
                 continue;
             }
@@ -1430,7 +1450,11 @@ fn main() {
                 }
 
                 let path = msg.get("model").and_then(|v| v.as_str()).unwrap_or("");
-                let max_seq = msg.get("params").and_then(|p| p.get("max_seq")).and_then(|v| v.as_u64()).unwrap_or(4096) as usize;
+                let max_seq = msg
+                    .get("params")
+                    .and_then(|p| p.get("max_seq"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(4096) as usize;
                 // Optional DFlash draft model path. When supplied AND the target
                 // is a Qwen3.5 arch (5 or 6), we load draft weights + scratch
                 // alongside the target and the temp=0 generate fast path routes
@@ -1443,41 +1467,68 @@ fn main() {
                 // primary path (saves the wire round-trip for the draft path
                 // string), but this guard makes the flag durable when the
                 // daemon is driven by a non-hipfire-CLI client.
-                let dflash_mode = msg.get("params").and_then(|p| p.get("dflash_mode"))
-                    .and_then(|v| v.as_str()).unwrap_or("auto");
-                let raw_draft = msg.get("params").and_then(|p| p.get("draft")).and_then(|v| v.as_str())
+                let dflash_mode = msg
+                    .get("params")
+                    .and_then(|p| p.get("dflash_mode"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("auto");
+                let raw_draft = msg
+                    .get("params")
+                    .and_then(|p| p.get("draft"))
+                    .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty());
                 let draft_path = if dflash_mode == "off" {
                     if raw_draft.is_some() {
-                        eprintln!("[hipfire-daemon] dflash_mode=off — skipping draft load ({})", raw_draft.unwrap());
+                        eprintln!(
+                            "[hipfire-daemon] dflash_mode=off — skipping draft load ({})",
+                            raw_draft.unwrap()
+                        );
                     }
                     None
                 } else {
                     raw_draft.map(|s| s.to_string())
                 };
-                let kv_mode_override = msg.get("params").and_then(|p| p.get("kv_mode")).and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty()).map(|s| s.to_string());
+                let kv_mode_override = msg
+                    .get("params")
+                    .and_then(|p| p.get("kv_mode"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
                 // Per-load adaptive-KV selector (mirrors kv_mode). Overrides the
                 // HIPFIRE_KV_ADAPTIVE env. off|conservative|balanced|aggressive|
                 // advanced:k=..,v=.. — resolved in load_model (param > env > off).
-                let kv_adaptive_override = msg.get("params").and_then(|p| p.get("kv_adaptive")).and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty()).map(|s| s.to_string());
+                let kv_adaptive_override = msg
+                    .get("params")
+                    .and_then(|p| p.get("kv_adaptive"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
 
                 // MTP speculative decode config. `mtp_mode` gates weight
                 // discovery at load time (off=skip, on=error-if-missing,
                 // auto=scan+log). `mtp_k` sets the draft window size.
-                let mtp_mode = msg.get("params").and_then(|p| p.get("mtp_mode"))
-                    .and_then(|v| v.as_str()).unwrap_or("auto").to_string();
-                let mtp_k: usize = msg.get("params").and_then(|p| p.get("mtp_k"))
-                    .and_then(|v| v.as_u64()).unwrap_or(3) as usize;
+                let mtp_mode = msg
+                    .get("params")
+                    .and_then(|p| p.get("mtp_mode"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("auto")
+                    .to_string();
+                let mtp_k: usize = msg
+                    .get("params")
+                    .and_then(|p| p.get("mtp_k"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(3) as usize;
 
                 // 0.1.7-alpha: DFlash tuning knobs forwarded from the CLI.
                 // `adaptive_b` matches dflash_spec_demo's --adaptive-b default.
                 // Accepted here; the generate loop will honor it in the
                 // 0.1.7-stable release where we port the demo's outer τ-window
                 // trip-wire (below 2.5 → shrink block to 8).
-                let _adaptive_b = msg.get("params").and_then(|p| p.get("dflash_adaptive_b"))
-                    .and_then(|v| v.as_bool()).unwrap_or(true);
+                let _adaptive_b = msg
+                    .get("params")
+                    .and_then(|p| p.get("dflash_adaptive_b"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
 
                 // 0.1.7: TriAttention / CASK eviction protocol fields. When
                 // `cask_sidecar` is set, `load_model` sizes the KV cache to a
@@ -1487,18 +1538,37 @@ fn main() {
                 // That decouples advertised context length from VRAM footprint —
                 // a 128K max_seq can run in ~1K-slot physical buffer when the
                 // operator opts in.
-                let cask_sidecar = msg.get("params").and_then(|p| p.get("cask_sidecar"))
-                    .and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
-                let cask_enabled = msg.get("params").and_then(|p| p.get("cask"))
-                    .and_then(|v| v.as_bool()).unwrap_or(false);
-                let cask_budget = msg.get("params").and_then(|p| p.get("cask_budget"))
-                    .and_then(|v| v.as_u64()).unwrap_or(512) as usize;
-                let cask_beta = msg.get("params").and_then(|p| p.get("cask_beta"))
-                    .and_then(|v| v.as_u64()).unwrap_or(128) as usize;
-                let cask_core_frac = msg.get("params").and_then(|p| p.get("cask_core_frac"))
-                    .and_then(|v| v.as_f64()).unwrap_or(0.5) as f32;
-                let cask_fold_m = msg.get("params").and_then(|p| p.get("cask_fold_m"))
-                    .and_then(|v| v.as_u64()).unwrap_or(2) as usize;
+                let cask_sidecar = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask_sidecar"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
+                let cask_enabled = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let cask_budget = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask_budget"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(512) as usize;
+                let cask_beta = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask_beta"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(128) as usize;
+                let cask_core_frac = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask_core_frac"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.5) as f32;
+                let cask_fold_m = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask_fold_m"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(2) as usize;
                 // Known-broken combo guard: CASK m-folding + DFlash spec decode
                 // degenerates into single-token loops after the first eviction
                 // (the m-folded synthetic K/V rows are off the draft's trained
@@ -1527,10 +1597,18 @@ fn main() {
                 // cause Q8_1 precision loss and fall back to WMMA for those
                 // weights. Disabled by default; enable with mmq_screen=true
                 // (or HIPFIRE_MMQ_SCREEN=1) when adding new quant formats.
-                if let Some(v) = msg.get("params").and_then(|p| p.get("mmq_screen")).and_then(|v| v.as_bool()) {
+                if let Some(v) = msg
+                    .get("params")
+                    .and_then(|p| p.get("mmq_screen"))
+                    .and_then(|v| v.as_bool())
+                {
                     gpu.mmq_screen.enabled = v;
                 }
-                if let Some(v) = msg.get("params").and_then(|p| p.get("mmq_screen_threshold")).and_then(|v| v.as_f64()) {
+                if let Some(v) = msg
+                    .get("params")
+                    .and_then(|p| p.get("mmq_screen_threshold"))
+                    .and_then(|v| v.as_f64())
+                {
                     gpu.mmq_screen.threshold = v as f32;
                 }
 
@@ -1541,32 +1619,70 @@ fn main() {
                 // optional drafter that PFlash uses for prompt scoring.
                 // Drafter loading happens AFTER target load succeeds so
                 // we can use the target's tokenizer for the compat check.
-                let pflash_mode_str = msg.get("params").and_then(|p| p.get("prefill_compression"))
-                    .and_then(|v| v.as_str()).unwrap_or("off").to_string();
-                let pflash_threshold = msg.get("params").and_then(|p| p.get("prefill_threshold"))
-                    .and_then(|v| v.as_u64()).unwrap_or(32768) as usize;
-                let pflash_keep_ratio = msg.get("params").and_then(|p| p.get("prefill_keep_ratio"))
-                    .and_then(|v| v.as_f64()).unwrap_or(0.05) as f32;
-                let pflash_alpha = msg.get("params").and_then(|p| p.get("prefill_alpha"))
-                    .and_then(|v| v.as_f64()).unwrap_or(0.85) as f32;
-                let pflash_min_keep = msg.get("params").and_then(|p| p.get("prefill_min_keep"))
-                    .and_then(|v| v.as_u64()).unwrap_or(2048) as usize;
-                let pflash_sink = msg.get("params").and_then(|p| p.get("prefill_sink"))
-                    .and_then(|v| v.as_u64()).unwrap_or(256) as usize;
-                let pflash_recent = msg.get("params").and_then(|p| p.get("prefill_recent"))
-                    .and_then(|v| v.as_u64()).unwrap_or(1024) as usize;
-                let pflash_block = msg.get("params").and_then(|p| p.get("prefill_block"))
-                    .and_then(|v| v.as_u64()).unwrap_or(128) as usize;
-                let pflash_drafter = msg.get("params").and_then(|p| p.get("prefill_drafter"))
-                    .and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
+                let pflash_mode_str = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_compression"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("off")
+                    .to_string();
+                let pflash_threshold = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_threshold"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(32768) as usize;
+                let pflash_keep_ratio = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_keep_ratio"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.05) as f32;
+                let pflash_alpha = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_alpha"))
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.85) as f32;
+                let pflash_min_keep = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_min_keep"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(2048) as usize;
+                let pflash_sink = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_sink"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(256) as usize;
+                let pflash_recent = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_recent"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1024) as usize;
+                let pflash_block = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_block"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(128) as usize;
+                let pflash_drafter = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_drafter"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
                 // -1 = drafter shares the target gpu (default). >=0 routes
                 // the drafter to that HIP device for hetero compress.
-                let pflash_drafter_device: i32 = msg.get("params").and_then(|p| p.get("prefill_drafter_device"))
-                    .and_then(|v| v.as_i64()).unwrap_or(-1) as i32;
-                let pflash_profile = msg.get("params").and_then(|p| p.get("prefill_profile"))
-                    .and_then(|v| v.as_bool()).unwrap_or(false);
-                let pflash_sparse_threshold = msg.get("params").and_then(|p| p.get("prefill_sparse_threshold"))
-                    .and_then(|v| v.as_u64()).unwrap_or(32768) as usize;
+                let pflash_drafter_device: i32 = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_drafter_device"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(-1) as i32;
+                let pflash_profile = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_profile"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let pflash_sparse_threshold = msg
+                    .get("params")
+                    .and_then(|p| p.get("prefill_sparse_threshold"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(32768) as usize;
 
                 // Validate load-time PFlash params before they reach
                 // PflashConfig + load_drafter. Same range rules the
@@ -1575,44 +1691,74 @@ fn main() {
                 // panic the daemon at the first generate request.
                 let pflash_load_err: Option<String> =
                     if !(pflash_keep_ratio > 0.0 && pflash_keep_ratio <= 1.0) {
-                        Some(format!("prefill_keep_ratio={pflash_keep_ratio} not in (0, 1]"))
+                        Some(format!(
+                            "prefill_keep_ratio={pflash_keep_ratio} not in (0, 1]"
+                        ))
                     } else if pflash_block == 0 {
                         Some("prefill_block must be > 0".to_string())
-                    } else { None };
+                    } else {
+                        None
+                    };
 
                 // Pipeline-parallel degree (Stage 7 of #58). Default 1 =
                 // single-GPU (no behavior change). pp > 1 routes through
                 // Gpus + *_multi paths and refuses VL / DFlash / CASK /
                 // PFlash at load time. v1 supports Qwen3.5 dense + MoE
                 // only — see load_model_pp for the arch_id check.
-                let pp = msg.get("params").and_then(|p| p.get("pp"))
-                    .and_then(|v| v.as_u64()).unwrap_or(1) as usize;
+                let pp = msg
+                    .get("params")
+                    .and_then(|p| p.get("pp"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1) as usize;
                 if pp > 1 {
                     if draft_path.is_some()
                         && std::env::var("HIPFIRE_PP_DFLASH").ok().as_deref() != Some("1")
                     {
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"DFlash speculative decode requires pp=1 in v1 (set HIPFIRE_PP_DFLASH=1 to opt into the experimental pp>1 PRD path; note PR2-4 of docs/plans/hetero-pflash-dflash.prd are not yet implemented — the load message will accept but generate will not run cross-card spec-decode). See issue #58 v1.1 roadmap."}}"#);
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","message":"DFlash speculative decode requires pp=1 in v1 (set HIPFIRE_PP_DFLASH=1 to opt into the experimental pp>1 PRD path; note PR2-4 of docs/plans/hetero-pflash-dflash.prd are not yet implemented — the load message will accept but generate will not run cross-card spec-decode). See issue #58 v1.1 roadmap."}}"#
+                        );
                         let _ = stdout.flush();
                         continue;
                     }
                     if cask.sidecar.is_some() {
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"CASK / TriAttention eviction requires pp=1 in v1; see issue #58 v1.1 roadmap"}}"#);
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","message":"CASK / TriAttention eviction requires pp=1 in v1; see issue #58 v1.1 roadmap"}}"#
+                        );
                         let _ = stdout.flush();
                         continue;
                     }
                     if (pflash_drafter.is_some() || pflash_mode_str != "off")
                         && std::env::var("HIPFIRE_PP_PFLASH").ok().as_deref() != Some("1")
                     {
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"PFlash prefill compression requires pp=1 in v1 (set HIPFIRE_PP_PFLASH=1 to opt into the experimental pp>1 PoC); see issue #58 v1.1 roadmap"}}"#);
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","message":"PFlash prefill compression requires pp=1 in v1 (set HIPFIRE_PP_PFLASH=1 to opt into the experimental pp>1 PoC); see issue #58 v1.1 roadmap"}}"#
+                        );
                         let _ = stdout.flush();
                         continue;
                     }
                 }
 
-                let state_quant_override = msg.get("params").and_then(|p| p.get("state_quant")).and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty()).map(|s| s.to_string());
+                let state_quant_override = msg
+                    .get("params")
+                    .and_then(|p| p.get("state_quant"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
 
-                match load_model(path, max_seq, draft_path.as_deref(), kv_mode_override.as_deref(), kv_adaptive_override.as_deref(), state_quant_override.as_deref(), &cask, pp, &mut gpu) {
+                match load_model(
+                    path,
+                    max_seq,
+                    draft_path.as_deref(),
+                    kv_mode_override.as_deref(),
+                    kv_adaptive_override.as_deref(),
+                    state_quant_override.as_deref(),
+                    &cask,
+                    pp,
+                    &mut gpu,
+                ) {
                     Ok(mut m) => {
                         let arch = match m.arch_id {
                             5 => "qwen3_5",
@@ -1630,8 +1776,14 @@ fn main() {
                         } else if let Some(ref c) = m.qwen2_config {
                             (c.hidden_size, c.num_hidden_layers, c.vocab_size)
                         } else if let Some(ref c) = m.dots_ocr_config {
-                            (c.text.hidden_size, c.text.num_hidden_layers, c.text.vocab_size)
-                        } else { (0, 0, 0) };
+                            (
+                                c.text.hidden_size,
+                                c.text.num_hidden_layers,
+                                c.text.vocab_size,
+                            )
+                        } else {
+                            (0, 0, 0)
+                        };
 
                         // Apply MTP config from load-message params.
                         m.mtp_mode = mtp_mode;
@@ -1639,7 +1791,8 @@ fn main() {
                         // Detect whether MTP weights are present in the loaded
                         // model (DeepSeek V4 only today). Used by mtp_mode=auto
                         // to decide whether to enable spec-decode at generate time.
-                        m.mtp_weights_present = m.deepseek4_weights
+                        m.mtp_weights_present = m
+                            .deepseek4_weights
                             .as_ref()
                             .and_then(|w| w.mtp_layer.as_ref())
                             .is_some();
@@ -1688,7 +1841,11 @@ fn main() {
                         // installed CLI predated the allowlist. Source of truth
                         // lives here, next to the cache implementation.
                         let cache_capable = matches!(m.arch_id, 5 | 6 | 9);
-                        let _ = writeln!(stdout, r#"{{"type":"loaded","arch":"{}","dim":{},"layers":{},"vocab":{},"vl":{},"cache_capable":{}}}"#, arch, dim, layers, vocab, vl, cache_capable);
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"loaded","arch":"{}","dim":{},"layers":{},"vocab":{},"vl":{},"cache_capable":{}}}"#,
+                            arch, dim, layers, vocab, vl, cache_capable
+                        );
 
                         // ── PFlash drafter load (Phase 4.0) ──────────────
                         //
@@ -1701,16 +1858,20 @@ fn main() {
                         if let Some(ref pf_drafter_path) = pflash_drafter {
                             if pflash_mode_str != "off" {
                                 if let Some(ref reason) = pflash_load_err {
-                                    let _ = writeln!(stdout,
+                                    let _ = writeln!(
+                                        stdout,
                                         r#"{{"type":"pflash_load_failed","reason":"invalid load param: {}"}}"#,
-                                        reason.replace('"', "'"));
+                                        reason.replace('"', "'")
+                                    );
                                     let _ = stdout.flush();
                                     model = Some(m);
                                     continue;
                                 }
                                 let pf_cfg = hipfire_arch_qwen35::pflash::PflashConfig {
-                                    mode: hipfire_arch_qwen35::pflash::PflashMode::parse(&pflash_mode_str)
-                                        .unwrap_or(hipfire_arch_qwen35::pflash::PflashMode::Off),
+                                    mode: hipfire_arch_qwen35::pflash::PflashMode::parse(
+                                        &pflash_mode_str,
+                                    )
+                                    .unwrap_or(hipfire_arch_qwen35::pflash::PflashMode::Off),
                                     threshold_tokens: pflash_threshold,
                                     keep_ratio: pflash_keep_ratio,
                                     alpha: pflash_alpha,
@@ -1722,7 +1883,8 @@ fn main() {
                                     drafter_path: Some(pf_drafter_path.clone()),
                                     sparse_threshold: pflash_sparse_threshold,
                                 };
-                                let mut pf_state = hipfire_arch_qwen35::pflash::PflashState::new(&pf_cfg);
+                                let mut pf_state =
+                                    hipfire_arch_qwen35::pflash::PflashState::new(&pf_cfg);
                                 // Pull the target tokenizer out of the loaded model
                                 // for the compat check. Both Qwen3.5 and plain
                                 // Qwen3 paths expose `tokenizer` on LoadedModel.
@@ -1736,45 +1898,62 @@ fn main() {
                                     // on target. -1 / 0 => share target gpu (unchanged).
                                     let mut sibling: Option<rdna_compute::Gpu> = None;
                                     if pflash_drafter_device > 0 {
-                                        match rdna_compute::Gpu::init_with_device(pflash_drafter_device) {
+                                        match rdna_compute::Gpu::init_with_device(
+                                            pflash_drafter_device,
+                                        ) {
                                             Ok(g) => sibling = Some(g),
                                             Err(e) => {
-                                                let _ = writeln!(stdout,
+                                                let _ = writeln!(
+                                                    stdout,
                                                     r#"{{"type":"pflash_load_failed","reason":"drafter device {} init: {}"}}"#,
-                                                    pflash_drafter_device, e.to_string().replace('"', "'"));
+                                                    pflash_drafter_device,
+                                                    e.to_string().replace('"', "'")
+                                                );
                                             }
                                         }
                                     }
-                                    let dg: &mut rdna_compute::Gpu = sibling.as_mut().unwrap_or(&mut gpu);
+                                    let dg: &mut rdna_compute::Gpu =
+                                        sibling.as_mut().unwrap_or(&mut gpu);
                                     dg.bind_thread_or_warn();
                                     match hipfire_arch_qwen35::pflash::load_drafter(
-                                        &mut pf_state, dg,
+                                        &mut pf_state,
+                                        dg,
                                         std::path::Path::new(pf_drafter_path),
-                                        tok, pf_max_kv,
+                                        tok,
+                                        pf_max_kv,
                                     ) {
                                         Ok(()) => {
                                             eprintln!("[pflash] LOADED drafter={} dev={} mode={} compat={} keep={} thr={}",
                                                 pf_drafter_path, pflash_drafter_device, pflash_mode_str,
                                                 pf_state.tokenizer_compat, pflash_keep_ratio, pflash_threshold);
-                                            let _ = writeln!(stdout,
+                                            let _ = writeln!(
+                                                stdout,
                                                 r#"{{"type":"pflash","mode":"{}","drafter":"{}","drafter_device":{},"tokenizer_compat":{},"keep_ratio":{},"threshold":{}}}"#,
-                                                pflash_mode_str, pf_drafter_path, pflash_drafter_device,
+                                                pflash_mode_str,
+                                                pf_drafter_path,
+                                                pflash_drafter_device,
                                                 pf_state.tokenizer_compat,
-                                                pflash_keep_ratio, pflash_threshold);
+                                                pflash_keep_ratio,
+                                                pflash_threshold
+                                            );
                                             pflash_state = Some(pf_state);
                                             pflash_cfg = Some(pf_cfg);
                                             pflash_drafter_gpu = sibling; // persist sibling across requests (None if shared)
                                         }
                                         Err(e) => {
                                             eprintln!("[pflash] LOAD FAILED: {}", e);
-                                            let _ = writeln!(stdout,
+                                            let _ = writeln!(
+                                                stdout,
                                                 r#"{{"type":"pflash_load_failed","reason":"{}"}}"#,
-                                                e.to_string().replace('"', "'"));
+                                                e.to_string().replace('"', "'")
+                                            );
                                         }
                                     }
                                 } else {
-                                    let _ = writeln!(stdout,
-                                        r#"{{"type":"pflash_load_failed","reason":"target tokenizer unavailable"}}"#);
+                                    let _ = writeln!(
+                                        stdout,
+                                        r#"{{"type":"pflash_load_failed","reason":"target tokenizer unavailable"}}"#
+                                    );
                                 }
                             }
                         }
@@ -1798,18 +1977,24 @@ fn main() {
                 let m = match model.as_mut() {
                     Some(m) => m,
                     None => {
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"no model loaded"}}"#);
+                        let _ =
+                            writeln!(stdout, r#"{{"type":"error","message":"no model loaded"}}"#);
                         let _ = stdout.flush();
                         continue;
                     }
                 };
 
                 let id = msg.get("id").and_then(|v| v.as_str()).unwrap_or("0");
-                let prompt = msg.get("prompt").and_then(|v| v.as_str()).unwrap_or("Hello");
+                let prompt = msg
+                    .get("prompt")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Hello");
                 let prompt_norm = hipfire_runtime::tokenizer::maybe_normalize_prompt(prompt);
                 let prompt: &str = &prompt_norm;
                 if std::env::var("HIPFIRE_PROMPT_TOKEN_HEAT").ok().as_deref() == Some("1") {
-                    if let Some(tok) = m.tokenizer.as_ref() { tok.dump_prompt_heat(prompt); }
+                    if let Some(tok) = m.tokenizer.as_ref() {
+                        tok.dump_prompt_heat(prompt);
+                    }
                 }
                 let system = msg.get("system").and_then(|v| v.as_str());
                 let image = msg.get("image").and_then(|v| v.as_str());
@@ -1836,7 +2021,8 @@ fn main() {
                             let _ = writeln!(
                                 stdout,
                                 r#"{{"type":"error","id":"{}","message":"invalid tools field: {}"}}"#,
-                                id, e.to_string().replace('"', "'"),
+                                id,
+                                e.to_string().replace('"', "'"),
                             );
                             let _ = stdout.flush();
                             continue;
@@ -1844,41 +2030,49 @@ fn main() {
                     },
                     None => None,
                 };
-                let messages_history: Option<Vec<hipfire_runtime::prompt_frame::Message>> = match msg.get("messages") {
-                    Some(v) => match serde_json::from_value::<Vec<hipfire_runtime::prompt_frame::Message>>(v.clone()) {
-                        Ok(mut m) => {
-                            // Apply the same normalization to each message's
-                            // content that the daemon applies to `prompt` at
-                            // line 1384 (`maybe_normalize_prompt`: strip
-                            // trailing whitespace before `\n`, collapse 3+
-                            // newlines to 2, etc.). Without this, turn N's
-                            // `prompt`-encoded user tokens diverge from turn
-                            // N+1's `messages[].content`-encoded history
-                            // tokens, breaking the LCP cache on any prompt
-                            // whose raw text has trailing whitespace or
-                            // run-of-newlines patterns.
-                            for entry in &mut m {
-                                if !entry.content.is_empty() {
-                                    let normalized = hipfire_runtime::tokenizer::maybe_normalize_prompt(&entry.content);
-                                    if matches!(normalized, std::borrow::Cow::Owned(_)) {
-                                        entry.content = normalized.into_owned();
+                let messages_history: Option<Vec<hipfire_runtime::prompt_frame::Message>> =
+                    match msg.get("messages") {
+                        Some(v) => match serde_json::from_value::<
+                            Vec<hipfire_runtime::prompt_frame::Message>,
+                        >(v.clone())
+                        {
+                            Ok(mut m) => {
+                                // Apply the same normalization to each message's
+                                // content that the daemon applies to `prompt` at
+                                // line 1384 (`maybe_normalize_prompt`: strip
+                                // trailing whitespace before `\n`, collapse 3+
+                                // newlines to 2, etc.). Without this, turn N's
+                                // `prompt`-encoded user tokens diverge from turn
+                                // N+1's `messages[].content`-encoded history
+                                // tokens, breaking the LCP cache on any prompt
+                                // whose raw text has trailing whitespace or
+                                // run-of-newlines patterns.
+                                for entry in &mut m {
+                                    if !entry.content.is_empty() {
+                                        let normalized =
+                                            hipfire_runtime::tokenizer::maybe_normalize_prompt(
+                                                &entry.content,
+                                            );
+                                        if matches!(normalized, std::borrow::Cow::Owned(_)) {
+                                            entry.content = normalized.into_owned();
+                                        }
                                     }
                                 }
+                                Some(m)
                             }
-                            Some(m)
-                        }
-                        Err(e) => {
-                            let _ = writeln!(
-                                stdout,
-                                r#"{{"type":"error","id":"{}","message":"invalid messages field: {}"}}"#,
-                                id, e.to_string().replace('"', "'"),
-                            );
-                            let _ = stdout.flush();
-                            continue;
-                        }
-                    },
-                    None => None,
-                };
+                            Err(e) => {
+                                let _ = writeln!(
+                                    stdout,
+                                    r#"{{"type":"error","id":"{}","message":"invalid messages field: {}"}}"#,
+                                    id,
+                                    e.to_string().replace('"', "'"),
+                                );
+                                let _ = stdout.flush();
+                                continue;
+                            }
+                        },
+                        None => None,
+                    };
                 // Sampling defaults differ by arch: qwen35 family was tuned
                 // at `temp=0.3, top_p=0.8` (DFlash-friendly, instruct-stable);
                 // DeepSeek V4 Flash's HF card recommends `temp=1.0, top_p=1.0`
@@ -1892,9 +2086,18 @@ fn main() {
                 } else {
                     (0.3_f64, 0.8_f64)
                 };
-                let temp = msg.get("temperature").and_then(|v| v.as_f64()).unwrap_or(default_temp) as f32;
-                let max_tokens = msg.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(4096) as usize;
-                let top_p = msg.get("top_p").and_then(|v| v.as_f64()).unwrap_or(default_top_p) as f32;
+                let temp = msg
+                    .get("temperature")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(default_temp) as f32;
+                let max_tokens = msg
+                    .get("max_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(4096) as usize;
+                let top_p = msg
+                    .get("top_p")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(default_top_p) as f32;
                 // Default 1.0 (off). Matches llama.cpp `--repeat-penalty 1.0`
                 // and HF transformers `generate(repetition_penalty=1.0)`
                 // defaults. The prior 1.3 default suppressed legitimately
@@ -1906,7 +2109,10 @@ fn main() {
                 // Root cause writeup: issue #258 comment "Bug B root cause"
                 // and docs/investigations/2026-05-15-9b-reasoning-loop/.
                 // Clients can still opt in to a non-1.0 value per request.
-                let repeat_penalty = msg.get("repeat_penalty").and_then(|v| v.as_f64()).unwrap_or(1.0) as f32;
+                let repeat_penalty = msg
+                    .get("repeat_penalty")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(1.0) as f32;
                 // OpenAI-compatible `reasoning_effort` (also accept our custom
                 // `thinking_mode` alias) — only consumed by arch_id=9 today.
                 // Default = NonThink, matching the safe HF chat frame.
@@ -1916,7 +2122,10 @@ fn main() {
                     .and_then(|v| v.as_str())
                     .map(ThinkMode::from_str)
                     .unwrap_or(ThinkMode::NonThink);
-                let repeat_window = msg.get("repeat_window").and_then(|v| v.as_u64()).unwrap_or(128) as usize;
+                let repeat_window = msg
+                    .get("repeat_window")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(128) as usize;
                 // Experimental: inject a nudge string at a specific generated-
                 // token count. The nudge tokens get forward-fed through the KV
                 // cache so the model "sees" them as part of its own trajectory,
@@ -1931,13 +2140,25 @@ fn main() {
                 // (`experimental_budget_alert: true` → HIPFIRE_EXPERIMENTAL_
                 // BUDGET_ALERT=1 set by the CLI). Research use only; not a
                 // stable contract.
-                let experimental_ok = std::env::var("HIPFIRE_EXPERIMENTAL_BUDGET_ALERT").ok().as_deref() == Some("1");
+                let experimental_ok = std::env::var("HIPFIRE_EXPERIMENTAL_BUDGET_ALERT")
+                    .ok()
+                    .as_deref()
+                    == Some("1");
                 let budget_alert_at_tok = if experimental_ok {
-                    msg.get("budget_alert_at_tok").and_then(|v| v.as_u64()).unwrap_or(0) as usize
-                } else { 0 };
+                    msg.get("budget_alert_at_tok")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize
+                } else {
+                    0
+                };
                 let budget_alert_text = if experimental_ok {
-                    msg.get("budget_alert_text").and_then(|v| v.as_str()).unwrap_or("").to_string()
-                } else { String::new() };
+                    msg.get("budget_alert_text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string()
+                } else {
+                    String::new()
+                };
                 // Budget for tokens emitted INSIDE the model's <think>...</think>
                 // block. 0 = uncapped (model thinks until it naturally closes).
                 // Triggered from the CLI by per-model `max_think_tokens` config,
@@ -1953,15 +2174,19 @@ fn main() {
                 // shipping in genParams since cli/index.ts but the daemon
                 // was silently ignoring it, making the new reasoning.effort
                 // / enable_thinking knobs no-ops on the wire.
-                let max_think_tokens = msg.get("max_think_tokens")
-                    .and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                let max_think_tokens = msg
+                    .get("max_think_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as usize;
 
                 // assistant_prefix: "plain", "open_think", or "closed_think"
                 // Controls the ChatML framing after the assistant role header.
                 // Consumed by the text path; VL path does not yet propagate
                 // it (tracked as a follow-up to the post-#169 rebase).
-                let assistant_prefix = match msg.get("assistant_prefix")
-                    .and_then(|v| v.as_str()).unwrap_or("plain")
+                let assistant_prefix = match msg
+                    .get("assistant_prefix")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("plain")
                 {
                     "open_think" => hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink,
                     "closed_think" => hipfire_runtime::prompt_frame::AssistantPrefix::ClosedThink,
@@ -1996,24 +2221,44 @@ fn main() {
                         m.prefill_checkpoints.clear();
                         m.dflash_checkpoints.clear();
                         if let Some(ref dn) = m.dn_state {
-                            for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                            for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                            for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                            for s in &dn.s_matrices {
+                                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                            }
+                            for s in &dn.s_scales {
+                                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                            }
+                            for s in &dn.conv_states {
+                                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                            }
                         }
-                        if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
-                        if let Some(kv) = m.llama_kv.as_mut() { kv.compact_offset = 0; }
-                        if let Some(ref mut s) = m.qwen2_state { s.reset(); }
-                        if let Some(ref mut s) = m.deepseek4_state { s.reset(); }
+                        if let Some(kv) = m.kv_cache.as_mut() {
+                            kv.compact_offset = 0;
+                        }
+                        if let Some(kv) = m.llama_kv.as_mut() {
+                            kv.compact_offset = 0;
+                        }
+                        if let Some(ref mut s) = m.qwen2_state {
+                            s.reset();
+                        }
+                        if let Some(ref mut s) = m.deepseek4_state {
+                            s.reset();
+                        }
                     }
                     if image_base64.is_some() && image.is_some() {
-                        eprintln!("[daemon/vl] both image and image_base64 provided — using image_base64");
+                        eprintln!(
+                            "[daemon/vl] both image and image_base64 provided — using image_base64"
+                        );
                     }
                     let source = if let Some(b64) = image_base64 {
                         if b64.len() > MAX_BASE64_ENCODED_LEN {
-                            write_error(&mut stdout, id, &format!(
-                                "image payload exceeds maximum encoded size ({} bytes)",
-                                MAX_BASE64_ENCODED_LEN,
-                            ));
+                            write_error(
+                                &mut stdout,
+                                id,
+                                &format!(
+                                    "image payload exceeds maximum encoded size ({} bytes)",
+                                    MAX_BASE64_ENCODED_LEN,
+                                ),
+                            );
                             continue;
                         }
                         ImageSource::Base64(b64)
@@ -2026,10 +2271,21 @@ fn main() {
                     // without needing the full `ThinkState` extraction. Text
                     // path keeps unwrap_or(0) — it has different defaults
                     // controlled per-model on the CLI side.
-                    let vl_max_think_tokens = if max_think_tokens == 0 { 256 } else { max_think_tokens };
+                    let vl_max_think_tokens = if max_think_tokens == 0 {
+                        256
+                    } else {
+                        max_think_tokens
+                    };
                     let params = GenerateVLParams {
-                        id, prompt, system_prompt: system, image_source: source,
-                        temp, top_p, max_tokens, repeat_penalty, repeat_window,
+                        id,
+                        prompt,
+                        system_prompt: system,
+                        image_source: source,
+                        temp,
+                        top_p,
+                        max_tokens,
+                        repeat_penalty,
+                        repeat_window,
                         max_think_tokens: vl_max_think_tokens,
                     };
                     if is_dots_ocr {
@@ -2051,31 +2307,61 @@ fn main() {
                     let mut pf_override_err: Option<String> = None;
                     let pf_cfg_owned = pflash_cfg.as_ref().map(|base| {
                         let mut c = base.clone();
-                        if let Some(s) = msg.get("params").and_then(|p| p.get("prefill_compression")).and_then(|v| v.as_str()) {
-                            if let Some(m) = hipfire_arch_qwen35::pflash::PflashMode::parse(s) { c.mode = m; }
+                        if let Some(s) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_compression"))
+                            .and_then(|v| v.as_str())
+                        {
+                            if let Some(m) = hipfire_arch_qwen35::pflash::PflashMode::parse(s) {
+                                c.mode = m;
+                            }
                         }
-                        if let Some(v) = msg.get("params").and_then(|p| p.get("prefill_threshold")).and_then(|v| v.as_u64()) {
+                        if let Some(v) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_threshold"))
+                            .and_then(|v| v.as_u64())
+                        {
                             c.threshold_tokens = v as usize;
                         }
-                        if let Some(v) = msg.get("params").and_then(|p| p.get("prefill_keep_ratio")).and_then(|v| v.as_f64()) {
+                        if let Some(v) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_keep_ratio"))
+                            .and_then(|v| v.as_f64())
+                        {
                             let r = v as f32;
                             if !(r > 0.0 && r <= 1.0) {
-                                pf_override_err = Some(format!(
-                                    "prefill_keep_ratio={r} not in (0, 1]"));
+                                pf_override_err =
+                                    Some(format!("prefill_keep_ratio={r} not in (0, 1]"));
                             } else {
                                 c.keep_ratio = r;
                             }
                         }
-                        if let Some(v) = msg.get("params").and_then(|p| p.get("prefill_min_keep")).and_then(|v| v.as_u64()) {
+                        if let Some(v) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_min_keep"))
+                            .and_then(|v| v.as_u64())
+                        {
                             c.min_keep_tokens = v as usize;
                         }
-                        if let Some(v) = msg.get("params").and_then(|p| p.get("prefill_sink")).and_then(|v| v.as_u64()) {
+                        if let Some(v) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_sink"))
+                            .and_then(|v| v.as_u64())
+                        {
                             c.sink_tokens = v as usize;
                         }
-                        if let Some(v) = msg.get("params").and_then(|p| p.get("prefill_recent")).and_then(|v| v.as_u64()) {
+                        if let Some(v) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_recent"))
+                            .and_then(|v| v.as_u64())
+                        {
                             c.recent_tokens = v as usize;
                         }
-                        if let Some(v) = msg.get("params").and_then(|p| p.get("prefill_block")).and_then(|v| v.as_u64()) {
+                        if let Some(v) = msg
+                            .get("params")
+                            .and_then(|p| p.get("prefill_block"))
+                            .and_then(|v| v.as_u64())
+                        {
                             let b = v as usize;
                             if b == 0 {
                                 pf_override_err = Some("prefill_block must be > 0".to_string());
@@ -2089,15 +2375,28 @@ fn main() {
                         let _ = writeln!(
                             stdout,
                             r#"{{"type":"error","id":"{}","message":"invalid pflash override: {}"}}"#,
-                            id, reason.replace('"', "'"),
+                            id,
+                            reason.replace('"', "'"),
                         );
                         let _ = stdout.flush();
                         continue;
                     }
                     generate(
-                        m, &mut gpu, pflash_drafter_gpu.as_mut(), &mut stdout, id, prompt, system,
-                        temp, top_p, max_tokens, repeat_penalty, repeat_window,
-                        budget_alert_at_tok, &budget_alert_text, max_think_tokens,
+                        m,
+                        &mut gpu,
+                        pflash_drafter_gpu.as_mut(),
+                        &mut stdout,
+                        id,
+                        prompt,
+                        system,
+                        temp,
+                        top_p,
+                        max_tokens,
+                        repeat_penalty,
+                        repeat_window,
+                        budget_alert_at_tok,
+                        &budget_alert_text,
+                        max_think_tokens,
                         assistant_prefix,
                         pflash_state.as_mut(),
                         pf_cfg_owned.as_ref(),
@@ -2159,14 +2458,20 @@ fn main() {
                             let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
                         }
                     }
-                    if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
-                    if let Some(kv) = m.llama_kv.as_mut() { kv.compact_offset = 0; }
+                    if let Some(kv) = m.kv_cache.as_mut() {
+                        kv.compact_offset = 0;
+                    }
+                    if let Some(kv) = m.llama_kv.as_mut() {
+                        kv.compact_offset = 0;
+                    }
                     // arch_id=7: rewind the Qwen2State position cursor so
                     // the next prefill writes from KV[0]. Without this, a
                     // reset between turns would leak the prior turn's KV
                     // entries into attention for the new turn — fluent
                     // garbage, no panic. See `Qwen2State::reset` doc.
-                    if let Some(ref mut s) = m.qwen2_state { s.reset(); }
+                    if let Some(ref mut s) = m.qwen2_state {
+                        s.reset();
+                    }
                     // arch_id=9: same rationale for DeepSeek V4. Prior to
                     // 2026-05-24 the V4F state was NEVER reset, so
                     // `state.n_tokens` accumulated across requests and
@@ -2234,27 +2539,73 @@ fn main() {
                 let (vram_free, vram_total) = gpu.hip.get_vram_info().unwrap_or((0, 0));
                 let hip_ver = gpu.hip.runtime_version().unwrap_or((0, 0));
                 let has_model = model.is_some();
-                let model_arch = model.as_ref().map(|m| match m.arch_id {
-                    5 => "qwen3_5",
-                    6 => "qwen3_5_moe",
-                    7 => "qwen2",
-                    9 => "deepseek4",
-                    _ => "qwen3",
-                }).unwrap_or("none");
+                let model_arch = model
+                    .as_ref()
+                    .map(|m| match m.arch_id {
+                        5 => "qwen3_5",
+                        6 => "qwen3_5_moe",
+                        7 => "qwen2",
+                        9 => "deepseek4",
+                        _ => "qwen3",
+                    })
+                    .unwrap_or("none");
                 // Count pre-compiled kernels
-                let kernel_dir = std::env::current_exe().ok()
-                    .and_then(|e| e.parent().map(|p| p.join("kernels").join("compiled").join(&gpu.arch)))
+                let kernel_dir = std::env::current_exe()
+                    .ok()
+                    .and_then(|e| {
+                        e.parent()
+                            .map(|p| p.join("kernels").join("compiled").join(&gpu.arch))
+                    })
                     .filter(|p| p.is_dir());
-                let (hsaco_count, hash_count) = kernel_dir.map(|d| {
-                    let hsaco = std::fs::read_dir(&d).map(|r| r.filter(|e| e.as_ref().ok().map(|e| e.path().extension().map(|x| x == "hsaco").unwrap_or(false)).unwrap_or(false)).count()).unwrap_or(0);
-                    let hash = std::fs::read_dir(&d).map(|r| r.filter(|e| e.as_ref().ok().map(|e| e.path().extension().map(|x| x == "hash").unwrap_or(false)).unwrap_or(false)).count()).unwrap_or(0);
-                    (hsaco, hash)
-                }).unwrap_or((0, 0));
-                let _ = writeln!(stdout,
+                let (hsaco_count, hash_count) = kernel_dir
+                    .map(|d| {
+                        let hsaco = std::fs::read_dir(&d)
+                            .map(|r| {
+                                r.filter(|e| {
+                                    e.as_ref()
+                                        .ok()
+                                        .map(|e| {
+                                            e.path()
+                                                .extension()
+                                                .map(|x| x == "hsaco")
+                                                .unwrap_or(false)
+                                        })
+                                        .unwrap_or(false)
+                                })
+                                .count()
+                            })
+                            .unwrap_or(0);
+                        let hash = std::fs::read_dir(&d)
+                            .map(|r| {
+                                r.filter(|e| {
+                                    e.as_ref()
+                                        .ok()
+                                        .map(|e| {
+                                            e.path()
+                                                .extension()
+                                                .map(|x| x == "hash")
+                                                .unwrap_or(false)
+                                        })
+                                        .unwrap_or(false)
+                                })
+                                .count()
+                            })
+                            .unwrap_or(0);
+                        (hsaco, hash)
+                    })
+                    .unwrap_or((0, 0));
+                let _ = writeln!(
+                    stdout,
                     r#"{{"type":"diag","arch":"{}","hip_version":"{}.{}","vram_free_mb":{},"vram_total_mb":{},"model_loaded":{},"model_arch":"{}","kernels":{},"kernel_hashes":{}}}"#,
-                    gpu.arch, hip_ver.0, hip_ver.1,
-                    vram_free / (1024 * 1024), vram_total / (1024 * 1024),
-                    has_model, model_arch, hsaco_count, hash_count
+                    gpu.arch,
+                    hip_ver.0,
+                    hip_ver.1,
+                    vram_free / (1024 * 1024),
+                    vram_total / (1024 * 1024),
+                    has_model,
+                    model_arch,
+                    hsaco_count,
+                    hash_count
                 );
                 let _ = stdout.flush();
             }
@@ -2267,7 +2618,8 @@ fn main() {
                 let m = match model.as_mut() {
                     Some(m) => m,
                     None => {
-                        let _ = writeln!(stdout, r#"{{"type":"error","message":"no model loaded"}}"#);
+                        let _ =
+                            writeln!(stdout, r#"{{"type":"error","message":"no model loaded"}}"#);
                         let _ = stdout.flush();
                         continue;
                     }
@@ -2279,8 +2631,10 @@ fn main() {
                 // review patch f253472. A pp>1 prefill bench is out of scope
                 // for v1.
                 if m.pp > 1 {
-                    let _ = writeln!(stdout,
-                        r#"{{"type":"error","message":"bench_prefill requires pp=1 (multi-GPU bench not implemented)"}}"#);
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","message":"bench_prefill requires pp=1 (multi-GPU bench not implemented)"}}"#
+                    );
                     let _ = stdout.flush();
                     continue;
                 }
@@ -2290,9 +2644,11 @@ fn main() {
                 // on the *physical* buffer (not the advertised max_seq) because this
                 // bench intentionally bypasses eviction to measure raw prefill.
                 if n + 32 > m.physical_cap {
-                    let _ = writeln!(stdout,
+                    let _ = writeln!(
+                        stdout,
                         r#"{{"type":"error","message":"bench_prefill tokens={} exceeds loaded physical_cap={}"}}"#,
-                        n, m.physical_cap);
+                        n, m.physical_cap
+                    );
                     let _ = stdout.flush();
                     continue;
                 }
@@ -2307,14 +2663,22 @@ fn main() {
                 m.seq_pos = 0;
                 m.conversation_tokens.clear();
                 if let Some(ref dn) = m.dn_state {
-                    for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                    for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                    for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                    for s in &dn.s_matrices {
+                        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                    }
+                    for s in &dn.s_scales {
+                        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                    }
+                    for s in &dn.conv_states {
+                        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                    }
                 }
                 // Qwen2 (arch_id=7) doesn't have a separate KV buffer — the cache
                 // and the per-step scratch share `Qwen2State`. Reset its position
                 // cursor here so bench_prefill measures cold prefill.
-                if let Some(ref mut s) = m.qwen2_state { s.reset(); }
+                if let Some(ref mut s) = m.qwen2_state {
+                    s.reset();
+                }
 
                 // Flush any residual GPU work so it doesn't bleed into the
                 // measured interval, then time forward_prefill_batch + a
@@ -2328,7 +2692,11 @@ fn main() {
                     let scratch = m.q35_scratch.as_ref().unwrap();
                     let kv = m.kv_cache.as_mut().unwrap();
                     let dn = m.dn_state.as_mut().unwrap();
-                    qwen35::forward_prefill_batch(&mut gpu, weights, config, &synthetic, 0, kv, dn, scratch, None, None, None, None).is_ok()
+                    qwen35::forward_prefill_batch(
+                        &mut gpu, weights, config, &synthetic, 0, kv, dn, scratch, None, None,
+                        None, None,
+                    )
+                    .is_ok()
                 } else if m.arch_id == 7 {
                     // Qwen2 has no batched prefill kernel yet — per-token loop
                     // mirroring the LLaMA fallback path. The loop seeds
@@ -2358,7 +2726,9 @@ fn main() {
                     for (i, &tok) in synthetic.iter().enumerate() {
                         if deepseek4::forward::decode_step(
                             config, weights, state, &mut gpu, tok, i as u32,
-                        ).is_err() {
+                        )
+                        .is_err()
+                        {
                             ok = false;
                             break;
                         }
@@ -2371,7 +2741,11 @@ fn main() {
                     let kv = m.llama_kv.as_mut().unwrap();
                     let mut ok = true;
                     for (i, &tok) in synthetic.iter().enumerate() {
-                        if llama::forward_scratch(&mut gpu, weights, config, tok, i, kv, scratch, 0.0, 1.0, 42, 0, 1.0).is_err() {
+                        if llama::forward_scratch(
+                            &mut gpu, weights, config, tok, i, kv, scratch, 0.0, 1.0, 42, 0, 1.0,
+                        )
+                        .is_err()
+                        {
                             ok = false;
                             break;
                         }
@@ -2386,18 +2760,35 @@ fn main() {
                 m.seq_pos = 0;
                 m.conversation_tokens.clear();
                 if let Some(ref dn) = m.dn_state {
-                    for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                    for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                    for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                    for s in &dn.s_matrices {
+                        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                    }
+                    for s in &dn.s_scales {
+                        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                    }
+                    for s in &dn.conv_states {
+                        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                    }
                 }
 
                 if run_ok {
-                    let tok_s = if elapsed > 0.0 { n as f64 / elapsed } else { 0.0 };
-                    let _ = writeln!(stdout,
+                    let tok_s = if elapsed > 0.0 {
+                        n as f64 / elapsed
+                    } else {
+                        0.0
+                    };
+                    let _ = writeln!(
+                        stdout,
                         r#"{{"type":"prefill_result","tokens":{},"ms":{:.2},"tok_s":{:.1}}}"#,
-                        n, elapsed * 1000.0, tok_s);
+                        n,
+                        elapsed * 1000.0,
+                        tok_s
+                    );
                 } else {
-                    let _ = writeln!(stdout, r#"{{"type":"error","message":"bench_prefill forward failed"}}"#);
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","message":"bench_prefill forward failed"}}"#
+                    );
                 }
                 let _ = stdout.flush();
             }
@@ -2416,15 +2807,21 @@ fn main() {
                 }
                 let (cap, kernels) = gpu.profile();
                 let kernels_json: Vec<String> = kernels.iter().map(|k| k.to_json()).collect();
-                let _ = writeln!(stdout,
+                let _ = writeln!(
+                    stdout,
                     r#"{{"type":"profile","gpu":{},"kernels":[{}]}}"#,
-                    cap.to_json(), kernels_json.join(",")
+                    cap.to_json(),
+                    kernels_json.join(",")
                 );
                 let _ = stdout.flush();
             }
 
             _ => {
-                let _ = writeln!(stdout, r#"{{"type":"error","message":"unknown type: {}"}}"#, msg_type);
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"error","message":"unknown type: {}"}}"#,
+                    msg_type
+                );
                 let _ = stdout.flush();
             }
         }
@@ -2452,10 +2849,7 @@ fn main() {
 /// not load-time resolution. It belongs in Stage 5 alongside the CLI
 /// passthrough refactor; this resolver only handles the load-time
 /// sources.
-fn resolve_chat_template(
-    hfq: &hipfire_runtime::hfq::HfqFile,
-    model_path: &str,
-) -> Option<String> {
+fn resolve_chat_template(hfq: &hipfire_runtime::hfq::HfqFile, model_path: &str) -> Option<String> {
     // 1. Env-var override.
     if let Ok(env_path) = std::env::var("HIPFIRE_CHAT_TEMPLATE_FILE") {
         if !env_path.is_empty() {
@@ -2485,7 +2879,10 @@ fn resolve_chat_template(
             if per_model.is_file() {
                 match std::fs::read_to_string(&per_model) {
                     Ok(s) => {
-                        eprintln!("[chat_template] using per-model override {}", per_model.display());
+                        eprintln!(
+                            "[chat_template] using per-model override {}",
+                            per_model.display()
+                        );
                         return Some(s);
                     }
                     Err(e) => eprintln!(
@@ -2501,13 +2898,17 @@ fn resolve_chat_template(
     hfq.chat_template()
 }
 
-fn parse_state_quant(mode: Option<&str>) -> Result<hipfire_arch_qwen35::qwen35::StateQuant, String> {
+fn parse_state_quant(
+    mode: Option<&str>,
+) -> Result<hipfire_arch_qwen35::qwen35::StateQuant, String> {
     use hipfire_arch_qwen35::qwen35::StateQuant;
     match mode.unwrap_or("q8").to_ascii_lowercase().as_str() {
         "" | "auto" | "q8" | "int8" => Ok(StateQuant::Q8),
         "fp32" | "f32" => Ok(StateQuant::FP32),
         "q4" | "int4" => Ok(StateQuant::Q4),
-        other => Err(format!("unsupported DeltaNet state_quant '{other}' (expected q8|fp32|q4)")),
+        other => Err(format!(
+            "unsupported DeltaNet state_quant '{other}' (expected q8|fp32|q4)"
+        )),
     }
 }
 
@@ -2605,7 +3006,17 @@ fn parse_kv_adaptive(
     }
 }
 
-fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_override: Option<&str>, kv_adaptive_override: Option<&str>, state_quant_override: Option<&str>, cask: &CaskConfig, pp: usize, gpu: &mut rdna_compute::Gpu) -> Result<LoadedModel, String> {
+fn load_model(
+    path: &str,
+    max_seq: usize,
+    draft_path: Option<&str>,
+    kv_mode_override: Option<&str>,
+    kv_adaptive_override: Option<&str>,
+    state_quant_override: Option<&str>,
+    cask: &CaskConfig,
+    pp: usize,
+    gpu: &mut rdna_compute::Gpu,
+) -> Result<LoadedModel, String> {
     if pp > 1 {
         // Refusal contracts (DFlash, CASK sidecar) are enforced upstream in
         // the "load" event handler so the operator gets a structured error
@@ -2614,7 +3025,14 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // Adaptive KV is Qwen3.5 single-process only (pp=1); not wired on the
         // tensor-parallel path. Consume the override so it isn't silently dropped.
         let _ = (draft_path, cask, kv_adaptive_override);
-        return load_model_pp(path, max_seq, kv_mode_override, state_quant_override, pp, gpu);
+        return load_model_pp(
+            path,
+            max_seq,
+            kv_mode_override,
+            state_quant_override,
+            pp,
+            gpu,
+        );
     }
     // Per-load kv_mode (sent in load message params) overrides the env var.
     // Lets the CLI set size-aware defaults — e.g. Qwen3.5-27B prefers asym4
@@ -2665,7 +3083,8 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
     // hfq::load_weights_hfq do at runtime, so the qt we read here is the
     // qt that will end up driving `weights.output.gpu_dtype`.
     if draft_path.is_some() {
-        let lm_qt = hfq.tensor_data("lm_head.weight")
+        let lm_qt = hfq
+            .tensor_data("lm_head.weight")
             .or_else(|| hfq.tensor_data("model.language_model.lm_head.weight"))
             .or_else(|| hfq.tensor_data("model.language_model.embed_tokens.weight"))
             .or_else(|| hfq.tensor_data("model.embed_tokens.weight"))
@@ -2682,8 +3101,7 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // (_w32 vs _w32_gfx12) but the dispatch wrappers route per-arch.
         let arch_is_gfx11 = matches!(
             gpu.arch.as_str(),
-            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151"
-            | "gfx1200" | "gfx1201"
+            "gfx1100" | "gfx1101" | "gfx1102" | "gfx1150" | "gfx1151" | "gfx1200" | "gfx1201"
         );
         let supported = match lm_qt {
             Some(3 | 6 | 13) => true,
@@ -2722,19 +3140,28 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // MQ2 body still has no batched WMMA kernels anywhere.
         let arch_is_dense_qwen35 = hfq.arch_id == 5;
         let mq3_supported = arch_is_gfx11 && arch_is_dense_qwen35;
-        let mq_unsupported = hfq.first_tensor_with_quant_type(18).map(|n| ("MQ2 (qt=18)", n));
+        let mq_unsupported = hfq
+            .first_tensor_with_quant_type(18)
+            .map(|n| ("MQ2 (qt=18)", n));
         let mq_unsupported = mq_unsupported.or_else(|| {
             if !mq3_supported {
-                hfq.first_tensor_with_quant_type(17).map(|n| ("MQ3 (qt=17)", n))
+                hfq.first_tensor_with_quant_type(17)
+                    .map(|n| ("MQ3 (qt=17)", n))
             } else {
                 None
             }
         });
         if let Some((qt_label, name)) = mq_unsupported {
             let arch_reason = if !arch_is_dense_qwen35 && qt_label.starts_with("MQ3") {
-                format!("arch_id={} (MoE/A3B-class) has no MQ3 MoE kernels", hfq.arch_id)
+                format!(
+                    "arch_id={} (MoE/A3B-class) has no MQ3 MoE kernels",
+                    hfq.arch_id
+                )
             } else {
-                format!("arch={} lacks the corresponding batched WMMA prefill family", gpu.arch)
+                format!(
+                    "arch={} lacks the corresponding batched WMMA prefill family",
+                    gpu.arch
+                )
             };
             return Err(format!(
                 "DFlash draft requested but model contains {qt_label} weight \
@@ -2756,7 +3183,8 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
     // The `HIPFIRE_KV_PHYSICAL_CAP` env var is an explicit operator override —
     // useful for ablations or reproducing dflash_spec_demo settings.
     let physical_cap = if cask.sidecar.is_some() {
-        let env_override = std::env::var("HIPFIRE_KV_PHYSICAL_CAP").ok()
+        let env_override = std::env::var("HIPFIRE_KV_PHYSICAL_CAP")
+            .ok()
             .and_then(|s| s.parse::<usize>().ok());
         let safety = 256usize;
         let floor = cask.budget + cask.beta + 4;
@@ -2772,17 +3200,23 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // trait surface gives us config + weights + state in three
         // calls; forward is direct `qwen2::forward_step` below.
         if draft_path.is_some() {
-            return Err("DFlash not supported on arch_id=7 (hipfire-arch-qwen2 bring-up). \
-                       Reload without a draft.".to_string());
+            return Err(
+                "DFlash not supported on arch_id=7 (hipfire-arch-qwen2 bring-up). \
+                       Reload without a draft."
+                    .to_string(),
+            );
         }
         if cask.sidecar.is_some() {
-            return Err("CASK eviction not supported on arch_id=7 (hipfire-arch-qwen2 bring-up). \
-                       Reload without --cask-sidecar.".to_string());
+            return Err(
+                "CASK eviction not supported on arch_id=7 (hipfire-arch-qwen2 bring-up). \
+                       Reload without --cask-sidecar."
+                    .to_string(),
+            );
         }
         let _ = kv_mode;
         let _ = state_quant_override;
-        use hipfire_runtime::arch::Architecture;
         use hipfire_arch_qwen2::Qwen2;
+        use hipfire_runtime::arch::Architecture;
         let config = <Qwen2 as Architecture>::config_from_hfq(&hfq)?;
         let weights = <Qwen2 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
         let state = qwen2::Qwen2State::new_with_max_seq(gpu, &config, max_seq)
@@ -2790,19 +3224,45 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         let chat_template = resolve_chat_template(&hfq, path);
         return Ok(LoadedModel {
             arch_id: hfq.arch_id,
-            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
-            q35_config: None, q35_weights: None, q35_scratch: None,
-            kv_cache: None, dn_state: None,
-            llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
-            qwen2_config: Some(config), qwen2_weights: Some(weights), qwen2_state: Some(state),
-            deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
-            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
-            dots_ocr_config: None, dots_ocr_weights: None,
-            vision_config: None, vision_weights: None,
+            pp: 1,
+            pp_gpus: None,
+            pp_scratch_set: None,
+            pp_dn_la_to_device: None,
+            q35_config: None,
+            q35_weights: None,
+            q35_scratch: None,
+            kv_cache: None,
+            dn_state: None,
+            llama_config: None,
+            llama_weights: None,
+            llama_scratch: None,
+            llama_kv: None,
+            qwen2_config: Some(config),
+            qwen2_weights: Some(weights),
+            qwen2_state: Some(state),
+            deepseek4_config: None,
+            deepseek4_weights: None,
+            deepseek4_state: None,
+            deepseek4_pbs: None,
+            deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(),
+            mtp_k: 3,
+            mtp_weights_present: false,
+            dots_ocr_config: None,
+            dots_ocr_weights: None,
+            vision_config: None,
+            vision_weights: None,
             tokenizer: Some(tokenizer),
-            seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None, kv_adaptive: None,
+            seq_pos: 0,
+            max_seq,
+            physical_cap: max_seq,
+            eviction: None,
+            kv_adaptive: None,
             conversation_tokens: Vec::new(),
-            asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(), decoded_vocab: None,
+            asst_turn_cache: AsstTurnCache::new_from_env(),
+            prefill_checkpoints: Vec::new(),
+            dflash_checkpoints: Vec::new(),
+            decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
             chat_template,
@@ -2815,18 +3275,22 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // DotsOcrWeights and stay resident. Single-image, greedy decode at
         // bring-up — no eviction, DFlash, CASK, or PP.
         if draft_path.is_some() {
-            return Err("DFlash not supported on arch_id=8 (dots.ocr). Reload without a draft.".to_string());
+            return Err(
+                "DFlash not supported on arch_id=8 (dots.ocr). Reload without a draft.".to_string(),
+            );
         }
         if cask.sidecar.is_some() {
             return Err("CASK eviction not supported on arch_id=8 (dots.ocr). Reload without --cask-sidecar.".to_string());
         }
         if pp > 1 {
-            return Err("pipeline-parallel (pp>1) not supported on arch_id=8 (dots.ocr).".to_string());
+            return Err(
+                "pipeline-parallel (pp>1) not supported on arch_id=8 (dots.ocr).".to_string(),
+            );
         }
         let _ = kv_mode;
         let _ = state_quant_override;
-        use hipfire_runtime::arch::Architecture;
         use hipfire_arch_dots_ocr::DotsOcr;
+        use hipfire_runtime::arch::Architecture;
         let config = <DotsOcr as Architecture>::config_from_hfq(&hfq)?;
         let weights = <DotsOcr as Architecture>::load_weights(&mut hfq, &config, gpu)?;
         // Size the decode KV cache to the requested window (the trait's
@@ -2836,19 +3300,45 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         let chat_template = resolve_chat_template(&hfq, path);
         return Ok(LoadedModel {
             arch_id: hfq.arch_id,
-            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
-            q35_config: None, q35_weights: None, q35_scratch: None,
-            kv_cache: None, dn_state: None,
-            llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
-            qwen2_config: None, qwen2_weights: None, qwen2_state: Some(state),
-            deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
-            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
-            dots_ocr_config: Some(config), dots_ocr_weights: Some(weights),
-            vision_config: None, vision_weights: None,
+            pp: 1,
+            pp_gpus: None,
+            pp_scratch_set: None,
+            pp_dn_la_to_device: None,
+            q35_config: None,
+            q35_weights: None,
+            q35_scratch: None,
+            kv_cache: None,
+            dn_state: None,
+            llama_config: None,
+            llama_weights: None,
+            llama_scratch: None,
+            llama_kv: None,
+            qwen2_config: None,
+            qwen2_weights: None,
+            qwen2_state: Some(state),
+            deepseek4_config: None,
+            deepseek4_weights: None,
+            deepseek4_state: None,
+            deepseek4_pbs: None,
+            deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(),
+            mtp_k: 3,
+            mtp_weights_present: false,
+            dots_ocr_config: Some(config),
+            dots_ocr_weights: Some(weights),
+            vision_config: None,
+            vision_weights: None,
             tokenizer: Some(tokenizer),
-            seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None, kv_adaptive: None,
+            seq_pos: 0,
+            max_seq,
+            physical_cap: max_seq,
+            eviction: None,
+            kv_adaptive: None,
             conversation_tokens: Vec::new(),
-            asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(), decoded_vocab: None,
+            asst_turn_cache: AsstTurnCache::new_from_env(),
+            prefill_checkpoints: Vec::new(),
+            dflash_checkpoints: Vec::new(),
+            decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
             chat_template,
@@ -2863,17 +3353,22 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // `decode_step` in the generate hot path.
         if draft_path.is_some() {
             return Err("DFlash not supported on arch_id=9 (DeepSeek V4 Flash). \
-                       Reload without a draft.".to_string());
+                       Reload without a draft."
+                .to_string());
         }
         if cask.sidecar.is_some() {
-            return Err("CASK eviction not supported on arch_id=9 (DeepSeek V4 Flash). \
-                       Reload without --cask-sidecar.".to_string());
+            return Err(
+                "CASK eviction not supported on arch_id=9 (DeepSeek V4 Flash). \
+                       Reload without --cask-sidecar."
+                    .to_string(),
+            );
         }
         let _ = kv_mode;
         let _ = state_quant_override;
         use hipfire_runtime::arch::Architecture;
         let config = <deepseek4::DeepseekV4 as Architecture>::config_from_hfq(&hfq)?;
-        let weights = <deepseek4::DeepseekV4 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
+        let weights =
+            <deepseek4::DeepseekV4 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
         let state = deepseek4::DeepseekV4State::new(&config)?;
         // Pre-allocate PrefillBatchScratch. Default B=1024 (bumped from 64
         // on 2026-05-26). PP_BATCH sweep on the 2.1k-tok bench (3 trials/cell):
@@ -2893,25 +3388,54 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // fall back to 1 if tokenizer lacks the entry.
         let eos_tok: u32 = {
             let ids = tokenizer.encode("<｜end▁of▁sentence｜>");
-            if ids.len() == 1 { ids[0] } else { 1 }
+            if ids.len() == 1 {
+                ids[0]
+            } else {
+                1
+            }
         };
         let chat_template = resolve_chat_template(&hfq, path);
         return Ok(LoadedModel {
             arch_id: hfq.arch_id,
-            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
-            q35_config: None, q35_weights: None, q35_scratch: None,
-            kv_cache: None, dn_state: None,
-            llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
-            qwen2_config: None, qwen2_weights: None, qwen2_state: None,
-            deepseek4_config: Some(config), deepseek4_weights: Some(weights), deepseek4_state: Some(state),
-            deepseek4_pbs: Some(pbs), deepseek4_eos_tok: eos_tok,
-            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
-            dots_ocr_config: None, dots_ocr_weights: None,
-            vision_config: None, vision_weights: None,
+            pp: 1,
+            pp_gpus: None,
+            pp_scratch_set: None,
+            pp_dn_la_to_device: None,
+            q35_config: None,
+            q35_weights: None,
+            q35_scratch: None,
+            kv_cache: None,
+            dn_state: None,
+            llama_config: None,
+            llama_weights: None,
+            llama_scratch: None,
+            llama_kv: None,
+            qwen2_config: None,
+            qwen2_weights: None,
+            qwen2_state: None,
+            deepseek4_config: Some(config),
+            deepseek4_weights: Some(weights),
+            deepseek4_state: Some(state),
+            deepseek4_pbs: Some(pbs),
+            deepseek4_eos_tok: eos_tok,
+            mtp_mode: "auto".to_string(),
+            mtp_k: 3,
+            mtp_weights_present: false,
+            dots_ocr_config: None,
+            dots_ocr_weights: None,
+            vision_config: None,
+            vision_weights: None,
             tokenizer: Some(tokenizer),
-            seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None, kv_adaptive: None,
+            seq_pos: 0,
+            max_seq,
+            physical_cap: max_seq,
+            eviction: None,
+            kv_adaptive: None,
             conversation_tokens: Vec::new(),
-            asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(), decoded_vocab: None,
+            asst_turn_cache: AsstTurnCache::new_from_env(),
+            prefill_checkpoints: Vec::new(),
+            dflash_checkpoints: Vec::new(),
+            decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
             chat_template,
@@ -2924,24 +3448,28 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // (config → load → state). Forward passes below still call
         // `qwen35::*` directly — see crates/hipfire-arch-qwen35/src/arch.rs
         // for why static dispatch wins for the hot path.
-        use hipfire_runtime::arch::Architecture;
         use hipfire_arch_qwen35::Qwen35;
         use hipfire_arch_qwen35_vl::Qwen35Vl;
-        let config = <Qwen35 as Architecture>::config_from_hfq(&hfq)
-            .map_err(|e| e.to_string())?;
+        use hipfire_runtime::arch::Architecture;
+        let config = <Qwen35 as Architecture>::config_from_hfq(&hfq).map_err(|e| e.to_string())?;
 
         // Detect VL model: vision_config presence (from HFQ metadata) AND
         // actual vision tensors are required. Text-only Qwen3.5 models can
         // have vision_config in metadata without the patch_embed weights.
         // PR 9: bring-up triple now goes through the Qwen35Vl trait impl;
         // forward (`qwen35_vl::vision_forward`) stays a direct static call.
-        let has_vision_tensors = hfq.tensor_data("model.visual.patch_embed.proj.weight").is_some();
+        let has_vision_tensors = hfq
+            .tensor_data("model.visual.patch_embed.proj.weight")
+            .is_some();
         let vision_config = <Qwen35Vl as Architecture>::config_from_hfq(&hfq).ok();
         let (vision_config, vision_weights) = if let Some(vc) = vision_config {
             if has_vision_tensors {
                 let vw = <Qwen35Vl as Architecture>::load_weights(&mut hfq, &vc, gpu)
                     .map_err(|e| format!("{e}"))?;
-                eprintln!("  VL model: vision encoder (hidden={}, layers={})", vc.hidden_size, vc.num_layers);
+                eprintln!(
+                    "  VL model: vision encoder (hidden={}, layers={})",
+                    vc.hidden_size, vc.num_layers
+                );
                 (Some(vc), Some(vw))
             } else {
                 (None, None) // text-only model, no vision tensors
@@ -2959,13 +3487,26 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // HIPFIRE_MMQ_SCREEN=1. gfx906 is included for the opt-in case so
         // its ~700 µs/weight screening-reference dispatch doesn't surprise
         // first prefill if a user enables it.
-        if gpu.mmq_screen.enabled && matches!(gpu.arch.as_str(), "gfx906" | "gfx1100" | "gfx1101" | "gfx1102" | "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152") {
+        if gpu.mmq_screen.enabled
+            && matches!(
+                gpu.arch.as_str(),
+                "gfx906"
+                    | "gfx1100"
+                    | "gfx1101"
+                    | "gfx1102"
+                    | "gfx1103"
+                    | "gfx1150"
+                    | "gfx1151"
+                    | "gfx1152"
+            )
+        {
             let t0 = std::time::Instant::now();
             let (n_safe, n_unsafe) = screen_weights_qwen35(&weights, gpu);
             let elapsed = t0.elapsed();
             eprintln!(
                 "  MMQ screening: {n_safe} safe, {n_unsafe} unsafe (threshold={:.2}, {:.1}ms)",
-                gpu.mmq_screen.threshold, elapsed.as_secs_f64() * 1000.0,
+                gpu.mmq_screen.threshold,
+                elapsed.as_secs_f64() * 1000.0,
             );
         }
 
@@ -2992,39 +3533,92 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             .map(|t| *t == LayerType::FullAttention)
             .collect();
         let mut kv = match kv_mode.as_str() {
-            "q8" => {
-                llama::KvCache::new_gpu_q8_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
-            }
+            "q8" => llama::KvCache::new_gpu_q8_capped_filtered(
+                gpu,
+                &is_kv_layer,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                physical_cap,
+            )
+            .map_err(|e| format!("{e}"))?,
             "asym4" | "turbo4" => {
                 // asym4/asym2/fwht4 have no _capped_filtered yet; physical_cap ==
                 // max_seq when CASK eviction is off (the default), so _filtered is
                 // exact. (Fully CASK-aware capped+filtered variants: follow-up.)
-                llama::KvCache::new_gpu_asym4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_asym4_filtered(
+                    gpu,
+                    &is_kv_layer,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    max_seq,
+                )
+                .map_err(|e| format!("{e}"))?
             }
-            "asym2" | "turbo2" => {
-                llama::KvCache::new_gpu_asym2_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
-            }
+            "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_filtered(
+                gpu,
+                &is_kv_layer,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+            )
+            .map_err(|e| format!("{e}"))?,
             "asym3" | "turbo3" | "turbo" | "auto" | "" => {
-                llama::KvCache::new_gpu_asym3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_asym3_capped_filtered(
+                    gpu,
+                    &is_kv_layer,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    max_seq,
+                    physical_cap,
+                )
+                .map_err(|e| format!("{e}"))?
             }
             // FWHT-rotated KV: same byte layout as the matching asym tier, but
             // the K-rotation basis matches the MQ4 weight/draft FWHT convention,
             // so DFlash speculative acceptance stays high (asym's Givens basis
             // does not — see CLAUDE.md: "DFlash perf gates must use q8 or FWHT").
-            "fwht3" => {
-                llama::KvCache::new_gpu_fwht3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
-            }
-            "fwht2" => {
-                llama::KvCache::new_gpu_fwht2_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
-            }
+            "fwht3" => llama::KvCache::new_gpu_fwht3_capped_filtered(
+                gpu,
+                &is_kv_layer,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                physical_cap,
+            )
+            .map_err(|e| format!("{e}"))?,
+            "fwht2" => llama::KvCache::new_gpu_fwht2_capped_filtered(
+                gpu,
+                &is_kv_layer,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                physical_cap,
+            )
+            .map_err(|e| format!("{e}"))?,
             "fwht4" => {
                 // fwht4 has no _capped_filtered yet; physical_cap == max_seq when
                 // CASK eviction is off (the default), so _filtered is exact here.
-                llama::KvCache::new_gpu_fwht4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_fwht4_filtered(
+                    gpu,
+                    &is_kv_layer,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    max_seq,
+                )
+                .map_err(|e| format!("{e}"))?
             }
             other => {
                 eprintln!("  KV cache: unrecognized '{other}', defaulting to asym3");
-                llama::KvCache::new_gpu_asym3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, physical_cap).map_err(|e| format!("{e}"))?
+                llama::KvCache::new_gpu_asym3_capped_filtered(
+                    gpu,
+                    &is_kv_layer,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    max_seq,
+                    physical_cap,
+                )
+                .map_err(|e| format!("{e}"))?
             }
         };
         // V-cache mode override (HIPFIRE_KV_V env). lloyd-V is 256-wide and
@@ -3035,12 +3629,17 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             "lloyd3" => Some(llama::VMode::Lloyd3),
             "lloyd4" => Some(llama::VMode::Lloyd4),
             "q8" | "" => None,
-            other => { eprintln!("[daemon] HIPFIRE_KV_V='{other}' unknown — ignoring (expected q8|lloyd2|lloyd3|lloyd4)"); None }
+            other => {
+                eprintln!("[daemon] HIPFIRE_KV_V='{other}' unknown — ignoring (expected q8|lloyd2|lloyd3|lloyd4)");
+                None
+            }
         };
         if let Some(vm) = v_mode_override {
             if (kv.quant_asym2 || kv.quant_asym3 || kv.quant_asym4) && kv.quant_fwht {
                 kv.set_v_mode_realloc(gpu, vm).map_err(|e| format!("{e}"))?;
-                eprintln!("[daemon] V-cache mode override → {kv_v_env} (256-wide lloyd-V on fwht K)");
+                eprintln!(
+                    "[daemon] V-cache mode override → {kv_v_env} (256-wide lloyd-V on fwht K)"
+                );
             } else {
                 eprintln!("[daemon] HIPFIRE_KV_V={kv_v_env} ignored — lloyd-V requires an FWHT K mode (fwht2/3/4); cache is a different mode");
             }
@@ -3065,8 +3664,16 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                     // so the guards below can read its start-tier capacity and
                     // thresholds BEFORE we shrink any buffers.
                     let ad = match preset {
-                        Some(p) => KvAdaptive::from_preset(p, max_seq, config.n_kv_heads, config.head_dim),
-                        None => KvAdaptive::new(max_seq, config.n_kv_heads, config.head_dim, k_floor, v_floor),
+                        Some(p) => {
+                            KvAdaptive::from_preset(p, max_seq, config.n_kv_heads, config.head_dim)
+                        }
+                        None => KvAdaptive::new(
+                            max_seq,
+                            config.n_kv_heads,
+                            config.head_dim,
+                            k_floor,
+                            v_floor,
+                        ),
                     };
                     // Guard 1: adaptive requires an FWHT K mode. Reuse the lloyd-V guard.
                     if !((kv.quant_asym2 || kv.quant_asym3 || kv.quant_asym4) && kv.quant_fwht) {
@@ -3104,7 +3711,8 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                         // signs to 256. For k_floor==fwht4 (V-only presets) the K
                         // footprint equals fwht4 so K is left unresized.
                         let k_floor_bph = k_floor.bytes_per_head(config.head_dim);
-                        kv.set_adaptive_floor_alloc(gpu, v_floor, k_floor_bph).map_err(|e| format!("{e}"))?;
+                        kv.set_adaptive_floor_alloc(gpu, v_floor, k_floor_bph)
+                            .map_err(|e| format!("{e}"))?;
                         eprintln!(
                             "[adaptive-kv] engaged: pattern={:?} k_floor={:?} v_floor={:?} thresholds={:?} start_cap={} (max_seq={}, V buffer sized at floor)",
                             ad.steps, ad.k_floor, ad.v_floor, ad.thresholds, ad.current_cap(), max_seq,
@@ -3120,11 +3728,13 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         let dn_quant = parse_state_quant(state_quant_override)?;
         eprintln!("  DeltaNet state: {}", state_quant_label(dn_quant));
         warn_tiny_model_state(&hfq, dn_quant);
-        let dn = DeltaNetState::new_with_quant(gpu, &config, dn_quant).map_err(|e| format!("{e}"))?;
+        let dn =
+            DeltaNetState::new_with_quant(gpu, &config, dn_quant).map_err(|e| format!("{e}"))?;
         // Flash partials size with physical_cap (bounds the max_tiles the
         // flash kernel must address). When physical_cap == max_seq this is
         // identical to sizing-by-max_seq; under eviction it's much smaller.
-        let scratch = qwen35::Qwen35Scratch::new_with_kv_max(gpu, &config, 128, physical_cap).map_err(|e| format!("{e}"))?;
+        let scratch = qwen35::Qwen35Scratch::new_with_kv_max(gpu, &config, 128, physical_cap)
+            .map_err(|e| format!("{e}"))?;
 
         // Build eviction policy if the operator supplied a sidecar. Qwen3 (arch_id < 5)
         // lacks the FA/LA hybrid wiring TriAttention needs, so sidecars only take
@@ -3145,8 +3755,17 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                 };
                 format!("cask sidecar load failed — {why} (regen: hipfire sidecar-gen, or HIPFIRE_CASK_OFF=1)")
             })?;
-            let fa_layer_ids: Vec<usize> = config.layer_types.iter().enumerate()
-                .filter_map(|(i, t)| if *t == LayerType::FullAttention { Some(i) } else { None })
+            let fa_layer_ids: Vec<usize> = config
+                .layer_types
+                .iter()
+                .enumerate()
+                .filter_map(|(i, t)| {
+                    if *t == LayerType::FullAttention {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
                 .collect();
             if fa_layer_ids.is_empty() {
                 eprintln!("  cask_sidecar set but model has no FullAttention layers — ignoring");
@@ -3154,16 +3773,29 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
             } else {
                 let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
                 let base = EvictionCtx::new(
-                    gpu, &centers, fa_layer_ids, cask.budget, cask.beta,
-                    config.n_heads, config.n_kv_heads, config.head_dim,
-                    n_rot, config.rope_theta, physical_cap,
-                ).map_err(|e| format!("build EvictionCtx: {e}"))?;
+                    gpu,
+                    &centers,
+                    fa_layer_ids,
+                    cask.budget,
+                    cask.beta,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    n_rot,
+                    config.rope_theta,
+                    physical_cap,
+                )
+                .map_err(|e| format!("build EvictionCtx: {e}"))?;
                 if cask.cask_m_folding {
                     eprintln!(
                         "  eviction: CASK α={:.2} m={} budget={} β={} physical_cap={}",
                         cask.core_frac, cask.fold_m, cask.budget, cask.beta, physical_cap,
                     );
-                    Some(Eviction::Cask(CaskCtx::new(base, cask.core_frac, cask.fold_m)))
+                    Some(Eviction::Cask(CaskCtx::new(
+                        base,
+                        cask.core_frac,
+                        cask.fold_m,
+                    )))
                 } else {
                     eprintln!(
                         "  eviction: TriAttention (plain drop) budget={} β={} physical_cap={}",
@@ -3172,7 +3804,9 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                     Some(Eviction::Plain(base))
                 }
             }
-        } else { None };
+        } else {
+            None
+        };
         // Optional DFlash draft: load the draft model's weights + a fresh set
         // of per-cycle scratch buffers (hidden ring, verify scratch, GdnTape,
         // DeltaNetSnapshot) sized for the target's max_seq. If the draft file
@@ -3188,34 +3822,67 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
                 Ok(state) => {
                     eprintln!(
                         "  DFlash draft loaded: {} (layers={}, hidden={}, block={})",
-                        dp, state.draft_config.n_layers, state.draft_config.hidden,
+                        dp,
+                        state.draft_config.n_layers,
+                        state.draft_config.hidden,
                         state.draft_config.block_size,
                     );
                     Some(state)
                 }
                 Err(e) => {
-                    eprintln!("  DFlash draft load failed ({}): {} — falling back to AR only", dp, e);
+                    eprintln!(
+                        "  DFlash draft load failed ({}): {} — falling back to AR only",
+                        dp, e
+                    );
                     None
                 }
             }
-        } else { None };
+        } else {
+            None
+        };
 
         let chat_template = resolve_chat_template(&hfq, path);
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
-            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
-            q35_config: Some(config), q35_weights: Some(weights), q35_scratch: Some(scratch),
-            kv_cache: Some(kv), dn_state: Some(dn),
-            llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
-            qwen2_config: None, qwen2_weights: None, qwen2_state: None,
-            deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
-            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
-            dots_ocr_config: None, dots_ocr_weights: None,
-            vision_config, vision_weights,
+            pp: 1,
+            pp_gpus: None,
+            pp_scratch_set: None,
+            pp_dn_la_to_device: None,
+            q35_config: Some(config),
+            q35_weights: Some(weights),
+            q35_scratch: Some(scratch),
+            kv_cache: Some(kv),
+            dn_state: Some(dn),
+            llama_config: None,
+            llama_weights: None,
+            llama_scratch: None,
+            llama_kv: None,
+            qwen2_config: None,
+            qwen2_weights: None,
+            qwen2_state: None,
+            deepseek4_config: None,
+            deepseek4_weights: None,
+            deepseek4_state: None,
+            deepseek4_pbs: None,
+            deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(),
+            mtp_k: 3,
+            mtp_weights_present: false,
+            dots_ocr_config: None,
+            dots_ocr_weights: None,
+            vision_config,
+            vision_weights,
             tokenizer: Some(tokenizer),
-            seq_pos: 0, max_seq, physical_cap, eviction, kv_adaptive,
+            seq_pos: 0,
+            max_seq,
+            physical_cap,
+            eviction,
+            kv_adaptive,
             conversation_tokens: Vec::new(),
-            asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(), decoded_vocab: None,
+            asst_turn_cache: AsstTurnCache::new_from_env(),
+            prefill_checkpoints: Vec::new(),
+            dflash_checkpoints: Vec::new(),
+            decoded_vocab: None,
             model_path: path.to_string(),
             dflash,
             chat_template,
@@ -3228,28 +3895,60 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
         // `llama::*` directly — see crates/hipfire-arch-llama/src/arch.rs
         // for why static dispatch wins for the hot path.
         use hipfire_runtime::arch::Architecture;
-        let config = <Llama as Architecture>::config_from_hfq(&hfq)
-            .map_err(|e| e.to_string())?;
+        let config = <Llama as Architecture>::config_from_hfq(&hfq).map_err(|e| e.to_string())?;
         let weights = <Llama as Architecture>::load_weights(&mut hfq, &config, gpu)?;
         eprintln!("  KV cache: Q8");
-        let kv = llama::KvCache::new_gpu_q8(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq).map_err(|e| format!("{e}"))?;
+        let kv = llama::KvCache::new_gpu_q8(
+            gpu,
+            config.n_layers,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?;
         let scratch = <Llama as Architecture>::new_state(gpu, &config)?;
         let chat_template = resolve_chat_template(&hfq, path);
         Ok(LoadedModel {
             arch_id: hfq.arch_id,
-            pp: 1, pp_gpus: None, pp_scratch_set: None, pp_dn_la_to_device: None,
-            q35_config: None, q35_weights: None, q35_scratch: None,
-            kv_cache: None, dn_state: None,
-            llama_config: Some(config), llama_weights: Some(weights), llama_scratch: Some(scratch), llama_kv: Some(kv),
-            qwen2_config: None, qwen2_weights: None, qwen2_state: None,
-            deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
-            mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
-            dots_ocr_config: None, dots_ocr_weights: None,
-            vision_config: None, vision_weights: None,
+            pp: 1,
+            pp_gpus: None,
+            pp_scratch_set: None,
+            pp_dn_la_to_device: None,
+            q35_config: None,
+            q35_weights: None,
+            q35_scratch: None,
+            kv_cache: None,
+            dn_state: None,
+            llama_config: Some(config),
+            llama_weights: Some(weights),
+            llama_scratch: Some(scratch),
+            llama_kv: Some(kv),
+            qwen2_config: None,
+            qwen2_weights: None,
+            qwen2_state: None,
+            deepseek4_config: None,
+            deepseek4_weights: None,
+            deepseek4_state: None,
+            deepseek4_pbs: None,
+            deepseek4_eos_tok: 0,
+            mtp_mode: "auto".to_string(),
+            mtp_k: 3,
+            mtp_weights_present: false,
+            dots_ocr_config: None,
+            dots_ocr_weights: None,
+            vision_config: None,
+            vision_weights: None,
             tokenizer: Some(tokenizer),
-            seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None, kv_adaptive: None,
+            seq_pos: 0,
+            max_seq,
+            physical_cap: max_seq,
+            eviction: None,
+            kv_adaptive: None,
             conversation_tokens: Vec::new(),
-            asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(), decoded_vocab: None,
+            asst_turn_cache: AsstTurnCache::new_from_env(),
+            prefill_checkpoints: Vec::new(),
+            dflash_checkpoints: Vec::new(),
+            decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
             chat_template,
@@ -3259,17 +3958,23 @@ fn load_model(path: &str, max_seq: usize, draft_path: Option<&str>, kv_mode_over
 
 /// Load a model from a HuggingFace safetensors directory (ParoQuant, AWQ, etc.).
 fn load_model_safetensors(
-    path: &str, max_seq: usize, kv_mode: &str, gpu: &mut rdna_compute::Gpu,
+    path: &str,
+    max_seq: usize,
+    kv_mode: &str,
+    gpu: &mut rdna_compute::Gpu,
 ) -> Result<LoadedModel, String> {
-    use hipfire_runtime::safetensors_source::SafetensorsSource;
     use hipfire_runtime::model_source::ModelSource;
+    use hipfire_runtime::safetensors_source::SafetensorsSource;
 
     eprintln!("  opening safetensors directory: {path}");
-    let source = SafetensorsSource::open(Path::new(path))
-        .map_err(|e| format!("safetensors open: {e}"))?;
+    let source =
+        SafetensorsSource::open(Path::new(path)).map_err(|e| format!("safetensors open: {e}"))?;
 
     let arch_id = source.arch_id();
-    let qm = source.quant_config().map(|q| q.method.as_str()).unwrap_or("none");
+    let qm = source
+        .quant_config()
+        .map(|q| q.method.as_str())
+        .unwrap_or("none");
     eprintln!("  arch_id={arch_id}, quant_method={qm}");
 
     // Tokenizer from tokenizer.json
@@ -3290,8 +3995,15 @@ fn load_model_safetensors(
         let config = hipfire_runtime::hfq::config_from_safetensors_llama(&source)
             .ok_or("failed to parse LLaMA/Qwen3 config from config.json")?;
 
-        eprintln!("  LLaMA/Qwen3: dim={}, layers={}, heads={}, kv_heads={}, head_dim={}, qk_norm={}",
-            config.dim, config.n_layers, config.n_heads, config.n_kv_heads, config.head_dim, config.has_qk_norm);
+        eprintln!(
+            "  LLaMA/Qwen3: dim={}, layers={}, heads={}, kv_heads={}, head_dim={}, qk_norm={}",
+            config.dim,
+            config.n_layers,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            config.has_qk_norm
+        );
 
         let weights = hipfire_runtime::hfq::load_weights_paroquant_llama(&source, &config, gpu)
             .map_err(|e| format!("load_weights_paroquant_llama: {e:?}"))?;
@@ -3302,12 +4014,48 @@ fn load_model_safetensors(
         // the panicking constructor so caller-misconfigured runs surface.
         let asym3_auto = matches!(kv_mode, "turbo3" | "turbo" | "auto" | "");
         let kv = match kv_mode {
-            "q8" => llama::KvCache::new_gpu_q8_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-            "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-            "asym3" => llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-            _ if asym3_auto && config.head_dim == 256 => llama::KvCache::new_gpu_asym3_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-            _ => llama::KvCache::new_gpu_q8_capped(gpu, config.n_layers, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-        }.map_err(|e| format!("KvCache: {e}"))?;
+            "q8" => llama::KvCache::new_gpu_q8_capped(
+                gpu,
+                config.n_layers,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            ),
+            "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped(
+                gpu,
+                config.n_layers,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            ),
+            "asym3" => llama::KvCache::new_gpu_asym3_capped(
+                gpu,
+                config.n_layers,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            ),
+            _ if asym3_auto && config.head_dim == 256 => llama::KvCache::new_gpu_asym3_capped(
+                gpu,
+                config.n_layers,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            ),
+            _ => llama::KvCache::new_gpu_q8_capped(
+                gpu,
+                config.n_layers,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            ),
+        }
+        .map_err(|e| format!("KvCache: {e}"))?;
 
         let scratch = llama::ForwardScratch::new(gpu, &config)
             .map_err(|e| format!("ForwardScratch::new: {e:?}"))?;
@@ -3349,7 +4097,9 @@ fn load_model_safetensors(
             eviction: None,
             kv_adaptive: None,
             conversation_tokens: Vec::new(),
-            asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(),
+            asst_turn_cache: AsstTurnCache::new_from_env(),
+            prefill_checkpoints: Vec::new(),
+            dflash_checkpoints: Vec::new(),
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
@@ -3365,7 +4115,10 @@ fn load_model_safetensors(
     let config = qwen35::config_from_safetensors(&source)
         .ok_or("failed to parse Qwen3.5 config from config.json")?;
 
-    eprintln!("  Qwen3.5/3.6: dim={}, layers={}, heads={}", config.dim, config.n_layers, config.n_heads);
+    eprintln!(
+        "  Qwen3.5/3.6: dim={}, layers={}, heads={}",
+        config.dim, config.n_layers, config.n_heads
+    );
 
     // Load weights via ParoQuant path
     let weights = qwen35::load_weights_paroquant(&source, &config, gpu)
@@ -3381,16 +4134,63 @@ fn load_model_safetensors(
         .map(|t| *t == LayerType::FullAttention)
         .collect();
     let kv_cache = match kv_mode {
-        "q8" => llama::KvCache::new_gpu_q8_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq),
-        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq),
-        "fwht4" => llama::KvCache::new_gpu_fwht4_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq),
-        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-        _ => llama::KvCache::new_gpu_asym3_capped_filtered(gpu, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq),
-    }.map_err(|e| format!("KvCache: {e}"))?;
-    let dn_state = DeltaNetState::new(gpu, &config)
-        .map_err(|e| format!("DeltaNetState::new: {e:?}"))?;
+        "q8" => llama::KvCache::new_gpu_q8_capped_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        ),
+        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+        ),
+        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+        ),
+        "fwht4" => llama::KvCache::new_gpu_fwht4_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+        ),
+        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        ),
+        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        ),
+        _ => llama::KvCache::new_gpu_asym3_capped_filtered(
+            gpu,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        ),
+    }
+    .map_err(|e| format!("KvCache: {e}"))?;
+    let dn_state =
+        DeltaNetState::new(gpu, &config).map_err(|e| format!("DeltaNetState::new: {e:?}"))?;
     let scratch = qwen35::Qwen35Scratch::new(gpu, &config, 256)
         .map_err(|e| format!("Qwen35Scratch::new: {e:?}"))?;
 
@@ -3431,7 +4231,9 @@ fn load_model_safetensors(
         eviction: None,
         kv_adaptive: None,
         conversation_tokens: Vec::new(),
-        asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(),
+        asst_turn_cache: AsstTurnCache::new_from_env(),
+        prefill_checkpoints: Vec::new(),
+        dflash_checkpoints: Vec::new(),
         decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
@@ -3471,7 +4273,9 @@ fn load_model_pp(
         ));
     }
     if qwen35_vl::vision_config_from_hfq(&hfq).is_some()
-        && hfq.tensor_data("model.visual.patch_embed.proj.weight").is_some()
+        && hfq
+            .tensor_data("model.visual.patch_embed.proj.weight")
+            .is_some()
     {
         return Err("pp>1 does not support VL models in v1; see issue #58 v1.1 roadmap".into());
     }
@@ -3481,17 +4285,19 @@ fn load_model_pp(
     // HIPFIRE_PP_LAYERS="a,b,..." overrides uniform split. Length must equal
     // pp; sum must equal n_layers; each entry >= 1. Used to shift layers off
     // dev 0 when token_embd asymmetry caps max_seq under uniform split.
-    let mut gpus = match std::env::var("HIPFIRE_PP_LAYERS").ok().filter(|s| !s.is_empty()) {
+    let mut gpus = match std::env::var("HIPFIRE_PP_LAYERS")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
         Some(spec) => {
-            let counts: Result<Vec<usize>, _> = spec
-                .split(',')
-                .map(|s| s.trim().parse::<usize>())
-                .collect();
+            let counts: Result<Vec<usize>, _> =
+                spec.split(',').map(|s| s.trim().parse::<usize>()).collect();
             let counts = counts.map_err(|e| format!("HIPFIRE_PP_LAYERS parse: {e}"))?;
             if counts.len() != pp {
                 return Err(format!(
                     "HIPFIRE_PP_LAYERS has {} entries, expected pp={}",
-                    counts.len(), pp
+                    counts.len(),
+                    pp
                 ));
             }
             let sum: usize = counts.iter().sum();
@@ -3507,7 +4313,8 @@ fn load_model_pp(
         None => Gpus::init_uniform(pp, config.n_layers).map_err(|e| format!("{e}"))?,
     };
 
-    let weights = qwen35::load_weights_multi(&hfq, &config, &mut gpus).map_err(|e| format!("{e}"))?;
+    let weights =
+        qwen35::load_weights_multi(&hfq, &config, &mut gpus).map_err(|e| format!("{e}"))?;
 
     // KV cache (asym3 default, q8/asym4/asym2/fwht{4,3,2} selectable).
     // physical_cap == max_seq on this path — eviction is refused at load.
@@ -3519,16 +4326,82 @@ fn load_model_pp(
         .map(|t| *t == LayerType::FullAttention)
         .collect();
     let kv = match kv_mode.as_str() {
-        "q8" => llama::KvCache::new_gpu_q8_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "asym3" | "turbo3" | "turbo" | "auto" | "" => llama::KvCache::new_gpu_asym3_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "fwht4" => llama::KvCache::new_gpu_fwht4_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
-        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?,
+        "q8" => llama::KvCache::new_gpu_q8_capped_multi_filtered(
+            &mut gpus,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?,
+        "asym4" | "turbo4" => llama::KvCache::new_gpu_asym4_capped_multi_filtered(
+            &mut gpus,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?,
+        "asym2" | "turbo2" => llama::KvCache::new_gpu_asym2_capped_multi_filtered(
+            &mut gpus,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?,
+        "asym3" | "turbo3" | "turbo" | "auto" | "" => {
+            llama::KvCache::new_gpu_asym3_capped_multi_filtered(
+                &mut gpus,
+                &is_kv_layer,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            )
+            .map_err(|e| format!("{e}"))?
+        }
+        "fwht4" => llama::KvCache::new_gpu_fwht4_capped_multi_filtered(
+            &mut gpus,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?,
+        "fwht3" => llama::KvCache::new_gpu_fwht3_capped_multi_filtered(
+            &mut gpus,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?,
+        "fwht2" => llama::KvCache::new_gpu_fwht2_capped_multi_filtered(
+            &mut gpus,
+            &is_kv_layer,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+            max_seq,
+        )
+        .map_err(|e| format!("{e}"))?,
         other => {
             eprintln!("  KV cache: unrecognized '{other}', defaulting to asym3");
-            llama::KvCache::new_gpu_asym3_capped_multi_filtered(&mut gpus, &is_kv_layer, config.n_kv_heads, config.head_dim, max_seq, max_seq).map_err(|e| format!("{e}"))?
+            llama::KvCache::new_gpu_asym3_capped_multi_filtered(
+                &mut gpus,
+                &is_kv_layer,
+                config.n_kv_heads,
+                config.head_dim,
+                max_seq,
+                max_seq,
+            )
+            .map_err(|e| format!("{e}"))?
         }
     };
 
@@ -3537,15 +4410,18 @@ fn load_model_pp(
     let dn_quant = parse_state_quant(state_quant_override)?;
     eprintln!("  DeltaNet state: {}", state_quant_label(dn_quant));
     warn_tiny_model_state(&hfq, dn_quant);
-    let (dn, la_to_device) =
-        DeltaNetState::new_with_quant_multi(&mut gpus, &config, dn_quant).map_err(|e| format!("{e}"))?;
+    let (dn, la_to_device) = DeltaNetState::new_with_quant_multi(&mut gpus, &config, dn_quant)
+        .map_err(|e| format!("{e}"))?;
 
-    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 128, max_seq).map_err(|e| format!("{e}"))?;
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 128, max_seq)
+        .map_err(|e| format!("{e}"))?;
 
     // ROCm 6.4.3 gotcha: enable_peer_access AFTER all allocations are live.
     // See multi_gpu.rs::enable_peer_all docstring for the silent-success bug
     // when the call precedes hipMalloc.
-    let _peer = gpus.enable_peer_all().map_err(|e| format!("enable_peer_all: {e}"))?;
+    let _peer = gpus
+        .enable_peer_all()
+        .map_err(|e| format!("enable_peer_all: {e}"))?;
 
     eprintln!(
         "  pp={pp} loaded: layer_to_device={:?}, output_device={}, peer_access={}",
@@ -3563,16 +4439,36 @@ fn load_model_pp(
         q35_scratch: None,
         kv_cache: Some(kv),
         dn_state: Some(dn),
-        llama_config: None, llama_weights: None, llama_scratch: None, llama_kv: None,
-        qwen2_config: None, qwen2_weights: None, qwen2_state: None,
-        deepseek4_config: None, deepseek4_weights: None, deepseek4_state: None, deepseek4_pbs: None, deepseek4_eos_tok: 0,
-        mtp_mode: "auto".to_string(), mtp_k: 3, mtp_weights_present: false,
-        dots_ocr_config: None, dots_ocr_weights: None,
-        vision_config: None, vision_weights: None,
+        llama_config: None,
+        llama_weights: None,
+        llama_scratch: None,
+        llama_kv: None,
+        qwen2_config: None,
+        qwen2_weights: None,
+        qwen2_state: None,
+        deepseek4_config: None,
+        deepseek4_weights: None,
+        deepseek4_state: None,
+        deepseek4_pbs: None,
+        deepseek4_eos_tok: 0,
+        mtp_mode: "auto".to_string(),
+        mtp_k: 3,
+        mtp_weights_present: false,
+        dots_ocr_config: None,
+        dots_ocr_weights: None,
+        vision_config: None,
+        vision_weights: None,
         tokenizer: Some(tokenizer),
-        seq_pos: 0, max_seq, physical_cap: max_seq, eviction: None, kv_adaptive: None,
+        seq_pos: 0,
+        max_seq,
+        physical_cap: max_seq,
+        eviction: None,
+        kv_adaptive: None,
         conversation_tokens: Vec::new(),
-        asst_turn_cache: AsstTurnCache::new_from_env(), prefill_checkpoints: Vec::new(), dflash_checkpoints: Vec::new(), decoded_vocab: None,
+        asst_turn_cache: AsstTurnCache::new_from_env(),
+        prefill_checkpoints: Vec::new(),
+        dflash_checkpoints: Vec::new(),
+        decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
         chat_template: resolve_chat_template(&hfq, path),
@@ -3581,7 +4477,10 @@ fn load_model_pp(
 
 /// Pre-screen all Qwen3.5/3.6 weight matrices for MMQ safety (#87).
 /// Returns (n_safe, n_unsafe). Results are cached in gpu.mmq_screen.cache.
-fn screen_weights_qwen35(weights: &qwen35::Qwen35Weights, gpu: &mut rdna_compute::Gpu) -> (usize, usize) {
+fn screen_weights_qwen35(
+    weights: &qwen35::Qwen35Weights,
+    gpu: &mut rdna_compute::Gpu,
+) -> (usize, usize) {
     use hipfire_arch_qwen35::qwen35::LayerWeights;
     let mut n_safe = 0usize;
     let mut n_unsafe = 0usize;
@@ -3590,23 +4489,33 @@ fn screen_weights_qwen35(weights: &qwen35::Qwen35Weights, gpu: &mut rdna_compute
         // Collect all weight tensors for this layer that could use MMQ
         let wts: Vec<(&hipfire_runtime::llama::WeightTensor, &str)> = match layer {
             LayerWeights::DeltaNet(l) => vec![
-                (&l.wqkv, "qkvza.qkv"), (&l.wz, "qkvza.z"),
-                (&l.w_beta, "qkvza.beta"), (&l.w_alpha, "qkvza.alpha"),
-                (&l.w_gate, "gate_up.gate"), (&l.w_up, "gate_up.up"),
+                (&l.wqkv, "qkvza.qkv"),
+                (&l.wz, "qkvza.z"),
+                (&l.w_beta, "qkvza.beta"),
+                (&l.w_alpha, "qkvza.alpha"),
+                (&l.w_gate, "gate_up.gate"),
+                (&l.w_up, "gate_up.up"),
                 (&l.wo, "residual"),
             ],
             LayerWeights::FullAttn(l) => vec![
-                (&l.wq, "qkv.q"), (&l.wk, "qkv.k"), (&l.wv, "qkv.v"),
-                (&l.w_gate, "gate_up.gate"), (&l.w_up, "gate_up.up"),
+                (&l.wq, "qkv.q"),
+                (&l.wk, "qkv.k"),
+                (&l.wv, "qkv.v"),
+                (&l.w_gate, "gate_up.gate"),
+                (&l.w_up, "gate_up.up"),
                 (&l.wo, "residual"),
             ],
             LayerWeights::DeltaNetMoe(l) => vec![
-                (&l.wqkv, "qkvza.qkv"), (&l.wz, "qkvza.z"),
-                (&l.w_beta, "qkvza.beta"), (&l.w_alpha, "qkvza.alpha"),
+                (&l.wqkv, "qkvza.qkv"),
+                (&l.wz, "qkvza.z"),
+                (&l.w_beta, "qkvza.beta"),
+                (&l.w_alpha, "qkvza.alpha"),
                 (&l.wo, "residual"),
             ],
             LayerWeights::FullAttnMoe(l) => vec![
-                (&l.wq, "qkv.q"), (&l.wk, "qkv.k"), (&l.wv, "qkv.v"),
+                (&l.wq, "qkv.q"),
+                (&l.wk, "qkv.k"),
+                (&l.wv, "qkv.v"),
                 (&l.wo, "residual"),
             ],
         };
@@ -3616,7 +4525,10 @@ fn screen_weights_qwen35(weights: &qwen35::Qwen35Weights, gpu: &mut rdna_compute
             // (MQ3, MQ2, HFQ6, etc.) use different dispatch paths and must
             // not be fed to the HFQ4-specific screening kernels — buffer
             // layout mismatch would read past the end. See PR #106.
-            if !matches!(wt.gpu_dtype, rdna_compute::DType::HFQ4G256 | rdna_compute::DType::MQ4G256) {
+            if !matches!(
+                wt.gpu_dtype,
+                rdna_compute::DType::HFQ4G256 | rdna_compute::DType::MQ4G256
+            ) {
                 continue;
             }
             if gpu.mmq_screen_weight(&wt.buf, wt.m, wt.k) {
@@ -3638,13 +4550,19 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     // weights, so each free targets a still-live owner.
     if m.pp > 1 {
         let mut gpus = m.pp_gpus.expect("pp>1 must carry pp_gpus");
-        if let Some(scratch_set) = m.pp_scratch_set { scratch_set.free_gpu_multi(&mut gpus); }
-        if let Some(kv) = m.kv_cache { kv.free_gpu_multi(&mut gpus); }
+        if let Some(scratch_set) = m.pp_scratch_set {
+            scratch_set.free_gpu_multi(&mut gpus);
+        }
+        if let Some(kv) = m.kv_cache {
+            kv.free_gpu_multi(&mut gpus);
+        }
         if let Some(dn) = m.dn_state {
             let la_to_device = m.pp_dn_la_to_device.expect("pp>1 must carry la_to_device");
             dn.free_gpu_multi(&mut gpus, &la_to_device);
         }
-        if let Some(w) = m.q35_weights { w.free_gpu_multi(&mut gpus); }
+        if let Some(w) = m.q35_weights {
+            w.free_gpu_multi(&mut gpus);
+        }
         for g in gpus.devices.iter_mut() {
             g.invalidate_weight_caches();
             g.invalidate_graph_state();
@@ -3663,30 +4581,58 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
         df.draft_scratch.free_gpu(gpu);
     }
     // Free eviction context (centers + scratch tensors) if active.
-    if let Some(ev) = m.eviction { ev.free_gpu(gpu); }
+    if let Some(ev) = m.eviction {
+        ev.free_gpu(gpu);
+    }
     // Free KV cache + DeltaNet state + scratch first (small fraction of VRAM).
-    if let Some(kv) = m.kv_cache { kv.free_gpu(gpu); }
-    if let Some(dn) = m.dn_state { dn.free_gpu(gpu); }
-    if let Some(s) = m.q35_scratch { s.free_gpu(gpu); }
-    if let Some(kv) = m.llama_kv { kv.free_gpu(gpu); }
-    if let Some(s) = m.llama_scratch { s.free_gpu(gpu); }
+    if let Some(kv) = m.kv_cache {
+        kv.free_gpu(gpu);
+    }
+    if let Some(dn) = m.dn_state {
+        dn.free_gpu(gpu);
+    }
+    if let Some(s) = m.q35_scratch {
+        s.free_gpu(gpu);
+    }
+    if let Some(kv) = m.llama_kv {
+        kv.free_gpu(gpu);
+    }
+    if let Some(s) = m.llama_scratch {
+        s.free_gpu(gpu);
+    }
     // Qwen2 state holds both the per-step scratch AND the KV cache — one
     // free_gpu call handles both. (Compare LLaMA where ForwardScratch and
     // KvCache are separate fields.)
-    if let Some(s) = m.qwen2_state { s.free_gpu(gpu); }
+    if let Some(s) = m.qwen2_state {
+        s.free_gpu(gpu);
+    }
     // V4F (arch_id=9) per-session scratch + per-layer SWA/indexer/
     // compressor caches. Without these `unload_model` would leak ~tens
     // of MB of state buffers per load/unload cycle, defeating idle
     // eviction.
-    if let Some(s) = m.deepseek4_state { s.free_gpu(gpu); }
-    if let Some(pbs) = m.deepseek4_pbs { pbs.free_gpu(gpu); }
+    if let Some(s) = m.deepseek4_state {
+        s.free_gpu(gpu);
+    }
+    if let Some(pbs) = m.deepseek4_pbs {
+        pbs.free_gpu(gpu);
+    }
     // Weights are the bulk of VRAM (~80%). Free them too so idle eviction
     // actually returns VRAM to the system, not just the cache.
-    if let Some(w) = m.q35_weights { w.free_gpu(gpu); }
-    if let Some(w) = m.llama_weights { w.free_gpu(gpu); }
-    if let Some(w) = m.qwen2_weights { w.free_gpu(gpu); }
-    if let Some(w) = m.vision_weights { w.free_gpu(gpu); }
-    if let Some(w) = m.deepseek4_weights { w.free_gpu(gpu); }
+    if let Some(w) = m.q35_weights {
+        w.free_gpu(gpu);
+    }
+    if let Some(w) = m.llama_weights {
+        w.free_gpu(gpu);
+    }
+    if let Some(w) = m.qwen2_weights {
+        w.free_gpu(gpu);
+    }
+    if let Some(w) = m.vision_weights {
+        w.free_gpu(gpu);
+    }
+    if let Some(w) = m.deepseek4_weights {
+        w.free_gpu(gpu);
+    }
     // Drop pointer-keyed caches whose keys point at weight buffers that are
     // about to be returned to the pool. Without this, the next model loaded
     // can land at the same device address and silently inherit stale
@@ -3711,10 +4657,16 @@ fn load_dflash_state(
 ) -> Result<DflashState, String> {
     let hfq = HfqFile::open(Path::new(draft_path)).map_err(|e| format!("open draft: {e}"))?;
     let draft_config = DflashConfig::from_hfq(&hfq).ok_or("parse DflashConfig")?;
-    let draft_weights = DflashWeights::load(gpu, &hfq, &draft_config).map_err(|e| format!("load weights: {e}"))?;
+    let draft_weights =
+        DflashWeights::load(gpu, &hfq, &draft_config).map_err(|e| format!("load weights: {e}"))?;
     let draft_scratch = DflashScratch::new_with_mq(
-        gpu, &draft_config, draft_config.block_size, ctx_capacity, draft_weights.has_mq,
-    ).map_err(|e| format!("draft scratch: {e}"))?;
+        gpu,
+        &draft_config,
+        draft_config.block_size,
+        ctx_capacity,
+        draft_weights.has_mq,
+    )
+    .map_err(|e| format!("draft scratch: {e}"))?;
 
     // Hidden ring: one row per target-layer selected by the draft config,
     // captured during each target forward. Sized so the whole context plus
@@ -3727,9 +4679,11 @@ fn load_dflash_state(
         draft_config.hidden,
         ctx_capacity + draft_config.block_size,
         hipfire_arch_qwen35::qwen35::PREFILL_MAX_BATCH.max(draft_config.block_size),
-    ).map_err(|e| format!("hidden_rb: {e}"))?;
+    )
+    .map_err(|e| format!("hidden_rb: {e}"))?;
 
-    let target_snap = DeltaNetSnapshot::new_for(gpu, target_dn).map_err(|e| format!("target_snap: {e}"))?;
+    let target_snap =
+        DeltaNetSnapshot::new_for(gpu, target_dn).map_err(|e| format!("target_snap: {e}"))?;
 
     // Read DDTree budget env-var BEFORE sizing GdnTape / VerifyScratch.
     // When DDTree is enabled, both must be sized for `1 + budget` nodes
@@ -3785,11 +4739,11 @@ fn load_dflash_state(
         target_config.vocab_size,
         target_config.dim,
         target_config,
-    ).map_err(|e| format!("verify_scratch: {e}"))?;
+    )
+    .map_err(|e| format!("verify_scratch: {e}"))?;
 
-    let target_hidden_host: Vec<f32> = Vec::with_capacity(
-        ctx_capacity * draft_config.num_extract() * draft_config.hidden,
-    );
+    let target_hidden_host: Vec<f32> =
+        Vec::with_capacity(ctx_capacity * draft_config.num_extract() * draft_config.hidden);
     let block_size = draft_config.block_size;
 
     // Optional DDTree allocation. `HIPFIRE_DDTREE_BUDGET=<n>` (positive
@@ -3853,10 +4807,8 @@ fn load_dflash_state(
                 .count();
             // qkv_dim mirrors GdnTape::new_for_config: linear-attention
             // qkv row width (k_dim × 2 + v_dim).
-            let k_dim = target_config.linear_num_key_heads
-                * target_config.linear_key_head_dim;
-            let v_dim = target_config.linear_num_value_heads
-                * target_config.linear_value_head_dim;
+            let k_dim = target_config.linear_num_key_heads * target_config.linear_key_head_dim;
+            let v_dim = target_config.linear_num_value_heads * target_config.linear_value_head_dim;
             let qkv_dim = k_dim * 2 + v_dim;
             let scratch = DdtreeScratch::new(
                 gpu,
@@ -3966,8 +4918,7 @@ fn plan_prompt_cache(
             asst_turn_cache.get(&fp).cloned()
         },
     );
-    let cache_eligible =
-        !cache_disabled && eviction_is_none && !conversation_tokens.is_empty();
+    let cache_eligible = !cache_disabled && eviction_is_none && !conversation_tokens.is_empty();
     if cache_eligible {
         let prior_len = conversation_tokens.len();
         let max_match = prior_len.min(rendered.len());
@@ -4118,7 +5069,9 @@ fn generate_dflash(
         match render_result {
             Ok(rendered) => tokenizer.encode(&rendered),
             Err(e) => {
-                eprintln!("[daemon] jinja render failed in dflash path ({e}) — falling back to Plain");
+                eprintln!(
+                    "[daemon] jinja render failed in dflash path ({e}) — falling back to Plain"
+                );
                 hipfire_runtime::prompt_frame::ChatFrame {
                     tokenizer,
                     system: system_prompt,
@@ -4142,15 +5095,19 @@ fn generate_dflash(
 
     // `im_end_token` is still needed downstream for the EOS check.
     let im_end = tokenizer.encode("<|im_end|>");
-    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    let im_end_token = if im_end.len() == 1 {
+        Some(im_end[0])
+    } else {
+        None
+    };
 
     // Prompt-cache plan (native DFlash reuse). For non-jinja chat with history,
     // decide whether this turn is a pure extension of the cached conversation.
     // On a HIT we reuse target KV + DeltaNet[0..start_pos] and the draft's
     // cumulative target_hidden, prefilling only the suffix; on a MISS we
     // full-reset and prefill the whole conversation (legacy behaviour).
-    let cache_disabled = try_jinja
-        || std::env::var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
+    let cache_disabled =
+        try_jinja || std::env::var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
     // DFlash divergent-render resume (default ON; opt out with
     // HIPFIRE_DFLASH_CKPT_RESUME=0). Requires no eviction (resume rewinds the
     // resident KV prefix). When on, the recurrent state is checkpointed during
@@ -4158,7 +5115,8 @@ fn generate_dflash(
     // ≤ lcp — byte-identical to a cold prefill of the same render (verified),
     // so worst case equals the legacy cold-reset path. Off ⇒ no checkpoints
     // (zero overhead) + legacy cold-reset-on-divergence.
-    let dflash_resume_enabled = std::env::var("HIPFIRE_DFLASH_CKPT_RESUME").ok().as_deref() != Some("0")
+    let dflash_resume_enabled = std::env::var("HIPFIRE_DFLASH_CKPT_RESUME").ok().as_deref()
+        != Some("0")
         && m.eviction.is_none();
     let dflash_ckpt_positions: Vec<usize> = m.dflash_checkpoints.iter().map(|(p, _)| *p).collect();
     let cache_plan: Option<PromptCachePlan> = if !try_jinja {
@@ -4189,11 +5147,20 @@ fn generate_dflash(
         Some(p) => p.rendered.clone(),
         None => prompt_tokens,
     };
-    let (prefill_tokens, prefill_start, cache_hit, cached_tokens_dflash): (Vec<u32>, usize, bool, usize) =
-        match &cache_plan {
-            Some(p) => (p.new_tokens.clone(), p.start_pos, p.cache_hit, p.cached_tokens),
-            None => (prompt_tokens.clone(), 0, false, 0),
-        };
+    let (prefill_tokens, prefill_start, cache_hit, cached_tokens_dflash): (
+        Vec<u32>,
+        usize,
+        bool,
+        usize,
+    ) = match &cache_plan {
+        Some(p) => (
+            p.new_tokens.clone(),
+            p.start_pos,
+            p.cache_hit,
+            p.cached_tokens,
+        ),
+        None => (prompt_tokens.clone(), 0, false, 0),
+    };
 
     // Divergent-render RESUME: restore the DeltaNet recurrent state to the
     // checkpoint and rewind seq_pos/conversation_tokens/checkpoints to it. The
@@ -4220,9 +5187,15 @@ fn generate_dflash(
         m.conversation_tokens.clear();
         {
             let dn = m.dn_state.as_ref().unwrap();
-            for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-            for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-            for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+            for s in &dn.s_matrices {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.s_scales {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.conv_states {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
         }
     } else if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
         eprintln!(
@@ -4255,10 +5228,16 @@ fn generate_dflash(
     let hfq = match HfqFile::open(Path::new(&m.model_path)) {
         Ok(h) => h,
         Err(e) => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"reopen model: {}"}}"#, id, e);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"reopen model: {}"}}"#,
+                id, e
+            );
             let _ = stdout.flush();
-            m.q35_weights = Some(weights); m.kv_cache = Some(kv_cache);
-            m.dn_state = Some(dn_state); m.q35_scratch = Some(scratch);
+            m.q35_weights = Some(weights);
+            m.kv_cache = Some(kv_cache);
+            m.dn_state = Some(dn_state);
+            m.q35_scratch = Some(scratch);
             return;
         }
     };
@@ -4280,13 +5259,21 @@ fn generate_dflash(
     // effectively unbounded (eviction fires between spec cycles), but the
     // *prompt* must still fit in one physical_cap span because
     // seed_target_hidden_from_prompt writes it per-token without chunking.
-    let eff_prompt_cap = if m.eviction.is_some() { m.physical_cap } else { ctx_capacity };
+    let eff_prompt_cap = if m.eviction.is_some() {
+        m.physical_cap
+    } else {
+        ctx_capacity
+    };
     if prompt_tokens.len() + df.block_size > eff_prompt_cap {
         let _ = writeln!(
             stdout,
             r#"{{"type":"error","id":"{}","message":"prompt+block_size exceeds {} {} (eviction {})"}}"#,
             id,
-            if m.eviction.is_some() { "physical_cap" } else { "ctx_capacity" },
+            if m.eviction.is_some() {
+                "physical_cap"
+            } else {
+                "ctx_capacity"
+            },
             eff_prompt_cap,
             if m.eviction.is_some() { "on" } else { "off" },
         );
@@ -4327,24 +5314,46 @@ fn generate_dflash(
     // from a checkpoint instead of cold-prefilling.
     let (ck_int, ck_cap) = (ckpt_interval(), ckpt_max());
     let ckpt_sink: Option<&mut Vec<(usize, speculative::DeltaNetSnapshot)>> =
-        if dflash_resume_enabled { Some(&mut m.dflash_checkpoints) } else { None };
+        if dflash_resume_enabled {
+            Some(&mut m.dflash_checkpoints)
+        } else {
+            None
+        };
     let seed_result = if cache_hit {
         // Incremental: prefill only the suffix, continuing from start_pos with
         // the reused target KV + DeltaNet state (no reset).
         speculative::seed_target_hidden_suffix_abortable(
-            gpu, &mut target, &mut df.hidden_rb, &prefill_tokens, prefill_start,
-            &|| check_abort(&id_for_abort), ckpt_sink, ck_int, ck_cap,
+            gpu,
+            &mut target,
+            &mut df.hidden_rb,
+            &prefill_tokens,
+            prefill_start,
+            &|| check_abort(&id_for_abort),
+            ckpt_sink,
+            ck_int,
+            ck_cap,
         )
     } else {
         speculative::seed_target_hidden_from_prompt_abortable(
-            gpu, &mut target, &mut df.hidden_rb, &mut df.target_hidden_host, &prompt_tokens,
-            &|| check_abort(&id_for_abort), ckpt_sink, ck_int, ck_cap,
+            gpu,
+            &mut target,
+            &mut df.hidden_rb,
+            &mut df.target_hidden_host,
+            &prompt_tokens,
+            &|| check_abort(&id_for_abort),
+            ckpt_sink,
+            ck_int,
+            ck_cap,
         )
     };
     let aborted = match seed_result {
         Ok(b) => b,
         Err(e) => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"prefill: {}"}}"#, id, e);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"prefill: {}"}}"#,
+                id, e
+            );
             let _ = stdout.flush();
             m.q35_weights = Some(target.weights);
             m.kv_cache = Some(target.kv_cache);
@@ -4363,8 +5372,16 @@ fn generate_dflash(
         m.kv_cache = Some(target.kv_cache);
         m.dn_state = Some(target.dn_state);
         m.q35_scratch = Some(target.scratch);
-        let _ = writeln!(stdout, r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#, id);
-        let _ = writeln!(stdout, r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":0,"prefill_ms":0,"decode_ms":0}}"#, id);
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
+            id
+        );
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":0,"prefill_ms":0,"decode_ms":0}}"#,
+            id
+        );
         let _ = stdout.flush();
         return;
     }
@@ -4377,23 +5394,30 @@ fn generate_dflash(
         // only [start_pos..position) — the same delta path decode uses.
         let suffix_len = prefill_tokens.len();
         if let Err(e) = speculative::scatter_hidden_block_to_interleaved(
-            gpu, &df.hidden_rb, &df.draft_scratch.target_hidden,
-            prefill_start, suffix_len, suffix_len,
+            gpu,
+            &df.hidden_rb,
+            &df.draft_scratch.target_hidden,
+            prefill_start,
+            suffix_len,
+            suffix_len,
         ) {
             eprintln!("[dflash] suffix scatter failed: {e}");
         }
     } else {
         // Full prefill: scatter all prompt rows from offset 0.
         if let Err(e) = speculative::scatter_hidden_block_to_interleaved(
-            gpu, &df.hidden_rb, &df.draft_scratch.target_hidden,
-            0, prompt_tokens.len(), prompt_tokens.len(),
+            gpu,
+            &df.hidden_rb,
+            &df.draft_scratch.target_hidden,
+            0,
+            prompt_tokens.len(),
+            prompt_tokens.len(),
         ) {
             eprintln!("[dflash] scatter failed: {e} — falling back to per-cycle upload");
         }
     }
     df.draft_scratch.uploaded_target_hidden_rows = prompt_tokens.len();
-    df.draft_scratch.target_hidden_abs_positions =
-        (0..prompt_tokens.len() as i32).collect();
+    df.draft_scratch.target_hidden_abs_positions = (0..prompt_tokens.len() as i32).collect();
     if let Some(ckpt) = resume_from {
         // Rows [ckpt..len) of target_hidden were just overwritten with the new
         // (divergent) content, so the draft's projection cache for them is
@@ -4409,7 +5433,11 @@ fn generate_dflash(
     let first_logits = match gpu.download_f32(&target.scratch.logits) {
         Ok(v) => v,
         Err(e) => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"download logits: {}"}}"#, id, e);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"download logits: {}"}}"#,
+                id, e
+            );
             let _ = stdout.flush();
             m.q35_weights = Some(target.weights);
             m.kv_cache = Some(target.kv_cache);
@@ -4418,10 +5446,17 @@ fn generate_dflash(
             return;
         }
     };
-    let first_token = first_logits.iter().enumerate()
+    let first_token = first_logits
+        .iter()
+        .enumerate()
         .fold((0u32, f32::NEG_INFINITY), |(best, bv), (i, &v)| {
-            if v > bv { (i as u32, v) } else { (best, bv) }
-        }).0;
+            if v > bv {
+                (i as u32, v)
+            } else {
+                (best, bv)
+            }
+        })
+        .0;
 
     let t_prefill = Instant::now();
 
@@ -4447,10 +5482,7 @@ fn generate_dflash(
     // tool_call header emission (~30-50 tokens).
     //
     // Disable with `HIPFIRE_QWEN35_GRAMMAR=0`.
-    let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR")
-        .ok()
-        .as_deref()
-        != Some("0");
+    let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() != Some("0");
     let tool_schemas_dflash: Vec<hipfire_arch_qwen35::grammar::ToolSchema> = if grammar_enabled {
         tools
             .map(|arr| {
@@ -4476,10 +5508,7 @@ fn generate_dflash(
                                     .collect()
                             })
                             .unwrap_or_default();
-                        Some(hipfire_arch_qwen35::grammar::ToolSchema {
-                            name,
-                            required,
-                        })
+                        Some(hipfire_arch_qwen35::grammar::ToolSchema { name, required })
                     })
                     .collect()
             })
@@ -4488,8 +5517,7 @@ fn generate_dflash(
         Vec::new()
     };
     let grammar_active = !tool_schemas_dflash.is_empty();
-    let mut grammar_matcher =
-        hipfire_arch_qwen35::grammar::Matcher::new(tool_schemas_dflash);
+    let mut grammar_matcher = hipfire_arch_qwen35::grammar::Matcher::new(tool_schemas_dflash);
     let mut grammar_violated = false;
 
     // Decode loop — spec_step_dflash returns a committed batch per cycle.
@@ -4525,8 +5553,12 @@ fn generate_dflash(
             position = res.new_physical;
             if !res.retain_mask.is_empty() {
                 let _ = speculative::apply_eviction_retain_to_draft(
-                    gpu, &mut df.draft_scratch, &res.retain_mask,
-                    df.draft_config.num_extract(), df.draft_config.hidden, pre_phys,
+                    gpu,
+                    &mut df.draft_scratch,
+                    &res.retain_mask,
+                    df.draft_config.num_extract(),
+                    df.draft_config.hidden,
+                    pre_phys,
                 );
             }
         }
@@ -4534,13 +5566,24 @@ fn generate_dflash(
 
     // Emit the first token immediately so TTFT is the prefill time.
     streamed_tokens.push(first_token);
-    emit_committed_event(stdout, id, first_token, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+    emit_committed_event(
+        stdout,
+        id,
+        first_token,
+        streamed_tokens.len() - 1,
+        t0.elapsed().as_millis() as u64,
+    );
     let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
     let new_bytes = &all_bytes[bytes_fed_to_filter..];
     bytes_fed_to_filter = all_bytes.len();
     if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
         let text = std::str::from_utf8(&text_bytes).unwrap();
-        let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"token","id":"{}","text":{}}}"#,
+            id,
+            serde_json::to_string(&text).unwrap_or_default()
+        );
         let _ = stdout.flush();
     }
     generated += 1;
@@ -4564,7 +5607,8 @@ fn generate_dflash(
     // `phase1` runs Step 1 only (linear main-path verify); `phase2` adds
     // the lazy branch FA-only re-verify (Steps 2+3). See
     // `docs/plans/ddtree-path-c-main-path-first-from-lucebox.prd`.
-    let path_c_mode_owned: Option<&'static str> = match std::env::var("HIPFIRE_DDTREE_PATH_C").ok() {
+    let path_c_mode_owned: Option<&'static str> = match std::env::var("HIPFIRE_DDTREE_PATH_C").ok()
+    {
         None => None,
         Some(s) if s.is_empty() => None,
         Some(s) if s == "phase1" => Some("phase1"),
@@ -4601,12 +5645,22 @@ fn generate_dflash(
             m.seq_pos = 0;
             m.conversation_tokens.clear();
             m.dflash_checkpoints.clear();
-            let _ = writeln!(stdout, r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#, id);
-            let _ = writeln!(stdout, r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":{},"prefill_ms":0,"decode_ms":0,"dflash":true}}"#, id, generated);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
+                id
+            );
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":{},"prefill_ms":0,"decode_ms":0,"dflash":true}}"#,
+                id, generated
+            );
             let _ = stdout.flush();
             return;
         }
-        if position + df.block_size >= ctx_capacity { break; }
+        if position + df.block_size >= ctx_capacity {
+            break;
+        }
 
         // Dispatch: when DDTree is configured (HIPFIRE_DDTREE_BUDGET set
         // at startup), route through `spec_step_ddtree_batched`. Otherwise
@@ -4626,50 +5680,78 @@ fn generate_dflash(
                     None
                 };
                 spec_step_ddtree_path_c(
-                    gpu, &mut target, &df.draft_weights, &df.draft_config,
-                    &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
-                    &mut df.target_snap, &mut df.gdn_tape, &df.verify_scratch,
-                    position, seed_token,
-                    None,                      // ctx_slice = full history
+                    gpu,
+                    &mut target,
+                    &df.draft_weights,
+                    &df.draft_config,
+                    &mut df.draft_scratch,
+                    &mut df.hidden_rb,
+                    &mut df.target_hidden_host,
+                    &mut df.target_snap,
+                    &mut df.gdn_tape,
+                    &df.verify_scratch,
+                    position,
+                    seed_token,
+                    None, // ctx_slice = full history
                     dd.budget,
                     dd.topk,
                     phase2_snaps,
                 )
             } else {
                 spec_step_ddtree_batched(
-                    gpu, &mut target, &df.draft_weights, &df.draft_config,
-                    &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
-                    &mut df.target_snap, &mut dd.post_seed_snap, &mut df.gdn_tape,
-                    &dd.scratch, &df.verify_scratch,
-                    position, seed_token,
-                    None,                      // ctx_slice = full history
+                    gpu,
+                    &mut target,
+                    &df.draft_weights,
+                    &df.draft_config,
+                    &mut df.draft_scratch,
+                    &mut df.hidden_rb,
+                    &mut df.target_hidden_host,
+                    &mut df.target_snap,
+                    &mut dd.post_seed_snap,
+                    &mut df.gdn_tape,
+                    &dd.scratch,
+                    &df.verify_scratch,
+                    position,
+                    seed_token,
+                    None, // ctx_slice = full history
                     dd.budget,
                     dd.topk,
                 )
             }
         } else {
             spec_step_dflash(
-                gpu, &mut target, &df.draft_weights, &df.draft_config,
-                &mut df.draft_scratch, &mut df.hidden_rb, &mut df.target_hidden_host,
-                &mut df.target_snap, &df.verify_scratch,
-                position, seed_token,
-                None,                      // ctx_slice = full history
+                gpu,
+                &mut target,
+                &df.draft_weights,
+                &df.draft_config,
+                &mut df.draft_scratch,
+                &mut df.hidden_rb,
+                &mut df.target_hidden_host,
+                &mut df.target_snap,
+                &df.verify_scratch,
+                position,
+                seed_token,
+                None, // ctx_slice = full history
                 Some(&mut df.gdn_tape),
-                0.0_f32,                   // temperature
+                0.0_f32, // temperature
                 &mut rng_state,
-                None,                      // block_size override
-                None,                      // ngram_cache
+                None, // block_size override
+                None, // ngram_cache
                 &emitted,
-                0.0_f32,                   // cactus_delta
-                None,                      // pld_spine
-                1.0_f32,                   // repeat_penalty (off)
-                0,                         // repeat_window
+                0.0_f32, // cactus_delta
+                None,    // pld_spine
+                1.0_f32, // repeat_penalty (off)
+                0,       // repeat_window
             )
         };
         let step = match step_result {
             Ok(s) => s,
             Err(e) => {
-                let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"spec_step: {}"}}"#, id, e);
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"error","id":"{}","message":"spec_step: {}"}}"#,
+                    id, e
+                );
                 let _ = stdout.flush();
                 break;
             }
@@ -4680,7 +5762,9 @@ fn generate_dflash(
         let mut hit_eos = false;
         let mut think_cap_hit = false;
         for &tok in &committed_tail {
-            if generated >= max_tokens { break; }
+            if generated >= max_tokens {
+                break;
+            }
             // Grammar pre-check (dflash path). Reject committed tokens
             // that would put the matcher into an invalid state — e.g.
             // `<|im_start|>` immediately after `<tool_call>` (Pi turn-12
@@ -4710,17 +5794,34 @@ fn generate_dflash(
             }
             emitted.push(tok);
             streamed_tokens.push(tok);
-            emit_committed_event(stdout, id, tok, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+            emit_committed_event(
+                stdout,
+                id,
+                tok,
+                streamed_tokens.len() - 1,
+                t0.elapsed().as_millis() as u64,
+            );
             let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
             let new_bytes = &all_bytes[bytes_fed_to_filter..];
             bytes_fed_to_filter = all_bytes.len();
             if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
                 let text = std::str::from_utf8(&text_bytes).unwrap();
-                let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"token","id":"{}","text":{}}}"#,
+                    id,
+                    serde_json::to_string(&text).unwrap_or_default()
+                );
                 let _ = stdout.flush();
             }
             generated += 1;
-            if tok == target.config.eos_token || im_end_token == Some(tok) || tokenizer.is_terminator(tok) { hit_eos = true; break; }
+            if tok == target.config.eos_token
+                || im_end_token == Some(tok)
+                || tokenizer.is_terminator(tok)
+            {
+                hit_eos = true;
+                break;
+            }
 
             // max_think_tokens enforcement (mirrors the AR path). Track
             // <think>/<⁄think> in decoded text and count tokens inside.
@@ -4734,8 +5835,12 @@ fn generate_dflash(
                     (Some(_), None) => true,
                     _ => false,
                 };
-                if in_think && !prev_in_think { think_count = 0; }
-                if in_think { think_count += 1; }
+                if in_think && !prev_in_think {
+                    think_count = 0;
+                }
+                if in_think {
+                    think_count += 1;
+                }
                 prev_in_think = in_think;
 
                 if in_think && think_count >= max_think_tokens {
@@ -4743,7 +5848,11 @@ fn generate_dflash(
                     // Unlike the AR path we can't splice into the KV cache mid-
                     // spec-cycle, so we just stream the close text and break.
                     // The next request will start fresh.
-                    let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":"</think>\n"}}"#, id);
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"token","id":"{}","text":"</think>\n"}}"#,
+                        id
+                    );
                     let _ = stdout.flush();
                     think_cap_hit = true;
                     break;
@@ -4761,13 +5870,19 @@ fn generate_dflash(
                 position = res.new_physical;
                 if !res.retain_mask.is_empty() {
                     let _ = speculative::apply_eviction_retain_to_draft(
-                        gpu, &mut df.draft_scratch, &res.retain_mask,
-                        df.draft_config.num_extract(), df.draft_config.hidden, pre_phys,
+                        gpu,
+                        &mut df.draft_scratch,
+                        &res.retain_mask,
+                        df.draft_config.num_extract(),
+                        df.draft_config.hidden,
+                        pre_phys,
                     );
                 }
             }
         }
-        if hit_eos || think_cap_hit { break; }
+        if hit_eos || think_cap_hit {
+            break;
+        }
     }
 
     // Put target state back on LoadedModel so the next request sees fresh
@@ -4866,8 +5981,7 @@ fn generate_dflash(
     }
     if !cached_seq.is_empty() {
         let stripped = strip_think_for_fingerprint(&decoded_full);
-        let emit_text = hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped)
-            .into_owned();
+        let emit_text = hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped).into_owned();
         let fp = asst_turn_fingerprint(&emit_text, &emit_tool_calls);
         if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
             eprintln!(
@@ -4883,12 +5997,28 @@ fn generate_dflash(
     let total_s = t_end.duration_since(t0).as_secs_f64();
     let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
     let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
-    let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
-    let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+    let tok_s = if total_s > 0.0 {
+        generated as f64 / total_s
+    } else {
+        0.0
+    };
+    let decode_tok_s = if decode_s > 0.0 {
+        generated as f64 / decode_s
+    } else {
+        0.0
+    };
     // New-token count (not full rendered length) so the prefill rate reflects
     // actual work on a cache HIT/resume — matches every other path's numerator.
-    let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens.len() as f64 / prefill_s } else { 0.0 };
-    let tau = if stats.cycles > 0 { stats.accepted_tokens as f64 / stats.cycles as f64 } else { 0.0 };
+    let prefill_tok_s = if prefill_s > 0.0 {
+        prefill_tokens.len() as f64 / prefill_s
+    } else {
+        0.0
+    };
+    let tau = if stats.cycles > 0 {
+        stats.accepted_tokens as f64 / stats.cycles as f64
+    } else {
+        0.0
+    };
     // Per PRD §3.1, when PFlash bypassed (e.g. dflash_decode_active for
     // this branch) the `done` object must surface the bypass reason and
     // alpha alongside the dflash perf metrics. Build a small fragment
@@ -4896,7 +6026,8 @@ fn generate_dflash(
     let pflash_done_field = match (pflash_bypass_reason, pflash_alpha) {
         (Some(r), Some(a)) => format!(
             r#","pflash":{{"bypass_reason":"{}","alpha":{:.6}}}"#,
-            r.replace('"', "'"), a,
+            r.replace('"', "'"),
+            a,
         ),
         _ => String::new(),
     };
@@ -4919,9 +6050,19 @@ fn generate_dflash(
         // (= p.new_tokens) is already the suffix; `cached_tokens_dflash` is the
         // reused prefix, so cached + new == full rendered length. Matches the AR
         // path (6754) which reports its `prefill_tokens` (new_tokens.len()).
-        id, generated, tok_s, prefill_tokens.len(),
-        prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0,
-        tau, stats.cycles, cached_tokens_dflash, finish_reason, pflash_done_field,
+        id,
+        generated,
+        tok_s,
+        prefill_tokens.len(),
+        prefill_s * 1000.0,
+        prefill_tok_s,
+        decode_tok_s,
+        prefill_s * 1000.0,
+        tau,
+        stats.cycles,
+        cached_tokens_dflash,
+        finish_reason,
+        pflash_done_field,
     );
     let _ = stdout.flush();
 }
@@ -4960,7 +6101,10 @@ fn generate_multi(
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
     if m.seq_pos + prompt_est + max_tokens > m.max_seq {
-        eprintln!("[daemon] context full ({}/{}) — resetting conversation", m.seq_pos, m.max_seq);
+        eprintln!(
+            "[daemon] context full ({}/{}) — resetting conversation",
+            m.seq_pos, m.max_seq
+        );
         m.seq_pos = 0;
         m.conversation_tokens.clear();
         if let (Some(ref dn), Some(ref mut gpus), Some(ref la)) = (
@@ -4984,7 +6128,9 @@ fn generate_multi(
                 let _ = g.hip.memset(&s.buf, 0, s.buf.size());
             }
         }
-        if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
+        if let Some(kv) = m.kv_cache.as_mut() {
+            kv.compact_offset = 0;
+        }
     }
 
     let im_end = tokenizer.encode("<|im_end|>");
@@ -5015,33 +6161,47 @@ fn generate_multi(
     let q_tokens = if let (Some(state), Some(cfg)) = (pflash_state, pflash_cfg) {
         if m.seq_pos == 0 {
             match hipfire_arch_qwen35::pflash::maybe_compress_prompt(
-                gpu, state, cfg, &raw_q_tokens, request_kind, &[],
+                gpu,
+                state,
+                cfg,
+                &raw_q_tokens,
+                request_kind,
+                &[],
             ) {
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Compressed(cp)) => {
-                    let _ = writeln!(stdout,
+                    let _ = writeln!(
+                        stdout,
                         r#"{{"type":"pflash_compressed","id":"{}","source_tokens":{},"kept_tokens":{},"keep_ratio":{:.6},"source_md5":"{}","compressed_md5":"{}","score_ms":{},"total_ms":{}}}"#,
-                        id, cp.source_tokens, cp.kept_tokens,
+                        id,
+                        cp.source_tokens,
+                        cp.kept_tokens,
                         cp.kept_tokens as f32 / cp.source_tokens.max(1) as f32,
-                        cp.source_md5, cp.compressed_md5,
-                        cp.timings.score_ms, cp.timings.total_ms,
+                        cp.source_md5,
+                        cp.compressed_md5,
+                        cp.timings.score_ms,
+                        cp.timings.total_ms,
                     );
                     let _ = stdout.flush();
                     cp.token_ids
                 }
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Bypass { reason }) => {
                     if !matches!(reason, hipfire_arch_qwen35::pflash::BypassReason::ModeOff) {
-                        let _ = writeln!(stdout,
+                        let _ = writeln!(
+                            stdout,
                             r#"{{"type":"pflash_bypass","id":"{}","reason":"{}"}}"#,
-                            id, reason.as_str().replace('"', "'"),
+                            id,
+                            reason.as_str().replace('"', "'"),
                         );
                         let _ = stdout.flush();
                     }
                     raw_q_tokens
                 }
                 Err(e) => {
-                    let _ = writeln!(stdout,
+                    let _ = writeln!(
+                        stdout,
                         r#"{{"type":"pflash_error","id":"{}","reason":"{}"}}"#,
-                        id, e.to_string().replace('"', "'"),
+                        id,
+                        e.to_string().replace('"', "'"),
                     );
                     let _ = stdout.flush();
                     raw_q_tokens
@@ -5136,13 +6296,22 @@ fn generate_multi(
         let _ = writeln!(
             stdout,
             r#"{{"type":"error","id":"{}","message":"request exceeds loaded KV budget: seq_pos={} + prefill={} + max_tokens={} + trailer={} > physical_cap={} — reload model with a larger max_seq"}}"#,
-            id, m.seq_pos, new_tokens.len(), max_tokens, trailer, m.physical_cap
+            id,
+            m.seq_pos,
+            new_tokens.len(),
+            max_tokens,
+            trailer,
+            m.physical_cap
         );
         let _ = stdout.flush();
         return;
     }
 
-    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    let im_end_token = if im_end.len() == 1 {
+        Some(im_end[0])
+    } else {
+        None
+    };
     let tool_call_pair = match (
         tokenizer.special_token_id("<tool_call>"),
         tokenizer.special_token_id("</tool_call>"),
@@ -5191,7 +6360,9 @@ fn generate_multi(
                 let _ = g.hip.memset(&s.buf, 0, s.buf.size());
             }
             kv.compact_offset = 0;
-            if let Some(llkv) = m.llama_kv.as_mut() { llkv.compact_offset = 0; }
+            if let Some(llkv) = m.llama_kv.as_mut() {
+                llkv.compact_offset = 0;
+            }
         }};
     }
 
@@ -5200,9 +6371,20 @@ fn generate_multi(
     let repeat_buf_cap = scratch_set.per_device[dev_last].repeat_buf.buf.size() / 4;
 
     if let Err(e) = qwen35::forward_prefill_batch_multi(
-        gpus, weights, config, &new_tokens, m.seq_pos, kv, dn, scratch_set,
+        gpus,
+        weights,
+        config,
+        &new_tokens,
+        m.seq_pos,
+        kv,
+        dn,
+        scratch_set,
     ) {
-        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"forward_prefill_batch_multi: {}"}}"#, id, e);
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"forward_prefill_batch_multi: {}"}}"#,
+            id, e
+        );
         let _ = stdout.flush();
         return;
     }
@@ -5211,8 +6393,16 @@ fn generate_multi(
 
     if check_abort(id) {
         reset_pp_uncommitted_state!();
-        let _ = writeln!(stdout, r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#, id);
-        let _ = writeln!(stdout, r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":0,"prefill_ms":0,"decode_ms":0}}"#, id);
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
+            id
+        );
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":0,"prefill_ms":0,"decode_ms":0}}"#,
+            id
+        );
         let _ = stdout.flush();
         return;
     }
@@ -5230,9 +6420,7 @@ fn generate_multi(
     // First sample on the output device.
     let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
     let mut blocked0: Vec<u32> = Vec::new();
-    sampler::collect_unclosed_attractor_blocks(
-        ngram_scope, &attractor_pairs, 20, 2, &mut blocked0,
-    );
+    sampler::collect_unclosed_attractor_blocks(ngram_scope, &attractor_pairs, 20, 2, &mut blocked0);
     let cfg0 = SamplerConfig {
         temperature: temp,
         top_p,
@@ -5267,46 +6455,89 @@ fn generate_multi(
     let mut force_answer_latched = false;
     let think_open_tok = tokenizer.special_token_id("<think>");
     let max_total_think: usize = std::env::var("HIPFIRE_MAX_TOTAL_THINK_TOKENS")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(0);
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
     let mut total_think_tokens: usize = 0;
-    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
+    let loop_guard =
+        hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
     while generated < max_tokens {
         if check_abort(id) {
             reset_pp_uncommitted_state!();
-            let _ = writeln!(stdout, r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#, id);
-            let _ = writeln!(stdout, r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":{},"prefill_ms":0,"decode_ms":0}}"#, id, generated);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
+                id
+            );
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":{},"prefill_ms":0,"decode_ms":0}}"#,
+                id, generated
+            );
             let _ = stdout.flush();
             return;
         }
         generated += 1;
         m.conversation_tokens.push(next_token);
         streamed_tokens.push(next_token);
-        emit_committed_event(stdout, id, next_token, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+        emit_committed_event(
+            stdout,
+            id,
+            next_token,
+            streamed_tokens.len() - 1,
+            t0.elapsed().as_millis() as u64,
+        );
         let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
         let new_bytes = &all_bytes[bytes_fed_to_filter..];
         bytes_fed_to_filter = all_bytes.len();
         if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
             let text = std::str::from_utf8(&text_bytes).unwrap();
-            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                id,
+                serde_json::to_string(&text).unwrap_or_default()
+            );
             let _ = stdout.flush();
         }
 
-        if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, next_token, m.seq_pos, kv, dn, scratch_set) {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"forward_scratch_multi decode: {}"}}"#, id, e);
+        if let Err(e) = qwen35::forward_scratch_multi(
+            gpus,
+            weights,
+            config,
+            next_token,
+            m.seq_pos,
+            kv,
+            dn,
+            scratch_set,
+        ) {
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"forward_scratch_multi decode: {}"}}"#,
+                id, e
+            );
             let _ = stdout.flush();
             return;
         }
         m.seq_pos += 1;
 
-        if next_token == config.eos_token { break; }
-        if im_end_token == Some(next_token) { break; }
-        if tokenizer.is_terminator(next_token) { break; }
+        if next_token == config.eos_token {
+            break;
+        }
+        if im_end_token == Some(next_token) {
+            break;
+        }
+        if tokenizer.is_terminator(next_token) {
+            break;
+        }
 
         // max_think_tokens / force-answer enforcement: same decoded-text scan
         // as pp=1, but all recurrent-state writes route through *_multi.
         let force_answer_now = check_force_answer(id);
-        if force_answer_now { force_answer_latched = true; }
+        if force_answer_now {
+            force_answer_latched = true;
+        }
         if max_think_tokens > 0 || force_answer_now || force_answer_latched || max_total_think > 0 {
             let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
             let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
@@ -5317,7 +6548,9 @@ fn generate_multi(
                 (Some(_), None) => true,
                 _ => false,
             };
-            if in_think { total_think_tokens += 1; }
+            if in_think {
+                total_think_tokens += 1;
+            }
             if max_total_think > 0 && total_think_tokens >= max_total_think {
                 force_answer_latched = true;
             }
@@ -5327,7 +6560,11 @@ fn generate_multi(
             }
             if max_think_tokens > 0 {
                 if in_think {
-                    if !prev_in_think { think_count = 1; } else { think_count += 1; }
+                    if !prev_in_think {
+                        think_count = 1;
+                    } else {
+                        think_count += 1;
+                    }
                 } else {
                     think_count = 0;
                 }
@@ -5337,7 +6574,10 @@ fn generate_multi(
 
             if in_think && (budget_hit || force_answer_now || force_answer_latched) {
                 if force_answer_now {
-                    eprintln!("[force-answer] id={} — closing <think> mid-turn to commit to the answer", id);
+                    eprintln!(
+                        "[force-answer] id={} — closing <think> mid-turn to commit to the answer",
+                        id
+                    );
                 } else if force_answer_latched {
                     eprintln!("[force-answer] id={} — re-closing a re-opened <think> (latched / think-cap)", id);
                 }
@@ -5345,27 +6585,49 @@ fn generate_multi(
                 let budget_left = max_tokens.saturating_sub(generated);
                 let take = close_tokens.len().min(budget_left);
                 for &t in &close_tokens[..take] {
-                    if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, t, m.seq_pos, kv, dn, scratch_set) {
+                    if let Err(e) = qwen35::forward_scratch_multi(
+                        gpus,
+                        weights,
+                        config,
+                        t,
+                        m.seq_pos,
+                        kv,
+                        dn,
+                        scratch_set,
+                    ) {
                         eprintln!("[daemon] max_think close forward_scratch_multi: {}", e);
                         break;
                     }
                     m.seq_pos += 1;
                     m.conversation_tokens.push(t);
                     streamed_tokens.push(t);
-                    emit_committed_event(stdout, id, t, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+                    emit_committed_event(
+                        stdout,
+                        id,
+                        t,
+                        streamed_tokens.len() - 1,
+                        t0.elapsed().as_millis() as u64,
+                    );
                     let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
                     let new_bytes = &all_bytes[bytes_fed_to_filter..];
                     bytes_fed_to_filter = all_bytes.len();
                     if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
                         let text = std::str::from_utf8(&text_bytes).unwrap();
-                        let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"token","id":"{}","text":{}}}"#,
+                            id,
+                            serde_json::to_string(&text).unwrap_or_default()
+                        );
                         let _ = stdout.flush();
                     }
                     generated += 1;
                 }
                 think_count = 0;
                 prev_in_think = false;
-                if generated >= max_tokens { break; }
+                if generated >= max_tokens {
+                    break;
+                }
             }
         }
 
@@ -5384,7 +6646,11 @@ fn generate_multi(
         }
 
         // Budget-alert injection: gated to inside an open <think> block.
-        if !alert_fired && budget_alert_at_tok > 0 && generated >= budget_alert_at_tok && !budget_alert_text.is_empty() {
+        if !alert_fired
+            && budget_alert_at_tok > 0
+            && generated >= budget_alert_at_tok
+            && !budget_alert_text.is_empty()
+        {
             alert_fired = true;
             let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
             let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
@@ -5394,21 +6660,46 @@ fn generate_multi(
                 _ => false,
             };
             if !in_think {
-                let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not inside an open <think> block"}}"#, id);
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not inside an open <think> block"}}"#,
+                    id
+                );
                 let _ = stdout.flush();
                 let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
                 let mut blocked: Vec<u32> = Vec::new();
-                sampler::collect_unclosed_attractor_blocks(ngram_scope, &attractor_pairs, 20, 2, &mut blocked);
-                if force_answer_latched { if let Some(t) = think_open_tok { blocked.push(t); } }
+                sampler::collect_unclosed_attractor_blocks(
+                    ngram_scope,
+                    &attractor_pairs,
+                    20,
+                    2,
+                    &mut blocked,
+                );
+                if force_answer_latched {
+                    if let Some(t) = think_open_tok {
+                        blocked.push(t);
+                    }
+                }
                 let cfg = SamplerConfig {
-                    temperature: temp, top_p, repeat_penalty,
+                    temperature: temp,
+                    top_p,
+                    repeat_penalty,
                     repeat_window: repeat_buf_cap,
                     blocked_tokens: blocked,
                 };
                 next_token = {
                     let s_last = &scratch_set.per_device[dev_last];
                     let g_last = &mut gpus.devices[dev_last];
-                    sampler::sample(g_last, &s_last.logits, &s_last.sample_buf, &s_last.repeat_buf, vocab_size, ngram_scope, &cfg, &mut rng_state)
+                    sampler::sample(
+                        g_last,
+                        &s_last.logits,
+                        &s_last.sample_buf,
+                        &s_last.repeat_buf,
+                        vocab_size,
+                        ngram_scope,
+                        &cfg,
+                        &mut rng_state,
+                    )
                 };
                 continue;
             }
@@ -5420,16 +6711,36 @@ fn generate_multi(
                 for &tok in &nudge_tokens[..nudge_len] {
                     m.conversation_tokens.push(tok);
                     streamed_tokens.push(tok);
-                    emit_committed_event(stdout, id, tok, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+                    emit_committed_event(
+                        stdout,
+                        id,
+                        tok,
+                        streamed_tokens.len() - 1,
+                        t0.elapsed().as_millis() as u64,
+                    );
                     let all_bytes2 = tokenizer.decode_bytes(&streamed_tokens);
                     let new_bytes2 = &all_bytes2[bytes_fed_to_filter..];
                     bytes_fed_to_filter = all_bytes2.len();
                     if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes2) {
                         let t = std::str::from_utf8(&text_bytes).unwrap();
-                        let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&t).unwrap_or_default());
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"token","id":"{}","text":{}}}"#,
+                            id,
+                            serde_json::to_string(&t).unwrap_or_default()
+                        );
                         let _ = stdout.flush();
                     }
-                    if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, tok, m.seq_pos, kv, dn, scratch_set) {
+                    if let Err(e) = qwen35::forward_scratch_multi(
+                        gpus,
+                        weights,
+                        config,
+                        tok,
+                        m.seq_pos,
+                        kv,
+                        dn,
+                        scratch_set,
+                    ) {
                         eprintln!("[daemon] budget_alert forward_scratch_multi: {}", e);
                         break;
                     }
@@ -5437,36 +6748,76 @@ fn generate_multi(
                     generated += 1;
                 }
             } else if nudge_len < nudge_tokens.len() {
-                let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert clipped or skipped: nudge_len={} budget_left={}"}}"#, id, nudge_len, budget_left);
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"info","id":"{}","message":"budget_alert clipped or skipped: nudge_len={} budget_left={}"}}"#,
+                    id, nudge_len, budget_left
+                );
                 let _ = stdout.flush();
             } else {
-                let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not enough KV headroom"}}"#, id);
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not enough KV headroom"}}"#,
+                    id
+                );
                 let _ = stdout.flush();
             }
-            if generated >= max_tokens { break; }
+            if generated >= max_tokens {
+                break;
+            }
         }
 
         // Steady-state sample.
         let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
         let mut blocked: Vec<u32> = Vec::new();
-        sampler::collect_unclosed_attractor_blocks(ngram_scope, &attractor_pairs, 20, 2, &mut blocked);
-        if force_answer_latched { if let Some(t) = think_open_tok { blocked.push(t); } }
+        sampler::collect_unclosed_attractor_blocks(
+            ngram_scope,
+            &attractor_pairs,
+            20,
+            2,
+            &mut blocked,
+        );
+        if force_answer_latched {
+            if let Some(t) = think_open_tok {
+                blocked.push(t);
+            }
+        }
         let cfg = SamplerConfig {
-            temperature: temp, top_p, repeat_penalty,
+            temperature: temp,
+            top_p,
+            repeat_penalty,
             repeat_window: repeat_buf_cap,
             blocked_tokens: blocked,
         };
         next_token = {
             let s_last = &scratch_set.per_device[dev_last];
             let g_last = &mut gpus.devices[dev_last];
-            sampler::sample(g_last, &s_last.logits, &s_last.sample_buf, &s_last.repeat_buf, vocab_size, ngram_scope, &cfg, &mut rng_state)
+            sampler::sample(
+                g_last,
+                &s_last.logits,
+                &s_last.sample_buf,
+                &s_last.repeat_buf,
+                vocab_size,
+                ngram_scope,
+                &cfg,
+                &mut rng_state,
+            )
         };
     }
 
     // ChatML \n trailer so the next turn opens cleanly.
     if im_end_token == Some(*m.conversation_tokens.last().unwrap_or(&0)) && !nl.is_empty() {
         for &t in &nl {
-            if let Err(e) = qwen35::forward_scratch_multi(gpus, weights, config, t, m.seq_pos, kv, dn, scratch_set) {
+            if let Err(e) = qwen35::forward_scratch_multi(
+                gpus,
+                weights,
+                config,
+                t,
+                m.seq_pos,
+                kv,
+                dn,
+                scratch_set,
+            ) {
                 eprintln!("[daemon] trailer forward_scratch_multi: {}", e);
                 break;
             }
@@ -5479,20 +6830,60 @@ fn generate_multi(
     let total_s = t_end.duration_since(t0).as_secs_f64();
     let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
     let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
-    let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
-    let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens as f64 / prefill_s } else { 0.0 };
-    let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+    let tok_s = if total_s > 0.0 {
+        generated as f64 / total_s
+    } else {
+        0.0
+    };
+    let prefill_tok_s = if prefill_s > 0.0 {
+        prefill_tokens as f64 / prefill_s
+    } else {
+        0.0
+    };
+    let decode_tok_s = if decode_s > 0.0 {
+        generated as f64 / decode_s
+    } else {
+        0.0
+    };
     let _ = writeln!(
         stdout,
         r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1}}}"#,
-        id, generated, tok_s, prefill_tokens,
-        prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0
+        id,
+        generated,
+        tok_s,
+        prefill_tokens,
+        prefill_s * 1000.0,
+        prefill_tok_s,
+        decode_tok_s,
+        prefill_s * 1000.0
     );
     let _ = stdout.flush();
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>, think_mode: ThinkMode) {
+fn generate(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    drafter_gpu: Option<&mut rdna_compute::Gpu>,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    temp: f32,
+    top_p: f32,
+    max_tokens: usize,
+    repeat_penalty: f32,
+    repeat_window: usize,
+    budget_alert_at_tok: usize,
+    budget_alert_text: &str,
+    max_think_tokens: usize,
+    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
+    pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>,
+    pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+    think_mode: ThinkMode,
+) {
     // Compress runs on the PFlash drafter handle when one is set (hetero
     // sibling device), else on the target gpu. The handle is consumed at
     // the seq_pos==0 compress site; decode always uses `gpu`.
@@ -5507,11 +6898,28 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // Silence the qwen35/llama-only params we deliberately don't
         // honor on this path. See generate_qwen2 doc for the deferral
         // list.
-        let _ = (budget_alert_at_tok, budget_alert_text, max_think_tokens,
-                 assistant_prefix, pflash_state, pflash_cfg, tools, messages_history);
+        let _ = (
+            budget_alert_at_tok,
+            budget_alert_text,
+            max_think_tokens,
+            assistant_prefix,
+            pflash_state,
+            pflash_cfg,
+            tools,
+            messages_history,
+        );
         generate_qwen2(
-            m, gpu, stdout, id, prompt, system_prompt,
-            temp, top_p, max_tokens, repeat_penalty, repeat_window,
+            m,
+            gpu,
+            stdout,
+            id,
+            prompt,
+            system_prompt,
+            temp,
+            top_p,
+            max_tokens,
+            repeat_penalty,
+            repeat_window,
         );
         return;
     }
@@ -5523,12 +6931,28 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // `messages_history` per HF V4 chat template + sampling
         // recommendations; everything else routes through future
         // follow-ups.
-        let _ = (budget_alert_at_tok, budget_alert_text, max_think_tokens,
-                 assistant_prefix, pflash_state, pflash_cfg);
+        let _ = (
+            budget_alert_at_tok,
+            budget_alert_text,
+            max_think_tokens,
+            assistant_prefix,
+            pflash_state,
+            pflash_cfg,
+        );
         let _ = (repeat_penalty, repeat_window);
         generate_deepseek4(
-            m, gpu, stdout, id, prompt, system_prompt,
-            temp, top_p, max_tokens, think_mode, tools, messages_history,
+            m,
+            gpu,
+            stdout,
+            id,
+            prompt,
+            system_prompt,
+            temp,
+            top_p,
+            max_tokens,
+            think_mode,
+            tools,
+            messages_history,
         );
         return;
     }
@@ -5537,11 +6961,25 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // doesn't need to thread any of those args through.
     if m.pp > 1 {
         generate_multi(
-            m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
-            temp, top_p, max_tokens, repeat_penalty, repeat_window,
-            budget_alert_at_tok, budget_alert_text, max_think_tokens,
+            m,
+            gpu,
+            pflash_state,
+            pflash_cfg,
+            stdout,
+            id,
+            prompt,
+            system_prompt,
+            temp,
+            top_p,
+            max_tokens,
+            repeat_penalty,
+            repeat_window,
+            budget_alert_at_tok,
+            budget_alert_text,
+            max_think_tokens,
             assistant_prefix,
-            tools, messages_history,
+            tools,
+            messages_history,
         );
         return;
     }
@@ -5555,7 +6993,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // splices </think> through KV and continues generation, so route budgeted
     // thinking requests there until DFlash continuation is implemented.
     let budgeted_thinking_needs_ar = max_think_tokens > 0
-        && !matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::ClosedThink);
+        && !matches!(
+            assistant_prefix,
+            hipfire_runtime::prompt_frame::AssistantPrefix::ClosedThink
+        );
     // Prompt-cache routing (2026-05-30, native-reuse update). `generate_dflash`
     // now implements LCP prompt-cache reuse natively: on a pure conversation
     // extension it reuses the target KV + DeltaNet prefix and extends the
@@ -5568,7 +7009,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // opt out to the simpler AR path (e.g. to avoid spec-decode) with
     // `HIPFIRE_DFLASH_CHAT=0`.
     let force_ar_chat = std::env::var("HIPFIRE_DFLASH_CHAT").ok().as_deref() == Some("0");
-    if m.dflash.is_some() && temp <= 1e-6 && (m.arch_id == 5 || m.arch_id == 6) && !budgeted_thinking_needs_ar && !force_ar_chat {
+    if m.dflash.is_some()
+        && temp <= 1e-6
+        && (m.arch_id == 5 || m.arch_id == 6)
+        && !budgeted_thinking_needs_ar
+        && !force_ar_chat
+    {
         // PFlash + DFlash decode path is not yet wired -- the DFlash spec
         // loop builds its own prompt token stream internally, so the
         // generate() PFlash block below never runs. Surface this loud so
@@ -5593,11 +7039,32 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // mirrors the AR path's <think>/</think> counter). The "ignored
         // on DFlash" warning that used to live here is gone -- the cap
         // is real on both paths now.
-        generate_dflash(m, gpu, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, assistant_prefix, dflash_bypass_reason, dflash_alpha, tools, messages_history);
+        generate_dflash(
+            m,
+            gpu,
+            stdout,
+            id,
+            prompt,
+            system_prompt,
+            max_tokens,
+            max_think_tokens,
+            assistant_prefix,
+            dflash_bypass_reason,
+            dflash_alpha,
+            tools,
+            messages_history,
+        );
         // Silence unused-variable warnings for the params DFlash doesn't
         // consume (top_p / repeat penalties are AR-only sampling knobs;
         // pflash_state is bypassed on the DFlash decode path).
-        let _ = (top_p, repeat_penalty, repeat_window, budget_alert_at_tok, budget_alert_text, pflash_state);
+        let _ = (
+            top_p,
+            repeat_penalty,
+            repeat_window,
+            budget_alert_at_tok,
+            budget_alert_text,
+            pflash_state,
+        );
         return;
     }
 
@@ -5609,20 +7076,37 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
     if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
-        eprintln!("[qwen-cache GEN-ENTRY] conv_tok={} seq_pos={}", m.conversation_tokens.len(), m.seq_pos);
+        eprintln!(
+            "[qwen-cache GEN-ENTRY] conv_tok={} seq_pos={}",
+            m.conversation_tokens.len(),
+            m.seq_pos
+        );
     }
     if m.eviction.is_none() && m.seq_pos + prompt_est + max_tokens > m.max_seq {
-        eprintln!("[daemon] context full ({}/{}) — resetting conversation", m.seq_pos, m.max_seq);
+        eprintln!(
+            "[daemon] context full ({}/{}) — resetting conversation",
+            m.seq_pos, m.max_seq
+        );
         m.seq_pos = 0;
         m.conversation_tokens.clear();
         // Zero DeltaNet state on reset
         if let Some(ref dn) = m.dn_state {
-            for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-            for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-            for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+            for s in &dn.s_matrices {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.s_scales {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.conv_states {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
         }
-        if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
-        if let Some(kv) = m.llama_kv.as_mut() { kv.compact_offset = 0; }
+        if let Some(kv) = m.kv_cache.as_mut() {
+            kv.compact_offset = 0;
+        }
+        if let Some(kv) = m.llama_kv.as_mut() {
+            kv.compact_offset = 0;
+        }
     }
 
     // `nl` is needed for the trailer write after natural <|im_end|>
@@ -5704,11 +7188,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         match (s, bypass_reason) {
             (Some(cp), _) => format!(
                 r#","pflash":{{"source_tokens":{},"kept_tokens":{},"keep_ratio":{:.6},"alpha":{:.6},"score_ms":{},"total_ms":{},"source_md5":"{}","compressed_md5":"{}"}}"#,
-                cp.source_tokens, cp.kept_tokens,
+                cp.source_tokens,
+                cp.kept_tokens,
                 cp.kept_tokens as f32 / cp.source_tokens.max(1) as f32,
                 alpha.unwrap_or(0.0),
-                cp.timings.score_ms, cp.timings.total_ms,
-                cp.source_md5, cp.compressed_md5,
+                cp.timings.score_ms,
+                cp.timings.total_ms,
+                cp.source_md5,
+                cp.compressed_md5,
             ),
             (None, Some(reason)) => format!(
                 r#","pflash":{{"bypass_reason":"{}","alpha":{:.6}}}"#,
@@ -5719,8 +7206,13 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         }
     }
     if std::env::var("HIPFIRE_PFLASH_DEBUG").is_ok() {
-        eprintln!("[pflash] gen: state={} cfg-present seq_pos={} q={} drafter_gpu={}",
-            pflash_state.is_some(), m.seq_pos, raw_q_tokens.len(), drafter_gpu.is_some());
+        eprintln!(
+            "[pflash] gen: state={} cfg-present seq_pos={} q={} drafter_gpu={}",
+            pflash_state.is_some(),
+            m.seq_pos,
+            raw_q_tokens.len(),
+            drafter_gpu.is_some()
+        );
     }
     let q_tokens = if let (Some(state), Some(cfg)) = (pflash_state, pflash_cfg) {
         if m.seq_pos == 0 {
@@ -5729,20 +7221,33 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             // restore the target binding for decode. No-op when shared.
             compress_gpu.bind_thread_or_warn();
             let decision = hipfire_arch_qwen35::pflash::maybe_compress_prompt(
-                compress_gpu, state, cfg, &raw_q_tokens, request_kind, &[],
+                compress_gpu,
+                state,
+                cfg,
+                &raw_q_tokens,
+                request_kind,
+                &[],
             );
             gpu.bind_thread_or_warn();
             match decision {
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Compressed(cp)) => {
-                    eprintln!("[pflash] COMPRESSED {} -> {} tok dev1 ({}ms)", cp.source_tokens, cp.kept_tokens, cp.timings.total_ms);
+                    eprintln!(
+                        "[pflash] COMPRESSED {} -> {} tok dev1 ({}ms)",
+                        cp.source_tokens, cp.kept_tokens, cp.timings.total_ms
+                    );
                     let _ = writeln!(
                         stdout,
                         r#"{{"type":"pflash_compressed","id":"{}","source_tokens":{},"kept_tokens":{},"keep_ratio":{:.6},"source_md5":"{}","compressed_md5":"{}","score_ms":{},"select_ms":{},"gather_ms":{},"total_ms":{}}}"#,
-                        id, cp.source_tokens, cp.kept_tokens,
+                        id,
+                        cp.source_tokens,
+                        cp.kept_tokens,
                         cp.kept_tokens as f32 / cp.source_tokens.max(1) as f32,
-                        cp.source_md5, cp.compressed_md5,
-                        cp.timings.score_ms, cp.timings.select_ms,
-                        cp.timings.gather_ms, cp.timings.total_ms,
+                        cp.source_md5,
+                        cp.compressed_md5,
+                        cp.timings.score_ms,
+                        cp.timings.select_ms,
+                        cp.timings.gather_ms,
+                        cp.timings.total_ms,
                     );
                     let _ = stdout.flush();
                     let token_ids = cp.token_ids.clone();
@@ -5750,7 +7255,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     token_ids
                 }
                 Ok(hipfire_arch_qwen35::pflash::PflashDecision::Bypass { reason }) => {
-                    eprintln!("[pflash] BYPASS reason={} q={}", reason.as_str(), raw_q_tokens.len());
+                    eprintln!(
+                        "[pflash] BYPASS reason={} q={}",
+                        reason.as_str(),
+                        raw_q_tokens.len()
+                    );
                     // Only emit bypass events for non-trivial reasons.
                     // ModeOff is the silent default; nothing to report.
                     if !matches!(reason, hipfire_arch_qwen35::pflash::BypassReason::ModeOff) {
@@ -5758,7 +7267,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                         let _ = writeln!(
                             stdout,
                             r#"{{"type":"pflash_bypass","id":"{}","reason":"{}"}}"#,
-                            id, r.replace('"', "'"),
+                            id,
+                            r.replace('"', "'"),
                         );
                         let _ = stdout.flush();
                         // Stash for the `done` object too so a single-line
@@ -5773,7 +7283,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     let _ = writeln!(
                         stdout,
                         r#"{{"type":"pflash_error","id":"{}","reason":"{}"}}"#,
-                        id, e.to_string().replace('"', "'"),
+                        id,
+                        e.to_string().replace('"', "'"),
                     );
                     let _ = stdout.flush();
                     raw_q_tokens
@@ -5905,8 +7416,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // (seq_pos=0, conversation_tokens.clear(), zero DeltaNet, KV
     // compact_offset=0) and prefill the FULL rendered prompt — DeltaNet
     // is not reversible to position M<N so partial rollback is unsafe.
-    let cache_kill_switch = std::env::var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref()
-        == Some("0");
+    let cache_kill_switch = std::env::var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
     let pflash_active = pflash_cfg
         .map(|c| !matches!(c.mode, hipfire_arch_qwen35::pflash::PflashMode::Off))
         .unwrap_or(false);
@@ -5940,8 +7450,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     let mut cached_tokens_count: usize = 0;
     let new_tokens: Vec<u32> = if cache_eligible {
         let history = messages_history.unwrap();
-        let trace_cache = std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref()
-            == Some("1");
+        let trace_cache = std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1");
         // Build the canonical full-conversation token stream, replaying
         // any historical assistant turn whose fingerprint matches a
         // cached emission (BPE-bijective replacement).
@@ -5968,8 +7477,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     // hash matches the store hash regardless of whether
                     // the client preserved the orphan.
                     let stripped = strip_think_for_fingerprint(&msg.content);
-                    let normalized = hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped)
-                        .into_owned();
+                    let normalized =
+                        hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped).into_owned();
                     let fp = asst_turn_fingerprint(&normalized, &msg.tool_calls);
                     let hit = cache_ref.get(&fp).cloned();
                     if trace_cache {
@@ -5993,7 +7502,9 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         if trace_cache {
             eprintln!(
                 "[qwen-cache lcp] prior_len={} rendered_len={} lcp={}",
-                prior_len, rendered.len(), lcp,
+                prior_len,
+                rendered.len(),
+                lcp,
             );
             if lcp < prior_len || lcp < rendered.len() {
                 // Print full token-ID context on each side past lcp,
@@ -6006,7 +7517,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 if lcp > pre {
                     eprintln!(
                         "  common[{}..{}] ids={:?} dec={:?}",
-                        pre, lcp,
+                        pre,
+                        lcp,
                         &m.conversation_tokens[pre..lcp],
                         tokenizer.decode(&m.conversation_tokens[pre..lcp]),
                     );
@@ -6014,7 +7526,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 if prior_post > lcp {
                     eprintln!(
                         "  prior_past[{}..{}] ids={:?} dec={:?}",
-                        lcp, prior_post,
+                        lcp,
+                        prior_post,
                         &m.conversation_tokens[lcp..prior_post],
                         tokenizer.decode(&m.conversation_tokens[lcp..prior_post]),
                     );
@@ -6022,7 +7535,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 if rend_post > lcp {
                     eprintln!(
                         "  rend_past[{}..{}] ids={:?} dec={:?}",
-                        lcp, rend_post,
+                        lcp,
+                        rend_post,
                         &rendered[lcp..rend_post],
                         tokenizer.decode(&rendered[lcp..rend_post]),
                     );
@@ -6072,18 +7586,23 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             };
             eprintln!(
                 "[qwen-cache miss] lcp={} prior_len={} rendered_len={}",
-                lcp, prior_len, rendered.len(),
+                lcp,
+                prior_len,
+                rendered.len(),
             );
             eprintln!(
                 "  common@{}..{}={:?}",
-                pre, lcp,
+                pre,
+                lcp,
                 common_dec.chars().take(60).collect::<String>(),
             );
             eprintln!(
                 "  prior_past@{}..{}={:?} rendered_past@{}..{}={:?}",
-                lcp, prior_post,
+                lcp,
+                prior_post,
                 prior_past_dec.chars().take(60).collect::<String>(),
-                lcp, rend_post,
+                lcp,
+                rend_post,
                 rend_past_dec.chars().take(60).collect::<String>(),
             );
             eprintln!(
@@ -6119,8 +7638,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             // Guarded by scripts/test-qwen35-abort-resume.sh.
             let evict_safe = m.pp <= 1
                 && m.eviction.is_none()
-                && m.kv_cache.as_ref().map(|k| k.compact_offset == 0).unwrap_or(true)
-                && m.llama_kv.as_ref().map(|k| k.compact_offset == 0).unwrap_or(true);
+                && m.kv_cache
+                    .as_ref()
+                    .map(|k| k.compact_offset == 0)
+                    .unwrap_or(true)
+                && m.llama_kv
+                    .as_ref()
+                    .map(|k| k.compact_offset == 0)
+                    .unwrap_or(true);
             let resume_idx = if ckpt_resume_enabled() && evict_safe && m.dn_state.is_some() {
                 m.prefill_checkpoints
                     .iter()
@@ -6220,7 +7745,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             let _ = writeln!(
                 stdout,
                 r#"{{"type":"error","id":"{}","message":"request exceeds loaded KV budget: seq_pos={} + prefill={} + max_tokens={} + trailer={} > physical_cap={} — reload model with a larger max_seq"}}"#,
-                id, m.seq_pos, new_tokens.len(), max_tokens, trailer, m.physical_cap
+                id,
+                m.seq_pos,
+                new_tokens.len(),
+                max_tokens,
+                trailer,
+                m.physical_cap
             );
             let _ = stdout.flush();
             return;
@@ -6229,13 +7759,22 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         let _ = writeln!(
             stdout,
             r#"{{"type":"error","id":"{}","message":"request exceeds advertised context window: absolute={} + prefill={} + max_tokens={} + trailer={} > max_seq={}"}}"#,
-            id, absolute_pos, new_tokens.len(), max_tokens, trailer, m.max_seq
+            id,
+            absolute_pos,
+            new_tokens.len(),
+            max_tokens,
+            trailer,
+            m.max_seq
         );
         let _ = stdout.flush();
         return;
     }
 
-    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    let im_end_token = if im_end.len() == 1 {
+        Some(im_end[0])
+    } else {
+        None
+    };
     // Special-token attractor blocking (#111). Resolve the token IDs once;
     // each pair is `Some` only when the tokenizer registers both opener
     // and closer as single special tokens (Qwen3+ vocabs). Older vocabs
@@ -6306,16 +7845,23 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             let window = ev.budget() + ev.beta();
             let mut remaining: &[u32] = &new_tokens;
             while !remaining.is_empty() {
-                if check_abort(id) { prefill_aborted = true; break; }
+                if check_abort(id) {
+                    prefill_aborted = true;
+                    break;
+                }
                 let space = window.saturating_sub(m.seq_pos).max(1);
                 let chunk_len = remaining.len().min(space);
                 let (chunk, rest) = remaining.split_at(chunk_len);
                 qwen35::forward_prefill_batch(
-                    gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch,
-                    None, None, None, None,
-                ).unwrap();
+                    gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch, None, None, None, None,
+                )
+                .unwrap();
                 m.seq_pos += chunk_len;
-                if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                if let Some(hipfire_runtime::triattn::EvictionResult {
+                    new_physical: new_phys,
+                    ..
+                }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                {
                     m.seq_pos = new_phys;
                 }
                 remaining = rest;
@@ -6328,13 +7874,16 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             let chunk_max = qwen35::PREFILL_MAX_BATCH;
             let mut start = 0usize;
             while start < new_tokens.len() {
-                if check_abort(id) { prefill_aborted = true; break; }
+                if check_abort(id) {
+                    prefill_aborted = true;
+                    break;
+                }
                 let end = (start + chunk_max).min(new_tokens.len());
                 let chunk = &new_tokens[start..end];
                 qwen35::forward_prefill_batch(
-                    gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch,
-                    None, None, None, None,
-                ).unwrap();
+                    gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch, None, None, None, None,
+                )
+                .unwrap();
                 m.seq_pos += chunk.len();
                 // Adaptive KV: downshift BETWEEN prefill chunks the moment the
                 // start-tier (q8/fwht4) buffer fills, so a long prompt can't
@@ -6345,14 +7894,26 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 // chunk. `m.kv_adaptive` is disjoint from the live kv/dn borrows.
                 if let Some(ad) = m.kv_adaptive.as_mut() {
                     for step in ad.maybe_downshift(gpu, kv, m.seq_pos).unwrap() {
-                        eprintln!("[adaptive-kv] downshift @ pos {} (prefill): {:?} (K={:?} V={:?})", m.seq_pos, step, ad.cur_k, ad.cur_v);
+                        eprintln!(
+                            "[adaptive-kv] downshift @ pos {} (prefill): {:?} (K={:?} V={:?})",
+                            m.seq_pos, step, ad.cur_k, ad.cur_v
+                        );
                     }
                 }
                 // Snapshot the recurrent state every ckpt_interval() tokens so a
                 // later divergent render can resume here instead of cold. `dn`
                 // (&mut m.dn_state) and &mut m.prefill_checkpoints are disjoint
                 // fields, so this composes with the live kv/dn borrows.
-                if ckpt_resume_enabled() { speculative::take_dn_checkpoint(&mut m.prefill_checkpoints, dn, gpu, m.seq_pos, ckpt_interval(), ckpt_max()); }
+                if ckpt_resume_enabled() {
+                    speculative::take_dn_checkpoint(
+                        &mut m.prefill_checkpoints,
+                        dn,
+                        gpu,
+                        m.seq_pos,
+                        ckpt_interval(),
+                        ckpt_max(),
+                    );
+                }
                 start = end;
             }
         }
@@ -6371,12 +7932,22 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             // Reset llama_kv too (decode-abort path does the same) so a model
             // carrying both caches can't be left with a stale RoPE phase on the
             // next cold prefill. No-op when llama_kv is absent.
-            if let Some(llkv) = m.llama_kv.as_mut() { llkv.compact_offset = 0; }
+            if let Some(llkv) = m.llama_kv.as_mut() {
+                llkv.compact_offset = 0;
+            }
             m.seq_pos = 0;
             m.conversation_tokens.clear();
             m.prefill_checkpoints.clear();
-            let _ = writeln!(stdout, r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#, id);
-            let _ = writeln!(stdout, r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":0,"prefill_ms":0,"decode_ms":0}}"#, id);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
+                id
+            );
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":0,"prefill_ms":0,"decode_ms":0}}"#,
+                id
+            );
             let _ = stdout.flush();
             return;
         }
@@ -6387,7 +7958,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         if let Some(ad) = m.kv_adaptive.as_mut() {
             let applied = ad.maybe_downshift(gpu, kv, m.seq_pos).unwrap();
             for step in &applied {
-                eprintln!("[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})", m.seq_pos, step, ad.cur_k, ad.cur_v);
+                eprintln!(
+                    "[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})",
+                    m.seq_pos, step, ad.cur_k, ad.cur_v
+                );
             }
         }
         m.conversation_tokens.extend_from_slice(&new_tokens);
@@ -6442,10 +8016,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // structurally-similar DSML grammar.
         //
         // Disable with `HIPFIRE_QWEN35_GRAMMAR=0` for A/B comparison.
-        let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR")
-            .ok()
-            .as_deref()
-            != Some("0");
+        let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() != Some("0");
         let tool_schemas_qwen: Vec<hipfire_arch_qwen35::grammar::ToolSchema> = if grammar_enabled {
             tools
                 .map(|arr| {
@@ -6467,10 +8038,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                                         .collect()
                                 })
                                 .unwrap_or_default();
-                            Some(hipfire_arch_qwen35::grammar::ToolSchema {
-                                name,
-                                required,
-                            })
+                            Some(hipfire_arch_qwen35::grammar::ToolSchema { name, required })
                         })
                         .collect()
                 })
@@ -6479,16 +8047,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             Vec::new()
         };
         let grammar_active = !tool_schemas_qwen.is_empty();
-        let mut grammar_matcher =
-            hipfire_arch_qwen35::grammar::Matcher::new(tool_schemas_qwen);
+        let mut grammar_matcher = hipfire_arch_qwen35::grammar::Matcher::new(tool_schemas_qwen);
         // One-time vocab decode for token mask construction. Reuses the
         // model-level cache so subsequent requests on the same model skip
         // the ~150k-entry decode.
         let qwen_grammar_vocab: Option<std::sync::Arc<Vec<String>>> = if grammar_active {
             if m.decoded_vocab.is_none() {
                 let n = tokenizer.vocab_size();
-                let v: Vec<String> =
-                    (0..n).map(|id| tokenizer.decode(&[id as u32])).collect();
+                let v: Vec<String> = (0..n).map(|id| tokenizer.decode(&[id as u32])).collect();
                 m.decoded_vocab = Some(std::sync::Arc::new(v));
             }
             m.decoded_vocab.clone()
@@ -6539,10 +8105,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 .download_f32(&scratch.logits)
                 .unwrap_or_else(|_| vec![0.0f32; vocab_size]);
             grammar_matcher.token_mask(grammar_vocab, &mut grammar_mask);
-            hipfire_arch_qwen35::grammar::Matcher::apply_mask_to_logits(
-                &grammar_mask,
-                &mut logits,
-            );
+            hipfire_arch_qwen35::grammar::Matcher::apply_mask_to_logits(&grammar_mask, &mut logits);
             sampler::sample_cpu(&mut logits, ngram_scope, &cfg0)
         } else {
             sampler::sample(
@@ -6601,7 +8164,9 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // force EOS so the turn can't run unbounded — 35b-a3b re-opens <think>
         // after the one-shot force-answer and out-thinks client timeouts.
         let max_total_think: usize = std::env::var("HIPFIRE_MAX_TOTAL_THINK_TOKENS")
-            .ok().and_then(|s| s.parse().ok()).unwrap_or(0);
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
         let mut total_think_tokens: usize = 0;
 
         // N-gram loop detector: track 4-gram token sequences. When any
@@ -6612,7 +8177,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // Implementation lives in `hipfire_runtime::loop_guard`; defaults read from
         // HIPFIRE_NGRAM_LOOP_THRESHOLD (default 8, 0 = disabled) and
         // HIPFIRE_NGRAM_WINDOW (default 256). See loop_guard.rs.
-        let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
+        let loop_guard =
+            hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
         // `while` instead of `for 0..max_tokens` so budget-alert injection
         // (which increments `generated` beyond the iteration count) can't
@@ -6642,20 +8208,42 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 m.seq_pos = 0;
                 m.conversation_tokens.clear();
                 m.prefill_checkpoints.clear();
-                for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-                for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                for s in &dn.s_matrices {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for s in &dn.s_scales {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for s in &dn.conv_states {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
                 kv.compact_offset = 0;
-                if let Some(llkv) = m.llama_kv.as_mut() { llkv.compact_offset = 0; }
-                let _ = writeln!(stdout, r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#, id);
-                let _ = writeln!(stdout, r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":{},"prefill_ms":0,"decode_ms":0}}"#, id, generated);
+                if let Some(llkv) = m.llama_kv.as_mut() {
+                    llkv.compact_offset = 0;
+                }
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
+                    id
+                );
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"done","id":"{}","finish_reason":"aborted","prompt_tokens":0,"completion_tokens":{},"prefill_ms":0,"decode_ms":0}}"#,
+                    id, generated
+                );
                 let _ = stdout.flush();
                 return;
             }
             generated += 1;
             m.conversation_tokens.push(next_token);
             streamed_tokens.push(next_token);
-            emit_committed_event(stdout, id, next_token, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+            emit_committed_event(
+                stdout,
+                id,
+                next_token,
+                streamed_tokens.len() - 1,
+                t0.elapsed().as_millis() as u64,
+            );
             // Incremental UTF-8 + filter routing: feed only the new
             // bytes since last call, let the filter buffer any partial
             // codepoint or marker prefix until disambiguated.
@@ -6664,7 +8252,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             bytes_fed_to_filter = all_bytes.len();
             if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
                 let text = std::str::from_utf8(&text_bytes).unwrap();
-                let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"token","id":"{}","text":{}}}"#,
+                    id,
+                    serde_json::to_string(&text).unwrap_or_default()
+                );
                 let _ = stdout.flush();
             }
 
@@ -6678,15 +8271,29 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             // advance and call maybe_evict immediately so the next write
             // never overruns physical_cap. compact_offset bookkeeping on
             // the cache itself keeps RoPE phase correct across evictions.
-            qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch).unwrap();
+            qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch)
+                .unwrap();
             m.seq_pos += 1;
             // Checkpoint during decode too, so a long generated turn (e.g. a
             // big code emission) can be resumed mid-region if the NEXT turn's
             // render diverges within it — without replaying the whole
             // generation. No-op under eviction (compact_offset != 0).
-            if ckpt_resume_enabled() { speculative::take_dn_checkpoint(&mut m.prefill_checkpoints, dn, gpu, m.seq_pos, ckpt_interval(), ckpt_max()); }
+            if ckpt_resume_enabled() {
+                speculative::take_dn_checkpoint(
+                    &mut m.prefill_checkpoints,
+                    dn,
+                    gpu,
+                    m.seq_pos,
+                    ckpt_interval(),
+                    ckpt_max(),
+                );
+            }
             if let Some(ref ev) = m.eviction {
-                if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                if let Some(hipfire_runtime::triattn::EvictionResult {
+                    new_physical: new_phys,
+                    ..
+                }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                {
                     m.seq_pos = new_phys;
                 }
             }
@@ -6696,13 +8303,22 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             if let Some(ad) = m.kv_adaptive.as_mut() {
                 let applied = ad.maybe_downshift(gpu, kv, m.seq_pos).unwrap();
                 for step in &applied {
-                    eprintln!("[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})", m.seq_pos, step, ad.cur_k, ad.cur_v);
+                    eprintln!(
+                        "[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})",
+                        m.seq_pos, step, ad.cur_k, ad.cur_v
+                    );
                 }
             }
 
-            if next_token == config.eos_token { break; }
-            if im_end_token == Some(next_token) { break; }
-            if tokenizer.is_terminator(next_token) { break; }
+            if next_token == config.eos_token {
+                break;
+            }
+            if im_end_token == Some(next_token) {
+                break;
+            }
+            if tokenizer.is_terminator(next_token) {
+                break;
+            }
 
             // max_think_tokens enforcement. Track whether we're inside an
             // open <think>...</think> block and how many tokens we've
@@ -6718,8 +8334,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             let force_answer_now = check_force_answer(id);
             // Latch: the CLI's force_answer is one-shot, so remember it for the
             // rest of the turn to keep enforcing the commit on any <think> re-open.
-            if force_answer_now { force_answer_latched = true; }
-            if max_think_tokens > 0 || force_answer_now || force_answer_latched || max_total_think > 0 {
+            if force_answer_now {
+                force_answer_latched = true;
+            }
+            if max_think_tokens > 0
+                || force_answer_now
+                || force_answer_latched
+                || max_total_think > 0
+            {
                 let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
                 let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
                 let open_idx = raw_str.rfind("<think>");
@@ -6733,7 +8355,9 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 // cap, latch force-answer (force-close + block <think>); a margin
                 // past the cap, hard-EOS so a model that keeps re-opening <think>
                 // can't run the turn out to the client timeout.
-                if in_think { total_think_tokens += 1; }
+                if in_think {
+                    total_think_tokens += 1;
+                }
                 if max_total_think > 0 && total_think_tokens >= max_total_think {
                     force_answer_latched = true;
                 }
@@ -6743,7 +8367,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 }
                 if max_think_tokens > 0 {
                     if in_think {
-                        if !prev_in_think { think_count = 1; } else { think_count += 1; }
+                        if !prev_in_think {
+                            think_count = 1;
+                        } else {
+                            think_count += 1;
+                        }
                     } else {
                         think_count = 0;
                     }
@@ -6767,10 +8395,17 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     let budget_left = max_tokens.saturating_sub(generated);
                     let take = close_tokens.len().min(budget_left);
                     for &t in &close_tokens[..take] {
-                        qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
+                        qwen35::forward_scratch(
+                            gpu, weights, config, t, m.seq_pos, kv, dn, scratch,
+                        )
+                        .unwrap();
                         m.seq_pos += 1;
                         if let Some(ref ev) = m.eviction {
-                            if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                            if let Some(hipfire_runtime::triattn::EvictionResult {
+                                new_physical: new_phys,
+                                ..
+                            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                            {
                                 m.seq_pos = new_phys;
                             }
                         }
@@ -6783,22 +8418,37 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                         // logit mask so the model SAMPLES the tag (matcher advances
                         // naturally); injecting it + advancing here is state-identical
                         // (the recurrent fwd over </think> is the same either way).
-                        if grammar_active { grammar_matcher.advance(&tokenizer.decode(&[t])); }
+                        if grammar_active {
+                            grammar_matcher.advance(&tokenizer.decode(&[t]));
+                        }
                         streamed_tokens.push(t);
-                        emit_committed_event(stdout, id, t, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+                        emit_committed_event(
+                            stdout,
+                            id,
+                            t,
+                            streamed_tokens.len() - 1,
+                            t0.elapsed().as_millis() as u64,
+                        );
                         let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
                         let new_bytes = &all_bytes[bytes_fed_to_filter..];
                         bytes_fed_to_filter = all_bytes.len();
                         if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
                             let text = std::str::from_utf8(&text_bytes).unwrap();
-                            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                                id,
+                                serde_json::to_string(&text).unwrap_or_default()
+                            );
                             let _ = stdout.flush();
                         }
                         generated += 1;
                     }
                     think_count = 0;
                     prev_in_think = false;
-                    if generated >= max_tokens { break; }
+                    if generated >= max_tokens {
+                        break;
+                    }
                 }
             }
 
@@ -6827,7 +8477,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             // — we never exceed the caller's requested budget — so we clip
             // the nudge if not enough room remains, and break out of the
             // outer loop if the budget is fully spent after injection.
-            if !alert_fired && budget_alert_at_tok > 0 && generated >= budget_alert_at_tok && !budget_alert_text.is_empty() {
+            if !alert_fired
+                && budget_alert_at_tok > 0
+                && generated >= budget_alert_at_tok
+                && !budget_alert_text.is_empty()
+            {
                 alert_fired = true;
                 // Only inject while the model is inside an open <think> block.
                 // The whole point of the feature is to nudge the model's
@@ -6845,7 +8499,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     _ => false,
                 };
                 if !in_think {
-                    let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not inside an open <think> block"}}"#, id);
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not inside an open <think> block"}}"#,
+                        id
+                    );
                     let _ = stdout.flush();
                     // Fall through — resample next token as normal
                     let ngram_scope = &m.conversation_tokens[ngram_scope_start..];
@@ -6901,12 +8559,19 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 // eviction the physical check is trivially satisfied (budget
                 // always holds post-evict), but we still respect the check for
                 // the non-eviction path.
-                let need_kv = m.seq_pos + nudge_len + (max_tokens - generated - nudge_len) + nl.len();
+                let need_kv =
+                    m.seq_pos + nudge_len + (max_tokens - generated - nudge_len) + nl.len();
                 if nudge_len > 0 && (m.eviction.is_some() || need_kv <= m.physical_cap) {
                     for &tok in &nudge_tokens[..nudge_len] {
                         m.conversation_tokens.push(tok);
                         streamed_tokens.push(tok);
-                        emit_committed_event(stdout, id, tok, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+                        emit_committed_event(
+                            stdout,
+                            id,
+                            tok,
+                            streamed_tokens.len() - 1,
+                            t0.elapsed().as_millis() as u64,
+                        );
                         // Emit the injected token's text to stdout so the client
                         // sees it as part of the stream (will be inside <think>
                         // if that's the current state, and get stripped client-
@@ -6916,28 +8581,50 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                         bytes_fed_to_filter = all_bytes2.len();
                         if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes2) {
                             let t = std::str::from_utf8(&text_bytes).unwrap();
-                            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&t).unwrap_or_default());
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                                id,
+                                serde_json::to_string(&t).unwrap_or_default()
+                            );
                             let _ = stdout.flush();
                         }
-                        qwen35::forward_scratch(gpu, weights, config, tok, m.seq_pos, kv, dn, scratch).unwrap();
+                        qwen35::forward_scratch(
+                            gpu, weights, config, tok, m.seq_pos, kv, dn, scratch,
+                        )
+                        .unwrap();
                         m.seq_pos += 1;
                         if let Some(ref ev) = m.eviction {
-                            if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                            if let Some(hipfire_runtime::triattn::EvictionResult {
+                                new_physical: new_phys,
+                                ..
+                            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                            {
                                 m.seq_pos = new_phys;
                             }
                         }
                         generated += 1;
                     }
                 } else if nudge_len < nudge_tokens.len() {
-                    let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert clipped or skipped: nudge_len={} budget_left={}"}}"#, id, nudge_len, budget_left);
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"info","id":"{}","message":"budget_alert clipped or skipped: nudge_len={} budget_left={}"}}"#,
+                        id, nudge_len, budget_left
+                    );
                     let _ = stdout.flush();
                 } else {
-                    let _ = writeln!(stdout, r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not enough KV headroom"}}"#, id);
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"info","id":"{}","message":"budget_alert skipped: not enough KV headroom"}}"#,
+                        id
+                    );
                     let _ = stdout.flush();
                 }
                 // Respect max_tokens: if injection used the remainder, bail
                 // before sampling another model token.
-                if generated >= max_tokens { break; }
+                if generated >= max_tokens {
+                    break;
+                }
             }
 
             // Decide which paired-opener tokens (if any) trip the depth
@@ -6956,7 +8643,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             );
             // Once force-answer has latched, forbid re-opening <think> so the
             // model commits to its answer instead of thinking unbounded.
-            if force_answer_latched { if let Some(t) = think_open_tok { blocked.push(t); } }
+            if force_answer_latched {
+                if let Some(t) = think_open_tok {
+                    blocked.push(t);
+                }
+            }
             let cfg = SamplerConfig {
                 temperature: temp,
                 top_p,
@@ -7010,10 +8701,15 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // and DeltaNet state stay in sync with seq_pos.
         if im_end_token == Some(*m.conversation_tokens.last().unwrap_or(&0)) && !nl.is_empty() {
             for &t in &nl {
-                qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
+                qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch)
+                    .unwrap();
                 m.seq_pos += 1;
                 if let Some(ref ev) = m.eviction {
-                    if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                    if let Some(hipfire_runtime::triattn::EvictionResult {
+                        new_physical: new_phys,
+                        ..
+                    }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                    {
                         m.seq_pos = new_phys;
                     }
                 }
@@ -7097,12 +8793,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 // the store-side fp from a raw-text emission diverges from
                 // the lookup-side fp computed on the normalized msg.content
                 // the CLI sends back next turn.
-                let emit_text = hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped)
-                    .into_owned();
+                let emit_text =
+                    hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped).into_owned();
                 let fp = asst_turn_fingerprint(&emit_text, &emit_tool_calls);
-                if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref()
-                    == Some("1")
-                {
+                if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
                     eprintln!(
                         "[qwen-cache store] fp={:#018x} cached_seq={} emit_text.len={} tool_calls={} preview={:?}",
                         fp,
@@ -7120,9 +8814,21 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         let total_s = t_end.duration_since(t0).as_secs_f64();
         let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
         let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
-        let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
-        let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens as f64 / prefill_s } else { 0.0 };
-        let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+        let tok_s = if total_s > 0.0 {
+            generated as f64 / total_s
+        } else {
+            0.0
+        };
+        let prefill_tok_s = if prefill_s > 0.0 {
+            prefill_tokens as f64 / prefill_s
+        } else {
+            0.0
+        };
+        let decode_tok_s = if decode_s > 0.0 {
+            generated as f64 / decode_s
+        } else {
+            0.0
+        };
         // finish_reason carried in `done` so the CLI doesn't have to
         // infer it from whether tool_calls were emitted (matches V4F).
         //
@@ -7147,8 +8853,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         let _ = writeln!(
             stdout,
             r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1},"cached_tokens":{},"finish_reason":"{}"{}}}"#,
-            id, generated, tok_s, prefill_tokens,
-            prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0,
+            id,
+            generated,
+            tok_s,
+            prefill_tokens,
+            prefill_s * 1000.0,
+            prefill_tok_s,
+            decode_tok_s,
+            prefill_s * 1000.0,
             cached_tokens_count,
             finish_reason,
             pflash_done_fragment(&pflash_summary, &pflash_bypass_reason, pflash_alpha),
@@ -7164,7 +8876,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         let mut rng_state = 42u32;
         for (i, &tok) in new_tokens.iter().enumerate() {
             let pos = m.seq_pos + i;
-            let (_, rng) = llama::forward_scratch(gpu, weights, config, tok, pos, kv, scratch, temp, top_p, rng_state, 0, 1.0).unwrap();
+            let (_, rng) = llama::forward_scratch(
+                gpu, weights, config, tok, pos, kv, scratch, temp, top_p, rng_state, 0, 1.0,
+            )
+            .unwrap();
             rng_state = rng;
         }
         let this_turn_prompt_len_llama = new_tokens.len();
@@ -7173,8 +8888,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         let ngram_scope_start_llama = m.conversation_tokens.len() - this_turn_prompt_len_llama;
 
         let mut out_bytes = [0u8; 8];
-        gpu.hip.memcpy_dtoh(&mut out_bytes, &scratch.sample_buf.buf).unwrap();
-        let mut next_token = u32::from_ne_bytes([out_bytes[0], out_bytes[1], out_bytes[2], out_bytes[3]]);
+        gpu.hip
+            .memcpy_dtoh(&mut out_bytes, &scratch.sample_buf.buf)
+            .unwrap();
+        let mut next_token =
+            u32::from_ne_bytes([out_bytes[0], out_bytes[1], out_bytes[2], out_bytes[3]]);
         rng_state = u32::from_ne_bytes([out_bytes[4], out_bytes[5], out_bytes[6], out_bytes[7]]);
         // Prefill ends here: prompt is processed AND first token is ready (D2H
         // sync is the user-observable "time to first token" boundary). Decode
@@ -7195,34 +8913,68 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             generated += 1;
             m.conversation_tokens.push(next_token);
             streamed_tokens.push(next_token);
-            emit_committed_event(stdout, id, next_token, streamed_tokens.len() - 1, t0.elapsed().as_millis() as u64);
+            emit_committed_event(
+                stdout,
+                id,
+                next_token,
+                streamed_tokens.len() - 1,
+                t0.elapsed().as_millis() as u64,
+            );
             let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
             let new_bytes = &all_bytes[bytes_fed_to_filter..];
             bytes_fed_to_filter = all_bytes.len();
             if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
                 let text = std::str::from_utf8(&text_bytes).unwrap();
-                let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"token","id":"{}","text":{}}}"#,
+                    id,
+                    serde_json::to_string(&text).unwrap_or_default()
+                );
                 let _ = stdout.flush();
             }
 
             // Scope repeat_buf to this turn's prompt + generated tokens
             // (same logic as the Qwen3.5 path: prompt anchor + current turn).
             let rw = repeat_window.min(64);
-            let scope_start = ngram_scope_start_llama.max(m.conversation_tokens.len().saturating_sub(rw));
+            let scope_start =
+                ngram_scope_start_llama.max(m.conversation_tokens.len().saturating_sub(rw));
             let hist_slice = &m.conversation_tokens[scope_start..];
             let hist_bytes: Vec<u8> = hist_slice.iter().flat_map(|t| t.to_ne_bytes()).collect();
-            gpu.hip.memcpy_htod(&scratch.repeat_buf.buf, &hist_bytes).unwrap();
+            gpu.hip
+                .memcpy_htod(&scratch.repeat_buf.buf, &hist_bytes)
+                .unwrap();
 
             // Write K/V for this token FIRST so the next turn's context is
             // always fully populated. The sampled next_token from this call
             // is discarded when we break on im_end/eos — wasteful by one
             // launch but avoids a KV cache gap at the terminator.
             let pos = m.seq_pos + generated - 1;
-            let (tok, rng) = llama::forward_scratch(gpu, weights, config, next_token, pos, kv, scratch, temp, top_p, rng_state, hist_slice.len(), repeat_penalty).unwrap();
+            let (tok, rng) = llama::forward_scratch(
+                gpu,
+                weights,
+                config,
+                next_token,
+                pos,
+                kv,
+                scratch,
+                temp,
+                top_p,
+                rng_state,
+                hist_slice.len(),
+                repeat_penalty,
+            )
+            .unwrap();
 
-            if next_token == config.eos_token { break; }
-            if im_end_token == Some(next_token) { break; }
-            if tokenizer.is_terminator(next_token) { break; }
+            if next_token == config.eos_token {
+                break;
+            }
+            if im_end_token == Some(next_token) {
+                break;
+            }
+            if tokenizer.is_terminator(next_token) {
+                break;
+            }
 
             next_token = tok;
             rng_state = rng;
@@ -7232,7 +8984,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // ChatML \n boundary — run through forward to keep KV cache in sync
         if im_end_token == Some(*m.conversation_tokens.last().unwrap_or(&0)) && !nl.is_empty() {
             for &t in &nl {
-                let (_, rng2) = llama::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, scratch, temp, top_p, rng_state, 0, 1.0).unwrap();
+                let (_, rng2) = llama::forward_scratch(
+                    gpu, weights, config, t, m.seq_pos, kv, scratch, temp, top_p, rng_state, 0, 1.0,
+                )
+                .unwrap();
                 rng_state = rng2;
                 m.seq_pos += 1;
                 m.conversation_tokens.push(t);
@@ -7243,14 +8998,32 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         let total_s = t_end.duration_since(t0).as_secs_f64();
         let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
         let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
-        let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
-        let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens as f64 / prefill_s } else { 0.0 };
-        let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+        let tok_s = if total_s > 0.0 {
+            generated as f64 / total_s
+        } else {
+            0.0
+        };
+        let prefill_tok_s = if prefill_s > 0.0 {
+            prefill_tokens as f64 / prefill_s
+        } else {
+            0.0
+        };
+        let decode_tok_s = if decode_s > 0.0 {
+            generated as f64 / decode_s
+        } else {
+            0.0
+        };
         let _ = writeln!(
             stdout,
             r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1}{}}}"#,
-            id, generated, tok_s, prefill_tokens,
-            prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0,
+            id,
+            generated,
+            tok_s,
+            prefill_tokens,
+            prefill_s * 1000.0,
+            prefill_tok_s,
+            decode_tok_s,
+            prefill_s * 1000.0,
             pflash_done_fragment(&pflash_summary, &pflash_bypass_reason, pflash_alpha),
         );
         let _ = stdout.flush();
@@ -7341,7 +9114,11 @@ fn generate_deepseek4(
     let tokenizer = match m.tokenizer.as_ref() {
         Some(t) => t,
         None => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"tokenizer not loaded"}}"#, id);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"tokenizer not loaded"}}"#,
+                id
+            );
             let _ = stdout.flush();
             return;
         }
@@ -7349,14 +9126,27 @@ fn generate_deepseek4(
     let cfg = match m.deepseek4_config.as_ref() {
         Some(c) => c,
         None => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"deepseek4_config missing on arch_id=9 generate"}}"#, id);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"deepseek4_config missing on arch_id=9 generate"}}"#,
+                id
+            );
             let _ = stdout.flush();
             return;
         }
     };
-    let weights = m.deepseek4_weights.as_ref().expect("deepseek4_weights missing on arch_id=9 generate");
-    let pbs = m.deepseek4_pbs.as_ref().expect("deepseek4_pbs missing on arch_id=9 generate");
-    let state = m.deepseek4_state.as_mut().expect("deepseek4_state missing on arch_id=9 generate");
+    let weights = m
+        .deepseek4_weights
+        .as_ref()
+        .expect("deepseek4_weights missing on arch_id=9 generate");
+    let pbs = m
+        .deepseek4_pbs
+        .as_ref()
+        .expect("deepseek4_pbs missing on arch_id=9 generate");
+    let state = m
+        .deepseek4_state
+        .as_mut()
+        .expect("deepseek4_state missing on arch_id=9 generate");
     let eos_tok = m.deepseek4_eos_tok;
 
     // DeepSeek V4 non-thinking chat template (per HF encoding/README.md):
@@ -7371,7 +9161,11 @@ fn generate_deepseek4(
     // emits a single non-thinking turn per /generate call.
     let lookup = |s: &str| -> Option<u32> {
         let ids = tokenizer.encode(s);
-        if ids.len() == 1 { Some(ids[0]) } else { None }
+        if ids.len() == 1 {
+            Some(ids[0])
+        } else {
+            None
+        }
     };
     let bos_tok = lookup("<｜begin▁of▁sentence｜>");
     let user_tok = lookup("<｜User｜>");
@@ -7379,7 +9173,8 @@ fn generate_deepseek4(
 
     // HF "Reasoning Effort: Absolute maximum..." preamble for `Max` mode.
     // Quoted from the model card's encoding/README.md.
-    const MAX_THINK_PREAMBLE: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted. \
+    const MAX_THINK_PREAMBLE: &str =
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted. \
 You MUST be very thorough in your thinking and comprehensively decompose the problem.";
 
     // Build the effective system message: optional user-supplied system
@@ -7398,7 +9193,10 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
     let tools_block: Option<String> = tools
         .filter(|t| !t.is_empty())
         .map(|t| deepseek4::dsml::tools_prompt_block(t));
-    let effective_system: Option<String> = match (system_prompt.filter(|s| !s.is_empty()), tools_block.as_deref()) {
+    let effective_system: Option<String> = match (
+        system_prompt.filter(|s| !s.is_empty()),
+        tools_block.as_deref(),
+    ) {
         (Some(sys), Some(tb)) => Some(format!("{sys}\n\n{tb}")),
         (Some(sys), None) => Some(sys.to_string()),
         (None, Some(tb)) => Some(format!("\n\n{tb}")),
@@ -7406,7 +9204,9 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
     };
 
     let mut prompt_ids: Vec<u32> = Vec::new();
-    if let Some(b) = bos_tok { prompt_ids.push(b); }
+    if let Some(b) = bos_tok {
+        prompt_ids.push(b);
+    }
     if matches!(think_mode, ThinkMode::Max) {
         prompt_ids.extend(tokenizer.encode(MAX_THINK_PREAMBLE));
     }
@@ -7426,7 +9226,11 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
         // Heuristic: if last message is role=user, treat its content as
         // the live prompt and drop it here.
         use hipfire_runtime::prompt_frame::Role;
-        let trim_end = if matches!(history.last().map(|m| m.role), Some(Role::User)) { 1 } else { 0 };
+        let trim_end = if matches!(history.last().map(|m| m.role), Some(Role::User)) {
+            1
+        } else {
+            0
+        };
         let end = history.len().saturating_sub(trim_end);
         // Track whether the previous emission was already a tool_result
         // wrapped in a user turn — when YES, the next consecutive tool
@@ -7444,7 +9248,9 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                     // Already handled via effective_system; skip.
                 }
                 Role::User => {
-                    if let Some(u) = user_tok { prompt_ids.push(u); }
+                    if let Some(u) = user_tok {
+                        prompt_ids.push(u);
+                    }
                     prompt_ids.extend(tokenizer.encode(&msg.content));
                     pending_tool_result = false;
                 }
@@ -7453,10 +9259,12 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                     // a new user turn ONLY if the prior message wasn't
                     // already a tool_result.
                     if !pending_tool_result {
-                        if let Some(u) = user_tok { prompt_ids.push(u); }
+                        if let Some(u) = user_tok {
+                            prompt_ids.push(u);
+                        }
                     }
                     prompt_ids.extend(
-                        tokenizer.encode(&deepseek4::dsml::render_tool_result(&msg.content))
+                        tokenizer.encode(&deepseek4::dsml::render_tool_result(&msg.content)),
                     );
                     pending_tool_result = true;
                 }
@@ -7474,9 +9282,11 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                     // emitted IDENTICALLY on both hit and miss paths so
                     // the prompt-cache LCP can extend through every
                     // prior assistant turn.
-                    if let Some(a) = asst_tok { prompt_ids.push(a); }
-                    let starts_with_think_tag = msg.content.starts_with("<think>")
-                        || msg.content.starts_with("</think>");
+                    if let Some(a) = asst_tok {
+                        prompt_ids.push(a);
+                    }
+                    let starts_with_think_tag =
+                        msg.content.starts_with("<think>") || msg.content.starts_with("</think>");
                     if !starts_with_think_tag {
                         prompt_ids.extend(tokenizer.encode("</think>"));
                     }
@@ -7492,10 +9302,14 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                     // LCP at the assistant-turn boundary).
                     // Match store-side stripping (see qwen35 path comment).
                     let stripped = strip_think_for_fingerprint(&msg.content);
-                    let normalized = hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped)
-                        .into_owned();
+                    let normalized =
+                        hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped).into_owned();
                     let fp = asst_turn_fingerprint(&normalized, &msg.tool_calls);
-                    if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE").ok().as_deref() == Some("1") {
+                    if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                        .ok()
+                        .as_deref()
+                        == Some("1")
+                    {
                         eprintln!(
                             "[asst-cache lookup] fp={:#018x} content.len={}/stripped.len={} tool_calls={} hit={}",
                             fp, msg.content.len(), normalized.len(),
@@ -7544,10 +9358,14 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
     // Lloyd checkpoint drifts into invented paths / repeated wrong tool
     // calls when fed one.
     if !prompt.is_empty() {
-        if let Some(u) = user_tok { prompt_ids.push(u); }
+        if let Some(u) = user_tok {
+            prompt_ids.push(u);
+        }
         prompt_ids.extend(tokenizer.encode(prompt));
     }
-    if let Some(a) = asst_tok { prompt_ids.push(a); }
+    if let Some(a) = asst_tok {
+        prompt_ids.push(a);
+    }
     // Thinking-mode signal token immediately after `<｜Assistant｜>`:
     //   NonThink → `</think>`   (skip reasoning, respond directly)
     //   High|Max → `<think>`    (open a reasoning block)
@@ -7557,16 +9375,32 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
     }
 
     if prompt_ids.is_empty() {
-        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"empty prompt after tokenize"}}"#, id);
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"empty prompt after tokenize"}}"#,
+            id
+        );
         let _ = stdout.flush();
         return;
     }
 
-    if std::env::var("HIPFIRE_DEEPSEEK4_DUMP_PROMPT").ok().as_deref() == Some("1") {
+    if std::env::var("HIPFIRE_DEEPSEEK4_DUMP_PROMPT")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
         let rendered = tokenizer.decode(&prompt_ids);
-        let path = format!("/tmp/hipfire-prompt-{}.txt", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0));
-        let _ = std::fs::write(&path, format!("# tokens: {}\n{}\n", prompt_ids.len(), rendered));
+        let path = format!(
+            "/tmp/hipfire-prompt-{}.txt",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0)
+        );
+        let _ = std::fs::write(
+            &path,
+            format!("# tokens: {}\n{}\n", prompt_ids.len(), rendered),
+        );
         eprintln!("[v4f prompt dump] tokens={} → {}", prompt_ids.len(), path);
     }
 
@@ -7575,14 +9409,10 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
     let spec_mode = std::env::var("HIPFIRE_DEEPSEEK4_SPEC_DECODE")
         .ok()
         .map(|v| v == "1")
-        .unwrap_or_else(|| {
-            match std::env::var("HIPFIRE_MTP_MODE").ok().as_deref() {
-                Some("on") => true,
-                Some("off") => false,
-                _ => {
-                    m.mtp_mode == "on" || (m.mtp_mode == "auto" && m.mtp_weights_present)
-                }
-            }
+        .unwrap_or_else(|| match std::env::var("HIPFIRE_MTP_MODE").ok().as_deref() {
+            Some("on") => true,
+            Some("off") => false,
+            _ => m.mtp_mode == "on" || (m.mtp_mode == "auto" && m.mtp_weights_present),
         });
     let spec_k: usize = std::env::var("HIPFIRE_DEEPSEEK4_SPEC_K")
         .ok()
@@ -7699,9 +9529,25 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
     // MTP layer's SWA cache (prefill_with_mtp_fill) so the first
     // draft step sees a populated MTP history.
     let prefill_result = if spec_mode {
-        deepseek4::forward::prefill_with_mtp_fill(cfg, weights, state, gpu, pbs, suffix_tokens, start_pos)
+        deepseek4::forward::prefill_with_mtp_fill(
+            cfg,
+            weights,
+            state,
+            gpu,
+            pbs,
+            suffix_tokens,
+            start_pos,
+        )
     } else {
-        deepseek4::forward::forward_prefill_batch_chunked(cfg, weights, state, gpu, suffix_tokens, start_pos, pbs)
+        deepseek4::forward::forward_prefill_batch_chunked(
+            cfg,
+            weights,
+            state,
+            gpu,
+            suffix_tokens,
+            start_pos,
+            pbs,
+        )
     };
     let last_logits = match prefill_result {
         Ok(l) => l,
@@ -7827,8 +9673,7 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
         let decoded_vocab_arc: Option<std::sync::Arc<Vec<String>>> = if grammar_active {
             if m.decoded_vocab.is_none() {
                 let n = tokenizer.vocab_size();
-                let v: Vec<String> =
-                    (0..n).map(|id| tokenizer.decode(&[id as u32])).collect();
+                let v: Vec<String> = (0..n).map(|id| tokenizer.decode(&[id as u32])).collect();
                 m.decoded_vocab = Some(std::sync::Arc::new(v));
             }
             m.decoded_vocab.clone()
@@ -7846,12 +9691,10 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
         let mut absorb_event = |ev: &StreamEvent| {
             if let StreamEvent::ToolCalls(calls) = ev {
                 for c in calls {
-                    emit_tool_calls_buf.push(
-                        hipfire_runtime::prompt_frame::ToolCall {
-                            name: c.name.clone(),
-                            arguments: c.arguments.clone(),
-                        }
-                    );
+                    emit_tool_calls_buf.push(hipfire_runtime::prompt_frame::ToolCall {
+                        name: c.name.clone(),
+                        arguments: c.arguments.clone(),
+                    });
                 }
             }
         };
@@ -7923,7 +9766,13 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                     });
                     let _ = writeln!(stdout, "{}", envelope);
                 }
-                emit_committed_event(stdout, id, t, generated_count, decode_t0.elapsed().as_millis() as u64);
+                emit_committed_event(
+                    stdout,
+                    id,
+                    t,
+                    generated_count,
+                    decode_t0.elapsed().as_millis() as u64,
+                );
                 let _ = stdout.flush();
                 m.conversation_tokens.push(t);
                 generated_count += 1;
@@ -8037,8 +9886,7 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
         let decoded_vocab_arc: Option<std::sync::Arc<Vec<String>>> = if grammar_active {
             if m.decoded_vocab.is_none() {
                 let n = tokenizer.vocab_size();
-                let v: Vec<String> =
-                    (0..n).map(|id| tokenizer.decode(&[id as u32])).collect();
+                let v: Vec<String> = (0..n).map(|id| tokenizer.decode(&[id as u32])).collect();
                 m.decoded_vocab = Some(std::sync::Arc::new(v));
             }
             m.decoded_vocab.clone()
@@ -8098,12 +9946,10 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                 StreamEvent::Reasoning(_) => {}
                 StreamEvent::ToolCalls(calls) => {
                     for c in calls {
-                        emit_tool_calls_buf.push(
-                            hipfire_runtime::prompt_frame::ToolCall {
-                                name: c.name.clone(),
-                                arguments: c.arguments.clone(),
-                            }
-                        );
+                        emit_tool_calls_buf.push(hipfire_runtime::prompt_frame::ToolCall {
+                            name: c.name.clone(),
+                            arguments: c.arguments.clone(),
+                        });
                     }
                 }
             }
@@ -8115,14 +9961,22 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
                 absorb_event(&ev);
                 emit_stream_event(stdout, id, ev);
             }
-            emit_committed_event(stdout, id, next_tok, generated_count, decode_t0.elapsed().as_millis() as u64);
+            emit_committed_event(
+                stdout,
+                id,
+                next_tok,
+                generated_count,
+                decode_t0.elapsed().as_millis() as u64,
+            );
             let _ = stdout.flush();
             m.conversation_tokens.push(next_tok);
             if grammar_active {
                 matcher.advance(&frag);
             }
             generated_count += 1;
-            match deepseek4::forward::decode_step_with_graph(cfg, weights, state, gpu, next_tok, pos) {
+            match deepseek4::forward::decode_step_with_graph(
+                cfg, weights, state, gpu, next_tok, pos,
+            ) {
                 Ok(mut logits) => {
                     if grammar_active && !matcher.is_free() {
                         matcher.token_mask(&decoded_vocab, &mut grammar_mask);
@@ -8156,9 +10010,9 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
         // pushes EOS, but a future model that emits EOS mid-stream
         // shouldn't end up with EOS landing in the cached tokens).
         drop(absorb_event); // release the &mut emit_*_buf borrow
-        // Now that the closure is dropped, we can read the buffers
-        // immutably. Snapshot the tool_calls count so the `done`
-        // envelope below can carry `finish_reason: "tool_calls"`.
+                            // Now that the closure is dropped, we can read the buffers
+                            // immutably. Snapshot the tool_calls count so the `done`
+                            // envelope below can carry `finish_reason: "tool_calls"`.
         tool_calls_parsed_count = emit_tool_calls_buf.len();
         // Skip caching when the turn produced no replay-able payload —
         // empty trimmed content AND no tool_calls. The fingerprint for
@@ -8178,13 +10032,19 @@ You MUST be very thorough in your thinking and comprehensively decompose the pro
             && generated_count > 0
             && m.conversation_tokens.len() > decode_start_tokens_idx
         {
-            let cached_seq: Vec<u32> =
-                m.conversation_tokens[decode_start_tokens_idx..].to_vec();
+            let cached_seq: Vec<u32> = m.conversation_tokens[decode_start_tokens_idx..].to_vec();
             let fp = asst_turn_fingerprint(&emit_text_buf, &emit_tool_calls_buf);
-            if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE").ok().as_deref() == Some("1") {
+            if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                .ok()
+                .as_deref()
+                == Some("1")
+            {
                 eprintln!(
                     "[asst-cache store] fp={:#018x} content.len={} tool_calls={} tokens={}",
-                    fp, emit_text_buf.len(), emit_tool_calls_buf.len(), cached_seq.len(),
+                    fp,
+                    emit_text_buf.len(),
+                    emit_tool_calls_buf.len(),
+                    cached_seq.len(),
                 );
             }
             m.asst_turn_cache.insert(fp, cached_seq);
@@ -8316,7 +10176,11 @@ fn generate_qwen2(
     let tokenizer = match m.tokenizer.as_ref() {
         Some(t) => t,
         None => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"tokenizer not loaded"}}"#, id);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"tokenizer not loaded"}}"#,
+                id
+            );
             let _ = stdout.flush();
             return;
         }
@@ -8324,17 +10188,31 @@ fn generate_qwen2(
     let cfg = match m.qwen2_config.as_ref() {
         Some(c) => c,
         None => {
-            let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"qwen2_config missing on arch_id=7 generate"}}"#, id);
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":"qwen2_config missing on arch_id=7 generate"}}"#,
+                id
+            );
             let _ = stdout.flush();
             return;
         }
     };
-    let weights = m.qwen2_weights.as_ref().expect("qwen2_weights missing on arch_id=7 generate");
-    let state = m.qwen2_state.as_mut().expect("qwen2_state missing on arch_id=7 generate");
+    let weights = m
+        .qwen2_weights
+        .as_ref()
+        .expect("qwen2_weights missing on arch_id=7 generate");
+    let state = m
+        .qwen2_state
+        .as_mut()
+        .expect("qwen2_state missing on arch_id=7 generate");
 
     let prompt_ids = tokenizer.encode(prompt);
     if prompt_ids.is_empty() {
-        let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"empty prompt after tokenize"}}"#, id);
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"empty prompt after tokenize"}}"#,
+            id
+        );
         let _ = stdout.flush();
         return;
     }
@@ -8434,14 +10312,30 @@ fn generate_qwen2(
     let _ = stdout.flush();
 }
 
-fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, params: &GenerateVLParams) {
+fn generate_vl(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    stdout: &mut std::io::Stdout,
+    params: &GenerateVLParams,
+) {
     // INVARIANT: all early returns before the `vision_forward` call (the
     // first expensive GPU allocation in this function) use `write_error`
     // and return without owning any GPU buffers. If you add a GPU
     // allocation above this line, you MUST clean it up on every early
     // return path — the current early returns are safe because they
     // only hold CPU-side data (tokenizer refs, preprocess output).
-    let GenerateVLParams { id, prompt, system_prompt, ref image_source, temp, top_p, max_tokens, repeat_penalty, repeat_window, max_think_tokens } = *params;
+    let GenerateVLParams {
+        id,
+        prompt,
+        system_prompt,
+        ref image_source,
+        temp,
+        top_p,
+        max_tokens,
+        repeat_penalty,
+        repeat_window,
+        max_think_tokens,
+    } = *params;
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let vision_config = m.vision_config.as_ref().unwrap();
 
@@ -8451,11 +10345,14 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
     // splices the wrong tokens into the prompt. Required at load time —
     // panic loudly here so the failure is at first-VL-request, not after
     // a successful but wrong forward pass.
-    let image_pad_id = tokenizer.special_token_id("<|image_pad|>")
+    let image_pad_id = tokenizer
+        .special_token_id("<|image_pad|>")
         .unwrap_or_else(|| panic!("VL tokenizer missing <|image_pad|> special token"));
-    let vision_start_id = tokenizer.special_token_id("<|vision_start|>")
+    let vision_start_id = tokenizer
+        .special_token_id("<|vision_start|>")
         .unwrap_or_else(|| panic!("VL tokenizer missing <|vision_start|> special token"));
-    let vision_end_id = tokenizer.special_token_id("<|vision_end|>")
+    let vision_end_id = tokenizer
+        .special_token_id("<|vision_end|>")
         .unwrap_or_else(|| panic!("VL tokenizer missing <|vision_end|> special token"));
 
     // Image preprocessing (CPU decode + smart resize). Cheap relative to
@@ -8493,11 +10390,18 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
             } else {
                 b64
             };
-            eprintln!("[VL-DEBUG] preprocessing image: <{}-byte buffer>", raw_b64.len());
+            eprintln!(
+                "[VL-DEBUG] preprocessing image: <{}-byte buffer>",
+                raw_b64.len()
+            );
             let bytes = match Engine::decode(&base64::engine::general_purpose::STANDARD, raw_b64) {
                 Ok(b) => b,
                 Err(e) => {
-                    write_error(stdout, id, &format!("failed to decode base64 image data: {e}"));
+                    write_error(
+                        stdout,
+                        id,
+                        &format!("failed to decode base64 image data: {e}"),
+                    );
                     return;
                 }
             };
@@ -8519,32 +10423,51 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
     let grid_h = img_h / vision_config.patch_size;
     let grid_w = img_w / vision_config.patch_size;
     let n_patches = grid_h * grid_w;
-    let n_visual_tokens = n_patches / (vision_config.spatial_merge_size * vision_config.spatial_merge_size);
+    let n_visual_tokens =
+        n_patches / (vision_config.spatial_merge_size * vision_config.spatial_merge_size);
 
     // Capacity estimate including system prompt — a long system prompt
     // on first turn would otherwise let an over-budget request through
     // the soft check, only to fail the hard check after the expensive
     // vision encoder runs.
-    let system_est = system_prompt.map(|s| tokenizer.encode(s).len()).unwrap_or(0);
+    let system_est = system_prompt
+        .map(|s| tokenizer.encode(s).len())
+        .unwrap_or(0);
     let prompt_est = tokenizer.encode(prompt).len() + system_est + n_visual_tokens + 20;
 
     if m.eviction.is_none() && m.seq_pos + prompt_est + max_tokens > m.max_seq {
-        eprintln!("[daemon/vl] context full ({}/{}) — resetting conversation", m.seq_pos, m.max_seq);
+        eprintln!(
+            "[daemon/vl] context full ({}/{}) — resetting conversation",
+            m.seq_pos, m.max_seq
+        );
         m.seq_pos = 0;
         m.conversation_tokens.clear();
         if let Some(ref dn) = m.dn_state {
-            for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-            for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
-            for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+            for s in &dn.s_matrices {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.s_scales {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.conv_states {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
         }
-        if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
+        if let Some(kv) = m.kv_cache.as_mut() {
+            kv.compact_offset = 0;
+        }
     }
 
     if m.eviction.is_none() && prompt_est + max_tokens > m.max_seq {
-        write_error(stdout, id, &format!(
-            "request size ({} tokens) exceeds loaded KV budget ({})",
-            prompt_est + max_tokens, m.max_seq,
-        ));
+        write_error(
+            stdout,
+            id,
+            &format!(
+                "request size ({} tokens) exceeds loaded KV budget ({})",
+                prompt_est + max_tokens,
+                m.max_seq,
+            ),
+        );
         return;
     }
 
@@ -8602,14 +10525,23 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
 
     // Now safe to run the expensive GPU vision encoder.
     let patches = hipfire_arch_qwen35_vl::image::extract_patches(
-        &pixels, 3, img_h, img_w,
-        vision_config.patch_size, vision_config.temporal_patch_size,
+        &pixels,
+        3,
+        img_h,
+        img_w,
+        vision_config.patch_size,
+        vision_config.temporal_patch_size,
         vision_config.spatial_merge_size,
     );
-    let visual_tokens = qwen35_vl::vision_forward(gpu, vision_weights, vision_config, &patches, grid_h, grid_w)
-        .expect("vision forward failed");
+    let visual_tokens =
+        qwen35_vl::vision_forward(gpu, vision_weights, vision_config, &patches, grid_h, grid_w)
+            .expect("vision forward failed");
 
-    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    let im_end_token = if im_end.len() == 1 {
+        Some(im_end[0])
+    } else {
+        None
+    };
     let prefill_tokens = prompt_tokens.len();
     let t0 = Instant::now();
 
@@ -8642,7 +10574,11 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
         }
         m.seq_pos += 1;
         if let Some(ref ev) = m.eviction {
-            if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+            if let Some(hipfire_runtime::triattn::EvictionResult {
+                new_physical: new_phys,
+                ..
+            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+            {
                 m.seq_pos = new_phys;
             }
         }
@@ -8689,16 +10625,23 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
     // tokenizer changes. Since `think_pair` already gives us the
     // open/close token IDs, we can track depth incrementally in O(1).
     let mut think_depth: usize = 0; // number of unmatched opens seen
-    let mut think_count: usize = 0;  // tokens emitted while depth > 0
+    let mut think_count: usize = 0; // tokens emitted while depth > 0
 
     // N-gram loop detector — mirrors the text path. Catches answer-phase
     // attractor loops that the think cap and repeat penalty miss.
-    let loop_guard = hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
+    let loop_guard =
+        hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
     while generated < max_tokens {
         generated += 1;
         m.conversation_tokens.push(next_token);
-        emit_committed_event(stdout, id, next_token, generated - 1, t0.elapsed().as_millis() as u64);
+        emit_committed_event(
+            stdout,
+            id,
+            next_token,
+            generated - 1,
+            t0.elapsed().as_millis() as u64,
+        );
         streamed_tokens.push(next_token);
 
         let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
@@ -8709,14 +10652,25 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
         };
         if valid_len > 0 {
             let text = std::str::from_utf8(&new_bytes[..valid_len]).unwrap();
-            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                id,
+                serde_json::to_string(&text).unwrap_or_default()
+            );
             let _ = stdout.flush();
             emitted_bytes += valid_len;
         }
 
-        if next_token == config.eos_token { break; }
-        if im_end_token == Some(next_token) { break; }
-        if tokenizer.is_terminator(next_token) { break; }
+        if next_token == config.eos_token {
+            break;
+        }
+        if im_end_token == Some(next_token) {
+            break;
+        }
+        if tokenizer.is_terminator(next_token) {
+            break;
+        }
 
         if let Some(hipfire_runtime::loop_guard::StopReason::NgramRepeat { count, .. }) =
             loop_guard.check(&streamed_tokens)
@@ -8731,10 +10685,15 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
             break;
         }
 
-        qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch).unwrap();
+        qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch)
+            .unwrap();
         m.seq_pos += 1;
         if let Some(ref ev) = m.eviction {
-            if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+            if let Some(hipfire_runtime::triattn::EvictionResult {
+                new_physical: new_phys,
+                ..
+            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+            {
                 m.seq_pos = new_phys;
             }
         }
@@ -8755,20 +10714,29 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
                     think_count = 1;
                 } else if next_token == close {
                     think_depth = think_depth.saturating_sub(1);
-                    if think_depth == 0 { think_count = 0; }
+                    if think_depth == 0 {
+                        think_count = 0;
+                    }
                 } else if think_depth > 0 {
                     think_count += 1;
                 }
 
                 if think_depth > 0 && think_count >= max_think_tokens {
-                    let close_tokens = tokenizer.encode("</think\n");
+                    let close_tokens = tokenizer.encode("</think>\n");
                     let budget_left = max_tokens.saturating_sub(generated);
                     let take = close_tokens.len().min(budget_left);
                     for &t in &close_tokens[..take] {
-                        qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
+                        qwen35::forward_scratch(
+                            gpu, weights, config, t, m.seq_pos, kv, dn, scratch,
+                        )
+                        .unwrap();
                         m.seq_pos += 1;
                         if let Some(ref ev) = m.eviction {
-                            if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                            if let Some(hipfire_runtime::triattn::EvictionResult {
+                                new_physical: new_phys,
+                                ..
+                            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                            {
                                 m.seq_pos = new_phys;
                             }
                         }
@@ -8783,7 +10751,12 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
                         };
                         if vl > 0 {
                             let text = std::str::from_utf8(&new_bytes[..vl]).unwrap();
-                            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                                id,
+                                serde_json::to_string(&text).unwrap_or_default()
+                            );
                             let _ = stdout.flush();
                             emitted_bytes += vl;
                         }
@@ -8791,12 +10764,21 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
                     }
                     think_count = 0;
                     think_depth = 0; // Must reset — the close tokens
-                    // above bypass the incremental tracker, so depth
-                    // is still > 0 here. Without this, any subsequent
-                    // non-open/close token would re-trigger the cap.
-                    if generated >= max_tokens { break; }
+                                     // above bypass the incremental tracker, so depth
+                                     // is still > 0 here. Without this, any subsequent
+                                     // non-open/close token would re-trigger the cap.
+                    if generated >= max_tokens {
+                        break;
+                    }
                     logits = gpu.download_f32(&scratch.logits).unwrap();
-                    block_attractor_unclosed_cpu(&mut logits, &m.conversation_tokens, open, close, 20, 2);
+                    block_attractor_unclosed_cpu(
+                        &mut logits,
+                        &m.conversation_tokens,
+                        open,
+                        close,
+                        20,
+                        2,
+                    );
                     next_token = sampler::sample_cpu(&mut logits, &m.conversation_tokens, &vl_cfg);
                 }
             }
@@ -8809,7 +10791,11 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
             qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
             m.seq_pos += 1;
             if let Some(ref ev) = m.eviction {
-                if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                if let Some(hipfire_runtime::triattn::EvictionResult {
+                    new_physical: new_phys,
+                    ..
+                }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                {
                     m.seq_pos = new_phys;
                 }
             }
@@ -8821,14 +10807,32 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
     let total_s = t_end.duration_since(t0).as_secs_f64();
     let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
     let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
-    let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
-    let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens as f64 / prefill_s } else { 0.0 };
-    let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+    let tok_s = if total_s > 0.0 {
+        generated as f64 / total_s
+    } else {
+        0.0
+    };
+    let prefill_tok_s = if prefill_s > 0.0 {
+        prefill_tokens as f64 / prefill_s
+    } else {
+        0.0
+    };
+    let decode_tok_s = if decode_s > 0.0 {
+        generated as f64 / decode_s
+    } else {
+        0.0
+    };
     let _ = writeln!(
         stdout,
         r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1}}}"#,
-        id, generated, tok_s, prefill_tokens,
-        prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0
+        id,
+        generated,
+        tok_s,
+        prefill_tokens,
+        prefill_s * 1000.0,
+        prefill_tok_s,
+        decode_tok_s,
+        prefill_s * 1000.0
     );
     let _ = stdout.flush();
 }
@@ -8845,10 +10849,21 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
 /// MVP scope: greedy only (sampling params ignored), single image,
 /// per-token prefill, `--image <path>` only (base64 deferred). The text
 /// side is Qwen2; the decode state reuses `m.qwen2_state`.
-fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, params: &GenerateVLParams) {
+fn generate_vl_dots_ocr(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    stdout: &mut std::io::Stdout,
+    params: &GenerateVLParams,
+) {
     use hipfire_arch_dots_ocr::image as dots_image;
     let t0 = Instant::now();
-    let GenerateVLParams { id, prompt, ref image_source, max_tokens, .. } = *params;
+    let GenerateVLParams {
+        id,
+        prompt,
+        ref image_source,
+        max_tokens,
+        ..
+    } = *params;
 
     // 1. Preprocess image (CPU; no model borrow yet so error returns are clean).
     let img = match image_source {
@@ -8861,25 +10876,43 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
             let raw_b64 = match b64.strip_prefix("data:") {
                 Some(rest) => match rest.split_once(',') {
                     Some((_, after)) => after,
-                    None => { write_error(stdout, id, "malformed data URL: missing ',' separator"); return; }
+                    None => {
+                        write_error(stdout, id, "malformed data URL: missing ',' separator");
+                        return;
+                    }
                 },
                 None => &b64[..],
             };
-            eprintln!("[dots-ocr] preprocessing base64 image (<{}-byte payload>)", raw_b64.len());
+            eprintln!(
+                "[dots-ocr] preprocessing base64 image (<{}-byte payload>)",
+                raw_b64.len()
+            );
             match Engine::decode(&base64::engine::general_purpose::STANDARD, raw_b64) {
                 Ok(bytes) => dots_image::preprocess_image_bytes(&bytes),
-                Err(e) => { write_error(stdout, id, &format!("dots.ocr: base64 decode failed: {e}")); return; }
+                Err(e) => {
+                    write_error(stdout, id, &format!("dots.ocr: base64 decode failed: {e}"));
+                    return;
+                }
             }
         }
     };
     let img = match img {
         Ok(i) => i,
-        Err(e) => { write_error(stdout, id, &format!("dots.ocr image preprocess failed: {e}")); return; }
+        Err(e) => {
+            write_error(
+                stdout,
+                id,
+                &format!("dots.ocr image preprocess failed: {e}"),
+            );
+            return;
+        }
     };
     let n_visual = img.n_visual_tokens();
     let n_patches = img.n_patches();
-    eprintln!("[dots-ocr] grid {}x{}, {} patches → {} visual tokens",
-        img.grid_h, img.grid_w, n_patches, n_visual);
+    eprintln!(
+        "[dots-ocr] grid {}x{}, {} patches → {} visual tokens",
+        img.grid_h, img.grid_w, n_patches, n_visual
+    );
 
     let max_seq = m.max_seq;
 
@@ -8904,24 +10937,54 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
     let patch_cols = img.patches.len() / n_patches;
     let patches_gpu = match gpu.upload_f32(&img.patches, &[n_patches, patch_cols]) {
         Ok(t) => t,
-        Err(e) => { write_error(stdout, id, &format!("dots.ocr patch upload failed: {e:?}")); return; }
+        Err(e) => {
+            write_error(stdout, id, &format!("dots.ocr patch upload failed: {e:?}"));
+            return;
+        }
     };
-    let merged_gpu = match dots_ocr::vision_forward(gpu, &weights.vision, &config.vision, &patches_gpu, img.grid_h, img.grid_w) {
+    let merged_gpu = match dots_ocr::vision_forward(
+        gpu,
+        &weights.vision,
+        &config.vision,
+        &patches_gpu,
+        img.grid_h,
+        img.grid_w,
+    ) {
         Ok(t) => t,
-        Err(e) => { let _ = gpu.free_tensor(patches_gpu); write_error(stdout, id, &format!("dots.ocr vision_forward failed: {e:?}")); return; }
+        Err(e) => {
+            let _ = gpu.free_tensor(patches_gpu);
+            write_error(
+                stdout,
+                id,
+                &format!("dots.ocr vision_forward failed: {e:?}"),
+            );
+            return;
+        }
     };
     let _ = gpu.free_tensor(patches_gpu);
     let merged = match gpu.download_f32(&merged_gpu) {
         Ok(v) => v,
-        Err(e) => { let _ = gpu.free_tensor(merged_gpu); write_error(stdout, id, &format!("dots.ocr merger download failed: {e:?}")); return; }
+        Err(e) => {
+            let _ = gpu.free_tensor(merged_gpu);
+            write_error(
+                stdout,
+                id,
+                &format!("dots.ocr merger download failed: {e:?}"),
+            );
+            return;
+        }
     };
     let _ = gpu.free_tensor(merged_gpu);
     // Hard guard: merger output count MUST equal the imgpad-slot count, or
     // the splice silently corrupts the text context (PRD §"Vision token splicing").
     if merged.len() != n_visual * dim {
-        write_error(stdout, id, &format!(
+        write_error(
+            stdout,
+            id,
+            &format!(
             "dots.ocr: merger produced {} values but prompt has {} <|imgpad|> slots × {} dims = {}",
-            merged.len(), n_visual, dim, n_visual * dim));
+            merged.len(), n_visual, dim, n_visual * dim),
+        );
         return;
     }
 
@@ -8935,7 +10998,14 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
     let mut embeds = vec![0f32; prompt_ids.len() * dim];
     let emb_scratch = match gpu.alloc_tensor(&[dim], rdna_compute::DType::F32) {
         Ok(t) => t,
-        Err(e) => { write_error(stdout, id, &format!("dots.ocr embed scratch alloc failed: {e:?}")); return; }
+        Err(e) => {
+            write_error(
+                stdout,
+                id,
+                &format!("dots.ocr embed scratch alloc failed: {e:?}"),
+            );
+            return;
+        }
     };
     let mut visual_idx = 0usize;
     let mut embed_err: Option<String> = None;
@@ -8946,21 +11016,39 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
             visual_idx += 1;
         } else {
             // dots.ocr text weights are Q8_0 (q8.hfq).
-            if let Err(e) = gpu.embedding_lookup_q8(&weights.text.token_embd, &emb_scratch, token, dim) {
-                embed_err = Some(format!("embedding lookup: {e:?}")); break;
+            if let Err(e) =
+                gpu.embedding_lookup_q8(&weights.text.token_embd, &emb_scratch, token, dim)
+            {
+                embed_err = Some(format!("embedding lookup: {e:?}"));
+                break;
             }
             match gpu.download_f32(&emb_scratch) {
                 Ok(row) => embeds[pos * dim..(pos + 1) * dim].copy_from_slice(&row),
-                Err(e) => { embed_err = Some(format!("embedding download: {e:?}")); break; }
+                Err(e) => {
+                    embed_err = Some(format!("embedding download: {e:?}"));
+                    break;
+                }
             }
         }
     }
     let _ = gpu.free_tensor(emb_scratch);
     if let Some(e) = embed_err {
-        write_error(stdout, id, &format!("dots.ocr prefill embed build failed: {e}")); return;
+        write_error(
+            stdout,
+            id,
+            &format!("dots.ocr prefill embed build failed: {e}"),
+        );
+        return;
     }
-    if let Err(e) = qwen2::forward_prefill_batch_embeds(gpu, &weights.text, text_cfg, state, &embeds) {
-        write_error(stdout, id, &format!("dots.ocr batched prefill failed: {e:?}")); return;
+    if let Err(e) =
+        qwen2::forward_prefill_batch_embeds(gpu, &weights.text, text_cfg, state, &embeds)
+    {
+        write_error(
+            stdout,
+            id,
+            &format!("dots.ocr batched prefill failed: {e:?}"),
+        );
+        return;
     }
     let prefill_tokens = prompt_ids.len();
     let prefill_s = t_prefill.elapsed().as_secs_f64();
@@ -8973,7 +11061,10 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
     };
     let mut next = match gpu.argmax_f32(&state.logits, text_cfg.vocab_size) {
         Ok(t) => t,
-        Err(e) => { write_error(stdout, id, &format!("dots.ocr argmax failed: {e:?}")); return; }
+        Err(e) => {
+            write_error(stdout, id, &format!("dots.ocr argmax failed: {e:?}"));
+            return;
+        }
     };
     let t_gen = Instant::now();
     let mut streamed: Vec<u32> = Vec::new();
@@ -8986,7 +11077,9 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
     // straight to EOS without a guard; see DotsOcr::loop_guard_overrides.
 
     while generated < max_tokens {
-        if eos_set.contains(&next) { break; }
+        if eos_set.contains(&next) {
+            break;
+        }
         emit_committed_event(stdout, id, next, generated, t0.elapsed().as_millis() as u64);
         generated += 1;
         streamed.push(next);
@@ -9000,27 +11093,53 @@ fn generate_vl_dots_ocr(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout
         };
         if valid_len > 0 {
             let text = std::str::from_utf8(&new_bytes[..valid_len]).unwrap();
-            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                id,
+                serde_json::to_string(&text).unwrap_or_default()
+            );
             let _ = stdout.flush();
             emitted_bytes += valid_len;
         }
 
         match qwen2::forward_step_greedy(gpu, &weights.text, text_cfg, state, next) {
             Ok(t) => next = t,
-            Err(e) => { write_error(stdout, id, &format!("dots.ocr decode failed: {e:?}")); return; }
+            Err(e) => {
+                write_error(stdout, id, &format!("dots.ocr decode failed: {e:?}"));
+                return;
+            }
         }
     }
 
     let decode_s = t_gen.elapsed().as_secs_f64();
     let total_s = t0.elapsed().as_secs_f64();
-    let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
-    let prefill_tok_s = if prefill_s > 0.0 { prefill_tokens as f64 / prefill_s } else { 0.0 };
-    let decode_tok_s = if decode_s > 0.0 { generated as f64 / decode_s } else { 0.0 };
+    let tok_s = if total_s > 0.0 {
+        generated as f64 / total_s
+    } else {
+        0.0
+    };
+    let prefill_tok_s = if prefill_s > 0.0 {
+        prefill_tokens as f64 / prefill_s
+    } else {
+        0.0
+    };
+    let decode_tok_s = if decode_s > 0.0 {
+        generated as f64 / decode_s
+    } else {
+        0.0
+    };
     let _ = writeln!(
         stdout,
         r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1}}}"#,
-        id, generated, tok_s, prefill_tokens,
-        prefill_s * 1000.0, prefill_tok_s, decode_tok_s, prefill_s * 1000.0
+        id,
+        generated,
+        tok_s,
+        prefill_tokens,
+        prefill_s * 1000.0,
+        prefill_tok_s,
+        decode_tok_s,
+        prefill_s * 1000.0
     );
     let _ = stdout.flush();
 }
@@ -9077,7 +11196,8 @@ mod tool_call_parser_tests {
         // Broken outer JSON (leading `{` lost to special-token leakage) but a
         // COMPLETE balanced args object — the fallback still recovers it,
         // distinguishing real recovery from the truncation case above.
-        let s = "<tool_call>\nname\": \"read\", \"arguments\": {\"path\": \"/tmp/x\"}\n</tool_call>";
+        let s =
+            "<tool_call>\nname\": \"read\", \"arguments\": {\"path\": \"/tmp/x\"}\n</tool_call>";
         let calls = extract_tool_calls_from_text(s);
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "read");
@@ -9118,7 +11238,10 @@ mod tool_call_parser_tests {
         // the fallback path by wrapping in <tool_call> with off-spec
         // shape that triggers fallback.)
         let body = r#"{"firstname":"X","name":"read","arguments":{"path":"/x"}}"#;
-        assert_eq!(super::extract_tool_call_name_fallback(body), Some("read".to_string()));
+        assert_eq!(
+            super::extract_tool_call_name_fallback(body),
+            Some("read".to_string())
+        );
     }
 
     #[test]
@@ -9137,7 +11260,10 @@ mod tool_call_parser_tests {
     fn form4_handles_unquoted_key() {
         // Off-spec JSON with unquoted key.
         let body = r#"{name: "read"}"#;
-        assert_eq!(super::extract_tool_call_name_fallback(body), Some("read".to_string()));
+        assert_eq!(
+            super::extract_tool_call_name_fallback(body),
+            Some("read".to_string())
+        );
     }
 
     #[test]

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1975,6 +1975,36 @@ fn main() {
                 if has_image && !has_vl {
                     write_error(&mut stdout, id, "model has no vision encoder");
                 } else if has_image && has_vl {
+                    // DEFENSIVE: VL is single-image, single-turn only. The
+                    // CLI rejects images in non-last turns, but a raw
+                    // JSONL client could send a second image on turn 2+.
+                    // If seq_pos > 0 here, a previous conversation's KV
+                    // entries are live — running vision_forward and
+                    // splicing visual tokens into that context would
+                    // produce garbage. Force a reset so VL always starts
+                    // from a clean KV state.
+                    //
+                    // Must mirror the "reset" command handler (line ~2098).
+                    // VL only runs on qwen35-vl (arch_id 5/8), so
+                    // qwen2_state, deepseek4_state, and llama_kv are
+                    // None — but clear them anyway for defense-in-depth
+                    // in case a future arch adds VL support.
+                    if m.seq_pos > 0 {
+                        eprintln!("[daemon/vl] non-zero seq_pos ({}) at VL dispatch — resetting conversation", m.seq_pos);
+                        m.seq_pos = 0;
+                        m.conversation_tokens.clear();
+                        m.prefill_checkpoints.clear();
+                        m.dflash_checkpoints.clear();
+                        if let Some(ref dn) = m.dn_state {
+                            for s in &dn.s_matrices { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                            for s in &dn.s_scales { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                            for s in &dn.conv_states { let _ = gpu.hip.memset(&s.buf, 0, s.buf.size()); }
+                        }
+                        if let Some(kv) = m.kv_cache.as_mut() { kv.compact_offset = 0; }
+                        if let Some(kv) = m.llama_kv.as_mut() { kv.compact_offset = 0; }
+                        if let Some(ref mut s) = m.qwen2_state { s.reset(); }
+                        if let Some(ref mut s) = m.deepseek4_state { s.reset(); }
+                    }
                     if image_base64.is_some() && image.is_some() {
                         eprintln!("[daemon/vl] both image and image_base64 provided — using image_base64");
                     }
@@ -8405,6 +8435,12 @@ fn generate_qwen2(
 }
 
 fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut std::io::Stdout, params: &GenerateVLParams) {
+    // INVARIANT: all early returns before the `vision_forward` call (the
+    // first expensive GPU allocation in this function) use `write_error`
+    // and return without owning any GPU buffers. If you add a GPU
+    // allocation above this line, you MUST clean it up on every early
+    // return path — the current early returns are safe because they
+    // only hold CPU-side data (tokenizer refs, preprocess output).
     let GenerateVLParams { id, prompt, system_prompt, ref image_source, temp, top_p, max_tokens, repeat_penalty, repeat_window, max_think_tokens } = *params;
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let vision_config = m.vision_config.as_ref().unwrap();
@@ -8647,8 +8683,13 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
     let mut generated = 0;
     let mut streamed_tokens: Vec<u32> = Vec::new();
     let mut emitted_bytes = 0usize;
-    let mut think_count: usize = 0;
-    let mut prev_in_think: bool = false;
+    // Think-depth tracking via token IDs (not UTF-8 rfind).
+    // The previous implementation decoded the full streamed output to a
+    // string and ran rfind on every token — O(N²) total, fragile to
+    // tokenizer changes. Since `think_pair` already gives us the
+    // open/close token IDs, we can track depth incrementally in O(1).
+    let mut think_depth: usize = 0; // number of unmatched opens seen
+    let mut think_count: usize = 0;  // tokens emitted while depth > 0
 
     // N-gram loop detector — mirrors the text path. Catches answer-phase
     // attractor loops that the think cap and repeat penalty miss.
@@ -8706,59 +8747,58 @@ fn generate_vl(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, stdout: &mut st
         next_token = sampler::sample_cpu(&mut logits, &m.conversation_tokens, &vl_cfg);
 
         if max_think_tokens > 0 {
-            let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
-            let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
-            let open_idx = raw_str.rfind("<think>");
-            let close_idx = raw_str.rfind("</think>");
-            let in_think = match (open_idx, close_idx) {
-                (Some(o), Some(c)) => o > c,
-                (Some(_), None) => true,
-                _ => false,
-            };
-            if in_think {
-                if !prev_in_think { think_count = 1; } else { think_count += 1; }
-            } else {
-                think_count = 0;
-            }
-            prev_in_think = in_think;
+            if let Some((open, close)) = think_pair {
+                // Incremental think-depth tracking via token IDs — O(1)
+                // per token instead of the previous O(N²) decode+rfind.
+                if next_token == open {
+                    think_depth += 1;
+                    think_count = 1;
+                } else if next_token == close {
+                    think_depth = think_depth.saturating_sub(1);
+                    if think_depth == 0 { think_count = 0; }
+                } else if think_depth > 0 {
+                    think_count += 1;
+                }
 
-            if in_think && think_count >= max_think_tokens {
-                let close_tokens = tokenizer.encode("</think>\n");
-                let budget_left = max_tokens.saturating_sub(generated);
-                let take = close_tokens.len().min(budget_left);
-                for &t in &close_tokens[..take] {
-                    qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
-                    m.seq_pos += 1;
-                    if let Some(ref ev) = m.eviction {
-                        if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
-                            m.seq_pos = new_phys;
+                if think_depth > 0 && think_count >= max_think_tokens {
+                    let close_tokens = tokenizer.encode("</think\n");
+                    let budget_left = max_tokens.saturating_sub(generated);
+                    let take = close_tokens.len().min(budget_left);
+                    for &t in &close_tokens[..take] {
+                        qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
+                        m.seq_pos += 1;
+                        if let Some(ref ev) = m.eviction {
+                            if let Some(hipfire_runtime::triattn::EvictionResult { new_physical: new_phys, .. }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap() {
+                                m.seq_pos = new_phys;
+                            }
                         }
-                    }
-                    m.conversation_tokens.push(t);
-                    streamed_tokens.push(t);
+                        m.conversation_tokens.push(t);
+                        streamed_tokens.push(t);
 
-                    let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
-                    let new_bytes = &all_bytes[emitted_bytes..];
-                    let vl = match std::str::from_utf8(new_bytes) {
-                        Ok(_) => new_bytes.len(),
-                        Err(e) => e.valid_up_to(),
-                    };
-                    if vl > 0 {
-                        let text = std::str::from_utf8(&new_bytes[..vl]).unwrap();
-                        let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
-                        let _ = stdout.flush();
-                        emitted_bytes += vl;
+                        let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
+                        let new_bytes = &all_bytes[emitted_bytes..];
+                        let vl = match std::str::from_utf8(new_bytes) {
+                            Ok(_) => new_bytes.len(),
+                            Err(e) => e.valid_up_to(),
+                        };
+                        if vl > 0 {
+                            let text = std::str::from_utf8(&new_bytes[..vl]).unwrap();
+                            let _ = writeln!(stdout, r#"{{"type":"token","id":"{}","text":{}}}"#, id, serde_json::to_string(&text).unwrap_or_default());
+                            let _ = stdout.flush();
+                            emitted_bytes += vl;
+                        }
+                        generated += 1;
                     }
-                    generated += 1;
-                }
-                think_count = 0;
-                prev_in_think = false;
-                if generated >= max_tokens { break; }
-                logits = gpu.download_f32(&scratch.logits).unwrap();
-                if let Some((open, close)) = think_pair {
+                    think_count = 0;
+                    think_depth = 0; // Must reset — the close tokens
+                    // above bypass the incremental tracker, so depth
+                    // is still > 0 here. Without this, any subsequent
+                    // non-open/close token would re-trigger the cap.
+                    if generated >= max_tokens { break; }
+                    logits = gpu.download_f32(&scratch.logits).unwrap();
                     block_attractor_unclosed_cpu(&mut logits, &m.conversation_tokens, open, close, 20, 2);
+                    next_token = sampler::sample_cpu(&mut logits, &m.conversation_tokens, &vl_cfg);
                 }
-                next_token = sampler::sample_cpu(&mut logits, &m.conversation_tokens, &vl_cfg);
             }
         }
     }

--- a/docs/plans/vision-pipeline-cleanup-326.md
+++ b/docs/plans/vision-pipeline-cleanup-326.md
@@ -1,0 +1,22 @@
+# Vision pipeline cleanup — issue #326
+
+Branch: `vision-pipeline-cleanup-326`
+
+## Status assessment (2026-06-01)
+
+| Item | Description | Status | Action |
+|------|-------------|--------|--------|
+| **A1** | `rfind` UTF-8 think-pair tracker — O(N²) | ✅ **Fixed** | Replaced with token-ID tracking (`think_depth`/`think_count`) |
+| **A2** | `generate_vl` is 401 lines, needs refactor | Deferred | Extract helpers (larger refactor, separate PR) |
+| **A3** | Multiple early-return `write_error` in `generate_vl` | ✅ **Fixed** | Added invariant comment documenting the GPU-safety property |
+| **A4** | `assistant_prefix` hardcoded | Already correct | `AssistantPrefix::Plain` with explanatory comment — correct for VL |
+| **B1** | `https://` image URLs silently dropped | ✅ **Fixed** | Added `unsupportedImage = true` for non-data: URLs |
+| **B2** | Multi-turn VL rejection relies on daemon reset | ✅ **Fixed** | Added defensive reset at VL dispatch when `seq_pos > 0` |
+| **B3** | Large base64 memory spike | Deferred | No use case yet |
+| **C1** | 189 GPU alloc/free per image in `vision_forward` | Deferred | Larger change, separate PR |
+| **C2** | `pos_embed` uploaded per image | Deferred | Single-image only currently |
+| **C3** | `vit_attention_opt` dead code | **NOT APPLICABLE** | Live code used by dots-ocr (has rotary in dots_ocr path) |
+| **C4** | No VL output coherence gate | Deferred | Needs GPU hardware to test, separate PR |
+| **C5** | channel_order tests are pure-color only | ✅ **Fixed** | Added `quadrant_pixels_keep_rgb_spatial_order` test with spatial+channel verification |
+| **D2** | `smart_resize` usize overflow on 32-bit | ✅ **Fixed** | Added u64 arithmetic in both qwen35-vl and dots-ocr `smart_resize` |
+| **D3** | `--no-verify` policy undocumented | Already documented | CONTRIBUTING.md line 91; CLAUDE.md § coherence-gate |


### PR DESCRIPTION
## Summary

Addresses 8 items from the May 2026 vision-parity review (issue #326), plus defers/investigates the remaining items.

Closes #326 (items A1, A3, B1, B2, C5, D2 — see per-item status below).

## Changes

### A1 — O(N²) rfind think-pair tracker → O(1) token-ID tracking ✅

`generate_vl` decoded the full streamed output to a UTF-8 string and ran `rfind` on every emitted token to track think-block depth — O(N²) total, fragile to tokenizer changes. Replaced with incremental `think_depth`/`think_count` tracking via the `think_pair` token IDs that were already resolved at function entry.

**Bug found and fixed during review**: after the force-close block emits `</think\n` tokens, `think_depth` was not reset to 0. The close tokens bypass the incremental tracker (they go through `forward_scratch` directly), so `think_depth` remained > 0, causing immediate re-triggering of the think cap on the next non-open/close token. Added `think_depth = 0` alongside `think_count = 0`.

### A3 — Document early-return invariant in `generate_vl` ✅

Added a comment at function entry documenting that all early returns before `vision_forward` (the first GPU allocation) hold no GPU buffers. If anyone adds a GPU allocation above that line, every early-return path must clean it up.

### B1 — Reject remote image URLs with a clear error ✅

`https://` image URLs were silently dropped by `extractContent` — the `else` branch after `url.startsWith("data:")` was empty. Added a `remoteImageUrl` flag (separate from `unsupportedImage`) so the error message distinguishes "unsupported transport" from "bad format":

- `remoteImageUrl` → `"remote image URLs are not supported — embed images as base64 data: URLs (supported formats: png, jpeg)"`
- `unsupportedImage` → `"unsupported image format — supported: png, jpeg"`

### B2 — Defensive reset at VL dispatch when `seq_pos > 0` ✅

The CLI rejects images in non-last turns, but a raw JSONL client could bypass that. Added a defensive reset at VL dispatch that mirrors the canonical `"reset"` command handler, clearing:

- `seq_pos`, `conversation_tokens`
- `prefill_checkpoints`, `dflash_checkpoints`
- DeltaNet recurrent state (s_matrices, s_scales, conv_states)
- `kv_cache.compact_offset`, `llama_kv.compact_offset`
- `qwen2_state.reset()`, `deepseek4_state.reset()`

**Review finding**: the initial implementation was incomplete — it only cleared `seq_pos`, `conversation_tokens`, dn_state, and kv_cache. Expanded to match the full `"reset"` command for defense-in-depth.

### C5 — Multi-pixel channel-order test ✅

Three of four existing `channel_order.rs` tests use solid-color images. Added `quadrant_pixels_keep_rgb_spatial_order` using a 256×256 image with unique per-quadrant color fingerprints, verifying both channel ordering and spatial positioning simultaneously.

### D2 — `smart_resize` usize overflow on 32-bit ✅

Both `qwen35-vl` and `dots-ocr` `smart_resize` functions used `usize` for pixel-count arithmetic. On 32-bit targets, `height * width` could overflow `usize` for images > ~65K×65K. Switched to `u64` for comparisons. (Defense-in-depth — callers already gate dimensions via `MAX_DIMENSION_PIXELS`.)

## Items not changed

| Item | Why |
|------|-----|
| **A2** | `generate_vl` refactor into helpers — larger scope, separate PR |
| **A4** | Already correct — `AssistantPrefix::Plain` with explanatory comment |
| **B3** | Large base64 memory spike — no use case yet |
| **C1** | Pre-allocate vision scratch — larger change, separate PR |
| **C2** | `pos_embed` per-image upload — single-image only currently |
| **C3** | `vit_attention_opt` is **not** dead code — live path used by dots-ocr |
| **C4** | VL coherence gate script — needs GPU hardware to validate |
| **D3** | `--no-verify` policy already documented in `CONTRIBUTING.md` line 91 and `CLAUDE.md` |

## Test plan

- [x] `cargo check --features deltanet -p hipfire-runtime --example daemon` — clean
- [x] `cargo test -p hipfire-arch-qwen35-vl --test channel_order` — 5/5 pass
- [x] `cargo test -p hipfire-arch-dots-ocr --lib` — 27/27 pass
- [x] `cargo check -p hipfire-arch-dots-ocr -p hipfire-arch-qwen35-vl` — clean
- [ ] Coherence gate on GPU hardware (deferred to maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)