### PR TITLE
tools: add AMD matrix instruction calculator submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/amd_matrix_instruction_calculator"]
+	path = third_party/amd_matrix_instruction_calculator
+	url = https://github.com/ROCm/amd_matrix_instruction_calculator.git


### PR DESCRIPTION
Adds the vendored AMD Matrix Instruction Calculator as a submodule plus repo-local agent skill metadata for using it during AMD WMMA/MFMA kernel work.\n\nValidation: not run; tooling/submodule metadata only.