### PR TITLE
feat(gemm): deterministic K-split wo_residual GEMM (ksplit_det), default on gfx11

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -511,6 +511,8 @@ impl Gpu {
                 fp8_x_source_ptr: std::ptr::null_mut(),
                 q8_1_mmq_x_scratch: None,
                 q8_1_mmq_x_scratch_bytes: 0,
+                ksplit_det_partials: None,
+                ksplit_det_partials_bytes: 0,
             },
             mmq_screen: MmqScreenState {
                 cache: HashMap::new(),
@@ -806,6 +808,14 @@ impl Gpu {
             x,
             n_elems,
         )
+    }
+
+    /// Ensure the deterministic-ksplit partials scratch is at least `n_bytes`.
+    pub(crate) fn ensure_ksplit_det_partials(
+        &mut self,
+        n_bytes: usize,
+    ) -> HipResult<*mut c_void> {
+        self.scratch.ensure_ksplit_det_partials(&self.hip, n_bytes)
     }
 
     /// Convert F32 to F16 without caching. Used when the same x tensor

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -10683,9 +10683,15 @@ impl Gpu {
         // ksplit side and M∈{17408} (draft gate/up/down) on the k2 side. lm_head
         // (M=vocab) is always way above threshold → k2.
         //
-        // HIPFIRE_WO_WMMA_VARIANT=ksplit|k2|k2x32|k4|wmma|wmma2 overrides the
-        // auto selection (applies to every call, both target and draft).
-        //   ksplit — K-split + atomicAdd (non-deterministic accum order)
+        // HIPFIRE_WO_WMMA_VARIANT=ksplit_det|ksplit|k2|k2x32|k4|wmma|wmma2
+        // overrides the auto selection (applies to every call, target+draft).
+        //   ksplit_det — K-split occupancy (grid.z) WITHOUT the racing
+        //            atomicAdd: each split writes its partial to scratch, a
+        //            fixed-order finalize sums them → bit-reproducible. Perf
+        //            parity with ksplit across all benched batches (16..1024)
+        //            on gfx1100; default for the CU-starved small-M case.
+        //   ksplit — K-split + atomicAdd (non-deterministic accum order;
+        //            kept as a perf-reference / debug variant — see ksplit_det)
         //   k2     — 2× K-tile pipeline (byte-exact accum order)
         //   k2x32  — 32-row block with shared X fragment per K-tile. Slower
         //            than k2 on gfx1100, but faster on gfx1151 Strix Halo for
@@ -10704,15 +10710,18 @@ impl Gpu {
         //   wmma   — base WMMA         (output-mapping bug — debug only)
         //   wmma2  — 2-wave block, 32 rows × 16 batch (output-mapping bug — debug only)
         let is_gfx115x = self.arch_caps.is_rdna3p5();
-        // ksplit's atomicAdd reduction across K_SPLITS partials is fp-non-
-        // associative — order varies with warp scheduling, so output bytes
-        // drift between processes and between cold/hot runs. The drift is
-        // sub-argmax-margin per call but cascades on long greedy decode
-        // (>50 tokens). HIPFIRE_DETERMINISTIC=1 forces k2 (single-block
-        // K reduction) at the cost of ~33% perf on small-batch / small-M.
-        // Required when chasing multi-GPU parity: pp=1 vs pp=2 outputs
-        // can't be compared byte-for-byte when the underlying single-GPU
-        // path itself is non-deterministic.
+        // The CU-starved small-M case (gfx11 RDNA3 discrete, the `else` arm
+        // below) needs K-split occupancy for throughput. The original ksplit
+        // got it via an atomicAdd reduction across K_SPLITS partials, which is
+        // fp-non-associative — order varies with warp scheduling, so output
+        // bytes drift between processes/runs. The drift is sub-argmax-margin
+        // per call but cascades on long greedy decode (>50 tokens), breaking
+        // bit-reproducibility (and multi-GPU pp=1 vs pp=2 parity). `ksplit_det`
+        // keeps the identical grid.z occupancy but replaces the race with a
+        // scratch + fixed-order finalize → deterministic at perf parity
+        // (benched 16..1024 batch on gfx1100), so it is now the default.
+        // HIPFIRE_DETERMINISTIC=1 still forces k2 (single-block K reduction)
+        // for the strictest single-kernel byte-parity escape hatch.
         // Cached — getenv on every decode token would re-parse 6× per layer
         // × N layers per step. Read once at first dispatch.
         static FORCE_DET: OnceLock<bool> = OnceLock::new();
@@ -10728,10 +10737,16 @@ impl Gpu {
         } else if m >= 8192 {
             "k2"
         } else {
-            "ksplit"
+            "ksplit_det"
         };
         let variant_override = self.flags.wo_wmma_variant.clone();
         let variant = variant_override.as_deref().unwrap_or(auto_variant);
+        // Deterministic K-split: same grid.z occupancy as ksplit but writes
+        // partials to scratch + a fixed-order finalize instead of racing
+        // atomicAdd. Two-kernel path → handled separately.
+        if variant == "ksplit_det" {
+            return self.gemm_hfq4g256_residual_wmma_ksplit_det(a_raw, x, y, m, k, batch_size);
+        }
         let (kernel_name, kernel_src, block_size, row_step, k_splits) = match variant {
             "k2"     => ("gemm_hfq4g256_residual_wmma_k2",
                          kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC, 32u32, 16usize, 1u32),
@@ -10804,6 +10819,108 @@ impl Gpu {
                 kernel_name, m, k, batch_size, bytes / 1024, us, gbs);
         }
         result
+    }
+
+    /// Deterministic K-split residual WMMA GEMM. Same K-split occupancy win
+    /// as `ksplit` (grid.z = K_SPLITS = 4 → ~13 blocks/CU on gfx1100), but
+    /// race-free: phase 1 writes each split's partial to its own scratch
+    /// slice (plain store, no atomicAdd, no residual); phase 2 sums the
+    /// K_SPLITS partials + residual into Y in fixed index order. Output is
+    /// bit-reproducible across runs/processes. Caller must initialize Y with
+    /// the residual stream before launching (same contract as ksplit/k2).
+    pub fn gemm_hfq4g256_residual_wmma_ksplit_det(
+        &mut self,
+        a_raw: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        const K_SPLITS: u32 = 4;
+        self.ensure_kernel(
+            "gemm_hfq4g256_residual_wmma_ksplit_det",
+            kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_SRC,
+            "gemm_hfq4g256_residual_wmma_ksplit_det",
+        )?;
+        self.ensure_kernel(
+            "gemm_ksplit_det_finalize",
+            kernels::GEMM_KSPLIT_DET_FINALIZE_SRC,
+            "gemm_ksplit_det_finalize",
+        )?;
+        let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
+        // Partials scratch: [K_SPLITS][batch_size][M] fp32.
+        let n_cells = batch_size * m;
+        let partials_ptr = self.ensure_ksplit_det_partials(K_SPLITS as usize * n_cells * 4)?;
+
+        // ── Phase 1: per-split partials (plain store, no atomic) ──
+        let mut a_ptr = a_raw.buf.as_ptr();
+        let mut x_ptr = x_f16_ptr;
+        let mut p_ptr = partials_ptr;
+        let mut m_val = m as i32;
+        let mut k_val = k as i32;
+        let mut bs_val = batch_size as i32;
+        let mut params1: Vec<*mut c_void> = vec![
+            &mut a_ptr as *mut _ as *mut c_void,
+            &mut x_ptr as *mut _ as *mut c_void,
+            &mut p_ptr as *mut _ as *mut c_void,
+            &mut m_val as *mut _ as *mut c_void,
+            &mut k_val as *mut _ as *mut c_void,
+            &mut bs_val as *mut _ as *mut c_void,
+        ];
+        let row_tiles = ((m + 15) / 16) as u32;
+        let batch_tiles = ((batch_size + 15) / 16) as u32;
+        let bytes = crate::profile::gemv_hfq4g256_bytes(m, k)
+            + batch_size * k * 2
+            + batch_size * m * 4 * 2;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", "gemm_hfq4g256_residual_wmma_ksplit_det", bytes);
+        self.launch_maybe_blob(
+            "gemm_hfq4g256_residual_wmma_ksplit_det",
+            [row_tiles, batch_tiles, K_SPLITS],
+            [32, 1, 1],
+            0,
+            &mut params1,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(a_ptr); b.push_ptr(x_ptr); b.push_ptr(p_ptr);
+                b.push_i32(m_val); b.push_i32(k_val); b.push_i32(bs_val);
+                b
+            },
+        )?;
+
+        // ── Phase 2: fixed-order finalize (residual + partials → Y) ──
+        // Pass batch_size + m (not a pre-multiplied cell count): the kernel
+        // computes the z-stride as batch_size*M in long long, matching the
+        // partial kernel's split_base literal and dodging any i32 overflow.
+        let mut y_ptr = y.buf.as_ptr();
+        let mut p_ptr2 = partials_ptr;
+        let mut bs_val2 = batch_size as i32;
+        let mut m_val2 = m as i32;
+        let mut params2: Vec<*mut c_void> = vec![
+            &mut y_ptr as *mut _ as *mut c_void,
+            &mut p_ptr2 as *mut _ as *mut c_void,
+            &mut bs_val2 as *mut _ as *mut c_void,
+            &mut m_val2 as *mut _ as *mut c_void,
+        ];
+        let fin_grid = ((n_cells + 255) / 256) as u32;
+        let r = self.launch_maybe_blob(
+            "gemm_ksplit_det_finalize",
+            [fin_grid, 1, 1],
+            [256, 1, 1],
+            0,
+            &mut params2,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(y_ptr); b.push_ptr(p_ptr2);
+                b.push_i32(bs_val2); b.push_i32(m_val2);
+                b
+            },
+        );
+        // Timer spans BOTH phases — finalize GPU time is included in the
+        // ksplit_det perf accounting (else it would undercount vs ksplit).
+        if let Some(t) = timer { t.finish(&self.hip); }
+        r
     }
 
     /// HFQ3-G256 sister of `gemm_hfq4g256_residual_wmma` (basic WMMA

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1251,6 +1251,8 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC: &str = include_str!("../../../kern
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K2X32_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_k2x32.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_K4_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_k4.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_SRC: &str = include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det.hip");
+pub const GEMM_KSPLIT_DET_FINALIZE_SRC: &str = include_str!("../../../kernels/src/gemm_ksplit_det_finalize.hip");
 // gfx12 (RDNA4) sister of GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC. Same recipe
 // as the qkv / qkvza / gate_up gfx12 ports (PR #56): `_w32_gfx12` builtin,
 // half8_t operands, K-split via tid>>4, contiguous C-row mapping. Closes

--- a/crates/rdna-compute/src/scratch.rs
+++ b/crates/rdna-compute/src/scratch.rs
@@ -35,6 +35,10 @@ pub struct ScratchState {
     pub fp8_x_source_ptr: *mut c_void,
     pub q8_1_mmq_x_scratch: Option<DeviceBuffer>,
     pub q8_1_mmq_x_scratch_bytes: usize,
+    /// Partials buffer for the deterministic K-split GEMM (ksplit_det):
+    /// [K_SPLITS][batch_size][M] fp32, grows-never-shrinks.
+    pub ksplit_det_partials: Option<DeviceBuffer>,
+    pub ksplit_det_partials_bytes: usize,
 }
 
 // ── Shared kernel dispatch helpers ──────────────────────────────────────
@@ -115,6 +119,21 @@ fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
 // ── ScratchState helpers ────────────────────────────────────────────────
 
 impl ScratchState {
+    /// Ensure the ksplit_det partials scratch is at least `n_bytes`, growing
+    /// (never shrinking). Returns the device pointer. No init needed: every
+    /// valid output cell is written exactly once per K-split before finalize.
+    pub fn ensure_ksplit_det_partials(
+        &mut self,
+        hip: &HipRuntime,
+        n_bytes: usize,
+    ) -> HipResult<*mut c_void> {
+        if self.ksplit_det_partials_bytes < n_bytes {
+            self.ksplit_det_partials = Some(hip.malloc(n_bytes)?);
+            self.ksplit_det_partials_bytes = n_bytes;
+        }
+        Ok(self.ksplit_det_partials.as_ref().unwrap().as_ptr())
+    }
+
     /// Lazily initialize MagnumQuant FWHT sign tables (256 floats each, seeds 42 and 1042).
     pub fn ensure_mq_signs(
         &mut self,

--- a/kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det.hip
+++ b/kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det.hip
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// DETERMINISTIC K-split, phase 1 (partial):
+// NOTE: K_SPLITS here MUST match K_SPLITS in gemm_ksplit_det_finalize.hip. identical compute to
+// gemm_hfq4g256_residual_wmma_ksplit, but instead of atomicAdd'ing each
+// K-split's partial into Y (race-ordered, non-deterministic fp accum),
+// it writes each partial to a SEPARATE scratch slice partials[ksplit].
+// A second kernel (gemm_ksplit_det_finalize) then sums the K_SPLITS
+// partials + residual in FIXED index order → bit-reproducible.
+//
+// Keeps ksplit's grid.z occupancy win (4× blocks → ~13/CU on gfx1100's
+// 96 CUs, vs 3.3/CU for the un-split k2 grid) — the perf edge is the
+// occupancy, NOT the atomicAdd, so determinism is recovered at ~zero
+// throughput cost (plain store < atomicAdd RMW; +one tiny finalize pass).
+//
+// partials layout: [K_SPLITS][batch_size][M], mirroring Y's
+// [batch_size][M] (index out_col*M + out_row). Each valid cell is written
+// exactly once per ksplit; finalize reads all K_SPLITS in fixed order.
+//
+// Grid: [ceil(M/16), ceil(N/16), K_SPLITS]. Block: [32]. LDS: 0.
+
+#define K_SPLITS 4
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq4g256_residual_wmma_ksplit_det(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ partials,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 16;
+    const int ksplit = blockIdx.z;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int safe_row = (row_start + (tid & 15) < M) ? (row_start + (tid & 15)) : (M - 1);
+    const int safe_batch = (batch_start + (tid & 15) < batch_size) ? (batch_start + (tid & 15)) : 0;
+
+    const int groups_per_row = K / 256;
+    const int groups_per_split = groups_per_row / K_SPLITS;
+    const int g_start = ksplit * groups_per_split;
+    const int g_end   = (ksplit == K_SPLITS - 1) ? groups_per_row
+                                                 : g_start + groups_per_split;
+
+    const char* row_base = A + (long long)safe_row * groups_per_row * 136;
+    const _Float16* x_base = X + (long long)safe_batch * K;
+
+    float8_t acc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = g_start; g < g_end; g++) {
+        const char* gp = row_base + g * 136;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg = x_base + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const int k_off_a = kt * 16;
+            unsigned int pk0a = *(const unsigned int*)(gp + 8 + k_off_a / 2);
+            unsigned int pk1a = *(const unsigned int*)(gp + 8 + k_off_a / 2 + 4);
+
+            const int k_off_b = (kt + 1) * 16;
+            unsigned int pk0b = *(const unsigned int*)(gp + 8 + k_off_b / 2);
+            unsigned int pk1b = *(const unsigned int*)(gp + 8 + k_off_b / 2 + 4);
+
+            half16_t b_a = *(const half16_t*)(xg + k_off_a);
+            half16_t b_b = *(const half16_t*)(xg + k_off_b);
+
+            half16_t a_a;
+            #define DQ(reg, i, pk, sh) reg[i] = sc_h * (_Float16)(float)(((pk) >> (sh)) & 0xFu) + zp_h
+            DQ(a_a, 0,  pk0a,  0); DQ(a_a, 1,  pk0a,  4); DQ(a_a, 2,  pk0a,  8); DQ(a_a, 3,  pk0a, 12);
+            DQ(a_a, 4,  pk0a, 16); DQ(a_a, 5,  pk0a, 20); DQ(a_a, 6,  pk0a, 24); DQ(a_a, 7,  pk0a, 28);
+            DQ(a_a, 8,  pk1a,  0); DQ(a_a, 9,  pk1a,  4); DQ(a_a, 10, pk1a,  8); DQ(a_a, 11, pk1a, 12);
+            DQ(a_a, 12, pk1a, 16); DQ(a_a, 13, pk1a, 20); DQ(a_a, 14, pk1a, 24); DQ(a_a, 15, pk1a, 28);
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b_a, acc);
+
+            DQ(a_a, 0,  pk0b,  0); DQ(a_a, 1,  pk0b,  4); DQ(a_a, 2,  pk0b,  8); DQ(a_a, 3,  pk0b, 12);
+            DQ(a_a, 4,  pk0b, 16); DQ(a_a, 5,  pk0b, 20); DQ(a_a, 6,  pk0b, 24); DQ(a_a, 7,  pk0b, 28);
+            DQ(a_a, 8,  pk1b,  0); DQ(a_a, 9,  pk1b,  4); DQ(a_a, 10, pk1b,  8); DQ(a_a, 11, pk1b, 12);
+            DQ(a_a, 12, pk1b, 16); DQ(a_a, 13, pk1b, 20); DQ(a_a, 14, pk1b, 24); DQ(a_a, 15, pk1b, 28);
+            #undef DQ
+
+            acc = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b_b, acc);
+        }
+    }
+
+    // RDNA3 wave32 WMMA output: acc[j] = C[2*j + (tid>>4)][tid & 15].
+    // Write this ksplit's partial to its OWN slice (plain store, no atomic,
+    // no residual — finalize adds residual + all partials in fixed order).
+    const int out_col = batch_start + (tid & 15);
+    if (out_col < batch_size) {
+        const long long split_base = (long long)ksplit * batch_size * M;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < M) {
+                partials[split_base + (long long)out_col * M + out_row] = acc[j];
+            }
+        }
+    }
+}

--- a/kernels/src/gemm_ksplit_det_finalize.hip
+++ b/kernels/src/gemm_ksplit_det_finalize.hip
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// DETERMINISTIC K-split, phase 2 (finalize): sum the K_SPLITS partials
+// produced by gemm_hfq4g256_residual_wmma_ksplit_det into Y, in FIXED
+// index order (z = 0,1,2,3), on top of the residual already in Y.
+//
+//   Y[idx] = Y[idx](residual) + sum_z partials[z*batch_size*M + idx]
+//
+// The z-stride is batch_size*M — the SAME literal expression the partial
+// kernel uses for split_base (ksplit*batch_size*M), so the layout contract
+// is self-documenting and cannot be broken by passing a wrong cell count.
+// Fixed loop order → bit-reproducible (unlike the race-ordered atomicAdd in
+// the non-det ksplit). partials is [K_SPLITS][batch_size][M] contiguous.
+//
+// K_SPLITS here MUST match K_SPLITS in
+// gemm_hfq4g256_residual_wmma_ksplit_det.hip.
+//
+// Grid: [ceil(batch_size*M/256)]. Block: [256]. LDS: 0.
+
+#define K_SPLITS 4
+
+extern "C" __global__ void gemm_ksplit_det_finalize(
+    float* __restrict__ Y,
+    const float* __restrict__ partials,
+    int batch_size, int M
+) {
+    const long long N = (long long)batch_size * M;
+    const long long idx = (long long)blockIdx.x * 256 + threadIdx.x;
+    if (idx >= N) return;
+    float s = Y[idx];
+    #pragma unroll
+    for (int z = 0; z < K_SPLITS; z++) {
+        s += partials[(long long)z * N + idx];
+    }
+    Y[idx] = s;
+}


### PR DESCRIPTION
## What
A deterministic version of the `ksplit` `wo_residual` HFQ4-G256 WMMA GEMM. Same grid.z K-split occupancy win, but **no racing `atomicAdd`** — so greedy decode is bit-reproducible on gfx11 at perf parity. Made the default for the gfx11 (RDNA3 discrete) `auto_variant` else-branch; old `ksplit` kept as `HIPFIRE_WO_WMMA_VARIANT=ksplit`.

## Root cause it fixes
`ksplit` reduces its `K_SPLITS=4` partials with `atomicAdd` (`gemm_hfq4g256_residual_wmma_ksplit.hip:109`). fp-addition is non-associative, so the partial-sum order varies with warp scheduling → output bytes drift run-to-run. Sub-argmax-margin per call, but it **cascades over long greedy decode (>50 tok)** and flips near-tie argmaxes. Result: pure-AR greedy (temp=0, qwen3.6-27b.mq4) is **not run-to-run reproducible on gfx1100** (diverges at deep indices). gfx1151 (RDNA3.5 → dispatches k2/k2x32) and gfx1201 (RDNA4 → HW-stable atomics) are already reproducible.

## Fix
`ksplit_det` = two kernels:
1. **partial** (`gemm_hfq4g256_residual_wmma_ksplit_det.hip`): identical compute to ksplit, but each split writes its partial to a `[K_SPLITS][batch][M]` scratch slice (plain store, no atomic, no residual).
2. **finalize** (`gemm_ksplit_det_finalize.hip`): sums the partials + residual into `Y` in **fixed index order** → deterministic.

Same grid.z occupancy → same throughput. Partials scratch lives in `ScratchState` (grows-never-shrinks).

## Validation (fleet: gfx1100 / gfx1151 / gfx1201)
- **Determinism:** 4/4 fresh AR runs bit-identical (ksplit diverged @41/@64).
- **Output:** == ksplit (a valid reduction order); coherence battery → no hard errors.
- **Perf (gfx1100, DFlash decode tok/s):** ksplit_det **113.0** ≈ ksplit 111.7 ≫ k2 97.8 / k4 68.5.
- **Batch sweep (prefill 16..1024):** parity with ksplit at every batch (finalize overhead invisible).
- **gfx1201:** ~89 tok/s all variants (neutral; already deterministic).
- **gfx1151:** un-dispatched (stays k2/k2x32, which is faster there — APU isn't grid-starved).
- **Mode-agnostic:** verified coherent + deterministic under temp=0.8 sampling too (it's a forward-pass GEMM, upstream of sampling).
- **Adversarial review:** partial/finalize confirmed a correct bijection with ksplit; finalize hardened to take `(batch_size, M)` (self-documenting stride, no i32 overflow), timer spans both phases.

## Perf note
Strictly better than `HIPFIRE_DETERMINISTIC=1` → k2 for this GEMM (k2 costs −13% DFlash decode); ksplit_det is ~free. `HIPFIRE_DETERMINISTIC=1` still forces k2 as the strictest single-kernel byte-parity escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)