### PR TITLE
fix(daemon): Jinja serve drops system prompt + skips per-request reset on turn 2+ (AR path)

### DIFF
--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -7407,7 +7407,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // `<think></think>` block after the assistant prefix). Each path
     // picks up the signal it needs.
     let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
-    let try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some();
+    // Jinja renders the FULL conversation every turn (stateless full-render,
+    // like generate_dflash) — fire on every turn, not just `seq_pos == 0`.
+    // `render_messages` below replays `messages_history` (all prior turns) and
+    // includes the system prompt, so turn 2+ no longer falls through to the
+    // Plain branch (which dropped the system prompt and lost the Jinja
+    // template). The cold-reset further down (`jinja_active && seq_pos > 0`)
+    // re-prefills this full render from position 0.
+    let try_jinja = jinja_enabled && m.chat_template.is_some();
     let new_tokens = if try_jinja {
         let template = m.chat_template.as_ref().unwrap();
         let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
@@ -7819,6 +7826,39 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     } else {
         new_tokens
     };
+
+    // Jinja path renders the full conversation each turn (the LCP cache is
+    // disabled when `jinja_active`, above). On turn 2+ (`seq_pos > 0`) cold-reset
+    // BEFORE the budget guard + prefill so the full render writes from position 0
+    // — otherwise it would append to the prior turn's dirty DeltaNet/KV/checkpoint
+    // state (stale recurrent state → drift; the reset that the non-Jinja LCP-miss
+    // path does below was being skipped, and the system prompt was dropped). This
+    // mirrors the unconditional cold reset generate_dflash already does under
+    // Jinja. Uses `free_checkpoints` (NOT a bare `.clear()`) so the checkpoint GPU
+    // buffers are actually freed rather than leaked.
+    if jinja_active && m.seq_pos > 0 {
+        m.seq_pos = 0;
+        m.conversation_tokens.clear();
+        free_checkpoints(&mut m.prefill_checkpoints, gpu);
+        free_checkpoints(&mut m.dflash_checkpoints, gpu);
+        if let Some(ref dn) = m.dn_state {
+            for s in &dn.s_matrices {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.s_scales {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.conv_states {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+        }
+        if let Some(kv) = m.kv_cache.as_mut() {
+            kv.compact_offset = 0;
+        }
+        if let Some(kv) = m.llama_kv.as_mut() {
+            kv.compact_offset = 0;
+        }
+    }
 
     // KV-budget guard. Without eviction the physical buffer is the hard cap;
     // we must fit prefill + generation + trailer in one allocation. With


### PR DESCRIPTION
## Bug (Hunt-1 straggler, partially fixed by #384)
`HIPFIRE_JINJA_CHAT=1` disables the LCP prompt-cache for all turns (`jinja_active`), but the AR `generate()` path had **no fallback cold-reset** and rendered Jinja only on turn 1 (`try_jinja` gated on `seq_pos==0`). On turn 2+ it fell to the Plain branch, which dropped the system prompt (`system: if seq_pos==0 {..} else {None}`), lost the Jinja template, and appended to the prior turn's **dirty DeltaNet/KV/checkpoint state** (no reset). The CLI is told `cache_capable=true` so it never sends a reset — nobody reset. `generate_dflash` was already correct (it always cold-resets under Jinja); this aligns `generate()` with it.

## Fix (generate() only)
- Render the **full conversation via Jinja every turn** (`render_messages` already replays `messages_history` + includes the system message — which the bun CLI sends *inside* the array).
- **Cold-reset** (seq_pos, conversation_tokens, `free_checkpoints` prefill+dflash — **not** bare `.clear()`, zero DeltaNet, compact_offset) when `jinja_active && seq_pos>0`, before the budget guard + prefill.

+41/−1, build clean.

## Validation (hiptrx/gfx1201, production A3B trunk, A/B master vs fixed)
Multi-turn Jinja chat, `temp=0.3` (forces the AR path):
- **Context retention:** fixed turn 2 recalls the prior turns; master turn 2 reported *"this is the first message in our exchange"* (lost everything).
- **System-prompt recall** (code planted in the turn-1 system message, asked back on turn 2): **fixed answers `HIPFIRE-7842` cleanly**; **master rambled 512 tokens, never closed `<think>`, never answered** (dirty-state confusion).

## Not in this PR
`generate_multi()` (pp>1, multi-GPU) has the same latent bug but a different budget-ordering structure (its reset macro is defined after the budget guard) — left untouched (no half-fix; `try_jinja` unchanged) as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)