### PR TITLE
fix(engine): hunt-3 batch — 16 bugs (pp / sampling+MoE / daemon / bun-CLI) [DRAFT: pending A3B validation]

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1093,8 +1093,25 @@ async function runViaHttp(
 
 // ─── Daemon IPC ─────────────────────────────────────────
 
+// hunt3 H-B: typed error thrown by recv() on daemon EOF in long-lived
+// (serve) mode. One-shot callers (run, bench, etc.) set `oneShot = true`
+// and recv() process.exit()s as before; serve leaves it false and catches
+// this to recover (500 + restart) instead of killing the whole serve for
+// all clients on a single daemon crash.
+class DaemonClosedError extends Error {
+  readonly code: number;
+  constructor(code: number) {
+    super("daemon closed");
+    this.name = "DaemonClosedError";
+    this.code = code;
+  }
+}
+
 class Engine {
   private proc: ReturnType<typeof spawn> | null = null;
+  // hunt3 H-B: one-shot mode (run/bench) → recv() exits on daemon EOF;
+  // long-lived serve leaves this false so recv() throws DaemonClosedError.
+  oneShot = false;
   private reader: {
     read(): Promise<{ done: boolean; value?: Uint8Array }>;
     releaseLock(): void;
@@ -1141,9 +1158,19 @@ class Engine {
         // unsupported environments, see #112) or via a real crash. In either
         // case, the daemon's stderr (which we inherit) already explained
         // what happened, so adding a Bun-rendered stack trace from here on
-        // top is pure noise. Exit cleanly with the daemon's own code (or 1
-        // if it hasn't exited yet) and let stderr stand on its own.
+        // top is pure noise.
         const code = (await this.proc?.exited) ?? 1;
+        // hunt3 H-B: in long-lived serve, a single daemon crash must NOT
+        // process.exit() the whole serve (kills every other client). Throw a
+        // typed error the serve handler catches → 500 + daemon restart. Clear
+        // buffered state and release the reader so a fresh start() is clean.
+        this.lines = [];
+        this.buffer = "";
+        try { this.reader?.releaseLock(); } catch {}
+        this.reader = null;
+        if (!this.oneShot) throw new DaemonClosedError(code);
+        // One-shot mode (run/bench): exit cleanly with the daemon's own code
+        // (or 1 if it hasn't exited yet) and let stderr stand on its own.
         process.exit(code === 0 ? 1 : code);
       }
       this.buffer += new TextDecoder().decode(value);
@@ -1181,15 +1208,36 @@ class Engine {
         new Promise<false>((res) => setTimeout(() => res(false), 10_000)),
       ]);
       drained = result;
-    } catch { /* daemon closed — already clean */ drained = true; }
+    } catch (err: any) {
+      // hunt3 H-B: a long-lived serve recv() throws DaemonClosedError when the
+      // daemon crashed mid-stream. The buffered EOF is NOT "already clean":
+      // recv() nulled this.reader but left this.proc non-null, so the caller's
+      // subsequent reload would send(loadMsg)/recv() against a dead pipe +
+      // null reader → a PLAIN Error("not running") that the request handler's
+      // outer catch does NOT recognize as DaemonClosedError → 500 with no
+      // restart → the daemon stays dead and every following request 500s
+      // forever (the exact "serve dies for everyone" outcome H-B prevents on
+      // the generate paths). Restart here so the caller reloads against a live
+      // daemon. A restart() failure propagates → the handler returns 500 for
+      // this one request, which is the honest outcome when recovery is
+      // genuinely impossible. Any non-DaemonClosedError is treated as the old
+      // best-effort "already clean" (drain is advisory resync, not load-bearing).
+      if (err instanceof DaemonClosedError) {
+        console.error(`[hipfire] daemon closed during drain (code ${err.code}) — restarting daemon`);
+        await this.restart();
+        return;
+      }
+      /* daemon closed — already clean */ drained = true;
+    }
 
     if (!drained) {
       // Timed out — dangling recv() still holds the reader.
       // Kill the daemon to cancel it, then restart fresh.
+      // hunt3 B-2: restart() awaits the killed proc's exit + retries the
+      // respawn with backoff so the new daemon doesn't collide with the old
+      // one's flock during teardown.
       console.error("[hipfire] drain timed out — restarting daemon");
-      await this.stop();
-      await this.start();
-      await this.send({ type: "ping" }); await this.recv();
+      await this.restart();
     }
   }
 
@@ -1197,9 +1245,44 @@ class Engine {
 
   async stop() {
     try { await this.send({ type: "unload" }); } catch {}
-    this.reader?.releaseLock();
+    try { this.reader?.releaseLock(); } catch {}
     this.reader = null;
-    this.proc?.kill();
+    const proc = this.proc;
+    proc?.kill();
+    // hunt3 B-2: AWAIT the killed process's exit before returning. Without
+    // this, start() can respawn while the old daemon still holds the
+    // LOCK_EX|LOCK_NB flock → the new daemon hits "FATAL: already running",
+    // exits immediately, and recv() sees EOF → serve dies. Bound the wait so
+    // a wedged daemon can't hang the restart forever.
+    try {
+      await Promise.race([
+        proc?.exited ?? Promise.resolve(),
+        new Promise<void>((res) => setTimeout(res, 5_000)),
+      ]);
+    } catch {}
+    this.proc = null;
+  }
+
+  /// hunt3 B-2: stop()+start()+ping with retry/backoff to tolerate the
+  /// residual flock-teardown window after a kill. Used by drain()'s timeout
+  /// path and by serve's daemon-crash recovery (hunt3 H-B). Throws if the
+  /// daemon can't be brought back after all retries.
+  async restart() {
+    await this.stop();
+    let lastErr: any = null;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        await this.start();
+        await this.send({ type: "ping" }); await this.recv();
+        return;
+      } catch (err: any) {
+        lastErr = err;
+        try { await this.stop(); } catch {}
+        // Backoff lets the old daemon's flock release before the next spawn.
+        await new Promise((res) => setTimeout(res, 250 * (attempt + 1)));
+      }
+    }
+    throw lastErr ?? new Error("daemon restart failed");
   }
 }
 
@@ -1391,11 +1474,23 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
   if (!useLocal && await isServeUp(cfg.port, cfg.host)) {
     const ok = await runViaHttp(cfg.port, cfg.host, model, prompt, image, temp, maxTokens, repeatPenalty, topP, system);
     if (ok) return;
-    // runViaHttp logged its own failure reason; fall back to local spawn.
+    // runViaHttp logged its own failure reason.
+    // hunt3 B-6: only fall back to a LOCAL daemon if the serve is now GONE.
+    // If the serve is still up, a local spawn would collide with its
+    // LOCK_EX|LOCK_NB flock → daemon FATAL "already running" → process.exit.
+    // The HTTP request failed for a per-request reason (e.g. a transient
+    // serve error), not because the GPU is free — surface it and bail.
+    if (await isServeUp(cfg.port, cfg.host)) {
+      console.error(`[hipfire] serve is up but the request failed — not spawning a local daemon (would collide with the serve's GPU lock).`);
+      console.error(`  Retry, or stop the serve first: hipfire stop`);
+      process.exit(1);
+    }
+    // Serve went away — safe to fall through to a local spawn.
   }
 
   applyConfigEnv(cfg, model);
   const e = new Engine();
+  e.oneShot = true; // hunt3 H-B: one-shot run — recv() may exit on daemon EOF
   await e.start();
   await e.send({ type: "ping" }); await e.recv();
   await e.send(buildLoadMessage(path, model));
@@ -1477,13 +1572,29 @@ async function serve(port: number, host: string) {
   // spawns an ephemeral daemon, so it doesn't clobber a long-lived `serve -d`.
   const ownsPidFile = !process.env.HIPFIRE_NO_PID_FILE;
   if (ownsPidFile) {
+    // hunt3 B-3: a foreground `serve` run over a running `serve -d` would
+    // overwrite the live daemon's pid file, then (on exit, cleanupPid below)
+    // DELETE it — orphaning the detached daemon's VRAM. Before claiming the
+    // pid file, refuse to start if another serve is already live on this bind.
+    if (await isServeUp(port, host)) {
+      const existing = readServePid();
+      console.error(`hipfire serve already running${existing ? ` (PID ${existing})` : ""} on ${formatServeBind(host, port)}.`);
+      console.error(`  Stop it first: hipfire stop`);
+      process.exit(1);
+    }
     try {
       require("fs").writeFileSync(SERVE_PID_FILE, String(process.pid));
     } catch {}
   }
   const cleanupPid = () => {
     if (!ownsPidFile) return;
-    try { require("fs").unlinkSync(SERVE_PID_FILE); } catch {}
+    // hunt3 B-3: only unlink if the file STILL names us. If a newer serve
+    // (or anything else) has since rewritten it, deleting it would orphan
+    // that live daemon's pid record. Read-back-and-compare.
+    try {
+      const cur = require("fs").readFileSync(SERVE_PID_FILE, "utf-8").trim();
+      if (cur === String(process.pid)) require("fs").unlinkSync(SERVE_PID_FILE);
+    } catch {}
   };
   process.on("exit", cleanupPid);
   process.on("SIGTERM", () => { cleanupPid(); process.exit(0); });
@@ -1534,24 +1645,79 @@ async function serve(port: number, host: string) {
   // since gone idle.
   let lastRequestTime = Date.now();
   const idleTimeoutMs = cfg.idle_timeout * 1000;
+
+  // Serve lock: serializes all daemon stdin/stdout access so only one
+  // caller is mid-send/recv on the single IPC pipe at a time. Declared
+  // BEFORE the eviction interval so the eviction tick can take it too
+  // (hunt3 B-1/B-5). `busy` covers the WHOLE lock-held window (incl. the
+  // model-reload window where e.generating is still false).
+  let busy = false;
+  const queue: Array<{ resolve: () => void }> = [];
+  async function acquireLock() {
+    if (!busy) { busy = true; return; }
+    await new Promise<void>(resolve => queue.push({ resolve }));
+  }
+  function releaseLock() {
+    const next = queue.shift();
+    if (next) next.resolve();
+    else busy = false;
+  }
+
   const evictionInterval = idleTimeoutMs > 0 ? setInterval(async () => {
+    // Cheap pre-checks before paying the lock-wait cost.
     if (!current) return;                              // nothing to unload
     if (e.generating) return;                          // active stream — don't yank
+    if (busy) return;                                  // hunt3 B-5: request holds the lock (incl. reload window) — don't contend
     if (Date.now() - lastRequestTime < idleTimeoutMs) return;
+    // hunt3 B-1: take the serve lock before touching the daemon pipe.
+    // Without it, this send(unload)+recv() races a concurrent request's
+    // recv() on the one stdout — two recv() callers cross-route acks.
+    await acquireLock();
     try {
+      // hunt3 B-1: re-validate the idle precondition AFTER the lock wait —
+      // a request may have arrived (and finished) while we were queued.
+      if (!current) return;
+      if (e.generating) return;
+      if (Date.now() - lastRequestTime < idleTimeoutMs) return;
       console.error(`[hipfire] idle for ${cfg.idle_timeout}s — unloading model (VRAM freed; next request will reload)`);
       await e.send({ type: "unload" });
       await e.recv();
-    } catch (err: any) {
-      console.error(`[hipfire] eviction failed: ${err?.message ?? err}`);
-    } finally {
-      // Reset capability state regardless of whether send/recv threw.
-      // Leaving these stale (e.g. modelHasVL=true after a broken-pipe
-      // eviction) makes the next request forward image_base64 to a
-      // daemon that has nothing loaded.
+      // Reset capability state only on a successful unload.
       current = null;
       currentMaxSeq = null;
       modelHasVL = false;
+      currentArch = null;
+      currentCacheCapable = null;
+    } catch (err: any) {
+      console.error(`[hipfire] eviction failed: ${err?.message ?? err}`);
+      // hunt3 B-5: clear capability state on ANY eviction error, not just
+      // DaemonClosedError. An eviction that reached the send(unload)/recv()
+      // (we are past the re-validation guards above, so `current` was set and
+      // we DID attempt the unload) but failed with a non-EOF error — e.g. a
+      // malformed unload-ack, or a plain Error("not running") because the
+      // daemon died without a clean stdout EOF — leaves the daemon in an
+      // unknown/unloaded state. Leaving `current` naming the model makes the
+      // next request compute needReload=false and dispatch a generate to a
+      // dead/unloaded daemon (the outer catch only restarts on
+      // DaemonClosedError, so a non-EOF death just 500s with no recovery).
+      // Resetting forces the next request to reload from scratch.
+      current = null;
+      currentMaxSeq = null;
+      modelHasVL = false;
+      currentArch = null;
+      currentCacheCapable = null;
+      // Only proactively restart on a clean daemon EOF (DaemonClosedError).
+      // For other errors the daemon may still be alive (e.g. it merely sent a
+      // malformed ack); the next request's reload will resync it, and if it is
+      // in fact dead the reload's recv() surfaces a DaemonClosedError that the
+      // generate catch-sites restart from.
+      if (err instanceof DaemonClosedError) {
+        try { await e.restart(); } catch (re: any) {
+          console.error(`[hipfire] daemon restart after eviction failure failed: ${re?.message ?? re}`);
+        }
+      }
+    } finally {
+      releaseLock();
     }
   }, Math.min(60_000, idleTimeoutMs)) : null;
   // Keep process alive irrespective of the interval; clean up on exit.
@@ -1591,18 +1757,6 @@ async function serve(port: number, host: string) {
     }
   }
 
-  let busy = false;
-  const queue: Array<{ resolve: () => void }> = [];
-  async function acquireLock() {
-    if (!busy) { busy = true; return; }
-    await new Promise<void>(resolve => queue.push({ resolve }));
-  }
-  function releaseLock() {
-    const next = queue.shift();
-    if (next) next.resolve();
-    else busy = false;
-  }
-
   console.error(`[hipfire] http://${formatServeBind(host, port)}/v1/chat/completions`);
 
   Bun.serve({
@@ -1628,17 +1782,42 @@ async function serve(port: number, host: string) {
       lastRequestTime = Date.now();
 
       await acquireLock();
+      // hunt3 B-5: re-bump after the lock wait so a request that sat QUEUED
+      // behind a long generation (potentially longer than idle_timeout) does
+      // not let the eviction tick fire the instant it finally begins. The
+      // `busy` lock flag already blocks eviction for the whole lock-held
+      // window (incl. the reload window where e.generating is still false).
+      lastRequestTime = Date.now();
       let lockReleased = false;
       const safeRelease = () => { if (!lockReleased) { lockReleased = true; releaseLock(); } };
 
       // If a previous generation was interrupted (client disconnect), drain
       // remaining daemon output before sending new commands.
-      // If drain restarts the daemon, clear current so model reloads.
+      // If drain restarts the daemon (timeout OR hunt3 H-B daemon-crash path),
+      // clear ALL capability state so the model reloads cleanly — matching the
+      // generate catch-site recovery below.
       if (e.generating) {
-        await e.drain();
+        try {
+          await e.drain();
+        } catch (drainErr: any) {
+          // drain() only throws when its own restart() exhausted retries (the
+          // daemon is unrecoverable). Surface a 500 for THIS request rather
+          // than letting the throw escape the handler — an escaped throw would
+          // skip safeRelease() and leak the serve lock, wedging every client.
+          console.error(`[hipfire] drain/daemon-recovery failed: ${drainErr?.message ?? drainErr}`);
+          e.generating = false;
+          current = null; currentMaxSeq = null; modelHasVL = false;
+          currentArch = null; currentCacheCapable = null;
+          safeRelease();
+          return Response.json(
+            { error: { message: "daemon crashed and could not be restarted; retry the request", type: "server_error" } },
+            { status: 500 },
+          );
+        }
         e.generating = false;
-        current = null; // daemon may have restarted — force model reload
-        currentMaxSeq = null;
+        // daemon may have restarted — force model reload + drop stale caps.
+        current = null; currentMaxSeq = null; modelHasVL = false;
+        currentArch = null; currentCacheCapable = null;
       }
 
       try {
@@ -1965,9 +2144,19 @@ async function serve(port: number, host: string) {
         // beyond currentMaxSeq we MUST reload instead of sending a request
         // the daemon would either reject or, worse, overrun the buffer with.
         const effective = resolveModelConfig(body.model);
-        const requestMaxTokens = body.max_tokens ?? effective.max_tokens;
+        // hunt3 H-D: `??` guards null but NOT type. A JSON-string max_tokens
+        // (e.g. "8192") makes `requestMaxTokens + 1024` STRING-CONCAT to
+        // "81921024", which Math.max coerces to ~80M → bumps load max_seq →
+        // unload-then-OOM. Accept only a sane positive integer; otherwise
+        // fall back to the per-model config value.
+        const rawMt = body.max_tokens;
+        const requestMaxTokens = (typeof rawMt === "number" && Number.isInteger(rawMt) && rawMt >= 1 && rawMt <= 131072)
+          ? rawMt
+          : effective.max_tokens;
         const visualHeadroom = requestImages.length > 0 ? 1024 : 0;
-        const requiredMaxSeq = Math.max(effective.max_seq, requestMaxTokens + 1024 + visualHeadroom);
+        // Clamp the KV-cache sizing to a hard ceiling (matches the daemon's
+        // independent max_seq <= 524288 clamp, hunt3 H-D contract).
+        const requiredMaxSeq = Math.min(524288, Math.max(effective.max_seq, requestMaxTokens + 1024 + visualHeadroom));
 
         const needReload = current !== path
           || (currentMaxSeq !== null && requiredMaxSeq > currentMaxSeq);
@@ -2258,6 +2447,19 @@ async function serve(port: number, host: string) {
           genParams.assistant_prefix = "open_think";
         }
         if (systemPrompt) genParams.system = systemPrompt;
+
+        // hunt3 M-F: forward OpenAI `stop` sequences to the daemon. Accept a
+        // single string or an array of strings; normalize to string[], drop
+        // empties, cap at 4 sequences of <= 64 chars each (the daemon matches
+        // them against the decoded-output suffix and emits finish_reason="stop").
+        {
+          const rawStop = (body as any).stop;
+          let stopSeqs: string[] = [];
+          if (typeof rawStop === "string") stopSeqs = [rawStop];
+          else if (Array.isArray(rawStop)) stopSeqs = rawStop.filter((s: any) => typeof s === "string");
+          stopSeqs = stopSeqs.filter(s => s.length > 0).slice(0, 4).map(s => s.slice(0, 64));
+          if (stopSeqs.length > 0) genParams.stop = stopSeqs;
+        }
 
         if (requestImages.length === 1) {
           if (!modelHasVL) {
@@ -2646,7 +2848,11 @@ async function serve(port: number, host: string) {
           return false;
         }
 
-        if (body.stream) {
+        // hunt3 C-1: OpenAI `stream` is a strict boolean — a JSON string
+        // "false" is JS-truthy and would wrongly select the streaming path.
+        // Match the include_usage===true convention.
+        const wantStream = body.stream === true;
+        if (wantStream) {
           const enc = new TextEncoder();
           let completionTokens = 0;
           let streamCancelled = false;
@@ -2962,6 +3168,26 @@ async function serve(port: number, host: string) {
                 }
                 // Safety: if loop exits without done/error (shouldn't happen), close stream
                 try { ctrl.close(); } catch {}
+              } catch (err: any) {
+                // hunt3 H-B: daemon crashed mid-stream (recv threw
+                // DaemonClosedError). Headers are already sent so we can't
+                // change status; surface the error in the stream body and
+                // restart the daemon so the NEXT request reloads cleanly
+                // instead of writing to a dead stdin.
+                try {
+                  ctrl.enqueue(enc.encode(`data: ${JSON.stringify({
+                    error: { message: (err instanceof DaemonClosedError) ? "daemon crashed mid-generation" : (err?.message || "internal error"), type: "server_error" }
+                  })}\n\n`));
+                  ctrl.enqueue(enc.encode("data: [DONE]\n\n"));
+                } catch {}
+                try { ctrl.close(); } catch {}
+                if (err instanceof DaemonClosedError) {
+                  current = null; currentMaxSeq = null; modelHasVL = false;
+                  currentArch = null; currentCacheCapable = null;
+                  try { await e.restart(); } catch (re: any) {
+                    console.error(`[hipfire] daemon restart failed: ${re?.message ?? re}`);
+                  }
+                }
               } finally {
                 clearInterval(heartbeat);
                 if (forceAnswerTimer) clearTimeout(forceAnswerTimer);
@@ -3106,22 +3332,26 @@ async function serve(port: number, host: string) {
         e.generating = false;
 
         // If the daemon rejected the request mid-generate (e.g. KV-budget
-        // overrun on a huge system prompt), surface that as a 400 instead of
-        // returning a 200 with empty content — otherwise a client that sent a
-        // too-large request can't distinguish failure from a zero-token reply.
+        // overrun on a huge system prompt), surface that error.
+        //
+        // hunt3 B-4: we are INSIDE the ReadableStream `start(ctrl)`, so the
+        // 200 headers were ALREADY sent (Bun streams the body lazily) — a
+        // `return Response.json(...)` here is silently DISCARDED and, worse,
+        // `start()` returns WITHOUT ctrl.enqueue/close, so the already-open
+        // 200 stream never terminates and the client hangs until the 255s
+        // idle timeout. Emit the error THROUGH the open controller and close
+        // it (status can't change post-headers; the failure rides in the
+        // body's `error` field, matching the streaming branch's convention).
         if (daemonError) {
+          bodyDelivered = true;
           safeRelease();
-          let status = 500;
-          const err = daemonError.toLowerCase();
-          if (err.includes("maximum size") || err.includes("exceeds maximum")) status = 413;
-          else if (err.includes("no vision encoder") || err.includes("unsupported image format")
-            || err.includes("image dimensions") || err.includes("failed to decode base64")
-            || err.includes("failed to decode image") || err.includes("exceeds loaded kv budget"))
-            status = 400;
-          return Response.json(
-            { error: { message: daemonError, type: "invalid_request_error" } },
-            { status }
-          );
+          try {
+            ctrl.enqueue(nsEnc.encode(JSON.stringify(
+              { error: { message: daemonError, type: "invalid_request_error" } }
+            )));
+          } catch {}
+          try { ctrl.close(); } catch {}
+          return;
         }
 
         // Strip think tags and special tokens.
@@ -3231,9 +3461,21 @@ async function serve(port: number, host: string) {
               ctrl.close();
             } catch (err: any) {
               bodyDelivered = true;
+              // hunt3 H-B: daemon crash (DaemonClosedError) mid-generate —
+              // restart so the next request reloads cleanly instead of
+              // writing to a dead stdin. Status stays 200 (header sent); the
+              // error rides in the body (matches the existing convention).
+              e.generating = false;
+              if (err instanceof DaemonClosedError) {
+                current = null; currentMaxSeq = null; modelHasVL = false;
+                currentArch = null; currentCacheCapable = null;
+                try { await e.restart(); } catch (re: any) {
+                  console.error(`[hipfire] daemon restart failed: ${re?.message ?? re}`);
+                }
+              }
               safeRelease();
               try {
-                ctrl.enqueue(nsEnc.encode(JSON.stringify({ error: err?.message || "internal error" })));
+                ctrl.enqueue(nsEnc.encode(JSON.stringify({ error: (err instanceof DaemonClosedError) ? "daemon crashed mid-generation" : (err?.message || "internal error") })));
               } catch {}
               try { ctrl.close(); } catch {}
             } finally {
@@ -3269,6 +3511,31 @@ async function serve(port: number, host: string) {
         }), { headers: { "Content-Type": "application/json" } });
         return nsResponse;
       } catch (err: any) {
+        // hunt3 H-B: a daemon crash now throws DaemonClosedError from recv()
+        // (instead of process.exit-ing the whole serve). Recover for THIS
+        // request only: restart the daemon, clear the loaded-model state so
+        // the next request reloads, and return 500 to this one client. Other
+        // clients' subsequent requests reload cleanly instead of the serve
+        // dying for everyone.
+        e.generating = false;
+        if (err instanceof DaemonClosedError) {
+          console.error(`[hipfire] daemon closed (code ${err.code}) — restarting for next request`);
+          current = null;
+          currentMaxSeq = null;
+          modelHasVL = false;
+          currentArch = null;
+          currentCacheCapable = null;
+          try {
+            await e.restart();
+          } catch (restartErr: any) {
+            console.error(`[hipfire] daemon restart failed: ${restartErr?.message ?? restartErr}`);
+          }
+          safeRelease();
+          return Response.json(
+            { error: { message: "daemon crashed and was restarted; retry the request", type: "server_error" } },
+            { status: 500 },
+          );
+        }
         safeRelease();
         return Response.json({ error: err?.message || "internal error" }, { status: 500 });
       }
@@ -3778,6 +4045,7 @@ async function bench(model: string, runs: number, experimental: boolean, prompt:
 
   // Start daemon
   const e = new Engine();
+  e.oneShot = true; // hunt3 H-B: one-shot bench — exit on daemon EOF is correct
   await e.start();
   await e.send({ type: "ping" }); await e.recv();
 
@@ -3847,6 +4115,7 @@ async function bench(model: string, runs: number, experimental: boolean, prompt:
       // Restart daemon with variant env var
       process.env.HIPFIRE_RDNA2_VARIANT = String(v.n);
       const ve = new Engine();
+      ve.oneShot = true; // hunt3 H-B: one-shot variant bench — exit on EOF is correct
       let variantOk = false;
       try {
         await ve.start();
@@ -4067,6 +4336,7 @@ async function bench(model: string, runs: number, experimental: boolean, prompt:
 async function profile(modelTag: string | undefined, jsonOutput: boolean, kernelFilter: string | undefined) {
   // Start daemon — we need kernels compiled to profile them
   const e = new Engine();
+  e.oneShot = true; // hunt3 H-B: one-shot profile — exit on daemon EOF is correct
   await e.start();
   await e.send({ type: "ping" }); await e.recv();
 
@@ -5898,6 +6168,7 @@ switch (cmd) {
       console.log("\nProbing GPU via HIP runtime...");
       try {
         const de = new Engine();
+        de.oneShot = true; // hunt3 H-B: one-shot GPU probe — exit on daemon EOF is correct
         await de.start();
         await de.send({ type: "ping" }); await de.recv();
         await de.send({ type: "diag" });

--- a/crates/hipfire-arch-deepseek4/src/sampling.rs
+++ b/crates/hipfire-arch-deepseek4/src/sampling.rs
@@ -56,20 +56,50 @@ pub fn sample_token(
     rng: &mut Xorshift,
 ) -> u32 {
     if temp <= 0.0 {
+        // hunt3 M-B (FinalFix): explicit `>`-based fold mirrors the GPU kernel
+        // (argmax.hip: `if (data[i] > lmax)`, seed -1e30). `v > best` is false
+        // for NaN, so a NaN logit never wins and never displaces the real max —
+        // unlike `max_by(partial_cmp.unwrap_or(Less))`, which keeps a trailing
+        // NaN candidate. Seeded at NEG_INFINITY so the first finite logit wins.
         return logits
             .iter()
             .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .unwrap()
+            .fold((0usize, f32::NEG_INFINITY), |best, (i, &v)| {
+                if v > best.1 {
+                    (i, v)
+                } else {
+                    best
+                }
+            })
             .0 as u32;
     }
     let n = logits.len();
-    let k = if top_k == 0 || top_k >= n { n } else { top_k };
 
-    // 1. Pick top-k indices by raw logit (descending).
-    let mut idx: Vec<usize> = (0..n).collect();
-    if k < n {
-        idx.select_nth_unstable_by(k - 1, |&a, &b| logits[b].partial_cmp(&logits[a]).unwrap());
+    // hunt3 M-B (FinalFix): drop NaN logits up front. A non-total comparator
+    // (NaN compares Less in both directions) makes select_nth_unstable_by /
+    // sort_unstable_by yield an *unspecified* partition — empirically NaNs can
+    // land at the HEAD of the top-k and displace real finalists. Partitioning
+    // NaN out here guarantees no NaN index ever reaches the top-k or the
+    // softmax, matching the GPU kernel's NaN-dropping argmax. The remaining
+    // comparators then only ever see finite values, so partial_cmp is total.
+    let mut idx: Vec<usize> = (0..n).filter(|&i| !logits[i].is_nan()).collect();
+    if idx.is_empty() {
+        // All-NaN logits: nothing finite to sample. Return token 0 rather than
+        // panicking; the recurrent-state guard upstream treats this as a
+        // degenerate request.
+        return 0;
+    }
+    let m = idx.len();
+    let k = if top_k == 0 || top_k >= m { m } else { top_k };
+
+    // 1. Pick top-k indices by raw logit (descending). Only finite logits
+    //    remain, so the comparator is a total order and never panics.
+    if k < m {
+        idx.select_nth_unstable_by(k - 1, |&a, &b| {
+            logits[b]
+                .partial_cmp(&logits[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         idx.truncate(k);
     }
 
@@ -84,11 +114,19 @@ pub fn sample_token(
         .collect();
     let sum: f32 = weights.iter().sum();
     if sum <= 0.0 || !sum.is_finite() {
+        // hunt3 M-B (FinalFix): degenerate-softmax fallback. `idx` holds only
+        // finite-logit indices (NaNs were partitioned out above), but use the
+        // same GPU-parity `>`-based fold for consistency — NaN can never win.
         return idx
             .iter()
-            .max_by(|&&a, &&b| logits[a].partial_cmp(&logits[b]).unwrap())
-            .copied()
-            .unwrap_or(0) as u32;
+            .fold((idx[0], f32::NEG_INFINITY), |best, &i| {
+                if logits[i] > best.1 {
+                    (i, logits[i])
+                } else {
+                    best
+                }
+            })
+            .0 as u32;
     }
     for w in weights.iter_mut() {
         *w /= sum;
@@ -98,7 +136,15 @@ pub fn sample_token(
     //    drop the tail once cumulative mass reaches top_p, renormalise.
     if top_p > 0.0 && top_p < 1.0 {
         let mut order: Vec<usize> = (0..idx.len()).collect();
-        order.sort_unstable_by(|&a, &b| weights[b].partial_cmp(&weights[a]).unwrap());
+        // hunt3 M-B (FinalFix): all weights are finite here — NaN logits were
+        // dropped at the top-k stage and the `!sum.is_finite()` guard above
+        // already returned for any +inf weight, so partial_cmp is total and the
+        // unwrap_or branch is unreachable. Equal is the safe neutral fallback.
+        order.sort_unstable_by(|&a, &b| {
+            weights[b]
+                .partial_cmp(&weights[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         let mut cum = 0.0;
         let mut cutoff = order.len();
         for (rank, &j) in order.iter().enumerate() {
@@ -137,4 +183,69 @@ pub fn sample_token(
         }
     }
     idx[idx.len() - 1] as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // hunt3 M-B (FinalFix): NaN logits must never be selected and must never
+    // displace the true max, mirroring argmax.hip's `data[i] > lmax` semantics.
+
+    #[test]
+    fn greedy_nan_at_last_index_not_selected() {
+        let mut rng = Xorshift::new(1);
+        // GPU kernel returns idx 1 (5.0) for this input; the old max_by idiom
+        // returned idx 3 (the NaN).
+        let logits = [1.0f32, 5.0, 3.0, f32::NAN];
+        assert_eq!(sample_token(&logits, 0.0, 0, 1.0, &mut rng), 1);
+    }
+
+    #[test]
+    fn greedy_nan_does_not_drop_true_max() {
+        let mut rng = Xorshift::new(1);
+        // The true max (5.0) precedes the NaN; the old idiom dropped it.
+        let logits = [5.0f32, f32::NAN, 0.1, 2.0];
+        assert_eq!(sample_token(&logits, 0.0, 0, 1.0, &mut rng), 0);
+    }
+
+    #[test]
+    fn greedy_all_nan_does_not_panic() {
+        let mut rng = Xorshift::new(1);
+        let logits = [f32::NAN, f32::NAN, f32::NAN];
+        // No finite max exists; fold seed (idx 0) is returned, no panic.
+        let _ = sample_token(&logits, 0.0, 0, 1.0, &mut rng);
+    }
+
+    #[test]
+    fn sampled_path_drops_nan_from_topk() {
+        let mut rng = Xorshift::new(42);
+        // Two scattered NaNs around three real finalists. With temp>0 + top_k,
+        // a surviving NaN would make the softmax sum NaN and route to the
+        // fallback. Repeated draws must only ever return a finite-logit index.
+        let logits = [1.0f32, f32::NAN, 3.0, 2.0, f32::NAN, 0.5];
+        let finite: std::collections::HashSet<u32> = [0u32, 2, 3, 5].into_iter().collect();
+        for _ in 0..256 {
+            let tok = sample_token(&logits, 1.0, 3, 0.9, &mut rng);
+            assert!(
+                finite.contains(&tok),
+                "sampler returned a NaN-indexed token: {tok}"
+            );
+        }
+    }
+
+    #[test]
+    fn sampled_path_all_nan_returns_zero() {
+        let mut rng = Xorshift::new(7);
+        let logits = [f32::NAN, f32::NAN];
+        assert_eq!(sample_token(&logits, 1.0, 0, 1.0, &mut rng), 0);
+    }
+
+    #[test]
+    fn greedy_finite_unaffected() {
+        let mut rng = Xorshift::new(1);
+        // Sanity: no NaN → behaves exactly like a plain argmax.
+        let logits = [0.1f32, 0.2, 0.9, 0.3, 0.4];
+        assert_eq!(sample_token(&logits, 0.0, 0, 1.0, &mut rng), 2);
+    }
 }

--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -224,13 +224,24 @@ pub fn sample_from_logits(logits: &[f32], cfg: &MtpSamplingConfig, rng: &mut Mtp
         .collect();
 
     // 2. Optional top_k: partial-sort to keep top_k by logit (descending).
+    //
+    // hunt3 M-B: a NaN logit makes `partial_cmp` return None; `.unwrap()` would
+    // panic (the panic class M-B exists to remove — matches the deepseek4
+    // sampling.rs sibling sites). `.unwrap_or(Less)` averts the panic. Note a
+    // NaN may NOT sort to the tail (with Less the NaN is ordered toward the
+    // front), so the kept top-k set can transiently include it; it is then
+    // neutralized downstream — exp(NaN)=NaN poisons the softmax sum and the
+    // multinomial loop's `r < acc` stays false, so sampling falls through to
+    // the last surviving candidate (line ~297) instead of panicking.
     if cfg.top_k > 0 && cfg.top_k < pairs.len() {
-        pairs.select_nth_unstable_by(cfg.top_k - 1, |a, b| b.1.partial_cmp(&a.1).unwrap());
+        pairs.select_nth_unstable_by(cfg.top_k - 1, |a, b| {
+            b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Less)
+        });
         pairs.truncate(cfg.top_k);
     }
 
     // 3. Sort by logit descending for top_p and min_p filtering + sampling.
-    pairs.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    pairs.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Less));
 
     // 4. Softmax with max-subtraction stability.
     let max_logit = pairs[0].1;

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -6540,193 +6540,197 @@ impl PrefillBatchScratch {
         let q_dim = config.n_heads * config.head_dim;
         let kv_dim = config.n_kv_heads * config.head_dim;
 
+        // hunt3 H-E residual: this struct literal allocates ~40 GpuTensors via
+        // `?` early-returns. PrefillBatchScratch has no Drop impl (GpuTensor
+        // carries no Gpu handle; free_tensor needs &mut Gpu), so a `?` failure
+        // partway through would drop the already-allocated tensors WITHOUT
+        // freeing them on the device — the exact intra-`new` leak the
+        // cross-band H-E recovery can't reach. OOM during new() is precisely
+        // when a mid-literal failure is most likely. Fix: route every alloc
+        // through a ledger and, on the first error, free everything allocated
+        // so far before propagating. `alloc!` records mandatory tensors;
+        // `alloc_opt!` records the inner tensor of an `if cond { Some(..) }`.
+        //
+        // The ledger stores non-owning aliases (DeviceBuffer has no Drop and
+        // GpuTensor is not Clone), so on success the aliases drop as no-ops and
+        // the real tensors live on in the struct (no double-free); on error we
+        // free each alias once, which releases the same pool buffer the
+        // partially-built (and about-to-be-dropped, never-freed) field held.
+        let mut ledger: Vec<GpuTensor> = Vec::with_capacity(48);
+        macro_rules! alloc {
+            ($shape:expr, $dt:expr) => {
+                match gpu.alloc_tensor($shape, $dt) {
+                    Ok(t) => {
+                        // SAFETY: alias lives only inside `new`; if used it is
+                        // freed in the error arm below (the original field is
+                        // dropped without freeing, no Drop on GpuTensor), and
+                        // on success it is dropped untouched (no Drop on
+                        // DeviceBuffer) while the original is moved into Self.
+                        ledger.push(GpuTensor {
+                            buf: unsafe { t.buf.alias() },
+                            shape: t.shape.clone(),
+                            dtype: t.dtype,
+                        });
+                        t
+                    }
+                    Err(e) => {
+                        for prev in ledger.drain(..) {
+                            let _ = gpu.free_tensor(prev);
+                        }
+                        return Err(e);
+                    }
+                }
+            };
+        }
+        macro_rules! alloc_opt {
+            ($cond:expr, $shape:expr, $dt:expr) => {
+                if $cond {
+                    Some(alloc!($shape, $dt))
+                } else {
+                    None
+                }
+            };
+        }
+
+        // Hoisted grouped-GEMM sizing (same value across the Path-2 fields).
+        let grouped_m_total_max =
+            moe_grouped_m_total_max(max_batch, config.num_experts_per_tok, config.num_experts);
+        let grouped_total_slots_max = max_batch * config.num_experts_per_tok;
+
         Ok(Self {
             max_batch,
-            x_batch: gpu.alloc_tensor(&[max_batch * dim], DType::F32)?,
-            x_rot_batch: gpu.alloc_tensor(&[max_batch * dim], DType::F32)?,
-            x_norm_batch: gpu.alloc_tensor(&[max_batch * dim], DType::F32)?,
-            dn_qkv_batch: gpu.alloc_tensor(&[max_batch * qkv_dim], DType::F32)?,
-            dn_z_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
-            dn_alpha_batch: gpu.alloc_tensor(&[max_batch * n_v_heads], DType::F32)?,
-            dn_beta_batch: gpu.alloc_tensor(&[max_batch * n_v_heads], DType::F32)?,
-            dn_q_raw_batch: gpu.alloc_tensor(&[max_batch * k_dim], DType::F32)?,
-            dn_k_raw_batch: gpu.alloc_tensor(&[max_batch * k_dim], DType::F32)?,
-            dn_v_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
-            dn_q_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
-            dn_k_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
-            dn_attn_out_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
-            dn_normed_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
-            gate_ffn_batch: gpu.alloc_tensor(&[max_batch * hidden_dim], DType::F32)?,
-            up_batch: gpu.alloc_tensor(&[max_batch * hidden_dim], DType::F32)?,
-            ffn_hidden_batch: gpu.alloc_tensor(&[max_batch * hidden_dim], DType::F32)?,
-            dn_normed_rot_batch: gpu.alloc_tensor(&[max_batch * v_dim], DType::F32)?,
+            x_batch: alloc!(&[max_batch * dim], DType::F32),
+            x_rot_batch: alloc!(&[max_batch * dim], DType::F32),
+            x_norm_batch: alloc!(&[max_batch * dim], DType::F32),
+            dn_qkv_batch: alloc!(&[max_batch * qkv_dim], DType::F32),
+            dn_z_batch: alloc!(&[max_batch * v_dim], DType::F32),
+            dn_alpha_batch: alloc!(&[max_batch * n_v_heads], DType::F32),
+            dn_beta_batch: alloc!(&[max_batch * n_v_heads], DType::F32),
+            dn_q_raw_batch: alloc!(&[max_batch * k_dim], DType::F32),
+            dn_k_raw_batch: alloc!(&[max_batch * k_dim], DType::F32),
+            dn_v_batch: alloc!(&[max_batch * v_dim], DType::F32),
+            dn_q_batch: alloc!(&[max_batch * v_dim], DType::F32),
+            dn_k_batch: alloc!(&[max_batch * v_dim], DType::F32),
+            dn_attn_out_batch: alloc!(&[max_batch * v_dim], DType::F32),
+            dn_normed_batch: alloc!(&[max_batch * v_dim], DType::F32),
+            gate_ffn_batch: alloc!(&[max_batch * hidden_dim], DType::F32),
+            up_batch: alloc!(&[max_batch * hidden_dim], DType::F32),
+            ffn_hidden_batch: alloc!(&[max_batch * hidden_dim], DType::F32),
+            dn_normed_rot_batch: alloc!(&[max_batch * v_dim], DType::F32),
             // F32 dtype = 4 bytes/element, same layout as i32. The rope /
             // attention / kv_write kernels cast the pointer to `const int*`,
             // so dtype is cosmetic. Upload i32 bits via memcpy_htod.
-            positions: gpu.alloc_tensor(&[max_batch], DType::F32)?,
-            tokens: gpu.alloc_tensor(&[max_batch], DType::F32)?,
-            fa_q_full_batch: gpu.alloc_tensor(&[max_batch * q_dim * 2], DType::F32)?,
-            fa_q_batch: gpu.alloc_tensor(&[max_batch * q_dim], DType::F32)?,
-            fa_gate_batch: gpu.alloc_tensor(&[max_batch * q_dim], DType::F32)?,
-            fa_k_batch: gpu.alloc_tensor(&[max_batch * kv_dim], DType::F32)?,
-            fa_v_batch: gpu.alloc_tensor(&[max_batch * kv_dim], DType::F32)?,
-            fa_attn_out_batch: gpu.alloc_tensor(&[max_batch * q_dim], DType::F32)?,
-            fa_attn_out_rot_batch: gpu.alloc_tensor(&[max_batch * q_dim], DType::F32)?,
-            moe_router_logits_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(&[max_batch * config.num_experts], DType::F32)?)
-            } else {
-                None
-            },
-            moe_shared_scalar_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(&[max_batch], DType::F32)?)
-            } else {
-                None
-            },
-            moe_shared_gate_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.shared_expert_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_shared_up_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.shared_expert_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_shared_rot_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.shared_expert_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_topk_indices_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(&[max_batch * config.num_experts_per_tok], DType::F32)?)
-            } else {
-                None
-            },
-            moe_topk_weights_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(&[max_batch * config.num_experts_per_tok], DType::F32)?)
-            } else {
-                None
-            },
-            moe_gate_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.num_experts_per_tok * config.moe_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_up_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.num_experts_per_tok * config.moe_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_rot_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.num_experts_per_tok * config.moe_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_down_expanded_batch: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.num_experts_per_tok * config.dim],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
+            positions: alloc!(&[max_batch], DType::F32),
+            tokens: alloc!(&[max_batch], DType::F32),
+            fa_q_full_batch: alloc!(&[max_batch * q_dim * 2], DType::F32),
+            fa_q_batch: alloc!(&[max_batch * q_dim], DType::F32),
+            fa_gate_batch: alloc!(&[max_batch * q_dim], DType::F32),
+            fa_k_batch: alloc!(&[max_batch * kv_dim], DType::F32),
+            fa_v_batch: alloc!(&[max_batch * kv_dim], DType::F32),
+            fa_attn_out_batch: alloc!(&[max_batch * q_dim], DType::F32),
+            fa_attn_out_rot_batch: alloc!(&[max_batch * q_dim], DType::F32),
+            moe_router_logits_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts],
+                DType::F32
+            ),
+            moe_shared_scalar_batch: alloc_opt!(config.num_experts > 0, &[max_batch], DType::F32),
+            moe_shared_gate_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.shared_expert_intermediate_size],
+                DType::F32
+            ),
+            moe_shared_up_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.shared_expert_intermediate_size],
+                DType::F32
+            ),
+            moe_shared_rot_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.shared_expert_intermediate_size],
+                DType::F32
+            ),
+            moe_topk_indices_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts_per_tok],
+                DType::F32
+            ),
+            moe_topk_weights_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts_per_tok],
+                DType::F32
+            ),
+            moe_gate_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts_per_tok * config.moe_intermediate_size],
+                DType::F32
+            ),
+            moe_up_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts_per_tok * config.moe_intermediate_size],
+                DType::F32
+            ),
+            moe_rot_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts_per_tok * config.moe_intermediate_size],
+                DType::F32
+            ),
+            moe_down_expanded_batch: alloc_opt!(
+                config.num_experts > 0,
+                &[max_batch * config.num_experts_per_tok * config.dim],
+                DType::F32
+            ),
             // Path 2 scatter + grouped-WMMA-GEMM scratch (gated at runtime by
             // HIPFIRE_MOE_GROUPED_GEMM=1). m_total_max = N*K_TOP + E*(BLOCK_M-1).
             // i32 buffers stored as Raw (4 bytes/elem matches; no DType::I32 yet).
-            moe_expert_token_counts: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(&[config.num_experts * 4], DType::Raw)?)
-            } else {
-                None
-            },
-            moe_expert_offsets: if config.num_experts > 0 {
-                Some(gpu.alloc_tensor(&[(config.num_experts + 1) * 4], DType::Raw)?)
-            } else {
-                None
-            },
-            moe_sorted_slot_index: if config.num_experts > 0 {
-                let m_total_max = moe_grouped_m_total_max(
-                    max_batch,
-                    config.num_experts_per_tok,
-                    config.num_experts,
-                );
-                Some(gpu.alloc_tensor(&[m_total_max * 4], DType::Raw)?)
-            } else {
-                None
-            },
-            moe_inverse_perm: if config.num_experts > 0 {
-                let total_slots_max = max_batch * config.num_experts_per_tok;
-                Some(gpu.alloc_tensor(&[total_slots_max * 4], DType::Raw)?)
-            } else {
-                None
-            },
-            moe_expert_tile_ids: if config.num_experts > 0 {
-                let m_total_max = moe_grouped_m_total_max(
-                    max_batch,
-                    config.num_experts_per_tok,
-                    config.num_experts,
-                );
-                Some(gpu.alloc_tensor(&[(m_total_max / MOE_GROUPED_BLOCK_M) * 4], DType::Raw)?)
-            } else {
-                None
-            },
-            moe_y_gate_up_grouped: if config.num_experts > 0 {
-                let m_total_max = moe_grouped_m_total_max(
-                    max_batch,
-                    config.num_experts_per_tok,
-                    config.num_experts,
-                );
-                Some(gpu.alloc_tensor(
-                    &[m_total_max * 2 * config.moe_intermediate_size],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
-            moe_y_down_grouped: if config.num_experts > 0 {
-                let m_total_max = moe_grouped_m_total_max(
-                    max_batch,
-                    config.num_experts_per_tok,
-                    config.num_experts,
-                );
-                Some(gpu.alloc_tensor(&[m_total_max * config.dim], DType::F32)?)
-            } else {
-                None
-            },
-            dn_s_tape_q8: if config.linear_num_value_heads > 0 {
-                let bytes = max_batch
+            moe_expert_token_counts: alloc_opt!(
+                config.num_experts > 0,
+                &[config.num_experts * 4],
+                DType::Raw
+            ),
+            moe_expert_offsets: alloc_opt!(
+                config.num_experts > 0,
+                &[(config.num_experts + 1) * 4],
+                DType::Raw
+            ),
+            moe_sorted_slot_index: alloc_opt!(
+                config.num_experts > 0,
+                &[grouped_m_total_max * 4],
+                DType::Raw
+            ),
+            moe_inverse_perm: alloc_opt!(
+                config.num_experts > 0,
+                &[grouped_total_slots_max * 4],
+                DType::Raw
+            ),
+            moe_expert_tile_ids: alloc_opt!(
+                config.num_experts > 0,
+                &[(grouped_m_total_max / MOE_GROUPED_BLOCK_M) * 4],
+                DType::Raw
+            ),
+            moe_y_gate_up_grouped: alloc_opt!(
+                config.num_experts > 0,
+                &[grouped_m_total_max * 2 * config.moe_intermediate_size],
+                DType::F32
+            ),
+            moe_y_down_grouped: alloc_opt!(
+                config.num_experts > 0,
+                &[grouped_m_total_max * config.dim],
+                DType::F32
+            ),
+            dn_s_tape_q8: alloc_opt!(
+                config.linear_num_value_heads > 0,
+                &[max_batch
                     * config.linear_num_value_heads
                     * config.linear_value_head_dim
-                    * config.linear_value_head_dim;
-                Some(gpu.alloc_tensor(&[bytes], DType::Raw)?)
-            } else {
-                None
-            },
-            dn_s_tape_scales: if config.linear_num_value_heads > 0 {
-                Some(gpu.alloc_tensor(
-                    &[max_batch * config.linear_num_value_heads * config.linear_value_head_dim],
-                    DType::F32,
-                )?)
-            } else {
-                None
-            },
+                    * config.linear_value_head_dim],
+                DType::Raw
+            ),
+            dn_s_tape_scales: alloc_opt!(
+                config.linear_num_value_heads > 0,
+                &[max_batch * config.linear_num_value_heads * config.linear_value_head_dim],
+                DType::F32
+            ),
         })
     }
 
@@ -16244,9 +16248,31 @@ pub fn forward_prefill_batch_multi(
     // own_pbs pattern). Future opt: cache on Qwen35ScratchSet.
     let mut pbs_per_band: Vec<PrefillBatchScratch> = Vec::with_capacity(n_bands);
     for b in 0..n_bands {
-        let g = &mut gpus.devices[b];
-        g.bind_thread()?;
-        pbs_per_band.push(PrefillBatchScratch::new(g, config, max_batch)?);
+        // hunt3 H-E: PrefillBatchScratch has no Drop impl, so a mid-loop OOM
+        // here would silently leak every already-allocated band's ~40 GpuTensors
+        // (incl. tens-of-MB MoE grouped-GEMM scratch). On the first failing
+        // PrefillBatchScratch::new, free the bands pushed so far on their own
+        // devices before propagating the error. Mirrors the single-GPU own_pbs
+        // cleanup pattern (allocation failure must not leak prior allocations).
+        // The intra-`new` partial-literal leak (a `?` failing partway through
+        // the struct literal) is handled inside PrefillBatchScratch::new itself
+        // via its alloc ledger, so the failing band's own allocations are also
+        // freed before its error reaches here.
+        let alloc = {
+            let g = &mut gpus.devices[b];
+            g.bind_thread().and_then(|()| PrefillBatchScratch::new(g, config, max_batch))
+        };
+        match alloc {
+            Ok(pbs) => pbs_per_band.push(pbs),
+            Err(e) => {
+                for (prev_b, prev_pbs) in pbs_per_band.into_iter().enumerate() {
+                    let pg = &mut gpus.devices[prev_b];
+                    let _ = pg.bind_thread();
+                    prev_pbs.free_gpu(pg);
+                }
+                return Err(e);
+            }
+        }
     }
 
     let dim = config.dim;

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -989,6 +989,13 @@ fn acquire_daemon_lock() -> std::fs::File {
 /// IPC. ~40 MB encoded → ~30 MB raw image bytes (4/3 expansion).
 const MAX_BASE64_ENCODED_LEN: usize = 40 * 1024 * 1024;
 
+/// hunt3 H-D: upper bound on a request-driven `max_seq` (512K). A defense-in-
+/// depth clamp only — it caps an unvalidated 10M `max_seq` that would otherwise
+/// drive a multi-GB KV allocation and OOM the daemon at load. It is NOT a
+/// VRAM-aware guard: a load that requests exactly this on a non-eviction config
+/// can still OOM at allocation; that VRAM validation is out of scope here.
+const MAX_REQUESTED_SEQ: usize = 512 * 1024;
+
 /// Emit a single-line `{"type":"error","id":"...","message":"..."}` JSON
 /// line on the IPC stream. Uses `serde_json` so user-controlled error
 /// strings (image decoder messages, base64 errors) can't desync the
@@ -1496,11 +1503,25 @@ fn main() {
                 }
 
                 let path = msg.get("model").and_then(|v| v.as_str()).unwrap_or("");
-                let max_seq = msg
+                // hunt3 H-D: clamp request-driven max_seq to the config ceiling
+                // (MAX_REQUESTED_SEQ = 512K). Without this an unvalidated 10M
+                // max_seq drives a multi-GB KV allocation and OOMs the daemon at
+                // load. Emit an info event when the clamp actually fires so the
+                // operator sees the truncation rather than silently getting 512K.
+                let requested_max_seq = msg
                     .get("params")
                     .and_then(|p| p.get("max_seq"))
                     .and_then(|v| v.as_u64())
                     .unwrap_or(4096) as usize;
+                let max_seq = requested_max_seq.min(MAX_REQUESTED_SEQ);
+                if requested_max_seq > MAX_REQUESTED_SEQ {
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"info","message":"requested max_seq {} exceeds ceiling {} — clamped"}}"#,
+                        requested_max_seq, MAX_REQUESTED_SEQ
+                    );
+                    let _ = stdout.flush();
+                }
                 // Optional DFlash draft model path. When supplied AND the target
                 // is a Qwen3.5 arch (5 or 6), we load draft weights + scratch
                 // alongside the target and the temp=0 generate fast path routes
@@ -2119,6 +2140,25 @@ fn main() {
                         },
                         None => None,
                     };
+                // hunt3 M-F: parse user stop sequences (top-level `stop` field on
+                // the generate message; the CLI forwards OpenAI `stop` here, already
+                // normalized to string[], <=4 entries, <=64 chars each). The decode
+                // loops match these against the decoded output suffix and finish
+                // with finish_reason="stop" on a hit. Re-apply the cap defensively
+                // in case a non-hipfire client drives the daemon directly.
+                let stop_seqs: Vec<String> = msg
+                    .get("stop")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|s| s.as_str())
+                            .filter(|s| !s.is_empty())
+                            .take(4)
+                            .map(|s| s.chars().take(64).collect::<String>())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
                 // Sampling defaults differ by arch: qwen35 family was tuned
                 // at `temp=0.3, top_p=0.8` (DFlash-friendly, instruct-stable);
                 // DeepSeek V4 Flash's HF card recommends `temp=1.0, top_p=1.0`
@@ -2446,6 +2486,7 @@ fn main() {
                         tools_json.as_deref(),
                         messages_history.as_deref(),
                         think_mode,
+                        &stop_seqs, // hunt3 M-F
                     );
                 }
             }
@@ -5070,6 +5111,7 @@ fn generate_dflash(
     pflash_alpha: Option<f32>,
     tools: Option<&[serde_json::Value]>,
     messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+    stop: &[String],
 ) {
     use hipfire_arch_qwen35::speculative::{
         spec_step_ddtree_batched, spec_step_ddtree_path_c, spec_step_dflash, ModelSlot,
@@ -5433,6 +5475,30 @@ fn generate_dflash(
         m.kv_cache = Some(target.kv_cache);
         m.dn_state = Some(target.dn_state);
         m.q35_scratch = Some(target.scratch);
+        // hunt3 #5-SLIVER: the suffix/cache_hit seed
+        // (seed_target_hidden_suffix_abortable) partially advances the COMMITTED
+        // dn_state through the new tokens then returns Ok(true) WITHOUT resetting
+        // ("state left as-is; caller must full-reset" per its doc). The next AR
+        // turn cold-prefills at seq_pos=0 but generate()'s DeltaNet memset is
+        // gated on the context-full branch (won't fire after this reset to
+        // seq_pos=0), so it would accumulate over the dirty recurrent state →
+        // drift / premature EOS. Zero it here, mirroring the decode-abort (H1)
+        // handler below. (The cold from_prompt seed already self-resets on
+        // abort, so this is a harmless no-op for that case.)
+        if let Some(ref dn) = m.dn_state {
+            for s in &dn.s_matrices {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.s_scales {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for s in &dn.conv_states {
+                let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+            }
+        }
+        if let Some(kv) = m.kv_cache.as_mut() {
+            kv.compact_offset = 0;
+        }
         let _ = writeln!(
             stdout,
             r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
@@ -5913,6 +5979,22 @@ fn generate_dflash(
                 break;
             }
 
+            // hunt3 M-F: user stop-sequence match against the decoded output
+            // suffix (DFlash path). Mirrors the AR generate() loop — match on
+            // the full decoded text so a stop string spanning a token boundary
+            // is caught. On a hit we treat it like a natural stop: break out of
+            // both the committed-tail loop and the outer spec-cycle loop via
+            // `hit_eos`, so finish_reason resolves to "stop" below (hit_length_cap
+            // false, no tool_calls). Gated behind `!stop.is_empty()` so the
+            // common bench/serve path pays nothing.
+            if !stop.is_empty() {
+                let decoded_suffix = tokenizer.decode(&streamed_tokens);
+                if stop.iter().any(|s| decoded_suffix.ends_with(s.as_str())) {
+                    hit_eos = true;
+                    break;
+                }
+            }
+
             // max_think_tokens enforcement (mirrors the AR path). Track
             // <think>/<⁄think> in decoded text and count tokens inside.
             if max_think_tokens > 0 {
@@ -6182,6 +6264,7 @@ fn generate_multi(
     assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
     tools: Option<&[serde_json::Value]>,
     messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+    stop: &[String],
 ) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
@@ -6317,7 +6400,13 @@ fn generate_multi(
     //      identical to the pp=1 default path so multi-turn behavior
     //      matches between pp=1 and pp>1 when both run the same prompt.
     let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() == Some("1");
-    let try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some();
+    // hunt3 H-A: drop the `seq_pos == 0` gate (PR #389 removed it from generate()).
+    // With the gate, turn 2+ fell through to the Plain scaffold, dropping the
+    // system prompt and the full history replay that render_messages provides.
+    // Now Jinja renders the full conversation every turn; the cold-reset block
+    // below (guarded on seq_pos > 0) re-zeros recurrent state so the full render
+    // writes from position 0 instead of appending to the prior turn's KV/DeltaNet.
+    let try_jinja = jinja_enabled && m.chat_template.is_some();
     let new_tokens = if try_jinja {
         let template = m.chat_template.as_ref().unwrap();
         let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
@@ -6380,6 +6469,49 @@ fn generate_multi(
         }
         .build_with_user_tokens(&q_tokens)
     };
+
+    // hunt3 H-A: under Jinja the full conversation (system + history) is
+    // re-rendered every turn, so turn 2+ must cold-reset BEFORE the budget guard
+    // + prefill — otherwise the full render appends to the prior turn's dirty
+    // KV / DeltaNet / checkpoint state (stale recurrent state → drift; the
+    // system prompt was also being silently dropped on turn 2+). Mirrors the
+    // `reset_pp_uncommitted_state!` semantics, written inline because that macro
+    // is defined later (after kv/dn/gpus are borrowed). Same shape as the
+    // context-full reset at the top of this fn and generate()'s `jinja_active &&
+    // seq_pos > 0` block.
+    if try_jinja && m.seq_pos > 0 {
+        m.seq_pos = 0;
+        m.conversation_tokens.clear();
+        free_checkpoints(&mut m.prefill_checkpoints, gpu);
+        free_checkpoints(&mut m.dflash_checkpoints, gpu);
+        if let (Some(ref dn), Some(ref mut gpus), Some(ref la)) = (
+            m.dn_state.as_ref(),
+            m.pp_gpus.as_mut(),
+            m.pp_dn_la_to_device.as_ref(),
+        ) {
+            for (i, s) in dn.s_matrices.iter().enumerate() {
+                let g = &mut gpus.devices[la[i] as usize];
+                let _ = g.bind_thread();
+                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for (i, s) in dn.s_scales.iter().enumerate() {
+                let g = &mut gpus.devices[la[i] as usize];
+                let _ = g.bind_thread();
+                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+            }
+            for (i, s) in dn.conv_states.iter().enumerate() {
+                let g = &mut gpus.devices[la[i] as usize];
+                let _ = g.bind_thread();
+                let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+            }
+        }
+        if let Some(kv) = m.kv_cache.as_mut() {
+            kv.compact_offset = 0;
+        }
+        if let Some(llkv) = m.llama_kv.as_mut() {
+            llkv.compact_offset = 0;
+        }
+    }
 
     let trailer = nl.len();
     if m.seq_pos + new_tokens.len() + max_tokens + trailer > m.physical_cap {
@@ -6463,6 +6595,53 @@ fn generate_multi(
     // only enables a larger window when a request explicitly sets one.
     let repeat_buf_cap = (scratch_set.per_device[dev_last].repeat_buf.buf.size() / 4).min(_repeat_window.max(1));
 
+    // hunt3 M-C: grammar-guided decoding for pp>1 (mirrors generate() ~8168).
+    // Without this, a pp>1 + tools request samples unconstrained once the model
+    // commits to <tool_call>, reproducing the ChatML-noise-in-tool_call-body
+    // attractor the single-GPU path masks via the qwen35 Matcher. The decoded
+    // vocab is built into a request-local Vec rather than cached on `m`
+    // (m.decoded_vocab) because `m` is already mutably borrowed here (kv/dn/gpus)
+    // — pp>1 + tools is uncommon, so the per-request decode is acceptable.
+    let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() != Some("0");
+    let tool_schemas_qwen: Vec<hipfire_arch_qwen35::grammar::ToolSchema> = if grammar_enabled {
+        tools
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        let func = t.get("function").unwrap_or(t);
+                        let name = func
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .filter(|s| !s.is_empty())?
+                            .to_string();
+                        let required: Vec<String> = func
+                            .get("parameters")
+                            .and_then(|p| p.get("required"))
+                            .and_then(|r| r.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        Some(hipfire_arch_qwen35::grammar::ToolSchema { name, required })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let grammar_active = !tool_schemas_qwen.is_empty();
+    let mut grammar_matcher = hipfire_arch_qwen35::grammar::Matcher::new(tool_schemas_qwen);
+    let grammar_vocab: Vec<String> = if grammar_active {
+        let n = tokenizer.vocab_size();
+        (0..n).map(|id| tokenizer.decode(&[id as u32])).collect()
+    } else {
+        Vec::new()
+    };
+    let mut grammar_mask: Vec<bool> = vec![true; grammar_vocab.len()];
+
     if let Err(e) = qwen35::forward_prefill_batch_multi(
         gpus,
         weights,
@@ -6473,6 +6652,10 @@ fn generate_multi(
         dn,
         scratch_set,
     ) {
+        // hunt3 M-A: a partial-band prefill failure leaves DeltaNet partially
+        // advanced; without resetting, the next cold turn prefills over dirty
+        // recurrent state (drift). Mirror both abort paths, which already reset.
+        reset_pp_uncommitted_state!();
         let _ = writeln!(
             stdout,
             r#"{{"type":"error","id":"{}","message":"forward_prefill_batch_multi: {}"}}"#,
@@ -6523,20 +6706,35 @@ fn generate_multi(
         frequency_penalty,
         blocked_tokens: blocked0,
     };
+    // hunt3 M-C: grammar-gated first sample (GPU fast path when matcher free;
+    // CPU mask-then-sample when constraining). Matches generate()'s tok0 site.
     let tok0 = {
         let s_last = &scratch_set.per_device[dev_last];
         let g_last = &mut gpus.devices[dev_last];
-        sampler::sample(
-            g_last,
-            &s_last.logits,
-            &s_last.sample_buf,
-            &s_last.repeat_buf,
-            vocab_size,
-            ngram_scope,
-            &cfg0,
-            &mut rng_state,
-        )
+        if grammar_active && !grammar_matcher.is_free() {
+            let _ = g_last.bind_thread();
+            let mut logits = g_last
+                .download_f32(&s_last.logits)
+                .unwrap_or_else(|_| vec![0.0f32; vocab_size]);
+            grammar_matcher.token_mask(&grammar_vocab, &mut grammar_mask);
+            hipfire_arch_qwen35::grammar::Matcher::apply_mask_to_logits(&grammar_mask, &mut logits);
+            sampler::sample_cpu(&mut logits, ngram_scope, &cfg0)
+        } else {
+            sampler::sample(
+                g_last,
+                &s_last.logits,
+                &s_last.sample_buf,
+                &s_last.repeat_buf,
+                vocab_size,
+                ngram_scope,
+                &cfg0,
+                &mut rng_state,
+            )
+        }
     };
+    if grammar_active {
+        grammar_matcher.advance(&tokenizer.decode(&[tok0]));
+    }
     let t_prefill = Instant::now();
     let mut next_token = tok0;
 
@@ -6617,6 +6815,10 @@ fn generate_multi(
             dn,
             scratch_set,
         ) {
+            // hunt3 M-A: a decode-step failure leaves DeltaNet advanced past the
+            // (un-baked) conversation_tokens; reset so the next cold turn starts
+            // clean. Mirrors both abort paths.
+            reset_pp_uncommitted_state!();
             let _ = writeln!(
                 stdout,
                 r#"{{"type":"error","id":"{}","message":"forward_scratch_multi decode: {}"}}"#,
@@ -6635,6 +6837,20 @@ fn generate_multi(
         }
         if tokenizer.is_terminator(next_token) {
             break;
+        }
+
+        // hunt3 M-F: user stop-sequence match against the decoded output suffix
+        // (pp>1 multi-GPU path). Mirrors the AR generate() loop; matches the
+        // full decoded text so a stop string spanning a token boundary is
+        // caught. A plain break exits the `while generated < max_tokens` loop
+        // (this path's `done` event carries no finish_reason field, so there is
+        // no reason to resolve — terminating generation is the contract). Gated
+        // behind `!stop.is_empty()` so the common path pays nothing.
+        if !stop.is_empty() {
+            let decoded_suffix = tokenizer.decode(&streamed_tokens);
+            if stop.iter().any(|s| decoded_suffix.ends_with(s.as_str())) {
+                break;
+            }
         }
 
         // max_think_tokens / force-answer enforcement: same decoded-text scan
@@ -6709,6 +6925,13 @@ fn generate_multi(
                     }
                     m.seq_pos += 1;
                     m.conversation_tokens.push(t);
+                    // hunt3 M-C: keep the grammar matcher in sync over force-closed
+                    // </think> tokens, exactly as generate() does (~8591). Without
+                    // this a tools request that force-closes <think> leaves the
+                    // matcher stale → malformed tool calls after the forced close.
+                    if grammar_active {
+                        grammar_matcher.advance(&tokenizer.decode(&[t]));
+                    }
                     streamed_tokens.push(t);
                     emit_committed_event(
                         stdout,
@@ -6797,20 +7020,37 @@ fn generate_multi(
                     frequency_penalty,
                     blocked_tokens: blocked,
                 };
+                // hunt3 M-C: grammar-gated budget-alert resample.
                 next_token = {
                     let s_last = &scratch_set.per_device[dev_last];
                     let g_last = &mut gpus.devices[dev_last];
-                    sampler::sample(
-                        g_last,
-                        &s_last.logits,
-                        &s_last.sample_buf,
-                        &s_last.repeat_buf,
-                        vocab_size,
-                        ngram_scope,
-                        &cfg,
-                        &mut rng_state,
-                    )
+                    if grammar_active && !grammar_matcher.is_free() {
+                        let _ = g_last.bind_thread();
+                        let mut logits = g_last
+                            .download_f32(&s_last.logits)
+                            .unwrap_or_else(|_| vec![0.0f32; vocab_size]);
+                        grammar_matcher.token_mask(&grammar_vocab, &mut grammar_mask);
+                        hipfire_arch_qwen35::grammar::Matcher::apply_mask_to_logits(
+                            &grammar_mask,
+                            &mut logits,
+                        );
+                        sampler::sample_cpu(&mut logits, ngram_scope, &cfg)
+                    } else {
+                        sampler::sample(
+                            g_last,
+                            &s_last.logits,
+                            &s_last.sample_buf,
+                            &s_last.repeat_buf,
+                            vocab_size,
+                            ngram_scope,
+                            &cfg,
+                            &mut rng_state,
+                        )
+                    }
                 };
+                if grammar_active {
+                    grammar_matcher.advance(&tokenizer.decode(&[next_token]));
+                }
                 continue;
             }
             let nudge_tokens = tokenizer.encode(budget_alert_text);
@@ -6901,20 +7141,44 @@ fn generate_multi(
             frequency_penalty,
             blocked_tokens: blocked,
         };
+        // hunt3 M-C: grammar-gated steady-state sample.
         next_token = {
             let s_last = &scratch_set.per_device[dev_last];
             let g_last = &mut gpus.devices[dev_last];
-            sampler::sample(
-                g_last,
-                &s_last.logits,
-                &s_last.sample_buf,
-                &s_last.repeat_buf,
-                vocab_size,
-                ngram_scope,
-                &cfg,
-                &mut rng_state,
-            )
+            if grammar_active && !grammar_matcher.is_free() {
+                let _ = g_last.bind_thread();
+                let mut logits = g_last
+                    .download_f32(&s_last.logits)
+                    .unwrap_or_else(|_| vec![0.0f32; vocab_size]);
+                grammar_matcher.token_mask(&grammar_vocab, &mut grammar_mask);
+                hipfire_arch_qwen35::grammar::Matcher::apply_mask_to_logits(
+                    &grammar_mask,
+                    &mut logits,
+                );
+                sampler::sample_cpu(&mut logits, ngram_scope, &cfg)
+            } else {
+                sampler::sample(
+                    g_last,
+                    &s_last.logits,
+                    &s_last.sample_buf,
+                    &s_last.repeat_buf,
+                    vocab_size,
+                    ngram_scope,
+                    &cfg,
+                    &mut rng_state,
+                )
+            }
         };
+        if grammar_active {
+            let was_detected = grammar_matcher.attractor_detected();
+            grammar_matcher.advance(&tokenizer.decode(&[next_token]));
+            if !was_detected && grammar_matcher.attractor_detected() {
+                eprintln!(
+                    "[grammar-ngram pp] attractor detected in tool_call args at gen={} — forcing close",
+                    generated,
+                );
+            }
+        }
     }
 
     // ChatML \n trailer so the next turn opens cleanly.
@@ -6973,7 +7237,12 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, presence_penalty: f32, frequency_penalty: f32, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>, think_mode: ThinkMode) {
+fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, presence_penalty: f32, frequency_penalty: f32, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>, think_mode: ThinkMode, stop: &[String]) {
+    // hunt3 M-E: seed the process-global CPU sampler RNG with this request's
+    // fixed seed so the grammar/CPU-fallback sample stream is deterministic per
+    // request and does not carry RNG state across requests. Matches the u32 the
+    // GPU sample path uses (0x13579BDF).
+    hipfire_runtime::llama::reset_cpu_sampler_rng(0x13579BDF);
     // Compress runs on the PFlash drafter handle when one is set (hetero
     // sibling device), else on the target gpu. The handle is consumed at
     // the seq_pos==0 compress site; decode always uses `gpu`.
@@ -6998,6 +7267,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             tools,
             messages_history,
         );
+        let _ = stop; // hunt3 M-F: not wired for arch_id=7 (qwen2 bring-up)
         generate_qwen2(
             m,
             gpu,
@@ -7030,6 +7300,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             pflash_cfg,
         );
         let _ = (repeat_penalty, repeat_window);
+        let _ = stop; // hunt3 M-F: not wired for arch_id=9 (deepseek4 bring-up)
         generate_deepseek4(
             m,
             gpu,
@@ -7058,6 +7329,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             assistant_prefix,
             tools,
             messages_history,
+            stop, // hunt3 M-F: thread user stop sequences into the pp>1 path
         );
         return;
     }
@@ -7131,6 +7403,7 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             dflash_alpha,
             tools,
             messages_history,
+            stop, // hunt3 M-F: thread user stop sequences into the default DFlash path
         );
         // Silence unused-variable warnings for the params DFlash doesn't
         // consume (top_p / repeat penalties are AR-only sampling knobs;
@@ -8482,6 +8755,18 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
             }
             if tokenizer.is_terminator(next_token) {
                 break;
+            }
+
+            // hunt3 M-F: user stop-sequence match against the decoded output
+            // suffix. Matching on the full decoded text (not per-token) handles
+            // stop strings that span a token boundary. On a hit we break out of
+            // the decode loop; finish_reason naturally resolves to "stop" below
+            // (hit_length_cap is false and no tool_calls were emitted).
+            if !stop.is_empty() {
+                let decoded_suffix = tokenizer.decode(&streamed_tokens);
+                if stop.iter().any(|s| decoded_suffix.ends_with(s.as_str())) {
+                    break;
+                }
             }
 
             // max_think_tokens enforcement. Track whether we're inside an
@@ -10489,6 +10774,12 @@ fn generate_vl(
     stdout: &mut std::io::Stdout,
     params: &GenerateVLParams,
 ) {
+    // hunt3 M-E: seed the process-global CPU sampler RNG with this request's
+    // fixed seed. The VL path samples exclusively via sampler::sample_cpu, which
+    // draws from this global; without the per-request reset it carried RNG state
+    // across requests (and across earlier text-path requests) → cross-request
+    // nondeterminism. Matches the GPU path's u32 (0x13579BDF).
+    hipfire_runtime::llama::reset_cpu_sampler_rng(0x13579BDF);
     // INVARIANT: all early returns before the `vision_forward` call (the
     // first expensive GPU allocation in this function) use `write_error`
     // and return without owning any GPU buffers. If you add a GPU
@@ -10762,6 +11053,13 @@ fn generate_vl(
 
     m.conversation_tokens.extend_from_slice(&prompt_tokens);
 
+    // hunt3 M-D: repeat-penalty / n-gram-block history must be scoped to the
+    // GENERATED tokens only (mirrors the text path's `ngram_scope_start` set to
+    // conversation_tokens.len() after prefill). Passing the full conversation
+    // makes the trailing window prompt-dominated, suppressing the names/numbers
+    // a VL transcription task must reproduce.
+    let vl_ngram_scope_start = m.conversation_tokens.len();
+
     // Generate. CPU-side sampling — VL path predates the GPU sampler
     // and downloads logits each step. The order of ops is preserved
     // from pre-PR3:
@@ -10878,12 +11176,14 @@ fn generate_vl(
             }
         }
         logits = gpu.download_f32(&scratch.logits).unwrap();
-        llama::apply_ngram_block(&mut logits, &m.conversation_tokens);
+        // hunt3 M-D: scope ngram-block + repeat-penalty history to generated-only.
+        let vl_ngram_scope = &m.conversation_tokens[vl_ngram_scope_start..];
+        llama::apply_ngram_block(&mut logits, vl_ngram_scope);
         if let Some((open, close)) = think_pair {
             block_attractor_unclosed_cpu(&mut logits, &m.conversation_tokens, open, close, 20, 2);
         }
 
-        next_token = sampler::sample_cpu(&mut logits, &m.conversation_tokens, &vl_cfg);
+        next_token = sampler::sample_cpu(&mut logits, vl_ngram_scope, &vl_cfg);
 
         if max_think_tokens > 0 {
             if let Some((open, close)) = think_pair {
@@ -10922,6 +11222,19 @@ fn generate_vl(
                         }
                         m.conversation_tokens.push(t);
                         streamed_tokens.push(t);
+                        // hunt3 H-F: emit the committed-token event for force-closed
+                        // </think> tokens too, BEFORE `generated += 1`, so the
+                        // committed pos stays in lockstep with the streamed count
+                        // under HIPFIRE_EMIT_TOKEN_IDS=1. The VL main loop uses
+                        // `generated - 1` after its increment; here `generated`
+                        // (pre-increment) is the same value.
+                        emit_committed_event(
+                            stdout,
+                            id,
+                            t,
+                            generated,
+                            t0.elapsed().as_millis() as u64,
+                        );
 
                         let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
                         let new_bytes = &all_bytes[emitted_bytes..];
@@ -10959,7 +11272,12 @@ fn generate_vl(
                         20,
                         2,
                     );
-                    next_token = sampler::sample_cpu(&mut logits, &m.conversation_tokens, &vl_cfg);
+                    // hunt3 M-D: generated-only repeat-penalty scope.
+                    next_token = sampler::sample_cpu(
+                        &mut logits,
+                        &m.conversation_tokens[vl_ngram_scope_start..],
+                        &vl_cfg,
+                    );
                 }
             }
         }

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -7491,12 +7491,24 @@ fn replicate_fwht_signs_to_all_devices(gpus: &mut Gpus, n_signs: usize) -> HipRe
 
 /// Sample the next token from logits using argmax (greedy).
 pub fn argmax(logits: &[f32]) -> u32 {
+    // hunt3 M-B (FinalFix): explicit `>`-based fold mirrors the GPU kernel
+    // (argmax.hip: `if (data[i] > lmax)`, seed -1e30). `v > best` is false for
+    // NaN, so a NaN logit is never selected and never displaces the real max.
+    // The previous `max_by(partial_cmp.unwrap_or(Less))` kept a trailing NaN
+    // candidate (verified: [1,5,3,NaN] → idx 3) — a NaN-indexed garbage token
+    // on the greedy path poisons the recurrent DeltaNet state. Empty logits
+    // would be a caller bug; fold over an empty slice returns index 0.
     logits
         .iter()
         .enumerate()
-        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-        .map(|(i, _)| i as u32)
-        .unwrap()
+        .fold((0usize, f32::NEG_INFINITY), |best, (i, &v)| {
+            if v > best.1 {
+                (i, v)
+            } else {
+                best
+            }
+        })
+        .0 as u32
 }
 
 /// Sample the next token using temperature + top-k + top-p (nucleus) sampling.
@@ -7948,6 +7960,18 @@ pub fn sampler_rng_restore(state: u32) {
     SAMPLER_STATE.store(state, Ordering::Relaxed);
 }
 
+/// hunt3 M-E: deterministic per-request reset entry point for the CPU sampler
+/// RNG stream. The daemon calls this once at the top of generate()/generate_vl()
+/// with the same per-request seed the GPU sampler uses, so CPU-fallback sampling
+/// is reproducible across requests instead of carrying state from the prior one.
+/// Note: `simple_rand` treats a stored 0 as "seed from time"; we map a 0 seed to
+/// 1 so the reset stays deterministic. The RNG algorithm itself is unchanged.
+pub fn reset_cpu_sampler_rng(seed: u32) {
+    use std::sync::atomic::Ordering;
+    let s = if seed == 0 { 1 } else { seed };
+    SAMPLER_STATE.store(s, Ordering::Relaxed);
+}
+
 use std::sync::atomic::AtomicU32;
 static SAMPLER_STATE: AtomicU32 = AtomicU32::new(0);
 
@@ -7978,6 +8002,29 @@ fn simple_rand() -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // hunt3 M-B (FinalFix): greedy argmax must drop NaN like the GPU kernel
+    // (argmax.hip `data[i] > lmax`), never selecting a NaN-indexed token and
+    // never dropping the true max that precedes a NaN.
+
+    #[test]
+    fn argmax_nan_at_last_index_not_selected() {
+        // Old max_by idiom returned idx 3 (NaN); GPU kernel + fix return idx 1.
+        let logits = [1.0f32, 5.0, 3.0, f32::NAN];
+        assert_eq!(argmax(&logits), 1);
+    }
+
+    #[test]
+    fn argmax_nan_does_not_drop_true_max() {
+        let logits = [5.0f32, f32::NAN, 0.1, 2.0];
+        assert_eq!(argmax(&logits), 0);
+    }
+
+    #[test]
+    fn argmax_finite_unaffected() {
+        let logits = [0.1f32, 0.2, 0.9, 0.3];
+        assert_eq!(argmax(&logits), 2);
+    }
 
     #[test]
     fn attractor_block_below_threshold() {

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -594,19 +594,11 @@ impl Tokenizer {
     /// For GPT-2 BPE: collects all bytes first, then does UTF-8 conversion once
     /// (individual tokens can be incomplete UTF-8 sequences in byte-level BPE).
     pub fn decode(&self, tokens: &[u32]) -> String {
-        if self.is_gpt2_bpe {
-            String::from_utf8_lossy(&self.decode_bytes(tokens)).into_owned()
-        } else {
-            let mut result = String::new();
-            for &id in tokens {
-                if let Some(tok) = self.vocab.get(id as usize) {
-                    let decoded = tok.replace('▁', " ");
-                    let decoded = decode_hex_escapes(&decoded);
-                    result.push_str(&decoded);
-                }
-            }
-            result
-        }
+        // hunt3 H-C: delegate to the byte-correct decode_bytes path then
+        // from_utf8_lossy once, so multi-byte chars split across <0xHH>
+        // fallback tokens (e.g. CJK 中 = E4 B8 AD) reassemble instead of
+        // mojibake-ing via `byte as char`. Covers both BPE and SentencePiece.
+        String::from_utf8_lossy(&self.decode_bytes(tokens)).into_owned()
     }
 
     /// Decode tokens to raw bytes (for incremental UTF-8 streaming).
@@ -635,9 +627,10 @@ impl Tokenizer {
                         }
                     }
                 } else {
+                    // hunt3 H-C: byte-correct path — <0xHH> fallback tokens must
+                    // emit raw bytes, not `byte as char` re-UTF8-encoded codepoints.
                     let decoded = tok.replace('▁', " ");
-                    let decoded = decode_hex_escapes(&decoded);
-                    bytes.extend_from_slice(decoded.as_bytes());
+                    bytes.extend_from_slice(&decode_hex_escapes_bytes(&decoded));
                 }
             }
         }
@@ -1077,9 +1070,20 @@ static GPT2_OFFSET_TO_BYTE: [u8; 68] = {
     table
 };
 
-/// Decode SentencePiece hex escapes like <0x0A> to actual bytes.
-fn decode_hex_escapes(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
+/// Decode SentencePiece hex escapes like `<0x0A>` to actual bytes.
+///
+/// Byte-fallback tokens like `<0xE4>` are emitted as the RAW byte 0xE4, NOT as
+/// the Unicode codepoint U+00E4 (which would re-UTF8-encode to two bytes and
+/// mangle CJK / any non-ASCII byte-fallback sequence). Ordinary chars are
+/// encoded as UTF-8. Returns bytes so a multi-byte char split across several
+/// `<0xHH>` tokens (e.g. 中 = E4 B8 AD) reassembles via a single
+/// `from_utf8`/`from_utf8_lossy` at the call site.
+// hunt3 H-C: prior `decode_hex_escapes` did `result.push(byte as char)` which
+// corrupted byte-fallback tokens (0xHH → U+00HH → 2-byte UTF-8); this variant
+// pushes the parsed value as a raw byte instead.
+fn decode_hex_escapes_bytes(s: &str) -> Vec<u8> {
+    let mut result: Vec<u8> = Vec::with_capacity(s.len());
+    let mut buf = [0u8; 4];
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '<' {
@@ -1104,7 +1108,8 @@ fn decode_hex_escapes(s: &str) -> String {
                     if chars.peek() == Some(&'>') && !hex.is_empty() {
                         chars.next(); // consume '>'
                         if let Ok(byte) = u8::from_str_radix(&hex, 16) {
-                            result.push(byte as char);
+                            // hunt3 H-C: raw byte, NOT `byte as char`
+                            result.push(byte);
                             matched = true;
                         }
                     }
@@ -1112,11 +1117,11 @@ fn decode_hex_escapes(s: &str) -> String {
             }
             if !matched {
                 for ch in temp {
-                    result.push(ch);
+                    result.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
                 }
             }
         } else {
-            result.push(c);
+            result.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
         }
     }
     result
@@ -1799,6 +1804,27 @@ mod sp_tests {
             eot_id: None,
             is_gpt2_bpe: false,
         }
+    }
+
+    #[test]
+    fn sp_decode_byte_fallback_cjk() {
+        // hunt3 H-C regression: SentencePiece byte-fallback emits a CJK char as
+        // a run of <0xHH> tokens. "中" = U+4E2D = bytes E4 B8 AD. The old
+        // `byte as char` path mapped each 0xHH to U+00HH and re-UTF8-encoded it
+        // to 2 bytes → mojibake. decode_bytes must reassemble the raw 3 bytes,
+        // and decode() must from_utf8 them back into "中".
+        let tok = synth_sp(&["<0xE4>", "<0xB8>", "<0xAD>"]);
+        let toks = [0u32, 1, 2];
+        assert_eq!(tok.decode_bytes(&toks), "中".as_bytes());
+        assert_eq!(tok.decode(&toks), "中");
+    }
+
+    #[test]
+    fn sp_decode_hex_escapes_bytes_ascii_and_literal() {
+        // ASCII byte-fallback (<0x0A> = newline) and a non-matching literal
+        // "<0xZZ>" must pass through untouched, encoded as UTF-8.
+        assert_eq!(decode_hex_escapes_bytes("<0x0A>"), vec![b'\n']);
+        assert_eq!(decode_hex_escapes_bytes("a<0xZZ>b"), b"a<0xZZ>b".to_vec());
     }
 
     #[test]

--- a/docs/investigations/2026-06-03-hunt3-engine-bugs.md
+++ b/docs/investigations/2026-06-03-hunt3-engine-bugs.md
@@ -1,0 +1,142 @@
+# Hunt-3 engine bug sweep (2026-06-03)
+
+Adversarial multi-agent bug-hunt (`wf_f58cd575-2a6`, 109 agents, ~8.7M tokens,
+~31 min) over 4 surfaces deliberately chosen to **avoid** the saturated
+single-GPU A3B decode path and the separate quant track (#392):
+
+1. **Multi-GPU / Pipeline-Parallel** (`generate_multi`, pp>1)
+2. **Sampling + MoE dispatch**
+3. **Daemon concurrency / streaming** (Rust JSON-lines)
+4. **Bun CLI → backend entry** (TS + IPC boundary)
+
+Method: 4 Explore scouts → 20 finder lenses (grounded by the map) → 3
+perspective-diverse skeptics per finding (reachability / intended-vs-bug /
+blast-radius, **refute-by-default**) → synthesis. Result: **20 confirmed
+(≥2/3 affirm), 1 contested (1/3), 7 rejected**.
+
+> ⚠️ **Line numbers in the raw swarm output are systematically unreliable**
+> (agents drifted / approximated). Every entry below has been **re-anchored by
+> symbol**. The CLAIMS are mostly sound when checked; **#5 is a falsified
+> verification miss** (see below). Items marked **[src-verified]** were checked
+> against live master `02634f4c` by hand; the rest rest on the 2/3 swarm verify
+> and should be re-confirmed at fix time.
+
+---
+
+## Cross-cutting themes
+
+1. **Sibling-path divergence (dominant).** `generate_multi` (pp>1) and
+   `generate_vl` are systematically missing lifecycle/correctness fixes that
+   the single-GPU `generate()` text path received: per-request Jinja
+   rerender+reset (#389), state cold-reset on error/abort, grammar-constrained
+   tool-call masking, generated-only repeat-penalty scope, committed-event
+   emission, per-request deterministic RNG. **Fix strategy: treat `generate()`
+   as the reference and audit each sibling against every invariant it enforces.**
+2. **Single stdin/stdout pipe without a shared mutex.** Bun's one daemon pipe is
+   serialized only by the busy/queue lock, but the idle-eviction timer,
+   drain-restart, run-HTTP-fallback, and foreground-serve all drive send/recv or
+   spawn outside that lock; `recv()`'s `EOF → process.exit` converts any pipe
+   desync or daemon death into a full multi-client outage. Root cause: one-shot
+   CLI design (process==request, flock singleton, exit-on-EOF) reused unchanged
+   for a long-lived multi-client serve.
+3. **Unchecked primitive coercion at boundaries.** `byte as char` re-UTF8s
+   byte-fallback tokens to mojibake; JSON-string `max_tokens` string-concats into
+   a 10M `max_seq`; JS-truthy `body.stream` diverges from OpenAI booleans.
+
+---
+
+## Confirmed (re-anchored + verification status)
+
+### HIGH
+
+- **H-A — `generate_multi` (pp>1) Jinja: drops system prompt + skips per-request cold-reset on turn 2+.** **[src-verified]**
+  `daemon.rs:6320` still reads `try_jinja = jinja_enabled && m.seq_pos == 0 && m.chat_template.is_some()`
+  — the `seq_pos==0` gate PR #389 *removed* from `generate()` (now `:7417` ungated) and `generate_dflash` (`:5091` ungated).
+  Turn 2+ → `try_jinja=false` → Plain ChatML branch with `system=None` → extends turn-1 dirty KV/DeltaNet, no cold reset.
+  This is the **explicitly-deferred #389 pp analogue**. cache_capable=true for arch 5/6/9 → CLI sends no per-turn reset, so it always fires.
+  **Fix:** ungate `:6320` + add a `jinja && seq_pos>0` cold-reset (mirror `reset_pp_uncommitted_state!`) before the budget guard.
+
+- **H-B — `recv()` EOF → `process.exit` kills the entire long-lived serve.** **[src-verified]**
+  `cli/index.ts:1147` `process.exit(code === 0 ? 1 : code)` inside `recv()` (1131). One daemon panic/OOM (the ~13-req KV-OOM class)
+  closes stdout → every queued/connected client dies; defeats the deliberate `drain()`-restart and the pre-warm try/catch.
+  **Fix:** `recv()` throws a typed `DaemonClosedError` on `done`; one-shot `run()` catches→exit, serve handler catches→500 + `stop()/start()`.
+
+- **H-C — tokenizer `byte as char` mojibake on SentencePiece byte-fallback.** **[src-verified]**
+  `tokenizer.rs:1107` `result.push(byte as char)` in `decode_hex_escapes` (called by `decode`/`decode_bytes` at 604/639).
+  `<0xHH>` → U+00HH → re-UTF8 to 2 bytes → mojibake. **Scope caveat:** only `is_gpt2_bpe==false` (Llama/SentencePiece) models —
+  Qwen3.x is GPT2-BPE and uses `byte_to_id`, so the *primary* workload is unaffected (synthesis overstated "every model").
+  Known-bad pattern: the same `byte as char` was already fixed elsewhere (see the regression comment at `:1969`).
+  **Fix:** byte-emitting `decode_hex_escapes_bytes` that pushes raw `<0xHH>` bytes + `char::encode_utf8` for ordinary chars.
+
+- **H-D — `max_tokens` string → string-concat → ~10M `max_seq` → unload-then-OOM (DoS).** **[src-verified]**
+  `cli/index.ts:1968` `body.max_tokens ?? effective.max_tokens` (`??` guards null, *not* type) → `:1970` `requestMaxTokens + 1024`
+  string-concats for a JSON-string `"100"` → `Math.max` coerces to ~10M → bumps load `max_seq`; daemon `:1499`
+  `.as_u64().unwrap_or(4096)` has no upper clamp (bypasses the 524288 ceiling). One malformed request unloads the resident model then OOMs.
+  **Fix:** type-validate/clamp `requestMaxTokens` at the boundary + clamp daemon-side `max_seq ≤ 524288`.
+
+- **H-E — `forward_prefill_batch_multi` leaks already-allocated per-band `PrefillBatchScratch` on a later band's OOM.** [swarm-verified]
+  `qwen35.rs:~11118` per-band `PrefillBatchScratch::new` loop is *outside* the result closure + free loop; band-1 OOM drops band-0's ~40
+  GpuTensors with no `Drop` → monotonic VRAM leak. Same class as the fixed `PrefillBatchScratch::free_gpu` MoE-scratch leak; pp-specific
+  (single-GPU sibling wraps `own_pbs` inside the closure). **Fix:** move per-band alloc inside a guarded closure whose Err arm frees pushed bands.
+
+- **H-F — `generate_vl` think-cap force-close emits text tokens but no `{type:committed}` events → token-id stream desync.** [swarm-verified]
+  VL force-close loop pushes close tokens + emits `{type:token}` + increments `generated` but never `emit_committed_event` → under
+  `HIPFIRE_EMIT_TOKEN_IDS=1` the committed pos permanently diverges from `streamed_tokens.len()`, breaking coherence_probe / DFlash-gate
+  detectors. AR `generate()` sibling emits correctly (`:6758`). **Fix:** add `emit_committed_event` in the VL force-close loop.
+
+### MEDIUM
+
+- **M-A — `generate_multi` forward-ERROR return paths leave DeltaNet/KV dirty across requests.** [swarm-verified; theme-consistent]
+  Both abort paths call `reset_pp_uncommitted_state!`; the two forward-error returns (prefill Err, decode Err) emit `{type:error}` and
+  return *without* it → partial-band failure leaves DeltaNet partially advanced; next cold turn prefills over non-zero state. **Fix:** call the
+  reset macro before both error returns. (Note: single-GPU `generate()` forward errors `.unwrap()`→panic→clean restart, so it never carries this.)
+
+- **M-B — deepseek4 greedy/top-k + llama argmax panic on NaN logit (`partial_cmp(..).unwrap()`).** [swarm-verified]
+  `deepseek4/sampling.rs:62`(greedy)/`:72`(top-k) + `llama.rs:~5272`. A NaN logit (aggressive quant) panics → kills the daemon decode loop;
+  the GPU kernel silently drops NaN, so there's a GPU/CPU split. **Fix:** `partial_cmp(..).unwrap_or(Ordering::Less)`, treat NaN as -inf.
+
+- **M-C — `generate_multi` drops grammar-constrained tool-call sampling that pp=1 enforces.** [swarm-verified; theme-consistent]
+  Its three sample sites are unconditional GPU `sampler::sample` with no grammar mask; `generate()` masks via the qwen35 `Matcher` on
+  `<tool_call>`. pp>1 + tools → unconstrained → reopens the Pi-turn-12 ChatML-noise-in-tool_call attractor. **Fix:** lift `generate()`'s grammar wrapper into all three sites.
+
+- **M-D — `generate_vl` repeat penalty scoped over prompt+generated, contradicting the text path's generated-only design.** [swarm-verified; theme-consistent]
+  VL passes full `m.conversation_tokens` to `sample_cpu`; text path sets `ngram_scope_start = conversation_tokens.len()` after prefill
+  (`:6371`, explicit MQ4/MQ6-recall comment). Prompt-dominated window suppresses names/numbers a transcription task must reproduce. **Fix:** capture VL scope start, pass generated-only slice.
+
+- **M-E — Grammar/VL CPU sampling uses a process-global wall-clock-seeded RNG → non-determinism + cross-request state leak.** [swarm-verified]
+  GPU path threads a per-request seed; `sample_cpu→llama::sample_top_p→simple_rand` reads/writes a process-global `AtomicU32` never reset.
+  Inside one tool-call request the RNG source silently switches per-token; CPU output depends on prior/concurrent requests' sampling. **Fix:** thread the per-request seed through `sample_cpu` (or reset `SAMPLER_STATE` at the top of `generate()/generate_vl`).
+
+- **M-F — `stop` sequences silently ignored end-to-end.** [swarm-verified]
+  `cli/index.ts:~2187` `genParams` never reads `body.stop`; daemon has no stop-string matching. Halts only on EOS/`<|im_end|>`/max_tokens.
+  **Fix:** parse+forward `body.stop`, add daemon-side stop-string match emitting `finish_reason="stop"` (min: stderr-warn so it's not silent).
+
+### Bun single-pipe-without-mutex cluster (availability) [swarm-verified]
+
+- **B-1 — idle-eviction timer drives `send/recv` without the request lock** → races a concurrent request on one pipe, cross-routes acks (consume unload-ack as reset-ack, `generate` to a null-model daemon). **Fix:** acquire the serve lock in eviction, re-validate idle precondition after the wait.
+- **B-2 — drain-timeout restart races the machine-wide flock** (`stop()` doesn't await `proc.exited`; `LOCK_EX|LOCK_NB` → respawn hits FATAL-already-running → EOF → serve dies). **Fix:** `await proc.exited` before respawn; retry spawn/ping with backoff.
+- **B-3 — foreground `serve` clobbers then deletes the live `serve -d` PID file**, orphaning a VRAM-holding daemon `hipfire stop` can't find. **Fix:** singleton-guard the foreground path; `cleanupPid` unlinks only on read-back-equals-own-pid.
+- **B-4 — non-stream daemon-error `Response` built inside `ReadableStream.start()` is discarded** → client hangs on a 200 with empty body until the 255s idle timeout (intended 400/413/500 is dead code). **Fix:** emit the error through the open controller + close it.
+- **B-5 — idle-eviction races the request handler's model reload** (request holds lock but `e.generating` still false during reload) → concurrent recv on one stdout, split JSON. **Fix:** eviction also respects a `busy` flag covering the whole lock-held window.
+- **B-6 — `hipfire run` HTTP-fallback spawns a local daemon that collides with the running serve's flock** → FATAL → process.exit. **Fix:** when `runViaHttp` fails but `isServeUp()`, retry HTTP instead of spawning local.
+
+---
+
+## Contested (1/3 affirm — human eyeball)
+
+- **C-1 — `body.stream` raw JS truthiness vs OpenAI strict-boolean.** `cli/index.ts:~2623` `if (body.stream)` — `"false"` (truthy) forces SSE; `0`/`""` forces non-stream. Contrast `stream_options.include_usage` which uses `=== true` (`:2097`). Real but low-confidence / client-mis-serialization only. **Fix:** `body.stream === true`.
+
+---
+
+## Falsified by hand-verification (do NOT action as ranked)
+
+- **#5 (raw rank 5, "generate_dflash abort handlers never memset DeltaNet")** — **FALSE for the dominant trigger.** The decode abort handler (`daemon.rs:~5707`) *explicitly* memsets `s_matrices/s_scales/conv_states` + zeros `compact_offset`, with the comment *"stale mid-decode recurrent state from the aborted DFlash run corrupts the next generation (drift → premature EOS)"* — i.e. it **is** the shipped H1 fix, and V4 validated it. The finding's cited lines (4326/4560) point at `load_model_pp`. **Residual sliver (unconfirmed):** the *seed/prefill* abort (`:5426`) clears bookkeeping but does not memset DeltaNet — only a real bug if the seed phase advances *committed* `dn_state` and the next cold prefill doesn't memset. Worth a focused look, but narrow (brief seed-phase window) and not HIGH.
+
+---
+
+## Rejected: 7 (refuted by ≥2/3 skeptics as unreachable / intended / theoretical-only).
+
+## Excluded by design (not hunted)
+- Known-fixed: H1–H4, M1–M9, AR double-advance, #388, #389, the 6 teardown leaks.
+- Separate track: quant-kernel numerical correctness / AWQ+GPTQ KLD (issue #392).
+- Saturated: single-GPU A3B per-token decode coherence (2 prior swarms).


### PR DESCRIPTION
## ⚠️ DRAFT — NOT YET GPU-VALIDATED

Builds green (cargo `--example daemon` + `bun build cli`), but the mandatory
coherence-gate + A3B behavioral validation has **not** run yet. This PR is
intentionally a draft pending a **hiptrx/gfx1201 + Qwen3.6-35B-A3B** run
(this box can't load A3B). Do not merge until the validation matrix below is green.

## What this is

Hunt-3: an adversarial multi-agent bug-hunt over the four engine surfaces the two
prior A3B swarms deliberately left untouched — **multi-GPU/PP**, **sampling + MoE
dispatch**, **daemon concurrency/streaming**, and the **Bun-CLI → backend entry**
(single-GPU A3B decode and the quant track #392 were excluded as saturated /
separate). 109-agent sweep → 3-skeptic perspective-diverse verify → 20 confirmed
findings. Then a **file-disjoint fix team → adversarial review → final fix**
pipeline (the review caught a real bug *in* a fix — see M-B). Catalog:
`docs/investigations/2026-06-03-hunt3-engine-bugs.md`.

## Fixes (16 distinct)

**Sibling-path divergence** — `generate_multi`/`generate_vl` were missing fixes `generate()` already had:
| id | bug | fix |
|----|-----|-----|
| H-A | `generate_multi` (pp>1) Jinja dropped the system prompt + skipped per-request cold-reset on turn 2+ (**the deferred #389 pp twin**) | ungate `try_jinja` + `jinja && seq_pos>0` cold-reset |
| H-F | `generate_vl` force-close emitted tokens with no committed-event → token-id stream desync | `emit_committed_event` in the force-close loop |
| M-A | `generate_multi` forward-error returns left DeltaNet dirty | call `reset_pp_uncommitted_state!` on both error returns |
| M-C | `generate_multi` had no grammar tool-call masking | lift `generate()`'s Matcher wrapper into its sample sites |
| M-D | `generate_vl` repeat-penalty scoped over prompt+gen | re-scope to generated-only |
| M-E | grammar/VL CPU sampler used a process-global wall-clock RNG (cross-request leak) | `llama::reset_cpu_sampler_rng(seed)` per request |
| M-F | OpenAI `stop` silently ignored | parse (cli→daemon) + match in `generate()`, `generate_dflash`, `generate_multi` |

**Memory-safety / leaks** (no `Drop` on `GpuTensor`):
| id | bug | fix |
|----|-----|-----|
| H-E | `forward_prefill_batch_multi` leaked per-band scratch on a later-band OOM (+ the residual intra-`new` partial-literal leak) | free already-allocated tensors on mid-loop alloc failure |
| M-B | NaN logit **panicked** the CPU greedy/argmax/top-k paths | NaN-safe argmax mirroring the GPU kernel (NaN never selected) — deepseek4 `sampling.rs`, `llama.rs`, `mtp_spec.rs`. *(The review caught that the first attempt, `unwrap_or(Less)`, still kept a trailing NaN — re-fixed with a `>`-fold.)* |

**Tokenizer:** H-C — `decode_hex_escapes` `byte as char` re-UTF8'd SentencePiece byte-fallback tokens into mojibake (Llama/SP-family only; Qwen unaffected) → byte-correct `decode_bytes` path + regression test.

**Daemon hardening:** H-D — clamp request-driven `max_seq` to `MAX_REQUESTED_SEQ` (512K) so a JSON-string `max_tokens` can't string-concat into a ~10M `max_seq` OOM. #5-sliver — dflash seed/prefill-abort now zeros DeltaNet (decode-abort already did, via the shipped H1 fix).

**Bun serve** (one stdin/stdout pipe, long-lived multi-client): H-B `recv()` throws `DaemonClosedError` instead of `process.exit` (one daemon crash no longer kills the whole serve; recovery in the generate catch sites **and** `drain()`); B-1 eviction takes the request lock; B-2 `stop()` awaits `proc.exited` before respawn; B-3 foreground-serve pidfile singleton-guard + read-back-compare cleanup; B-4 non-stream errors emit through the controller (no 255s hang); B-5 eviction resets capability state on non-EOF failure; B-6 `run()` HTTP-fallback only local-spawns when serve is gone; C-1 `body.stream === true`.

**Known-minor (deferred):** stop-string not stripped from emitted output + O(n²) re-decode per stop-using step — kept uniform with the shipped AR path, gated behind `!stop.is_empty()`.

## Validation matrix (run on hiptrx/gfx1201 + A3B before un-drafting)

- [ ] `./scripts/coherence-gate.sh` — fluent, on-topic, no attractor (touches forward/sampling/tokenizer)
- [ ] **H-A**: pp=2 + `HIPFIRE_JINJA_CHAT=1`, multi-turn with a system prompt — turn-2+ keeps the system prompt + answers cleanly (vs master rambling)
- [ ] **M-B**: NaN-logit / aggressive-quant greedy decode does not panic the daemon
- [ ] **H-C**: round-trip a CJK/emoji prompt on a SentencePiece/Llama model — bytes correct (no mojibake)
- [ ] **H-E / leaks**: VRAM flat over ~30 gens (pp>1 path) + baseline-return across load/unload cycles
- [ ] **H-B / bun**: kill the daemon mid-request under serve — other clients survive + serve self-restarts
- [ ] **perf**: A/B decode tok/s neutral vs master (all fixes are cold-path or gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
