### PR TITLE
docs: fix stale KV defaults + DFlash-gate thresholds + false GPU-lock claim + crates/engine rot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,14 @@ works, what to measure, what counts as pass/fail.
    gate.sh is deprecated — its byte-exact baselines drift faster than
    the engine evolves. Run `./scripts/coherence-gate-dflash.sh` after
    any change touching kernels, quant formats, dispatch, fusion,
-   rotation, rmsnorm, or the spec-decode path.
+   rotation, rmsnorm, or the spec-decode path. Its detector enforces
+   three tiers (matching the CLAUDE.md "DFlash Coherence Gate" section):
+   **Tier 1** (first 128 tokens, HARD fail) `unique_token_ratio < 0.15`
+   OR `max_single_token_frequency > 0.50`; **Tier 2** (last 128 tokens,
+   HARD fail) `unique_token_ratio < 0.30` OR
+   `max_single_token_frequency > 0.50`; **Tier 3** (full output, SOFT
+   `FLAG` for human eyeball) consecutive-3gram repetition density > 0.50
+   in the final half OR full-output `unique_token_ratio < 0.10`.
 2. **Prompt structure dictates τ.** One newline character can swing τ
    by 17%. Any tok/s comparison across sessions, agents, or commits
    MUST use **byte-identical prompts**. Embed prompts as committed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,7 +325,9 @@ now implemented in `hipfire-detect::ngram` as a soft warn.
 
 Any DDTree / spec-decode / slow-path-kill change that claims a τ or tok/s
 improvement MUST pass `scripts/coherence-gate-dflash.sh` (shipped 9883e98)
-before commit. Enhanced three-tier thresholds (as of 2026-04-26):
+before commit. The script's inline detector enforces all three tiers below:
+Tier 1 + Tier 2 are hard fails (non-zero exit), Tier 3 is a soft `FLAG`
+status in the report for human eyeball. Thresholds (as of 2026-04-26):
 
 **Tier 1 — First 128 tokens (hard fail, catches single-token attractors):**
 - `unique_token_ratio < 0.15` OR `max_single_token_frequency > 0.50`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,8 +400,8 @@ identically.
 correctness cost. Opt out with `HIPFIRE_NORMALIZE_PROMPT=0` (or
 `prompt_normalize=false` in config) only when raw `\n{3,}` whitespace is
 semantically load-bearing. See:
-- `crates/engine/src/tokenizer.rs:maybe_normalize_prompt()` — engine impl
-- `crates/engine/examples/encode_prompt.rs` — verification utility
+- `crates/hipfire-runtime/src/tokenizer.rs:maybe_normalize_prompt()` — engine impl
+- `crates/hipfire-runtime/examples/encode_prompt.rs` — verification utility
 - commit 9a2c667 — root cause + bench data behind the default flip
 
 **Canonical bench config (post-2026-04-26) for 27B-3.5 LRU code DFlash:**
@@ -419,15 +419,16 @@ only. Drift >5% from the current q8/max256 baseline is a regression
 ## GPU Lock Protocol (Multi-Agent)
 
 When multiple Claude Code agents work in parallel (e.g. via worktrees), they coordinate
-GPU access through `gpu-lock.sh`. **This is enforced automatically via hooks in
-`.claude/settings.json`** — any `cargo` command triggers lock acquire before execution
-and release after completion.
+GPU access through `scripts/gpu-lock.sh`. **Coordination is currently MANUAL** — there is
+no committed hook that auto-acquires the lock. (`.claude/settings.json` is not tracked in
+the repo; if you want `cargo` commands to auto-acquire/release, wire a PreToolUse/PostToolUse
+hook in your own local `.claude/settings.json` that sources `scripts/gpu-lock.sh`.)
 
 - Lock file: `/tmp/hipfire-gpu.lock`
 - Contains a human-readable status like `model-ingestion agent is using the gpu`
 - Agents poll every 5s (configurable via `GPU_POLL_INTERVAL`) when the GPU is busy
-- Manual usage: `source gpu-lock.sh && gpu_acquire "<branch>" && gpu_release`
-- Check status: `source gpu-lock.sh && gpu_status`
+- Manual usage: `source scripts/gpu-lock.sh && gpu_acquire "<branch>" && gpu_release`
+- Check status: `source scripts/gpu-lock.sh && gpu_status`
 
 ## Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,9 +137,9 @@ the skill end-to-end and shipped a full validated 5-kernel port +
 ### New model architectures
 
 Start with [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)'s "Two model
-paths" section — `crates/engine/src/llama.rs` is the template for
-dense Llama-style models, `qwen35.rs` is the Qwen 3.5 hybrid path
-with DeltaNet linear attention. Add the architecture string to
+paths" section — `crates/hipfire-runtime/src/llama.rs` is the template
+for dense Llama-style models, `crates/hipfire-arch-qwen35/src/qwen35.rs`
+is the Qwen 3.5 hybrid path with DeltaNet linear attention. Add the architecture string to
 `from_gguf` / `from_hfq` and patch the tensor-shape divergences.
 
 For a new GGUF dequant type (Q5_K, IQ-quants, etc.), port from

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,10 +1,16 @@
 # Benchmarks
 
-All measurements on the indicated arch with the engine's default config
-(asym3 KV, FlashAttention auto, prompt_normalize=on). Numbers are
+All measurements on the indicated arch with the engine's then-default
+config (asym3 KV, FlashAttention auto, prompt_normalize=on). Numbers are
 medians across 5 runs unless noted. See
 [methodology/perf-benchmarking.md](methodology/perf-benchmarking.md) for
 the protocol and the noise band you should expect when reproducing.
+
+> **KV-mode note:** these numbers were measured pre-fwht3-default (the
+> per-arch default is now `fwht3`/`fwht2`, not `asym3`). They remain
+> valid for `asym3` KV. `fwht3` shares `asym3`'s byte layout and is
+> perf-equivalent (it differs only in K-rotation basis), so the decode /
+> BW figures carry over; the asym3 rows are not re-benched here.
 
 ## Autoregressive decode (no spec) — 7900 XTX (gfx1100)
 
@@ -28,7 +34,8 @@ target's high-entropy continuations diverge from draft predictions can
 be a net loss.
 
 5-run medians, asym3 KV, `--no-chatml`, `max_tokens=120`,
-`prompt_normalize=true`:
+`prompt_normalize=true` (measured pre-fwht3-default; numbers remain
+valid for asym3 KV):
 
 | Model | genre | AR tok/s | DFlash tok/s | speedup | τ |
 |---|---|---:|---:|---:|---:|
@@ -52,7 +59,8 @@ on.
 
 ## vs ollama (Q4_K_M GGUF) — 7900 XTX
 
-Same machine, same models. hipfire MQ4 (asym3 KV, FlashAttention) vs
+Same machine, same models. hipfire MQ4 (asym3 KV, FlashAttention;
+measured pre-fwht3-default, numbers remain valid for asym3 KV) vs
 ollama default Q4_K_M through llama.cpp's ROCm backend. Matched
 ~140-token and ~530-token prompts and matched 128-token generation
 lengths. Ollama numbers extracted from its own `prompt_eval_duration` /

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,12 +27,27 @@ Edit interactively with `hipfire config` (global) or `hipfire config
 
 | Key | Default | Values |
 |---|---|---|
-| `kv_cache` | auto (per arch) | auto / q8 / asym4 / asym3 / asym2 / turbo / turbo4 / turbo3 / turbo2 |
+| `kv_cache` | auto (per arch) | auto / q8 / fwht4 / fwht3 / fwht2 / asym4 / asym3 / asym2 / turbo / turbo4 / turbo3 / turbo2 |
+| `kv_adaptive` | off | off / conservative / balanced / aggressive / `advanced:k=<fwht4\|fwht3\|fwht2>,v=<lloyd4\|lloyd3\|lloyd2>` |
 
-Per-arch defaults: gfx1100 → asym3, gfx1030 → asym3, gfx1010/1013 →
-asym2. asym3 is rotated K (Lloyd-Max) + Q8 V — the multi-turn quality
-sweet spot. Use `q8` for byte-exact reference behavior at higher VRAM
-cost.
+Per-arch defaults (live, set in `cli/index.ts::archDefaults`): **fwht3**
+on RDNA3+ (gfx1100/1101/1102), RDNA4 (gfx1200/1201), and the
+larger-VRAM RDNA2 parts (gfx1030/1031); **fwht2** on the tight-memory
+parts — RDNA1 (gfx1010/1013), gfx1032 (6600 XT 8 GB), and gfx1151
+(Strix Halo APU, shared memory). The unknown-arch fall-through is
+fwht3. `fwhtN` is FWHT-rotated K (N-bit) + Q8 V — same ~5.5×
+compression and byte layout as the legacy `asymN` Givens modes, but the
+K-rotation basis matches the MQ4 weight/draft FWHT convention so DFlash
+speculative acceptance stays high. Use `q8` for byte-exact reference
+behavior at higher VRAM cost; the `asym*` modes are the legacy Givens
+behavior (kept for backward compat).
+
+`kv_adaptive` (opt-in, default off) downshifts K/V precision at runtime
+to fit growing context. The `conservative`/`balanced`/`aggressive`
+presets pick a built-in floor/threshold schedule; the
+`advanced:k=...,v=...` form pins an explicit K floor (fwht4/fwht3/fwht2)
+and V floor (lloyd4/lloyd3/lloyd2). With adaptive on, `max_seq` is the
+context guaranteed at the floor tier.
 
 ## Speculative decode (DFlash)
 
@@ -154,8 +169,10 @@ hipfire config cask-profile                            # list active + available
 | `conservative` | budget=2048, ≈275 MB on 27B | ≥20 GB VRAM, very long advertised contexts | dense only |
 | `aggressive-vram` | budget=512, ≈96 MB on 27B | dense 27B on a 16 GB card with tight headroom; aggressive long-ctx fit | **AR only** — m-fold + DFlash has a documented attractor regression. Set `dflash_mode=off`. Not for A3B. |
 
-¹ KV footprint estimates for dense 27B with `kv_cache=asym3` (~107 KB/token).
-Scale linearly with the model's `n_layers × n_kv_heads × head_dim`.
+¹ KV footprint estimates for dense 27B with `kv_cache=fwht3` (~107 KB/token;
+the legacy `asym3` shares the identical 3-bit-K + Q8-V byte layout, so the
+estimate holds for either). Scale linearly with the model's
+`n_layers × n_kv_heads × head_dim`.
 
 Picking a profile rewrites a bundle of CASK config keys in one shot. The
 `balanced` / `conservative` / `aggressive-vram` profiles set the policy
@@ -350,7 +367,7 @@ Delete a row's override with the TUI's `d` key.
 For testing without touching the config file:
 
 ```
-HIPFIRE_KV_MODE=asym3
+HIPFIRE_KV_MODE=fwht3
 HIPFIRE_ATTN_FLASH=auto
 HIPFIRE_NORMALIZE_PROMPT=0          # opt out of \n{3,} collapse
 HIPFIRE_LOCAL=1                     # skip the running daemon

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -88,7 +88,8 @@ hipfire config qwen3.5:9b                        # per-model overlay
 ```
 
 Common overrides: `temperature` (default 0.30), `kv_cache` (default
-`asym3`), `dflash_mode` (default `auto`). Full key list in
+`auto` → per-arch: `fwht3` on most arches, `fwht2` on tight-memory
+parts), `dflash_mode` (default `auto`). Full key list in
 [CONFIG.md](CONFIG.md).
 
 ## Long context: KV cache eviction

--- a/docs/QUANTIZATION.md
+++ b/docs/QUANTIZATION.md
@@ -110,10 +110,23 @@ impact on long-context inference.
 mode      K layout                              V layout
 ─────────────────────────────────────────────────────────
 q8        Q8_0 (32-element blocks)              Q8_0
-asym4     Lloyd-Max rotated 4-bit               Q8_0
-asym3     Lloyd-Max rotated 3-bit  (default)    Q8_0
-asym2     rotated 2-bit                         Q8_0
+fwht4     FWHT-rotated 4-bit                    Q8_0
+fwht3     FWHT-rotated 3-bit  (default*)        Q8_0
+fwht2     FWHT-rotated 2-bit  (default*)        Q8_0
+asym4     Lloyd-Max (Givens) rotated 4-bit      Q8_0   (legacy)
+asym3     Lloyd-Max (Givens) rotated 3-bit      Q8_0   (legacy)
+asym2     Givens-rotated 2-bit                  Q8_0   (legacy)
 ```
+
+\* The live default is `fwht3` on most arches and `fwht2` on the
+tight-memory parts — see the per-arch table below. The `fwhtN` modes
+share the byte layout of the legacy `asymN` Givens modes but rotate K on
+the FWHT basis the MQ4 weights/draft are calibrated against, which keeps
+DFlash speculative acceptance high (the Givens `asym*` basis degrades it
+→ attractors under DFlash). The `asym*` modes remain available for the
+legacy Givens behavior. An adaptive runtime-downshift policy
+(`kv_adaptive`) can lower these tiers further as context grows — see
+`docs/CONFIG.md`.
 
 K and V are quantized differently because they have different
 sensitivities. K participates in the softmax — small numerical errors
@@ -132,25 +145,34 @@ not a uniform scale + zero. The codebook is two floats (min / max)
 plus 2^K codes implied uniformly between them — same storage cost as
 asymmetric uniform, slightly better fit on the actual K distribution.
 
-## Asym KV per arch defaults
+The rotation basis differs by mode family: the live default `fwhtN`
+modes rotate K on the FWHT (Walsh-Hadamard) basis the MQ4 weights/draft
+are calibrated against; the legacy `asymN` modes use a Givens rotation
+with the Lloyd-Max codebook described above. Same K-bitwidth byte cost
+either way.
+
+## KV cache per-arch defaults
 
 Set in `cli/index.ts::archDefaults`. Override with `hipfire config set
 kv_cache <mode>` or `HIPFIRE_KV_MODE=<mode>` env.
 
 | Arch | Default | Reason |
 |---|---|---|
-| gfx1100 (7900 XTX) | asym3 | 24 GB VRAM affords it; quality matches Q8 |
-| gfx1101 (7900 XT) | asym3 | Same |
-| gfx1102 (7800 XT) | asym3 | Same |
-| gfx1030 (V620 / 6800 XT) | asym3 | 32 GB on V620 — plenty of headroom |
-| gfx1031 (6700 XT) | asym3 | 12 GB |
-| gfx1032 (6600 XT) | asym2 | 8 GB — tighter quant for headroom |
-| gfx1010 (5700 XT) | asym2 | 8 GB |
-| gfx1013 (BC-250 APU) | asym2 | 14 GB shared, prioritize ctx length |
-| gfx1151 (Strix Halo APU) | asym2 | 16 GB shared |
-| gfx1200 (9070 XT) | asym3 | 16 GB |
-| (default fall-through) | asym3 | Includes gfx94x / MI300X — override to `q8` if you have spare HBM |
+| gfx1100 (7900 XTX) | fwht3 | 24 GB VRAM affords it; quality matches Q8 |
+| gfx1101 (7900 XT) | fwht3 | Same |
+| gfx1102 (7800 XT) | fwht3 | Same |
+| gfx1030 (V620 / 6800 XT) | fwht3 | 32 GB on V620 — plenty of headroom |
+| gfx1031 (6700 XT) | fwht3 | 12 GB |
+| gfx1032 (6600 XT) | fwht2 | 8 GB — tighter quant for headroom |
+| gfx1010 (5700 XT) | fwht2 | 8 GB |
+| gfx1013 (BC-250 APU) | fwht2 | 14 GB shared, prioritize ctx length |
+| gfx1151 (Strix Halo APU) | fwht2 | shared LPDDR5x — tight |
+| gfx1200 (9070 XT) | fwht3 | 16 GB |
+| gfx1201 (9070 XT / R9700) | fwht3 | 16 GB |
+| (default fall-through) | fwht3 | Includes gfx94x / MI300X — override to `q8` if you have spare HBM |
 
+The `fwhtN` defaults replaced the legacy `asymN` Givens modes (same byte
+layout, FWHT-rotated K) so DFlash speculative acceptance stays high.
 Override with `hipfire config set kv_cache <mode>` or
 `HIPFIRE_KV_MODE=<mode>` env.
 

--- a/docs/plans/cdna-calibration-optimization.prd
+++ b/docs/plans/cdna-calibration-optimization.prd
@@ -18,8 +18,8 @@ Goal: flip GPU-default at production chunk_len, plus targeted kernel-side optimi
 
 ## Reference
 
-- `crates/engine/examples/triattn_validate.rs` — calibration harness, owns the CPU-vs-GPU dispatch.
-- `crates/engine/src/triattn.rs` — TriAttention scoring + accumulator kernels.
+- `crates/hipfire-runtime/examples/triattn_validate.rs` — calibration harness, owns the CPU-vs-GPU dispatch.
+- `crates/hipfire-runtime/src/triattn.rs` — TriAttention scoring + accumulator kernels.
 - `kernels/src/triattn_score_*.hip` — per-arch score-extract kernels.
 - Phase B/C measurements: `project/mi300x_phase_b_done_phase_c_running_2026_04_26.md`.
 - rocBLAS / MFMA validation: `project_rocblas_mfma_validation.md` (MI300X 4.46× prefill, default-on for CDNA3).

--- a/docs/plans/completions_vision.md
+++ b/docs/plans/completions_vision.md
@@ -510,7 +510,7 @@ final streaming chunk before `[DONE]`.
 |---|---|
 | `engine/src/image.rs` | Add `load_and_preprocess_from_bytes()` with `Result` return; extract shared `preprocess_dynamic_image(DynamicImage, ...)` helper; add dimension ceiling check; add format-specific error messages |
 | `engine/Cargo.toml` | Add `base64 = "0.22"` dependency |
-| `crates/engine/examples/daemon.rs` | Parse `image_base64` in generate dispatch; refactor `generate_vl` to take `GenerateVLParams` struct with `ImageSource` enum; decode base64 + from-bytes path; move capacity guard below preprocess; fix log line for bytes path; error on `image` + non-VL model (was silent-ignore) |
+| `crates/hipfire-runtime/examples/daemon.rs` | Parse `image_base64` in generate dispatch; refactor `generate_vl` to take `GenerateVLParams` struct with `ImageSource` enum; decode base64 + from-bytes path; move capacity guard below preprocess; fix log line for bytes path; error on `image` + non-VL model (was silent-ignore) |
 | `cli/index.ts` | Add `extractContent()` (keep `extractText` as wrapper); MIME validation on `data:` URIs; multi-turn VL rejection (400); multi-image rejection (400); track `modelHasVL` at 3 write sites; add `image_base64` to `genParams`; remove both image guards (787 + 1123); bump `requiredMaxSeq` for visual tokens; map daemon errors to HTTP status codes |
 
 ---

--- a/docs/plans/mq-sub4bit-prd.md
+++ b/docs/plans/mq-sub4bit-prd.md
@@ -50,7 +50,7 @@ Prove (or disprove) that `gemv_mq3g256_with_rotate` and `gemv_mq2g256_with_rotat
 
 ### 3.2 Method
 
-- **Harness:** `crates/engine/examples/verify_mq_kernel.rs` (committed 2026-04-30).
+- **Harness:** `crates/hipfire-runtime/examples/verify_mq_kernel.rs` (committed 2026-04-30).
 - **Inputs:** Deterministic pseudo-random weights and activations (`fract_sin` PRNG) at shapes `(4,256)`, `(4,512)`, `(8,1024)`.
 - **CPU reference:**
   1. Rotate `x` with `cpu_fwht_256(signs1, signs2)` matching quantizer math exactly.

--- a/docs/plans/mq-sub4bit-research-queue.md
+++ b/docs/plans/mq-sub4bit-research-queue.md
@@ -62,7 +62,7 @@ rounding) to a CPU reference of the same math.
 
 ### Owner / files
 
-- New: `crates/engine/examples/verify_mq3_kernel.rs` (CPU/GPU compare).
+- New: `crates/hipfire-runtime/examples/verify_mq3_kernel.rs` (CPU/GPU compare).
 - Reads: `crates/rdna-compute/src/dispatch.rs` (kernel wrapper), 
   `kernels/src/gemv_hfq3g256.hip` (decode formula),
   `crates/hipfire-quantize/src/main.rs` (`quantize_mq3g256` output layout).
@@ -202,7 +202,7 @@ codebooks fine. They're NOT per-block Lloyd-Max — that's what Q1 adds.
 ### Files
 
 - `crates/hipfire-quantize/src/main.rs`: new `quantize_mq2g256_lloyd`.
-- `crates/engine/src/hfq.rs`: qt 19 → `DType::MQ2G256Lloyd`.
+- `crates/hipfire-runtime/src/hfq.rs`: qt 19 → `DType::MQ2G256Lloyd`.
 - `crates/rdna-compute/src/dispatch.rs`: new dispatch arm + GEMV
   wrapper paralleling `gemv_mq2g256_with_rotate`.
 - `kernels/src/gemv_mq2g256_lloyd.hip`: new — codebook-lookup variant.
@@ -260,7 +260,7 @@ needs Q2 (GPTQ) or Q4 (mixed-precision) on top.
 | `quantize_mq3g256_lloyd` (parallel rayon `par_chunks_mut`) | `crates/hipfire-quantize/src/main.rs` | ~110 |
 | `gemv_mq3g256_lloyd.hip` (8-way switch codebook lookup) | `kernels/src/` | ~85 |
 | `DType::MQ3G256Lloyd` + dispatch wrappers | `crates/rdna-compute/src/dispatch.rs` | ~30 |
-| Engine load arms (qt=20 in 3 sites + DeltaNet CPU dequant) | `crates/engine/src/{hfq,llama,qwen35}.rs` | ~80 |
+| Engine load arms (qt=20 in 3 sites + DeltaNet CPU dequant) | `crates/hipfire-runtime/src/{hfq,llama}.rs + crates/hipfire-arch-qwen35/src/qwen35.rs` | ~80 |
 | `--allow-mq3-lloyd` / `HIPFIRE_ALLOW_MQ3_LLOYD=1` guard | quantizer | ~15 |
 
 Quantize time: 9B Lloyd-MQ3 ~85s wall on 24-core (rayon parallelized over
@@ -301,7 +301,7 @@ uniform MQ3 from 114 → 141). Tracked separately.
 
 - `benchmarks/results/lloyd_max_findings_20260501.md` — full empirical
   writeup with all four formats compared.
-- `crates/engine/examples/perplexity.rs` — single-window NLL harness
+- `crates/hipfire-runtime/examples/perplexity.rs` — single-window NLL harness
   (issue #113 alpha→beta gate is now answered by data, not eyeball).
 - Engine wiring as above.
 

--- a/docs/plans/path_d.md
+++ b/docs/plans/path_d.md
@@ -186,7 +186,7 @@ if convenient.
 
 #### D0a — `commit_staging_to_ring` async-on-stream
 
-**File:** `crates/engine/src/speculative.rs:1302-1338`
+**File:** `crates/hipfire-arch-qwen35/src/speculative.rs:1302-1338`
 
 Today the function host-blocks on `stream_synchronize(active_stream)` (line
 1311) and then issues sync `memcpy_dtod_at` calls (lines 1316-1333), all on
@@ -220,7 +220,7 @@ within ±2 % on speed-gate (per-class).
 
 #### D0b — `scatter_hidden_block_to_interleaved` async-on-stream
 
-**File:** `crates/engine/src/speculative.rs:2238-2273`
+**File:** `crates/hipfire-arch-qwen35/src/speculative.rs:2238-2273`
 
 Today the function uses sync `memcpy_dtod_at` (line 2263) inside a 2D loop.
 Add a new variant:
@@ -247,7 +247,7 @@ unchanged.
 
 #### D0c — Thread `stream_override: Option<&Stream>` through `draft_forward`
 
-**File:** `crates/engine/src/dflash.rs:663` plus every kernel/memset callee.
+**File:** `crates/hipfire-runtime/src/dflash.rs:663` plus every kernel/memset callee.
 
 Today `draft_forward(gpu: &mut Gpu, ...)` rides on `gpu.active_stream`
 implicitly. Add a `stream_override: Option<&Stream>` parameter and route every
@@ -316,7 +316,7 @@ set, `gpu.draft_stream.is_some()` becomes true after the first
 
 ### D2 — DflashScratchPair + draft lm_head scratch
 
-**File:** `crates/engine/src/dflash.rs:304-393`
+**File:** `crates/hipfire-runtime/src/dflash.rs:304-393`
 
 Path D needs two `DflashScratch` instances so cycle N can write while cycle
 N+1 reads. Add:
@@ -392,7 +392,7 @@ this is split into two PR commits on top of the D0 refactors.
 
 #### D3a — Hoist commit out of `verify_dflash_block_inner`
 
-**File:** `crates/engine/src/speculative.rs:2057`
+**File:** `crates/hipfire-arch-qwen35/src/speculative.rs:2057`
 
 The commit at speculative.rs:2057 lives **inside** `verify_dflash_block_inner`,
 not at the top-level cycle scope. The pipelined cycle structure needs to
@@ -410,7 +410,7 @@ This is a small, byte-exact-at-default refactor. Land it before D3b.
 
 #### D3b — `spec_step_dflash` mode flag (refactor, not mirror)
 
-**File:** `crates/engine/src/speculative.rs:2384`
+**File:** `crates/hipfire-arch-qwen35/src/speculative.rs:2384`
 
 **Update from v1:** *do not mirror* `spec_step_dflash` into a sibling 700 LOC
 function. Instead, refactor `spec_step_dflash` to take a `pipeline_mode: bool`
@@ -489,7 +489,7 @@ of the 779 LOC core.
 
 ### D4 — Adaptive bypass (τ guard)
 
-**File:** `crates/engine/src/speculative.rs` (within `spec_step_dflash`,
+**File:** `crates/hipfire-arch-qwen35/src/speculative.rs` (within `spec_step_dflash`,
 pipelined branch).
 
 Telemetry already tracks accept-length per cycle (drives adaptive-B). Add a
@@ -581,10 +581,10 @@ Sequence (each step blocks on the previous):
 
 | File | Change |
 |------|--------|
-| `crates/engine/src/speculative.rs:1302-1338` | D0a — `commit_staging_to_ring_on_stream(&Stream)` async variant; thin wrapper preserves old API |
-| `crates/engine/src/speculative.rs:2238-2273` | D0b — `scatter_hidden_block_to_interleaved_on_stream(&Stream, head_snapshot)` async variant |
-| `crates/engine/src/dflash.rs:663` | D0c — `stream_override: Option<&Stream>` parameter on `draft_forward`; thread through callees |
-| `crates/engine/src/dflash.rs` (helpers) | D0c — propagate `stream_override` to upload_slice_f32 path, memset_async helper, kernel launches |
+| `crates/hipfire-arch-qwen35/src/speculative.rs:1302-1338` | D0a — `commit_staging_to_ring_on_stream(&Stream)` async variant; thin wrapper preserves old API |
+| `crates/hipfire-arch-qwen35/src/speculative.rs:2238-2273` | D0b — `scatter_hidden_block_to_interleaved_on_stream(&Stream, head_snapshot)` async variant |
+| `crates/hipfire-runtime/src/dflash.rs:663` | D0c — `stream_override: Option<&Stream>` parameter on `draft_forward`; thread through callees |
+| `crates/hipfire-runtime/src/dflash.rs` (helpers) | D0c — propagate `stream_override` to upload_slice_f32 path, memset_async helper, kernel launches |
 
 ### Phase D1–D5 (Path D PR, on top of D0)
 
@@ -592,12 +592,12 @@ Sequence (each step blocks on the previous):
 |------|--------|
 | `crates/rdna-compute/src/dispatch.rs:226-227` | D1 — delete `verify_stream` field; keep only `draft_stream` |
 | `crates/rdna-compute/src/dispatch.rs:434-435` | D1 — `init_pipeline_streams()`, DPM warmup hook for draft stream, `Drop` cleanup |
-| `crates/engine/src/dflash.rs:304-393` | D2 — `DflashScratchPair` struct (gated env=1 alloc, drop_unused_half, draft_lm_head buffers) + ctor |
-| `crates/engine/src/speculative.rs` (verify_dflash_block_inner) | D3a — `skip_internal_commit: bool` parameter |
-| `crates/engine/src/speculative.rs:2384` | D3b — `pipeline_mode: bool` branch in `spec_step_dflash`; snapshot-head, async scatter, cross-stream events |
-| `crates/engine/src/speculative.rs` (top) | D4 — rolling-τ helper, per-class baseline cache, bypass state |
-| `crates/engine/examples/dflash_spec_demo.rs` | D1–D5 — thread env-flag to scratch alloc + step selection |
-| `crates/engine/examples/daemon.rs` | D1–D5 — same threading; daemon path also calls `spec_step_dflash` (line 1717) and was missed in v1 touch list |
+| `crates/hipfire-runtime/src/dflash.rs:304-393` | D2 — `DflashScratchPair` struct (gated env=1 alloc, drop_unused_half, draft_lm_head buffers) + ctor |
+| `crates/hipfire-arch-qwen35/src/speculative.rs` (verify_dflash_block_inner) | D3a — `skip_internal_commit: bool` parameter |
+| `crates/hipfire-arch-qwen35/src/speculative.rs:2384` | D3b — `pipeline_mode: bool` branch in `spec_step_dflash`; snapshot-head, async scatter, cross-stream events |
+| `crates/hipfire-arch-qwen35/src/speculative.rs` (top) | D4 — rolling-τ helper, per-class baseline cache, bypass state |
+| `crates/hipfire-runtime/examples/dflash_spec_demo.rs` | D1–D5 — thread env-flag to scratch alloc + step selection |
+| `crates/hipfire-runtime/examples/daemon.rs` | D1–D5 — same threading; daemon path also calls `spec_step_dflash` (line 1717) and was missed in v1 touch list |
 | `crates/hip-bridge/src/ffi.rs` | (none — APIs already exposed) |
 | `docs/methodology/perf-benchmarking.md` | D5 — bench-matrix results, baseline update, bandwidth-contention finding |
 

--- a/docs/plans/pflash-speculative-prefill.prd
+++ b/docs/plans/pflash-speculative-prefill.prd
@@ -58,13 +58,13 @@ hipfire already has several ingredients that make a native version plausible:
 
 | Need | Existing hipfire surface |
 |---|---|
-| Quantized 27B target | HFQ / MQ4 / MQ3 target loading in `crates/engine/src/qwen35.rs` and daemon load path |
+| Quantized 27B target | HFQ / MQ4 / MQ3 target loading in `crates/hipfire-arch-qwen35/src/qwen35.rs` and daemon load path |
 | Fast prefill chunks | `qwen35::forward_prefill_batch` / `forward_prefill_batch_with_pbs` |
-| Spec-decode handoff | `crates/engine/src/dflash.rs`, `crates/engine/src/speculative.rs`, `crates/engine/src/ddtree.rs` |
-| Long-context KV formats | `llama::KvCache` asym2/asym3/asym4/q8 paths in `crates/engine/src/llama.rs` |
-| KV / hidden compaction concepts | TriAttention / CASK scaffolding in `crates/engine/src/triattn.rs` and `crates/engine/src/cask.rs` |
+| Spec-decode handoff | `crates/hipfire-runtime/src/dflash.rs`, `crates/hipfire-arch-qwen35/src/speculative.rs`, `crates/hipfire-runtime/src/ddtree.rs` |
+| Long-context KV formats | `llama::KvCache` asym2/asym3/asym4/q8 paths in `crates/hipfire-runtime/src/llama.rs` |
+| KV / hidden compaction concepts | TriAttention / CASK scaffolding in `crates/hipfire-runtime/src/triattn.rs` and `crates/hipfire-runtime/src/cask.rs` |
 | HIP kernel pipeline | `kernels/src/*.hip`, `crates/rdna-compute/src/kernels.rs`, `crates/rdna-compute/src/dispatch.rs` |
-| Daemon state machine | `crates/engine/examples/daemon.rs` |
+| Daemon state machine | `crates/hipfire-runtime/examples/daemon.rs` |
 
 PFlash should be treated as a **front-of-prefill compression stage**, not as a replacement for DFlash decode. It should produce a shorter token stream that the target prefills normally.
 
@@ -178,7 +178,7 @@ The target sees the compressed stream as the actual prompt. Positions are contig
 Add a new module:
 
 ```text
-crates/engine/src/pflash.rs
+crates/hipfire-arch-qwen35/src/pflash.rs
 ```
 
 Suggested API:
@@ -229,7 +229,7 @@ pub fn maybe_compress_prompt(
 
 Initial drafter target: Qwen3-0.6B.
 
-Because `crates/engine/examples/daemon.rs` currently loads target models from HFQ, the cleanest first implementation is:
+Because `crates/hipfire-runtime/examples/daemon.rs` currently loads target models from HFQ, the cleanest first implementation is:
 
 1. Add or extend quantizer support so `hipfire-quantize` can produce a Qwen3-0.6B BF16 or MQ4 HFQ drafter artifact.
 2. Require tokenizer compatibility with the target:
@@ -277,7 +277,7 @@ benchmarks/longctx/niah/
   niah_64k.jsonl
   niah_128k.jsonl
 
-crates/engine/examples/pflash_niah_bench.rs
+crates/hipfire-runtime/examples/pflash_niah_bench.rs
 ```
 
 Requirements:
@@ -299,16 +299,16 @@ Goal: prove attention-based compression quality before optimizing drafter cost.
 Add:
 
 ```text
-crates/engine/src/pflash.rs
-crates/engine/examples/pflash_compress_demo.rs
+crates/hipfire-arch-qwen35/src/pflash.rs
+crates/hipfire-runtime/examples/pflash_compress_demo.rs
 ```
 
 Modify:
 
 ```text
-crates/engine/src/lib.rs
-crates/engine/src/llama.rs
-crates/engine/examples/daemon.rs   # only enough to load / debug the drafter, not auto-enable
+crates/hipfire-runtime/src/lib.rs
+crates/hipfire-runtime/src/llama.rs
+crates/hipfire-runtime/examples/daemon.rs   # only enough to load / debug the drafter, not auto-enable
 ```
 
 Work:
@@ -374,8 +374,8 @@ kernels/src/attention_pflash_sparse_fwd.hip
 Potentially modify:
 
 ```text
-crates/engine/src/llama.rs
-crates/engine/src/pflash.rs
+crates/hipfire-runtime/src/llama.rs
+crates/hipfire-arch-qwen35/src/pflash.rs
 crates/rdna-compute/src/kernels.rs
 crates/rdna-compute/src/dispatch.rs
 ```
@@ -401,8 +401,8 @@ Goal: make PFlash a user-facing, opt-in feature.
 Modify:
 
 ```text
-crates/engine/examples/daemon.rs
-crates/engine/examples/run.rs
+crates/hipfire-runtime/examples/daemon.rs
+crates/hipfire-runtime/examples/run.rs
 # CLI/config crates if present in the active branch
 # docs/CONFIG.md or equivalent config docs
 ```

--- a/docs/superpowers/plans/2026-04-30-mmq-channel-test.md
+++ b/docs/superpowers/plans/2026-04-30-mmq-channel-test.md
@@ -13,7 +13,7 @@
 ### Task 1: Scaffold the binary with arg parsing and model loading
 
 **Files:**
-- Create: `crates/engine/examples/channel_test_mmq.rs`
+- Create: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 - [ ] **Step 1: Create the binary with arg parsing and model load**
 
@@ -115,7 +115,7 @@ If you don't have `qwen3.5-9b.mq4`, use whichever `.mq4` model is available in `
 - [ ] **Step 4: Commit**
 
 ```bash
-git add crates/engine/examples/channel_test_mmq.rs
+git add crates/hipfire-runtime/examples/channel_test_mmq.rs
 git commit -m "feat(diag): scaffold channel_test_mmq binary for #87 MMQ analysis"
 ```
 
@@ -126,7 +126,7 @@ git commit -m "feat(diag): scaffold channel_test_mmq binary for #87 MMQ analysis
 These are the shared building blocks all three stages use.
 
 **Files:**
-- Modify: `crates/engine/examples/channel_test_mmq.rs`
+- Modify: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 - [ ] **Step 1: Add the comparison stats struct and diff function**
 
@@ -275,7 +275,7 @@ pub fn gemm_hfq4g256_mmq_set_prequant(...)
 - [ ] **Step 5: Commit**
 
 ```bash
-git add crates/engine/examples/channel_test_mmq.rs crates/rdna-compute/src/dispatch.rs
+git add crates/hipfire-runtime/examples/channel_test_mmq.rs crates/rdna-compute/src/dispatch.rs
 git commit -m "feat(diag): add comparison helpers and synth activation gen for channel_test_mmq"
 ```
 
@@ -284,7 +284,7 @@ git commit -m "feat(diag): add comparison helpers and synth activation gen for c
 ### Task 3: Implement site-scan stage
 
 **Files:**
-- Modify: `crates/engine/examples/channel_test_mmq.rs`
+- Modify: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 - [ ] **Step 1: Implement `site_scan`**
 
@@ -411,7 +411,7 @@ should show non-zero error. Record which sites are worst.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add crates/engine/examples/channel_test_mmq.rs
+git add crates/hipfire-runtime/examples/channel_test_mmq.rs
 git commit -m "feat(diag): implement site-scan stage for channel_test_mmq"
 ```
 
@@ -420,7 +420,7 @@ git commit -m "feat(diag): implement site-scan stage for channel_test_mmq"
 ### Task 4: Implement channel-map stage
 
 **Files:**
-- Modify: `crates/engine/examples/channel_test_mmq.rs`
+- Modify: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 - [ ] **Step 1: Add per-row stats struct and computation**
 
@@ -587,7 +587,7 @@ Expected: Prints per-row error table for layer 0's `wo` projection.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add crates/engine/examples/channel_test_mmq.rs
+git add crates/hipfire-runtime/examples/channel_test_mmq.rs
 git commit -m "feat(diag): implement channel-map stage for channel_test_mmq"
 ```
 
@@ -596,7 +596,7 @@ git commit -m "feat(diag): implement channel-map stage for channel_test_mmq"
 ### Task 5: Implement layer-sweep stage
 
 **Files:**
-- Modify: `crates/engine/examples/channel_test_mmq.rs`
+- Modify: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 - [ ] **Step 1: Implement `layer_sweep`**
 
@@ -694,7 +694,7 @@ Expected: Prints per-layer error for the `residual` site across all layers.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add crates/engine/examples/channel_test_mmq.rs
+git add crates/hipfire-runtime/examples/channel_test_mmq.rs
 git commit -m "feat(diag): implement layer-sweep stage for channel_test_mmq"
 ```
 
@@ -706,7 +706,7 @@ The `match (layer, site) => wt` block is duplicated across `site_scan`, `channel
 and `layer_sweep`. Extract it into a shared function.
 
 **Files:**
-- Modify: `crates/engine/examples/channel_test_mmq.rs`
+- Modify: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 - [ ] **Step 1: Extract `get_weight_for_site`**
 
@@ -777,7 +777,7 @@ Expected: Same output as before.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add crates/engine/examples/channel_test_mmq.rs
+git add crates/hipfire-runtime/examples/channel_test_mmq.rs
 git commit -m "refactor(diag): extract get_weight_for_site helper, DRY site lookups"
 ```
 

--- a/docs/superpowers/specs/2026-04-30-mmq-channel-test-design.md
+++ b/docs/superpowers/specs/2026-04-30-mmq-channel-test-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-30
 **Ref:** Kaden-Schutt/hipfire#87 (auto-MMQ regression on tool-call output, gfx1151)
-**Deliverable:** `crates/engine/examples/channel_test_mmq.rs`
+**Deliverable:** `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 ## Problem
 
@@ -182,7 +182,7 @@ Layer | MaxErr   | MeanErr  | >Thresh
 
 ## Implementation plan
 
-### Single file: `crates/engine/examples/channel_test_mmq.rs`
+### Single file: `crates/hipfire-runtime/examples/channel_test_mmq.rs`
 
 Estimated ~350-450 lines. Structure:
 

--- a/scripts/coherence-gate-dflash.sh
+++ b/scripts/coherence-gate-dflash.sh
@@ -175,9 +175,13 @@ hard_errors=0
     echo "- target: $TARGET_27B"
     echo "- draft:  $DRAFT_27B"
     echo
-    echo "Hard-fail thresholds: zero tokens, panic, max_token_freq > 0.40,"
-    echo "unique_token_ratio < 0.30 (token-attractor detection — see Path A"
-    echo "failure mode in commit 6c84b13)."
+    echo "Hard-fail thresholds (three-tier, see CLAUDE.md DFlash Coherence Gate):"
+    echo "  Tier 1 (first 128): unique_token_ratio < 0.15 OR max_single_token_frequency > 0.50"
+    echo "  Tier 2 (last 128):  unique_token_ratio < 0.30 OR max_single_token_frequency > 0.50"
+    echo "  Tier 3 (full, SOFT flag — human eyeball, not commit-blocking):"
+    echo "          consecutive-3gram repetition density > 0.50 in final half"
+    echo "          OR full-output unique_token_ratio < 0.10"
+    echo "Plus: zero tokens / panic. (Path A failure mode — see commit 6c84b13.)"
     echo
 } > "$OUT"
 
@@ -197,21 +201,60 @@ if [ ! -f "$TARGET_27B" ] || [ ! -f "$DRAFT_27B" ]; then
     exit 0
 fi
 
-# Token-attractor detector. Targets the Path A failure mode specifically:
-# single-token attractor mid-generation that would otherwise pass τ/tok-s
-# stat gates. Looks at the FIRST 128 tokens up to (but not including) the
-# first end-of-text token. Post-EOT output (model spamming "#" after a
-# clean function close) is degenerate but NOT the failure class we're
-# guarding against — generation has already finished by that point.
+# Token-attractor detector. Implements the three-tier intent documented in
+# CLAUDE.md ("DFlash Coherence Gate"). Attractors manifest in two forms:
+# (1) single-token loops visible in the FIRST 128 tokens, and (2) block-level
+# structural loops (5+ token sequences repeating) that only appear LATER in
+# generation. The detector trims at the first end-of-text token, then applies:
 #
-# Thresholds are calibrated to catch Path A's "numbers(numbers(..." (where
-# unique_ratio ≈ 0.05, max_freq ≈ 0.60) without false-positiving sentence-
-# level repetition (where the early window is still diverse).
+#   Tier 1 — FIRST 128 tokens (HARD fail):
+#     unique_token_ratio < 0.15  OR  max_single_token_frequency > 0.50
+#     Catches Path-A-class single-token attractors ("numbers(numbers(...",
+#     unique≈0.05/max≈0.60) without false-positiving sentence-level repetition.
+#
+#   Tier 2 — LAST 128 tokens (HARD fail):
+#     unique_token_ratio < 0.30  OR  max_single_token_frequency > 0.50
+#     Catches block-level structural loops that pass Tier 1 (diverse early
+#     window) but collapse later — e.g. the m-fold drift case in CLAUDE.md
+#     (τ=8.98 passed first-128 but emitted a 47-token-vocab tail).
+#
+#   Tier 3 — FULL output (SOFT flag, human eyeball, NOT commit-blocking):
+#     consecutive-3gram repetition density > 0.50 in the final half
+#     OR full-output unique_token_ratio < 0.10
+#     Flags structural code loops even when both hard windows pass.
+#
+# A legacy "soft_warn" (paragraph-level repetition in the first window) is
+# retained so existing report wording stays meaningful.
 #
 # Qwen3.5 EOT token IDs: 248044 (<|endoftext|>) + 248046 (<|im_end|>).
 DETECT_PY=$(cat <<'PYEOF'
 import sys, re, json, collections
 EOT_IDS = {248044, 248046}
+
+def ratios(window):
+    """unique_ratio, max_freq for a token window."""
+    counter = collections.Counter(window)
+    total = len(window)
+    unique = len(counter)
+    max_tok, max_count = counter.most_common(1)[0]
+    return unique / total, max_count / total, unique, total, max_tok, max_count
+
+def trigram_repeat_density(seq):
+    """Fraction of consecutive overlapping 3-grams that repeat a previously
+    seen 3-gram. Captures block-level structural loops (5+ token blocks show
+    up as many repeating 3-grams)."""
+    if len(seq) < 6:
+        return 0.0
+    grams = [tuple(seq[i:i+3]) for i in range(len(seq) - 2)]
+    seen = set()
+    repeats = 0
+    for g in grams:
+        if g in seen:
+            repeats += 1
+        else:
+            seen.add(g)
+    return repeats / len(grams)
+
 out = sys.stdin.read()
 m = re.search(r"DFlash tokens: \[([^\]]+)\]", out)
 ar_m = re.search(r"AR tokens: \[([^\]]+)\]", out)
@@ -229,7 +272,7 @@ for i, t in enumerate(toks):
     if t in EOT_IDS:
         trimmed = toks[:i]
         break
-# Apply detector to the first 128 tokens of the pre-EOT window.
+# Tier 1 — first 128 of the pre-EOT window.
 window = trimmed[:128]
 if len(window) < 16:
     # Too short to judge; accept as OK (clean early termination is fine).
@@ -237,28 +280,43 @@ if len(window) < 16:
         "ok": True, "total": len(window), "reason": "short_window_ok",
     }))
     sys.exit(0)
-counter = collections.Counter(window)
-unique = len(counter)
-total = len(window)
-unique_ratio = unique / total
-max_tok, max_count = counter.most_common(1)[0]
-max_freq = max_count / total
-# Two-tier thresholds:
-#   Hard block (commit-blocking): only on Path-A-class single-token
-#     attractors (max_freq > 0.50 OR unique_ratio < 0.15). These are
-#     unrecoverable — same token >50% of generation = degenerate loop.
-#   Soft warn (printed in report, no exit code): paragraph-level
-#     repetition (unique_ratio < 0.30 or max_freq > 0.40). Pre-existing
-#     DDTree-b12 prose has this and isn't caused by Path B work.
-hard_fail = max_freq > 0.50 or unique_ratio < 0.15
-soft_warn = (max_freq > 0.40 or unique_ratio < 0.30) and not hard_fail
+u1, f1, unique, total, max_tok, max_count = ratios(window)
+# Tier 1 hard fail: Path-A-class single-token attractors.
+t1_hard = f1 > 0.50 or u1 < 0.15
+# Legacy soft warn (paragraph-level repetition in the first window).
+soft_warn = (f1 > 0.40 or u1 < 0.30) and not t1_hard
+
+# Tier 2 — LAST 128 of the pre-EOT window (block-level attractors that pass
+# the early window). Only evaluated when there are enough tokens to judge.
+t2_hard = False
+t2 = None
+if len(trimmed) >= 16:
+    last = trimmed[-128:]
+    u2, f2, _, t2n, _, _ = ratios(last)
+    t2_hard = u2 < 0.30 or f2 > 0.50
+    t2 = {"total": t2n, "unique_ratio": round(u2, 3), "max_freq": round(f2, 3)}
+
+# Tier 3 — FULL output structural loop (SOFT flag, human eyeball only).
+#   3gram repeat density > 0.50 over the FINAL HALF, OR full-output unique < 0.10
+second_half = trimmed[len(trimmed) // 2:]
+gram_density = trigram_repeat_density(second_half)
+full_u, _, _, _, _, _ = ratios(trimmed) if trimmed else (1.0, 0, 0, 0, 0, 0)
+tier3_warn = gram_density > 0.50 or full_u < 0.10
+
+hard_fail = t1_hard or t2_hard
 print(json.dumps({
     "ok": not hard_fail,
+    "t1_hard": t1_hard,
+    "t2_hard": t2_hard,
     "soft_warn": soft_warn,
+    "tier3_warn": tier3_warn,
     "total": total, "unique": unique,
-    "unique_ratio": round(unique_ratio, 3),
-    "max_freq": round(max_freq, 3),
+    "unique_ratio": round(u1, 3),
+    "max_freq": round(f1, 3),
     "max_tok": max_tok, "max_count": max_count,
+    "tier2": t2,
+    "gram_density": round(gram_density, 3),
+    "full_unique_ratio": round(full_u, 3),
 }))
 PYEOF
 )
@@ -296,14 +354,19 @@ for entry in "${tests[@]}"; do
     detect=$(python3 -c "$DETECT_PY" < "$out_file")
     detect_ok=$(echo "$detect" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('ok',False))")
     detect_warn=$(echo "$detect" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('soft_warn',False))")
+    detect_t3=$(echo "$detect" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('tier3_warn',False))")
 
     status="OK"
     if [ "$ec" -ne 0 ] || [ -n "$panic" ]; then
         status="HARD_ERROR (exit=$ec panic=${panic:+yes})"
         hard_errors=$((hard_errors + 1))
     elif [ "$detect_ok" != "True" ]; then
+        # Tier 1 (first 128) or Tier 2 (last 128) hard fail.
         status="HARD_ERROR (token attractor: $detect)"
         hard_errors=$((hard_errors + 1))
+    elif [ "$detect_t3" = "True" ]; then
+        # Tier 3 (full-output structural loop) — soft flag, human eyeball.
+        status="FLAG (Tier-3 structural 3gram loop — soft, needs human eyeball)"
     elif [ "$detect_warn" = "True" ]; then
         status="WARN (paragraph-level repetition — soft, not blocking)"
     fi


### PR DESCRIPTION
Four documentation-correctness fixes, all grounded in live source:
1. **KV defaults** — docs said deprecated `asym3`; live `archDefaults()` (`cli/index.ts`) is `fwht3` (RDNA3+/RDNA2/RDNA4) / `fwht2` (RDNA1/gfx1151/gfx1032). Fixed CONFIG/QUANTIZATION/GETTING_STARTED/BENCHMARKS; added the missing `gfx1201` row + `fwht2/3/4` + `kv_adaptive` modes.
2. **DFlash gate** — implemented the documented Tier-2 (last-128) + Tier-3 (3gram) windows in `scripts/coherence-gate-dflash.sh` (were doc-only) and reconciled CLAUDE.md/AGENTS.md to match. Detector unit-tested on 3 synthetic cases.
3. Removed the false `.claude/settings.json` GPU-lock-hook claim; fixed `source scripts/gpu-lock.sh` path.
4. Repathed ~81 broken `crates/engine/` refs → live crates.

---
**Note:** independent of #393/#397, but holding for merge until the dispatch-unification work lands, per maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)