### PR TITLE
fix: hunt stragglers batch A — 4 GPU leaks + GGUF Promote6 Mq4Lloyd + dead-doc

### DIFF
--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -4012,8 +4012,12 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
                     (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
                 }
                 GgufFormat::Mq4Lloyd => {
-                    let q = quantize_mq4g256_lloyd(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ4G256Lloyd, 256u32, "MQ4G256Lloyd")
+                    // Promote6 → MQ6, consistent with default_promote_target
+                    // (Mq4Lloyd→Mq6) and its Lloyd siblings Mq2Lloyd/Mq3Lloyd
+                    // (in the first arm). Previously this stayed at MQ4G256Lloyd
+                    // (4-bit) — no actual promotion under --kmap-promote 6.
+                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
                 }
                 GgufFormat::Hfq4 => {
                     let q = quantize_hfq4g256(&f32_data);

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -305,21 +305,24 @@ impl DflashWeights {
     }
 
     pub fn free_gpu(self, gpu: &mut Gpu) {
-        let _ = gpu.free_tensor(self.fc.buf);
+        // free_all (not .buf) so the awq_scale / paro sidecars are released too —
+        // on an AWQ-trunk drafter every weight carries an awq_scale GpuTensor, so
+        // .buf-only freeing leaks one tensor per weight per layer on each unload.
+        self.fc.free_all(gpu);
         let _ = gpu.free_tensor(self.hidden_norm);
         let _ = gpu.free_tensor(self.norm);
         for l in self.layers {
             let _ = gpu.free_tensor(l.attn_norm);
-            let _ = gpu.free_tensor(l.wq.buf);
-            let _ = gpu.free_tensor(l.wk.buf);
-            let _ = gpu.free_tensor(l.wv.buf);
-            let _ = gpu.free_tensor(l.wo.buf);
+            l.wq.free_all(gpu);
+            l.wk.free_all(gpu);
+            l.wv.free_all(gpu);
+            l.wo.free_all(gpu);
             let _ = gpu.free_tensor(l.q_norm);
             let _ = gpu.free_tensor(l.k_norm);
             let _ = gpu.free_tensor(l.ffn_norm);
-            let _ = gpu.free_tensor(l.w_gate.buf);
-            let _ = gpu.free_tensor(l.w_up.buf);
-            let _ = gpu.free_tensor(l.w_down.buf);
+            l.w_gate.free_all(gpu);
+            l.w_up.free_all(gpu);
+            l.w_down.free_all(gpu);
         }
     }
 }

--- a/crates/hipfire-runtime/src/triattn.rs
+++ b/crates/hipfire-runtime/src/triattn.rs
@@ -410,6 +410,15 @@ impl TriAttnCalibStateGpu {
             &self.accs_count,
         )?;
 
+        // Free the GPU accumulators now that they're downloaded — `self` is
+        // consumed by this method and DeviceBuffer has no Drop, so scope exit
+        // would otherwise leak all four calibration buffers. (Partial-move out
+        // of `self` is fine: the Ok(..) below only reads the scalar fields.)
+        let _ = gpu.hip.free(self.accs_sum_re);
+        let _ = gpu.hip.free(self.accs_sum_im);
+        let _ = gpu.hip.free(self.accs_sum_abs);
+        let _ = gpu.hip.free(self.accs_count);
+
         // Same math as BandAccumulator::finalize: mean(re), mean(im), mean(|q|).
         let centers: Vec<BandCenter> = (0..n_accs).map(|i| {
             let c = count[i];

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -411,6 +411,9 @@ impl Gpu {
             1000.0 * elapsed / n as f32,
             (n as f64 * SCRATCH_BYTES as f64) / (1024.0 * 1024.0 * 1024.0) / elapsed as f64
         );
+        // Free the 256 MB scratch — DeviceBuffer has no Drop, so scope exit
+        // would otherwise leak it for the lifetime of the process.
+        let _ = self.hip.free(scratch);
         Ok(())
     }
 

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -68,12 +68,6 @@ impl Gpu {
 
     /// Batched RMSNorm: normalize `batch` vectors of length `n` independently.
     /// x and out can be the same buffer (in-place). Weight is [n], applied per vector.
-    /// TriAttention sidecar calibration: accumulate band statistics for one
-    /// chunk's Q tensor (batched across all tokens in the chunk).
-    ///
-    /// q_batch: [n_tokens, n_heads, head_dim] f32 pre-RoPE Q (already on GPU).
-    /// accs_sum_re/im/abs: [n_layers * n_heads * n_bands] f64 accumulators.
-
     pub fn rmsnorm_batched(
         &mut self,
         x: &GpuTensor, weight: &GpuTensor, out: &GpuTensor,


### PR DESCRIPTION
Low-priority stragglers from the prior hunts. Mechanical + low-risk; file-disjoint.

| Item | Fix | File |
|------|-----|------|
| **L1** DFlash drafter awq leak | `free_all` (frees awq_scale/paro sidecars), matching the M2 pattern | `hipfire-runtime/src/dflash.rs` |
| **L2** TriAttn calib leak | free the 4 accumulator `DeviceBuffer`s after the dtoh downloads | `hipfire-runtime/src/triattn.rs` |
| **L3** dpm_warmup 256 MB leak | free `scratch` after the warmup loop | `rdna-compute/src/dispatch.rs` |
| **L6** GGUF Promote6: `Mq4Lloyd` stayed MQ4G256Lloyd (4-bit) | → MQ6G256, consistent with `default_promote_target` (Mq4Lloyd→Mq6) + its Lloyd siblings | `hipfire-quantize/src/main.rs` |
| **dead-doc** stale `rmsnorm_batched` docstring (described `triattn_accumulate`) | removed | `rdna-compute/src/norm.rs` |

**Investigated & debunked (not a bug):** the "q/k L2-norm eps should be a literal `1e-6`" item — both hipfire and the HF Qwen3 reference use `rms_norm_eps` for q/k norm, so there's no discrepancy.

## Verification
- Build clean: daemon example + `hipfire-quantize` (RC=0).
- GPU smoke (hiptrx/gfx1201, production A3B, `HIPFIRE_DPM_WARMUP_SECS=5`): **exit 0, dpm-warmup ran (L3 free path exercised), 0 panics/double-frees**, both prompts coherent (sheep→9, square fn), clean unload.
- L1/L2/L6 are build + diff-review verified (exercising them needs a drafter / calibration / quantize-with-`--kmap-promote 6` config; the frees match the GPU-validated M1/M2/M3 pattern, and L6 dispatches an already-tested kernel).

## Note
The Promote6 match has **pre-existing** dead arms (the first arm shadows Mq4/Mq3/Mq2/Mq2Lloyd/Mq3Lloyd/Hfq4). Left as-is (separate cleanup; possible `--kmap-promote` future intent). This fix keeps the `Mq4Lloyd` arm reachable rather than adding a new dead arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)