### PR TITLE
fix(gemm,llama): admit gfx12/RDNA4 in 3 WMMA lm_head + Q8 arch gates

### DIFF
--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -2018,9 +2018,12 @@ fn forward_prefill_chunk(
     let kv_dim = config.n_kv_heads * config.head_dim;
     let dim_row_bytes = dim * 4;
     // Q8 WMMA arch gate — see qwen35.rs q8_wmma_arch for the matching capture
-    // and rationale (gfx11-only; gfx12 needs a `_w32_gfx12` builtin variant
-    // that has not been authored yet, so routing gfx12 here would crash at JIT).
-    let q8_wmma_arch = gpu.arch_caps.has_wmma_w32();
+    // and rationale. RDNA3 (_w32 builtin) AND RDNA4 (_w32_gfx12 builtin): the
+    // fused qkv/gate_up/residual Q8 WMMA helpers route is_rdna4()→_gfx12
+    // internally (gemm_qkv_q8_0_wmma_gfx12 et al., silicon-validated on R9700),
+    // so has_wmma() is the correct gate — matches qwen35.rs:9008. Bare
+    // has_wmma_w32() left RDNA4 on the slower unfused per-projection path.
+    let q8_wmma_arch = gpu.arch_caps.has_wmma();
 
     // 1. Embed N tokens into pbs.x_batch.
     if matches!(

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -14401,7 +14401,7 @@ impl Gpu {
         // ~26.68% of composition cycle wall in this scalar path).
         let arch = self.arch.as_str();
         let wmma_eligible = batch_size > 1
-            && self.arch_caps.has_wmma_w32()
+            && (self.arch_caps.has_wmma_w32() || self.arch_caps.has_wmma_w32_gfx12())
             && !self.flags.fp16_disabled
             && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {
@@ -14457,7 +14457,7 @@ impl Gpu {
         // this wrapper just needed the gate widened.
         let arch_str = self.arch.as_str();
         let wmma_eligible = batch_size > 1
-            && self.arch_caps.has_wmma_w32()
+            && (self.arch_caps.has_wmma_w32() || self.arch_caps.has_wmma_w32_gfx12())
             && !self.flags.fp16_disabled
             && !self.flags.lm_head_wmma_disabled;
         if wmma_eligible {


### PR DESCRIPTION
## Fix 3 RDNA4 (gfx12) dead-gates in WMMA lm_head + Q8 prefill paths

Three `has_wmma_w32()` arch gates on master are **gfx11-only** (`has_wmma_w32() == is_rdna3`, FALSE on RDNA4), so on gfx1200/gfx1201 the WMMA path is unreachable and execution silently falls to a slower scalar/unfused path — even though the gfx12 WMMA kernels ship and are exercised elsewhere. Corroborates the 2026-06-03 codebase-audit findings D-1/D-2.

### The fixes (all widen to `(has_wmma_w32() || has_wmma_w32_gfx12())`, matching the correct sibling `gemm_hfq3g256_batched_lmhead`)

| # | Site | Bug | gfx12 kernel (confirmed exists) |
|---|------|-----|------|
| 1 | `gemm_hfq4g256_batched_lmhead` (gemm.rs) | #342 refactor dropped the `\|\| has_wmma_w32_gfx12()` term; inner `if arch.starts_with("gfx12")` branch unreachable on RDNA4 → scalar `gemm_hfq4g256` (~8-10× slower; audit rocprof ~26% of DFlash composition wall) | `gemm_hfq4g256_residual_wmma_gfx12` |
| 2 | `gemm_hfq6g256_batched_lmhead` (gemm.rs) | Same pattern; the in-code comment claims "this wrapper just needed the gate widened" — but it wasn't | `gemm_hfq6g256_residual_wmma_gfx12` |
| 3 | `forward_prefill_chunk` Q8 gate (llama.rs) | `has_wmma_w32()` left RDNA4 on the unfused per-projection path; the stale comment ("`_w32_gfx12` not authored yet, would crash at JIT") is false — those kernels exist and are silicon-validated. Sibling `qwen35.rs:9008` already uses `has_wmma()` | `gemm_qkv/gate_up/q8_0_residual_q8_0_wmma_gfx12` |

### Methodology — full sweep, not a blind replace
Swept **all 27** `has_wmma_w32()` call sites with a classify → adversarial-verify pass (each proposed fix had to prove the gfx12 kernel it routes to **actually exists**, so widening can't produce a `MissingImpl`/crash):
- **3 confirmed dead-gate bugs** (above)
- **16 correctly RDNA3-only** — gfx12 handled by a separate dispatch arm; left unchanged
- **1 correctly scalar** — `gemm_f16_batched_lmhead` has no gfx12 f16-lmhead WMMA kernel, so scalar on RDNA4 is correct (authoring one would be a feature, not a fix)

### Validation (hiptrx, R9700 / gfx1201)
- `coherence-gate.sh --full`: **0 hard errors** (coherent)
- `coherence-gate-dflash.sh`: **0 hard errors** — exercises fix #1 via batched verify
- Warm A/B (2 tight samples/side, byte-identical dflash prose prompt, fresh process), non-tree `dflash-prose`: **34.52 → 40.66 tok/s (+17.8%)**. Cold first-run discarded per perf methodology.

Fixes #2/#3 are parity-validated (identical pattern; gfx12 kernels confirmed to exist and already exercised via the residual dispatcher / qwen35 forward) but not directly hardware-exercised here (no HFQ6-lm_head or llama-arch-Q8 model in the gate matrix).

### Relationship to #393
Same dead-gate **class** as the gfx12 fix in #393, but a **different layer**: #393's fix is in the new `hipfire-dispatch` crate (which only exists on that branch); these three are in existing master code. #393 carries the identical bare gates (inherited from master) and will pick these up on its next rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
