### PR TITLE
fix(qwen35): batched RoPE ignored compact_offset → phase skew after KV eviction (H4)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/mtp_head.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_head.rs
@@ -2378,6 +2378,8 @@ pub fn mtp_head_forward_block_batched(
         cfg.n_rot,
         cfg.rope_theta,
         n,
+        // pos_offset=0: MTP head has its own non-compacted KV. Unchanged behavior.
+        0,
     )?;
 
     // ── 6. v1 simplification: per-slot K/V writes + attention = V

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -10187,6 +10187,9 @@ fn forward_prefill_chunk(
                 }
 
                 // 5. Batched partial-interleaved RoPE (per-row positions).
+                // pos_offset = compact_offset so new Q/K rotate at ABSOLUTE phase
+                // after eviction (cached keys are absolute-phased); pbs.positions
+                // stays physical for the KV-write below. 0 when no compaction.
                 let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
                 gpu.rope_partial_interleaved_f32_batched(
                     &pbs.fa_q_batch,
@@ -10198,6 +10201,7 @@ fn forward_prefill_chunk(
                     n_rot,
                     config.rope_theta,
                     n,
+                    kv_cache.compact_offset as i32,
                 )?;
 
                 // 6. Batched KV cache writes (per-row positions).
@@ -11752,6 +11756,8 @@ fn forward_prefill_chunk(
                     }
                 }
                 let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
+                // pos_offset = compact_offset (absolute RoPE phase post-eviction);
+                // pbs.positions stays physical for the KV-write. 0 when no compaction.
                 gpu.rope_partial_interleaved_f32_batched(
                     &pbs.fa_q_batch,
                     &pbs.fa_k_batch,
@@ -11762,6 +11768,7 @@ fn forward_prefill_chunk(
                     n_rot,
                     config.rope_theta,
                     n,
+                    kv_cache.compact_offset as i32,
                 )?;
                 if kv_cache.quant_asym4 {
                     let ct = givens_cos_view!().unwrap();

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -4822,6 +4822,9 @@ pub fn spec_step_ddtree_batched(
                 n_rot,
                 target.config.rope_theta,
                 n_positions,
+                // pos_offset=0: tree-mode re-rotation uses committed gather indices
+                // as positions directly (no compact_offset overlay). Unchanged behavior.
+                0,
             )?;
 
             // 3. V gather via the existing kv_compact_gather pattern.

--- a/crates/rdna-compute/examples/rope_compact_offset_check.rs
+++ b/crates/rdna-compute/examples/rope_compact_offset_check.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+// H4 verification: the batched RoPE `pos_offset` param (carries
+// kv_cache.compact_offset) must rotate at ABSOLUTE phase = positions[b] + offset.
+// Proves, without needing a CASK-eviction setup:
+//   T1 (offset applied / equivalence): batched(positions=[K..K+B], offset=0)
+//        == batched(positions=[0..B], offset=K)   — both rotate at K..K+B.
+//   T2 (matches the absolute-phase reference): batched(B=1, positions=[0], offset=K)
+//        == per-token rope at pos=K  — i.e. the fix makes batched Q/K rotate at
+//        the same absolute phase the cached (per-token-written) keys carry.
+//
+// Run: cargo run --release --example rope_compact_offset_check   (gfx10xx ok; no model)
+
+use rdna_compute::{DType, Gpu};
+
+fn lcg(seed: u64, n: usize) -> Vec<f32> {
+    let mut s = seed | 1;
+    (0..n)
+        .map(|_| {
+            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((s >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+        })
+        .collect()
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y).abs()).fold(0.0f32, f32::max)
+}
+
+fn main() {
+    let b = 4usize;
+    let n_heads_q = 4usize;
+    let n_heads_k = 2usize;
+    let head_dim = 64usize;
+    let n_rot = 64usize;
+    let freq_base = 1.0e6f32;
+    let k_off = 137i32; // stand-in for a post-eviction compact_offset
+
+    let mut gpu = Gpu::init().expect("GPU init");
+    eprintln!("GPU: {}  (b={b} nhq={n_heads_q} nhk={n_heads_k} hd={head_dim} n_rot={n_rot} K={k_off})", gpu.arch);
+
+    let q_src = lcg(0xA5A5, b * n_heads_q * head_dim);
+    let k_src = lcg(0xC3C3, b * n_heads_k * head_dim);
+
+    // positions tensor helper (i32 bytes into a 4-byte/elem tensor, as the kernel reads int*).
+    let pos_tensor = |gpu: &mut Gpu, vals: &[i32]| {
+        let t = gpu.alloc_tensor(&[vals.len()], DType::F32).unwrap();
+        let bytes: Vec<u8> = vals.iter().flat_map(|p| p.to_ne_bytes()).collect();
+        gpu.hip.memcpy_htod(&t.buf, &bytes).unwrap();
+        t
+    };
+
+    // ---- T1: offset applied == shifting positions ----
+    // Run A: positions = [K, K+1, K+2, K+3], offset = 0
+    let qa = gpu.upload_f32(&q_src, &[q_src.len()]).unwrap();
+    let ka = gpu.upload_f32(&k_src, &[k_src.len()]).unwrap();
+    let pos_a = pos_tensor(&mut gpu, &(0..b as i32).map(|i| k_off + i).collect::<Vec<_>>());
+    gpu.rope_partial_interleaved_f32_batched(&qa, &ka, &pos_a, n_heads_q, n_heads_k, head_dim, n_rot, freq_base, b, 0).unwrap();
+    let qa_out = gpu.download_f32(&qa).unwrap();
+    let ka_out = gpu.download_f32(&ka).unwrap();
+
+    // Run B: positions = [0,1,2,3], offset = K
+    let qb = gpu.upload_f32(&q_src, &[q_src.len()]).unwrap();
+    let kb = gpu.upload_f32(&k_src, &[k_src.len()]).unwrap();
+    let pos_b = pos_tensor(&mut gpu, &(0..b as i32).collect::<Vec<_>>());
+    gpu.rope_partial_interleaved_f32_batched(&qb, &kb, &pos_b, n_heads_q, n_heads_k, head_dim, n_rot, freq_base, b, k_off).unwrap();
+    let qb_out = gpu.download_f32(&qb).unwrap();
+    let kb_out = gpu.download_f32(&kb).unwrap();
+
+    let t1q = max_abs_diff(&qa_out, &qb_out);
+    let t1k = max_abs_diff(&ka_out, &kb_out);
+    eprintln!("T1 offset-equivalence  max|dq|={t1q:.3e}  max|dk|={t1k:.3e}");
+
+    // ---- T2: batched(B=1, pos=[0], offset=K) == per-token(pos=K) ----
+    let q1 = q_src[..n_heads_q * head_dim].to_vec();
+    let k1 = k_src[..n_heads_k * head_dim].to_vec();
+
+    // per-token reference at absolute pos = K (what a cached key carries)
+    let qt = gpu.upload_f32(&q1, &[q1.len()]).unwrap();
+    let kt = gpu.upload_f32(&k1, &[k1.len()]).unwrap();
+    let pos_buf = gpu.hip.malloc(4).unwrap();
+    gpu.hip.memcpy_htod(&pos_buf, &k_off.to_ne_bytes()).unwrap();
+    gpu.rope_partial_interleaved_f32(&qt, &kt, &pos_buf, n_heads_q, n_heads_k, head_dim, n_rot, freq_base).unwrap();
+    let qt_out = gpu.download_f32(&qt).unwrap();
+    let kt_out = gpu.download_f32(&kt).unwrap();
+
+    // batched B=1, positions=[0], offset=K  -> rotates at pos 0+K = K
+    let qc = gpu.upload_f32(&q1, &[q1.len()]).unwrap();
+    let kc = gpu.upload_f32(&k1, &[k1.len()]).unwrap();
+    let pos_c = pos_tensor(&mut gpu, &[0]);
+    gpu.rope_partial_interleaved_f32_batched(&qc, &kc, &pos_c, n_heads_q, n_heads_k, head_dim, n_rot, freq_base, 1, k_off).unwrap();
+    let qc_out = gpu.download_f32(&qc).unwrap();
+    let kc_out = gpu.download_f32(&kc).unwrap();
+
+    let t2q = max_abs_diff(&qt_out, &qc_out);
+    let t2k = max_abs_diff(&kt_out, &kc_out);
+    eprintln!("T2 batched+offset==per-token@K  max|dq|={t2q:.3e}  max|dk|={t2k:.3e}");
+
+    let eps = 1e-4f32;
+    let pass = t1q < eps && t1k < eps && t2q < eps && t2k < eps;
+    println!("RESULT: {}", if pass { "PASS" } else { "FAIL" });
+    if !pass {
+        std::process::exit(1);
+    }
+}

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -490,6 +490,11 @@ impl Gpu {
         q: &GpuTensor, k: &GpuTensor, positions: &GpuTensor,
         n_heads_q: usize, n_heads_k: usize, head_dim: usize, n_rot: usize,
         freq_base: f32, batch_size: usize,
+        // Added to each positions[b] for the RoPE angle only (the caller's KV-write
+        // keeps the raw physical positions). Pass kv_cache.compact_offset so batched
+        // Q/K rotate at absolute phase after eviction/compaction; pass 0 when there
+        // is no compaction (the common case) — it's a literal no-op offset then.
+        pos_offset: i32,
     ) -> HipResult<()> {
         self.bind_thread()?;
         // Halfsplit is the default since 2026-05-12; HIPFIRE_ROPE_INTERLEAVED_LEGACY=1
@@ -517,6 +522,7 @@ impl Gpu {
         let mut nr = n_rot as i32;
         let mut fb = freq_base;
         let mut bs = batch_size as i32;
+        let mut po = pos_offset;
         let mut params: Vec<*mut c_void> = vec![
             &mut qp as *mut _ as *mut c_void,
             &mut kp as *mut _ as *mut c_void,
@@ -527,6 +533,7 @@ impl Gpu {
             &mut nr as *mut _ as *mut c_void,
             &mut fb as *mut _ as *mut c_void,
             &mut bs as *mut _ as *mut c_void,
+            &mut po as *mut _ as *mut c_void,
         ];
         let n_pairs = (n_rot / 2) as u32;
         let block = 32u32.min(n_pairs);
@@ -543,7 +550,7 @@ impl Gpu {
                 let mut b = hip_bridge::KernargBlob::new();
                 b.push_ptr(qp); b.push_ptr(kp); b.push_ptr(pp);
                 b.push_i32(nhq); b.push_i32(nhk); b.push_i32(hd); b.push_i32(nr);
-                b.push_f32(fb); b.push_i32(bs);
+                b.push_f32(fb); b.push_i32(bs); b.push_i32(po);
                 b
             },
         );

--- a/kernels/src/rope_partial_halfsplit_batched.hip
+++ b/kernels/src/rope_partial_halfsplit_batched.hip
@@ -24,14 +24,17 @@ extern "C" __global__ void rope_partial_halfsplit_batched_f32(
     int head_dim,
     int n_rot,
     float freq_base,
-    int batch_size
+    int batch_size,
+    int pos_offset   // added to positions[b] for the RoPE angle (NOT the KV slot);
+                     // carries kv_cache.compact_offset so post-eviction batched
+                     // Q/K rotate at absolute phase matching the cached keys. 0 = no-op.
 ) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     int b = blockIdx.y;
     int half = n_rot / 2;
     if (i >= half || b >= batch_size) return;
 
-    int pos = positions[b];
+    int pos = positions[b] + pos_offset;
 
     float freq = 1.0f / powf(freq_base, (float)(2 * i) / (float)n_rot);
     float angle = (float)pos * freq;

--- a/kernels/src/rope_partial_interleaved_batched.hip
+++ b/kernels/src/rope_partial_interleaved_batched.hip
@@ -24,14 +24,17 @@ extern "C" __global__ void rope_partial_interleaved_batched_f32(
     int head_dim,
     int n_rot,          // number of dims to rotate (64 for Qwen3.5)
     float freq_base,
-    int batch_size
+    int batch_size,
+    int pos_offset      // added to positions[b] for the RoPE angle (NOT the KV slot);
+                        // carries kv_cache.compact_offset so post-eviction batched
+                        // Q/K rotate at absolute phase matching cached keys. 0 = no-op.
 ) {
     int pair = blockIdx.x * blockDim.x + threadIdx.x;
     int b = blockIdx.y;
     int n_pairs = n_rot / 2;
     if (pair >= n_pairs || b >= batch_size) return;
 
-    int pos = positions[b];
+    int pos = positions[b] + pos_offset;
 
     // Interleaved: pair i rotates dims (2*i, 2*i+1)
     int d0 = pair * 2;


### PR DESCRIPTION
## Bug
After a CASK/TriAttention eviction, retained KV keys keep their **absolute-position** RoPE phase baked in (compaction is a pure gather — no re-rotation), and `compact_offset = absolute_seq_len − physical_seq_len` bridges physical slot → absolute position. The per-token decode path and the DFlash drafter add `compact_offset` before RoPE; the **batched FA path** (DFlash-verify + batched-prefill) did **not** — it rotated new Q/K at physical-slot phase, a constant `compact_offset` skew vs the absolute-phased cached keys → attention misalignment / drift after eviction. (The daemon.rs:5602 comment falsely claimed the verify forward read it automatically.)

**Root design issue:** the single `pbs.positions` buffer served *both* the RoPE angle (wants absolute) and the KV-write slot (wants physical) — equal pre-eviction, divergent after.

## Fix — decouple phase from slot via a scalar `pos_offset` kernel param
- `rope_partial_{halfsplit,interleaved}_batched` kernels: `pos = positions[b] + pos_offset`.
- `rope_partial_interleaved_f32_batched` wrapper: thread the new `i32` arg (both kernarg paths).
- The 2 batched FA call sites (dense + MoE) pass `kv_cache.compact_offset`; `pbs.positions` stays physical for the KV-write. Applied at rotate-time → covers verify **and** prefill. No-compaction → `pos_offset=0` → exact no-op.
- The 2 non-FA callers (DFlash tree-mode drafter, MTP head) pass `0` — unchanged.

Mirrors the proven per-token formula (`pos + compact_offset`). No new GPU buffer (avoids the PrefillBatchScratch leak class).

## Verification
- **Unit test (bit-exact, new `rope_compact_offset_check` example, gfx1100):**
  - T1 — `batched(positions+K, offset=0)` ≡ `batched(positions, offset=K)` → `max|d|=0` (offset applied).
  - T2 — `batched(B=1, positions=[0], offset=K)` ≡ per-token rope @ pos=K → `max|d|=0` (matches the absolute-phase reference cached keys carry — exactly the H4 claim).
- **No-eviction A/B (A3B trunk, gfx1201):** master vs H4 **byte-identical** (md5 `36c8eca0`, distinct binaries), 0 panics → zero regression on the common path + modified kernel JIT-runs clean on gfx1201.
- The eviction (`compact_offset>0`) behavioral case needs a CASK sidecar (not present); offset-\>0 correctness is instead proven directly by the unit test above.

7 files + 1 test example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)