### PR TITLE
docs: add FWHT residual QJL TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+## FWHT Residual QJL Transform
+
+- Implement a Johnson-Lindenstrauss / QJL transformation on the residual in the FWHT path. The current FWHT path applies a signed-FWHT rotation to Q/K for attention and leaves the residual stream without a separate QJL transform.


### PR DESCRIPTION
## Summary
- add a minimal `TODO.md` note for a deferred FWHT residual QJL transform

## Validation
- `git diff --check origin/master..HEAD`

Docs-only split from the local archive stack.