### PR TITLE
chore: ignore local agent and quantization artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ kernels/compiled/
 .remember/
 .codex
 .sisyphus/
+AGENTS.local.md
 
 # Local secrets (lmx api key, etc.) — never commit
 .env
@@ -69,6 +70,7 @@ cli/CLAUDE.md
 # Training artifacts (draft ckpts, converted hfq, prompt files, logs)
 .dflash-runs/
 artifacts/
+Quantization/
 .codeinsight
 .codeinsight+research/
 .local-bench-scratch/


### PR DESCRIPTION
## Summary
- ignore `AGENTS.local.md` local agent notes
- ignore local `Quantization/` artifact directories

## Validation
- `git diff --check origin/master..HEAD`

Small housekeeping split from the local archive stack.