### PR TITLE
fix(engine): hunt-2 batch — premature-stop, OOB write, daemon crash, 4 GPU leaks (9 bugs)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/mtp_compose.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_compose.rs
@@ -138,7 +138,10 @@ impl MtpComposeState {
         let _ = gpu.free_tensor(self.mtp_lm_logits);
         let _ = gpu.free_tensor(self.mtp_lm_argmax);
         self.mtp_scratch.free_gpu(gpu);
-        self.mtp_kv.free_gpu(gpu);
+        // Qwen35MtpHeadKvCache::free_gpu does `drop(inner)` which does not
+        // release GPU memory (llama::KvCache has no Drop). Call the inner
+        // KvCache's own free_gpu directly to properly hipFree each tensor.
+        self.mtp_kv.inner.free_gpu(gpu);
     }
 }
 
@@ -670,7 +673,10 @@ impl MtpComposeTreeState {
         let _ = gpu.free_tensor(self.mtp_lm_logits);
         let _ = gpu.free_tensor(self.mtp_lm_argmax);
         self.mtp_scratch.free_gpu(gpu);
-        self.mtp_kv.free_gpu(gpu);
+        // Qwen35MtpHeadKvCache::free_gpu does `drop(inner)` which does not
+        // release GPU memory (llama::KvCache has no Drop). Call the inner
+        // KvCache's own free_gpu directly to properly hipFree each tensor.
+        self.mtp_kv.inner.free_gpu(gpu);
     }
 }
 

--- a/crates/hipfire-arch-qwen35/src/mtp_head.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_head.rs
@@ -724,10 +724,12 @@ impl Qwen35MtpHeadKvCache {
         Ok(())
     }
 
-    pub fn free_gpu(self, _gpu: &mut Gpu) {
-        // llama::KvCache owns its GpuTensors; they free on Drop.
-        // Explicit method kept for API parity with old callers.
-        drop(self.inner);
+    pub fn free_gpu(self, gpu: &mut Gpu) {
+        // llama::KvCache holds GpuTensors with NO Drop impl — dropping it
+        // leaks the k_gpu/v_gpu buffers. Free them explicitly. (The old
+        // "they free on Drop" comment was false; see mtp_spec/mtp_compose
+        // which already bypass this wrapper for the same reason.)
+        self.inner.free_gpu(gpu);
     }
 }
 

--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -754,8 +754,9 @@ impl MtpSpecState {
         let _ = gpu.free_tensor(self.mtp_gather_prob_draft);
         let _ = gpu.free_tensor(self.mtp_gather_idx_verify);
         let _ = gpu.free_tensor(self.mtp_gather_prob_verify);
-        // DeltaNetSnapshot's DeviceBuffers free on drop.
-        drop(self.trunk_snap);
+        // DeltaNetSnapshot holds DeviceBuffers which have no Drop impl —
+        // use free_gpu to release the GPU allocations rather than bare drop.
+        self.trunk_snap.free_gpu(gpu);
         if let Some(event) = self.trunk_snap_start_event {
             let _ = gpu.hip.event_destroy(event);
         }
@@ -765,7 +766,10 @@ impl MtpSpecState {
         self.trunk_pbs.free_gpu(gpu);
         self.trunk_gdn_tape.free_gpu(gpu);
         self.mtp_scratch.free_gpu(gpu);
-        self.mtp_kv.free_gpu(gpu);
+        // Qwen35MtpHeadKvCache::free_gpu does `drop(inner)` which does not
+        // release GPU memory (llama::KvCache has no Drop). Call the inner
+        // KvCache's own free_gpu directly to properly hipFree each tensor.
+        self.mtp_kv.inner.free_gpu(gpu);
     }
 }
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -668,58 +668,58 @@ impl Qwen35Weights {
     pub fn free_gpu(self, gpu: &mut Gpu) {
         let _ = gpu.free_tensor(self.token_embd);
         let _ = gpu.free_tensor(self.output_norm);
-        let _ = gpu.free_tensor(self.output.buf);
+        self.output.free_all(gpu);
         for layer in self.layers {
             match layer {
                 LayerWeights::DeltaNet(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wqkv.buf);
-                    let _ = gpu.free_tensor(l.wz.buf);
-                    let _ = gpu.free_tensor(l.w_alpha.buf);
-                    let _ = gpu.free_tensor(l.w_beta.buf);
+                    l.wqkv.free_all(gpu);
+                    l.wz.free_all(gpu);
+                    l.w_alpha.free_all(gpu);
+                    l.w_beta.free_all(gpu);
                     let _ = gpu.free_tensor(l.a_log);
                     let _ = gpu.free_tensor(l.dt_bias);
                     let _ = gpu.free_tensor(l.conv_weight);
                     let _ = gpu.free_tensor(l.norm_weight);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.ffn_norm);
-                    let _ = gpu.free_tensor(l.w_gate.buf);
-                    let _ = gpu.free_tensor(l.w_up.buf);
-                    let _ = gpu.free_tensor(l.w_down.buf);
+                    l.w_gate.free_all(gpu);
+                    l.w_up.free_all(gpu);
+                    l.w_down.free_all(gpu);
                 }
                 LayerWeights::FullAttn(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wq.buf);
-                    let _ = gpu.free_tensor(l.wk.buf);
-                    let _ = gpu.free_tensor(l.wv.buf);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wq.free_all(gpu);
+                    l.wk.free_all(gpu);
+                    l.wv.free_all(gpu);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.q_norm);
                     let _ = gpu.free_tensor(l.k_norm);
                     let _ = gpu.free_tensor(l.ffn_norm);
-                    let _ = gpu.free_tensor(l.w_gate.buf);
-                    let _ = gpu.free_tensor(l.w_up.buf);
-                    let _ = gpu.free_tensor(l.w_down.buf);
+                    l.w_gate.free_all(gpu);
+                    l.w_up.free_all(gpu);
+                    l.w_down.free_all(gpu);
                 }
                 LayerWeights::DeltaNetMoe(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wqkv.buf);
-                    let _ = gpu.free_tensor(l.wz.buf);
-                    let _ = gpu.free_tensor(l.w_alpha.buf);
-                    let _ = gpu.free_tensor(l.w_beta.buf);
+                    l.wqkv.free_all(gpu);
+                    l.wz.free_all(gpu);
+                    l.w_alpha.free_all(gpu);
+                    l.w_beta.free_all(gpu);
                     let _ = gpu.free_tensor(l.a_log);
                     let _ = gpu.free_tensor(l.dt_bias);
                     let _ = gpu.free_tensor(l.conv_weight);
                     let _ = gpu.free_tensor(l.norm_weight);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.ffn_norm);
                     free_moe_ffn(gpu, l.ffn);
                 }
                 LayerWeights::FullAttnMoe(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wq.buf);
-                    let _ = gpu.free_tensor(l.wk.buf);
-                    let _ = gpu.free_tensor(l.wv.buf);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wq.free_all(gpu);
+                    l.wk.free_all(gpu);
+                    l.wv.free_all(gpu);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.q_norm);
                     let _ = gpu.free_tensor(l.k_norm);
                     let _ = gpu.free_tensor(l.ffn_norm);
@@ -750,60 +750,60 @@ impl Qwen35Weights {
         let _ = gpus.devices[0].free_tensor(self.token_embd);
         let out_dev = gpus.output_device;
         let _ = gpus.devices[out_dev].free_tensor(self.output_norm);
-        let _ = gpus.devices[out_dev].free_tensor(self.output.buf);
+        self.output.free_all(&mut gpus.devices[out_dev]);
         for (i, layer) in self.layers.into_iter().enumerate() {
             let dev_idx = gpus.device_for_layer(i);
             let gpu = &mut gpus.devices[dev_idx];
             match layer {
                 LayerWeights::DeltaNet(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wqkv.buf);
-                    let _ = gpu.free_tensor(l.wz.buf);
-                    let _ = gpu.free_tensor(l.w_alpha.buf);
-                    let _ = gpu.free_tensor(l.w_beta.buf);
+                    l.wqkv.free_all(gpu);
+                    l.wz.free_all(gpu);
+                    l.w_alpha.free_all(gpu);
+                    l.w_beta.free_all(gpu);
                     let _ = gpu.free_tensor(l.a_log);
                     let _ = gpu.free_tensor(l.dt_bias);
                     let _ = gpu.free_tensor(l.conv_weight);
                     let _ = gpu.free_tensor(l.norm_weight);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.ffn_norm);
-                    let _ = gpu.free_tensor(l.w_gate.buf);
-                    let _ = gpu.free_tensor(l.w_up.buf);
-                    let _ = gpu.free_tensor(l.w_down.buf);
+                    l.w_gate.free_all(gpu);
+                    l.w_up.free_all(gpu);
+                    l.w_down.free_all(gpu);
                 }
                 LayerWeights::FullAttn(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wq.buf);
-                    let _ = gpu.free_tensor(l.wk.buf);
-                    let _ = gpu.free_tensor(l.wv.buf);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wq.free_all(gpu);
+                    l.wk.free_all(gpu);
+                    l.wv.free_all(gpu);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.q_norm);
                     let _ = gpu.free_tensor(l.k_norm);
                     let _ = gpu.free_tensor(l.ffn_norm);
-                    let _ = gpu.free_tensor(l.w_gate.buf);
-                    let _ = gpu.free_tensor(l.w_up.buf);
-                    let _ = gpu.free_tensor(l.w_down.buf);
+                    l.w_gate.free_all(gpu);
+                    l.w_up.free_all(gpu);
+                    l.w_down.free_all(gpu);
                 }
                 LayerWeights::DeltaNetMoe(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wqkv.buf);
-                    let _ = gpu.free_tensor(l.wz.buf);
-                    let _ = gpu.free_tensor(l.w_alpha.buf);
-                    let _ = gpu.free_tensor(l.w_beta.buf);
+                    l.wqkv.free_all(gpu);
+                    l.wz.free_all(gpu);
+                    l.w_alpha.free_all(gpu);
+                    l.w_beta.free_all(gpu);
                     let _ = gpu.free_tensor(l.a_log);
                     let _ = gpu.free_tensor(l.dt_bias);
                     let _ = gpu.free_tensor(l.conv_weight);
                     let _ = gpu.free_tensor(l.norm_weight);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.ffn_norm);
                     free_moe_ffn(gpu, l.ffn);
                 }
                 LayerWeights::FullAttnMoe(l) => {
                     let _ = gpu.free_tensor(l.attn_norm);
-                    let _ = gpu.free_tensor(l.wq.buf);
-                    let _ = gpu.free_tensor(l.wk.buf);
-                    let _ = gpu.free_tensor(l.wv.buf);
-                    let _ = gpu.free_tensor(l.wo.buf);
+                    l.wq.free_all(gpu);
+                    l.wk.free_all(gpu);
+                    l.wv.free_all(gpu);
+                    l.wo.free_all(gpu);
                     let _ = gpu.free_tensor(l.q_norm);
                     let _ = gpu.free_tensor(l.k_norm);
                     let _ = gpu.free_tensor(l.ffn_norm);
@@ -815,16 +815,16 @@ impl Qwen35Weights {
 }
 
 fn free_moe_ffn(gpu: &mut Gpu, ffn: MoeFfnWeights) {
-    let _ = gpu.free_tensor(ffn.router.buf);
-    let _ = gpu.free_tensor(ffn.shared_expert_gate.buf);
-    let _ = gpu.free_tensor(ffn.shared_expert.gate.buf);
-    let _ = gpu.free_tensor(ffn.shared_expert.up.buf);
-    let _ = gpu.free_tensor(ffn.shared_expert.down.buf);
+    ffn.router.free_all(gpu);
+    ffn.shared_expert_gate.free_all(gpu);
+    ffn.shared_expert.gate.free_all(gpu);
+    ffn.shared_expert.up.free_all(gpu);
+    ffn.shared_expert.down.free_all(gpu);
     let _ = gpu.free_tensor(ffn.expert_gate_up_ptrs);
     let _ = gpu.free_tensor(ffn.expert_down_ptrs);
     for e in ffn.experts {
-        let _ = gpu.free_tensor(e.gate_up.buf);
-        let _ = gpu.free_tensor(e.down.buf);
+        e.gate_up.free_all(gpu);
+        e.down.free_all(gpu);
     }
     // ParoQuant MoE: free the owning shared sidecars (per-expert `paro` fields
     // alias these and must NOT be freed separately — they're non-owning views).
@@ -12467,32 +12467,63 @@ fn run_fa_layer_body(
     if kv_cache.quant_asym4 {
         let ct = kv_cache.givens_cos.as_ref().unwrap();
         let st = kv_cache.givens_sin.as_ref().unwrap();
-        gpu.kv_cache_write_asym4_fused(
-            &kv_cache.k_gpu[layer_idx],
-            &kv_cache.v_gpu[layer_idx],
-            &s.fa_k,
-            &s.fa_v,
-            &s.pos_buf,
-            ct,
-            st,
-            config.n_kv_heads,
-            config.head_dim,
-        )?;
-        gpu.attention_flash_asym4(
-            &s.fa_q,
-            &kv_cache.k_gpu[layer_idx],
-            &kv_cache.v_gpu[layer_idx],
-            &s.fa_attn_out,
-            &s.pos_buf,
-            ct,
-            st,
-            pos + 1,
-            config.n_heads,
-            config.n_kv_heads,
-            config.head_dim,
-            kv_cache.physical_cap,
-            &s.flash_partials,
-        )?;
+        if kv_cache.quant_fwht {
+            gpu.kv_cache_write_fwht4_fused(
+                &kv_cache.k_gpu[layer_idx],
+                &kv_cache.v_gpu[layer_idx],
+                &s.fa_k,
+                &s.fa_v,
+                &s.pos_buf,
+                ct,
+                st,
+                config.n_kv_heads,
+                config.head_dim,
+                kv_cache.v_mode_bits(),
+            )?;
+            gpu.attention_flash_fwht4(
+                &s.fa_q,
+                &kv_cache.k_gpu[layer_idx],
+                &kv_cache.v_gpu[layer_idx],
+                &s.fa_attn_out,
+                &s.pos_buf,
+                ct,
+                st,
+                pos + 1,
+                config.n_heads,
+                config.n_kv_heads,
+                config.head_dim,
+                kv_cache.physical_cap,
+                &s.flash_partials,
+                kv_cache.v_mode_bits(),
+            )?;
+        } else {
+            gpu.kv_cache_write_asym4_fused(
+                &kv_cache.k_gpu[layer_idx],
+                &kv_cache.v_gpu[layer_idx],
+                &s.fa_k,
+                &s.fa_v,
+                &s.pos_buf,
+                ct,
+                st,
+                config.n_kv_heads,
+                config.head_dim,
+            )?;
+            gpu.attention_flash_asym4(
+                &s.fa_q,
+                &kv_cache.k_gpu[layer_idx],
+                &kv_cache.v_gpu[layer_idx],
+                &s.fa_attn_out,
+                &s.pos_buf,
+                ct,
+                st,
+                pos + 1,
+                config.n_heads,
+                config.n_kv_heads,
+                config.head_dim,
+                kv_cache.physical_cap,
+                &s.flash_partials,
+            )?;
+        }
     } else if kv_cache.quant_asym3 {
         let ct = kv_cache.givens_cos.as_ref().unwrap();
         let st = kv_cache.givens_sin.as_ref().unwrap();

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2272,6 +2272,9 @@ fn main() {
                         if let Some(ref mut s) = m.deepseek4_state {
                             s.reset();
                         }
+                        if let Some(ref mut ad) = m.kv_adaptive {
+                            ad.reset();
+                        }
                     }
                     if image_base64.is_some() && image.is_some() {
                         eprintln!(
@@ -2525,6 +2528,12 @@ fn main() {
                         // ensures we retrace warmup → capture → replay
                         // rather than jumping straight back to replay.
                         gpu.invalidate_graph_state();
+                    }
+                    // Restore adaptive-KV controller to start tier (q8/fwht4)
+                    // so thresholds fire correctly on the fresh conversation
+                    // instead of staying pinned at the floor tier.
+                    if let Some(ref mut ad) = m.kv_adaptive {
+                        ad.reset();
                     }
                     let _ = writeln!(stdout, r#"{{"type":"reset","seq_pos":0}}"#);
                 } else {
@@ -5694,6 +5703,24 @@ fn generate_dflash(
             m.seq_pos = 0;
             m.conversation_tokens.clear();
             free_checkpoints(&mut m.dflash_checkpoints, gpu);
+            // Zero DeltaNet recurrent state so the next AR turn cold-prefills
+            // over clean buffers. Without this, stale mid-decode recurrent
+            // state from the aborted DFlash run corrupts the next generation
+            // (drift → premature EOS). Mirrors grammar-dflash reset above.
+            if let Some(ref dn) = m.dn_state {
+                for s in &dn.s_matrices {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for s in &dn.s_scales {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for s in &dn.conv_states {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+            }
+            if let Some(kv) = m.kv_cache.as_mut() {
+                kv.compact_offset = 0;
+            }
             let _ = writeln!(
                 stdout,
                 r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
@@ -6156,6 +6183,8 @@ fn generate_multi(
         );
         m.seq_pos = 0;
         m.conversation_tokens.clear();
+        free_checkpoints(&mut m.prefill_checkpoints, gpu);
+        free_checkpoints(&mut m.dflash_checkpoints, gpu);
         if let (Some(ref dn), Some(ref mut gpus), Some(ref la)) = (
             m.dn_state.as_ref(),
             m.pp_gpus.as_mut(),
@@ -6179,6 +6208,9 @@ fn generate_multi(
         }
         if let Some(kv) = m.kv_cache.as_mut() {
             kv.compact_offset = 0;
+        }
+        if let Some(ad) = m.kv_adaptive.as_mut() {
+            ad.reset();
         }
     }
 
@@ -7138,6 +7170,8 @@ fn generate(
         );
         m.seq_pos = 0;
         m.conversation_tokens.clear();
+        free_checkpoints(&mut m.prefill_checkpoints, gpu);
+        free_checkpoints(&mut m.dflash_checkpoints, gpu);
         // Zero DeltaNet state on reset
         if let Some(ref dn) = m.dn_state {
             for s in &dn.s_matrices {
@@ -7155,6 +7189,9 @@ fn generate(
         }
         if let Some(kv) = m.llama_kv.as_mut() {
             kv.compact_offset = 0;
+        }
+        if let Some(ad) = m.kv_adaptive.as_mut() {
+            ad.reset();
         }
     }
 
@@ -7950,11 +7987,18 @@ fn generate(
                 // re-quantizes [0, seq_pos) down a tier, freeing room for the next
                 // chunk. `m.kv_adaptive` is disjoint from the live kv/dn borrows.
                 if let Some(ad) = m.kv_adaptive.as_mut() {
-                    for step in ad.maybe_downshift(gpu, kv, m.seq_pos).unwrap() {
-                        eprintln!(
-                            "[adaptive-kv] downshift @ pos {} (prefill): {:?} (K={:?} V={:?})",
-                            m.seq_pos, step, ad.cur_k, ad.cur_v
-                        );
+                    match ad.maybe_downshift(gpu, kv, m.seq_pos) {
+                        Ok(steps) => {
+                            for step in steps {
+                                eprintln!(
+                                    "[adaptive-kv] downshift @ pos {} (prefill): {:?} (K={:?} V={:?})",
+                                    m.seq_pos, step, ad.cur_k, ad.cur_v
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("[adaptive-kv] maybe_downshift error @ pos {} (prefill): {:?} — skipping", m.seq_pos, e);
+                        }
                     }
                 }
                 // Snapshot the recurrent state every ckpt_interval() tokens so a
@@ -8013,12 +8057,18 @@ fn generate(
         // decode starts). `kv` (=m.kv_cache) and m.kv_adaptive are distinct
         // fields → NLL splits the borrow.
         if let Some(ad) = m.kv_adaptive.as_mut() {
-            let applied = ad.maybe_downshift(gpu, kv, m.seq_pos).unwrap();
-            for step in &applied {
-                eprintln!(
-                    "[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})",
-                    m.seq_pos, step, ad.cur_k, ad.cur_v
-                );
+            match ad.maybe_downshift(gpu, kv, m.seq_pos) {
+                Ok(applied) => {
+                    for step in &applied {
+                        eprintln!(
+                            "[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})",
+                            m.seq_pos, step, ad.cur_k, ad.cur_v
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[adaptive-kv] maybe_downshift error @ pos {} (post-prefill): {:?} — skipping", m.seq_pos, e);
+                }
             }
         }
         m.conversation_tokens.extend_from_slice(&new_tokens);
@@ -8358,12 +8408,18 @@ fn generate(
             // thresholds. `kv` (=m.kv_cache) and m.kv_adaptive are distinct
             // fields → NLL splits the borrow.
             if let Some(ad) = m.kv_adaptive.as_mut() {
-                let applied = ad.maybe_downshift(gpu, kv, m.seq_pos).unwrap();
-                for step in &applied {
-                    eprintln!(
-                        "[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})",
-                        m.seq_pos, step, ad.cur_k, ad.cur_v
-                    );
+                match ad.maybe_downshift(gpu, kv, m.seq_pos) {
+                    Ok(applied) => {
+                        for step in &applied {
+                            eprintln!(
+                                "[adaptive-kv] downshift @ pos {}: {:?} (K={:?} V={:?})",
+                                m.seq_pos, step, ad.cur_k, ad.cur_v
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[adaptive-kv] maybe_downshift error @ pos {} (decode): {:?} — skipping", m.seq_pos, e);
+                    }
                 }
             }
 
@@ -10499,6 +10555,8 @@ fn generate_vl(
         );
         m.seq_pos = 0;
         m.conversation_tokens.clear();
+        free_checkpoints(&mut m.prefill_checkpoints, gpu);
+        free_checkpoints(&mut m.dflash_checkpoints, gpu);
         if let Some(ref dn) = m.dn_state {
             for s in &dn.s_matrices {
                 let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
@@ -10512,6 +10570,9 @@ fn generate_vl(
         }
         if let Some(kv) = m.kv_cache.as_mut() {
             kv.compact_offset = 0;
+        }
+        if let Some(ad) = m.kv_adaptive.as_mut() {
+            ad.reset();
         }
     }
 

--- a/crates/hipfire-runtime/src/cask.rs
+++ b/crates/hipfire-runtime/src/cask.rs
@@ -132,10 +132,14 @@ impl CaskCtx {
         // Scratch GPU buffers for per-layer (indices, weights) table. Small
         // (budget × m × 4 B each), allocated once per call. Reusing across
         // layers to avoid repeated allocs.
+        //
+        // GpuTensor has no Drop impl — bare scope exit leaks device memory.
+        // Capture every fallible exit inside a closure and free on ALL paths.
         let table_len = budget * self.fold_m;
         let indices_dev = gpu.alloc_tensor(&[table_len], rdna_compute::DType::F32)?;
         let weights_dev = gpu.alloc_tensor(&[table_len], rdna_compute::DType::F32)?;
 
+        let inner_result = (|| -> HipResult<()> {
         for (fa_i, &layer_idx) in self.base.fa_layer_ids.iter().enumerate() {
             // 1. TriAttention scoring (GPU), mode-appropriate.
             let offset = fa_i * self.base.centers_per_layer;
@@ -310,6 +314,15 @@ impl CaskCtx {
                 budget * v_row_bytes,
             )?;
         }
+        Ok(())
+        })();
+
+        // Free the per-eviction scratch GPU buffers on EVERY exit path.
+        // GpuTensor has no Drop impl — bare scope exit (including ? returns
+        // inside the closure above) would leak device memory.
+        let _ = gpu.free_tensor(indices_dev);
+        let _ = gpu.free_tensor(weights_dev);
+        inner_result?;
 
         // Output size is always `budget` slots (core_slots + merge_slots = budget).
         kv.compact_offset += current_physical - budget;

--- a/crates/hipfire-runtime/src/kv_adaptive.rs
+++ b/crates/hipfire-runtime/src/kv_adaptive.rs
@@ -160,6 +160,16 @@ impl KvAdaptive {
         }
     }
 
+    /// Reset the tier state to the start (Q8/fwht4) position.  Call this
+    /// whenever the KV cache is cold-reset (context-full rollover, explicit
+    /// "reset" command) so the threshold sequence restarts from the beginning
+    /// instead of staying pinned at the floor tier permanently.
+    pub fn reset(&mut self) {
+        self.cur_k = KMode::Fwht4;
+        self.cur_v = crate::llama::VMode::Q8;
+        self.next_step = 0;
+    }
+
     /// Apply ALL downshift steps whose threshold seq_pos has crossed (handles
     /// coincident thresholds — e.g. V→lloyd3 and K→fwht2 sharing a binding
     /// point). Called after each committed token write at the same site as


### PR DESCRIPTION
## Summary

A second adversarial bug-hunt (40 agents) on the post-#385 tree surfaced 21 new engine bugs. This PR fixes **9** of them — the reachable correctness / memory-safety / crash / leak ones — via a **file-disjoint fix-team** (one agent per file-locus → conflict-free recombination; no two agents touch the same file).

**Stacks on #385** (base = `fix/prefill-moe-scratch-oom-leak`). Merge #385 first, or retarget this base to `master` once #385 lands.

## Bugs fixed (9)

| ID | Sev | What | Fix |
|----|-----|------|-----|
| **H1** | HIGH | **Premature-stop root cause.** DFlash decode-abort left the DeltaNet recurrent state dirty; a temp>0 / think-budget / `DFLASH_CHAT=0` follow-up then cold-prefilled the AR path over it → recurrent drift → early EOS. | memset `s_matrices`/`s_scales`/`conv_states` + `compact_offset=0` in the abort handler (mirrors the cold-reset) |
| **H2** | HIGH | Context-full auto-reset (incl. VL) zeroed DeltaNet/KV but left `prefill_checkpoints`/`dflash_checkpoints` populated → checkpoint-resume restores against a divergent prefix. | clear both rings via the existing `free_checkpoints` helper (frees the GPU bufs — a bare `.clear()` would re-leak, the OOM we just fixed) |
| **H3** | HIGH · mem-safety | Per-token FA prefill fallback `asym4` branch ignored `quant_fwht` (wrong-basis K) **and** hard-coded a Q8 V layout → under adaptive lloyd-V it **overran the floor V buffer (OOB write)**. | gate on `quant_fwht` (mirror asym3/asym2 siblings); route V through `v_mode_bits()` |
| **M1** | MED · leak | CASK per-eviction GPU scratch (`indices_dev`/`weights_dev`) leaked on the fold-loop's `?` early-return paths. | free on every exit path (wrap loop in a closure) |
| **M2** | MED · leak | `Qwen35Weights::free_gpu`/`free_gpu_multi`/`free_moe_ffn` freed only `.buf`, leaking the `awq_scale` sidecars — **the production AWQ-MQ4 trunk, on every unload**. | route through `WeightTensor::free_all` |
| **M3** | MED · leak | MTP-head `KvCache` + `DeltaNetSnapshot` dropped instead of freed (`llama::KvCache` has no `Drop`). | `free_gpu` at the call sites + fixed the root `Qwen35MtpHeadKvCache::free_gpu` wrapper |
| **M5** | MED | VL context-full reset didn't mirror the text path. | add `free_checkpoints` + adaptive reset |
| **M6** | MED | Adaptive-KV controller stayed pinned at floor tier after a context reset. | `KvAdaptive::reset()` on the reset paths |
| **M7** | MED · crash | `maybe_downshift().unwrap()` panicked the daemon on a kv_mode/adaptive mismatch. | log + skip the downshift instead of unwrapping |

7 files, +236/−109. Build-clean across all 3 crates.

## Validation — hiptrx / gfx1201, production A3B trunk (`qwen3.6-35b-a3b.mq4-awq-mi300x`)

5/5 GPU runs pass:

| Run | Proves | Result |
|-----|--------|--------|
| V1 coherence (DFlash, temp 0) | forward path intact | sheep→**9**, Paris, `def square(n): return n*n` |
| V2 **H3** OOB path | exercised the exact path — daemon logged `V(Q8)→Lloyd4@768→Lloyd3@1854`, K=Fwht4 | 1800 tok coherent (incl. post-downshift), **zero panic/OOB/fault** |
| V3a within-serve leak | M3 + OOM territory | summed VRAM **flat at 28201 MB across 30 gens** (16 MB spread = noise) |
| V3b unload cycles | **M2** awq_scale | returns to **465 MB baseline after each of 4 cycles** |
| V4 **H1** premature-stop | dirty-DeltaNet repro | DFlash gen aborted @252 tok → temp>0 AR follow-up **coherent** (Paris/Seine), no drift/early-EOS |

**Perf: neutral** (A/B base vs fixed, 3 runs/cell median, fresh process, warmup 12 / gen 150):
q8 decode `84.9→84.6 tok/s` (−0.35%, sub-noise) · asym4 `82.6→82.6` (+0.00%). All fixes are cold-path (abort/reset/free) or gated behind `if quant_asym4` (false on the default q8 serve config).

## Deferred (not in this PR — design judgment / global blast radius)

- **H4** — batched-RoPE `compact_offset` phase/slot decouple (design change).
- **M8 / M9** — tokenizer pre-tokenizer regex (`\s+(?!\S)` lookahead, NFC); changes tokenization for *all* models → needs its own coherence + eval pass.
- **L1–L6** — low/cosmetic (drafter/calib/dpm-warmup leaks, stream `reasoning_content` asymmetry, GGUF dead match arms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
