### PR TITLE
tools: add KVarN submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/KVarN"]
+	path = third_party/KVarN
+	url = https://github.com/huawei-csl/KVarN.git


### PR DESCRIPTION
Adds KVarN as a third_party submodule at huawei-csl/KVarN@6c7dacd. This preserves the local nested checkout as a reviewable gitlink instead of vendoring the 138 MB tree.\n\nValidation: not run; submodule metadata only.