### PR TITLE
fix(serve): open <think> by default for thinking models on the OpenAI endpoint

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2230,6 +2230,16 @@ async function serve(port: number, host: string) {
         } else if ((body as any).reasoning?.effort === "none") {
           genParams.assistant_prefix = "closed_think";
           genParams.max_think_tokens = 1;
+        } else {
+          // Thinking is ON (config default, or explicit enable_thinking=true /
+          // reasoning.effort>=minimal). OPEN the <think> block so the model
+          // actually reasons instead of emitting an empty <think></think> and
+          // answering directly. Without this, generic OpenAI clients (which
+          // never send assistant_prefix) get no-think behaviour, which fails
+          // hard reasoning on thinking models like Qwen3.6. Safe for non-
+          // thinking models: the daemon's prompt frame falls back to Plain
+          // when the tokenizer has no `<think>` special token.
+          genParams.assistant_prefix = "open_think";
         }
         if (systemPrompt) genParams.system = systemPrompt;
 


### PR DESCRIPTION
## Problem

The `/v1/chat/completions` handler only wires the thinking-**off** cases:

```
thinking=off                          -> assistant_prefix=closed_think
chat_template_kwargs.enable_thinking=false -> closed_think + max_think_tokens=1
reasoning.effort=none                 -> closed_think + max_think_tokens=1
```

The thinking-**on** case sets no `assistant_prefix`, so the daemon falls back to
plain framing and the model emits an empty `<think></think>` then answers directly.
Net effects:

- `chat_template_kwargs.enable_thinking=true` is a **no-op** (only `false` is handled).
- Generic OpenAI clients (which never send hipfire's custom `assistant_prefix`) get
  **no-think** behaviour even for thinking models.

On thinking models like **Qwen3.6** this breaks hard reasoning. Served via the
endpoint at temperature 0.6, the model reasons in plain prose, derails, and stops
before emitting the required answer — e.g. on LiveBench `zebra_puzzle` it produces
no `<solution>` and scores 0. (Reproduced: LiveBench reasoning ~20% via Hipfire vs
~100% via a llama.cpp server that opens thinking through the Qwen3.6 chat template.)

## Fix

Default `assistant_prefix="open_think"` whenever thinking is on (config default, or
explicit `enable_thinking=true` / `reasoning.effort>=minimal`). The model then opens
a real `<think>` block, reasons, closes `</think>`, and emits its answer.

Safe for non-thinking models: the daemon's prompt frame falls back to `Plain` when
the tokenizer has no `<think>` special token.

## Validation (Qwen3.6-35B-A3B, gfx1151)

Same `zebra_puzzle` prompt, temperature 0.6:

- Before: `finish=stop`, ~649 tok, no `</think>`, no `<solution>` (unparseable → scored 0).
- After:  `finish=stop`, ~5.8k tok, `</think>` present, `<solution>` present (gradeable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)