### PR TITLE
Qwen3.6-A3B serving + DeltaNet-state fixes + KLD eval-tooling

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2198,9 +2198,15 @@ async function serve(port: number, host: string) {
           type: "generate", id: reqId, prompt: userPrompt,
           temperature: (body.temperature ?? effective.temperature) * TEMP_CORRECTION,
           max_tokens: requestMaxTokens,
-          repeat_penalty: body.repeat_penalty ?? (oaiPenaltySet ? 1.0 + oaiPenalty : effective.repeat_penalty),
+          // The daemon now applies OpenAI presence/frequency penalties natively
+          // (subtractive, over the full repeat window) — strictly better than the
+          // old #79 fold into the multiplicative repeat_penalty. Pass them raw.
+          repeat_penalty: body.repeat_penalty ?? effective.repeat_penalty,
+          presence_penalty: Math.max(0, Number(body.presence_penalty) || 0),
+          frequency_penalty: Math.max(0, Number(body.frequency_penalty) || 0),
           top_p: body.top_p ?? effective.top_p,
         };
+        void oaiPenalty; void oaiPenaltySet; // superseded by native presence/frequency
         // Mirror the `hipfire run` path's per-model max_think_tokens
         // propagation. Without this, models with thinking=on can consume
         // the entire max_tokens budget inside a single <think>...</think>
@@ -2240,6 +2246,16 @@ async function serve(port: number, host: string) {
         } else if ((body as any).reasoning?.effort === "none") {
           genParams.assistant_prefix = "closed_think";
           genParams.max_think_tokens = 1;
+        } else {
+          // Thinking is ON (config default, or explicit enable_thinking=true /
+          // reasoning.effort>=minimal). OPEN the <think> block so the model
+          // actually reasons instead of emitting an empty <think></think> and
+          // answering directly. Without this, generic OpenAI clients (which
+          // never send assistant_prefix) get no-think behaviour, which fails
+          // hard reasoning on thinking models like Qwen3.6. Safe for non-
+          // thinking models: the daemon's prompt frame falls back to Plain
+          // when the tokenizer has no `<think>` special token.
+          genParams.assistant_prefix = "open_think";
         }
         if (systemPrompt) genParams.system = systemPrompt;
 
@@ -2677,7 +2693,11 @@ async function serve(port: number, host: string) {
                   }, forceAnswerSecs * 1000)
                 : null;
               try {
-                let inThink = false;
+                // open_think injects the opening <think> into the PROMPT, so the
+                // output begins inside the think span (no <think> token to detect
+                // at 2725). Start in-think so the leading reasoning streams as
+                // reasoning_content and is split off content at the first </think>.
+                let inThink = genParams.assistant_prefix === "open_think";
                 let stripNextLeadingNl = false;
                 // Track whether we've emitted any visible content yet. Used
                 // to detect an orphan `</think>` opener — when the daemon
@@ -3112,7 +3132,7 @@ async function serve(port: number, host: string) {
         // representation including reasoning. <|im_end|> stripping always
         // applies (it would break clients that re-encode message history).
         const strippedContent = content;
-        content = stripVisibleThinking(content, preserveThinking);
+        content = stripVisibleThinking(content, preserveThinking, genParams.assistant_prefix === "open_think");
 
         // Diagnostic: detect empty-after-unclosed-think-strip.
         let thinkWarning: string | null = null;
@@ -5145,8 +5165,15 @@ function findDep(binary: string, extraDirs: string[]): string | null {
   return null;
 }
 
-function stripVisibleThinking(content: string, preserveThinking: boolean = false): string {
+function stripVisibleThinking(content: string, preserveThinking: boolean = false, startedInThink: boolean = false): string {
   if (preserveThinking) return content.replace(/<\|im_end\|>/g, "").trim();
+  // `open_think` injects the opening <think> into the PROMPT, so the output
+  // begins INSIDE the think span and only a dangling </think> appears — none of
+  // the strips below (which key on a `<think>` opener) would fire, leaking the
+  // reasoning + a stray </think> into content. Prepend a synthetic opener so
+  // the closed case (strip the pair, keep the answer) and the unclosed case
+  // (strip <think>..end) are handled identically to a normal think span.
+  if (startedInThink && !content.includes("<think>")) content = "<think>" + content;
   return content
     .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
     .replace(/<think>[\s\S]*$/, "")

--- a/crates/hipfire-runtime/examples/build_kld_ref.rs
+++ b/crates/hipfire-runtime/examples/build_kld_ref.rs
@@ -124,6 +124,7 @@ fn main() {
         .args(["-f", &args.slice.display().to_string()])
         .args(["-c", &args.n_ctx.to_string()])
         .args(["-b", &args.n_batch.to_string()])
+        .args(["-ngl", &std::env::var("HIPFIRE_KLD_NGL").unwrap_or_else(|_| "99".to_string())])
         .args(["--kl-divergence-base", &fifo_path.display().to_string()])
         .arg("--no-mmap")
         .stderr(Stdio::inherit())

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -107,6 +107,23 @@ fn think_continuation() -> String {
     std::env::var("HIPFIRE_THINK_CONTINUATION").unwrap_or_else(|_| "</think>\n\n".to_string())
 }
 
+/// Whether the model is currently inside an open `<think>` span, from the
+/// generated text so far plus whether thinking was opened via the assistant
+/// prefix. `assistant_prefix=open_think` injects the `<think>` opener into the
+/// PROMPT, so it never shows up in the generated stream: without
+/// `started_in_think` the `(None, None)` case reads as "not thinking", the
+/// `max_think_tokens` force-close never fires, and a model that out-thinks its
+/// budget runs away to `max_tokens`. Centralises the scan used by every
+/// force-close / budget-alert site so they stay consistent.
+fn currently_in_think(raw_str: &str, started_in_think: bool) -> bool {
+    match (raw_str.rfind("<think>"), raw_str.rfind("</think>")) {
+        (Some(o), Some(c)) => o > c,      // both present: in-think iff opener is latest
+        (Some(_), None) => true,          // generated opener, not yet closed
+        (None, Some(_)) => false,         // closed (e.g. a prompt-injected opener) → answering
+        (None, None) => started_in_think, // no tags generated yet → trust the prompt prefix
+    }
+}
+
 /// Message types pushed from the stdin-reader thread to the main
 /// processing loop. Abort messages are NOT forwarded — they're
 /// handled inline in the reader thread by setting `abort_for_id()`.
@@ -2122,10 +2139,15 @@ fn main() {
                     .and_then(|v| v.as_str())
                     .map(ThinkMode::from_str)
                     .unwrap_or(ThinkMode::NonThink);
-                let repeat_window = msg
-                    .get("repeat_window")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(128) as usize;
+                let repeat_window = msg.get("repeat_window").and_then(|v| v.as_u64()).unwrap_or(128) as usize;
+                // OpenAI subtractive penalties. The CLI forwards raw
+                // `presence_penalty`/`frequency_penalty` (0.0 = off). Unlike the
+                // recency-weighted multiplicative `repeat_penalty`, these are
+                // flat across the (now long) window, which is what breaks the
+                // block-level repetition loops on long reasoning generations.
+                // Clamp negatives to 0 (negative would REWARD repetition).
+                let presence_penalty = (msg.get("presence_penalty").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32).max(0.0);
+                let frequency_penalty = (msg.get("frequency_penalty").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32).max(0.0);
                 // Experimental: inject a nudge string at a specific generated-
                 // token count. The nudge tokens get forward-fed through the KV
                 // cache so the model "sees" them as part of its own trajectory,
@@ -2382,21 +2404,10 @@ fn main() {
                         continue;
                     }
                     generate(
-                        m,
-                        &mut gpu,
-                        pflash_drafter_gpu.as_mut(),
-                        &mut stdout,
-                        id,
-                        prompt,
-                        system,
-                        temp,
-                        top_p,
-                        max_tokens,
-                        repeat_penalty,
-                        repeat_window,
-                        budget_alert_at_tok,
-                        &budget_alert_text,
-                        max_think_tokens,
+                        m, &mut gpu, pflash_drafter_gpu.as_mut(), &mut stdout, id, prompt, system,
+                        temp, top_p, max_tokens, repeat_penalty, repeat_window,
+                        presence_penalty, frequency_penalty,
+                        budget_alert_at_tok, &budget_alert_text, max_think_tokens,
                         assistant_prefix,
                         pflash_state.as_mut(),
                         pf_cfg_owned.as_ref(),
@@ -3733,8 +3744,12 @@ fn load_model(
         // Flash partials size with physical_cap (bounds the max_tiles the
         // flash kernel must address). When physical_cap == max_seq this is
         // identical to sizing-by-max_seq; under eviction it's much smaller.
-        let scratch = qwen35::Qwen35Scratch::new_with_kv_max(gpu, &config, 128, physical_cap)
-            .map_err(|e| format!("{e}"))?;
+        // repeat_buf window = 2048 (was 128). The penalty/presence window is
+        // clipped to this buffer's capacity; 128 was shorter than the period of
+        // a block-level repetition loop (~150 tok on Qwen3.6-A3B long reasoning),
+        // so the anti-repeat machinery literally could not see a full loop to
+        // suppress it. 2048 spans the loop period. Buffer is [2048] F32 = 8 KB.
+        let scratch = qwen35::Qwen35Scratch::new_with_kv_max(gpu, &config, 2048, physical_cap).map_err(|e| format!("{e}"))?;
 
         // Build eviction policy if the operator supplied a sidecar. Qwen3 (arch_id < 5)
         // lacks the FA/LA hybrid wiring TriAttention needs, so sidecars only take
@@ -4413,8 +4428,7 @@ fn load_model_pp(
     let (dn, la_to_device) = DeltaNetState::new_with_quant_multi(&mut gpus, &config, dn_quant)
         .map_err(|e| format!("{e}"))?;
 
-    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 128, max_seq)
-        .map_err(|e| format!("{e}"))?;
+    let scratch_set = Qwen35ScratchSet::new_with_kv_max_multi(&mut gpus, &config, 2048, max_seq).map_err(|e| format!("{e}"))?;
 
     // ROCm 6.4.3 gotcha: enable_peer_access AFTER all allocations are live.
     // See multi_gpu.rs::enable_peer_all docstring for the silent-success bug
@@ -5828,19 +5842,12 @@ fn generate_dflash(
             if max_think_tokens > 0 {
                 let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
                 let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
-                let open_idx = raw_str.rfind("<think>");
-                let close_idx = raw_str.rfind("</think>");
-                let in_think = match (open_idx, close_idx) {
-                    (Some(o), Some(c)) => o > c,
-                    (Some(_), None) => true,
-                    _ => false,
-                };
-                if in_think && !prev_in_think {
-                    think_count = 0;
-                }
-                if in_think {
-                    think_count += 1;
-                }
+                let in_think = currently_in_think(
+                    raw_str,
+                    matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink),
+                );
+                if in_think && !prev_in_think { think_count = 0; }
+                if in_think { think_count += 1; }
                 prev_in_think = in_think;
 
                 if in_think && think_count >= max_think_tokens {
@@ -6091,6 +6098,8 @@ fn generate_multi(
     max_tokens: usize,
     repeat_penalty: f32,
     _repeat_window: usize,
+    presence_penalty: f32,
+    frequency_penalty: f32,
     budget_alert_at_tok: usize,
     budget_alert_text: &str,
     max_think_tokens: usize,
@@ -6368,7 +6377,10 @@ fn generate_multi(
 
     let dev_last = gpus.output_device;
     let vocab_size = config.vocab_size;
-    let repeat_buf_cap = scratch_set.per_device[dev_last].repeat_buf.buf.size() / 4;
+    // Effective penalty window = request `_repeat_window` (default 128),
+    // bounded by repeat_buf capacity (2048). Default stays 128; the wide buffer
+    // only enables a larger window when a request explicitly sets one.
+    let repeat_buf_cap = (scratch_set.per_device[dev_last].repeat_buf.buf.size() / 4).min(_repeat_window.max(1));
 
     if let Err(e) = qwen35::forward_prefill_batch_multi(
         gpus,
@@ -6426,6 +6438,8 @@ fn generate_multi(
         top_p,
         repeat_penalty,
         repeat_window: repeat_buf_cap,
+        presence_penalty,
+        frequency_penalty,
         blocked_tokens: blocked0,
     };
     let tok0 = {
@@ -6541,16 +6555,11 @@ fn generate_multi(
         if max_think_tokens > 0 || force_answer_now || force_answer_latched || max_total_think > 0 {
             let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
             let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
-            let open_idx = raw_str.rfind("<think>");
-            let close_idx = raw_str.rfind("</think>");
-            let in_think = match (open_idx, close_idx) {
-                (Some(o), Some(c)) => o > c,
-                (Some(_), None) => true,
-                _ => false,
-            };
-            if in_think {
-                total_think_tokens += 1;
-            }
+            let in_think = currently_in_think(
+                raw_str,
+                matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink),
+            );
+            if in_think { total_think_tokens += 1; }
             if max_total_think > 0 && total_think_tokens >= max_total_think {
                 force_answer_latched = true;
             }
@@ -6654,11 +6663,10 @@ fn generate_multi(
             alert_fired = true;
             let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
             let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
-            let in_think = match (raw_str.rfind("<think>"), raw_str.rfind("</think>")) {
-                (Some(o), Some(c)) => o > c,
-                (Some(_), None) => true,
-                _ => false,
-            };
+            let in_think = currently_in_think(
+                raw_str,
+                matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink),
+            );
             if !in_think {
                 let _ = writeln!(
                     stdout,
@@ -6685,6 +6693,8 @@ fn generate_multi(
                     top_p,
                     repeat_penalty,
                     repeat_window: repeat_buf_cap,
+                    presence_penalty,
+                    frequency_penalty,
                     blocked_tokens: blocked,
                 };
                 next_token = {
@@ -6787,6 +6797,8 @@ fn generate_multi(
             top_p,
             repeat_penalty,
             repeat_window: repeat_buf_cap,
+            presence_penalty,
+            frequency_penalty,
             blocked_tokens: blocked,
         };
         next_token = {
@@ -6861,29 +6873,7 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(
-    m: &mut LoadedModel,
-    gpu: &mut rdna_compute::Gpu,
-    drafter_gpu: Option<&mut rdna_compute::Gpu>,
-    stdout: &mut std::io::Stdout,
-    id: &str,
-    prompt: &str,
-    system_prompt: Option<&str>,
-    temp: f32,
-    top_p: f32,
-    max_tokens: usize,
-    repeat_penalty: f32,
-    repeat_window: usize,
-    budget_alert_at_tok: usize,
-    budget_alert_text: &str,
-    max_think_tokens: usize,
-    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
-    pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>,
-    pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>,
-    tools: Option<&[serde_json::Value]>,
-    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
-    think_mode: ThinkMode,
-) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, presence_penalty: f32, frequency_penalty: f32, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>, think_mode: ThinkMode) {
     // Compress runs on the PFlash drafter handle when one is set (hetero
     // sibling device), else on the target gpu. The handle is consumed at
     // the seq_pos==0 compress site; decode always uses `gpu`.
@@ -6961,22 +6951,10 @@ fn generate(
     // doesn't need to thread any of those args through.
     if m.pp > 1 {
         generate_multi(
-            m,
-            gpu,
-            pflash_state,
-            pflash_cfg,
-            stdout,
-            id,
-            prompt,
-            system_prompt,
-            temp,
-            top_p,
-            max_tokens,
-            repeat_penalty,
-            repeat_window,
-            budget_alert_at_tok,
-            budget_alert_text,
-            max_think_tokens,
+            m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
+            temp, top_p, max_tokens, repeat_penalty, repeat_window,
+            presence_penalty, frequency_penalty,
+            budget_alert_at_tok, budget_alert_text, max_think_tokens,
             assistant_prefix,
             tools,
             messages_history,
@@ -7990,7 +7968,12 @@ fn generate(
         // naturally.
         let vocab_size = config.vocab_size;
         let mut rng_state: u32 = 0x13579BDFu32;
-        let repeat_buf_cap = scratch.repeat_buf.buf.size() / 4;
+        // Effective penalty window = request `repeat_window` (default 128),
+        // bounded by the GPU repeat_buf capacity (2048). The buffer is sized
+        // large so presence/frequency penalties CAN use a wider window when a
+        // request asks for it, but the default stays at the historical 128 —
+        // we do NOT widen the repeat-penalty window for all traffic.
+        let repeat_buf_cap = (scratch.repeat_buf.buf.size() / 4).min(repeat_window.max(1));
 
         // Build the list of paired (open, close) attractor pairs once;
         // sampler::collect_unclosed_attractor_blocks decides per-call
@@ -8094,6 +8077,8 @@ fn generate(
             // sampler::sample do the same `min(window, buf_cap)`
             // internally.
             repeat_window: repeat_buf_cap,
+            presence_penalty,
+            frequency_penalty,
             blocked_tokens: blocked0,
         };
         // Grammar-gated sample: GPU fast path when the matcher is free
@@ -8344,13 +8329,10 @@ fn generate(
             {
                 let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
                 let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
-                let open_idx = raw_str.rfind("<think>");
-                let close_idx = raw_str.rfind("</think>");
-                let in_think = match (open_idx, close_idx) {
-                    (Some(o), Some(c)) => o > c,
-                    (Some(_), None) => true,
-                    _ => false,
-                };
+                let in_think = currently_in_think(
+                    raw_str,
+                    matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink),
+                );
                 // Total-think bound (re-arm-proof). Count every think token; at the
                 // cap, latch force-answer (force-close + block <think>); a margin
                 // past the cap, hard-EOS so a model that keeps re-opening <think>
@@ -8491,13 +8473,10 @@ fn generate(
                 // multi-token sequence in Qwen3.5's vocab.
                 let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
                 let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
-                let think_open_idx = raw_str.rfind("<think>");
-                let think_close_idx = raw_str.rfind("</think>");
-                let in_think = match (think_open_idx, think_close_idx) {
-                    (Some(o), Some(c)) => o > c,
-                    (Some(_), None) => true,
-                    _ => false,
-                };
+                let in_think = currently_in_think(
+                    raw_str,
+                    matches!(assistant_prefix, hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink),
+                );
                 if !in_think {
                     let _ = writeln!(
                         stdout,
@@ -8520,6 +8499,8 @@ fn generate(
                         top_p,
                         repeat_penalty,
                         repeat_window: repeat_buf_cap,
+                        presence_penalty,
+                        frequency_penalty,
                         blocked_tokens: blocked,
                     };
                     next_token = if grammar_active && !grammar_matcher.is_free() {
@@ -8653,6 +8634,8 @@ fn generate(
                 top_p,
                 repeat_penalty,
                 repeat_window: repeat_buf_cap,
+                presence_penalty,
+                frequency_penalty,
                 blocked_tokens: blocked,
             };
             // Grammar-gated sample (see setup block + tok0 site above).
@@ -10605,6 +10588,8 @@ fn generate_vl(
         top_p,
         repeat_penalty: 1.0,
         repeat_window: 0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
         blocked_tokens: Vec::new(),
     };
     let vl_cfg = SamplerConfig {
@@ -10612,6 +10597,8 @@ fn generate_vl(
         top_p,
         repeat_penalty,
         repeat_window,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
         blocked_tokens: Vec::new(),
     };
     let mut next_token = sampler::sample_cpu(&mut logits, &[], &vl_cfg_first);

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -6473,6 +6473,15 @@ fn generate_multi(
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
     let mut total_think_tokens: usize = 0;
+    // Post-latch answer bound. Once the think-cap latches we force-close <think>
+    // and ask the model to answer; but `total_think_tokens` only advances
+    // in-think, so a model that rambles a NON-think answer (or re-opens <think>
+    // in a tight loop the force-close keeps re-closing) never trips the +256 EOS
+    // and runs to max_tokens. Mark the latch position and hard-EOS once
+    // generation runs this many tokens past it — generous for a real final
+    // answer, bounded against runaway.
+    const POST_LATCH_ANSWER_BUDGET: usize = 768;
+    let mut latch_gen_mark: Option<usize> = None;
     let loop_guard =
         hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
@@ -6563,9 +6572,18 @@ fn generate_multi(
             if max_total_think > 0 && total_think_tokens >= max_total_think {
                 force_answer_latched = true;
             }
+            if force_answer_latched && latch_gen_mark.is_none() {
+                latch_gen_mark = Some(generated);
+            }
             if max_total_think > 0 && in_think && total_think_tokens >= max_total_think + 256 {
                 eprintln!("[think-cap] id={} — total think {} exceeded cap {}+256 while still thinking; forcing EOS", id, total_think_tokens, max_total_think);
                 break;
+            }
+            if let Some(mark) = latch_gen_mark {
+                if generated.saturating_sub(mark) >= POST_LATCH_ANSWER_BUDGET {
+                    eprintln!("[think-cap] id={} — {} tokens since think-cap latch without finishing; forcing EOS", id, generated.saturating_sub(mark));
+                    break;
+                }
             }
             if max_think_tokens > 0 {
                 if in_think {
@@ -8153,6 +8171,12 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
         let mut total_think_tokens: usize = 0;
+        // Post-latch answer bound (see the _multi decode path for rationale): the
+        // +256 EOS below only counts in-think tokens, so a non-think ramble or a
+        // re-open loop after the cap latches would run to max_tokens. Hard-EOS
+        // once generation runs this many tokens past the latch.
+        const POST_LATCH_ANSWER_BUDGET: usize = 768;
+        let mut latch_gen_mark: Option<usize> = None;
 
         // N-gram loop detector: track 4-gram token sequences. When any
         // 4-gram repeats more than `ngram_loop_threshold` times in the
@@ -8343,9 +8367,18 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 if max_total_think > 0 && total_think_tokens >= max_total_think {
                     force_answer_latched = true;
                 }
+                if force_answer_latched && latch_gen_mark.is_none() {
+                    latch_gen_mark = Some(generated);
+                }
                 if max_total_think > 0 && in_think && total_think_tokens >= max_total_think + 256 {
                     eprintln!("[think-cap] id={} — total think {} exceeded cap {}+256 while still thinking; forcing EOS", id, total_think_tokens, max_total_think);
                     break;
+                }
+                if let Some(mark) = latch_gen_mark {
+                    if generated.saturating_sub(mark) >= POST_LATCH_ANSWER_BUDGET {
+                        eprintln!("[think-cap] id={} — {} tokens since think-cap latch without finishing; forcing EOS", id, generated.saturating_sub(mark));
+                        break;
+                    }
                 }
                 if max_think_tokens > 0 {
                     if in_think {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -6480,7 +6480,8 @@ fn generate_multi(
     // and runs to max_tokens. Mark the latch position and hard-EOS once
     // generation runs this many tokens past it — generous for a real final
     // answer, bounded against runaway.
-    const POST_LATCH_ANSWER_BUDGET: usize = 768;
+    let post_latch_answer_budget: usize = std::env::var("HIPFIRE_POST_LATCH_ANSWER_TOKENS")
+        .ok().and_then(|s| s.parse().ok()).unwrap_or(768);
     let mut latch_gen_mark: Option<usize> = None;
     let loop_guard =
         hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
@@ -6580,7 +6581,7 @@ fn generate_multi(
                 break;
             }
             if let Some(mark) = latch_gen_mark {
-                if generated.saturating_sub(mark) >= POST_LATCH_ANSWER_BUDGET {
+                if generated.saturating_sub(mark) >= post_latch_answer_budget {
                     eprintln!("[think-cap] id={} — {} tokens since think-cap latch without finishing; forcing EOS", id, generated.saturating_sub(mark));
                     break;
                 }
@@ -8175,7 +8176,8 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // +256 EOS below only counts in-think tokens, so a non-think ramble or a
         // re-open loop after the cap latches would run to max_tokens. Hard-EOS
         // once generation runs this many tokens past the latch.
-        const POST_LATCH_ANSWER_BUDGET: usize = 768;
+        let post_latch_answer_budget: usize = std::env::var("HIPFIRE_POST_LATCH_ANSWER_TOKENS")
+            .ok().and_then(|s| s.parse().ok()).unwrap_or(768);
         let mut latch_gen_mark: Option<usize> = None;
 
         // N-gram loop detector: track 4-gram token sequences. When any
@@ -8375,7 +8377,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                     break;
                 }
                 if let Some(mark) = latch_gen_mark {
-                    if generated.saturating_sub(mark) >= POST_LATCH_ANSWER_BUDGET {
+                    if generated.saturating_sub(mark) >= post_latch_answer_budget {
                         eprintln!("[think-cap] id={} — {} tokens since think-cap latch without finishing; forcing EOS", id, generated.saturating_sub(mark));
                         break;
                     }

--- a/crates/hipfire-runtime/examples/eval_gguf.rs
+++ b/crates/hipfire-runtime/examples/eval_gguf.rs
@@ -160,6 +160,7 @@ fn main() {
         .args(["-f", &args.slice.display().to_string()])
         .args(["-c", &ref_n_ctx.to_string()])
         .args(["-b", &args.n_batch.to_string()])
+        .args(["-ngl", &std::env::var("HIPFIRE_KLD_NGL").unwrap_or_else(|_| "99".to_string())])
         .args(["--kl-divergence-base", &fifo_path.display().to_string()])
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit())

--- a/crates/hipfire-runtime/examples/infer_qwen3.rs
+++ b/crates/hipfire-runtime/examples/infer_qwen3.rs
@@ -202,6 +202,8 @@ fn main() {
         top_p,
         repeat_penalty,
         repeat_window: repeat_buf_cap.min(repeat_window),
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
         blocked_tokens: Vec::new(),
     };
     let mut rng_state_u32: u32 = rng_state;

--- a/crates/hipfire-runtime/examples/infer_qwen35.rs
+++ b/crates/hipfire-runtime/examples/infer_qwen35.rs
@@ -235,6 +235,8 @@ fn main() {
             top_p: sc.top_p,
             repeat_penalty: sc.repeat_penalty,
             repeat_window: repeat_buf_cap.min(sc.repeat_window),
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
             blocked_tokens: Vec::new(),
         };
         sampler::sample(
@@ -327,6 +329,8 @@ fn main() {
                 top_p: sc.top_p,
                 repeat_penalty: sc.repeat_penalty,
                 repeat_window: repeat_buf_cap.min(sc.repeat_window),
+                presence_penalty: 0.0,
+                frequency_penalty: 0.0,
                 blocked_tokens: Vec::new(),
             };
             sampler::sample(

--- a/crates/hipfire-runtime/src/eval_common.rs
+++ b/crates/hipfire-runtime/src/eval_common.rs
@@ -148,6 +148,14 @@ pub fn verify_slice_md5(slice_path: &Path, tool_name: &str) {
 ///
 /// On any mismatch, `std::process::exit(2)`.
 pub fn verify_llama_commit(bin: &str, pinned: &str, tool_name: &str) {
+    // Reproducibility guard, not a correctness requirement. Skip it when the
+    // available llama.cpp build differs from the pinned commit (the KLD value
+    // is insensitive to the exact llama.cpp commit). Set
+    // HIPFIRE_SKIP_LLAMA_COMMIT_CHECK=1 to bypass.
+    if std::env::var("HIPFIRE_SKIP_LLAMA_COMMIT_CHECK").ok().as_deref() == Some("1") {
+        eprintln!("{tool_name}: HIPFIRE_SKIP_LLAMA_COMMIT_CHECK=1 — skipping llama.cpp commit verification (pinned {pinned})");
+        return;
+    }
     let out = Command::new(bin).arg("--version").output();
     let out = match out {
         Ok(o) => o,

--- a/crates/hipfire-runtime/src/sampler.rs
+++ b/crates/hipfire-runtime/src/sampler.rs
@@ -71,6 +71,15 @@ pub struct SamplerConfig {
     /// Effective window is `min(history.len(), repeat_window)` and is
     /// also clipped to the GPU `repeat_buf` capacity by the caller.
     pub repeat_window: usize,
+    /// OpenAI `presence_penalty`: flat logit subtraction applied once to any
+    /// token that occurred within `repeat_window`. 0.0 = disabled. Unlike the
+    /// recency-weighted `repeat_penalty`, this is constant across the window,
+    /// so it suppresses block-level repetition loops a short recency-weighted
+    /// window cannot see (matches llama.cpp / Lemonade semantics).
+    pub presence_penalty: f32,
+    /// OpenAI `frequency_penalty`: logit subtraction scaled by the token's
+    /// occurrence count within `repeat_window`. 0.0 = disabled.
+    pub frequency_penalty: f32,
     /// Token IDs whose logit is unconditionally set to `-INF` before
     /// sampling. Used for the unclosed-opener attractor block (#111).
     pub blocked_tokens: Vec<u32>,
@@ -85,6 +94,8 @@ impl SamplerConfig {
             top_p: 1.0,
             repeat_penalty: 1.0,
             repeat_window: 0,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
             blocked_tokens: Vec::new(),
         }
     }
@@ -101,6 +112,8 @@ impl Default for SamplerConfig {
             top_p: 0.95,
             repeat_penalty: 1.05,
             repeat_window: 128,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
             blocked_tokens: Vec::new(),
         }
     }
@@ -178,7 +191,7 @@ pub fn sample(
     //   - writeback (token_id, new_rng) to `sample_buf`
     //   - 8-byte D2H sync (returned by the wrapper)
     let (tok, new_rng) = gpu
-        .sample_top_p(
+        .sample_top_p_pf(
             logits,
             sample_buf,
             repeat_buf,
@@ -188,6 +201,8 @@ pub fn sample(
             *rng_state,
             scope.len(),
             cfg.repeat_penalty,
+            cfg.presence_penalty,
+            cfg.frequency_penalty,
         )
         .expect("sample_top_p kernel launch / readback failed");
     *rng_state = new_rng;
@@ -206,6 +221,23 @@ pub fn sample(
 pub fn sample_cpu(logits: &mut [f32], history: &[u32], cfg: &SamplerConfig) -> u32 {
     if cfg.repeat_penalty != 1.0 && cfg.repeat_window > 0 {
         llama::apply_repeat_penalty(logits, history, cfg.repeat_window, cfg.repeat_penalty);
+    }
+    // OpenAI-style subtractive presence/frequency penalties over the same
+    // window (mirrors the GPU `sample_top_p` kernel). logit -= freq*count +
+    // presence, applied once per unique token. Keeps the GPU and CPU
+    // (grammar-active) decode paths consistent.
+    if (cfg.presence_penalty > 0.0 || cfg.frequency_penalty > 0.0) && cfg.repeat_window > 0 {
+        let start = history.len().saturating_sub(cfg.repeat_window);
+        let window = &history[start..];
+        let mut counts: std::collections::HashMap<u32, f32> = std::collections::HashMap::new();
+        for &t in window {
+            *counts.entry(t).or_insert(0.0) += 1.0;
+        }
+        for (tok, count) in counts {
+            if (tok as usize) < logits.len() {
+                logits[tok as usize] -= cfg.frequency_penalty * count + cfg.presence_penalty;
+            }
+        }
     }
     for &tok in &cfg.blocked_tokens {
         if (tok as usize) < logits.len() {

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -11,6 +11,14 @@ use crate::dispatch::{DType, Gpu, GpuTensor};
 use crate::kernels;
 use hip_bridge::{DeviceBuffer, HipResult};
 
+/// Monotonic per-launch counter feeding the Q8 GatedDeltaNet state
+/// stochastic-rounding dither. Supplies fresh, data-INDEPENDENT entropy each
+/// requant so the rounding is genuinely unbiased across the recurrence — the
+/// old seed used the state-derived `my_max` with no temporal term, which made
+/// the dither a deterministic, data-correlated function and accumulated a
+/// systematic bias that drifted the recurrent state on long generations.
+static GDN_REQUANT_FRAME: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
 impl Gpu {
     /// out = rmsnorm(x, weight, eps)
     pub fn rmsnorm_f32(
@@ -1321,13 +1329,16 @@ impl Gpu {
         let nt = n_tokens as i32;
         let nh = n_heads as i32;
         let hd = head_dim as i32;
+        // Per-launch monotonic frame for the Q8 state stochastic-rounding
+        // dither (data-INDEPENDENT entropy; see GATED_DELTA_NET_Q8 kernel).
+        let fr = GDN_REQUANT_FRAME.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as i32;
         let mut params: Vec<*mut c_void> = vec![
             &qp as *const _ as *mut c_void, &kp as *const _ as *mut c_void,
             &vp as *const _ as *mut c_void, &gp as *const _ as *mut c_void,
             &bp as *const _ as *mut c_void, &sp as *const _ as *mut c_void,
             &scp as *const _ as *mut c_void, &op as *const _ as *mut c_void,
             &nt as *const _ as *mut c_void, &nh as *const _ as *mut c_void,
-            &hd as *const _ as *mut c_void,
+            &hd as *const _ as *mut c_void, &fr as *const _ as *mut c_void,
         ];
         let n_tiles = (128 / 4) as u32;
         let bytes = crate::profile::gated_delta_net_q8_bytes(n_tokens, n_heads, head_dim);
@@ -1339,7 +1350,7 @@ impl Gpu {
                 b.push_ptr(qp); b.push_ptr(kp); b.push_ptr(vp);
                 b.push_ptr(gp); b.push_ptr(bp); b.push_ptr(sp);
                 b.push_ptr(scp); b.push_ptr(op);
-                b.push_i32(nt); b.push_i32(nh); b.push_i32(hd);
+                b.push_i32(nt); b.push_i32(nh); b.push_i32(hd); b.push_i32(fr);
                 b
             },
         );
@@ -1395,6 +1406,7 @@ impl Gpu {
         let mut nt = n_tokens as i32;
         let mut nh = n_heads as i32;
         let mut hd = head_dim as i32;
+        let mut fr = GDN_REQUANT_FRAME.fetch_add(1, std::sync::atomic::Ordering::Relaxed) as i32;
         let mut params: Vec<*mut c_void> = vec![
             &mut qp as *mut _ as *mut c_void,
             &mut kp as *mut _ as *mut c_void,
@@ -1407,6 +1419,7 @@ impl Gpu {
             &mut nt as *mut _ as *mut c_void,
             &mut nh as *mut _ as *mut c_void,
             &mut hd as *mut _ as *mut c_void,
+            &mut fr as *mut _ as *mut c_void,
         ];
 
         let bytes = crate::profile::gated_delta_net_q8_bytes(n_tokens, n_heads, head_dim);
@@ -1427,7 +1440,7 @@ impl Gpu {
                 b.push_ptr(qp); b.push_ptr(kp); b.push_ptr(vp);
                 b.push_ptr(gp); b.push_ptr(bp);
                 b.push_ptr(sp); b.push_ptr(scp); b.push_ptr(op);
-                b.push_i32(nt); b.push_i32(nh); b.push_i32(hd);
+                b.push_i32(nt); b.push_i32(nh); b.push_i32(hd); b.push_i32(fr);
                 b
             },
         );

--- a/crates/rdna-compute/src/sampling.rs
+++ b/crates/rdna-compute/src/sampling.rs
@@ -123,6 +123,35 @@ impl Gpu {
         repeat_window: usize,
         repeat_penalty: f32,
     ) -> HipResult<(u32, u32)> {
+        // Back-compat shim: no presence/frequency penalties (byte-identical
+        // to the pre-PF kernel, which had `if (repeat_penalty > 1.0f)`).
+        self.sample_top_p_pf(
+            logits, result_buf, repeat_buf, vocab_size, temperature, top_p,
+            rng_state, repeat_window, repeat_penalty, 0.0, 0.0,
+        )
+    }
+
+    /// Like [`sample_top_p`], plus OpenAI-style subtractive `presence_penalty`
+    /// and `frequency_penalty` applied over the same `repeat_window`. Passing
+    /// `0.0` for both is byte-identical to `sample_top_p`. These flat (non
+    /// recency-weighted) penalties break block-level repetition loops the
+    /// recency-weighted multiplicative repeat penalty cannot — provided the
+    /// `repeat_buf` window is large enough to span a full loop period.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sample_top_p_pf(
+        &mut self,
+        logits: &GpuTensor,
+        result_buf: &GpuTensor,
+        repeat_buf: &GpuTensor,
+        vocab_size: usize,
+        temperature: f32,
+        top_p: f32,
+        rng_state: u32,
+        repeat_window: usize,
+        repeat_penalty: f32,
+        presence_penalty: f32,
+        frequency_penalty: f32,
+    ) -> HipResult<(u32, u32)> {
         self.bind_thread()?;
         self.ensure_kernel("sample_top_p", kernels::SAMPLE_TOP_P_SRC, "sample_top_p")?;
         let func = &self.functions["sample_top_p"];
@@ -136,6 +165,8 @@ impl Gpu {
         let mut rng = rng_state;
         let mut rw = repeat_window as i32;
         let mut rp = repeat_penalty;
+        let mut pp = presence_penalty;
+        let mut fp = frequency_penalty;
 
         let mut params: Vec<*mut std::ffi::c_void> = vec![
             &mut logits_ptr as *mut _ as *mut std::ffi::c_void,
@@ -147,6 +178,8 @@ impl Gpu {
             &mut rng as *mut _ as *mut std::ffi::c_void,
             &mut rw as *mut _ as *mut std::ffi::c_void,
             &mut rp as *mut _ as *mut std::ffi::c_void,
+            &mut pp as *mut _ as *mut std::ffi::c_void,
+            &mut fp as *mut _ as *mut std::ffi::c_void,
         ];
 
         let block_size = 256u32;
@@ -197,6 +230,9 @@ impl Gpu {
         let mut rng = rng_state;
         let mut rw = repeat_window as i32;
         let mut rp = repeat_penalty;
+        // Graph-capture path does not expose presence/frequency penalties.
+        let mut pp = 0.0f32;
+        let mut fp = 0.0f32;
 
         let mut params: Vec<*mut std::ffi::c_void> = vec![
             &mut logits_ptr as *mut _ as *mut std::ffi::c_void,
@@ -208,6 +244,8 @@ impl Gpu {
             &mut rng as *mut _ as *mut std::ffi::c_void,
             &mut rw as *mut _ as *mut std::ffi::c_void,
             &mut rp as *mut _ as *mut std::ffi::c_void,
+            &mut pp as *mut _ as *mut std::ffi::c_void,
+            &mut fp as *mut _ as *mut std::ffi::c_void,
         ];
 
         let block_size = 256u32;

--- a/kernels/src/gated_delta_net_q8.hip
+++ b/kernels/src/gated_delta_net_q8.hip
@@ -19,7 +19,11 @@ __global__ void gated_delta_net_q8(
     float* __restrict__ output,
     int n_tokens,
     int n_heads,
-    int head_dim
+    int head_dim,
+    unsigned int frame   // per-launch monotonic counter (host-supplied) — fresh,
+                         // data-INDEPENDENT entropy for the stochastic-rounding
+                         // dither. Without it the dither was seeded from my_max
+                         // (state-derived) → correlated, biased over the recurrence.
 ) {
     const int h = blockIdx.x;
     const int tile = blockIdx.y;
@@ -105,11 +109,17 @@ __global__ void gated_delta_net_q8(
         signed char* dst = sq_base + r * HD;
 
         // Stochastic rounding: generate 4 uniform random values in [0, 1).
-        // Seed tied to thread id (was col=tid*4 before); same deterministic
-        // family, different seed values — resulting sequence is equivalently
-        // uniform; no bias.
+        // Seed = spatial location (h, row, tid) + per-launch `frame` counter.
+        // CRITICAL: the dither MUST be independent of the value being rounded
+        // and fresh per requant. The old seed used __float_as_uint(my_max)
+        // (state-derived) and no temporal term — so across the thousands of
+        // per-token decode requants the dither was a deterministic, data-
+        // correlated function, defeating stochastic rounding's unbiasedness
+        // and accumulating a systematic bias that drifts the recurrent state
+        // off-distribution on long generations (length-dependent coherence
+        // collapse). `frame` supplies the missing per-step entropy.
         unsigned int rng = (unsigned int)(h * 1664525u + (row_start + r) * 1013904223u
-                         + tid * 214013u + __float_as_uint(my_max) * 2531011u);
+                         + tid * 214013u + frame * 2531011u);
         #define STOCH_ROUND(val) ({ \
             rng = rng * 1664525u + 1013904223u; \
             float noise = (float)(rng >> 8) * (1.0f / 16777216.0f); \

--- a/kernels/src/sample_top_p.hip
+++ b/kernels/src/sample_top_p.hip
@@ -31,7 +31,9 @@ extern "C" __global__ void sample_top_p(
     float top_p,
     unsigned int rand_seed,
     int repeat_window,
-    float repeat_penalty
+    float repeat_penalty,
+    float presence_penalty,                         // OpenAI: flat logit subtraction for any token seen in window
+    float frequency_penalty                         // OpenAI: logit subtraction scaled by occurrence count
 ) {
     const int TOP_K = 20;
     extern __shared__ char smem[];
@@ -49,7 +51,8 @@ extern "C" __global__ void sample_top_p(
     // determines whether position i holds the LAST occurrence of its token;
     // if so, it counts total occurrences, computes recency = (i+1)/window_len,
     // and applies penalty^(count*recency) (capped at 1.5×) to logits[tok].
-    if (repeat_penalty > 1.0f && repeat_window > 0) {
+    bool any_penalty = (repeat_penalty > 1.0f) || (presence_penalty > 0.0f) || (frequency_penalty > 0.0f);
+    if (any_penalty && repeat_window > 0) {
         float window_len = (float)repeat_window;
         for (int i = tid; i < repeat_window; i += nthreads) {
             unsigned int tok = repeat_tokens[i];
@@ -64,11 +67,25 @@ extern "C" __global__ void sample_top_p(
                 }
             }
             if (has_later) continue;
-            float recency = ((float)i + 1.0f) / window_len;
-            float effective = powf(repeat_penalty, (float)count * recency);
-            if (effective > 1.5f) effective = 1.5f;
-            float v = logits[tok];
-            logits[tok] = (v > 0.0f) ? (v / effective) : (v * effective);
+            // `count` is now the total occurrences of `tok` in the window (this
+            // is the last occurrence). Apply the existing multiplicative,
+            // recency-weighted repeat penalty first...
+            if (repeat_penalty > 1.0f) {
+                float recency = ((float)i + 1.0f) / window_len;
+                float effective = powf(repeat_penalty, (float)count * recency);
+                if (effective > 1.5f) effective = 1.5f;
+                float v = logits[tok];
+                logits[tok] = (v > 0.0f) ? (v / effective) : (v * effective);
+            }
+            // ...then the OpenAI-style subtractive presence/frequency penalties.
+            // These are flat in logit space (not recency-weighted) so they
+            // suppress a token equally no matter where in the (long) window it
+            // recurred — the mechanism that breaks block-level repetition loops
+            // a short recency-weighted window cannot see. Matches llama.cpp /
+            // Lemonade semantics: logit -= frequency*count + presence.
+            if (presence_penalty > 0.0f || frequency_penalty > 0.0f) {
+                logits[tok] -= frequency_penalty * (float)count + presence_penalty;
+            }
         }
     }
     __syncthreads();


### PR DESCRIPTION
## Qwen3.6-A3B serving + DeltaNet-state fixes (+ KLD eval-tooling)

A bundle of validated serving-robustness fixes for Qwen3.5/3.6, surfaced while
investigating a Hipfire-vs-llama.cpp(Lemonade) LiveBench quality gap on
Qwen3.6-35B-A3B at matched 4-bit.

### Commits
- **`open <think>` by default** for thinking models on the OpenAI endpoint
  (`enable_thinking=true` was a no-op).
- **force-close fires for prompt-opened `<think>`** — `max_think_tokens` detected
  thinking by scanning *generated* text, but `open_think` injects `<think>` into
  the *prompt*, so the cap never fired → 16k-token runaways. Fixed via
  `currently_in_think(raw, started_in_think)`. (Rebased to keep upstream's newer
  token-ID think-tracking on the VL path; uses the helper only where it's the fix.)
- **Q8 DeltaNet-state dither fix** — the state requant's "stochastic rounding"
  seeded its dither from the state-derived `my_max` with **no per-step entropy**,
  so it wasn't actually stochastic → a systematic bias accumulated over the
  recurrence and drifted the state on long generations (space-stripping /
  free-association). Now seeded from a per-launch counter; `my_max` dropped.
- **OpenAI `presence_penalty` / `frequency_penalty`** — added to the GPU
  `sample_top_p` kernel (subtractive, llama.cpp-style), `SamplerConfig`, the
  daemon request path, and the CLI. **Off by default; byte-identical when 0.**
- **request-controlled penalty window (default 128)** — the repeat_buf grows to
  2048 *capacity* (so presence/frequency can use a wider window when a request
  asks), but the effective window defaults to the historical 128. No silent
  widening of repeat-penalty reach for all traffic.
- **eval-tooling**: `build_kld_ref`/`eval_gguf` now pass `-ngl` (they ran the
  reference/candidate on CPU); `verify_llama_commit` gains an
  `HIPFIRE_SKIP_LLAMA_COMMIT_CHECK=1` bypass (reproducibility guard, not a
  correctness req).

### Testing
- `cargo build --release` clean against current `master`.
- Coherence gate: **no hard errors** (0.8b/4b/9b · cap/code/reason/tool-call).

### Scope notes
- These are **coherence / serving-correctness fixes, not a quality-parity fix.**
  Separate KLD measurement (Hipfire mq4 KLD 0.104 vs llama.cpp Q4_K_XL 0.023 vs a
  BF16 ref) pinned the remaining LiveBench gap to MoE-expert quant **scale
  granularity** (coarse MQ4G256 vs Q4_K per-32 sub-block) — a follow-up
  finer-grained MoE-FFN quant/kernel, tracked separately.
- An FP32-DeltaNet-state CLI knob was prototyped then **dropped** (it's a
  per-token-prefill-cost mitigation, not the fix); one commit adds it and a later
  commit removes it, so the net diff carries no FP32 plumbing.
