### PR TITLE
feat(awq): support AWQ on sub-4-bit quant arms

### DIFF
--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -2276,6 +2276,94 @@ fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
     output
 }
 
+/// Ternary "MQ1.58" probe: K=3 Lloyd-placed codebook packed into the MQ2-Lloyd
+/// container (slot 3 = duplicate of slot 2, never indexed) so it runs on the
+/// existing MQ2G256Lloyd kernel with NO new kernel. Measures sub-2-bit
+/// *information* (3 levels = log2(3) ≈ 1.58 bit) coherence; storage stays
+/// 72 B/group (true 1.58-bpw packing — 5 ternary/byte — is a mechanical
+/// follow-up once coherence is established). Gated by HIPFIRE_LLOYD_K3=1 on the
+/// `--format mq2lloyd` path. Output DType = MQ2G256Lloyd (kernel-agnostic to K).
+fn quantize_mq2g256_lloyd_k3(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+    use rayon::prelude::*;
+    let group_size = 256;
+    let block_bytes = 72;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+    output
+        .par_chunks_mut(block_bytes)
+        .enumerate()
+        .for_each(|(b, out_chunk)| {
+            let start = b * group_size;
+            let end = (start + group_size).min(n);
+            let actual_len = end - start;
+            let mut group = [0.0f32; 256];
+            group[..actual_len].copy_from_slice(&f32_data[start..end]);
+            cpu_fwht_256(&mut group, signs1, signs2);
+
+            let mut sorted: [f32; 256] = group;
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let percentile = |frac: f32| -> f32 {
+                let idx = ((frac * 255.0).round() as usize).min(255);
+                sorted[idx]
+            };
+            // 3 centroids: ~1/6, 1/2, 5/6 percentiles.
+            let mut cb: [f32; 3] = [percentile(0.167), percentile(0.5), percentile(0.833)];
+            let range = sorted[255] - sorted[0];
+            let mut indices = [0u8; 256];
+            if range > 0.0 {
+                let max_iter = 8;
+                let mut prev = [0u8; 256];
+                for it in 0..max_iter {
+                    let mut sums = [0.0f64; 3];
+                    let mut counts = [0u32; 3];
+                    let mut changed = 0u32;
+                    for i in 0..256 {
+                        let w = group[i];
+                        let mut best = 0usize;
+                        let mut best_d = (w - cb[0]).abs();
+                        for k in 1..3 {
+                            let d = (w - cb[k]).abs();
+                            if d < best_d { best_d = d; best = k; }
+                        }
+                        if it == 0 || prev[i] != best as u8 { changed += 1; }
+                        prev[i] = best as u8;
+                        indices[i] = best as u8;
+                        sums[best] += w as f64;
+                        counts[best] += 1;
+                    }
+                    if it > 0 && changed == 0 { break; }
+                    for k in 0..3 {
+                        if counts[k] > 0 { cb[k] = (sums[k] / counts[k] as f64) as f32; }
+                    }
+                }
+            }
+            // Sort the 3 centroids ascending; remap indices.
+            let mut order: [usize; 3] = [0, 1, 2];
+            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            let mut sorted_cb = [0.0f32; 3];
+            let mut inv: [u8; 3] = [0; 3];
+            for new_idx in 0..3 {
+                sorted_cb[new_idx] = cb[order[new_idx]];
+                inv[order[new_idx]] = new_idx as u8;
+            }
+            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            // Header: slots 0..2 = the 3 centroids; slot 3 = dup of slot 2 (never indexed).
+            let header = [sorted_cb[0], sorted_cb[1], sorted_cb[2], sorted_cb[2]];
+            for k in 0..4 {
+                let bits = f32_to_fp16_bits(header[k]);
+                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k + 1] = (bits >> 8) as u8;
+            }
+            for i in 0..64 {
+                let mut byte_val = 0u8;
+                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                out_chunk[8 + i] = byte_val;
+            }
+        });
+    output
+}
+
 /// Inverse FWHT for MQ-family dequantization (sibling of cpu_fwht_256).
 fn cpu_inv_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
     assert!(x.len() == 256);
@@ -3409,6 +3497,16 @@ fn load_imatrix(path: &Path) -> HashMap<String, Vec<f32>> {
 ///     tensor wasn't exercised by the calibration corpus).
 fn imatrix_weights_for(safetensors_name: &str) -> Option<&'static [f32]> {
     let im = IMATRIX.get()?;
+    // `load_imatrix` keys the map by the imatrix FILE's tensor names (`.in_sum2`
+    // stripped). hipfire's `collect_imatrix` emits *safetensors* names
+    // (`model.language_model.layers.N.linear_attn.in_proj_qkv.weight`), so try the
+    // direct safetensors name FIRST — this was the AWQ no-op: the map is
+    // safetensors-keyed but we only tried the GGML-converted name, which always
+    // missed (and 27B-3.6 hybrid linear_attn names don't round-trip anyway).
+    // Fall back to the GGML name for llama.cpp-style (blk.*) imatrices.
+    if let Some(v) = im.get(safetensors_name) {
+        return Some(v.as_slice());
+    }
     let ggml_name = safetensors_to_ggml_name(safetensors_name)?;
     im.get(&ggml_name).map(|v| v.as_slice())
 }
@@ -3459,7 +3557,17 @@ fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
     let mut log_s_raw = Vec::with_capacity(k);
     let mut sum_log: f64 = 0.0;
     for &v in in_sum2 {
-        let v_clamped = (v as f64).max(1e-12);
+        // Floor dead channels to 1e-12 (NaN also maps here: f64::max returns the
+        // non-NaN arg) AND cap non-finite / pathologically-large values to a
+        // finite ceiling. An inf in_sum2 — f32 overflow during imatrix
+        // collection, which the 27B tier1 imatrix actually contains — would
+        // otherwise make this tensor's `mean_log = inf`, and then `l - mean_log`
+        // = inf - inf = NaN for the inf channel. That NaN survives the output
+        // clamp below (f32::clamp propagates NaN), poisoning the F16 sidecar and
+        // NaN'ing the whole forward (37747 such values measured pre-fix).
+        // Capping the input keeps mean_log finite; the output clamp then bounds
+        // the final scale. 1e30 is well inside f64 range (ln ≈ 69).
+        let v_clamped = (v as f64).max(1e-12).min(1e30);
         let log_s = half_alpha * v_clamped.ln();   // log(v^(alpha/2)) = (alpha/2) * log(v)
         log_s_raw.push(log_s);
         sum_log += log_s;
@@ -3468,8 +3576,26 @@ fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
 
     // Step 3: subtract mean in log space, then exp back. After this,
     // geo_mean(s) = exp(0) = 1.0 exactly (within floating-point precision).
+    //
+    // Step 4 (CRITICAL — f16 safety): clamp to an f16-representable,
+    // non-exploding range. The geo-mean is 1.0 by construction, so the bulk
+    // of channels sit near 1; only pathological outliers reach the rails —
+    // dead channels floored to 1e-12, or hot channels with huge activation
+    // sums. Without this, exp() overflows to f32 inf and/or the F16 sidecar
+    // under/overflows, and the inference-time `x / awq_scale` divide produces
+    // inf → NaN. (Verified via dump_awq_scales on the 27B tier1 imatrix:
+    // 49293 scales underflowed to 0.0 and 37747 stored as inf/NaN pre-clamp,
+    // which NaN'd the whole forward — KLD 0.0 / PPL NaN on gfx11.)
+    //
+    // The SAME clamped vector is used for both the weight pre-scale (W*s) and
+    // the emitted sidecar (x/s at inference), so the cancellation stays exact;
+    // clamping only limits how aggressively pathological channels redistribute
+    // quant difficulty. Real AWQ scales live in ~[0.2, 5]; [1e-2, 1e2] keeps
+    // all genuine signal while removing the representability blow-ups.
+    const AWQ_SCALE_MIN: f32 = 1e-2;
+    const AWQ_SCALE_MAX: f32 = 1e2;
     log_s_raw.into_iter()
-        .map(|l| ((l - mean_log).exp()) as f32)
+        .map(|l| ((l - mean_log).exp() as f32).clamp(AWQ_SCALE_MIN, AWQ_SCALE_MAX))
         .collect()
 }
 
@@ -5849,7 +5975,24 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                    // AWQ × MQ3-Lloyd composition (MQ3G256Lloyd is forward-path-ready +
+                    // now in supports_awq_sidecar). Pre-scale by imatrix, then Lloyd-fit.
+                    let q = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            quantize_mq3g256_lloyd(&scaled, &signs1, &signs2)
+                        } else {
+                            quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
+                        }
+                    } else {
+                        quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
                 } else {
                     let q = quantize_hfq3g128(&f32_data);
@@ -5860,7 +6003,27 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                    // AWQ × MQ2-Lloyd (MQ2G256Lloyd is in supports_awq_sidecar): pre-scale
+                    // by imatrix first, then Lloyd-fit (K=4, or K=3-ternary under the flag).
+                    let awq_scaled: Option<Vec<f32>> = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            Some(scaled)
+                        } else { None }
+                    } else { None };
+                    let data: &[f32] = awq_scaled.as_deref().unwrap_or(&f32_data);
+                    // HIPFIRE_LLOYD_K3=1 → ternary "MQ1.58" (3-level codebook, reuses kernel).
+                    let q = if std::env::var("HIPFIRE_LLOYD_K3").ok().as_deref() == Some("1") {
+                        quantize_mq2g256_lloyd_k3(data, &signs1, &signs2)
+                    } else {
+                        quantize_mq2g256_lloyd(data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
                 } else {
                     // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
@@ -5872,7 +6035,27 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
+                    // AWQ pre-scaling for MQ3 base body (mirrors the MQ4 base arm).
+                    // MQ3G256 is on DType::supports_awq_sidecar, so the runtime applies
+                    // the inverse divide via rotate_x_mq. Without this, `--format mq3
+                    // --awq` was a silent no-op on body tensors (md5(mq3-awq)==md5(mq3)).
+                    // awq_eligible gates to tensors whose runtime path has the inverse.
+                    let q = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            quantize_mq3g256(&scaled, &signs1, &signs2)
+                        } else {
+                            quantize_mq3g256(&f32_data, &signs1, &signs2)
+                        }
+                    } else {
+                        quantize_mq3g256(&f32_data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ3G256, 256u32, "MQ3G256")
                 } else {
                     // Fallback to HFQ3-G128 for non-256-aligned (no rotation)
@@ -5884,7 +6067,25 @@ fn main() {
                 if k_dim % 256 == 0 {
                     let signs1 = gen_fwht_signs(42, 256);
                     let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                    // AWQ × plain MQ2 (MQ2G256 now in supports_awq_sidecar). Pre-scale by
+                    // imatrix, then quantize. (Plain MQ2 collapses uncalibrated; AWQ is the
+                    // test of whether activation-aware scaling rescues uniform 2-bit.)
+                    let q = if let (Some(alpha), Some(im_weights))
+                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    {
+                        if awq_eligible(name) {
+                            let scales = compute_awq_scales(im_weights, alpha);
+                            awq_sidecar_scales = Some(scales.clone());
+                            let m_dim = meta.shape[0];
+                            let mut scaled = f32_data.clone();
+                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                            quantize_mq2g256(&scaled, &signs1, &signs2)
+                        } else {
+                            quantize_mq2g256(&f32_data, &signs1, &signs2)
+                        }
+                    } else {
+                        quantize_mq2g256(&f32_data, &signs1, &signs2)
+                    };
                     (q, QuantType::MQ2G256, 256u32, "MQ2G256")
                 } else {
                     // Fallback to HFQ2-G128 for non-256-aligned (no rotation)

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -132,7 +132,9 @@ impl SafetensorsFile {
             use std::os::unix::io::AsRawFd;
             // POSIX_FADV_DONTNEED = 4
             unsafe {
-                extern "C" { fn posix_fadvise(fd: i32, offset: i64, len: i64, advice: i32) -> i32; }
+                extern "C" {
+                    fn posix_fadvise(fd: i32, offset: i64, len: i64, advice: i32) -> i32;
+                }
                 posix_fadvise(self._file.as_raw_fd(), start as i64, len as i64, 4);
             }
         }
@@ -181,10 +183,15 @@ fn f16_to_f32(bits: u16) -> f32 {
     let exp = ((bits >> 10) & 0x1F) as u32;
     let frac = (bits & 0x3FF) as u32;
     if exp == 0 {
-        if frac == 0 { return f32::from_bits(sign << 31); }
+        if frac == 0 {
+            return f32::from_bits(sign << 31);
+        }
         let mut e = 0i32;
         let mut f = frac;
-        while f & 0x400 == 0 { f <<= 1; e -= 1; }
+        while f & 0x400 == 0 {
+            f <<= 1;
+            e -= 1;
+        }
         f &= 0x3FF;
         let exp32 = (127 - 15 + 1 + e) as u32;
         return f32::from_bits((sign << 31) | (exp32 << 23) | (f << 13));
@@ -210,9 +217,13 @@ fn f32_to_f16(val: f32) -> u16 {
         return ((sign << 15) | (0x1F << 10) | f16_frac) as u16;
     }
     let new_exp = exp - 127 + 15;
-    if new_exp >= 31 { return ((sign << 15) | (0x1F << 10)) as u16; }
+    if new_exp >= 31 {
+        return ((sign << 15) | (0x1F << 10)) as u16;
+    }
     if new_exp <= 0 {
-        if new_exp < -10 { return (sign << 15) as u16; }
+        if new_exp < -10 {
+            return (sign << 15) as u16;
+        }
         let f = frac | 0x800000;
         let shift = (1 - new_exp + 13) as u32;
         return ((sign << 15) | (f >> shift)) as u16;
@@ -223,21 +234,18 @@ fn f32_to_f16(val: f32) -> u16 {
 /// Convert raw tensor bytes to F32 based on dtype string
 fn to_f32(data: &[u8], dtype: &str) -> Vec<f32> {
     match dtype {
-        "F16" => {
-            data.chunks_exact(2)
-                .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
-                .collect()
-        }
-        "BF16" => {
-            data.chunks_exact(2)
-                .map(|c| bf16_to_f32(u16::from_le_bytes([c[0], c[1]])))
-                .collect()
-        }
-        "F32" => {
-            data.chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect()
-        }
+        "F16" => data
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        "BF16" => data
+            .chunks_exact(2)
+            .map(|c| bf16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        "F32" => data
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
         other => panic!("unsupported dtype: {other}"),
     }
 }
@@ -276,7 +284,9 @@ fn e4m3_to_f32(byte: u8) -> f32 {
         return 0.0;
     }
     if exp == 0 {
-        if mant == 0.0 { return 0.0; }
+        if mant == 0.0 {
+            return 0.0;
+        }
         return sign * (2.0f32.powi(-6)) * (mant / 8.0);
     }
     sign * (2.0f32.powi(exp - 7)) * (1.0 + mant / 8.0)
@@ -308,22 +318,23 @@ fn tensor_to_f32_with_optional_fp8_scale(
     // FP8 E4M3 + UE8M0 paired storage (DeepSeek V4). The dtype tag is either
     // `I8` (older safetensors writer) or `F8_E4M3` (newer); both
     // store identical E4M3 bytes, so the dequant math is the same.
-    if (meta.dtype == "I8" || meta.dtype == "F8_E4M3")
-        && fp8_scale_for.contains_key(name)
-    {
+    if (meta.dtype == "I8" || meta.dtype == "F8_E4M3") && fp8_scale_for.contains_key(name) {
         let (sfi, sname) = &fp8_scale_for[name];
         let (smeta, sbytes) = st_files[*sfi]
             .tensor_data(sname)
             .unwrap_or_else(|| panic!("FP8 scale tensor missing: {sname}"));
-        assert_eq!(smeta.dtype, "F8_E8M0",
-            "expected F8_E8M0 scale for {name}, got {}", smeta.dtype);
-        return dequantize_e4m3_ue8m0_to_f32(
-            raw_data, &meta.shape, sbytes, &smeta.shape,
+        assert_eq!(
+            smeta.dtype, "F8_E8M0",
+            "expected F8_E8M0 scale for {name}, got {}",
+            smeta.dtype
         );
+        return dequantize_e4m3_ue8m0_to_f32(raw_data, &meta.shape, sbytes, &smeta.shape);
     }
     if meta.dtype == "I8" {
-        panic!("tensor {name} has dtype I8 but no .scale sibling registered \
-                — unexpected on a non-DeepSeek V4 checkpoint.");
+        panic!(
+            "tensor {name} has dtype I8 but no .scale sibling registered \
+                — unexpected on a non-DeepSeek V4 checkpoint."
+        );
     }
     to_f32(raw_data, &meta.dtype)
 }
@@ -349,7 +360,11 @@ fn e2m1_to_f32(nibble: u8) -> f32 {
     const MAG: [f32; 8] = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0];
     let n = (nibble & 0x0f) as usize;
     let mag = MAG[n & 0x7];
-    if (n & 0x8) != 0 { -mag } else { mag }
+    if (n & 0x8) != 0 {
+        -mag
+    } else {
+        mag
+    }
 }
 
 /// Dequantize a paired E2M1 weight + UE8M0 scale tensor to f32.
@@ -369,16 +384,34 @@ fn dequantize_e2m1_ue8m0_to_f32(
     scale_bytes: &[u8],
     scale_shape: &[usize],
 ) -> (Vec<f32>, Vec<usize>) {
-    assert_eq!(storage_shape.len(), 2, "expected 2D storage shape, got {:?}", storage_shape);
-    assert_eq!(scale_shape.len(),   2, "expected 2D scale shape, got {:?}",   scale_shape);
+    assert_eq!(
+        storage_shape.len(),
+        2,
+        "expected 2D storage shape, got {:?}",
+        storage_shape
+    );
+    assert_eq!(
+        scale_shape.len(),
+        2,
+        "expected 2D scale shape, got {:?}",
+        scale_shape
+    );
     let (rows, cols_stored) = (storage_shape[0], storage_shape[1]);
     let logical_cols = cols_stored * 2;
     let (sr, sc) = (scale_shape[0], scale_shape[1]);
-    assert_eq!(weight_bytes.len(), rows * cols_stored, "FP4 weight byte count mismatch");
-    assert_eq!(scale_bytes.len(),  sr * sc,            "FP4 scale byte count mismatch");
-    assert!(rows % sr == 0 && logical_cols % sc == 0,
+    assert_eq!(
+        weight_bytes.len(),
+        rows * cols_stored,
+        "FP4 weight byte count mismatch"
+    );
+    assert_eq!(scale_bytes.len(), sr * sc, "FP4 scale byte count mismatch");
+    assert!(
+        rows % sr == 0 && logical_cols % sc == 0,
         "FP4 scale shape {:?} doesn't tile logical weight shape [{}, {}]",
-        scale_shape, rows, logical_cols);
+        scale_shape,
+        rows,
+        logical_cols
+    );
     let block_rows = rows / sr;
     let block_cols_logical = logical_cols / sc;
 
@@ -415,14 +448,32 @@ fn dequantize_e4m3_ue8m0_to_f32(
     scale_bytes: &[u8],
     scale_shape: &[usize],
 ) -> Vec<f32> {
-    assert_eq!(weight_shape.len(), 2, "expected 2D weight, got {:?}", weight_shape);
-    assert_eq!(scale_shape.len(), 2,  "expected 2D scale,  got {:?}", scale_shape);
+    assert_eq!(
+        weight_shape.len(),
+        2,
+        "expected 2D weight, got {:?}",
+        weight_shape
+    );
+    assert_eq!(
+        scale_shape.len(),
+        2,
+        "expected 2D scale,  got {:?}",
+        scale_shape
+    );
     let (rows, cols) = (weight_shape[0], weight_shape[1]);
-    let (sr, sc)    = (scale_shape[0], scale_shape[1]);
-    assert_eq!(weight_bytes.len(), rows * cols, "weight byte count mismatch");
-    assert_eq!(scale_bytes.len(),  sr * sc,     "scale  byte count mismatch");
-    assert!(rows % sr == 0 && cols % sc == 0,
-            "scale shape {:?} doesn't tile weight shape {:?}", scale_shape, weight_shape);
+    let (sr, sc) = (scale_shape[0], scale_shape[1]);
+    assert_eq!(
+        weight_bytes.len(),
+        rows * cols,
+        "weight byte count mismatch"
+    );
+    assert_eq!(scale_bytes.len(), sr * sc, "scale  byte count mismatch");
+    assert!(
+        rows % sr == 0 && cols % sc == 0,
+        "scale shape {:?} doesn't tile weight shape {:?}",
+        scale_shape,
+        weight_shape
+    );
     let block_rows = rows / sr;
     let block_cols = cols / sc;
 
@@ -476,7 +527,11 @@ fn quantize_q4f16_g64(f32_data: &[f32]) -> Vec<u8> {
         let actual_len = end - start;
         for i in 0..32 {
             let lo_val = if i < actual_len { group[i] } else { min_val };
-            let hi_val = if 32 + i < actual_len { group[32 + i] } else { min_val };
+            let hi_val = if 32 + i < actual_len {
+                group[32 + i]
+            } else {
+                min_val
+            };
 
             let lo_q = ((lo_val - min_val) * inv_scale + 0.5) as u8;
             let hi_q = ((hi_val - min_val) * inv_scale + 0.5) as u8;
@@ -512,7 +567,9 @@ fn quantize_q4k(f32_data: &[f32]) -> Vec<u8> {
         for sb in 0..8 {
             let start = sb_start + sb * 32;
             let end = (start + 32).min(sb_end);
-            if start >= sb_end { break; }
+            if start >= sb_end {
+                break;
+            }
             let group = &f32_data[start..end];
 
             let min_val = group.iter().cloned().fold(f32::INFINITY, f32::min);
@@ -527,7 +584,11 @@ fn quantize_q4k(f32_data: &[f32]) -> Vec<u8> {
         let max_scale = sub_scales.iter().cloned().fold(0.0f32, f32::max);
         let max_min = sub_mins.iter().map(|m| -m).fold(0.0f32, f32::max); // mins are typically negative
 
-        let d = if max_scale > 0.0 { max_scale / 63.0 } else { 0.0 }; // 6-bit scale range
+        let d = if max_scale > 0.0 {
+            max_scale / 63.0
+        } else {
+            0.0
+        }; // 6-bit scale range
         let dmin = if max_min > 0.0 { max_min / 63.0 } else { 0.0 };
 
         let inv_d = if d > 0.0 { 1.0 / d } else { 0.0 };
@@ -567,11 +628,19 @@ fn quantize_q4k(f32_data: &[f32]) -> Vec<u8> {
 
             let eff_scale_e = d * scale_ints[sb_even] as f32;
             let eff_min_e = dmin * min_ints[sb_even] as f32;
-            let inv_se = if eff_scale_e > 0.0 { 1.0 / eff_scale_e } else { 0.0 };
+            let inv_se = if eff_scale_e > 0.0 {
+                1.0 / eff_scale_e
+            } else {
+                0.0
+            };
 
             let eff_scale_o = d * scale_ints[sb_odd] as f32;
             let eff_min_o = dmin * min_ints[sb_odd] as f32;
-            let inv_so = if eff_scale_o > 0.0 { 1.0 / eff_scale_o } else { 0.0 };
+            let inv_so = if eff_scale_o > 0.0 {
+                1.0 / eff_scale_o
+            } else {
+                0.0
+            };
 
             for l in 0..32 {
                 let idx_e = sb_start + group * 64 + l;
@@ -706,7 +775,9 @@ fn quantize_q8hfq(f32_data: &[f32], m: usize, k: usize) -> (Vec<u8>, usize) {
 /// Matches the GPU-side fwht_forward_256 in turbo_common: signs1 → butterfly → scale → signs2.
 fn cpu_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
     assert!(x.len() == 256);
-    for i in 0..256 { x[i] *= signs1[i]; }
+    for i in 0..256 {
+        x[i] *= signs1[i];
+    }
     let mut stride = 1;
     while stride < 256 {
         let mut i = 0;
@@ -722,18 +793,25 @@ fn cpu_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
         stride <<= 1;
     }
     let scale = 0.0625; // 1/sqrt(256) = 1/16
-    for i in 0..256 { x[i] *= scale * signs2[i]; }
+    for i in 0..256 {
+        x[i] *= scale * signs2[i];
+    }
 }
 
 /// Generate FWHT sign table (matches engine's gen_fwht_signs).
 fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     let mut state = seed;
-    (0..n).map(|_| {
-        state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
-        if (state >> 16) & 1 == 1 { 1.0f32 } else { -1.0f32 }
-    }).collect()
+    (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
+            if (state >> 16) & 1 == 1 {
+                1.0f32
+            } else {
+                -1.0f32
+            }
+        })
+        .collect()
 }
-
 
 /// MagnumQuant HFQ4-G256: FWHT-rotated 4-bit quantization.
 /// Same binary format as HFQ4-G256 (136 bytes/group) — the rotation is baked
@@ -823,7 +901,7 @@ fn quantize_mq6g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8>
             let q3 = q3.min(63);
 
             let byte_off = 8 + (i / 4) * 3;
-            output[out_off + byte_off]     = q0 | (q1 << 6);
+            output[out_off + byte_off] = q0 | (q1 << 6);
             output[out_off + byte_off + 1] = (q1 >> 2) | (q2 << 4);
             output[out_off + byte_off + 2] = (q2 >> 4) | (q3 << 2);
         }
@@ -905,8 +983,16 @@ fn quantize_hfq4g256(f32_data: &[f32]) -> Vec<u8> {
         for i in 0..128 {
             let idx_lo = 2 * i;
             let idx_hi = 2 * i + 1;
-            let lo_val = if idx_lo < actual_len { group[idx_lo] } else { min_val };
-            let hi_val = if idx_hi < actual_len { group[idx_hi] } else { min_val };
+            let lo_val = if idx_lo < actual_len {
+                group[idx_lo]
+            } else {
+                min_val
+            };
+            let hi_val = if idx_hi < actual_len {
+                group[idx_hi]
+            } else {
+                min_val
+            };
 
             let lo_q = ((lo_val - min_val) * inv_scale + 0.5) as u8;
             let hi_q = ((hi_val - min_val) * inv_scale + 0.5) as u8;
@@ -929,8 +1015,7 @@ fn quantize_hfq4g256(f32_data: &[f32]) -> Vec<u8> {
 /// OCP E2M1 magnitude lattice (signed 4-bit FP). 16 codes: {±0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}.
 /// Order: positive 0..7, then negative 0..7 (mirrors hardware-canonical sign-magnitude packing).
 const E2M1_LUT: [f32; 16] = [
-    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
-    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
 ];
 
 /// E2M1 round-to-nearest in the 16-code lattice. Returns the nibble (0..15).
@@ -955,7 +1040,11 @@ fn e2m1_round(x: f32) -> u8 {
 /// K must be a multiple of 32 (hipfire model dims always satisfy this).
 /// Returns 16-B header + (K/32) × 17-B blocks = 16 + 17 * (K/32) bytes.
 fn quantize_hfp4g32_row(row: &[f32]) -> Vec<u8> {
-    assert!(row.len() % 32 == 0, "HFP4G32 requires K%32 == 0, got K={}", row.len());
+    assert!(
+        row.len() % 32 == 0,
+        "HFP4G32 requires K%32 == 0, got K={}",
+        row.len()
+    );
     let k = row.len();
     let n_blocks = k / 32;
     let row_bytes = 16 + n_blocks * 17;
@@ -963,16 +1052,24 @@ fn quantize_hfp4g32_row(row: &[f32]) -> Vec<u8> {
 
     // Per-row FP16 second-level scale: row_scale_a = max_abs(row) / 6.0  (E2M1 max = 6.0).
     let row_max_abs = row.iter().cloned().fold(0.0f32, |m, v| m.max(v.abs()));
-    let row_scale_a = if row_max_abs > 0.0 { row_max_abs / 6.0 } else { 1.0 };
-    let inv_row_scale = if row_max_abs > 0.0 { 1.0 / row_scale_a } else { 0.0 };
+    let row_scale_a = if row_max_abs > 0.0 {
+        row_max_abs / 6.0
+    } else {
+        1.0
+    };
+    let inv_row_scale = if row_max_abs > 0.0 {
+        1.0 / row_scale_a
+    } else {
+        0.0
+    };
 
     // Header.
     out[0..2].copy_from_slice(&f32_to_f16(row_scale_a).to_le_bytes());
-    out[2..4].copy_from_slice(&0u16.to_le_bytes());           // row_scale_b unused in v1
+    out[2..4].copy_from_slice(&0u16.to_le_bytes()); // row_scale_b unused in v1
     out[4..6].copy_from_slice(&(n_blocks as u16).to_le_bytes()); // block_count
-    out[6] = 0u8;                                              // format_flags = 0 (no rotation)
-    out[7] = 0u8;                                              // reserved
-    // out[8..16] reserved zeros (already zeroed by vec![0u8; ...])
+    out[6] = 0u8; // format_flags = 0 (no rotation)
+    out[7] = 0u8; // reserved
+                  // out[8..16] reserved zeros (already zeroed by vec![0u8; ...])
 
     // Per-block payload.
     for b in 0..n_blocks {
@@ -999,7 +1096,11 @@ fn quantize_hfp4g32_row(row: &[f32]) -> Vec<u8> {
 
         let block_scale = (block_e as i32 - 127) as f32;
         let block_scale_factor = block_scale.exp2(); // 2^(block_e - 127)
-        let inv_block_scale = if block_scale_factor > 0.0 { 1.0 / block_scale_factor } else { 0.0 };
+        let inv_block_scale = if block_scale_factor > 0.0 {
+            1.0 / block_scale_factor
+        } else {
+            0.0
+        };
 
         // Block payload offset in the row buffer.
         let payload_off = 16 + b * 17;
@@ -1028,7 +1129,14 @@ fn quantize_hfp4g32_row(row: &[f32]) -> Vec<u8> {
 /// makes the failure mode "quantize rejects bad input" rather than "runtime
 /// panics on first dispatch with a tensor a previous step already accepted."
 fn quantize_hfp4g32_2d(f32_data: &[f32], m: usize, k: usize) -> Vec<u8> {
-    assert_eq!(f32_data.len(), m * k, "2D shape mismatch: {} vs {}*{}", f32_data.len(), m, k);
+    assert_eq!(
+        f32_data.len(),
+        m * k,
+        "2D shape mismatch: {} vs {}*{}",
+        f32_data.len(),
+        m,
+        k
+    );
     assert!(k % 256 == 0, "HFP4G32 v1 requires K%256==0 (gemv_hfp4g32 kernel constraint; v2 will lift to K%32==0), got K={}", k);
     let row_bytes = 16 + 17 * (k / 32);
     let mut out = Vec::with_capacity(m * row_bytes);
@@ -1049,9 +1157,26 @@ fn quantize_hfp4g32_2d(f32_data: &[f32], m: usize, k: usize) -> Vec<u8> {
 /// Sets per-row `format_flags` to `0x05` (bit 0 = rotation present, bits 2-3 = 01
 /// = offline FWHT). This is metadata only — the kernel can still consume the
 /// row as plain HFP4G32 because the rotation is baked into the codes.
-fn quantize_mfp4g32_2d(f32_data: &[f32], m: usize, k: usize, signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
-    assert_eq!(f32_data.len(), m * k, "2D shape mismatch: {} vs {}*{}", f32_data.len(), m, k);
-    assert!(k % 256 == 0, "MFP4G32 requires k % 256 == 0 for 256-element FWHT, got k={}", k);
+fn quantize_mfp4g32_2d(
+    f32_data: &[f32],
+    m: usize,
+    k: usize,
+    signs1: &[f32],
+    signs2: &[f32],
+) -> Vec<u8> {
+    assert_eq!(
+        f32_data.len(),
+        m * k,
+        "2D shape mismatch: {} vs {}*{}",
+        f32_data.len(),
+        m,
+        k
+    );
+    assert!(
+        k % 256 == 0,
+        "MFP4G32 requires k % 256 == 0 for 256-element FWHT, got k={}",
+        k
+    );
     let row_bytes = 16 + 17 * (k / 32);
     let mut out = Vec::with_capacity(m * row_bytes);
 
@@ -1080,7 +1205,11 @@ fn quantize_mfp4g32_2d(f32_data: &[f32], m: usize, k: usize, signs1: &[f32], sig
 fn dequant_hfp4g32_row(packed: &[u8], k: usize) -> Vec<f32> {
     assert!(k % 32 == 0, "HFP4G32 requires K%32 == 0");
     let n_blocks = k / 32;
-    assert_eq!(packed.len(), 16 + n_blocks * 17, "HFP4G32 row size mismatch");
+    assert_eq!(
+        packed.len(),
+        16 + n_blocks * 17,
+        "HFP4G32 row size mismatch"
+    );
 
     let row_scale_a_bits = u16::from_le_bytes([packed[0], packed[1]]);
     let row_scale_a = f16_to_f32(row_scale_a_bits);
@@ -1097,7 +1226,7 @@ fn dequant_hfp4g32_row(packed: &[u8], k: usize) -> Vec<f32> {
             let byte = packed[payload_off + 1 + i];
             let lo_nibble = (byte & 0x0F) as usize;
             let hi_nibble = ((byte >> 4) & 0x0F) as usize;
-            out[b * 32 + 2 * i]     = scale * E2M1_LUT[lo_nibble];
+            out[b * 32 + 2 * i] = scale * E2M1_LUT[lo_nibble];
             out[b * 32 + 2 * i + 1] = scale * E2M1_LUT[hi_nibble];
         }
     }
@@ -1115,18 +1244,18 @@ mod awq_tests {
     fn awq_scales_geomean_is_one() {
         // Realistic-ish imatrix: log-normal-ish per-channel statistics
         let in_sum2: Vec<f32> = (0..256)
-            .map(|j| (1.0 + 10.0 * (j as f32 / 256.0)).exp())  // 1.0 → e^11
+            .map(|j| (1.0 + 10.0 * (j as f32 / 256.0)).exp()) // 1.0 → e^11
             .collect();
         for &alpha in &[0.0f32, 0.25, 0.5, 0.75, 1.0] {
             let s = compute_awq_scales(&in_sum2, alpha);
             assert_eq!(s.len(), in_sum2.len());
             // Geometric mean = exp(mean(log(s)))
-            let log_mean = s.iter()
-                .map(|&v| (v as f64).ln())
-                .sum::<f64>() / s.len() as f64;
+            let log_mean = s.iter().map(|&v| (v as f64).ln()).sum::<f64>() / s.len() as f64;
             let geo_mean = log_mean.exp();
-            assert!((geo_mean - 1.0).abs() < 1e-4,
-                "alpha={alpha}: geo_mean={geo_mean} (want 1.0)");
+            assert!(
+                (geo_mean - 1.0).abs() < 1e-4,
+                "alpha={alpha}: geo_mean={geo_mean} (want 1.0)"
+            );
         }
     }
 
@@ -1189,8 +1318,13 @@ mod awq_tests {
         // Compare
         for i in 0..m {
             let rel = (y_awq[i] - y_ref[i]).abs() / y_ref[i].abs().max(1e-6);
-            assert!(rel < 1e-5,
-                "row {i}: AWQ y={} ref y={} rel_err={}", y_awq[i], y_ref[i], rel);
+            assert!(
+                rel < 1e-5,
+                "row {i}: AWQ y={} ref y={} rel_err={}",
+                y_awq[i],
+                y_ref[i],
+                rel
+            );
         }
     }
 
@@ -1201,7 +1335,10 @@ mod awq_tests {
         let in_sum2 = vec![0.0_f32, 1.0, 4.0, 0.0];
         let s = compute_awq_scales(&in_sum2, 0.5);
         for &v in &s {
-            assert!(v.is_finite() && v > 0.0, "scale {v} should be finite + positive");
+            assert!(
+                v.is_finite() && v > 0.0,
+                "scale {v} should be finite + positive"
+            );
         }
     }
 }
@@ -1217,9 +1354,17 @@ mod hfp4_tests {
             let nibble = e2m1_round(val);
             // +0 and -0 are both at value 0.0; either nibble is acceptable.
             if val.abs() < 1e-6 {
-                assert!(nibble == 0 || nibble == 8, "zero rounds to nibble {}", nibble);
+                assert!(
+                    nibble == 0 || nibble == 8,
+                    "zero rounds to nibble {}",
+                    nibble
+                );
             } else {
-                assert_eq!(nibble, i as u8, "code {} rounded to nibble {} not {}", i, nibble, i);
+                assert_eq!(
+                    nibble, i as u8,
+                    "code {} rounded to nibble {} not {}",
+                    i, nibble, i
+                );
             }
         }
     }
@@ -1248,10 +1393,12 @@ mod hfp4_tests {
     #[test]
     fn round_trip_mixed_magnitudes() {
         // Row with mixed positive/negative E2M1 magnitudes — should round-trip exactly.
-        let row: Vec<f32> = (0..64).map(|i| {
-            let v = E2M1_LUT[i % 16];
-            v * 6.0 // scale up so row_scale_a sees max abs at 6 * 6 = 36, brings code lattice back to [-6, 6]
-        }).collect();
+        let row: Vec<f32> = (0..64)
+            .map(|i| {
+                let v = E2M1_LUT[i % 16];
+                v * 6.0 // scale up so row_scale_a sees max abs at 6 * 6 = 36, brings code lattice back to [-6, 6]
+            })
+            .collect();
         let packed = quantize_hfp4g32_row(&row);
         let recovered = dequant_hfp4g32_row(&packed, 64);
         // Bound: |recovered - input| ≤ row_scale * 2^(block_e - 127) * 0.5 (half min E2M1 step).
@@ -1259,7 +1406,14 @@ mod hfp4_tests {
         // Actual tolerance should be much tighter for exact lattice values; allow some headroom.
         for (i, (&got, &want)) in recovered.iter().zip(row.iter()).enumerate() {
             let rel_err = (got - want).abs() / want.abs().max(1.0);
-            assert!(rel_err < 0.1, "elem {}: got {} want {} rel_err {}", i, got, want, rel_err);
+            assert!(
+                rel_err < 0.1,
+                "elem {}: got {} want {} rel_err {}",
+                i,
+                got,
+                want,
+                rel_err
+            );
         }
     }
 
@@ -1280,13 +1434,15 @@ mod hfp4_tests {
             ((rng_state & 0x00FF_FFFF) as f32 / 0x0100_0000 as f32).max(1e-7)
         };
         // Box-Muller Gaussian std=0.5.
-        let row: Vec<f32> = (0..512).flat_map(|_| {
-            let u1 = next_uniform();
-            let u2 = next_uniform();
-            let r = (-2.0 * u1.ln()).sqrt();
-            let t = 2.0 * std::f32::consts::PI * u2;
-            [r * t.cos() * 0.5, r * t.sin() * 0.5]
-        }).collect();
+        let row: Vec<f32> = (0..512)
+            .flat_map(|_| {
+                let u1 = next_uniform();
+                let u2 = next_uniform();
+                let r = (-2.0 * u1.ln()).sqrt();
+                let t = 2.0 * std::f32::consts::PI * u2;
+                [r * t.cos() * 0.5, r * t.sin() * 0.5]
+            })
+            .collect();
 
         let k = row.len();
         let packed = quantize_hfp4g32_row(&row);
@@ -1345,7 +1501,13 @@ mod hfp4_tests {
         assert_eq!(packed.len(), m * row_bytes, "MFP4G32 byte length mismatch");
         for r in 0..m {
             let off = r * row_bytes;
-            assert_eq!(packed[off + 6], 0x05, "row {} format_flags expected 0x05, got {:#x}", r, packed[off + 6]);
+            assert_eq!(
+                packed[off + 6],
+                0x05,
+                "row {} format_flags expected 0x05, got {:#x}",
+                r,
+                packed[off + 6]
+            );
             // block_count must equal k/32.
             let bc = u16::from_le_bytes([packed[off + 4], packed[off + 5]]);
             assert_eq!(bc as usize, k / 32);
@@ -1499,7 +1661,9 @@ fn f32_to_fp16_bits(v: f32) -> u16 {
             // Mantissa overflow → carry into exponent
             m16 = 0;
             exp += 1;
-            if exp >= 0x1F { return sign | 0x7C00; }
+            if exp >= 0x1F {
+                return sign | 0x7C00;
+            }
         }
     }
     sign | ((exp as u16) << 10) | m16
@@ -1555,15 +1719,22 @@ fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..8 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        if it == 0 || prev_assignments[i] != best as u8 {
+                            changed += 1;
+                        }
                         prev_assignments[i] = best as u8;
                         indices[i] = best as u8;
                         sums[best] += w as f64;
                         counts[best] += 1;
                     }
-                    if it > 0 && changed == 0 { break; }
+                    if it > 0 && changed == 0 {
+                        break;
+                    }
                     for k in 0..8 {
                         if counts[k] > 0 {
                             cb[k] = (sums[k] / counts[k] as f64) as f32;
@@ -1574,19 +1745,25 @@ fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
 
             // Sort centroids ascending; remap indices.
             let mut order: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            order.sort_by(|&a, &b| {
+                cb[a]
+                    .partial_cmp(&cb[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             let mut sorted_cb = [0.0f32; 8];
             let mut inv: [u8; 8] = [0; 8];
             for new_idx in 0..8 {
                 sorted_cb[new_idx] = cb[order[new_idx]];
                 inv[order[new_idx]] = new_idx as u8;
             }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            for i in 0..256 {
+                indices[i] = inv[indices[i] as usize];
+            }
 
             // Header: 8 fp16 centroids = 16 bytes.
             for k in 0..8 {
                 let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k] = (bits & 0xFF) as u8;
                 out_chunk[2 * k + 1] = (bits >> 8) as u8;
             }
 
@@ -1596,8 +1773,14 @@ fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
             for chunk in 0..32 {
                 let ci = chunk * 8;
                 let q = [
-                    indices[ci]     & 7, indices[ci + 1] & 7, indices[ci + 2] & 7, indices[ci + 3] & 7,
-                    indices[ci + 4] & 7, indices[ci + 5] & 7, indices[ci + 6] & 7, indices[ci + 7] & 7,
+                    indices[ci] & 7,
+                    indices[ci + 1] & 7,
+                    indices[ci + 2] & 7,
+                    indices[ci + 3] & 7,
+                    indices[ci + 4] & 7,
+                    indices[ci + 5] & 7,
+                    indices[ci + 6] & 7,
+                    indices[ci + 7] & 7,
                 ];
                 let b0 = q[0] | (q[1] << 3) | ((q[2] & 3) << 6);
                 let b1 = (q[2] >> 2) | (q[3] << 1) | (q[4] << 4) | ((q[5] & 1) << 7);
@@ -1665,15 +1848,22 @@ fn quantize_mq4g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..16 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        if it == 0 || prev_assignments[i] != best as u8 {
+                            changed += 1;
+                        }
                         prev_assignments[i] = best as u8;
                         indices[i] = best as u8;
                         sums[best] += w as f64;
                         counts[best] += 1;
                     }
-                    if it > 0 && changed == 0 { break; }
+                    if it > 0 && changed == 0 {
+                        break;
+                    }
                     for k in 0..16 {
                         if counts[k] > 0 {
                             cb[k] = (sums[k] / counts[k] as f64) as f32;
@@ -1684,19 +1874,25 @@ fn quantize_mq4g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
 
             // Sort centroids ascending; remap indices.
             let mut order: [usize; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            order.sort_by(|&a, &b| {
+                cb[a]
+                    .partial_cmp(&cb[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             let mut sorted_cb = [0.0f32; 16];
             let mut inv: [u8; 16] = [0; 16];
             for new_idx in 0..16 {
                 sorted_cb[new_idx] = cb[order[new_idx]];
                 inv[order[new_idx]] = new_idx as u8;
             }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            for i in 0..256 {
+                indices[i] = inv[indices[i] as usize];
+            }
 
             // Header: 16 fp16 centroids = 32 bytes.
             for k in 0..16 {
                 let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k] = (bits & 0xFF) as u8;
                 out_chunk[2 * k + 1] = (bits >> 8) as u8;
             }
 
@@ -1705,7 +1901,7 @@ fn quantize_mq4g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
             // unpack code is identical; only the recon changes from
             // `min + scale*q` to `cb[q]`.
             for i in 0..128 {
-                let lo = indices[2 * i]     & 0x0F;
+                let lo = indices[2 * i] & 0x0F;
                 let hi = indices[2 * i + 1] & 0x0F;
                 out_chunk[32 + i] = lo | (hi << 4);
             }
@@ -1772,16 +1968,22 @@ fn imatrix_col_weights_for_parent(
     let k = in_sum2.shape[0];
     let n_exp = in_sum2.shape[1];
     if n_exp != n_experts {
-        eprintln!("  imatrix: {} n_experts mismatch ({} vs {})",
-            in_sum2_name, n_exp, n_experts);
+        eprintln!(
+            "  imatrix: {} n_experts mismatch ({} vs {})",
+            in_sum2_name, n_exp, n_experts
+        );
         return None;
     }
     let in_sum2_bytes = gguf.tensor_data(in_sum2);
     let counts_bytes = gguf.tensor_data(counts);
-    let in_sum2_flat: Vec<f32> = in_sum2_bytes.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
-    let counts_flat: Vec<f32> = counts_bytes.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+    let in_sum2_flat: Vec<f32> = in_sum2_bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+    let counts_flat: Vec<f32> = counts_bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
     if in_sum2_flat.len() != k * n_exp || counts_flat.len() != n_exp {
         eprintln!("  imatrix: {} length mismatch", in_sum2_name);
         return None;
@@ -1830,11 +2032,13 @@ fn imatrix_layer_activation_counts(
         if let (Some(s2), Some(c)) = (sum2, cts) {
             let s2_bytes = gguf.tensor_data(s2);
             let c_bytes = gguf.tensor_data(c);
-            let sum2_total: f64 = s2_bytes.chunks_exact(4)
-                .map(|b| f32::from_le_bytes([b[0],b[1],b[2],b[3]]) as f64)
+            let sum2_total: f64 = s2_bytes
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f64)
                 .sum();
-            let counts_total: f64 = c_bytes.chunks_exact(4)
-                .map(|b| f32::from_le_bytes([b[0],b[1],b[2],b[3]]) as f64)
+            let counts_total: f64 = c_bytes
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f64)
                 .sum();
             if counts_total > 0.0 {
                 // mean activation magnitude per K-column per expert in this layer
@@ -1843,7 +2047,11 @@ fn imatrix_layer_activation_counts(
             }
         }
     }
-    if found_any { Some(out) } else { None }
+    if found_any {
+        Some(out)
+    } else {
+        None
+    }
 }
 
 /// Imatrix-weighted MQ2-Lloyd quantization. Per-column importance weights
@@ -1865,7 +2073,8 @@ fn imatrix_layer_activation_counts(
 fn quantize_mq2g256_lloyd_weighted(
     f32_data: &[f32],
     col_weights: &[f32],
-    signs1: &[f32], signs2: &[f32],
+    signs1: &[f32],
+    signs2: &[f32],
 ) -> Vec<u8> {
     use rayon::prelude::*;
     let group_size = 256;
@@ -1928,16 +2137,23 @@ fn quantize_mq2g256_lloyd_weighted(
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..4 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        if it == 0 || prev_assignments[i] != best as u8 {
+                            changed += 1;
+                        }
                         prev_assignments[i] = best as u8;
                         indices[i] = best as u8;
                         let pw = block_w[i] as f64;
                         weighted_sums[best] += pw * w as f64;
                         weight_totals[best] += pw;
                     }
-                    if it > 0 && changed == 0 { break; }
+                    if it > 0 && changed == 0 {
+                        break;
+                    }
                     for k in 0..4 {
                         if weight_totals[k] > 0.0 {
                             cb[k] = (weighted_sums[k] / weight_totals[k]) as f32;
@@ -1948,23 +2164,31 @@ fn quantize_mq2g256_lloyd_weighted(
 
             // Sort centroids ascending (canonical header).
             let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            order.sort_by(|&a, &b| {
+                cb[a]
+                    .partial_cmp(&cb[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             let mut sorted_cb = [0.0f32; 4];
             let mut inv: [u8; 4] = [0; 4];
             for new_idx in 0..4 {
                 sorted_cb[new_idx] = cb[order[new_idx]];
                 inv[order[new_idx]] = new_idx as u8;
             }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            for i in 0..256 {
+                indices[i] = inv[indices[i] as usize];
+            }
 
             for k in 0..4 {
                 let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k] = (bits & 0xFF) as u8;
                 out_chunk[2 * k + 1] = (bits >> 8) as u8;
             }
             for i in 0..64 {
                 let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                for j in 0..4 {
+                    byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                }
                 out_chunk[8 + i] = byte_val;
             }
         });
@@ -1993,7 +2217,8 @@ fn quantize_mq2g256_lloyd_weighted(
 fn quantize_mq2g256_lloyd_gptq(
     f32_data: &[f32],
     col_weights: &[f32],
-    signs1: &[f32], signs2: &[f32],
+    signs1: &[f32],
+    signs2: &[f32],
 ) -> Vec<u8> {
     use rayon::prelude::*;
     let group_size = 256;
@@ -2088,15 +2313,22 @@ fn quantize_mq2g256_lloyd_gptq(
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..4 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        if it == 0 || prev_assignments[i] != best as u8 {
+                            changed += 1;
+                        }
                         prev_assignments[i] = best as u8;
                         let pw = block_w[i] as f64;
                         weighted_sums[best] += pw * w as f64;
                         weight_totals[best] += pw;
                     }
-                    if it > 0 && changed == 0 { break; }
+                    if it > 0 && changed == 0 {
+                        break;
+                    }
                     for k in 0..4 {
                         if weight_totals[k] > 0.0 {
                             cb[k] = (weighted_sums[k] / weight_totals[k]) as f32;
@@ -2107,7 +2339,11 @@ fn quantize_mq2g256_lloyd_gptq(
 
             // Sort centroids ascending (canonical header).
             let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            order.sort_by(|&a, &b| {
+                cb[a]
+                    .partial_cmp(&cb[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             let mut sorted_cb = [0.0f32; 4];
             for new_idx in 0..4 {
                 sorted_cb[new_idx] = cb[order[new_idx]];
@@ -2131,7 +2367,10 @@ fn quantize_mq2g256_lloyd_gptq(
                 let mut best_d = (target - cb_final[0]).abs();
                 for k in 1..4 {
                     let d = (target - cb_final[k]).abs();
-                    if d < best_d { best_d = d; best = k; }
+                    if d < best_d {
+                        best_d = d;
+                        best = k;
+                    }
                 }
                 indices[i] = best as u8;
                 let err = target - cb_final[best];
@@ -2141,12 +2380,14 @@ fn quantize_mq2g256_lloyd_gptq(
             // Pack header + indices.
             for k in 0..4 {
                 let bits = f32_to_fp16_bits(cb_final[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k] = (bits & 0xFF) as u8;
                 out_chunk[2 * k + 1] = (bits >> 8) as u8;
             }
             for i in 0..64 {
                 let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                for j in 0..4 {
+                    byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                }
                 out_chunk[8 + i] = byte_val;
             }
         });
@@ -2231,15 +2472,22 @@ fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..4 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
+                        if it == 0 || prev_assignments[i] != best as u8 {
+                            changed += 1;
+                        }
                         prev_assignments[i] = best as u8;
                         indices[i] = best as u8;
                         sums[best] += w as f64;
                         counts[best] += 1;
                     }
-                    if it > 0 && changed == 0 { break; }
+                    if it > 0 && changed == 0 {
+                        break;
+                    }
                     for k in 0..4 {
                         if counts[k] > 0 {
                             cb[k] = (sums[k] / counts[k] as f64) as f32;
@@ -2251,24 +2499,32 @@ fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
             // Sort centroids ascending; remap indices to keep header canonical
             // and the permutation deterministic across re-runs.
             let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            order.sort_by(|&a, &b| {
+                cb[a]
+                    .partial_cmp(&cb[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             let mut sorted_cb = [0.0f32; 4];
             let mut inv: [u8; 4] = [0; 4];
             for new_idx in 0..4 {
                 sorted_cb[new_idx] = cb[order[new_idx]];
                 inv[order[new_idx]] = new_idx as u8;
             }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            for i in 0..256 {
+                indices[i] = inv[indices[i] as usize];
+            }
 
             for k in 0..4 {
                 let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k] = (bits & 0xFF) as u8;
                 out_chunk[2 * k + 1] = (bits >> 8) as u8;
             }
             // 256 indices × 2 bits = 64 bytes. Same packing as uniform MQ2.
             for i in 0..64 {
                 let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                for j in 0..4 {
+                    byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                }
                 out_chunk[8 + i] = byte_val;
             }
         });
@@ -2324,40 +2580,57 @@ fn quantize_mq2g256_lloyd_k3(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..3 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        if it == 0 || prev[i] != best as u8 { changed += 1; }
+                        if it == 0 || prev[i] != best as u8 {
+                            changed += 1;
+                        }
                         prev[i] = best as u8;
                         indices[i] = best as u8;
                         sums[best] += w as f64;
                         counts[best] += 1;
                     }
-                    if it > 0 && changed == 0 { break; }
+                    if it > 0 && changed == 0 {
+                        break;
+                    }
                     for k in 0..3 {
-                        if counts[k] > 0 { cb[k] = (sums[k] / counts[k] as f64) as f32; }
+                        if counts[k] > 0 {
+                            cb[k] = (sums[k] / counts[k] as f64) as f32;
+                        }
                     }
                 }
             }
             // Sort the 3 centroids ascending; remap indices.
             let mut order: [usize; 3] = [0, 1, 2];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
+            order.sort_by(|&a, &b| {
+                cb[a]
+                    .partial_cmp(&cb[b])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
             let mut sorted_cb = [0.0f32; 3];
             let mut inv: [u8; 3] = [0; 3];
             for new_idx in 0..3 {
                 sorted_cb[new_idx] = cb[order[new_idx]];
                 inv[order[new_idx]] = new_idx as u8;
             }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
+            for i in 0..256 {
+                indices[i] = inv[indices[i] as usize];
+            }
             // Header: slots 0..2 = the 3 centroids; slot 3 = dup of slot 2 (never indexed).
             let header = [sorted_cb[0], sorted_cb[1], sorted_cb[2], sorted_cb[2]];
             for k in 0..4 {
                 let bits = f32_to_fp16_bits(header[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
+                out_chunk[2 * k] = (bits & 0xFF) as u8;
                 out_chunk[2 * k + 1] = (bits >> 8) as u8;
             }
             for i in 0..64 {
                 let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
+                for j in 0..4 {
+                    byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                }
                 out_chunk[8 + i] = byte_val;
             }
         });
@@ -2367,7 +2640,9 @@ fn quantize_mq2g256_lloyd_k3(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -
 /// Inverse FWHT for MQ-family dequantization (sibling of cpu_fwht_256).
 fn cpu_inv_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
     assert!(x.len() == 256);
-    for i in 0..256 { x[i] *= signs2[i]; }
+    for i in 0..256 {
+        x[i] *= signs2[i];
+    }
     let mut stride = 1;
     while stride < 256 {
         let mut i = 0;
@@ -2383,14 +2658,19 @@ fn cpu_inv_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
         stride <<= 1;
     }
     let scale = 0.0625; // 1/sqrt(256) = 1/16
-    for i in 0..256 { x[i] *= scale * signs1[i]; }
+    for i in 0..256 {
+        x[i] *= scale * signs1[i];
+    }
 }
 
 /// MQ2-Lloyd dequantize for round-trip / re-quant pipelines. Mirrors
 /// the kernel's decode: 4-entry fp16 codebook + 2-bit indices per 256-
 /// weight group, then inverse FWHT.
 fn dequantize_mq2g256_lloyd_to_f32(
-    data: &[u8], n_weights: usize, signs1: &[f32], signs2: &[f32],
+    data: &[u8],
+    n_weights: usize,
+    signs1: &[f32],
+    signs2: &[f32],
 ) -> Vec<f32> {
     let group_size = 256;
     let block_bytes = 72;
@@ -2398,26 +2678,28 @@ fn dequantize_mq2g256_lloyd_to_f32(
     assert!(data.len() == n_blocks * block_bytes);
     let mut out = vec![0.0f32; n_weights];
     use rayon::prelude::*;
-    out.par_chunks_mut(group_size).enumerate().for_each(|(b, out_chunk)| {
-        let blk = &data[b * block_bytes..(b + 1) * block_bytes];
-        let cb: [f32; 4] = [
-            f16_to_f32(u16::from_le_bytes([blk[0], blk[1]])),
-            f16_to_f32(u16::from_le_bytes([blk[2], blk[3]])),
-            f16_to_f32(u16::from_le_bytes([blk[4], blk[5]])),
-            f16_to_f32(u16::from_le_bytes([blk[6], blk[7]])),
-        ];
-        let mut group = [0.0f32; 256];
-        for i in 0..64 {
-            let byte_val = blk[8 + i];
-            for j in 0..4 {
-                let idx = (byte_val >> (j * 2)) & 0x3;
-                group[4 * i + j] = cb[idx as usize];
+    out.par_chunks_mut(group_size)
+        .enumerate()
+        .for_each(|(b, out_chunk)| {
+            let blk = &data[b * block_bytes..(b + 1) * block_bytes];
+            let cb: [f32; 4] = [
+                f16_to_f32(u16::from_le_bytes([blk[0], blk[1]])),
+                f16_to_f32(u16::from_le_bytes([blk[2], blk[3]])),
+                f16_to_f32(u16::from_le_bytes([blk[4], blk[5]])),
+                f16_to_f32(u16::from_le_bytes([blk[6], blk[7]])),
+            ];
+            let mut group = [0.0f32; 256];
+            for i in 0..64 {
+                let byte_val = blk[8 + i];
+                for j in 0..4 {
+                    let idx = (byte_val >> (j * 2)) & 0x3;
+                    group[4 * i + j] = cb[idx as usize];
+                }
             }
-        }
-        cpu_inv_fwht_256(&mut group, signs1, signs2);
-        let actual = out_chunk.len();
-        out_chunk.copy_from_slice(&group[..actual]);
-    });
+            cpu_inv_fwht_256(&mut group, signs1, signs2);
+            let actual = out_chunk.len();
+            out_chunk.copy_from_slice(&group[..actual]);
+        });
     out
 }
 
@@ -2456,7 +2738,11 @@ fn quantize_hfq3g256(f32_data: &[f32]) -> Vec<u8> {
             let mut q = [0u8; 8];
             for j in 0..8 {
                 let idx = ci + j;
-                let val = if idx < actual_len { group[idx] } else { min_val };
+                let val = if idx < actual_len {
+                    group[idx]
+                } else {
+                    min_val
+                };
                 q[j] = ((val - min_val) * inv_scale + 0.5).clamp(0.0, 7.0) as u8;
             }
             // Pack 8 × 3-bit into 3 bytes (little-endian bitstream)
@@ -2515,7 +2801,11 @@ fn quantize_hfq3g128(f32_data: &[f32]) -> Vec<u8> {
             let mut q = [0u8; 8];
             for j in 0..8 {
                 let idx = ci + j;
-                let val = if idx < actual_len { group[idx] } else { min_val };
+                let val = if idx < actual_len {
+                    group[idx]
+                } else {
+                    min_val
+                };
                 q[j] = ((val - min_val) * inv_scale + 0.5).clamp(0.0, 7.0) as u8;
             }
             let b0 = (q[0] & 7) | ((q[1] & 7) << 3) | ((q[2] & 3) << 6);
@@ -2550,7 +2840,7 @@ fn quantize_hfq2g256(f32_data: &[f32]) -> Vec<u8> {
         let max_val = group.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
 
         let range = max_val - min_val;
-        let scale = if range > 0.0 { range / 3.0 } else { 1.0 };  // 2-bit: 4 levels (0-3)
+        let scale = if range > 0.0 { range / 3.0 } else { 1.0 }; // 2-bit: 4 levels (0-3)
         let inv_scale = if range > 0.0 { 1.0 / scale } else { 0.0 };
 
         let out_off = b * block_bytes;
@@ -2563,7 +2853,11 @@ fn quantize_hfq2g256(f32_data: &[f32]) -> Vec<u8> {
             let mut byte_val = 0u8;
             for j in 0..4 {
                 let idx = 4 * i + j;
-                let val = if idx < actual_len { group[idx] } else { min_val };
+                let val = if idx < actual_len {
+                    group[idx]
+                } else {
+                    min_val
+                };
                 let q = ((val - min_val) * inv_scale + 0.5) as u8;
                 byte_val |= q.min(3) << (j * 2);
             }
@@ -2604,7 +2898,11 @@ fn quantize_hfq2g128(f32_data: &[f32]) -> Vec<u8> {
             let mut byte_val = 0u8;
             for j in 0..4 {
                 let idx = 4 * i + j;
-                let val = if idx < actual_len { group[idx] } else { min_val };
+                let val = if idx < actual_len {
+                    group[idx]
+                } else {
+                    min_val
+                };
                 let q = ((val - min_val) * inv_scale + 0.5) as u8;
                 byte_val |= q.min(3) << (j * 2);
             }
@@ -2642,17 +2940,33 @@ fn quantize_hfq6g256(f32_data: &[f32]) -> Vec<u8> {
         let actual_len = end - start;
         // Pack 4 values per 3 bytes: v0[5:0]|v1[1:0], v1[5:2]|v2[3:0], v2[5:4]|v3[5:0]
         for i in (0..256).step_by(4) {
-            let q0 = if i < actual_len { ((group[i] - min_val) * inv_scale + 0.5) as u8 } else { 0 };
-            let q1 = if i + 1 < actual_len { ((group[i+1] - min_val) * inv_scale + 0.5) as u8 } else { 0 };
-            let q2 = if i + 2 < actual_len { ((group[i+2] - min_val) * inv_scale + 0.5) as u8 } else { 0 };
-            let q3 = if i + 3 < actual_len { ((group[i+3] - min_val) * inv_scale + 0.5) as u8 } else { 0 };
+            let q0 = if i < actual_len {
+                ((group[i] - min_val) * inv_scale + 0.5) as u8
+            } else {
+                0
+            };
+            let q1 = if i + 1 < actual_len {
+                ((group[i + 1] - min_val) * inv_scale + 0.5) as u8
+            } else {
+                0
+            };
+            let q2 = if i + 2 < actual_len {
+                ((group[i + 2] - min_val) * inv_scale + 0.5) as u8
+            } else {
+                0
+            };
+            let q3 = if i + 3 < actual_len {
+                ((group[i + 3] - min_val) * inv_scale + 0.5) as u8
+            } else {
+                0
+            };
             let q0 = q0.min(63);
             let q1 = q1.min(63);
             let q2 = q2.min(63);
             let q3 = q3.min(63);
 
             let byte_off = 8 + (i / 4) * 3;
-            output[out_off + byte_off]     = q0 | (q1 << 6);
+            output[out_off + byte_off] = q0 | (q1 << 6);
             output[out_off + byte_off + 1] = (q1 >> 2) | (q2 << 4);
             output[out_off + byte_off + 2] = (q2 >> 4) | (q3 << 2);
         }
@@ -2690,8 +3004,16 @@ fn quantize_hfq4g128(f32_data: &[f32]) -> Vec<u8> {
         for i in 0..64 {
             let idx_lo = 2 * i;
             let idx_hi = 2 * i + 1;
-            let lo_val = if idx_lo < actual_len { group[idx_lo] } else { min_val };
-            let hi_val = if idx_hi < actual_len { group[idx_hi] } else { min_val };
+            let lo_val = if idx_lo < actual_len {
+                group[idx_lo]
+            } else {
+                min_val
+            };
+            let hi_val = if idx_hi < actual_len {
+                group[idx_hi]
+            } else {
+                min_val
+            };
 
             let lo_q = ((lo_val - min_val) * inv_scale + 0.5) as u8;
             let hi_q = ((hi_val - min_val) * inv_scale + 0.5) as u8;
@@ -2724,22 +3046,22 @@ enum QuantType {
     HFQ2G128 = 10,
     HFQ3G256 = 11,
     HFQ3G128 = 12,
-    MQ4G256 = 13,  // MagnumQuant: FWHT-rotated HFQ4-G256
-    MQ8G256 = 14,  // MagnumQuant: FWHT-rotated symmetric INT8, dp4a target
-    MQ6G256 = 15,  // MagnumQuant: FWHT-rotated HFQ6-G256 (6-bit, 200 B/group)
-    BF16 = 16,     // Original BF16 weights (zero precision loss for vision)
-    MQ3G256 = 17,  // MagnumQuant: FWHT-rotated HFQ3-G256 (3-bit, 104 B/group)
-    MQ2G256 = 18,  // MagnumQuant: FWHT-rotated HFQ2-G256 (2-bit, 72 B/group)
+    MQ4G256 = 13,      // MagnumQuant: FWHT-rotated HFQ4-G256
+    MQ8G256 = 14,      // MagnumQuant: FWHT-rotated symmetric INT8, dp4a target
+    MQ6G256 = 15,      // MagnumQuant: FWHT-rotated HFQ6-G256 (6-bit, 200 B/group)
+    BF16 = 16,         // Original BF16 weights (zero precision loss for vision)
+    MQ3G256 = 17,      // MagnumQuant: FWHT-rotated HFQ3-G256 (3-bit, 104 B/group)
+    MQ2G256 = 18,      // MagnumQuant: FWHT-rotated HFQ2-G256 (2-bit, 72 B/group)
     MQ2G256Lloyd = 19, // MagnumQuant 2-bit + per-block Lloyd-Max 4-entry fp16 codebook (72 B/group)
     MQ3G256Lloyd = 20, // MagnumQuant 3-bit + per-block Lloyd-Max 8-entry fp16 codebook (112 B/group)
     // HFP4 family — RDNA-optimal FP4 (E2M1 elements + UE8M0 block scale + FP16 row scale).
     // See docs/quant-formats/hfp4.md for byte layout, dequant, rotation modes.
     // Per-row header is 16 B; per-block payload is (1 + g/2) bytes (UE8M0 + nibbles).
-    HFP4G32 = 21,      // E2M1 + UE8M0 g32 + FP16 row scale — canonical (FP8-WMMA-K aligned)
+    HFP4G32 = 21, // E2M1 + UE8M0 g32 + FP16 row scale — canonical (FP8-WMMA-K aligned)
     // MFP4G32 = HFP4G32 + offline FWHT rotation (256-element FWHT applied to weights at quant time;
     // runtime applies the same FWHT to x via mq_rotate_x). format_flags bit 0 + bits 2-3 = 0b0101
     // signals "rotation present, offline FWHT" for future interop/detection.
-    MFP4G32 = 24,      // v1.5 — HFP4G32 + offline FWHT (drop-in MQ4 replacement)
+    MFP4G32 = 24, // v1.5 — HFP4G32 + offline FWHT (drop-in MQ4 replacement)
     /// I64→U32 downcast of DeepSeek V4 hash-routing `tid2eid` lookup tables.
     /// Shape `[vocab, num_experts_per_tok]`. Stored as raw u32 LE; the
     /// loader reads `bytes.chunks_exact(4)`. ID 22 was reserved for the
@@ -2752,10 +3074,10 @@ enum QuantType {
     // HFP4G32MX   = 25, // v2  — strict OCP MXFP4 interop alias (no row scale, UE8M0 only)
     // HFP4G16NV   = 26, // v2  — strict NVFP4 interop alias (E4M3 scale + FP32 tensor)
     // HFP8E4M3G32 = 27, // v2  — HFP8 E4M3 family
-    PARO4G128 = 28,     // ParoQuant native AWQ W4 + pairwise activation rotation metadata
-    PARO4G128T = 29,    // ParoQuant engine-tiled qweight [M/8, K] for coalesced GEMV reads
+    PARO4G128 = 28,  // ParoQuant native AWQ W4 + pairwise activation rotation metadata
+    PARO4G128T = 29, // ParoQuant engine-tiled qweight [M/8, K] for coalesced GEMV reads
     // MFP4G32R    = 29, // v3  — HFP4G32 + online block-diag-128 rotation (AMD recipe)
-// HFP8E5M2G32 = 30, // v2  — HFP8 E5M2 family
+    // HFP8E5M2G32 = 30, // v2  — HFP8 E5M2 family
     MQ4G256Lloyd = 30, // MagnumQuant 4-bit + per-block Lloyd-Max 16-entry fp16 codebook (160 B/group)
                        // Renumbered from 21 → 30 in mq4-lloyd merge to avoid HFP4G32=21 collision.
                        // Models quantized pre-renumber MUST be re-quantized.
@@ -2788,8 +3110,13 @@ enum QuantLevel {
 /// MQ6, HFQ-family to HFQ6, FP4-family is a no-op (no FP6 sibling).
 fn default_promote_target(base: GgufFormat) -> GgufFormat {
     match base {
-        GgufFormat::Mq2 | GgufFormat::Mq3 | GgufFormat::Mq4 | GgufFormat::Mq6
-        | GgufFormat::Mq2Lloyd | GgufFormat::Mq3Lloyd | GgufFormat::Mq4Lloyd => GgufFormat::Mq6,
+        GgufFormat::Mq2
+        | GgufFormat::Mq3
+        | GgufFormat::Mq4
+        | GgufFormat::Mq6
+        | GgufFormat::Mq2Lloyd
+        | GgufFormat::Mq3Lloyd
+        | GgufFormat::Mq4Lloyd => GgufFormat::Mq6,
         GgufFormat::Hfq4 | GgufFormat::Hfq6 => GgufFormat::Hfq6,
         GgufFormat::Hfp4 => GgufFormat::Hfp4,
         GgufFormat::Mfp4 => GgufFormat::Mfp4,
@@ -2865,8 +3192,12 @@ const ALTERNATING_STRIDE: usize = 3;
 /// llama.cpp-style alternating promotion: edge layers always promoted,
 /// middle layers promoted every `stride` layers.
 fn is_positional_promote(idx: usize, n_layers: usize, stride: usize) -> bool {
-    if n_layers == 0 || stride == 0 { return false; }
-    if idx < 2 || idx >= n_layers.saturating_sub(2) { return true; }
+    if n_layers == 0 || stride == 0 {
+        return false;
+    }
+    if idx < 2 || idx >= n_layers.saturating_sub(2) {
+        return true;
+    }
     (idx - 2) % stride == 0
 }
 
@@ -2890,17 +3221,16 @@ fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -
     }
 
     // Rule 2: embeddings, lm_head, output projection
-    if name.contains("embed_tokens") || name.contains("token_embd")
-        || name.contains("lm_head") || name.ends_with("output.weight")
+    if name.contains("embed_tokens")
+        || name.contains("token_embd")
+        || name.contains("lm_head")
+        || name.ends_with("output.weight")
     {
         return QuantLevel::Q8;
     }
 
     // Rule 3: MoE routers
-    if is_moe
-        && (name.ends_with("mlp.gate.weight")
-            || name.contains("shared_expert_gate"))
-    {
+    if is_moe && (name.ends_with("mlp.gate.weight") || name.contains("shared_expert_gate")) {
         return QuantLevel::Q8;
     }
 
@@ -3010,11 +3340,12 @@ struct TensorSpill {
 impl TensorSpill {
     fn new(dir: &Path) -> std::io::Result<Self> {
         let path = dir.join(".hipfire_quant_spill.tmp");
-        let file = std::io::BufWriter::with_capacity(
-            4 * 1024 * 1024,
-            File::create(&path)?,
-        );
-        Ok(Self { file, path, offset: 0 })
+        let file = std::io::BufWriter::with_capacity(4 * 1024 * 1024, File::create(&path)?);
+        Ok(Self {
+            file,
+            path,
+            offset: 0,
+        })
     }
 
     /// Write tensor data to the spill file. Returns the byte count written.
@@ -3046,8 +3377,14 @@ impl Drop for TensorSpill {
 /// Spill tensors whose data is in memory to the spill file, freeing RAM.
 /// Called after each layer's expert batch to keep peak RSS bounded.
 fn maybe_spill(tensors: &mut [HfqTensor], spill: &mut TensorSpill, threshold: usize) {
-    let in_mem: usize = tensors.iter().filter(|t| t.spilled_len == 0).map(|t| t.data.len()).sum();
-    if in_mem < threshold { return; }
+    let in_mem: usize = tensors
+        .iter()
+        .filter(|t| t.spilled_len == 0)
+        .map(|t| t.data.len())
+        .sum();
+    if in_mem < threshold {
+        return;
+    }
     for t in tensors.iter_mut() {
         if t.spilled_len == 0 && !t.data.is_empty() {
             let len = spill.spill(&t.data).unwrap_or(0);
@@ -3094,7 +3431,11 @@ fn write_hfq(
         // group size
         index_bytes.extend_from_slice(&t.group_size.to_le_bytes());
         // data size (offset computed at read time from cumulative sizes)
-        let data_len = if t.spilled_len > 0 { t.spilled_len } else { t.data.len() as u64 };
+        let data_len = if t.spilled_len > 0 {
+            t.spilled_len
+        } else {
+            t.data.len() as u64
+        };
         index_bytes.extend_from_slice(&data_len.to_le_bytes());
     }
 
@@ -3123,9 +3464,7 @@ fn write_hfq(
     // Write tensor data — from spill file or from memory
     if let Some(spill) = spill {
         let _ = spill.flush();
-        let mut spill_reader = std::io::BufReader::new(
-            File::open(&spill.path)?
-        );
+        let mut spill_reader = std::io::BufReader::new(File::open(&spill.path)?);
         let mut buf = vec![0u8; 4 * 1024 * 1024]; // 4 MB copy buffer
         for t in tensors {
             if t.spilled_len > 0 {
@@ -3250,7 +3589,9 @@ fn resolve_model_path(input: &str) -> String {
     }
 
     // Check if it looks like a HuggingFace model ID (contains exactly one /)
-    if input.contains('/') && !input.contains(std::path::MAIN_SEPARATOR) || (cfg!(unix) && input.matches('/').count() == 1) {
+    if input.contains('/') && !input.contains(std::path::MAIN_SEPARATOR)
+        || (cfg!(unix) && input.matches('/').count() == 1)
+    {
         let parts: Vec<&str> = input.splitn(2, '/').collect();
         if parts.len() == 2 {
             let org = parts[0];
@@ -3294,7 +3635,9 @@ fn resolve_model_path(input: &str) -> String {
                     }
                 }
                 Ok(s) => eprintln!("huggingface-cli download failed with status {s}"),
-                Err(e) => eprintln!("Failed to run huggingface-cli: {e}. Install with: pip install huggingface_hub"),
+                Err(e) => eprintln!(
+                    "Failed to run huggingface-cli: {e}. Install with: pip install huggingface_hub"
+                ),
             }
         }
     }
@@ -3331,7 +3674,7 @@ fn gguf_to_safetensors_name(gguf_name: &str) -> Option<String> {
         let dot = rest.find('.')?;
         let layer_idx = &rest[..dot];
         let slot_full = &rest[dot + 1..]; // "<slot>.weight"
-        // Drop the trailing ".weight" so we can rewrite slots like "attn_q"→"self_attn.q_proj".
+                                          // Drop the trailing ".weight" so we can rewrite slots like "attn_q"→"self_attn.q_proj".
         let slot = slot_full.strip_suffix(".weight")?;
         let translated = match slot {
             "attn_norm" => "input_layernorm".to_string(),
@@ -3451,8 +3794,10 @@ fn load_imatrix(path: &Path) -> HashMap<String, Vec<f32>> {
             None => continue, // ignore .counts and any other entries
         };
         if t.dtype != GgmlType::F32 {
-            eprintln!("warning: imatrix entry {} has non-F32 dtype {:?}; skipping",
-                t.name, t.dtype);
+            eprintln!(
+                "warning: imatrix entry {} has non-F32 dtype {:?}; skipping",
+                t.name, t.dtype
+            );
             continue;
         }
         // Shape is [k] (1D) for non-MoE; [k, n_mat] for MoE. Skip multi-mat
@@ -3568,7 +3913,7 @@ fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
         // Capping the input keeps mean_log finite; the output clamp then bounds
         // the final scale. 1e30 is well inside f64 range (ln ≈ 69).
         let v_clamped = (v as f64).max(1e-12).min(1e30);
-        let log_s = half_alpha * v_clamped.ln();   // log(v^(alpha/2)) = (alpha/2) * log(v)
+        let log_s = half_alpha * v_clamped.ln(); // log(v^(alpha/2)) = (alpha/2) * log(v)
         log_s_raw.push(log_s);
         sum_log += log_s;
     }
@@ -3594,7 +3939,8 @@ fn compute_awq_scales(in_sum2: &[f32], alpha: f32) -> Vec<f32> {
     // all genuine signal while removing the representability blow-ups.
     const AWQ_SCALE_MIN: f32 = 1e-2;
     const AWQ_SCALE_MAX: f32 = 1e2;
-    log_s_raw.into_iter()
+    log_s_raw
+        .into_iter()
         .map(|l| ((l - mean_log).exp() as f32).clamp(AWQ_SCALE_MIN, AWQ_SCALE_MAX))
         .collect()
 }
@@ -3622,7 +3968,8 @@ fn awq_pre_scale_weights(weights: &mut [f32], m: usize, k: usize, scales: &[f32]
 /// Helper: convert a `Vec<f32>` AWQ-scale vector into the F16 byte
 /// payload that `HfqTensor` consumes for sidecar emission.
 fn awq_scales_to_f16_bytes(scales: &[f32]) -> Vec<u8> {
-    scales.iter()
+    scales
+        .iter()
         .flat_map(|&s| f32_to_f16(s).to_le_bytes())
         .collect()
 }
@@ -3658,9 +4005,7 @@ fn awq_eligible(name: &str) -> bool {
     // are excluded — produces an F1-equivalent quant for comparison
     // bench against the same binary's F2 quant. Default (env unset):
     // the full F2 whitelist applies.
-    let f1_only = std::env::var("HIPFIRE_AWQ_F1_ONLY")
-        .ok()
-        .as_deref() == Some("1");
+    let f1_only = std::env::var("HIPFIRE_AWQ_F1_ONLY").ok().as_deref() == Some("1");
     let f1_match =
     // Full-attention input projections (HF naming + fused variants).
     name.ends_with("q_proj.weight")
@@ -3693,7 +4038,9 @@ fn awq_eligible(name: &str) -> bool {
         // arch might choose; kept for safety.
         || name.ends_with("mlp.gate.weight")
         || name.ends_with("router.weight");
-    if f1_only { return f1_match; }
+    if f1_only {
+        return f1_match;
+    }
     let f2_match =
         // ── F2 (2026-05-14): output-side projections ────────────────────
         // These now have AWQ-aware runtime kernels (rotate_x_mq_awq for
@@ -3722,44 +4069,36 @@ fn gguf_is_embed_tensor(name: &str) -> bool {
 /// reads. Mirrors the field names HuggingFace uses in `config.json` for
 /// LlamaForCausalLM / Qwen3ForCausalLM, populated from the GGUF
 /// `<arch>.*` metadata keys.
-fn config_json_from_gguf(
-    gguf: &gguf_input::GgufFile,
-    arch_str: &str,
-) -> serde_json::Value {
+fn config_json_from_gguf(gguf: &gguf_input::GgufFile, arch_str: &str) -> serde_json::Value {
     // GGUF prefixes its model hyperparameters with the architecture name —
     // e.g. for `general.architecture=llama` the keys live under `llama.*`.
     let prefix = arch_str;
 
     let read_u = |k: &str| -> Option<u64> {
-        gguf.metadata
-            .get(k)
-            .and_then(|v| match v {
-                gguf_input::MetaValue::U8(x) => Some(*x as u64),
-                gguf_input::MetaValue::I8(x) => Some(*x as u64),
-                gguf_input::MetaValue::U16(x) => Some(*x as u64),
-                gguf_input::MetaValue::I16(x) => Some(*x as u64),
-                gguf_input::MetaValue::U32(x) => Some(*x as u64),
-                gguf_input::MetaValue::I32(x) => Some(*x as u64),
-                gguf_input::MetaValue::U64(x) => Some(*x),
-                gguf_input::MetaValue::I64(x) => Some(*x as u64),
-                _ => None,
-            })
+        gguf.metadata.get(k).and_then(|v| match v {
+            gguf_input::MetaValue::U8(x) => Some(*x as u64),
+            gguf_input::MetaValue::I8(x) => Some(*x as u64),
+            gguf_input::MetaValue::U16(x) => Some(*x as u64),
+            gguf_input::MetaValue::I16(x) => Some(*x as u64),
+            gguf_input::MetaValue::U32(x) => Some(*x as u64),
+            gguf_input::MetaValue::I32(x) => Some(*x as u64),
+            gguf_input::MetaValue::U64(x) => Some(*x),
+            gguf_input::MetaValue::I64(x) => Some(*x as u64),
+            _ => None,
+        })
     };
     let read_f = |k: &str| -> Option<f64> {
-        gguf.metadata
-            .get(k)
-            .and_then(|v| match v {
-                gguf_input::MetaValue::F32(x) => Some(*x as f64),
-                gguf_input::MetaValue::F64(x) => Some(*x),
-                _ => None,
-            })
+        gguf.metadata.get(k).and_then(|v| match v {
+            gguf_input::MetaValue::F32(x) => Some(*x as f64),
+            gguf_input::MetaValue::F64(x) => Some(*x),
+            _ => None,
+        })
     };
 
     let dim = read_u(&format!("{prefix}.embedding_length"));
     let n_layers = read_u(&format!("{prefix}.block_count"));
     let n_heads = read_u(&format!("{prefix}.attention.head_count"));
-    let n_kv_heads = read_u(&format!("{prefix}.attention.head_count_kv"))
-        .or(n_heads);
+    let n_kv_heads = read_u(&format!("{prefix}.attention.head_count_kv")).or(n_heads);
     let hidden_dim = read_u(&format!("{prefix}.feed_forward_length"));
     // vocab_size: prefer metadata, fall back to token_embd shape[1].
     let vocab_size = read_u(&format!("{prefix}.vocab_size")).or_else(|| {
@@ -3771,12 +4110,10 @@ fn config_json_from_gguf(
     let max_seq_len = read_u(&format!("{prefix}.context_length"));
     let rope_theta = read_f(&format!("{prefix}.rope.freq_base"));
     let rms_eps = read_f(&format!("{prefix}.attention.layer_norm_rms_epsilon"));
-    let head_dim = read_u(&format!("{prefix}.attention.key_length"))
-        .or_else(|| {
-            // Fall back: head_dim = dim / n_heads.
-            dim.zip(n_heads)
-                .map(|(d, h)| if h > 0 { d / h } else { d })
-        });
+    let head_dim = read_u(&format!("{prefix}.attention.key_length")).or_else(|| {
+        // Fall back: head_dim = dim / n_heads.
+        dim.zip(n_heads).map(|(d, h)| if h > 0 { d / h } else { d })
+    });
     let bos = read_u("tokenizer.ggml.bos_token_id").unwrap_or(1);
     let eos = read_u("tokenizer.ggml.eos_token_id").unwrap_or(2);
 
@@ -3804,10 +4141,7 @@ fn config_json_from_gguf(
         );
     }
     if let Some(v) = hidden_dim {
-        cfg.insert(
-            "intermediate_size".to_string(),
-            serde_json::Value::from(v),
-        );
+        cfg.insert("intermediate_size".to_string(), serde_json::Value::from(v));
     }
     if let Some(v) = vocab_size {
         cfg.insert("vocab_size".to_string(), serde_json::Value::from(v));
@@ -3862,9 +4196,7 @@ fn mv_to_json(v: &gguf_input::MetaValue) -> serde_json::Value {
         MV::F64(x) => serde_json::Value::from(*x),
         // Tokenizer arrays (tokens, scores, merges, ...) can be huge —
         // serialize them as JSON arrays so the engine side can re-parse.
-        MV::Array(arr) => {
-            serde_json::Value::Array(arr.iter().map(mv_to_json).collect())
-        }
+        MV::Array(arr) => serde_json::Value::Array(arr.iter().map(mv_to_json).collect()),
     }
 }
 
@@ -3896,8 +4228,8 @@ enum GgufFormat {
     Mq2Lloyd,
     Mq3Lloyd,
     Mq4Lloyd,
-    Hfp4,  // HFP4G32 — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale)
-    Mfp4,  // MFP4G32 — HFP4G32 + offline FWHT rotation (drop-in MQ4 replacement)
+    Hfp4, // HFP4G32 — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale)
+    Mfp4, // MFP4G32 — HFP4G32 + offline FWHT rotation (drop-in MQ4 replacement)
 }
 
 impl GgufFormat {
@@ -3940,7 +4272,14 @@ impl GgufFormat {
 /// (Q4-grade is too lossy for embeddings) and 1D norms stay F16. Tensor
 /// names are translated GGUF → safetensors style so the engine's existing
 /// `load_weights_hfq` can consume the output.
-fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: bool, kmap_dense: bool, kmap_mode: u8) -> std::io::Result<()> {
+fn run_gguf_pipeline(
+    input: &Path,
+    output: &Path,
+    format: GgufFormat,
+    no_kmap: bool,
+    kmap_dense: bool,
+    kmap_mode: u8,
+) -> std::io::Result<()> {
     eprintln!("=== GGUF → {} conversion ===", format.label());
     eprintln!("Input:  {}", input.display());
     eprintln!("Output: {}", output.display());
@@ -3990,12 +4329,27 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
 
     // FWHT signs — only used when --format is mq4/mq6. Same seed pair as the
     // safetensors path so the engine's runtime FWHT inverse stays identical.
-    let needs_signs = matches!(format,
-        GgufFormat::Mq4 | GgufFormat::Mq6 | GgufFormat::Mq3 | GgufFormat::Mq2
-        | GgufFormat::Mq2Lloyd | GgufFormat::Mq3Lloyd | GgufFormat::Mq4Lloyd
-        | GgufFormat::Mfp4);
-    let signs1 = if needs_signs { gen_fwht_signs(42, 256) } else { Vec::new() };
-    let signs2 = if needs_signs { gen_fwht_signs(1042, 256) } else { Vec::new() };
+    let needs_signs = matches!(
+        format,
+        GgufFormat::Mq4
+            | GgufFormat::Mq6
+            | GgufFormat::Mq3
+            | GgufFormat::Mq2
+            | GgufFormat::Mq2Lloyd
+            | GgufFormat::Mq3Lloyd
+            | GgufFormat::Mq4Lloyd
+            | GgufFormat::Mfp4
+    );
+    let signs1 = if needs_signs {
+        gen_fwht_signs(42, 256)
+    } else {
+        Vec::new()
+    };
+    let signs2 = if needs_signs {
+        gen_fwht_signs(1042, 256)
+    } else {
+        Vec::new()
+    };
 
     // K-map setup for GGUF path
     let is_moe = arch_id == 6;
@@ -4019,8 +4373,8 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
         let mut map = HashMap::new();
         let mut counts = [0u32; 4];
         for info in &gguf.tensors {
-            let out_name = gguf_to_safetensors_name(&info.name)
-                .unwrap_or_else(|| info.name.clone());
+            let out_name =
+                gguf_to_safetensors_name(&info.name).unwrap_or_else(|| info.name.clone());
             let level = kmap_resolve_mode(&out_name, n_layers, is_moe, kmap_mode);
             match level {
                 QuantLevel::F16 => counts[0] += 1,
@@ -4032,10 +4386,17 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
             map.insert(out_name, level);
         }
         if !map.is_empty() {
-            let mode_label = match kmap_mode { 0 => "full", 1 => "alternating", 2 => "typed", _ => "?" };
-            eprintln!("K-map plan ({} base, {n_layers} layers{}, mode={mode_label}):",
+            let mode_label = match kmap_mode {
+                0 => "full",
+                1 => "alternating",
+                2 => "typed",
+                _ => "?",
+            };
+            eprintln!(
+                "K-map plan ({} base, {n_layers} layers{}, mode={mode_label}):",
                 format.label(),
-                if is_moe { ", MoE" } else { "" });
+                if is_moe { ", MoE" } else { "" }
+            );
             eprintln!("  F16:       {:>4} tensors", counts[0]);
             eprintln!("  Q8:        {:>4} tensors", counts[1]);
             eprintln!("  Promote6:  {:>4} tensors", counts[2]);
@@ -4067,8 +4428,7 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
         // Translate to the safetensors-style name `hipfire_runtime::hfq::load_weights_hfq`
         // expects. If we don't have a translation, keep the original name —
         // the future loader can ignore unknown tensors.
-        let out_name = gguf_to_safetensors_name(&info.name)
-            .unwrap_or_else(|| info.name.clone());
+        let out_name = gguf_to_safetensors_name(&info.name).unwrap_or_else(|| info.name.clone());
 
         let kmap_level = kmap.get(&out_name).copied().unwrap_or(QuantLevel::Base);
 
@@ -4091,8 +4451,12 @@ fn run_gguf_pipeline(input: &Path, output: &Path, format: GgufFormat, no_kmap: b
             let f32_data = gguf_input::tensor_to_f32(info, raw);
             quant_params += n_elements as u64;
             match format {
-                GgufFormat::Mq4 | GgufFormat::Mq3 | GgufFormat::Mq2
-                | GgufFormat::Mq2Lloyd | GgufFormat::Mq3Lloyd | GgufFormat::Mq6 => {
+                GgufFormat::Mq4
+                | GgufFormat::Mq3
+                | GgufFormat::Mq2
+                | GgufFormat::Mq2Lloyd
+                | GgufFormat::Mq3Lloyd
+                | GgufFormat::Mq6 => {
                     let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
                     (q, QuantType::MQ6G256, 256u32, "MQ6G256")
                 }
@@ -4316,42 +4680,73 @@ fn main() {
     // or HIPFIRE_QUANT_THREADS env). Quantization is CPU-bound and saturates
     // memory bandwidth, so leaving headroom for the rest of the system avoids
     // making the whole box unresponsive during a multi-hour quantize run.
-    let cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8);
     let default_threads = ((cores * 8) / 10).max(1);
-    let threads = args.iter().position(|a| a == "--threads")
+    let threads = args
+        .iter()
+        .position(|a| a == "--threads")
         .and_then(|i| args.get(i + 1).and_then(|s| s.parse::<usize>().ok()))
-        .or_else(|| std::env::var("HIPFIRE_QUANT_THREADS").ok().and_then(|s| s.parse().ok()))
+        .or_else(|| {
+            std::env::var("HIPFIRE_QUANT_THREADS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap_or(default_threads);
-    let _ = rayon::ThreadPoolBuilder::new().num_threads(threads).build_global();
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build_global();
     eprintln!("Rayon: {threads} worker threads ({cores} cores available, default 80% = {default_threads})");
 
-
-    let input_dir = args.iter().position(|a| a == "--input")
+    let input_dir = args
+        .iter()
+        .position(|a| a == "--input")
         .map(|i| &args[i + 1])
-        .unwrap_or_else(|| { eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq>"); std::process::exit(1); });
+        .unwrap_or_else(|| {
+            eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq>");
+            std::process::exit(1);
+        });
 
     let output_path = args.iter().position(|a| a == "--output")
         .map(|i| &args[i + 1])
         .unwrap_or_else(|| { eprintln!("Usage: hipfire-quantize --input <model_dir> --output <output.hfq> [--format q8f16|q4f16]"); std::process::exit(1); });
 
-    let format = args.iter().position(|a| a == "--format")
+    let format = args
+        .iter()
+        .position(|a| a == "--format")
         .map(|i| args[i + 1].as_str())
         .unwrap_or("q8f16");
 
     // Optional imatrix (llama.cpp GGUF format with .in_sum2 / .counts per-tensor).
     // When provided, MQ2-Lloyd quantization uses per-column importance weights
     // to bias centroid placement. See `quantize_mq2g256_lloyd_weighted`.
-    let imatrix_path: Option<&str> = args.iter().position(|a| a == "--imatrix")
+    let imatrix_path: Option<&str> = args
+        .iter()
+        .position(|a| a == "--imatrix")
         .map(|i| args[i + 1].as_str());
     let imatrix_gguf: Option<gguf_input::GgufFile> = imatrix_path.map(|p| {
         eprintln!("Loading imatrix: {p}");
-        gguf_input::GgufFile::open(Path::new(p))
-            .unwrap_or_else(|e| { eprintln!("imatrix open failed: {e}"); std::process::exit(2); })
+        gguf_input::GgufFile::open(Path::new(p)).unwrap_or_else(|e| {
+            eprintln!("imatrix open failed: {e}");
+            std::process::exit(2);
+        })
     });
     if let Some(ref gg) = imatrix_gguf {
-        let n_in_sum2 = gg.tensors.iter().filter(|t| t.name.ends_with(".in_sum2")).count();
-        let n_counts  = gg.tensors.iter().filter(|t| t.name.ends_with(".counts")).count();
-        eprintln!("  imatrix: {} in_sum2 + {} counts tensors", n_in_sum2, n_counts);
+        let n_in_sum2 = gg
+            .tensors
+            .iter()
+            .filter(|t| t.name.ends_with(".in_sum2"))
+            .count();
+        let n_counts = gg
+            .tensors
+            .iter()
+            .filter(|t| t.name.ends_with(".counts"))
+            .count();
+        eprintln!(
+            "  imatrix: {} in_sum2 + {} counts tensors",
+            n_in_sum2, n_counts
+        );
     }
     // q8f16 = all weights Q8 (interleaved blocks)
     // q4f16 = all weights Q4_F16_G64
@@ -4392,7 +4787,7 @@ fn main() {
     let use_hfq3g128 = format == "hfq3g128" || format == "hfq3" || format == "hf3"; // default HF3 = G128
     let use_hfq2g256 = format == "hfq2g256";
     let use_hfq2g128 = format == "hfq2g128" || format == "hfq2" || format == "hf2";
-    let use_hfq_mixed = format == "hfq-mixed";  // Q8 attn + HFQ4 FFN
+    let use_hfq_mixed = format == "hfq-mixed"; // Q8 attn + HFQ4 FFN
     let use_mq6g256 = format == "mq6" || format == "mq6g256";
     // Mixed: MQ4 for attention/shared-expert + MQ6 for routed experts only.
     // Saves ~15 GB vs full MQ6 on 122B-A10B (75 GB vs 90 GB), fits in 125 GB UMA.
@@ -4486,9 +4881,8 @@ fn main() {
     // direction because it writes back into the residual stream — gate/up
     // errors get partially absorbed by silu. Mirror that asymmetry in
     // MQ-family: 2-bit on gate_up, 3-bit on down.
-    let use_mq4_mqlloyd_antirez = format == "mq4-mqlloyd-antirez"
-        || format == "mq4-mqlloyd-asym"
-        || format == "antirez-mq";
+    let use_mq4_mqlloyd_antirez =
+        format == "mq4-mqlloyd-antirez" || format == "mq4-mqlloyd-asym" || format == "antirez-mq";
     // Lever 2: same recipe as antirez but with sequential-GPTQ Lloyd
     // on the gate_up_proj path instead of plain imatrix-weighted Lloyd.
     // Aims to reduce attractor risk at 2 bpw — if successful, opens path
@@ -4523,12 +4917,17 @@ fn main() {
     let use_mq4_mq2lloyd_gptq_all = format == "mq4-mq2lloyd-gptq-all"
         || format == "mq4-mq2lloyd-gptq"
         || format == "all-mq2-gptq";
-    if use_mq4_mq2lloyd_gptq_all && imatrix_path.is_none() &&
-        std::env::var("HIPFIRE_ALLOW_UNIT_IMATRIX").ok().as_deref() != Some("1")
+    if use_mq4_mq2lloyd_gptq_all
+        && imatrix_path.is_none()
+        && std::env::var("HIPFIRE_ALLOW_UNIT_IMATRIX").ok().as_deref() != Some("1")
     {
         eprintln!("error: --format mq4-mq2lloyd-gptq-all requires --imatrix <PATH>");
-        eprintln!("       (DeepSeek V4: set HIPFIRE_ALLOW_UNIT_IMATRIX=1 to use unit column weights —");
-        eprintln!("        captures GPTQ sequential error-feedback win without imatrix calibration.)");
+        eprintln!(
+            "       (DeepSeek V4: set HIPFIRE_ALLOW_UNIT_IMATRIX=1 to use unit column weights —"
+        );
+        eprintln!(
+            "        captures GPTQ sequential error-feedback win without imatrix calibration.)"
+        );
         std::process::exit(2);
     }
     if use_mq4_mq2lloyd_gptq_all {
@@ -4558,9 +4957,15 @@ fn main() {
              Estimated DeepSeek V4 size: 70% × MQ2 + 20% × MQ3 + 10% × MQ4 ≈ 96 GB."
         );
     }
-    let tier_ratio: f64 = args.iter().position(|a| a == "--tier-ratio")
+    let tier_ratio: f64 = args
+        .iter()
+        .position(|a| a == "--tier-ratio")
         .and_then(|i| args.get(i + 1).and_then(|s| s.parse().ok()))
-        .or_else(|| std::env::var("HIPFIRE_TIER_RATIO").ok().and_then(|s| s.parse().ok()))
+        .or_else(|| {
+            std::env::var("HIPFIRE_TIER_RATIO")
+                .ok()
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap_or(0.30);
     if use_mq4_mqlloyd_tiered {
         if imatrix_path.is_none() {
@@ -4620,9 +5025,12 @@ fn main() {
     }
     let use_mq3g256 = format == "mq3" || format == "mq3g256";
     let use_mq2g256 = format == "mq2" || format == "mq2g256";
-    let use_mq2g256_lloyd = format == "mq2-lloyd" || format == "mq2g256-lloyd" || format == "mq2lloyd";
-    let use_mq3g256_lloyd = format == "mq3-lloyd" || format == "mq3g256-lloyd" || format == "mq3lloyd";
-    let use_mq4g256_lloyd = format == "mq4-lloyd" || format == "mq4g256-lloyd" || format == "mq4lloyd";
+    let use_mq2g256_lloyd =
+        format == "mq2-lloyd" || format == "mq2g256-lloyd" || format == "mq2lloyd";
+    let use_mq3g256_lloyd =
+        format == "mq3-lloyd" || format == "mq3g256-lloyd" || format == "mq3lloyd";
+    let use_mq4g256_lloyd =
+        format == "mq4-lloyd" || format == "mq4g256-lloyd" || format == "mq4lloyd";
     let use_hfq6 = format == "hfq6" || format == "hfq6g256" || format == "hf6";
     // HFP4G32 — RDNA-optimal FP4 (E2M1 + UE8M0 g32 + FP16 row scale). Spec at docs/quant-formats/hfp4.md.
     let use_hfp4 = format == "hfp4" || format == "hfp4g32" || format == "hf4p" || format == "fp4";
@@ -4648,7 +5056,9 @@ fn main() {
     // linear_attn.{in_proj_qkv,in_proj_z,in_proj_a,in_proj_b,out_proj}
     // (linear-attention layers via SSM-naming). Norms / biases / 1D scalars /
     // conv1d / lookup tables have no imatrix entry.
-    let imatrix_path = args.iter().position(|a| a == "--imatrix")
+    let imatrix_path = args
+        .iter()
+        .position(|a| a == "--imatrix")
         .and_then(|i| args.get(i + 1))
         .map(PathBuf::from);
     if let Some(path) = &imatrix_path {
@@ -4657,7 +5067,9 @@ fn main() {
             std::process::exit(1);
         }
         let table = load_imatrix(path);
-        IMATRIX.set(table).expect("IMATRIX set twice — should not happen");
+        IMATRIX
+            .set(table)
+            .expect("IMATRIX set twice — should not happen");
         eprintln!("imatrix loaded from {}", path.display());
     }
 
@@ -4677,9 +5089,10 @@ fn main() {
     // outlier mitigation techniques" — MR-GPTQ is the right lever there,
     // tracked as Stage C). HFP4/MFP4 are explicitly NOT awq-pre-scaled
     // in this patch.
-    let awq_enabled = args.iter().any(|a| a == "--awq")
-        || args.iter().any(|a| a == "--awq-alpha");
-    let awq_alpha = args.iter().position(|a| a == "--awq-alpha")
+    let awq_enabled = args.iter().any(|a| a == "--awq") || args.iter().any(|a| a == "--awq-alpha");
+    let awq_alpha = args
+        .iter()
+        .position(|a| a == "--awq-alpha")
         .and_then(|i| args.get(i + 1))
         .and_then(|s| s.parse::<f32>().ok())
         .unwrap_or(0.55);
@@ -4689,9 +5102,13 @@ fn main() {
             std::process::exit(1);
         }
         if !(0.0..=1.0).contains(&awq_alpha) {
-            eprintln!("warning: --awq-alpha {awq_alpha} outside typical [0, 1] range; using anyway");
+            eprintln!(
+                "warning: --awq-alpha {awq_alpha} outside typical [0, 1] range; using anyway"
+            );
         }
-        AWQ_ALPHA.set(awq_alpha).expect("AWQ_ALPHA set twice — should not happen");
+        AWQ_ALPHA
+            .set(awq_alpha)
+            .expect("AWQ_ALPHA set twice — should not happen");
         eprintln!("AWQ pre-scaling: ENABLED (alpha={awq_alpha}, formula: s[j]=(RMS_act[j])^alpha, geo-mean normalized to 1)");
     }
     // K-map gate: applies to MoE models by default. Dense models opt in
@@ -4703,13 +5120,18 @@ fn main() {
     // K-map mode: 0=full (all candidates promoted), 1=alternating (edge + every 3rd),
     // 2=typed (ffn_down+attn_v everywhere). Default: alternating — same PPL as full
     // at 17% less model size on MoE (22.9 vs 27.7 GB, PPL 8K: 19.96 vs 20.07).
-    let kmap_mode: u8 = args.iter().position(|a| a == "--kmap-mode")
+    let kmap_mode: u8 = args
+        .iter()
+        .position(|a| a == "--kmap-mode")
         .and_then(|i| args.get(i + 1))
         .map(|v| match v.as_str() {
             "full" | "0" => 0,
             "alternating" | "alt" | "1" => 1,
             "typed" | "2" => 2,
-            _ => { eprintln!("warning: unknown --kmap-mode '{v}', using alternating"); 1 }
+            _ => {
+                eprintln!("warning: unknown --kmap-mode '{v}', using alternating");
+                1
+            }
         })
         .unwrap_or(1);
 
@@ -4755,7 +5177,20 @@ fn main() {
     }
     let allow_mq2_lloyd = args.iter().any(|a| a == "--allow-mq2-lloyd")
         || std::env::var("HIPFIRE_ALLOW_MQ2_LLOYD").ok().as_deref() == Some("1");
-    if (use_mq2g256_lloyd || use_mq4_mq2lloydexp || use_mq4_mq2lloyd_native || use_mq4_mq2lloyd_kmap || use_mq4_mq2lloyd_imatrix || use_mq4_mq3lloyd_kmap || use_mq4_mq2lloyd_kmap || use_mq4_mqlloyd_tiered || use_mq4_mqlloyd_antirez || use_mq4_mqlloyd_antirez_gptq || use_mq4_mq2lloyd_gptq_all || use_deepseek4_source_precision) && !allow_mq2_lloyd {
+    if (use_mq2g256_lloyd
+        || use_mq4_mq2lloydexp
+        || use_mq4_mq2lloyd_native
+        || use_mq4_mq2lloyd_kmap
+        || use_mq4_mq2lloyd_imatrix
+        || use_mq4_mq3lloyd_kmap
+        || use_mq4_mq2lloyd_kmap
+        || use_mq4_mqlloyd_tiered
+        || use_mq4_mqlloyd_antirez
+        || use_mq4_mqlloyd_antirez_gptq
+        || use_mq4_mq2lloyd_gptq_all
+        || use_deepseek4_source_precision)
+        && !allow_mq2_lloyd
+    {
         eprintln!(
             "error: --format mq2-lloyd is research-only — Lloyd-Max codebook lifts\n\
              uniform MQ2 by 41–55× ppl but absolute quality is still collapse\n\
@@ -4825,7 +5260,9 @@ fn main() {
                 GgufFormat::Hfq4
             });
             let out = Path::new(output_path);
-            if let Err(e) = run_gguf_pipeline(raw_input, out, gguf_format, no_kmap, kmap_dense, kmap_mode) {
+            if let Err(e) =
+                run_gguf_pipeline(raw_input, out, gguf_format, no_kmap, kmap_dense, kmap_mode)
+            {
                 eprintln!("GGUF pipeline failed: {e}");
                 std::process::exit(2);
             }
@@ -4844,7 +5281,10 @@ fn main() {
         .unwrap_or_else(|_| panic!("Cannot read {}. If using a HuggingFace model ID, ensure it's downloaded: huggingface-cli download {}", config_path.display(), input_dir.display()));
     let config: serde_json::Value = serde_json::from_str(&config_str).unwrap();
 
-    let arch_str = config.get("model_type").and_then(|v| v.as_str()).unwrap_or("llama");
+    let arch_str = config
+        .get("model_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("llama");
     let auto_arch_id = match arch_str {
         "llama" => 0u32,
         "qwen3" | "qwen2" => 1,
@@ -4864,7 +5304,10 @@ fn main() {
         // path yet; tensor names ship in DeepSeek V4's native shape (split w1/w2/w3,
         // per-expert) and are translated when the forward bring-up lands.
         "deepseek_v4" => 9,
-        other => { eprintln!("Warning: unknown architecture '{other}', treating as llama"); 0 }
+        other => {
+            eprintln!("Warning: unknown architecture '{other}', treating as llama");
+            0
+        }
     };
     // --arch-id <u32> overrides the auto-detected id. Use when the
     // model's family maps to a different crate than the default
@@ -4901,11 +5344,17 @@ fn main() {
     // Qwen3.5+ nests config under "text_config"; try both paths.
     let n_layers: usize = config
         .get("num_hidden_layers")
-        .or_else(|| config.get("text_config").and_then(|tc| tc.get("num_hidden_layers")))
+        .or_else(|| {
+            config
+                .get("text_config")
+                .and_then(|tc| tc.get("num_hidden_layers"))
+        })
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as usize;
     if n_layers == 0 {
-        eprintln!("  warning: num_hidden_layers not found in config.json — edge-layer promotion disabled");
+        eprintln!(
+            "  warning: num_hidden_layers not found in config.json — edge-layer promotion disabled"
+        );
     }
 
     // Read tokenizer if present
@@ -4985,8 +5434,11 @@ fn main() {
         }
     }
     all_tensors.sort_by_key(|(name, _)| name.to_string());
-    eprintln!("Found {} tensors ({} FP8 scale siblings indexed)",
-        all_tensors.len(), fp8_scale_for.len());
+    eprintln!(
+        "Found {} tensors ({} FP8 scale siblings indexed)",
+        all_tensors.len(),
+        fp8_scale_for.len()
+    );
 
     // ── K-map pre-pass ──────────────────────────────────────────────────────
     // Build per-tensor quant level map. Gated to MoE models by default
@@ -5014,11 +5466,21 @@ fn main() {
             map.insert(name.to_string(), level);
         }
         if !map.is_empty() {
-            let mode_label = match kmap_mode { 0 => "full", 1 => "alternating", 2 => "typed", _ => "?" };
-            eprintln!("K-map plan ({format} base, {n_layers} layers{}, mode={mode_label}):",
-                if is_moe { ", MoE" } else { "" });
+            let mode_label = match kmap_mode {
+                0 => "full",
+                1 => "alternating",
+                2 => "typed",
+                _ => "?",
+            };
+            eprintln!(
+                "K-map plan ({format} base, {n_layers} layers{}, mode={mode_label}):",
+                if is_moe { ", MoE" } else { "" }
+            );
             eprintln!("  F16:       {:>4} tensors (norms, biases)", counts[0]);
-            eprintln!("  Q8:        {:>4} tensors (embed, lm_head, routers)", counts[1]);
+            eprintln!(
+                "  Q8:        {:>4} tensors (embed, lm_head, routers)",
+                counts[1]
+            );
             eprintln!("  Promote6:  {:>4} tensors", counts[2]);
             eprintln!("  Base:      {:>4} tensors (remaining)", counts[3]);
         }
@@ -5035,12 +5497,15 @@ fn main() {
                 // Indexes of layers NOT promoted by K-map. We need a name
                 // representative of each layer's expert tensor to query
                 // kmap; use the canonical safetensors name format.
-                let candidates: Vec<usize> = (0..n_layers).filter(|&l| {
-                    let probe_name = format!(
-                        "model.language_model.layers.{}.mlp.experts.gate_up_proj", l);
-                    kmap.get(&probe_name) != Some(&QuantLevel::Promote6)
-                }).collect();
-                let mut ranked: Vec<(usize, f64)> = candidates.iter()
+                let candidates: Vec<usize> = (0..n_layers)
+                    .filter(|&l| {
+                        let probe_name =
+                            format!("model.language_model.layers.{}.mlp.experts.gate_up_proj", l);
+                        kmap.get(&probe_name) != Some(&QuantLevel::Promote6)
+                    })
+                    .collect();
+                let mut ranked: Vec<(usize, f64)> = candidates
+                    .iter()
                     .filter(|&&l| layer_counts[l].is_finite())
                     .map(|&l| (l, layer_counts[l]))
                     .collect();
@@ -5053,12 +5518,20 @@ fn main() {
                 eprintln!(
                     "Tiered MQ-Lloyd: {} candidate non-promoted layers; \
                      {} (top {:.0}%) → MQ3-Lloyd, {} → MQ2-Lloyd",
-                    ranked.len(), set.len(), tier_ratio * 100.0,
+                    ranked.len(),
+                    set.len(),
+                    tier_ratio * 100.0,
                     ranked.len().saturating_sub(set.len())
                 );
                 if set.len() <= 16 {
-                    eprintln!("  MQ3-Lloyd layers (by count): {:?}",
-                        ranked.iter().take(n_mq3).map(|&(l, c)| (l, c as u64)).collect::<Vec<_>>());
+                    eprintln!(
+                        "  MQ3-Lloyd layers (by count): {:?}",
+                        ranked
+                            .iter()
+                            .take(n_mq3)
+                            .map(|&(l, c)| (l, c as u64))
+                            .collect::<Vec<_>>()
+                    );
                 }
                 set
             } else {
@@ -5085,7 +5558,8 @@ fn main() {
     let mut _n_quant_groups = 0u64;
 
     let include_vision = std::env::args().any(|a| a == "--include-vision");
-    let vision_quant = std::env::args().position(|a| a == "--vision-quant")
+    let vision_quant = std::env::args()
+        .position(|a| a == "--vision-quant")
         .and_then(|i| std::env::args().nth(i + 1))
         .unwrap_or_default();
     // --include-prefix <prefix>: when set, ONLY tensors whose name starts
@@ -5094,10 +5568,13 @@ fn main() {
     // MTP-only addon that pairs with an existing base HFQ via the loader's
     // `.mtp-addon.hfq` discovery). When unset (default), all tensors pass
     // this gate and the usual mtp/vision skip rules below apply.
-    let include_prefix = std::env::args().position(|a| a == "--include-prefix")
+    let include_prefix = std::env::args()
+        .position(|a| a == "--include-prefix")
         .and_then(|i| std::env::args().nth(i + 1));
     if let Some(ref p) = include_prefix {
-        eprintln!("  [filter] --include-prefix {p:?} — only tensors with this prefix will be ingested");
+        eprintln!(
+            "  [filter] --include-prefix {p:?} — only tensors with this prefix will be ingested"
+        );
     }
     let mut skipped_params = 0u64;
     for (name, file_idx) in &all_tensors {
@@ -5159,33 +5636,46 @@ fn main() {
         if meta.dtype == "I64" {
             if name.ends_with("tid2eid") {
                 if n_elements * 8 != raw_data.len() {
-                    panic!("tid2eid '{name}': expected {} bytes (8 × {}), got {}",
-                        n_elements * 8, n_elements, raw_data.len());
+                    panic!(
+                        "tid2eid '{name}': expected {} bytes (8 × {}), got {}",
+                        n_elements * 8,
+                        n_elements,
+                        raw_data.len()
+                    );
                 }
                 let mut u32_bytes: Vec<u8> = Vec::with_capacity(n_elements * 4);
                 for i in 0..n_elements {
                     let off = i * 8;
-                    let v = i64::from_le_bytes(
-                        raw_data[off..off + 8].try_into().unwrap());
-                    let v_u32 = v as u32;  // downcast — values fit
+                    let v = i64::from_le_bytes(raw_data[off..off + 8].try_into().unwrap());
+                    let v_u32 = v as u32; // downcast — values fit
                     u32_bytes.extend_from_slice(&v_u32.to_le_bytes());
                 }
                 let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
-                eprintln!("  {:>8}: {} {:?} (I64 → U32, {} elements, {:.1} KB)",
-                    "TID2EID", name, meta.shape, n_elements,
-                    u32_bytes.len() as f64 / 1024.0);
+                eprintln!(
+                    "  {:>8}: {} {:?} (I64 → U32, {} elements, {:.1} KB)",
+                    "TID2EID",
+                    name,
+                    meta.shape,
+                    n_elements,
+                    u32_bytes.len() as f64 / 1024.0
+                );
                 quantized_params += n_elements as u64;
                 hfq_tensors.push(HfqTensor {
                     name: name.to_string(),
                     quant_type: QuantType::TidI32,
-                    shape, group_size: 0, data: u32_bytes, spilled_len: 0,
+                    shape,
+                    group_size: 0,
+                    data: u32_bytes,
+                    spilled_len: 0,
                 });
                 st_files[*file_idx].drop_tensor_pages(name);
                 continue;
             }
             // Other I64 (none expected in DeepSeek V4): skip with explicit warning.
-            eprintln!("  [skip-I64] {} {:?} ({} elements) — unexpected I64 tensor, not ingested",
-                name, meta.shape, n_elements);
+            eprintln!(
+                "  [skip-I64] {} {:?} ({} elements) — unexpected I64 tensor, not ingested",
+                name, meta.shape, n_elements
+            );
             skipped_params += n_elements as u64;
             continue;
         }
@@ -5224,47 +5714,58 @@ fn main() {
             // experts.` infix). So everything reaching here is a routed
             // expert → unconditionally FP4 unpack. Logical K dim doubles.
             let name_owned = name.to_string();
-            let (f32_data, logical_shape) = if (meta.dtype == "I8"
-                || meta.dtype == "F8_E4M3")
+            let (f32_data, logical_shape) = if (meta.dtype == "I8" || meta.dtype == "F8_E4M3")
                 && fp8_scale_for.contains_key(&name_owned)
             {
                 let (sfi, sname) = &fp8_scale_for[&name_owned];
                 let (smeta, sbytes) = st_files[*sfi]
                     .tensor_data(sname)
                     .unwrap_or_else(|| panic!("FP scale tensor missing: {sname}"));
-                dequantize_e2m1_ue8m0_to_f32(
-                    raw_data, &meta.shape, sbytes, &smeta.shape)
+                dequantize_e2m1_ue8m0_to_f32(raw_data, &meta.shape, sbytes, &smeta.shape)
             } else {
                 let vals = tensor_to_f32_with_optional_fp8_scale(
-                    name, raw_data, meta, &fp8_scale_for, &st_files);
+                    name,
+                    raw_data,
+                    meta,
+                    &fp8_scale_for,
+                    &st_files,
+                );
                 (vals, meta.shape.clone())
             };
             let k = logical_shape[1];
             if k % 256 == 0
-                && (use_mq4_mq2lloyd_gptq_all || use_mq4_mqlloyd_antirez_gptq
-                    || use_mq4_mq2lloyd_native || use_mq4_mq2lloyd_imatrix
+                && (use_mq4_mq2lloyd_gptq_all
+                    || use_mq4_mqlloyd_antirez_gptq
+                    || use_mq4_mq2lloyd_native
+                    || use_mq4_mq2lloyd_imatrix
                     || use_mq4_mqlloyd_antirez
                     || use_deepseek4_source_precision)
             {
                 let signs1 = gen_fwht_signs(42, 256);
                 let signs2 = gen_fwht_signs(1042, 256);
                 let unit_col_weights: Vec<f32> = vec![1.0; k];
-                let q = if use_mq4_mq2lloyd_gptq_all
-                    || use_mq4_mqlloyd_antirez_gptq
-                {
+                let q = if use_mq4_mq2lloyd_gptq_all || use_mq4_mqlloyd_antirez_gptq {
                     quantize_mq2g256_lloyd_gptq(&f32_data, &unit_col_weights, &signs1, &signs2)
                 } else {
                     quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2)
                 };
                 let shape: Vec<u32> = logical_shape.iter().map(|&s| s as u32).collect();
-                eprintln!("  {:>8}: {} storage{:?} → logical{:?} ({:.1} KB → {:.1} KB)",
-                    "MQ2L-DeepSeek V4", name, meta.shape, logical_shape,
+                eprintln!(
+                    "  {:>8}: {} storage{:?} → logical{:?} ({:.1} KB → {:.1} KB)",
+                    "MQ2L-DeepSeek V4",
+                    name,
+                    meta.shape,
+                    logical_shape,
                     raw_data.len() as f64 / 1024.0,
-                    q.len() as f64 / 1024.0);
+                    q.len() as f64 / 1024.0
+                );
                 hfq_tensors.push(HfqTensor {
                     name: name.to_string(),
                     quant_type: QuantType::MQ2G256Lloyd,
-                    shape, group_size: 256, data: q, spilled_len: 0,
+                    shape,
+                    group_size: 256,
+                    data: q,
+                    spilled_len: 0,
                 });
                 quantized_params += (logical_shape[0] * logical_shape[1]) as u64;
                 st_files[*file_idx].drop_tensor_pages(name);
@@ -5284,12 +5785,17 @@ fn main() {
             let n_experts = meta.shape[0];
             let inner_n: usize = meta.shape[1..].iter().product();
             let elem_size = match meta.dtype.as_str() {
-                "F32" => 4, "F16" | "BF16" => 2,
+                "F32" => 4,
+                "F16" | "BF16" => 2,
                 other => panic!("unsupported expert tensor dtype: {other}"),
             };
             let inner_bytes = inner_n * elem_size;
             let inner_shape: Vec<u32> = meta.shape[1..].iter().map(|&s| s as u32).collect();
-            let base_name = if name.ends_with("gate_up_proj") { "gate_up_proj" } else { "down_proj" };
+            let base_name = if name.ends_with("gate_up_proj") {
+                "gate_up_proj"
+            } else {
+                "down_proj"
+            };
             // Strip the trailing base; what remains is the parent path with `experts.` already on the end
             let parent = &name[..name.len() - base_name.len()];
 
@@ -5318,17 +5824,23 @@ fn main() {
             };
             let tiered_layer_is_mq3 = use_mq4_mqlloyd_tiered
                 && !kmap_promote
-                && parent_layer.map(|l| mq3_tier_layers.contains(&l)).unwrap_or(false);
+                && parent_layer
+                    .map(|l| mq3_tier_layers.contains(&l))
+                    .unwrap_or(false);
             let tiered_layer_is_mq2 = use_mq4_mqlloyd_tiered
                 && !kmap_promote
-                && parent_layer.map(|l| !mq3_tier_layers.contains(&l)).unwrap_or(false);
+                && parent_layer
+                    .map(|l| !mq3_tier_layers.contains(&l))
+                    .unwrap_or(false);
             // Antirez-style: gate_up → MQ2, down → MQ3 (kmap-respecting).
             // Selects based on `base_name` ("gate_up_proj" vs "down_proj").
             let is_gate_up = base_name == "gate_up_proj";
             let antirez_mq3 = (use_mq4_mqlloyd_antirez || use_mq4_mqlloyd_antirez_gptq)
-                && !kmap_promote && !is_gate_up;
+                && !kmap_promote
+                && !is_gate_up;
             let antirez_mq2 = (use_mq4_mqlloyd_antirez || use_mq4_mqlloyd_antirez_gptq)
-                && !kmap_promote && is_gate_up;
+                && !kmap_promote
+                && is_gate_up;
             // Lever 2: GPTQ-style sequential Lloyd specifically for the
             // gate_up MQ2 path. Sets a flag the inner quant dispatch will
             // honor (separate from the imatrix-only path).
@@ -5336,12 +5848,12 @@ fn main() {
             // For the kmap-respecting MQ2-Lloyd variants, kmap_promote experts
             // get MQ6 instead of MQ2-Lloyd. Falls through to expert_mq6 below.
             let expert_mq6 = (use_mq6g256
-                              || use_mq4_mq6exp
-                              || (kmap_promote && use_mq4g256)
-                              || (kmap_promote && use_mq4_mq2lloyd_kmap)
-                              || (kmap_promote && use_mq4_mq2lloyd_imatrix)
-                              || (kmap_promote && use_mq4_mq2lloyd_gptq_all)
-                              || (kmap_promote && use_mq4_mq3lloyd_kmap))
+                || use_mq4_mq6exp
+                || (kmap_promote && use_mq4g256)
+                || (kmap_promote && use_mq4_mq2lloyd_kmap)
+                || (kmap_promote && use_mq4_mq2lloyd_imatrix)
+                || (kmap_promote && use_mq4_mq2lloyd_gptq_all)
+                || (kmap_promote && use_mq4_mq3lloyd_kmap))
                 && supports_g256;
             let expert_hfq6 = (use_hfq6 || (kmap_promote && use_hfq4g256)) && supports_g256;
             let expert_hfq4 = use_hfq4g256 && !kmap_promote && supports_g256;
@@ -5361,15 +5873,16 @@ fn main() {
             // the `use_gptq_for_all_mq2` flag below.
             let all_mq2_gptq = use_mq4_mq2lloyd_gptq_all && !kmap_promote;
             let expert_mq2lloyd_native = (use_mq4_mq2lloyd_native
-                                          || (use_mq4_mq2lloyd_kmap && !kmap_promote)
-                                          || (use_mq4_mq2lloyd_imatrix && !kmap_promote)
-                                          || tiered_layer_is_mq2
-                                          || antirez_mq2
-                                          || all_mq2_gptq)
+                || (use_mq4_mq2lloyd_kmap && !kmap_promote)
+                || (use_mq4_mq2lloyd_imatrix && !kmap_promote)
+                || tiered_layer_is_mq2
+                || antirez_mq2
+                || all_mq2_gptq)
                 && supports_g256;
             // GPTQ assignment fires for both gate_up and down when in
             // all-MQ2-GPTQ mode (not just gate_up like the antirez split).
-            let use_gptq_for_gate_up = use_gptq_for_gate_up || (all_mq2_gptq && imatrix_path.is_some());
+            let use_gptq_for_gate_up =
+                use_gptq_for_gate_up || (all_mq2_gptq && imatrix_path.is_some());
             // MQ3-Lloyd asymmetric: non-promoted experts → qt=20 (3.5 bpw).
             // Promoted ones hit `expert_mq6` above (note: kmap_promote already
             // includes use_mq4_mq3lloyd_kmap via the expert_mq6 expression).
@@ -5377,10 +5890,9 @@ fn main() {
             // Phase 5 tiered variant: also MQ3-Lloyd on hot non-promoted
             // layers (the ones in `mq3_tier_layers`, decided above by imatrix
             // .counts ranking).
-            let expert_mq3lloyd_native = ((use_mq4_mq3lloyd_kmap && !kmap_promote)
-                                          || tiered_layer_is_mq3
-                                          || antirez_mq3)
-                && supports_g256;
+            let expert_mq3lloyd_native =
+                ((use_mq4_mq3lloyd_kmap && !kmap_promote) || tiered_layer_is_mq3 || antirez_mq3)
+                    && supports_g256;
             // Per-expert column-weights from the imatrix file, used only by
             // the imatrix variant. Built once per parent (cheap), then sliced
             // per expert inside the rayon loop. Falls back to None when the
@@ -5388,17 +5900,26 @@ fn main() {
             // tensor we accidentally route here, or a layer that wasn't in
             // the calibration set).
             let imatrix_lookup_name = format!("{}{}", parent, base_name);
-            let imatrix_per_expert: Option<Vec<Vec<f32>>> =
-                if (use_mq4_mq2lloyd_imatrix || use_mq4_mqlloyd_antirez
-                    || use_mq4_mqlloyd_antirez_gptq
-                    || use_mq4_mq2lloyd_gptq_all)
-                    && imatrix_gguf.is_some() && expert_mq2lloyd_native {
-                    imatrix_col_weights_for_parent(
-                        imatrix_gguf.as_ref().unwrap(), &imatrix_lookup_name, n_experts,
-                    )
-                } else { None };
+            let imatrix_per_expert: Option<Vec<Vec<f32>>> = if (use_mq4_mq2lloyd_imatrix
+                || use_mq4_mqlloyd_antirez
+                || use_mq4_mqlloyd_antirez_gptq
+                || use_mq4_mq2lloyd_gptq_all)
+                && imatrix_gguf.is_some()
+                && expert_mq2lloyd_native
+            {
+                imatrix_col_weights_for_parent(
+                    imatrix_gguf.as_ref().unwrap(),
+                    &imatrix_lookup_name,
+                    n_experts,
+                )
+            } else {
+                None
+            };
             if use_mq4_mq2lloyd_imatrix && expert_mq2lloyd_native && imatrix_per_expert.is_none() {
-                eprintln!("  imatrix: no entry for {} → falling back to uniform Lloyd", imatrix_lookup_name);
+                eprintln!(
+                    "  imatrix: no entry for {} → falling back to uniform Lloyd",
+                    imatrix_lookup_name
+                );
             }
 
             // Parallelize across the 256 expert slices via rayon. Each slice
@@ -5409,73 +5930,101 @@ fn main() {
             let parent_owned = parent.to_string();
             let inner_shape_clone = inner_shape.clone();
             let base_owned = base_name.to_string();
-            let mut new_tensors: Vec<HfqTensor> = (0..n_experts).into_par_iter().map(|x| {
-                let slice_off = x * inner_bytes;
-                let slice = &raw_data[slice_off..slice_off + inner_bytes];
-                let f32_slice = to_f32(slice, &dtype);
-                let (quantized, qt, gs) = if expert_mq3lloyd_native {
-                    let q = quantize_mq3g256_lloyd(&f32_slice, &signs1, &signs2);
-                    (q, QuantType::MQ3G256Lloyd, 256u32)
-                } else if expert_mq2lloyd_native {
-                    // Native MQ2-Lloyd: ship qt=19 bytes (72 B / 256 weights).
-                    // Selection order:
-                    //   1. GPTQ-Lloyd (sequential error feedback) — Lever 2
-                    //      path, requires imatrix.
-                    //   2. Imatrix-weighted Lloyd — standard Phase 3b path.
-                    //   3. Uniform Lloyd — fallback when no imatrix available.
-                    let q = match imatrix_per_expert.as_ref() {
-                        Some(table) if x < table.len() && !table[x].is_empty() && use_gptq_for_gate_up => {
-                            quantize_mq2g256_lloyd_gptq(&f32_slice, &table[x], &signs1, &signs2)
-                        }
-                        Some(table) if x < table.len() && !table[x].is_empty() => {
-                            quantize_mq2g256_lloyd_weighted(&f32_slice, &table[x], &signs1, &signs2)
-                        }
-                        _ => quantize_mq2g256_lloyd(&f32_slice, &signs1, &signs2),
+            let mut new_tensors: Vec<HfqTensor> = (0..n_experts)
+                .into_par_iter()
+                .map(|x| {
+                    let slice_off = x * inner_bytes;
+                    let slice = &raw_data[slice_off..slice_off + inner_bytes];
+                    let f32_slice = to_f32(slice, &dtype);
+                    let (quantized, qt, gs) = if expert_mq3lloyd_native {
+                        let q = quantize_mq3g256_lloyd(&f32_slice, &signs1, &signs2);
+                        (q, QuantType::MQ3G256Lloyd, 256u32)
+                    } else if expert_mq2lloyd_native {
+                        // Native MQ2-Lloyd: ship qt=19 bytes (72 B / 256 weights).
+                        // Selection order:
+                        //   1. GPTQ-Lloyd (sequential error feedback) — Lever 2
+                        //      path, requires imatrix.
+                        //   2. Imatrix-weighted Lloyd — standard Phase 3b path.
+                        //   3. Uniform Lloyd — fallback when no imatrix available.
+                        let q = match imatrix_per_expert.as_ref() {
+                            Some(table)
+                                if x < table.len()
+                                    && !table[x].is_empty()
+                                    && use_gptq_for_gate_up =>
+                            {
+                                quantize_mq2g256_lloyd_gptq(&f32_slice, &table[x], &signs1, &signs2)
+                            }
+                            Some(table) if x < table.len() && !table[x].is_empty() => {
+                                quantize_mq2g256_lloyd_weighted(
+                                    &f32_slice, &table[x], &signs1, &signs2,
+                                )
+                            }
+                            _ => quantize_mq2g256_lloyd(&f32_slice, &signs1, &signs2),
+                        };
+                        (q, QuantType::MQ2G256Lloyd, 256u32)
+                    } else if expert_mq2lloyd_roundtrip {
+                        // MQ2-Lloyd → F32 → HFQ4 round-trip. The MQ2 step injects
+                        // the 2-bit Lloyd-codebook noise; the HFQ4 step re-packs
+                        // for runtime. Final on-disk format is HFQ4G256, no
+                        // engine changes required.
+                        let mq2_bytes = quantize_mq2g256_lloyd(&f32_slice, &signs1, &signs2);
+                        let dequant = dequantize_mq2g256_lloyd_to_f32(
+                            &mq2_bytes,
+                            f32_slice.len(),
+                            &signs1,
+                            &signs2,
+                        );
+                        let q = quantize_hfq4g256(&dequant);
+                        (q, QuantType::HFQ4G256, 256u32)
+                    } else if expert_mq6 {
+                        let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
+                        (q, QuantType::MQ6G256, 256u32)
+                    } else if expert_hfq6 {
+                        let q = quantize_hfq6g256(&f32_slice);
+                        (q, QuantType::HFQ6G256, 256u32)
+                    } else if expert_hfq4 {
+                        let q = quantize_hfq4g256(&f32_slice);
+                        (q, QuantType::HFQ4G256, 256u32)
+                    } else if supports_g256 {
+                        let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
+                        (q, QuantType::MQ4G256, 256u32)
+                    } else {
+                        let q = quantize_hfq4g128(&f32_slice);
+                        (q, QuantType::HFQ4G128, 128u32)
                     };
-                    (q, QuantType::MQ2G256Lloyd, 256u32)
-                } else if expert_mq2lloyd_roundtrip {
-                    // MQ2-Lloyd → F32 → HFQ4 round-trip. The MQ2 step injects
-                    // the 2-bit Lloyd-codebook noise; the HFQ4 step re-packs
-                    // for runtime. Final on-disk format is HFQ4G256, no
-                    // engine changes required.
-                    let mq2_bytes = quantize_mq2g256_lloyd(&f32_slice, &signs1, &signs2);
-                    let dequant = dequantize_mq2g256_lloyd_to_f32(
-                        &mq2_bytes, f32_slice.len(), &signs1, &signs2,
-                    );
-                    let q = quantize_hfq4g256(&dequant);
-                    (q, QuantType::HFQ4G256, 256u32)
-                } else if expert_mq6 {
-                    let q = quantize_mq6g256(&f32_slice, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32)
-                } else if expert_hfq6 {
-                    let q = quantize_hfq6g256(&f32_slice);
-                    (q, QuantType::HFQ6G256, 256u32)
-                } else if expert_hfq4 {
-                    let q = quantize_hfq4g256(&f32_slice);
-                    (q, QuantType::HFQ4G256, 256u32)
-                } else if supports_g256 {
-                    let q = quantize_mq4g256(&f32_slice, &signs1, &signs2);
-                    (q, QuantType::MQ4G256, 256u32)
-                } else {
-                    let q = quantize_hfq4g128(&f32_slice);
-                    (q, QuantType::HFQ4G128, 128u32)
-                };
-                HfqTensor {
-                    name: format!("{parent_owned}{x}.{base_owned}.weight"),
-                    quant_type: qt,
-                    shape: inner_shape_clone.clone(),
-                    group_size: gs,
-                    data: quantized,
-                    spilled_len: 0,
-                }
-            }).collect();
+                    HfqTensor {
+                        name: format!("{parent_owned}{x}.{base_owned}.weight"),
+                        quant_type: qt,
+                        shape: inner_shape_clone.clone(),
+                        group_size: gs,
+                        data: quantized,
+                        spilled_len: 0,
+                    }
+                })
+                .collect();
             quantized_params += inner_n as u64 * n_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
             let label = if expert_mq3lloyd_native {
                 "MQ3G256L"
             } else if expert_mq2lloyd_native {
-                if imatrix_per_expert.is_some() { "MQ2L+imatrix" } else { "MQ2G256L" }
-            } else if expert_mq2lloyd_roundtrip { "MQ2L→HFQ4" } else if expert_mq6 { "MQ6G256" } else if expert_hfq6 { "HFQ6G256" } else if expert_hfq4 { "HFQ4G256" } else if supports_g256 { "MQ4G256" } else { "HFQ4G128" };
+                if imatrix_per_expert.is_some() {
+                    "MQ2L+imatrix"
+                } else {
+                    "MQ2G256L"
+                }
+            } else if expert_mq2lloyd_roundtrip {
+                "MQ2L→HFQ4"
+            } else if expert_mq6 {
+                "MQ6G256"
+            } else if expert_hfq6 {
+                "HFQ6G256"
+            } else if expert_hfq4 {
+                "HFQ4G256"
+            } else if supports_g256 {
+                "MQ4G256"
+            } else {
+                "HFQ4G128"
+            };
             let bytes_per = new_tensors.first().map(|t| t.data.len()).unwrap_or(0);
             eprintln!("  {label:>8}: {parent_owned}{{0..{n_experts}}}.{base_owned}.weight {:?} (×{n_experts} experts || {:.1} KB/expert, parallel)",
                 inner_shape, bytes_per as f64 / 1024.0);
@@ -5511,23 +6060,39 @@ fn main() {
             && name.starts_with("mtp.")
             && !name.contains(".ffn.experts.")
             && should_quantize(name);
-        if (use_deepseek4_source_precision && is_deepseek4_keep_f16(name) || keep_f16_mtp) && n_elements >= 32 {
+        if (use_deepseek4_source_precision && is_deepseek4_keep_f16(name) || keep_f16_mtp)
+            && n_elements >= 32
+        {
             let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
             let src_dtype = meta.dtype.as_str();
             let f32_data = tensor_to_f32_with_optional_fp8_scale(
-                name, raw_data, meta, &fp8_scale_for, &st_files,
+                name,
+                raw_data,
+                meta,
+                &fp8_scale_for,
+                &st_files,
             );
             quantized_params += n_elements as u64;
-            let f16_bytes: Vec<u8> = f32_data.iter()
+            let f16_bytes: Vec<u8> = f32_data
+                .iter()
                 .flat_map(|&v| f32_to_f16(v).to_le_bytes())
                 .collect();
-            eprintln!("  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB) [src={src_dtype}, keep-F16]",
-                "F16", name, meta.shape, n_elements,
-                raw_data.len() as f64 / 1024.0, f16_bytes.len() as f64 / 1024.0);
+            eprintln!(
+                "  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB) [src={src_dtype}, keep-F16]",
+                "F16",
+                name,
+                meta.shape,
+                n_elements,
+                raw_data.len() as f64 / 1024.0,
+                f16_bytes.len() as f64 / 1024.0
+            );
             hfq_tensors.push(HfqTensor {
                 name: name.to_string(),
                 quant_type: QuantType::F16,
-                shape, group_size: 0, data: f16_bytes, spilled_len: 0,
+                shape,
+                group_size: 0,
+                data: f16_bytes,
+                spilled_len: 0,
             });
             st_files[*file_idx].drop_tensor_pages(name);
             if let Some(ref mut s) = spill {
@@ -5539,17 +6104,30 @@ fn main() {
             let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
             let src_dtype = meta.dtype.as_str();
             let f32_data = tensor_to_f32_with_optional_fp8_scale(
-                name, raw_data, meta, &fp8_scale_for, &st_files,
+                name,
+                raw_data,
+                meta,
+                &fp8_scale_for,
+                &st_files,
             );
             quantized_params += n_elements as u64;
             let q = quantize_q8f16(&f32_data);
-            eprintln!("  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB) [src={src_dtype}]",
-                "Q8_F16", name, meta.shape, n_elements,
-                raw_data.len() as f64 / 1024.0, q.len() as f64 / 1024.0);
+            eprintln!(
+                "  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB) [src={src_dtype}]",
+                "Q8_F16",
+                name,
+                meta.shape,
+                n_elements,
+                raw_data.len() as f64 / 1024.0,
+                q.len() as f64 / 1024.0
+            );
             hfq_tensors.push(HfqTensor {
                 name: name.to_string(),
                 quant_type: QuantType::Q8F16,
-                shape, group_size: 32, data: q, spilled_len: 0,
+                shape,
+                group_size: 32,
+                data: q,
+                spilled_len: 0,
             });
             st_files[*file_idx].drop_tensor_pages(name);
             if let Some(ref mut s) = spill {
@@ -5560,7 +6138,11 @@ fn main() {
 
         if should_quantize(name) && n_elements >= 32 {
             let f32_data = tensor_to_f32_with_optional_fp8_scale(
-                name, raw_data, meta, &fp8_scale_for, &st_files,
+                name,
+                raw_data,
+                meta,
+                &fp8_scale_for,
+                &st_files,
             );
             quantized_params += n_elements as u64;
 
@@ -5595,11 +6177,16 @@ fn main() {
                     }
                 }
 
-                eprintln!("  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB, stride={})",
-                    "Q8_HFQ", name, meta.shape, n_elements,
+                eprintln!(
+                    "  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB, stride={})",
+                    "Q8_HFQ",
+                    name,
+                    meta.shape,
+                    n_elements,
                     raw_data.len() as f64 / 1024.0,
                     quantized.len() as f64 / 1024.0,
-                    row_stride);
+                    row_stride
+                );
 
                 hfq_tensors.push(HfqTensor {
                     name: name.to_string(),
@@ -5610,81 +6197,477 @@ fn main() {
                     spilled_len: 0,
                 });
             } else {
+                // ── K-map override ──────────────────────────────────────────────
+                let kmap_level = kmap.get(&**name).copied().unwrap_or(QuantLevel::Base);
 
-            // ── K-map override ──────────────────────────────────────────────
-            let kmap_level = kmap.get(&**name).copied().unwrap_or(QuantLevel::Base);
+                // AWQ sidecar scales for this tensor — populated only inside the
+                // MQ4G256 arm when --awq is enabled and an imatrix entry exists
+                // for this tensor's ggml-translated name. After the main tensor
+                // push, we emit an `<name>.awq_scale` 1D F16 sidecar tensor so
+                // the runtime can apply `x / s` before the rotation kernel at
+                // inference time.
+                let mut awq_sidecar_scales: Option<Vec<f32>> = None;
 
-            // AWQ sidecar scales for this tensor — populated only inside the
-            // MQ4G256 arm when --awq is enabled and an imatrix entry exists
-            // for this tensor's ggml-translated name. After the main tensor
-            // push, we emit an `<name>.awq_scale` 1D F16 sidecar tensor so
-            // the runtime can apply `x / s` before the rotation kernel at
-            // inference time.
-            let mut awq_sidecar_scales: Option<Vec<f32>> = None;
-
-            let (quantized, qt, gs, label) = if q8_conv1d_default && is_conv1d_tensor(name) {
-                // DeltaNet conv1d defaults to Q8 (see --no-q8-conv1d to disable).
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if kmap_level == QuantLevel::Q8 {
-                // K-map says Q8 (embed, lm_head, router)
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if kmap_level == QuantLevel::F16 {
-                // K-map says F16 (should not normally reach here — should_quantize filters first)
-                let f16_bytes: Vec<u8> = f32_data
-                    .iter()
-                    .flat_map(|&v| f32_to_f16(v).to_le_bytes())
-                    .collect();
-                (f16_bytes, QuantType::F16, 0u32, "F16")
-            } else if kmap_level == QuantLevel::Promote6 {
-                // K-map says promote to 6-bit
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if (use_mq4g256 || use_mq4_mq6exp || use_mq4_mq2lloydexp || use_mq4_mq2lloyd_native || use_mq4_mq2lloyd_kmap || use_mq4_mq2lloyd_imatrix || use_mq4_mq3lloyd_kmap || use_mq4_mqlloyd_tiered || use_mq4_mqlloyd_antirez || use_mq4_mqlloyd_antirez_gptq || use_mq4_mq2lloyd_gptq_all
-                    || use_mq3g256 || use_mq2g256
-                    || use_mq2g256_lloyd || use_mq3g256_lloyd) && k_dim % 256 == 0
-                {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
-                } else if (use_hfq4g256 || use_hfq3g256 || use_hfq3g128
-                    || use_hfq2g256 || use_hfq2g128) && k_dim % 256 == 0
-                {
-                    let q = quantize_hfq6g256(&f32_data);
-                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
-                } else if use_mq6g256 && k_dim % 256 == 0 {
-                    // Already 6-bit MQ — no-op promotion
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
-                } else if use_hfq6 && k_dim % 256 == 0 {
-                    // Already 6-bit HFQ — no-op promotion
-                    let q = quantize_hfq6g256(&f32_data);
-                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
-                } else {
-                    // Non-256-aligned fallback: Q8
+                let (quantized, qt, gs, label) = if q8_conv1d_default && is_conv1d_tensor(name) {
+                    // DeltaNet conv1d defaults to Q8 (see --no-q8-conv1d to disable).
                     let q = quantize_q8f16(&f32_data);
                     (q, QuantType::Q8F16, 32u32, "Q8_F16")
-                }
-            } else if let QuantLevel::Override(override_fmt) = kmap_level {
-                // K-map says override (today: lm_head when --lm-head-format set).
-                // Dispatch on the carried format. For MQ4 with AWQ enabled,
-                // apply AWQ pre-scaling + emit a sidecar so the runtime
-                // (once the CUDA-branch AWQ-aware lm_head dispatch lands)
-                // sees scaled bytes and inverse-divides correctly. For any
-                // other format, plain quantize (the AWQ wiring outside MQ4
-                // is a follow-up).
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    match override_fmt {
-                        GgufFormat::Mq4 => {
-                            // Inline AWQ + MQ4 dance (mirrors the Base MQ4 arm).
-                            let q = if let (Some(alpha), Some(im_weights))
-                                = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                } else if kmap_level == QuantLevel::Q8 {
+                    // K-map says Q8 (embed, lm_head, router)
+                    let q = quantize_q8f16(&f32_data);
+                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                } else if kmap_level == QuantLevel::F16 {
+                    // K-map says F16 (should not normally reach here — should_quantize filters first)
+                    let f16_bytes: Vec<u8> = f32_data
+                        .iter()
+                        .flat_map(|&v| f32_to_f16(v).to_le_bytes())
+                        .collect();
+                    (f16_bytes, QuantType::F16, 0u32, "F16")
+                } else if kmap_level == QuantLevel::Promote6 {
+                    // K-map says promote to 6-bit
+                    let k_dim = if meta.shape.len() == 2 {
+                        meta.shape[1]
+                    } else {
+                        n_elements
+                    };
+                    if (use_mq4g256
+                        || use_mq4_mq6exp
+                        || use_mq4_mq2lloydexp
+                        || use_mq4_mq2lloyd_native
+                        || use_mq4_mq2lloyd_kmap
+                        || use_mq4_mq2lloyd_imatrix
+                        || use_mq4_mq3lloyd_kmap
+                        || use_mq4_mqlloyd_tiered
+                        || use_mq4_mqlloyd_antirez
+                        || use_mq4_mqlloyd_antirez_gptq
+                        || use_mq4_mq2lloyd_gptq_all
+                        || use_mq3g256
+                        || use_mq2g256
+                        || use_mq2g256_lloyd
+                        || use_mq3g256_lloyd)
+                        && k_dim % 256 == 0
+                    {
+                        let signs1 = gen_fwht_signs(42, 256);
+                        let signs2 = gen_fwht_signs(1042, 256);
+                        let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                        (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                    } else if (use_hfq4g256
+                        || use_hfq3g256
+                        || use_hfq3g128
+                        || use_hfq2g256
+                        || use_hfq2g128)
+                        && k_dim % 256 == 0
+                    {
+                        let q = quantize_hfq6g256(&f32_data);
+                        (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                    } else if use_mq6g256 && k_dim % 256 == 0 {
+                        // Already 6-bit MQ — no-op promotion
+                        let signs1 = gen_fwht_signs(42, 256);
+                        let signs2 = gen_fwht_signs(1042, 256);
+                        let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                        (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                    } else if use_hfq6 && k_dim % 256 == 0 {
+                        // Already 6-bit HFQ — no-op promotion
+                        let q = quantize_hfq6g256(&f32_data);
+                        (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                    } else {
+                        // Non-256-aligned fallback: Q8
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    }
+                } else if let QuantLevel::Override(override_fmt) = kmap_level {
+                    // K-map says override (today: lm_head when --lm-head-format set).
+                    // Dispatch on the carried format. For MQ4 with AWQ enabled,
+                    // apply AWQ pre-scaling + emit a sidecar so the runtime
+                    // (once the CUDA-branch AWQ-aware lm_head dispatch lands)
+                    // sees scaled bytes and inverse-divides correctly. For any
+                    // other format, plain quantize (the AWQ wiring outside MQ4
+                    // is a follow-up).
+                    let k_dim = if meta.shape.len() == 2 {
+                        meta.shape[1]
+                    } else {
+                        n_elements
+                    };
+                    if k_dim % 256 == 0 {
+                        let signs1 = gen_fwht_signs(42, 256);
+                        let signs2 = gen_fwht_signs(1042, 256);
+                        match override_fmt {
+                            GgufFormat::Mq4 => {
+                                // Inline AWQ + MQ4 dance (mirrors the Base MQ4 arm).
+                                let q = if let (Some(alpha), Some(im_weights)) =
+                                    (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                                {
+                                    if awq_eligible(name) {
+                                        let scales = compute_awq_scales(im_weights, alpha);
+                                        awq_sidecar_scales = Some(scales.clone());
+                                        let m_dim = meta.shape[0];
+                                        let mut scaled = f32_data.clone();
+                                        awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                        quantize_mq4g256(&scaled, &signs1, &signs2)
+                                    } else {
+                                        quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                    }
+                                } else {
+                                    quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                };
+                                (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                            }
+                            GgufFormat::Mq6 => {
+                                let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                                (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                            }
+                            GgufFormat::Mq3 => {
+                                // MQ3 + AWQ on lm_head: runtime supports the sidecar via
+                                // DType::supports_awq_sidecar(MQ3G256)=true (per the
+                                // fix/lm-head-awq-runtime branch). Wire the same AWQ
+                                // inline-quantize dance as the MQ4 arm.
+                                let q = if let (Some(alpha), Some(im_weights)) =
+                                    (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                                {
+                                    if awq_eligible(name) {
+                                        let scales = compute_awq_scales(im_weights, alpha);
+                                        awq_sidecar_scales = Some(scales.clone());
+                                        let m_dim = meta.shape[0];
+                                        let mut scaled = f32_data.clone();
+                                        awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                        quantize_mq3g256(&scaled, &signs1, &signs2)
+                                    } else {
+                                        quantize_mq3g256(&f32_data, &signs1, &signs2)
+                                    }
+                                } else {
+                                    quantize_mq3g256(&f32_data, &signs1, &signs2)
+                                };
+                                (q, QuantType::MQ3G256, 256u32, "MQ3G256")
+                            }
+                            GgufFormat::Hfq4 => {
+                                let q = quantize_hfq4g256(&f32_data);
+                                (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                            }
+                            GgufFormat::Hfq6 => {
+                                let q = quantize_hfq6g256(&f32_data);
+                                (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                            }
+                            // Other Override targets: not yet wired with AWQ;
+                            // emit plain quantization. Used in Phase 0 sweeps
+                            // for non-AWQ lm_head experiments.
+                            GgufFormat::Mq2 => {
+                                let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
+                                (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                            }
+                            GgufFormat::Mq2Lloyd => {
+                                let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
+                                (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                            }
+                            GgufFormat::Mq3Lloyd => {
+                                let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
+                                (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                            }
+                            GgufFormat::Mq4Lloyd => {
+                                let q = quantize_mq4g256_lloyd(&f32_data, &signs1, &signs2);
+                                (q, QuantType::MQ4G256Lloyd, 256u32, "MQ4G256Lloyd")
+                            }
+                            GgufFormat::Mfp4 => {
+                                let m = if meta.shape.len() == 2 {
+                                    meta.shape[0]
+                                } else {
+                                    1
+                                };
+                                let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
+                                (q, QuantType::MFP4G32, 32u32, "MFP4G32")
+                            }
+                            GgufFormat::Hfp4 => {
+                                let m = if meta.shape.len() == 2 {
+                                    meta.shape[0]
+                                } else {
+                                    1
+                                };
+                                let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
+                                (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                            }
+                        }
+                    } else {
+                        // Non-256-aligned override target: Q8 fallback.
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    }
+                } else {
+                    // QuantLevel::Base — existing format-specific logic below
+
+                    // Choose quant format per tensor
+                    let this_q8 = if use_q4k_all {
+                        false // everything Q4_K
+                    } else if use_q4k_q8embed {
+                        name.contains("embed") || name.contains("lm_head") // only embed/output Q8
+                    } else if use_mixed || use_fast {
+                        is_q8_tensor(name)
+                    } else {
+                        use_q8 || use_q8hfq // 1D Q8HFQ tensors fall back to Q8F16
+                    };
+                    let this_q4as8 = use_fast && !this_q8; // FFN tensors in q8-fast mode
+                    let this_q4k = use_q4k_all || use_q4k_q8embed || use_mixed;
+
+                    // Embeddings stored as Q8 in HFQ4 mode — Q4 is too lossy for
+                    // large-dim models (9B: dim=4096, values ~0.016, Q4 step ~0.007)
+                    let is_embed = name.contains("embed_tokens");
+
+                    if use_hfq_mixed {
+                        // hfq-mixed: Q8 for attention, HFQ4 for FFN (fits 9B in 8GB VRAM)
+                        let is_ffn = name.contains("mlp.") || name.contains("ffn");
+                        if !is_ffn {
+                            let q = quantize_q8f16(&f32_data);
+                            (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                        } else {
+                            let k_dim = if meta.shape.len() == 2 {
+                                meta.shape[1]
+                            } else {
+                                n_elements
+                            };
+                            if k_dim % 256 == 0 {
+                                let q = quantize_hfq4g256(&f32_data);
+                                (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                            } else {
+                                let q = quantize_hfq4g128(&f32_data);
+                                (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                            }
+                        }
+                    } else if use_hfq6 {
+                        // HFQ6-G256: all weights 6-bit, embeddings Q8
+                        if is_embed {
+                            let q = quantize_q8f16(&f32_data);
+                            (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                        } else {
+                            let q = quantize_hfq6g256(&f32_data);
+                            (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                        }
+                    } else if (use_hfq2g256 || use_hfq2g128) && is_embed {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_hfq2g128 {
+                        let q = quantize_hfq2g128(&f32_data);
+                        (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
+                    } else if use_hfq2g256 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let q = quantize_hfq2g256(&f32_data);
+                            (q, QuantType::HFQ2G256, 256u32, "HFQ2G256")
+                        } else {
+                            // Fallback to HFQ4 for non-256-aligned
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        }
+                    } else if use_mq8g256 && is_embed {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_mq8g256 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            let q = quantize_mq8g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ8G256, 256u32, "MQ8G256")
+                        } else {
+                            // Fallback to Q8 for non-256-aligned
+                            let q = quantize_q8f16(&f32_data);
+                            (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                        }
+                    } else if q8_router && is_q8_tensor(name) {
+                        // Q8 router for MoE: keep mlp.gate.weight and
+                        // shared_expert_gate.weight at Q8 regardless of --format.
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if (use_mq4g256
+                        || use_mq4_mq6exp
+                        || use_mq4_mq2lloydexp
+                        || use_mq4_mq2lloyd_native
+                        || use_mq4_mq2lloyd_kmap
+                        || use_mq4_mq2lloyd_imatrix
+                        || use_mq4_mq3lloyd_kmap
+                        || use_mq4_mqlloyd_tiered
+                        || use_mq4_mqlloyd_antirez
+                        || use_mq4_mqlloyd_antirez_gptq
+                        || use_mq4_mq2lloyd_gptq_all)
+                        && is_embed
+                    {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_mq4g256
+                        || use_mq4_mq6exp
+                        || use_mq4_mq2lloydexp
+                        || use_mq4_mq2lloyd_native
+                        || use_mq4_mq2lloyd_kmap
+                        || use_mq4_mq2lloyd_imatrix
+                        || use_mq4_mq3lloyd_kmap
+                        || use_mq4_mqlloyd_tiered
+                        || use_mq4_mqlloyd_antirez
+                        || use_mq4_mqlloyd_antirez_gptq
+                        || use_mq4_mq2lloyd_gptq_all
+                    {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            // Phase A Stage A — AWQ pre-scaling, when --awq is enabled
+                            // AND we have imatrix data for this tensor AND the tensor
+                            // is on the AWQ whitelist (see `awq_eligible`). Mutates a
+                            // local copy of the weights so the original f32_data
+                            // returned by to_f32() is left intact for downstream
+                            // consumers (we don't currently have any here, but this
+                            // is hygienic).
+                            //
+                            // The `awq_eligible(name)` guard is critical: pre-scaling
+                            // weights whose runtime path lacks the inverse divide
+                            // produces `(W·s)·x ≠ W·x` and catastrophically corrupts
+                            // logits (KLD 0.67 → 13.5 measured on 0.8B Qwen3.5 before
+                            // this guard landed). See `docs/plans/awq_fix_claude.md`.
+                            let q = if let (Some(alpha), Some(im_weights)) =
+                                (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                            {
+                                if awq_eligible(name) {
+                                    debug_assert_eq!(
+                                        im_weights.len(),
+                                        k_dim,
+                                        "imatrix length ({}) != K dim ({}) for {}",
+                                        im_weights.len(),
+                                        k_dim,
+                                        name
+                                    );
+                                    let scales = compute_awq_scales(im_weights, alpha);
+                                    // Stash for sidecar emission after the main tensor push.
+                                    awq_sidecar_scales = Some(scales.clone());
+                                    let m_dim = meta.shape[0];
+                                    // Copy weights so we don't mutate to_f32's buffer
+                                    // (might be shared/borrowed depending on dtype path).
+                                    let mut scaled = f32_data.clone();
+                                    awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                    quantize_mq4g256(&scaled, &signs1, &signs2)
+                                } else {
+                                    // Runtime path for this weight has no AWQ inverse
+                                    // (rotate_x_mq for o_proj/out_proj/wo, or
+                                    // fused_silu_mul_rotate_mq for down_proj/w_down).
+                                    // Skip AWQ for this tensor — emit plain MQ4 and
+                                    // no sidecar.
+                                    quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                }
+                            } else {
+                                quantize_mq4g256(&f32_data, &signs1, &signs2)
+                            };
+                            (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                        } else {
+                            // Fallback to standard HFQ4-G128 for non-256-aligned
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        }
+                    } else if use_hfp4 && is_embed {
+                        // HFP4 embeddings stay Q8F16 (matches MQ4 / HFQ4 pattern — embedding lookup is
+                        // accuracy-sensitive, FP4 codes too lossy for vocab-sized tables).
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_hfp4 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 32 == 0 && meta.shape.len() == 2 {
+                            let m = meta.shape[0];
+                            let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
+                            (q, QuantType::HFP4G32, 32u32, "HFP4G32")
+                        } else {
+                            // Fallback to HFQ4-G128 for non-32-aligned ragged dims (rare).
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        }
+                    } else if use_mfp4 && is_embed {
+                        // MFP4 embeddings stay Q8F16 (same rationale as HFP4 / MQ4).
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_mfp4 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 && meta.shape.len() == 2 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            let m = meta.shape[0];
+                            let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
+                            (q, QuantType::MFP4G32, 32u32, "MFP4G32")
+                        } else {
+                            // Fallback to HFQ4-G128 for non-256-aligned ragged dims (rotation
+                            // requires 256-element segments). Matches MQ4's ragged fallback.
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        }
+                    } else if use_mq6g256 && is_embed {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_mq6g256 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                        } else {
+                            // Fallback to HFQ6-G256 for non-256-aligned (no rotation)
+                            let q = quantize_hfq6g256(&f32_data);
+                            (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
+                        }
+                    } else if (use_mq3g256
+                        || use_mq2g256
+                        || use_mq2g256_lloyd
+                        || use_mq3g256_lloyd
+                        || use_mq4g256_lloyd)
+                        && is_embed
+                    {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_mq4g256_lloyd {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            let q = quantize_mq4g256_lloyd(&f32_data, &signs1, &signs2);
+                            (q, QuantType::MQ4G256Lloyd, 256u32, "MQ4G256Lloyd")
+                        } else {
+                            // Fallback to HFQ4-G128 for non-256-aligned (no rotation).
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        }
+                    } else if use_mq3g256_lloyd {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            // AWQ × MQ3-Lloyd composition (MQ3G256Lloyd is forward-path-ready +
+                            // now in supports_awq_sidecar). Pre-scale by imatrix, then Lloyd-fit.
+                            let q = if let (Some(alpha), Some(im_weights)) =
+                                (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
                             {
                                 if awq_eligible(name) {
                                     let scales = compute_awq_scales(im_weights, alpha);
@@ -5692,26 +6675,76 @@ fn main() {
                                     let m_dim = meta.shape[0];
                                     let mut scaled = f32_data.clone();
                                     awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
-                                    quantize_mq4g256(&scaled, &signs1, &signs2)
+                                    quantize_mq3g256_lloyd(&scaled, &signs1, &signs2)
                                 } else {
-                                    quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                    quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
                                 }
                             } else {
-                                quantize_mq4g256(&f32_data, &signs1, &signs2)
+                                quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
                             };
-                            (q, QuantType::MQ4G256, 256u32, "MQ4G256")
+                            (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
+                        } else {
+                            let q = quantize_hfq3g128(&f32_data);
+                            (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
                         }
-                        GgufFormat::Mq6 => {
-                            let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
-                            (q, QuantType::MQ6G256, 256u32, "MQ6G256")
+                    } else if use_mq2g256_lloyd {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            // AWQ × MQ2-Lloyd (MQ2G256Lloyd is in supports_awq_sidecar): pre-scale
+                            // by imatrix first, then Lloyd-fit (K=4, or K=3-ternary under the flag).
+                            let awq_scaled: Option<Vec<f32>> =
+                                if let (Some(alpha), Some(im_weights)) =
+                                    (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                                {
+                                    if awq_eligible(name) {
+                                        let scales = compute_awq_scales(im_weights, alpha);
+                                        awq_sidecar_scales = Some(scales.clone());
+                                        let m_dim = meta.shape[0];
+                                        let mut scaled = f32_data.clone();
+                                        awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                        Some(scaled)
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                };
+                            let data: &[f32] = awq_scaled.as_deref().unwrap_or(&f32_data);
+                            // HIPFIRE_LLOYD_K3=1 → ternary "MQ1.58" (3-level codebook, reuses kernel).
+                            let q =
+                                if std::env::var("HIPFIRE_LLOYD_K3").ok().as_deref() == Some("1") {
+                                    quantize_mq2g256_lloyd_k3(data, &signs1, &signs2)
+                                } else {
+                                    quantize_mq2g256_lloyd(data, &signs1, &signs2)
+                                };
+                            (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
+                        } else {
+                            // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
+                            let q = quantize_hfq2g128(&f32_data);
+                            (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
                         }
-                        GgufFormat::Mq3 => {
-                            // MQ3 + AWQ on lm_head: runtime supports the sidecar via
-                            // DType::supports_awq_sidecar(MQ3G256)=true (per the
-                            // fix/lm-head-awq-runtime branch). Wire the same AWQ
-                            // inline-quantize dance as the MQ4 arm.
-                            let q = if let (Some(alpha), Some(im_weights))
-                                = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                    } else if use_mq3g256 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            // AWQ pre-scaling for MQ3 base body (mirrors the MQ4 base arm).
+                            // MQ3G256 is on DType::supports_awq_sidecar, so the runtime applies
+                            // the inverse divide via rotate_x_mq. Without this, `--format mq3
+                            // --awq` was a silent no-op on body tensors (md5(mq3-awq)==md5(mq3)).
+                            // awq_eligible gates to tensors whose runtime path has the inverse.
+                            let q = if let (Some(alpha), Some(im_weights)) =
+                                (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
                             {
                                 if awq_eligible(name) {
                                     let scales = compute_awq_scales(im_weights, alpha);
@@ -5727,540 +6760,274 @@ fn main() {
                                 quantize_mq3g256(&f32_data, &signs1, &signs2)
                             };
                             (q, QuantType::MQ3G256, 256u32, "MQ3G256")
+                        } else {
+                            // Fallback to HFQ3-G128 for non-256-aligned (no rotation)
+                            let q = quantize_hfq3g128(&f32_data);
+                            (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
                         }
-                        GgufFormat::Hfq4 => {
+                    } else if use_mq2g256 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let signs1 = gen_fwht_signs(42, 256);
+                            let signs2 = gen_fwht_signs(1042, 256);
+                            // AWQ × plain MQ2 (MQ2G256 now in supports_awq_sidecar). Pre-scale by
+                            // imatrix, then quantize. (Plain MQ2 collapses uncalibrated; AWQ is the
+                            // test of whether activation-aware scaling rescues uniform 2-bit.)
+                            let q = if let (Some(alpha), Some(im_weights)) =
+                                (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
+                            {
+                                if awq_eligible(name) {
+                                    let scales = compute_awq_scales(im_weights, alpha);
+                                    awq_sidecar_scales = Some(scales.clone());
+                                    let m_dim = meta.shape[0];
+                                    let mut scaled = f32_data.clone();
+                                    awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
+                                    quantize_mq2g256(&scaled, &signs1, &signs2)
+                                } else {
+                                    quantize_mq2g256(&f32_data, &signs1, &signs2)
+                                }
+                            } else {
+                                quantize_mq2g256(&f32_data, &signs1, &signs2)
+                            };
+                            (q, QuantType::MQ2G256, 256u32, "MQ2G256")
+                        } else {
+                            // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
+                            let q = quantize_hfq2g128(&f32_data);
+                            (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
+                        }
+                    } else if (use_hfq3g256 || use_hfq3g128) && is_embed {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_F16")
+                    } else if use_hfq3g128 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 128 == 0 {
+                            let q = quantize_hfq3g128(&f32_data);
+                            (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
+                        } else {
+                            let q = quantize_hfq3g128(&f32_data);
+                            (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
+                        }
+                    } else if use_hfq3g256 {
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
+                            let q = quantize_hfq3g256(&f32_data);
+                            (q, QuantType::HFQ3G256, 256u32, "HFQ3G256")
+                        } else {
+                            let q = quantize_hfq3g128(&f32_data);
+                            (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
+                        }
+                    } else if use_hfq4g256 && is_embed {
+                        // HFQ4 embeddings: half the size of Q8, same 18-VGPR lookup kernel
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
+                        } else {
+                            n_elements
+                        };
+                        if k_dim % 256 == 0 {
                             let q = quantize_hfq4g256(&f32_data);
                             (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
-                        }
-                        GgufFormat::Hfq6 => {
-                            let q = quantize_hfq6g256(&f32_data);
-                            (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
-                        }
-                        // Other Override targets: not yet wired with AWQ;
-                        // emit plain quantization. Used in Phase 0 sweeps
-                        // for non-AWQ lm_head experiments.
-                        GgufFormat::Mq2 => {
-                            let q = quantize_mq2g256(&f32_data, &signs1, &signs2);
-                            (q, QuantType::MQ2G256, 256u32, "MQ2G256")
-                        }
-                        GgufFormat::Mq2Lloyd => {
-                            let q = quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2);
-                            (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
-                        }
-                        GgufFormat::Mq3Lloyd => {
-                            let q = quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2);
-                            (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
-                        }
-                        GgufFormat::Mq4Lloyd => {
-                            let q = quantize_mq4g256_lloyd(&f32_data, &signs1, &signs2);
-                            (q, QuantType::MQ4G256Lloyd, 256u32, "MQ4G256Lloyd")
-                        }
-                        GgufFormat::Mfp4 => {
-                            let m = if meta.shape.len() == 2 { meta.shape[0] } else { 1 };
-                            let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
-                            (q, QuantType::MFP4G32, 32u32, "MFP4G32")
-                        }
-                        GgufFormat::Hfp4 => {
-                            let m = if meta.shape.len() == 2 { meta.shape[0] } else { 1 };
-                            let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
-                            (q, QuantType::HFP4G32, 32u32, "HFP4G32")
-                        }
-                    }
-                } else {
-                    // Non-256-aligned override target: Q8 fallback.
-                    let q = quantize_q8f16(&f32_data);
-                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
-                }
-            } else {
-            // QuantLevel::Base — existing format-specific logic below
-
-            // Choose quant format per tensor
-            let this_q8 = if use_q4k_all {
-                false // everything Q4_K
-            } else if use_q4k_q8embed {
-                name.contains("embed") || name.contains("lm_head") // only embed/output Q8
-            } else if use_mixed || use_fast {
-                is_q8_tensor(name)
-            } else {
-                use_q8 || use_q8hfq // 1D Q8HFQ tensors fall back to Q8F16
-            };
-            let this_q4as8 = use_fast && !this_q8; // FFN tensors in q8-fast mode
-            let this_q4k = use_q4k_all || use_q4k_q8embed || use_mixed;
-
-            // Embeddings stored as Q8 in HFQ4 mode — Q4 is too lossy for
-            // large-dim models (9B: dim=4096, values ~0.016, Q4 step ~0.007)
-            let is_embed = name.contains("embed_tokens");
-
-            if use_hfq_mixed {
-                // hfq-mixed: Q8 for attention, HFQ4 for FFN (fits 9B in 8GB VRAM)
-                let is_ffn = name.contains("mlp.") || name.contains("ffn");
-                if !is_ffn {
-                    let q = quantize_q8f16(&f32_data);
-                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
-                } else {
-                    let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                    if k_dim % 256 == 0 {
-                        let q = quantize_hfq4g256(&f32_data);
-                        (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
-                    } else {
-                        let q = quantize_hfq4g128(&f32_data);
-                        (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                    }
-                }
-            } else if use_hfq6 {
-                // HFQ6-G256: all weights 6-bit, embeddings Q8
-                if is_embed {
-                    let q = quantize_q8f16(&f32_data);
-                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
-                } else {
-                    let q = quantize_hfq6g256(&f32_data);
-                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
-                }
-            } else if (use_hfq2g256 || use_hfq2g128) && is_embed {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_hfq2g128 {
-                let q = quantize_hfq2g128(&f32_data);
-                (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
-            } else if use_hfq2g256 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let q = quantize_hfq2g256(&f32_data);
-                    (q, QuantType::HFQ2G256, 256u32, "HFQ2G256")
-                } else {
-                    // Fallback to HFQ4 for non-256-aligned
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if use_mq8g256 && is_embed {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_mq8g256 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq8g256(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ8G256, 256u32, "MQ8G256")
-                } else {
-                    // Fallback to Q8 for non-256-aligned
-                    let q = quantize_q8f16(&f32_data);
-                    (q, QuantType::Q8F16, 32u32, "Q8_F16")
-                }
-            } else if q8_router && is_q8_tensor(name) {
-                // Q8 router for MoE: keep mlp.gate.weight and
-                // shared_expert_gate.weight at Q8 regardless of --format.
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if (use_mq4g256 || use_mq4_mq6exp || use_mq4_mq2lloydexp || use_mq4_mq2lloyd_native || use_mq4_mq2lloyd_kmap || use_mq4_mq2lloyd_imatrix || use_mq4_mq3lloyd_kmap || use_mq4_mqlloyd_tiered || use_mq4_mqlloyd_antirez || use_mq4_mqlloyd_antirez_gptq || use_mq4_mq2lloyd_gptq_all) && is_embed {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_mq4g256 || use_mq4_mq6exp || use_mq4_mq2lloydexp || use_mq4_mq2lloyd_native || use_mq4_mq2lloyd_kmap || use_mq4_mq2lloyd_imatrix || use_mq4_mq3lloyd_kmap || use_mq4_mqlloyd_tiered || use_mq4_mqlloyd_antirez || use_mq4_mqlloyd_antirez_gptq || use_mq4_mq2lloyd_gptq_all {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    // Phase A Stage A — AWQ pre-scaling, when --awq is enabled
-                    // AND we have imatrix data for this tensor AND the tensor
-                    // is on the AWQ whitelist (see `awq_eligible`). Mutates a
-                    // local copy of the weights so the original f32_data
-                    // returned by to_f32() is left intact for downstream
-                    // consumers (we don't currently have any here, but this
-                    // is hygienic).
-                    //
-                    // The `awq_eligible(name)` guard is critical: pre-scaling
-                    // weights whose runtime path lacks the inverse divide
-                    // produces `(W·s)·x ≠ W·x` and catastrophically corrupts
-                    // logits (KLD 0.67 → 13.5 measured on 0.8B Qwen3.5 before
-                    // this guard landed). See `docs/plans/awq_fix_claude.md`.
-                    let q = if let (Some(alpha), Some(im_weights))
-                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
-                    {
-                        if awq_eligible(name) {
-                            debug_assert_eq!(im_weights.len(), k_dim,
-                                "imatrix length ({}) != K dim ({}) for {}",
-                                im_weights.len(), k_dim, name);
-                            let scales = compute_awq_scales(im_weights, alpha);
-                            // Stash for sidecar emission after the main tensor push.
-                            awq_sidecar_scales = Some(scales.clone());
-                            let m_dim = meta.shape[0];
-                            // Copy weights so we don't mutate to_f32's buffer
-                            // (might be shared/borrowed depending on dtype path).
-                            let mut scaled = f32_data.clone();
-                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
-                            quantize_mq4g256(&scaled, &signs1, &signs2)
                         } else {
-                            // Runtime path for this weight has no AWQ inverse
-                            // (rotate_x_mq for o_proj/out_proj/wo, or
-                            // fused_silu_mul_rotate_mq for down_proj/w_down).
-                            // Skip AWQ for this tensor — emit plain MQ4 and
-                            // no sidecar.
-                            quantize_mq4g256(&f32_data, &signs1, &signs2)
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
                         }
-                    } else {
-                        quantize_mq4g256(&f32_data, &signs1, &signs2)
-                    };
-                    (q, QuantType::MQ4G256, 256u32, "MQ4G256")
-                } else {
-                    // Fallback to standard HFQ4-G128 for non-256-aligned
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if use_hfp4 && is_embed {
-                // HFP4 embeddings stay Q8F16 (matches MQ4 / HFQ4 pattern — embedding lookup is
-                // accuracy-sensitive, FP4 codes too lossy for vocab-sized tables).
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_hfp4 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 32 == 0 && meta.shape.len() == 2 {
-                    let m = meta.shape[0];
-                    let q = quantize_hfp4g32_2d(&f32_data, m, k_dim);
-                    (q, QuantType::HFP4G32, 32u32, "HFP4G32")
-                } else {
-                    // Fallback to HFQ4-G128 for non-32-aligned ragged dims (rare).
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if use_mfp4 && is_embed {
-                // MFP4 embeddings stay Q8F16 (same rationale as HFP4 / MQ4).
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_mfp4 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 && meta.shape.len() == 2 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let m = meta.shape[0];
-                    let q = quantize_mfp4g32_2d(&f32_data, m, k_dim, &signs1, &signs2);
-                    (q, QuantType::MFP4G32, 32u32, "MFP4G32")
-                } else {
-                    // Fallback to HFQ4-G128 for non-256-aligned ragged dims (rotation
-                    // requires 256-element segments). Matches MQ4's ragged fallback.
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if use_mq6g256 && is_embed {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_mq6g256 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ6G256, 256u32, "MQ6G256")
-                } else {
-                    // Fallback to HFQ6-G256 for non-256-aligned (no rotation)
-                    let q = quantize_hfq6g256(&f32_data);
-                    (q, QuantType::HFQ6G256, 256u32, "HFQ6G256")
-                }
-            } else if (use_mq3g256 || use_mq2g256 || use_mq2g256_lloyd || use_mq3g256_lloyd || use_mq4g256_lloyd) && is_embed {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_mq4g256_lloyd {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    let q = quantize_mq4g256_lloyd(&f32_data, &signs1, &signs2);
-                    (q, QuantType::MQ4G256Lloyd, 256u32, "MQ4G256Lloyd")
-                } else {
-                    // Fallback to HFQ4-G128 for non-256-aligned (no rotation).
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if use_mq3g256_lloyd {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    // AWQ × MQ3-Lloyd composition (MQ3G256Lloyd is forward-path-ready +
-                    // now in supports_awq_sidecar). Pre-scale by imatrix, then Lloyd-fit.
-                    let q = if let (Some(alpha), Some(im_weights))
-                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
-                    {
-                        if awq_eligible(name) {
-                            let scales = compute_awq_scales(im_weights, alpha);
-                            awq_sidecar_scales = Some(scales.clone());
-                            let m_dim = meta.shape[0];
-                            let mut scaled = f32_data.clone();
-                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
-                            quantize_mq3g256_lloyd(&scaled, &signs1, &signs2)
+                    } else if use_hfq4g256 {
+                        // Auto-select G128 vs G256 based on K dimension
+                        // G256 preferred: better coalescing, fewer scale/zero overheads
+                        // G128 only as fallback when K isn't divisible by 256
+                        let k_dim = if meta.shape.len() == 2 {
+                            meta.shape[1]
                         } else {
-                            quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
-                        }
-                    } else {
-                        quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2)
-                    };
-                    (q, QuantType::MQ3G256Lloyd, 256u32, "MQ3G256Lloyd")
-                } else {
-                    let q = quantize_hfq3g128(&f32_data);
-                    (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
-                }
-            } else if use_mq2g256_lloyd {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    // AWQ × MQ2-Lloyd (MQ2G256Lloyd is in supports_awq_sidecar): pre-scale
-                    // by imatrix first, then Lloyd-fit (K=4, or K=3-ternary under the flag).
-                    let awq_scaled: Option<Vec<f32>> = if let (Some(alpha), Some(im_weights))
-                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
-                    {
-                        if awq_eligible(name) {
-                            let scales = compute_awq_scales(im_weights, alpha);
-                            awq_sidecar_scales = Some(scales.clone());
-                            let m_dim = meta.shape[0];
-                            let mut scaled = f32_data.clone();
-                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
-                            Some(scaled)
-                        } else { None }
-                    } else { None };
-                    let data: &[f32] = awq_scaled.as_deref().unwrap_or(&f32_data);
-                    // HIPFIRE_LLOYD_K3=1 → ternary "MQ1.58" (3-level codebook, reuses kernel).
-                    let q = if std::env::var("HIPFIRE_LLOYD_K3").ok().as_deref() == Some("1") {
-                        quantize_mq2g256_lloyd_k3(data, &signs1, &signs2)
-                    } else {
-                        quantize_mq2g256_lloyd(data, &signs1, &signs2)
-                    };
-                    (q, QuantType::MQ2G256Lloyd, 256u32, "MQ2G256Lloyd")
-                } else {
-                    // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
-                    let q = quantize_hfq2g128(&f32_data);
-                    (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
-                }
-            } else if use_mq3g256 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    // AWQ pre-scaling for MQ3 base body (mirrors the MQ4 base arm).
-                    // MQ3G256 is on DType::supports_awq_sidecar, so the runtime applies
-                    // the inverse divide via rotate_x_mq. Without this, `--format mq3
-                    // --awq` was a silent no-op on body tensors (md5(mq3-awq)==md5(mq3)).
-                    // awq_eligible gates to tensors whose runtime path has the inverse.
-                    let q = if let (Some(alpha), Some(im_weights))
-                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
-                    {
-                        if awq_eligible(name) {
-                            let scales = compute_awq_scales(im_weights, alpha);
-                            awq_sidecar_scales = Some(scales.clone());
-                            let m_dim = meta.shape[0];
-                            let mut scaled = f32_data.clone();
-                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
-                            quantize_mq3g256(&scaled, &signs1, &signs2)
-                        } else {
-                            quantize_mq3g256(&f32_data, &signs1, &signs2)
-                        }
-                    } else {
-                        quantize_mq3g256(&f32_data, &signs1, &signs2)
-                    };
-                    (q, QuantType::MQ3G256, 256u32, "MQ3G256")
-                } else {
-                    // Fallback to HFQ3-G128 for non-256-aligned (no rotation)
-                    let q = quantize_hfq3g128(&f32_data);
-                    (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
-                }
-            } else if use_mq2g256 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let signs1 = gen_fwht_signs(42, 256);
-                    let signs2 = gen_fwht_signs(1042, 256);
-                    // AWQ × plain MQ2 (MQ2G256 now in supports_awq_sidecar). Pre-scale by
-                    // imatrix, then quantize. (Plain MQ2 collapses uncalibrated; AWQ is the
-                    // test of whether activation-aware scaling rescues uniform 2-bit.)
-                    let q = if let (Some(alpha), Some(im_weights))
-                        = (AWQ_ALPHA.get().copied(), imatrix_weights_for(name))
-                    {
-                        if awq_eligible(name) {
-                            let scales = compute_awq_scales(im_weights, alpha);
-                            awq_sidecar_scales = Some(scales.clone());
-                            let m_dim = meta.shape[0];
-                            let mut scaled = f32_data.clone();
-                            awq_pre_scale_weights(&mut scaled, m_dim, k_dim, &scales);
-                            quantize_mq2g256(&scaled, &signs1, &signs2)
-                        } else {
-                            quantize_mq2g256(&f32_data, &signs1, &signs2)
-                        }
-                    } else {
-                        quantize_mq2g256(&f32_data, &signs1, &signs2)
-                    };
-                    (q, QuantType::MQ2G256, 256u32, "MQ2G256")
-                } else {
-                    // Fallback to HFQ2-G128 for non-256-aligned (no rotation)
-                    let q = quantize_hfq2g128(&f32_data);
-                    (q, QuantType::HFQ2G128, 128u32, "HFQ2G128")
-                }
-            } else if (use_hfq3g256 || use_hfq3g128) && is_embed {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_F16")
-            } else if use_hfq3g128 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 128 == 0 {
-                    let q = quantize_hfq3g128(&f32_data);
-                    (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
-                } else {
-                    let q = quantize_hfq3g128(&f32_data);
-                    (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
-                }
-            } else if use_hfq3g256 {
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let q = quantize_hfq3g256(&f32_data);
-                    (q, QuantType::HFQ3G256, 256u32, "HFQ3G256")
-                } else {
-                    let q = quantize_hfq3g128(&f32_data);
-                    (q, QuantType::HFQ3G128, 128u32, "HFQ3G128")
-                }
-            } else if use_hfq4g256 && is_embed {
-                // HFQ4 embeddings: half the size of Q8, same 18-VGPR lookup kernel
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let q = quantize_hfq4g256(&f32_data);
-                    (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
-                } else {
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if use_hfq4g256 {
-                // Auto-select G128 vs G256 based on K dimension
-                // G256 preferred: better coalescing, fewer scale/zero overheads
-                // G128 only as fallback when K isn't divisible by 256
-                let k_dim = if meta.shape.len() == 2 { meta.shape[1] } else { n_elements };
-                if k_dim % 256 == 0 {
-                    let q = quantize_hfq4g256(&f32_data);
-                    (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
-                } else if k_dim % 128 == 0 {
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                } else {
-                    // Pad to 128-element boundary
-                    let q = quantize_hfq4g128(&f32_data);
-                    (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
-                }
-            } else if this_q8 {
-                let q = quantize_q8f16(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q8_FP16")
-            } else if this_q4as8 {
-                let q = quantize_q4_as_q8(&f32_data);
-                (q, QuantType::Q8F16, 32u32, "Q4asQ8")
-            } else if this_q4k {
-                let q = quantize_q4k(&f32_data);
-                (q, QuantType::Q4K, 256u32, "Q4_K")
-            } else {
-                let q = quantize_q4f16_g64(&f32_data);
-                (q, QuantType::Q4F16G64, 64u32, "Q4_F16")
-            }
-            }; // end K-map outer if-else
-
-            // Compute quantization error (skip for Q8 embeddings — always negligible)
-            let block_size = gs as usize;
-            let is_hfq4 = label == "HFQ4G256" || label == "HFQ4G128";
-            // Only compute detailed error for HFQ4 tensors — Q8/HFQ6 error is negligible
-            let skip_error = !is_hfq4;
-            let n_blocks = if !skip_error { (n_elements + block_size - 1) / block_size } else { 0 };
-            for b in 0..n_blocks {
-                let start = b * block_size;
-                let end = (start + block_size).min(n_elements);
-                if is_hfq4 {
-                    // Both G128 (72B) and G256 (136B): [f32 scale][f32 zero][nibbles]
-                    let block_bytes = if block_size == 256 { 136 } else { 72 };
-                    let off = b * block_bytes;
-                    let scale = f32::from_le_bytes([quantized[off], quantized[off+1], quantized[off+2], quantized[off+3]]);
-                    let zero = f32::from_le_bytes([quantized[off+4], quantized[off+5], quantized[off+6], quantized[off+7]]);
-                    for i in 0..(end - start) {
-                        let byte_idx = i / 2;
-                        let nibble = if i % 2 == 0 { quantized[off + 8 + byte_idx] & 0xF } else { quantized[off + 8 + byte_idx] >> 4 };
-                        let dequant = scale * nibble as f32 + zero;
-                        let err = (dequant - f32_data[start + i]).abs();
-                        total_quant_error += err as f64;
-                        max_quant_error = max_quant_error.max(err);
-                    }
-                } else if label == "Q8_FP16" || label == "Q4asQ8" || label == "Q8_F16" {
-                    // NB: string match because this_q8/this_q4as8 are scoped inside Base block.
-                    let off = b * 34;
-                    let scale = f16_to_f32(u16::from_le_bytes([quantized[off], quantized[off + 1]]));
-                    for i in 0..(end - start) {
-                        let qval = quantized[off + 2 + i] as i8;
-                        let dequant = scale * qval as f32;
-                        let err = (dequant - f32_data[start + i]).abs();
-                        total_quant_error += err as f64;
-                        max_quant_error = max_quant_error.max(err);
-                    }
-                } else {
-                    let off = b * 36;
-                    let scale = f16_to_f32(u16::from_le_bytes([quantized[off], quantized[off + 1]]));
-                    let min_val = f16_to_f32(u16::from_le_bytes([quantized[off + 2], quantized[off + 3]]));
-                    for i in 0..(end - start) {
-                        let byte_idx = if i < 32 { i } else { i - 32 };
-                        let nibble = if i < 32 {
-                            quantized[off + 4 + byte_idx] & 0xF
-                        } else {
-                            quantized[off + 4 + byte_idx] >> 4
+                            n_elements
                         };
-                        let dequant = nibble as f32 * scale + min_val;
-                        let err = (dequant - f32_data[start + i]).abs();
-                        total_quant_error += err as f64;
-                        max_quant_error = max_quant_error.max(err);
+                        if k_dim % 256 == 0 {
+                            let q = quantize_hfq4g256(&f32_data);
+                            (q, QuantType::HFQ4G256, 256u32, "HFQ4G256")
+                        } else if k_dim % 128 == 0 {
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        } else {
+                            // Pad to 128-element boundary
+                            let q = quantize_hfq4g128(&f32_data);
+                            (q, QuantType::HFQ4G128, 128u32, "HFQ4G128")
+                        }
+                    } else if this_q8 {
+                        let q = quantize_q8f16(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q8_FP16")
+                    } else if this_q4as8 {
+                        let q = quantize_q4_as_q8(&f32_data);
+                        (q, QuantType::Q8F16, 32u32, "Q4asQ8")
+                    } else if this_q4k {
+                        let q = quantize_q4k(&f32_data);
+                        (q, QuantType::Q4K, 256u32, "Q4_K")
+                    } else {
+                        let q = quantize_q4f16_g64(&f32_data);
+                        (q, QuantType::Q4F16G64, 64u32, "Q4_F16")
                     }
-                }
-                _n_quant_groups += 1;
-            }
+                }; // end K-map outer if-else
 
-            eprintln!("  {label:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB)",
-                name, meta.shape, n_elements,
-                raw_data.len() as f64 / 1024.0,
-                quantized.len() as f64 / 1024.0);
-
-            hfq_tensors.push(HfqTensor {
-                name: name.to_string(),
-                quant_type: qt,
-                shape: shape.clone(),
-                group_size: gs,
-                data: quantized,
-                spilled_len: 0,
-            });
-            // Phase A Stage A — emit AWQ scale sidecar tensor immediately
-            // after the parent weight. Naming convention:
-            // `<weight_name>.awq_scale` (strip the trailing `.weight` and
-            // append `.awq_scale.weight` so the runtime loader recognizes
-            // it as a 1D F16 tensor of length K). 1D shape [K]; runtime
-            // pairs it with the parent weight at model open.
-            if let Some(scales) = awq_sidecar_scales.take() {
-                let sidecar_name = match name.strip_suffix(".weight") {
-                    Some(stem) => format!("{stem}.awq_scale.weight"),
-                    None => format!("{name}.awq_scale.weight"),
+                // Compute quantization error (skip for Q8 embeddings — always negligible)
+                let block_size = gs as usize;
+                let is_hfq4 = label == "HFQ4G256" || label == "HFQ4G128";
+                // Only compute detailed error for HFQ4 tensors — Q8/HFQ6 error is negligible
+                let skip_error = !is_hfq4;
+                let n_blocks = if !skip_error {
+                    (n_elements + block_size - 1) / block_size
+                } else {
+                    0
                 };
-                let bytes = awq_scales_to_f16_bytes(&scales);
-                eprintln!("    AWQ:    {} [{}] (1D F16, {} B)",
-                    sidecar_name, scales.len(), bytes.len());
+                for b in 0..n_blocks {
+                    let start = b * block_size;
+                    let end = (start + block_size).min(n_elements);
+                    if is_hfq4 {
+                        // Both G128 (72B) and G256 (136B): [f32 scale][f32 zero][nibbles]
+                        let block_bytes = if block_size == 256 { 136 } else { 72 };
+                        let off = b * block_bytes;
+                        let scale = f32::from_le_bytes([
+                            quantized[off],
+                            quantized[off + 1],
+                            quantized[off + 2],
+                            quantized[off + 3],
+                        ]);
+                        let zero = f32::from_le_bytes([
+                            quantized[off + 4],
+                            quantized[off + 5],
+                            quantized[off + 6],
+                            quantized[off + 7],
+                        ]);
+                        for i in 0..(end - start) {
+                            let byte_idx = i / 2;
+                            let nibble = if i % 2 == 0 {
+                                quantized[off + 8 + byte_idx] & 0xF
+                            } else {
+                                quantized[off + 8 + byte_idx] >> 4
+                            };
+                            let dequant = scale * nibble as f32 + zero;
+                            let err = (dequant - f32_data[start + i]).abs();
+                            total_quant_error += err as f64;
+                            max_quant_error = max_quant_error.max(err);
+                        }
+                    } else if label == "Q8_FP16" || label == "Q4asQ8" || label == "Q8_F16" {
+                        // NB: string match because this_q8/this_q4as8 are scoped inside Base block.
+                        let off = b * 34;
+                        let scale =
+                            f16_to_f32(u16::from_le_bytes([quantized[off], quantized[off + 1]]));
+                        for i in 0..(end - start) {
+                            let qval = quantized[off + 2 + i] as i8;
+                            let dequant = scale * qval as f32;
+                            let err = (dequant - f32_data[start + i]).abs();
+                            total_quant_error += err as f64;
+                            max_quant_error = max_quant_error.max(err);
+                        }
+                    } else {
+                        let off = b * 36;
+                        let scale =
+                            f16_to_f32(u16::from_le_bytes([quantized[off], quantized[off + 1]]));
+                        let min_val = f16_to_f32(u16::from_le_bytes([
+                            quantized[off + 2],
+                            quantized[off + 3],
+                        ]));
+                        for i in 0..(end - start) {
+                            let byte_idx = if i < 32 { i } else { i - 32 };
+                            let nibble = if i < 32 {
+                                quantized[off + 4 + byte_idx] & 0xF
+                            } else {
+                                quantized[off + 4 + byte_idx] >> 4
+                            };
+                            let dequant = nibble as f32 * scale + min_val;
+                            let err = (dequant - f32_data[start + i]).abs();
+                            total_quant_error += err as f64;
+                            max_quant_error = max_quant_error.max(err);
+                        }
+                    }
+                    _n_quant_groups += 1;
+                }
+
+                eprintln!(
+                    "  {label:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB)",
+                    name,
+                    meta.shape,
+                    n_elements,
+                    raw_data.len() as f64 / 1024.0,
+                    quantized.len() as f64 / 1024.0
+                );
+
                 hfq_tensors.push(HfqTensor {
-                    name: sidecar_name,
-                    quant_type: QuantType::F16,
-                    shape: vec![scales.len() as u32],
-                    group_size: 0,
-                    data: bytes,
+                    name: name.to_string(),
+                    quant_type: qt,
+                    shape: shape.clone(),
+                    group_size: gs,
+                    data: quantized,
                     spilled_len: 0,
                 });
-            }
+                // Phase A Stage A — emit AWQ scale sidecar tensor immediately
+                // after the parent weight. Naming convention:
+                // `<weight_name>.awq_scale` (strip the trailing `.weight` and
+                // append `.awq_scale.weight` so the runtime loader recognizes
+                // it as a 1D F16 tensor of length K). 1D shape [K]; runtime
+                // pairs it with the parent weight at model open.
+                if let Some(scales) = awq_sidecar_scales.take() {
+                    let sidecar_name = match name.strip_suffix(".weight") {
+                        Some(stem) => format!("{stem}.awq_scale.weight"),
+                        None => format!("{name}.awq_scale.weight"),
+                    };
+                    let bytes = awq_scales_to_f16_bytes(&scales);
+                    eprintln!(
+                        "    AWQ:    {} [{}] (1D F16, {} B)",
+                        sidecar_name,
+                        scales.len(),
+                        bytes.len()
+                    );
+                    hfq_tensors.push(HfqTensor {
+                        name: sidecar_name,
+                        quant_type: QuantType::F16,
+                        shape: vec![scales.len() as u32],
+                        group_size: 0,
+                        data: bytes,
+                        spilled_len: 0,
+                    });
+                }
             } // end else (non-Q8HFQ path)
         } else if is_vision && vision_quant == "hfq4" && n_elements >= 32 {
             // Quantize vision weights to HFQ4G256 (for speed-critical VL workloads)
             let f32_data = to_f32(raw_data, &meta.dtype);
             quantized_params += n_elements as u64;
             let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
-            let k_dim = if shape.len() == 2 { shape[1] as usize } else { n_elements };
+            let k_dim = if shape.len() == 2 {
+                shape[1] as usize
+            } else {
+                n_elements
+            };
             let (quantized, gs) = if k_dim % 256 == 0 {
                 (quantize_hfq4g256(&f32_data), 256u32)
             } else {
                 (quantize_hfq4g128(&f32_data), 128u32)
             };
-            let qt = if gs == 256 { QuantType::HFQ4G256 } else { QuantType::HFQ4G128 };
+            let qt = if gs == 256 {
+                QuantType::HFQ4G256
+            } else {
+                QuantType::HFQ4G128
+            };
             let label = if gs == 256 { "HFQ4G256" } else { "HFQ4G128" };
-            eprintln!("  {label:>8}: {} {:?} ({} elements, {:.1} KB -> {:.1} KB) [vision]",
-                name, meta.shape, n_elements,
-                raw_data.len() as f64 / 1024.0, quantized.len() as f64 / 1024.0);
+            eprintln!(
+                "  {label:>8}: {} {:?} ({} elements, {:.1} KB -> {:.1} KB) [vision]",
+                name,
+                meta.shape,
+                n_elements,
+                raw_data.len() as f64 / 1024.0,
+                quantized.len() as f64 / 1024.0
+            );
             hfq_tensors.push(HfqTensor {
                 name: name.to_string(),
                 quant_type: qt,
@@ -6273,8 +7040,13 @@ fn main() {
             // Store vision weights as original BF16 (zero precision loss)
             quantized_params += n_elements as u64;
             let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
-            eprintln!("  BF16:       {} {:?} ({} elements, {:.1} KB) [vision, lossless]",
-                name, meta.shape, n_elements, raw_data.len() as f64 / 1024.0);
+            eprintln!(
+                "  BF16:       {} {:?} ({} elements, {:.1} KB) [vision, lossless]",
+                name,
+                meta.shape,
+                n_elements,
+                raw_data.len() as f64 / 1024.0
+            );
             hfq_tensors.push(HfqTensor {
                 name: name.to_string(),
                 quant_type: QuantType::BF16,
@@ -6285,17 +7057,30 @@ fn main() {
             });
         } else if is_vision && vision_quant == "bf16" {
             // Non-BF16 source (F16/F32) — store as F16
-            let data = if meta.dtype == "F16" { raw_data.to_vec() } else {
+            let data = if meta.dtype == "F16" {
+                raw_data.to_vec()
+            } else {
                 let f32_vals = to_f32(raw_data, &meta.dtype);
-                f32_vals.iter().flat_map(|&v| f32_to_f16(v).to_le_bytes()).collect()
+                f32_vals
+                    .iter()
+                    .flat_map(|&v| f32_to_f16(v).to_le_bytes())
+                    .collect()
             };
             quantized_params += n_elements as u64;
             let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
-            eprintln!("  F16:        {} {:?} ({:.1} KB) [vision, bf16 fallback]",
-                name, meta.shape, data.len() as f64 / 1024.0);
+            eprintln!(
+                "  F16:        {} {:?} ({:.1} KB) [vision, bf16 fallback]",
+                name,
+                meta.shape,
+                data.len() as f64 / 1024.0
+            );
             hfq_tensors.push(HfqTensor {
-                name: name.to_string(), quant_type: QuantType::F16,
-                shape, group_size: 0, data, spilled_len: 0,
+                name: name.to_string(),
+                quant_type: QuantType::F16,
+                shape,
+                group_size: 0,
+                data,
+                spilled_len: 0,
             });
         } else {
             // Keep as F16 (convert BF16 -> F16 if needed)
@@ -6304,13 +7089,15 @@ fn main() {
                 "BF16" => {
                     // BF16 → F32 → F16
                     let f32_vals = to_f32(raw_data, "BF16");
-                    f32_vals.iter()
+                    f32_vals
+                        .iter()
                         .flat_map(|&v| f32_to_f16(v).to_le_bytes())
                         .collect()
                 }
                 "F32" => {
                     let f32_vals = to_f32(raw_data, "F32");
-                    f32_vals.iter()
+                    f32_vals
+                        .iter()
                         .flat_map(|&v| f32_to_f16(v).to_le_bytes())
                         .collect()
                 }
@@ -6318,8 +7105,13 @@ fn main() {
             };
 
             let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
-            eprintln!("  F16:        {} {:?} ({} elements, {:.1} KB)",
-                name, meta.shape, n_elements, f16_data.len() as f64 / 1024.0);
+            eprintln!(
+                "  F16:        {} {:?} ({} elements, {:.1} KB)",
+                name,
+                meta.shape,
+                n_elements,
+                f16_data.len() as f64 / 1024.0
+            );
 
             hfq_tensors.push(HfqTensor {
                 name: name.to_string(),
@@ -6336,17 +7128,33 @@ fn main() {
     }
 
     // Summary
-    let total_bytes: usize = hfq_tensors.iter().map(|t| if t.spilled_len > 0 { t.spilled_len as usize } else { t.data.len() }).sum();
+    let total_bytes: usize = hfq_tensors
+        .iter()
+        .map(|t| {
+            if t.spilled_len > 0 {
+                t.spilled_len as usize
+            } else {
+                t.data.len()
+            }
+        })
+        .sum();
     let mean_quant_error = if quantized_params > 0 {
         total_quant_error / quantized_params as f64
-    } else { 0.0 };
+    } else {
+        0.0
+    };
 
     eprintln!("\n=== Quantization Summary ===");
     if skipped_params > 0 {
-        eprintln!("  Skipped params:   {skipped_params} (mtp/visual — use --include-vision for VL)");
+        eprintln!(
+            "  Skipped params:   {skipped_params} (mtp/visual — use --include-vision for VL)"
+        );
     }
     eprintln!("  Total params:     {total_params}");
-    eprintln!("  Quantized params: {quantized_params} ({:.1}%)", 100.0 * quantized_params as f64 / total_params as f64);
+    eprintln!(
+        "  Quantized params: {quantized_params} ({:.1}%)",
+        100.0 * quantized_params as f64 / total_params as f64
+    );
     eprintln!("  Mean quant error: {mean_quant_error:.8}");
     eprintln!("  Max quant error:  {max_quant_error:.8}");
     eprintln!("  Output size:      {:.1} MB", total_bytes as f64 / 1e6);
@@ -6357,8 +7165,17 @@ fn main() {
     if let Some(ref mut s) = spill {
         maybe_spill(&mut hfq_tensors, s, 0); // spill everything remaining
     }
-    write_hfq(output_path, arch_id, &metadata_json, &hfq_tensors, spill.as_mut()).unwrap();
-    if let Some(s) = spill { s.cleanup(); }
+    write_hfq(
+        output_path,
+        arch_id,
+        &metadata_json,
+        &hfq_tensors,
+        spill.as_mut(),
+    )
+    .unwrap();
+    if let Some(s) = spill {
+        s.cleanup();
+    }
 
     let file_size = std::fs::metadata(output_path).unwrap().len();
     eprintln!("Done: {:.1} MB written", file_size as f64 / 1e6);
@@ -6381,20 +7198,28 @@ mod gptq_damping_probe {
     /// Deterministic Box-Muller-from-LCG Gaussian sampler — no external dep.
     /// Returns N samples with zero mean and unit variance.
     fn gaussian_samples(n: usize, seed: u64) -> Vec<f32> {
-        let mut state = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let mut state = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         let mut step = || {
-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((state >> 11) as u64 & ((1u64 << 53) - 1)) as f64 / (1u64 << 53) as f64
         };
         let mut out = Vec::with_capacity(n);
         while out.len() < n {
             let mut u1 = step() as f64;
-            if u1 < 1e-12 { u1 = 1e-12; }
+            if u1 < 1e-12 {
+                u1 = 1e-12;
+            }
             let u2 = step() as f64;
             let r = (-2.0 * u1.ln()).sqrt();
             let theta = 2.0 * std::f64::consts::PI * u2;
             out.push((r * theta.cos()) as f32);
-            if out.len() < n { out.push((r * theta.sin()) as f32); }
+            if out.len() < n {
+                out.push((r * theta.sin()) as f32);
+            }
         }
         out
     }
@@ -6430,8 +7255,10 @@ mod gptq_damping_probe {
             let gptq_recon = dequantize_mq2g256_lloyd_to_f32(&gptq_bytes, n, &signs1, &signs2);
             let gptq_mse = mse(weights, &gptq_recon);
             let delta = ((gptq_mse - lloyd_mse) / lloyd_mse) * 100.0;
-            eprintln!("  GPTQ d={damping:>4.1}             MSE = {:.6e}  ({:+.2}% vs Lloyd)",
-                gptq_mse, delta);
+            eprintln!(
+                "  GPTQ d={damping:>4.1}             MSE = {:.6e}  ({:+.2}% vs Lloyd)",
+                gptq_mse, delta
+            );
         }
         std::env::remove_var("HIPFIRE_GPTQ_DAMPING");
     }
@@ -6439,7 +7266,10 @@ mod gptq_damping_probe {
     /// Variant of plain Lloyd with tunable iteration count. Used to test
     /// whether the production 8-iter cap is leaving headroom.
     fn quantize_mq2g256_lloyd_niter(
-        f32_data: &[f32], signs1: &[f32], signs2: &[f32], max_iter: usize,
+        f32_data: &[f32],
+        signs1: &[f32],
+        signs2: &[f32],
+        max_iter: usize,
     ) -> Vec<u8> {
         use rayon::prelude::*;
         let group_size = 256;
@@ -6447,73 +7277,93 @@ mod gptq_damping_probe {
         let n = f32_data.len();
         let n_blocks = (n + group_size - 1) / group_size;
         let mut output = vec![0u8; n_blocks * block_bytes];
-        output.par_chunks_mut(block_bytes).enumerate().for_each(|(b, out_chunk)| {
-            let start = b * group_size;
-            let end = (start + group_size).min(n);
-            let actual_len = end - start;
-            let mut group = [0.0f32; 256];
-            group[..actual_len].copy_from_slice(&f32_data[start..end]);
-            cpu_fwht_256(&mut group, signs1, signs2);
-            let mut sorted: [f32; 256] = group;
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            let percentile = |frac: f32| -> f32 {
-                let idx = ((frac * 255.0).round() as usize).min(255);
-                sorted[idx]
-            };
-            let mut cb: [f32; 4] = [
-                percentile(0.125), percentile(0.375),
-                percentile(0.625), percentile(0.875),
-            ];
-            let range = sorted[255] - sorted[0];
-            let mut indices = [0u8; 256];
-            if range > 0.0 {
-                let mut prev_assignments = [0u8; 256];
-                for it in 0..max_iter {
-                    let mut sums = [0.0f64; 4];
-                    let mut counts = [0u32; 4];
-                    let mut changed = 0u32;
-                    for i in 0..256 {
-                        let w = group[i];
-                        let mut best = 0usize;
-                        let mut best_d = (w - cb[0]).abs();
-                        for k in 1..4 {
-                            let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+        output
+            .par_chunks_mut(block_bytes)
+            .enumerate()
+            .for_each(|(b, out_chunk)| {
+                let start = b * group_size;
+                let end = (start + group_size).min(n);
+                let actual_len = end - start;
+                let mut group = [0.0f32; 256];
+                group[..actual_len].copy_from_slice(&f32_data[start..end]);
+                cpu_fwht_256(&mut group, signs1, signs2);
+                let mut sorted: [f32; 256] = group;
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let percentile = |frac: f32| -> f32 {
+                    let idx = ((frac * 255.0).round() as usize).min(255);
+                    sorted[idx]
+                };
+                let mut cb: [f32; 4] = [
+                    percentile(0.125),
+                    percentile(0.375),
+                    percentile(0.625),
+                    percentile(0.875),
+                ];
+                let range = sorted[255] - sorted[0];
+                let mut indices = [0u8; 256];
+                if range > 0.0 {
+                    let mut prev_assignments = [0u8; 256];
+                    for it in 0..max_iter {
+                        let mut sums = [0.0f64; 4];
+                        let mut counts = [0u32; 4];
+                        let mut changed = 0u32;
+                        for i in 0..256 {
+                            let w = group[i];
+                            let mut best = 0usize;
+                            let mut best_d = (w - cb[0]).abs();
+                            for k in 1..4 {
+                                let d = (w - cb[k]).abs();
+                                if d < best_d {
+                                    best_d = d;
+                                    best = k;
+                                }
+                            }
+                            if it == 0 || prev_assignments[i] != best as u8 {
+                                changed += 1;
+                            }
+                            prev_assignments[i] = best as u8;
+                            indices[i] = best as u8;
+                            sums[best] += w as f64;
+                            counts[best] += 1;
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
-                        prev_assignments[i] = best as u8;
-                        indices[i] = best as u8;
-                        sums[best] += w as f64;
-                        counts[best] += 1;
-                    }
-                    if it > 0 && changed == 0 { break; }
-                    for k in 0..4 {
-                        if counts[k] > 0 {
-                            cb[k] = (sums[k] / counts[k] as f64) as f32;
+                        if it > 0 && changed == 0 {
+                            break;
+                        }
+                        for k in 0..4 {
+                            if counts[k] > 0 {
+                                cb[k] = (sums[k] / counts[k] as f64) as f32;
+                            }
                         }
                     }
                 }
-            }
-            let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
-            let mut sorted_cb = [0.0f32; 4];
-            let mut inv: [u8; 4] = [0; 4];
-            for new_idx in 0..4 {
-                sorted_cb[new_idx] = cb[order[new_idx]];
-                inv[order[new_idx]] = new_idx as u8;
-            }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
-            for k in 0..4 {
-                let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
-                out_chunk[2 * k + 1] = (bits >> 8) as u8;
-            }
-            for i in 0..64 {
-                let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
-                out_chunk[8 + i] = byte_val;
-            }
-        });
+                let mut order: [usize; 4] = [0, 1, 2, 3];
+                order.sort_by(|&a, &b| {
+                    cb[a]
+                        .partial_cmp(&cb[b])
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                let mut sorted_cb = [0.0f32; 4];
+                let mut inv: [u8; 4] = [0; 4];
+                for new_idx in 0..4 {
+                    sorted_cb[new_idx] = cb[order[new_idx]];
+                    inv[order[new_idx]] = new_idx as u8;
+                }
+                for i in 0..256 {
+                    indices[i] = inv[indices[i] as usize];
+                }
+                for k in 0..4 {
+                    let bits = f32_to_fp16_bits(sorted_cb[k]);
+                    out_chunk[2 * k] = (bits & 0xFF) as u8;
+                    out_chunk[2 * k + 1] = (bits >> 8) as u8;
+                }
+                for i in 0..64 {
+                    let mut byte_val = 0u8;
+                    for j in 0..4 {
+                        byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                    }
+                    out_chunk[8 + i] = byte_val;
+                }
+            });
         output
     }
 
@@ -6529,7 +7379,9 @@ mod gptq_damping_probe {
             let m = mse(weights, &recon);
             let delta = if prev.is_finite() {
                 format!("  ({:+.3}% vs niter=prev)", ((m - prev) / prev) * 100.0)
-            } else { String::new() };
+            } else {
+                String::new()
+            };
             eprintln!("  Lloyd niter={niter:>3}        MSE = {m:.6e}{delta}");
             prev = m;
         }
@@ -6543,7 +7395,10 @@ mod gptq_damping_probe {
     /// rotated weights the long tails are dampened but not eliminated;
     /// this tests whether residual heavy-tailedness is hurting MSE.
     fn quantize_mq2g256_huber_lloyd(
-        f32_data: &[f32], signs1: &[f32], signs2: &[f32], k_huber: f32,
+        f32_data: &[f32],
+        signs1: &[f32],
+        signs2: &[f32],
+        k_huber: f32,
         max_iter: usize,
     ) -> Vec<u8> {
         use rayon::prelude::*;
@@ -6552,114 +7407,137 @@ mod gptq_damping_probe {
         let n = f32_data.len();
         let n_blocks = (n + group_size - 1) / group_size;
         let mut output = vec![0u8; n_blocks * block_bytes];
-        output.par_chunks_mut(block_bytes).enumerate().for_each(|(b, out_chunk)| {
-            let start = b * group_size;
-            let end = (start + group_size).min(n);
-            let actual_len = end - start;
-            let mut group = [0.0f32; 256];
-            group[..actual_len].copy_from_slice(&f32_data[start..end]);
-            cpu_fwht_256(&mut group, signs1, signs2);
-            let mut sorted: [f32; 256] = group;
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            let percentile = |frac: f32| -> f32 {
-                let idx = ((frac * 255.0).round() as usize).min(255);
-                sorted[idx]
-            };
-            let mut cb: [f32; 4] = [
-                percentile(0.125), percentile(0.375),
-                percentile(0.625), percentile(0.875),
-            ];
-            let range = sorted[255] - sorted[0];
-            let mut indices = [0u8; 256];
-            if range > 0.0 {
-                let mut prev_assignments = [0u8; 256];
-                for it in 0..max_iter {
-                    // Assignment pass — same as plain Lloyd.
+        output
+            .par_chunks_mut(block_bytes)
+            .enumerate()
+            .for_each(|(b, out_chunk)| {
+                let start = b * group_size;
+                let end = (start + group_size).min(n);
+                let actual_len = end - start;
+                let mut group = [0.0f32; 256];
+                group[..actual_len].copy_from_slice(&f32_data[start..end]);
+                cpu_fwht_256(&mut group, signs1, signs2);
+                let mut sorted: [f32; 256] = group;
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let percentile = |frac: f32| -> f32 {
+                    let idx = ((frac * 255.0).round() as usize).min(255);
+                    sorted[idx]
+                };
+                let mut cb: [f32; 4] = [
+                    percentile(0.125),
+                    percentile(0.375),
+                    percentile(0.625),
+                    percentile(0.875),
+                ];
+                let range = sorted[255] - sorted[0];
+                let mut indices = [0u8; 256];
+                if range > 0.0 {
+                    let mut prev_assignments = [0u8; 256];
+                    for it in 0..max_iter {
+                        // Assignment pass — same as plain Lloyd.
+                        for i in 0..256 {
+                            let w = group[i];
+                            let mut best = 0usize;
+                            let mut best_d = (w - cb[0]).abs();
+                            for k in 1..4 {
+                                let d = (w - cb[k]).abs();
+                                if d < best_d {
+                                    best_d = d;
+                                    best = k;
+                                }
+                            }
+                            prev_assignments[i] = best as u8;
+                            indices[i] = best as u8;
+                        }
+                        // Within-cluster sigma estimate (one pass).
+                        let mut sums = [0.0f64; 4];
+                        let mut sqs = [0.0f64; 4];
+                        let mut cnts = [0u32; 4];
+                        for i in 0..256 {
+                            let k = indices[i] as usize;
+                            let d = (group[i] - cb[k]) as f64;
+                            sums[k] += group[i] as f64;
+                            sqs[k] += d * d;
+                            cnts[k] += 1;
+                        }
+                        let mut sigma = [0.0f64; 4];
+                        for k in 0..4 {
+                            if cnts[k] > 0 {
+                                sigma[k] = (sqs[k] / cnts[k] as f64).sqrt();
+                            }
+                        }
+                        // Huber-clipped update.
+                        let mut wsums = [0.0f64; 4];
+                        let mut wcnts = [0.0f64; 4];
+                        for i in 0..256 {
+                            let k = indices[i] as usize;
+                            let lim = (k_huber as f64) * sigma[k].max(1e-9);
+                            let resid = (group[i] - cb[k]) as f64;
+                            let clipped = resid.max(-lim).min(lim);
+                            let effective_w = cb[k] as f64 + clipped;
+                            wsums[k] += effective_w;
+                            wcnts[k] += 1.0;
+                        }
+                        let mut changed = 0u32;
+                        for k in 0..4 {
+                            if wcnts[k] > 0.0 {
+                                let new_cb = (wsums[k] / wcnts[k]) as f32;
+                                if new_cb != cb[k] {
+                                    changed += 1;
+                                }
+                                cb[k] = new_cb;
+                            }
+                        }
+                        // Suppress unused warnings on sums.
+                        let _ = sums;
+                        if it > 0 && changed == 0 {
+                            break;
+                        }
+                    }
+                    // Final argmin pass to lock indices to the final centroids.
                     for i in 0..256 {
                         let w = group[i];
                         let mut best = 0usize;
                         let mut best_d = (w - cb[0]).abs();
                         for k in 1..4 {
                             let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                            if d < best_d {
+                                best_d = d;
+                                best = k;
+                            }
                         }
-                        prev_assignments[i] = best as u8;
                         indices[i] = best as u8;
                     }
-                    // Within-cluster sigma estimate (one pass).
-                    let mut sums = [0.0f64; 4];
-                    let mut sqs  = [0.0f64; 4];
-                    let mut cnts = [0u32; 4];
-                    for i in 0..256 {
-                        let k = indices[i] as usize;
-                        let d = (group[i] - cb[k]) as f64;
-                        sums[k] += group[i] as f64;
-                        sqs[k]  += d * d;
-                        cnts[k] += 1;
-                    }
-                    let mut sigma = [0.0f64; 4];
-                    for k in 0..4 {
-                        if cnts[k] > 0 {
-                            sigma[k] = (sqs[k] / cnts[k] as f64).sqrt();
-                        }
-                    }
-                    // Huber-clipped update.
-                    let mut wsums = [0.0f64; 4];
-                    let mut wcnts = [0.0f64; 4];
-                    for i in 0..256 {
-                        let k = indices[i] as usize;
-                        let lim = (k_huber as f64) * sigma[k].max(1e-9);
-                        let resid = (group[i] - cb[k]) as f64;
-                        let clipped = resid.max(-lim).min(lim);
-                        let effective_w = cb[k] as f64 + clipped;
-                        wsums[k] += effective_w;
-                        wcnts[k] += 1.0;
-                    }
-                    let mut changed = 0u32;
-                    for k in 0..4 {
-                        if wcnts[k] > 0.0 {
-                            let new_cb = (wsums[k] / wcnts[k]) as f32;
-                            if new_cb != cb[k] { changed += 1; }
-                            cb[k] = new_cb;
-                        }
-                    }
-                    // Suppress unused warnings on sums.
-                    let _ = sums;
-                    if it > 0 && changed == 0 { break; }
                 }
-                // Final argmin pass to lock indices to the final centroids.
+                // Sort centroids, remap, pack.
+                let mut order: [usize; 4] = [0, 1, 2, 3];
+                order.sort_by(|&a, &b| {
+                    cb[a]
+                        .partial_cmp(&cb[b])
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                let mut sorted_cb = [0.0f32; 4];
+                let mut inv: [u8; 4] = [0; 4];
+                for new_idx in 0..4 {
+                    sorted_cb[new_idx] = cb[order[new_idx]];
+                    inv[order[new_idx]] = new_idx as u8;
+                }
                 for i in 0..256 {
-                    let w = group[i];
-                    let mut best = 0usize;
-                    let mut best_d = (w - cb[0]).abs();
-                    for k in 1..4 {
-                        let d = (w - cb[k]).abs();
-                        if d < best_d { best_d = d; best = k; }
-                    }
-                    indices[i] = best as u8;
+                    indices[i] = inv[indices[i] as usize];
                 }
-            }
-            // Sort centroids, remap, pack.
-            let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
-            let mut sorted_cb = [0.0f32; 4];
-            let mut inv: [u8; 4] = [0; 4];
-            for new_idx in 0..4 {
-                sorted_cb[new_idx] = cb[order[new_idx]];
-                inv[order[new_idx]] = new_idx as u8;
-            }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
-            for k in 0..4 {
-                let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
-                out_chunk[2 * k + 1] = (bits >> 8) as u8;
-            }
-            for i in 0..64 {
-                let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
-                out_chunk[8 + i] = byte_val;
-            }
-        });
+                for k in 0..4 {
+                    let bits = f32_to_fp16_bits(sorted_cb[k]);
+                    out_chunk[2 * k] = (bits & 0xFF) as u8;
+                    out_chunk[2 * k + 1] = (bits >> 8) as u8;
+                }
+                for i in 0..64 {
+                    let mut byte_val = 0u8;
+                    for j in 0..4 {
+                        byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                    }
+                    out_chunk[8 + i] = byte_val;
+                }
+            });
         output
     }
 
@@ -6678,7 +7556,9 @@ mod gptq_damping_probe {
             let recon = dequantize_mq2g256_lloyd_to_f32(&bytes, n, &signs1, &signs2);
             let m = mse(weights, &recon);
             let delta = ((m - ref_mse) / ref_mse) * 100.0;
-            eprintln!("  Huber k={k_huber:>4.1} (niter=16)   MSE = {m:.6e}  ({delta:+.2}% vs Lloyd16)");
+            eprintln!(
+                "  Huber k={k_huber:>4.1} (niter=16)   MSE = {m:.6e}  ({delta:+.2}% vs Lloyd16)"
+            );
         }
     }
 
@@ -6688,7 +7568,9 @@ mod gptq_damping_probe {
     /// (correlated input) should help when input weights have
     /// channel correlation.
     fn quantize_mq2g256_lloyd_gptq_no_fwht(
-        f32_data: &[f32], damping: f32, max_iter: usize,
+        f32_data: &[f32],
+        damping: f32,
+        max_iter: usize,
     ) -> Vec<u8> {
         use rayon::prelude::*;
         let group_size = 256;
@@ -6696,84 +7578,105 @@ mod gptq_damping_probe {
         let n = f32_data.len();
         let n_blocks = (n + group_size - 1) / group_size;
         let mut output = vec![0u8; n_blocks * block_bytes];
-        output.par_chunks_mut(block_bytes).enumerate().for_each(|(b, out_chunk)| {
-            let start = b * group_size;
-            let end = (start + group_size).min(n);
-            let actual_len = end - start;
-            let mut group = [0.0f32; 256];
-            group[..actual_len].copy_from_slice(&f32_data[start..end]);
-            // NO FWHT here — operate on raw correlated weights.
-            let mut sorted: [f32; 256] = group;
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            let percentile = |frac: f32| -> f32 {
-                let idx = ((frac * 255.0).round() as usize).min(255);
-                sorted[idx]
-            };
-            let mut cb: [f32; 4] = [
-                percentile(0.125), percentile(0.375),
-                percentile(0.625), percentile(0.875),
-            ];
-            let range = sorted[255] - sorted[0];
-            if range > 0.0 {
-                let mut prev = [0u8; 256];
-                for it in 0..max_iter {
-                    let mut sums = [0.0f64; 4];
-                    let mut counts = [0u32; 4];
-                    let mut changed = 0u32;
-                    for i in 0..256 {
-                        let w = group[i];
-                        let mut best = 0usize;
-                        let mut best_d = (w - cb[0]).abs();
-                        for k in 1..4 {
-                            let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+        output
+            .par_chunks_mut(block_bytes)
+            .enumerate()
+            .for_each(|(b, out_chunk)| {
+                let start = b * group_size;
+                let end = (start + group_size).min(n);
+                let actual_len = end - start;
+                let mut group = [0.0f32; 256];
+                group[..actual_len].copy_from_slice(&f32_data[start..end]);
+                // NO FWHT here — operate on raw correlated weights.
+                let mut sorted: [f32; 256] = group;
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let percentile = |frac: f32| -> f32 {
+                    let idx = ((frac * 255.0).round() as usize).min(255);
+                    sorted[idx]
+                };
+                let mut cb: [f32; 4] = [
+                    percentile(0.125),
+                    percentile(0.375),
+                    percentile(0.625),
+                    percentile(0.875),
+                ];
+                let range = sorted[255] - sorted[0];
+                if range > 0.0 {
+                    let mut prev = [0u8; 256];
+                    for it in 0..max_iter {
+                        let mut sums = [0.0f64; 4];
+                        let mut counts = [0u32; 4];
+                        let mut changed = 0u32;
+                        for i in 0..256 {
+                            let w = group[i];
+                            let mut best = 0usize;
+                            let mut best_d = (w - cb[0]).abs();
+                            for k in 1..4 {
+                                let d = (w - cb[k]).abs();
+                                if d < best_d {
+                                    best_d = d;
+                                    best = k;
+                                }
+                            }
+                            if it == 0 || prev[i] != best as u8 {
+                                changed += 1;
+                            }
+                            prev[i] = best as u8;
+                            sums[best] += w as f64;
+                            counts[best] += 1;
                         }
-                        if it == 0 || prev[i] != best as u8 { changed += 1; }
-                        prev[i] = best as u8;
-                        sums[best] += w as f64;
-                        counts[best] += 1;
-                    }
-                    if it > 0 && changed == 0 { break; }
-                    for k in 0..4 {
-                        if counts[k] > 0 {
-                            cb[k] = (sums[k] / counts[k] as f64) as f32;
+                        if it > 0 && changed == 0 {
+                            break;
+                        }
+                        for k in 0..4 {
+                            if counts[k] > 0 {
+                                cb[k] = (sums[k] / counts[k] as f64) as f32;
+                            }
                         }
                     }
                 }
-            }
-            let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
-            let mut sorted_cb = [0.0f32; 4];
-            for new_idx in 0..4 {
-                sorted_cb[new_idx] = cb[order[new_idx]];
-            }
-            let cb_final = sorted_cb;
-            // Sequential GPTQ with no inner FWHT.
-            let mut indices = [0u8; 256];
-            let mut residual = 0.0f32;
-            for i in 0..256 {
-                let target = group[i] + residual;
-                let mut best = 0usize;
-                let mut best_d = (target - cb_final[0]).abs();
-                for k in 1..4 {
-                    let d = (target - cb_final[k]).abs();
-                    if d < best_d { best_d = d; best = k; }
+                let mut order: [usize; 4] = [0, 1, 2, 3];
+                order.sort_by(|&a, &b| {
+                    cb[a]
+                        .partial_cmp(&cb[b])
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                let mut sorted_cb = [0.0f32; 4];
+                for new_idx in 0..4 {
+                    sorted_cb[new_idx] = cb[order[new_idx]];
                 }
-                indices[i] = best as u8;
-                let err = target - cb_final[best];
-                residual = err * damping;
-            }
-            for k in 0..4 {
-                let bits = f32_to_fp16_bits(cb_final[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
-                out_chunk[2 * k + 1] = (bits >> 8) as u8;
-            }
-            for i in 0..64 {
-                let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
-                out_chunk[8 + i] = byte_val;
-            }
-        });
+                let cb_final = sorted_cb;
+                // Sequential GPTQ with no inner FWHT.
+                let mut indices = [0u8; 256];
+                let mut residual = 0.0f32;
+                for i in 0..256 {
+                    let target = group[i] + residual;
+                    let mut best = 0usize;
+                    let mut best_d = (target - cb_final[0]).abs();
+                    for k in 1..4 {
+                        let d = (target - cb_final[k]).abs();
+                        if d < best_d {
+                            best_d = d;
+                            best = k;
+                        }
+                    }
+                    indices[i] = best as u8;
+                    let err = target - cb_final[best];
+                    residual = err * damping;
+                }
+                for k in 0..4 {
+                    let bits = f32_to_fp16_bits(cb_final[k]);
+                    out_chunk[2 * k] = (bits & 0xFF) as u8;
+                    out_chunk[2 * k + 1] = (bits >> 8) as u8;
+                }
+                for i in 0..64 {
+                    let mut byte_val = 0u8;
+                    for j in 0..4 {
+                        byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                    }
+                    out_chunk[8 + i] = byte_val;
+                }
+            });
         output
     }
 
@@ -6823,7 +7726,10 @@ mod gptq_damping_probe {
     /// Dequant for MQ3-Lloyd (qt=20): 16 B fp16 codebook (8 entries) +
     /// 96 B 3-bit packed indices = 112 B / 256 weights.
     fn dequantize_mq3g256_lloyd_to_f32(
-        data: &[u8], n_weights: usize, signs1: &[f32], signs2: &[f32],
+        data: &[u8],
+        n_weights: usize,
+        signs1: &[f32],
+        signs2: &[f32],
     ) -> Vec<f32> {
         let group_size = 256;
         let block_bytes = 112;
@@ -6839,7 +7745,9 @@ mod gptq_damping_probe {
             let mut group = [0.0f32; 256];
             for chunk in 0..32 {
                 let bo = 16 + chunk * 3;
-                let b0 = blk[bo]; let b1 = blk[bo + 1]; let b2 = blk[bo + 2];
+                let b0 = blk[bo];
+                let b1 = blk[bo + 1];
+                let b2 = blk[bo + 2];
                 let mut q = [0u8; 8];
                 q[0] = b0 & 7;
                 q[1] = (b0 >> 3) & 7;
@@ -6894,15 +7802,20 @@ mod gptq_damping_probe {
     fn antirez_mq3_to_mq2_downgrade_cost() {
         // Tests on the same DeepSeek V4-realistic distributions as the GPTQ probe.
         eprintln!("\n=== Antirez MQ3-down → MQ2-down downgrade cost ===");
-        antirez_downgrade_cost("Gaussian 16x256",
-            &gaussian_samples(16 * 256, 0xc001cafe));
+        antirez_downgrade_cost("Gaussian 16x256", &gaussian_samples(16 * 256, 0xc001cafe));
         let mut htw = gaussian_samples(16 * 256, 0xfeed);
         let tail = gaussian_samples((16 * 256) / 20, 0xbeef);
-        for (i, t) in tail.iter().enumerate() { htw[i * 20] = t * 3.0; }
+        for (i, t) in tail.iter().enumerate() {
+            htw[i * 20] = t * 3.0;
+        }
         antirez_downgrade_cost("Heavy-tailed 16x256", &htw);
         let mut sw = gaussian_samples(16 * 256, 0x5_a55e);
-        for v in sw.iter_mut() { *v *= 0.1; }
-        for i in 0..(16 * 256 / 20) { sw[i * 20] *= 30.0; }
+        for v in sw.iter_mut() {
+            *v *= 0.1;
+        }
+        for i in 0..(16 * 256 / 20) {
+            sw[i * 20] *= 30.0;
+        }
         antirez_downgrade_cost("Sparse + outliers 16x256", &sw);
     }
 
@@ -6918,10 +7831,12 @@ mod gptq_damping_probe {
         // into dequant or change the runtime kernel to apply it on
         // dequant'd values).
         eprintln!("\n=== GPTQ on correlated weights (no inner FWHT) ===");
-        for (label, decay) in [("decay=0.0 (uncorrelated)", 0.0f32),
-                               ("decay=0.4 (moderately correlated)", 0.4),
-                               ("decay=0.7 (strongly correlated)", 0.7),
-                               ("decay=0.9 (very correlated)", 0.9)] {
+        for (label, decay) in [
+            ("decay=0.0 (uncorrelated)", 0.0f32),
+            ("decay=0.4 (moderately correlated)", 0.4),
+            ("decay=0.7 (strongly correlated)", 0.7),
+            ("decay=0.9 (very correlated)", 0.9),
+        ] {
             let n = 16 * 256;
             let w = correlated_weights(n, 0xc011a7ed, decay);
             // Reference: plain Lloyd via no-FWHT path with d=0.
@@ -6935,7 +7850,9 @@ mod gptq_damping_probe {
                 let r = dequant_no_fwht(&b, n);
                 let m = mse(&w, &r);
                 let delta = ((m - ref_mse) / ref_mse) * 100.0;
-                eprintln!("    GPTQ d={damping:>4.2} (no-fwht)   MSE = {m:.6e}  ({delta:+.2}% vs Lloyd)");
+                eprintln!(
+                    "    GPTQ d={damping:>4.2} (no-fwht)   MSE = {m:.6e}  ({delta:+.2}% vs Lloyd)"
+                );
             }
         }
     }
@@ -6949,8 +7866,12 @@ mod gptq_damping_probe {
         }
         run_huber_sweep("Heavy-tailed 16x256", &htw);
         let mut sw = gaussian_samples(16 * 256, 0x5_a55e);
-        for v in sw.iter_mut() { *v *= 0.1; }
-        for i in 0..(16 * 256 / 20) { sw[i * 20] *= 30.0; }
+        for v in sw.iter_mut() {
+            *v *= 0.1;
+        }
+        for i in 0..(16 * 256 / 20) {
+            sw[i * 20] *= 30.0;
+        }
         run_huber_sweep("Sparse + outliers 16x256", &sw);
         run_huber_sweep("Gaussian 16x256", &gaussian_samples(16 * 256, 0xc001cafe));
     }
@@ -7004,7 +7925,9 @@ mod gptq_damping_probe {
         let proxy_recon = dequantize_mq2g256_lloyd_to_f32(&proxy_bytes, n, &signs1, &signs2);
         let proxy_mse = mse(weights, &proxy_recon);
         let delta = ((proxy_mse - ref_mse) / ref_mse) * 100.0;
-        eprintln!("  Weight-norm-proxy Lloyd      MSE = {proxy_mse:.6e}  ({delta:+.2}% vs uniform)");
+        eprintln!(
+            "  Weight-norm-proxy Lloyd      MSE = {proxy_mse:.6e}  ({delta:+.2}% vs uniform)"
+        );
     }
 
     /// Quantize via Lloyd WITHOUT the FWHT step — Lloyd applied directly
@@ -7017,74 +7940,94 @@ mod gptq_damping_probe {
         let n = f32_data.len();
         let n_blocks = (n + group_size - 1) / group_size;
         let mut output = vec![0u8; n_blocks * block_bytes];
-        output.par_chunks_mut(block_bytes).enumerate().for_each(|(b, out_chunk)| {
-            let start = b * group_size;
-            let end = (start + group_size).min(n);
-            let actual_len = end - start;
-            let mut group = [0.0f32; 256];
-            group[..actual_len].copy_from_slice(&f32_data[start..end]);
-            // NO FWHT — Lloyd directly on natural distribution.
-            let mut sorted: [f32; 256] = group;
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            let percentile = |frac: f32| -> f32 {
-                let idx = ((frac * 255.0).round() as usize).min(255);
-                sorted[idx]
-            };
-            let mut cb: [f32; 4] = [
-                percentile(0.125), percentile(0.375),
-                percentile(0.625), percentile(0.875),
-            ];
-            let range = sorted[255] - sorted[0];
-            let mut indices = [0u8; 256];
-            if range > 0.0 {
-                let max_iter = 16;
-                let mut prev_assignments = [0u8; 256];
-                for it in 0..max_iter {
-                    let mut sums = [0.0f64; 4];
-                    let mut counts = [0u32; 4];
-                    let mut changed = 0u32;
-                    for i in 0..256 {
-                        let w = group[i];
-                        let mut best = 0usize;
-                        let mut best_d = (w - cb[0]).abs();
-                        for k in 1..4 {
-                            let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+        output
+            .par_chunks_mut(block_bytes)
+            .enumerate()
+            .for_each(|(b, out_chunk)| {
+                let start = b * group_size;
+                let end = (start + group_size).min(n);
+                let actual_len = end - start;
+                let mut group = [0.0f32; 256];
+                group[..actual_len].copy_from_slice(&f32_data[start..end]);
+                // NO FWHT — Lloyd directly on natural distribution.
+                let mut sorted: [f32; 256] = group;
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let percentile = |frac: f32| -> f32 {
+                    let idx = ((frac * 255.0).round() as usize).min(255);
+                    sorted[idx]
+                };
+                let mut cb: [f32; 4] = [
+                    percentile(0.125),
+                    percentile(0.375),
+                    percentile(0.625),
+                    percentile(0.875),
+                ];
+                let range = sorted[255] - sorted[0];
+                let mut indices = [0u8; 256];
+                if range > 0.0 {
+                    let max_iter = 16;
+                    let mut prev_assignments = [0u8; 256];
+                    for it in 0..max_iter {
+                        let mut sums = [0.0f64; 4];
+                        let mut counts = [0u32; 4];
+                        let mut changed = 0u32;
+                        for i in 0..256 {
+                            let w = group[i];
+                            let mut best = 0usize;
+                            let mut best_d = (w - cb[0]).abs();
+                            for k in 1..4 {
+                                let d = (w - cb[k]).abs();
+                                if d < best_d {
+                                    best_d = d;
+                                    best = k;
+                                }
+                            }
+                            if it == 0 || prev_assignments[i] != best as u8 {
+                                changed += 1;
+                            }
+                            prev_assignments[i] = best as u8;
+                            indices[i] = best as u8;
+                            sums[best] += w as f64;
+                            counts[best] += 1;
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
-                        prev_assignments[i] = best as u8;
-                        indices[i] = best as u8;
-                        sums[best] += w as f64;
-                        counts[best] += 1;
-                    }
-                    if it > 0 && changed == 0 { break; }
-                    for k in 0..4 {
-                        if counts[k] > 0 {
-                            cb[k] = (sums[k] / counts[k] as f64) as f32;
+                        if it > 0 && changed == 0 {
+                            break;
+                        }
+                        for k in 0..4 {
+                            if counts[k] > 0 {
+                                cb[k] = (sums[k] / counts[k] as f64) as f32;
+                            }
                         }
                     }
                 }
-            }
-            let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
-            let mut sorted_cb = [0.0f32; 4];
-            let mut inv: [u8; 4] = [0; 4];
-            for new_idx in 0..4 {
-                sorted_cb[new_idx] = cb[order[new_idx]];
-                inv[order[new_idx]] = new_idx as u8;
-            }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
-            for k in 0..4 {
-                let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
-                out_chunk[2 * k + 1] = (bits >> 8) as u8;
-            }
-            for i in 0..64 {
-                let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
-                out_chunk[8 + i] = byte_val;
-            }
-        });
+                let mut order: [usize; 4] = [0, 1, 2, 3];
+                order.sort_by(|&a, &b| {
+                    cb[a]
+                        .partial_cmp(&cb[b])
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                let mut sorted_cb = [0.0f32; 4];
+                let mut inv: [u8; 4] = [0; 4];
+                for new_idx in 0..4 {
+                    sorted_cb[new_idx] = cb[order[new_idx]];
+                    inv[order[new_idx]] = new_idx as u8;
+                }
+                for i in 0..256 {
+                    indices[i] = inv[indices[i] as usize];
+                }
+                for k in 0..4 {
+                    let bits = f32_to_fp16_bits(sorted_cb[k]);
+                    out_chunk[2 * k] = (bits & 0xFF) as u8;
+                    out_chunk[2 * k + 1] = (bits >> 8) as u8;
+                }
+                for i in 0..64 {
+                    let mut byte_val = 0u8;
+                    for j in 0..4 {
+                        byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                    }
+                    out_chunk[8 + i] = byte_val;
+                }
+            });
         output
     }
 
@@ -7117,9 +8060,7 @@ mod gptq_damping_probe {
 
     /// Quantize W (natural basis) with imatrix-weighted Lloyd, no FWHT.
     /// Returns (codebook, indices) — both in natural basis.
-    fn lloyd_imatrix_no_fwht(
-        weights: &[f32], col_weights: &[f32],
-    ) -> Vec<u8> {
+    fn lloyd_imatrix_no_fwht(weights: &[f32], col_weights: &[f32]) -> Vec<u8> {
         use rayon::prelude::*;
         let group_size = 256;
         let block_bytes = 72;
@@ -7127,78 +8068,98 @@ mod gptq_damping_probe {
         let n_blocks = (n + group_size - 1) / group_size;
         let mut output = vec![0u8; n_blocks * block_bytes];
         let blocks_per_row = col_weights.len() / group_size;
-        output.par_chunks_mut(block_bytes).enumerate().for_each(|(b, out_chunk)| {
-            let start = b * group_size;
-            let end = (start + group_size).min(n);
-            let actual_len = end - start;
-            let mut group = [0.0f32; 256];
-            group[..actual_len].copy_from_slice(&weights[start..end]);
-            // Use natural distribution; NO FWHT.
-            let col_off = (b % blocks_per_row) * group_size;
-            let block_w: &[f32] = &col_weights[col_off..col_off + group_size];
+        output
+            .par_chunks_mut(block_bytes)
+            .enumerate()
+            .for_each(|(b, out_chunk)| {
+                let start = b * group_size;
+                let end = (start + group_size).min(n);
+                let actual_len = end - start;
+                let mut group = [0.0f32; 256];
+                group[..actual_len].copy_from_slice(&weights[start..end]);
+                // Use natural distribution; NO FWHT.
+                let col_off = (b % blocks_per_row) * group_size;
+                let block_w: &[f32] = &col_weights[col_off..col_off + group_size];
 
-            let mut sorted: [f32; 256] = group;
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-            let percentile = |frac: f32| -> f32 {
-                let idx = ((frac * 255.0).round() as usize).min(255);
-                sorted[idx]
-            };
-            let mut cb: [f32; 4] = [
-                percentile(0.125), percentile(0.375),
-                percentile(0.625), percentile(0.875),
-            ];
-            let range = sorted[255] - sorted[0];
-            let mut indices = [0u8; 256];
-            if range > 0.0 {
-                let max_iter = 16;
-                let mut prev_assignments = [0u8; 256];
-                for it in 0..max_iter {
-                    let mut wsums = [0.0f64; 4];
-                    let mut wtotals = [0.0f64; 4];
-                    let mut changed = 0u32;
-                    for i in 0..256 {
-                        let w = group[i];
-                        let mut best = 0usize;
-                        let mut best_d = (w - cb[0]).abs();
-                        for k in 1..4 {
-                            let d = (w - cb[k]).abs();
-                            if d < best_d { best_d = d; best = k; }
+                let mut sorted: [f32; 256] = group;
+                sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let percentile = |frac: f32| -> f32 {
+                    let idx = ((frac * 255.0).round() as usize).min(255);
+                    sorted[idx]
+                };
+                let mut cb: [f32; 4] = [
+                    percentile(0.125),
+                    percentile(0.375),
+                    percentile(0.625),
+                    percentile(0.875),
+                ];
+                let range = sorted[255] - sorted[0];
+                let mut indices = [0u8; 256];
+                if range > 0.0 {
+                    let max_iter = 16;
+                    let mut prev_assignments = [0u8; 256];
+                    for it in 0..max_iter {
+                        let mut wsums = [0.0f64; 4];
+                        let mut wtotals = [0.0f64; 4];
+                        let mut changed = 0u32;
+                        for i in 0..256 {
+                            let w = group[i];
+                            let mut best = 0usize;
+                            let mut best_d = (w - cb[0]).abs();
+                            for k in 1..4 {
+                                let d = (w - cb[k]).abs();
+                                if d < best_d {
+                                    best_d = d;
+                                    best = k;
+                                }
+                            }
+                            if it == 0 || prev_assignments[i] != best as u8 {
+                                changed += 1;
+                            }
+                            prev_assignments[i] = best as u8;
+                            indices[i] = best as u8;
+                            let pw = block_w[i] as f64;
+                            wsums[best] += pw * w as f64;
+                            wtotals[best] += pw;
                         }
-                        if it == 0 || prev_assignments[i] != best as u8 { changed += 1; }
-                        prev_assignments[i] = best as u8;
-                        indices[i] = best as u8;
-                        let pw = block_w[i] as f64;
-                        wsums[best] += pw * w as f64;
-                        wtotals[best] += pw;
-                    }
-                    if it > 0 && changed == 0 { break; }
-                    for k in 0..4 {
-                        if wtotals[k] > 0.0 {
-                            cb[k] = (wsums[k] / wtotals[k]) as f32;
+                        if it > 0 && changed == 0 {
+                            break;
+                        }
+                        for k in 0..4 {
+                            if wtotals[k] > 0.0 {
+                                cb[k] = (wsums[k] / wtotals[k]) as f32;
+                            }
                         }
                     }
                 }
-            }
-            let mut order: [usize; 4] = [0, 1, 2, 3];
-            order.sort_by(|&a, &b| cb[a].partial_cmp(&cb[b]).unwrap_or(std::cmp::Ordering::Equal));
-            let mut sorted_cb = [0.0f32; 4];
-            let mut inv: [u8; 4] = [0; 4];
-            for new_idx in 0..4 {
-                sorted_cb[new_idx] = cb[order[new_idx]];
-                inv[order[new_idx]] = new_idx as u8;
-            }
-            for i in 0..256 { indices[i] = inv[indices[i] as usize]; }
-            for k in 0..4 {
-                let bits = f32_to_fp16_bits(sorted_cb[k]);
-                out_chunk[2 * k]     = (bits & 0xFF) as u8;
-                out_chunk[2 * k + 1] = (bits >> 8) as u8;
-            }
-            for i in 0..64 {
-                let mut byte_val = 0u8;
-                for j in 0..4 { byte_val |= (indices[4 * i + j] & 0x3) << (j * 2); }
-                out_chunk[8 + i] = byte_val;
-            }
-        });
+                let mut order: [usize; 4] = [0, 1, 2, 3];
+                order.sort_by(|&a, &b| {
+                    cb[a]
+                        .partial_cmp(&cb[b])
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                let mut sorted_cb = [0.0f32; 4];
+                let mut inv: [u8; 4] = [0; 4];
+                for new_idx in 0..4 {
+                    sorted_cb[new_idx] = cb[order[new_idx]];
+                    inv[order[new_idx]] = new_idx as u8;
+                }
+                for i in 0..256 {
+                    indices[i] = inv[indices[i] as usize];
+                }
+                for k in 0..4 {
+                    let bits = f32_to_fp16_bits(sorted_cb[k]);
+                    out_chunk[2 * k] = (bits & 0xFF) as u8;
+                    out_chunk[2 * k + 1] = (bits >> 8) as u8;
+                }
+                for i in 0..64 {
+                    let mut byte_val = 0u8;
+                    for j in 0..4 {
+                        byte_val |= (indices[4 * i + j] & 0x3) << (j * 2);
+                    }
+                    out_chunk[8 + i] = byte_val;
+                }
+            });
         output
     }
 
@@ -7262,7 +8223,9 @@ mod gptq_damping_probe {
         let mut col_scales = vec![0.0f32; k];
         let mut state: u64 = 0xc0ffeeed;
         for j in 0..k {
-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             let u = ((state >> 11) & ((1u64 << 53) - 1)) as f64 / (1u64 << 53) as f64;
             // log-uniform in [0.1, 3.0]
             col_scales[j] = (0.1_f64.ln() + u * (3.0_f64.ln() - 0.1_f64.ln())).exp() as f32;
@@ -7283,7 +8246,9 @@ mod gptq_damping_probe {
             imatrix[j] = sum2.sqrt() as f32;
         }
         let mut sum_log = 0.0f64;
-        for &v in &imatrix { sum_log += (v.max(1e-12) as f64).ln(); }
+        for &v in &imatrix {
+            sum_log += (v.max(1e-12) as f64).ln();
+        }
         let mean_log = sum_log / k as f64;
         for v in imatrix.iter_mut() {
             *v = ((*v as f64).ln() - mean_log).exp() as f32;
@@ -7300,25 +8265,34 @@ mod gptq_damping_probe {
         let bytes_a = quantize_mq2g256_lloyd_weighted(&w, &imatrix, &signs1, &signs2);
         let recon_a = dequantize_mq2g256_lloyd_to_f32(&bytes_a, n, &signs1, &signs2);
         let y_a = gemv_f32(&recon_a, &x, m, k);
-        let err_a: f64 = y_ref.iter().zip(y_a.iter())
+        let err_a: f64 = y_ref
+            .iter()
+            .zip(y_a.iter())
             .map(|(r, q)| (*r as f64 - *q as f64).powi(2))
-            .sum::<f64>() / m as f64;
+            .sum::<f64>()
+            / m as f64;
 
         // METHOD B: pre-FWHT imatrix-Lloyd (proposed refactor).
         let bytes_b = lloyd_imatrix_no_fwht(&w, &imatrix);
         let recon_b = dequant_no_fwht_natural(&bytes_b, n);
         let y_b = gemv_f32(&recon_b, &x, m, k);
-        let err_b: f64 = y_ref.iter().zip(y_b.iter())
+        let err_b: f64 = y_ref
+            .iter()
+            .zip(y_b.iter())
             .map(|(r, q)| (*r as f64 - *q as f64).powi(2))
-            .sum::<f64>() / m as f64;
+            .sum::<f64>()
+            / m as f64;
 
         // METHOD C: post-FWHT uniform Lloyd (current production w/o imatrix).
         let bytes_c = quantize_mq2g256_lloyd(&w, &signs1, &signs2);
         let recon_c = dequantize_mq2g256_lloyd_to_f32(&bytes_c, n, &signs1, &signs2);
         let y_c = gemv_f32(&recon_c, &x, m, k);
-        let err_c: f64 = y_ref.iter().zip(y_c.iter())
+        let err_c: f64 = y_ref
+            .iter()
+            .zip(y_c.iter())
             .map(|(r, q)| (*r as f64 - *q as f64).powi(2))
-            .sum::<f64>() / m as f64;
+            .sum::<f64>()
+            / m as f64;
 
         eprintln!("\n=== Pre-FWHT vs post-FWHT imatrix-Lloyd (activation-weighted) ===");
         eprintln!("  W shape [{m}, {k}], heterogeneous column variances (0.1-3.0x)");
@@ -7351,32 +8325,51 @@ mod gptq_damping_probe {
         let signs2 = gen_fwht_signs(1042, 256);
 
         let cases: &[(&str, Box<dyn Fn() -> Vec<f32>>)] = &[
-            ("Gaussian 16x256",
-                Box::new(|| gaussian_samples(16 * 256, 0xc001cafe))),
-            ("Heavy-tailed 16x256", Box::new(|| {
-                let mut htw = gaussian_samples(16 * 256, 0xfeed);
-                let tail = gaussian_samples((16 * 256) / 20, 0xbeef);
-                for (i, t) in tail.iter().enumerate() { htw[i * 20] = t * 3.0; }
-                htw
-            })),
-            ("Sparse + outliers 16x256", Box::new(|| {
-                let mut sw = gaussian_samples(16 * 256, 0x5_a55e);
-                for v in sw.iter_mut() { *v *= 0.1; }
-                for i in 0..(16 * 256 / 20) { sw[i * 20] *= 30.0; }
-                sw
-            })),
-            ("Bimodal (50% near -1, 50% near +1)", Box::new(|| {
-                let mut bw = gaussian_samples(16 * 256, 0xb1ba1);
-                for (i, v) in bw.iter_mut().enumerate() {
-                    *v = 0.3 * *v + if i % 2 == 0 { -1.0 } else { 1.0 };
-                }
-                bw
-            })),
+            (
+                "Gaussian 16x256",
+                Box::new(|| gaussian_samples(16 * 256, 0xc001cafe)),
+            ),
+            (
+                "Heavy-tailed 16x256",
+                Box::new(|| {
+                    let mut htw = gaussian_samples(16 * 256, 0xfeed);
+                    let tail = gaussian_samples((16 * 256) / 20, 0xbeef);
+                    for (i, t) in tail.iter().enumerate() {
+                        htw[i * 20] = t * 3.0;
+                    }
+                    htw
+                }),
+            ),
+            (
+                "Sparse + outliers 16x256",
+                Box::new(|| {
+                    let mut sw = gaussian_samples(16 * 256, 0x5_a55e);
+                    for v in sw.iter_mut() {
+                        *v *= 0.1;
+                    }
+                    for i in 0..(16 * 256 / 20) {
+                        sw[i * 20] *= 30.0;
+                    }
+                    sw
+                }),
+            ),
+            (
+                "Bimodal (50% near -1, 50% near +1)",
+                Box::new(|| {
+                    let mut bw = gaussian_samples(16 * 256, 0xb1ba1);
+                    for (i, v) in bw.iter_mut().enumerate() {
+                        *v = 0.3 * *v + if i % 2 == 0 { -1.0 } else { 1.0 };
+                    }
+                    bw
+                }),
+            ),
         ];
 
         eprintln!("\n=== FWHT value audit ===");
-        eprintln!("{:35} {:>14} {:>14} {:>10}",
-            "distribution", "fwht MSE", "no-fwht MSE", "fwht win %");
+        eprintln!(
+            "{:35} {:>14} {:>14} {:>10}",
+            "distribution", "fwht MSE", "no-fwht MSE", "fwht win %"
+        );
         for (label, gen) in cases {
             let w = gen();
             let n = w.len();
@@ -7387,8 +8380,10 @@ mod gptq_damping_probe {
             let nofwht_recon = dequant_mq2_no_fwht(&nofwht_bytes, n);
             let nofwht_mse = mse(&w, &nofwht_recon);
             let win_pct = ((nofwht_mse - fwht_mse) / nofwht_mse) * 100.0;
-            eprintln!("{:35} {:14.6e} {:14.6e} {:+9.2}%",
-                label, fwht_mse, nofwht_mse, win_pct);
+            eprintln!(
+                "{:35} {:14.6e} {:14.6e} {:+9.2}%",
+                label, fwht_mse, nofwht_mse, win_pct
+            );
         }
     }
 
@@ -7404,7 +8399,9 @@ mod gptq_damping_probe {
         eprintln!("\n=== Weight-norm proxy imatrix sweep ===");
         run_weight_norm_proxy_sweep(
             "Gaussian [2048, 4096]",
-            &gaussian_samples(n, 0xc001cafe), m, k,
+            &gaussian_samples(n, 0xc001cafe),
+            m,
+            k,
         );
         // Heavy-tailed: 5% of weights drawn from N(0, 3).
         let mut htw = gaussian_samples(n, 0xfeed);
@@ -7439,20 +8436,25 @@ mod gptq_damping_probe {
         }
         run_lloyd_iter_sweep("Heavy-tailed 16x256", &htw);
         let mut sw = gaussian_samples(16 * 256, 0x5_a55e);
-        for v in sw.iter_mut() { *v *= 0.1; }
-        for i in 0..(16 * 256 / 20) { sw[i * 20] *= 30.0; }
+        for v in sw.iter_mut() {
+            *v *= 0.1;
+        }
+        for i in 0..(16 * 256 / 20) {
+            sw[i * 20] *= 30.0;
+        }
         run_lloyd_iter_sweep("Sparse + outliers 16x256", &sw);
     }
 
     #[test]
     fn sweep_deepseek4_like_distributions() {
         // 1) Pure Gaussian — baseline.
-        run_one_distribution("N(0,1), 256 weights",
-            &gaussian_samples(256, 0xc001cafe));
+        run_one_distribution("N(0,1), 256 weights", &gaussian_samples(256, 0xc001cafe));
 
         // 2) Pure Gaussian, larger sample — averages across multiple blocks.
-        run_one_distribution("N(0,1), 16x256 weights",
-            &gaussian_samples(16 * 256, 0xc001cafe));
+        run_one_distribution(
+            "N(0,1), 16x256 weights",
+            &gaussian_samples(16 * 256, 0xc001cafe),
+        );
 
         // 3) Heavy-tailed mixture — 5% from N(0, 3), rest N(0, 1).
         //    Mimics DeepSeek V4's expert distributions with occasional outliers.
@@ -7520,11 +8522,34 @@ mod hfq_block_diag {
         let mut esc = false;
         let mut json_end = 0usize;
         for (i, &b) in mmap[metadata_offset..data_offset].iter().enumerate() {
-            if esc { esc = false; continue; }
-            if in_str { if b == b'\\' { esc = true; continue; } if b == b'"' { in_str = false; } continue; }
-            if b == b'"' { in_str = true; continue; }
-            if b == b'{' { depth += 1; }
-            if b == b'}' { depth -= 1; if depth == 0 { json_end = i + 1; break; } }
+            if esc {
+                esc = false;
+                continue;
+            }
+            if in_str {
+                if b == b'\\' {
+                    esc = true;
+                    continue;
+                }
+                if b == b'"' {
+                    in_str = false;
+                }
+                continue;
+            }
+            if b == b'"' {
+                in_str = true;
+                continue;
+            }
+            if b == b'{' {
+                depth += 1;
+            }
+            if b == b'}' {
+                depth -= 1;
+                if depth == 0 {
+                    json_end = i + 1;
+                    break;
+                }
+            }
         }
         Ok(String::from_utf8_lossy(&mmap[metadata_offset..metadata_offset + json_end]).to_string())
     }
@@ -7558,61 +8583,116 @@ mod hfq_block_diag {
         let mut esc = false;
         let mut json_end = 0usize;
         for (i, &b) in mmap[metadata_offset..data_offset].iter().enumerate() {
-            if esc { esc = false; continue; }
-            if in_str { if b == b'\\' { esc = true; continue; } if b == b'"' { in_str = false; } continue; }
-            if b == b'"' { in_str = true; continue; }
-            if b == b'{' { depth += 1; }
-            if b == b'}' { depth -= 1; if depth == 0 { json_end = i + 1; break; } }
+            if esc {
+                esc = false;
+                continue;
+            }
+            if in_str {
+                if b == b'\\' {
+                    esc = true;
+                    continue;
+                }
+                if b == b'"' {
+                    in_str = false;
+                }
+                continue;
+            }
+            if b == b'"' {
+                in_str = true;
+                continue;
+            }
+            if b == b'{' {
+                depth += 1;
+            }
+            if b == b'}' {
+                depth -= 1;
+                if depth == 0 {
+                    json_end = i + 1;
+                    break;
+                }
+            }
         }
         let mut pos = metadata_offset + json_end;
-        let idx_n = u32::from_le_bytes(mmap[pos..pos+4].try_into().unwrap()) as usize;
+        let idx_n = u32::from_le_bytes(mmap[pos..pos + 4].try_into().unwrap()) as usize;
         assert_eq!(idx_n, n_tensors);
         pos += 4;
         let mut tensors = Vec::with_capacity(n_tensors);
         let mut cum = data_offset;
         for _ in 0..n_tensors {
-            let name_len = u16::from_le_bytes(mmap[pos..pos+2].try_into().unwrap()) as usize;
+            let name_len = u16::from_le_bytes(mmap[pos..pos + 2].try_into().unwrap()) as usize;
             pos += 2;
-            let name = String::from_utf8_lossy(&mmap[pos..pos+name_len]).into_owned();
+            let name = String::from_utf8_lossy(&mmap[pos..pos + name_len]).into_owned();
             pos += name_len;
-            let quant_type = mmap[pos]; pos += 1;
-            let n_dims = mmap[pos] as usize; pos += 1;
+            let quant_type = mmap[pos];
+            pos += 1;
+            let n_dims = mmap[pos] as usize;
+            pos += 1;
             let mut shape = Vec::with_capacity(n_dims);
             for _ in 0..n_dims {
-                shape.push(u32::from_le_bytes(mmap[pos..pos+4].try_into().unwrap()));
+                shape.push(u32::from_le_bytes(mmap[pos..pos + 4].try_into().unwrap()));
                 pos += 4;
             }
             // Skip group_size u32.
             pos += 4;
-            let data_size = u64::from_le_bytes(mmap[pos..pos+8].try_into().unwrap()) as usize;
+            let data_size = u64::from_le_bytes(mmap[pos..pos + 8].try_into().unwrap()) as usize;
             pos += 8;
-            tensors.push(TensorInfo { name, quant_type, shape, data_offset: cum, data_size });
+            tensors.push(TensorInfo {
+                name,
+                quant_type,
+                shape,
+                data_offset: cum,
+                data_size,
+            });
             cum += data_size;
         }
         Ok((mmap, tensors))
     }
 
     fn classify(name: &str) -> &'static str {
-        if name.contains("ffn.experts.") && name.ends_with("w1.weight") { return "routed.w1 (gate)"; }
-        if name.contains("ffn.experts.") && name.ends_with("w2.weight") { return "routed.w2 (down)"; }
-        if name.contains("ffn.experts.") && name.ends_with("w3.weight") { return "routed.w3 (up)"; }
-        if name.contains("shared_experts.w1") { return "shared.w1"; }
-        if name.contains("shared_experts.w2") { return "shared.w2"; }
-        if name.contains("shared_experts.w3") { return "shared.w3"; }
-        if name.ends_with("attn.wq_a.weight") || name.ends_with("attn.wq_b.weight") { return "attn.q"; }
-        if name.ends_with("attn.wkv.weight") { return "attn.kv"; }
-        if name.ends_with("attn.wo_a.weight") || name.ends_with("attn.wo_b.weight") { return "attn.wo"; }
-        if name.contains("compressor.wkv") || name.contains("compressor.wgate") { return "compressor"; }
-        if name.contains("indexer.") { return "indexer"; }
+        if name.contains("ffn.experts.") && name.ends_with("w1.weight") {
+            return "routed.w1 (gate)";
+        }
+        if name.contains("ffn.experts.") && name.ends_with("w2.weight") {
+            return "routed.w2 (down)";
+        }
+        if name.contains("ffn.experts.") && name.ends_with("w3.weight") {
+            return "routed.w3 (up)";
+        }
+        if name.contains("shared_experts.w1") {
+            return "shared.w1";
+        }
+        if name.contains("shared_experts.w2") {
+            return "shared.w2";
+        }
+        if name.contains("shared_experts.w3") {
+            return "shared.w3";
+        }
+        if name.ends_with("attn.wq_a.weight") || name.ends_with("attn.wq_b.weight") {
+            return "attn.q";
+        }
+        if name.ends_with("attn.wkv.weight") {
+            return "attn.kv";
+        }
+        if name.ends_with("attn.wo_a.weight") || name.ends_with("attn.wo_b.weight") {
+            return "attn.wo";
+        }
+        if name.contains("compressor.wkv") || name.contains("compressor.wgate") {
+            return "compressor";
+        }
+        if name.contains("indexer.") {
+            return "indexer";
+        }
         "other"
     }
 
     /// Stats per block at MQ2 (4 codepoints, 8 B codebook + 64 B indices = 72 B/group).
     fn block_stats_mq2(data: &[u8]) -> Option<(f32, f32, f32)> {
-        if data.len() < 8 { return None; }
+        if data.len() < 8 {
+            return None;
+        }
         let mut cb = [0.0f32; 4];
         for k in 0..4 {
-            cb[k] = f16_to_f32(u16::from_le_bytes([data[2*k], data[2*k+1]]));
+            cb[k] = f16_to_f32(u16::from_le_bytes([data[2 * k], data[2 * k + 1]]));
         }
         let lo = cb.iter().cloned().fold(f32::INFINITY, f32::min);
         let hi = cb.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
@@ -7623,7 +8703,9 @@ mod hfq_block_diag {
         let mut hist = [0u32; 4];
         for i in 0..64 {
             let b = data[8 + i];
-            for j in 0..4 { hist[((b >> (j*2)) & 0x3) as usize] += 1; }
+            for j in 0..4 {
+                hist[((b >> (j * 2)) & 0x3) as usize] += 1;
+            }
         }
         let total: u32 = hist.iter().sum();
         let mut h_bits = 0.0f32;
@@ -7638,10 +8720,12 @@ mod hfq_block_diag {
 
     /// Stats per block at MQ3 (8 codepoints, 16 B codebook + 96 B indices = 112 B/group).
     fn block_stats_mq3(data: &[u8]) -> Option<(f32, f32, f32)> {
-        if data.len() < 16 { return None; }
+        if data.len() < 16 {
+            return None;
+        }
         let mut cb = [0.0f32; 8];
         for k in 0..8 {
-            cb[k] = f16_to_f32(u16::from_le_bytes([data[2*k], data[2*k+1]]));
+            cb[k] = f16_to_f32(u16::from_le_bytes([data[2 * k], data[2 * k + 1]]));
         }
         let lo = cb.iter().cloned().fold(f32::INFINITY, f32::min);
         let hi = cb.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
@@ -7652,13 +8736,22 @@ mod hfq_block_diag {
         let mut hist = [0u32; 8];
         for chunk in 0..32 {
             let bo = 16 + chunk * 3;
-            let b0 = data[bo]; let b1 = data[bo+1]; let b2 = data[bo+2];
+            let b0 = data[bo];
+            let b1 = data[bo + 1];
+            let b2 = data[bo + 2];
             let q = [
-                b0 & 7, (b0 >> 3) & 7, ((b0 >> 6) & 3) | ((b1 & 1) << 2),
-                (b1 >> 1) & 7, (b1 >> 4) & 7, ((b1 >> 7) & 1) | ((b2 & 3) << 1),
-                (b2 >> 2) & 7, (b2 >> 5) & 7,
+                b0 & 7,
+                (b0 >> 3) & 7,
+                ((b0 >> 6) & 3) | ((b1 & 1) << 2),
+                (b1 >> 1) & 7,
+                (b1 >> 4) & 7,
+                ((b1 >> 7) & 1) | ((b2 & 3) << 1),
+                (b2 >> 2) & 7,
+                (b2 >> 5) & 7,
             ];
-            for v in q { hist[v as usize] += 1; }
+            for v in q {
+                hist[v as usize] += 1;
+            }
         }
         let total: u32 = hist.iter().sum();
         let mut h_bits = 0.0f32;
@@ -7675,7 +8768,12 @@ mod hfq_block_diag {
         super::cpu_inv_fwht_256(x, signs1, signs2);
     }
 
-    fn dequant_mq3_lloyd(data: &[u8], n_weights: usize, signs1: &[f32], signs2: &[f32]) -> Vec<f32> {
+    fn dequant_mq3_lloyd(
+        data: &[u8],
+        n_weights: usize,
+        signs1: &[f32],
+        signs2: &[f32],
+    ) -> Vec<f32> {
         let group_size = 256;
         let block_bytes = 112;
         let n_blocks = (n_weights + group_size - 1) / group_size;
@@ -7684,33 +8782,54 @@ mod hfq_block_diag {
             let blk = &data[b * block_bytes..(b + 1) * block_bytes];
             let mut cb = [0.0f32; 8];
             for k in 0..8 {
-                cb[k] = f16_to_f32(u16::from_le_bytes([blk[2*k], blk[2*k+1]]));
+                cb[k] = f16_to_f32(u16::from_le_bytes([blk[2 * k], blk[2 * k + 1]]));
             }
             let mut group = [0.0f32; 256];
             for chunk in 0..32 {
                 let bo = 16 + chunk * 3;
-                let b0 = blk[bo]; let b1 = blk[bo+1]; let b2 = blk[bo+2];
+                let b0 = blk[bo];
+                let b1 = blk[bo + 1];
+                let b2 = blk[bo + 2];
                 let q = [
-                    b0 & 7, (b0 >> 3) & 7, ((b0 >> 6) & 3) | ((b1 & 1) << 2),
-                    (b1 >> 1) & 7, (b1 >> 4) & 7, ((b1 >> 7) & 1) | ((b2 & 3) << 1),
-                    (b2 >> 2) & 7, (b2 >> 5) & 7,
+                    b0 & 7,
+                    (b0 >> 3) & 7,
+                    ((b0 >> 6) & 3) | ((b1 & 1) << 2),
+                    (b1 >> 1) & 7,
+                    (b1 >> 4) & 7,
+                    ((b1 >> 7) & 1) | ((b2 & 3) << 1),
+                    (b2 >> 2) & 7,
+                    (b2 >> 5) & 7,
                 ];
-                for j in 0..8 { group[chunk * 8 + j] = cb[q[j] as usize]; }
+                for j in 0..8 {
+                    group[chunk * 8 + j] = cb[q[j] as usize];
+                }
             }
             cpu_inv_fwht_local(&mut group, signs1, signs2);
             let actual = (n_weights - b * 256).min(256);
-            for j in 0..actual { out[b * 256 + j] = group[j]; }
+            for j in 0..actual {
+                out[b * 256 + j] = group[j];
+            }
         }
         out
     }
 
     fn qt_name(qt: u8) -> &'static str {
         match qt {
-            1 => "F16", 2 => "F32", 3 => "Q8F16", 5 => "Q8HFQ",
-            6 => "HFQ4G256", 7 => "HFQ4G128", 13 => "MQ4G256",
-            14 => "MQ8G256", 15 => "MQ6G256", 17 => "MQ3G256",
-            18 => "MQ2G256", 19 => "MQ2G256Lloyd", 20 => "MQ3G256Lloyd",
-            21 => "HFP4G32", 24 => "MFP4G32",
+            1 => "F16",
+            2 => "F32",
+            3 => "Q8F16",
+            5 => "Q8HFQ",
+            6 => "HFQ4G256",
+            7 => "HFQ4G128",
+            13 => "MQ4G256",
+            14 => "MQ8G256",
+            15 => "MQ6G256",
+            17 => "MQ3G256",
+            18 => "MQ2G256",
+            19 => "MQ2G256Lloyd",
+            20 => "MQ3G256Lloyd",
+            21 => "HFP4G32",
+            24 => "MFP4G32",
             _ => "?",
         }
     }
@@ -7730,31 +8849,43 @@ mod hfq_block_diag {
         // Take 8 different routed-expert tensors (w1, w2, w3 from a few
         // layers/experts) and one attention tensor + one shared tensor.
         let sample_names = [
-            "layers.5.ffn.experts.0.w1.weight",     // gate (mid layer)
-            "layers.5.ffn.experts.0.w2.weight",     // down
-            "layers.5.ffn.experts.0.w3.weight",     // up
-            "layers.20.ffn.experts.50.w1.weight",   // gate (later layer)
+            "layers.5.ffn.experts.0.w1.weight",   // gate (mid layer)
+            "layers.5.ffn.experts.0.w2.weight",   // down
+            "layers.5.ffn.experts.0.w3.weight",   // up
+            "layers.20.ffn.experts.50.w1.weight", // gate (later layer)
             "layers.20.ffn.experts.50.w2.weight",
-            "layers.40.ffn.experts.100.w2.weight",  // down (deep layer)
+            "layers.40.ffn.experts.100.w2.weight", // down (deep layer)
             "layers.5.ffn.shared_experts.w2.weight", // shared down
-            "layers.5.attn.wo_b.weight",             // attention output
+            "layers.5.attn.wo_b.weight",           // attention output
         ];
         let signs1 = gen_fwht_signs(42, 256);
         let signs2 = gen_fwht_signs(1042, 256);
 
         eprintln!("\n=== Real DeepSeek V4 weight distribution stats (4096 weights per tensor) ===");
-        eprintln!("{:55} {:>10} {:>10} {:>10} {:>10} {:>10}",
-            "tensor", "qt", "mean", "stddev", "p99/sd", "kurtosis");
+        eprintln!(
+            "{:55} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "tensor", "qt", "mean", "stddev", "p99/sd", "kurtosis"
+        );
         for sname in sample_names {
             let t_idx = tensors.iter().position(|t| t.name == sname);
-            let t = match t_idx { Some(i) => &tensors[i], None => continue };
+            let t = match t_idx {
+                Some(i) => &tensors[i],
+                None => continue,
+            };
             // Sample first 16 blocks = 4096 weights. Skip unsupported qts.
             let block_bytes = match t.quant_type {
-                19 => 72, 20 => 112, 3 => 34,
-                _ => { eprintln!("  {:55} {:>2} (skip qt)", sname, t.quant_type); continue; }
+                19 => 72,
+                20 => 112,
+                3 => 34,
+                _ => {
+                    eprintln!("  {:55} {:>2} (skip qt)", sname, t.quant_type);
+                    continue;
+                }
             };
             let n_blocks = (t.data_size / block_bytes).min(16);
-            if n_blocks == 0 { continue; }
+            if n_blocks == 0 {
+                continue;
+            }
             let n_w = n_blocks * 256;
             let recon: Vec<f32> = if t.quant_type == 19 {
                 let raw = &mmap[t.data_offset..t.data_offset + n_blocks * 72];
@@ -7763,25 +8894,38 @@ mod hfq_block_diag {
                 let raw = &mmap[t.data_offset..t.data_offset + n_blocks * 112];
                 dequant_mq3_lloyd(raw, n_w, &signs1, &signs2)
             } else {
-                eprintln!("  {:55} {:>2} (unsupported qt for dequant, skipping)",
-                    sname, t.quant_type);
+                eprintln!(
+                    "  {:55} {:>2} (unsupported qt for dequant, skipping)",
+                    sname, t.quant_type
+                );
                 continue;
             };
             // Compute stats.
             let n = recon.len() as f64;
             let mean = recon.iter().map(|&x| x as f64).sum::<f64>() / n;
-            let var = recon.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>() / n;
+            let var = recon
+                .iter()
+                .map(|&x| (x as f64 - mean).powi(2))
+                .sum::<f64>()
+                / n;
             let stddev = var.sqrt();
             // Kurtosis (Pearson) — measures heavy-tailedness; Gaussian = 3.
-            let mu4 = recon.iter().map(|&x| (x as f64 - mean).powi(4)).sum::<f64>() / n;
+            let mu4 = recon
+                .iter()
+                .map(|&x| (x as f64 - mean).powi(4))
+                .sum::<f64>()
+                / n;
             let kurt = mu4 / var.powi(2);
             // p99/sd — ratio of 99th percentile abs value to sd.
             let mut absvals: Vec<f64> = recon.iter().map(|&x| (x as f64 - mean).abs()).collect();
-            absvals.sort_by(|a: &f64, b: &f64| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            absvals
+                .sort_by(|a: &f64, b: &f64| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let p99 = absvals[(absvals.len() * 99 / 100).min(absvals.len() - 1)];
             let p99_over_sd = p99 / stddev;
-            eprintln!("{:55} {:>2} {:>10.4e} {:>10.4e} {:>10.3} {:>10.3}",
-                sname, t.quant_type, mean, stddev, p99_over_sd, kurt);
+            eprintln!(
+                "{:55} {:>2} {:>10.4e} {:>10.4e} {:>10.3} {:>10.3}",
+                sname, t.quant_type, mean, stddev, p99_over_sd, kurt
+            );
         }
         // Reference values from synthetic distributions:
         eprintln!("\nReference (synthetic):");
@@ -7807,16 +8951,29 @@ mod hfq_block_diag {
         for t in &tensors {
             let fam = classify(&t.name);
             let e = counts.entry((fam, t.quant_type)).or_default();
-            e.0 += 1; e.1 += t.data_size as u64;
+            e.0 += 1;
+            e.1 += t.data_size as u64;
             total_bytes += t.data_size as u64;
         }
-        eprintln!("{:30} {:>14} {:>8} {:>14}", "family", "qt", "count", "bytes");
+        eprintln!(
+            "{:30} {:>14} {:>8} {:>14}",
+            "family", "qt", "count", "bytes"
+        );
         for ((fam, qt), (cnt, bytes)) in &counts {
-            eprintln!("{:30} {:>2} {:12} {:>8} {:>14}",
-                fam, qt, qt_name(*qt), cnt, bytes);
+            eprintln!(
+                "{:30} {:>2} {:12} {:>8} {:>14}",
+                fam,
+                qt,
+                qt_name(*qt),
+                cnt,
+                bytes
+            );
         }
-        eprintln!("\ntotal data bytes: {} ({:.2} GiB)",
-            total_bytes, total_bytes as f64 / (1024.0_f64.powi(3)));
+        eprintln!(
+            "\ntotal data bytes: {} ({:.2} GiB)",
+            total_bytes,
+            total_bytes as f64 / (1024.0_f64.powi(3))
+        );
     }
 
     #[test]
@@ -7831,7 +8988,8 @@ mod hfq_block_diag {
 
         // Bucket by (family, qt) → list of (mean_range, mean_var, mean_entropy, n_blocks).
         use std::collections::BTreeMap;
-        let mut buckets: BTreeMap<(&'static str, u8), Vec<(f32, f32, f32, usize)>> = BTreeMap::new();
+        let mut buckets: BTreeMap<(&'static str, u8), Vec<(f32, f32, f32, usize)>> =
+            BTreeMap::new();
 
         // Sample at most this many blocks per tensor; routed-expert tensors are
         // huge (~1 MB each in the layer's batched blob form, 256 experts × 43
@@ -7839,11 +8997,15 @@ mod hfq_block_diag {
         const MAX_BLOCKS_PER_TENSOR: usize = 64;
 
         for t in &tensors {
-            if t.quant_type != 19 && t.quant_type != 20 { continue; }
+            if t.quant_type != 19 && t.quant_type != 20 {
+                continue;
+            }
             let block_bytes = if t.quant_type == 19 { 72 } else { 112 };
             let raw = &mmap[t.data_offset..t.data_offset + t.data_size];
             let n_blocks = t.data_size / block_bytes;
-            if n_blocks == 0 { continue; }
+            if n_blocks == 0 {
+                continue;
+            }
             let stride = (n_blocks / MAX_BLOCKS_PER_TENSOR.min(n_blocks)).max(1);
             let mut sum_range = 0.0f64;
             let mut sum_var = 0.0f64;
@@ -7865,7 +9027,9 @@ mod hfq_block_diag {
                 }
                 bi += stride;
             }
-            if n_sampled == 0 { continue; }
+            if n_sampled == 0 {
+                continue;
+            }
             let fam = classify(&t.name);
             buckets.entry((fam, t.quant_type)).or_default().push((
                 (sum_range / n_sampled as f64) as f32,
@@ -7876,14 +9040,22 @@ mod hfq_block_diag {
         }
 
         eprintln!("\n=== Per-family block stats (sampled {MAX_BLOCKS_PER_TENSOR}/tensor) ===");
-        eprintln!("{:30} {:3} {:>6} {:>10} {:>10} {:>10}", "family", "qt", "tensors", "mean_range", "mean_var", "mean_entropy");
+        eprintln!(
+            "{:30} {:3} {:>6} {:>10} {:>10} {:>10}",
+            "family", "qt", "tensors", "mean_range", "mean_var", "mean_entropy"
+        );
         for ((fam, qt), entries) in &buckets {
             let n_tensors = entries.len();
-            let mean_range = entries.iter().map(|(r, _, _, _)| *r as f64).sum::<f64>() / n_tensors as f64;
-            let mean_var = entries.iter().map(|(_, v, _, _)| *v as f64).sum::<f64>() / n_tensors as f64;
-            let mean_h = entries.iter().map(|(_, _, h, _)| *h as f64).sum::<f64>() / n_tensors as f64;
-            eprintln!("{:30} {:3} {:>6} {:>10.4} {:>10.4} {:>10.4}",
-                fam, qt, n_tensors, mean_range, mean_var, mean_h);
+            let mean_range =
+                entries.iter().map(|(r, _, _, _)| *r as f64).sum::<f64>() / n_tensors as f64;
+            let mean_var =
+                entries.iter().map(|(_, v, _, _)| *v as f64).sum::<f64>() / n_tensors as f64;
+            let mean_h =
+                entries.iter().map(|(_, _, h, _)| *h as f64).sum::<f64>() / n_tensors as f64;
+            eprintln!(
+                "{:30} {:3} {:>6} {:>10.4} {:>10.4} {:>10.4}",
+                fam, qt, n_tensors, mean_range, mean_var, mean_h
+            );
         }
     }
 }
@@ -7897,14 +9069,32 @@ mod tests {
         // OCP MX FP4 (E2M1) spec values for the 8 magnitude codes.
         // Sign bit (0x8) flips sign of the magnitude.
         let expected: &[(u8, f32)] = &[
-            (0x0,  0.0), (0x1,  0.5), (0x2,  1.0), (0x3,  1.5),
-            (0x4,  2.0), (0x5,  3.0), (0x6,  4.0), (0x7,  6.0),
-            (0x8, -0.0), (0x9, -0.5), (0xA, -1.0), (0xB, -1.5),
-            (0xC, -2.0), (0xD, -3.0), (0xE, -4.0), (0xF, -6.0),
+            (0x0, 0.0),
+            (0x1, 0.5),
+            (0x2, 1.0),
+            (0x3, 1.5),
+            (0x4, 2.0),
+            (0x5, 3.0),
+            (0x6, 4.0),
+            (0x7, 6.0),
+            (0x8, -0.0),
+            (0x9, -0.5),
+            (0xA, -1.0),
+            (0xB, -1.5),
+            (0xC, -2.0),
+            (0xD, -3.0),
+            (0xE, -4.0),
+            (0xF, -6.0),
         ];
         for &(nib, want) in expected {
-            assert_eq!(e2m1_to_f32(nib), want,
-                "e2m1_to_f32(0x{:x}) = {} want {}", nib, e2m1_to_f32(nib), want);
+            assert_eq!(
+                e2m1_to_f32(nib),
+                want,
+                "e2m1_to_f32(0x{:x}) = {} want {}",
+                nib,
+                e2m1_to_f32(nib),
+                want
+            );
         }
     }
 
@@ -7913,8 +9103,7 @@ mod tests {
         // Storage: 1 row × 1 col-byte. Byte = 0x42 → low nibble 0x2 (=1.0),
         // high nibble 0x4 (=2.0). Scale: 1 row × 1 col, UE8M0=127 (=2^0=1.0).
         // → logical row should be [1.0, 2.0] (length 2).
-        let (vals, shape) = dequantize_e2m1_ue8m0_to_f32(
-            &[0x42], &[1, 1], &[127], &[1, 1]);
+        let (vals, shape) = dequantize_e2m1_ue8m0_to_f32(&[0x42], &[1, 1], &[127], &[1, 1]);
         assert_eq!(shape, vec![1, 2]);
         assert_eq!(vals, vec![1.0, 2.0]);
     }
@@ -7923,15 +9112,20 @@ mod tests {
     fn e2m1_dequant_applies_ue8m0_scale() {
         // Byte = 0x12 → low=2 (=1.0), high=1 (=0.5). Scale byte 128 → 2^1=2.0.
         // → logical [2.0, 1.0].
-        let (vals, _) = dequantize_e2m1_ue8m0_to_f32(
-            &[0x12], &[1, 1], &[128], &[1, 1]);
+        let (vals, _) = dequantize_e2m1_ue8m0_to_f32(&[0x12], &[1, 1], &[128], &[1, 1]);
         assert_eq!(vals, vec![2.0, 1.0]);
     }
 
     #[test]
     fn parse_layer_idx_safetensors_dense() {
-        assert_eq!(parse_layer_idx("model.layers.0.self_attn.q_proj.weight"), Some(0));
-        assert_eq!(parse_layer_idx("model.layers.63.mlp.gate_proj.weight"), Some(63));
+        assert_eq!(
+            parse_layer_idx("model.layers.0.self_attn.q_proj.weight"),
+            Some(0)
+        );
+        assert_eq!(
+            parse_layer_idx("model.layers.63.mlp.gate_proj.weight"),
+            Some(63)
+        );
     }
 
     #[test]
@@ -7956,13 +9150,22 @@ mod tests {
 
     #[test]
     fn kmap_norms_are_f16() {
-        assert_eq!(kmap_resolve("model.layers.0.input_layernorm.weight", 64, false), QuantLevel::F16);
-        assert_eq!(kmap_resolve("model.layers.30.post_attention_layernorm.weight", 64, false), QuantLevel::F16);
+        assert_eq!(
+            kmap_resolve("model.layers.0.input_layernorm.weight", 64, false),
+            QuantLevel::F16
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.30.post_attention_layernorm.weight", 64, false),
+            QuantLevel::F16
+        );
     }
 
     #[test]
     fn kmap_embeds_are_q8() {
-        assert_eq!(kmap_resolve("model.embed_tokens.weight", 64, false), QuantLevel::Q8);
+        assert_eq!(
+            kmap_resolve("model.embed_tokens.weight", 64, false),
+            QuantLevel::Q8
+        );
         assert_eq!(kmap_resolve("lm_head.weight", 64, false), QuantLevel::Q8);
         assert_eq!(kmap_resolve("output.weight", 64, false), QuantLevel::Q8);
     }
@@ -7974,7 +9177,11 @@ mod tests {
             QuantLevel::Q8
         );
         assert_eq!(
-            kmap_resolve("model.language_model.layers.5.mlp.shared_expert_gate.weight", 64, true),
+            kmap_resolve(
+                "model.language_model.layers.5.mlp.shared_expert_gate.weight",
+                64,
+                true
+            ),
             QuantLevel::Q8
         );
     }
@@ -7991,11 +9198,19 @@ mod tests {
     #[test]
     fn kmap_moe_expert_ffn_promote6() {
         assert_eq!(
-            kmap_resolve("model.language_model.layers.30.mlp.experts.5.gate_up_proj.weight", 64, true),
+            kmap_resolve(
+                "model.language_model.layers.30.mlp.experts.5.gate_up_proj.weight",
+                64,
+                true
+            ),
             QuantLevel::Promote6
         );
         assert_eq!(
-            kmap_resolve("model.language_model.layers.30.mlp.experts.5.down_proj.weight", 64, true),
+            kmap_resolve(
+                "model.language_model.layers.30.mlp.experts.5.down_proj.weight",
+                64,
+                true
+            ),
             QuantLevel::Promote6
         );
     }
@@ -8003,60 +9218,149 @@ mod tests {
     #[test]
     fn kmap_edge_layers_dense_ffn_only() {
         // Dense: FFN in edge layers — promoted
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.1.mlp.down_proj.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.62.mlp.up_proj.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.63.mlp.down_proj.weight", 64, false), QuantLevel::Promote6);
+        assert_eq!(
+            kmap_resolve("model.layers.0.mlp.gate_proj.weight", 64, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.1.mlp.down_proj.weight", 64, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.62.mlp.up_proj.weight", 64, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.63.mlp.down_proj.weight", 64, false),
+            QuantLevel::Promote6
+        );
         // Dense: attn in edge layers — NOT promoted
-        assert_eq!(kmap_resolve("model.layers.0.self_attn.q_proj.weight", 64, false), QuantLevel::Base);
-        assert_eq!(kmap_resolve("model.layers.63.self_attn.v_proj.weight", 64, false), QuantLevel::Base);
-        assert_eq!(kmap_resolve("model.layers.0.linear_attn.in_proj_qkv.weight", 64, false), QuantLevel::Base);
+        assert_eq!(
+            kmap_resolve("model.layers.0.self_attn.q_proj.weight", 64, false),
+            QuantLevel::Base
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.63.self_attn.v_proj.weight", 64, false),
+            QuantLevel::Base
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.0.linear_attn.in_proj_qkv.weight", 64, false),
+            QuantLevel::Base
+        );
     }
 
     #[test]
     fn kmap_edge_layers_moe_attn_and_ffn() {
         // MoE: both attn and FFN in edge layers — promoted
-        assert_eq!(kmap_resolve("model.language_model.layers.0.self_attn.q_proj.weight", 64, true), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.language_model.layers.0.mlp.gate_proj.weight", 64, true), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.language_model.layers.0.linear_attn.in_proj_qkv.weight", 64, true), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.language_model.layers.63.self_attn.v_proj.weight", 64, true), QuantLevel::Promote6);
+        assert_eq!(
+            kmap_resolve(
+                "model.language_model.layers.0.self_attn.q_proj.weight",
+                64,
+                true
+            ),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve(
+                "model.language_model.layers.0.mlp.gate_proj.weight",
+                64,
+                true
+            ),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve(
+                "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+                64,
+                true
+            ),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve(
+                "model.language_model.layers.63.self_attn.v_proj.weight",
+                64,
+                true
+            ),
+            QuantLevel::Promote6
+        );
     }
 
     #[test]
     fn kmap_middle_layers_base() {
-        assert_eq!(kmap_resolve("model.layers.2.self_attn.q_proj.weight", 64, false), QuantLevel::Base);
-        assert_eq!(kmap_resolve("model.layers.30.mlp.gate_proj.weight", 64, false), QuantLevel::Base);
-        assert_eq!(kmap_resolve("model.layers.61.mlp.down_proj.weight", 64, false), QuantLevel::Base);
+        assert_eq!(
+            kmap_resolve("model.layers.2.self_attn.q_proj.weight", 64, false),
+            QuantLevel::Base
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.30.mlp.gate_proj.weight", 64, false),
+            QuantLevel::Base
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.61.mlp.down_proj.weight", 64, false),
+            QuantLevel::Base
+        );
     }
 
     #[test]
     fn kmap_edge_layers_small_model_24_layers() {
         // 24 layers: edge = 0,1 and 22,23
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.1.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.2.mlp.gate_proj.weight", 24, false), QuantLevel::Base);
-        assert_eq!(kmap_resolve("model.layers.22.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.23.mlp.gate_proj.weight", 24, false), QuantLevel::Promote6);
+        assert_eq!(
+            kmap_resolve("model.layers.0.mlp.gate_proj.weight", 24, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.1.mlp.gate_proj.weight", 24, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.2.mlp.gate_proj.weight", 24, false),
+            QuantLevel::Base
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.22.mlp.gate_proj.weight", 24, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.23.mlp.gate_proj.weight", 24, false),
+            QuantLevel::Promote6
+        );
     }
 
     #[test]
     fn kmap_n_layers_zero_disables_edge() {
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 0, false), QuantLevel::Base);
+        assert_eq!(
+            kmap_resolve("model.layers.0.mlp.gate_proj.weight", 0, false),
+            QuantLevel::Base
+        );
     }
 
     #[test]
     fn kmap_edge_layers_tiny_model_3_layers() {
         // 3 layers: first-2 = {0,1}, last-2 = {1,2}. All layers promoted.
-        assert_eq!(kmap_resolve("model.layers.0.mlp.gate_proj.weight", 3, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.1.mlp.gate_proj.weight", 3, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("model.layers.2.mlp.gate_proj.weight", 3, false), QuantLevel::Promote6);
+        assert_eq!(
+            kmap_resolve("model.layers.0.mlp.gate_proj.weight", 3, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.1.mlp.gate_proj.weight", 3, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("model.layers.2.mlp.gate_proj.weight", 3, false),
+            QuantLevel::Promote6
+        );
     }
 
     #[test]
     fn kmap_expert_not_promoted_on_dense() {
         // "mlp.experts." in name but is_moe=false — should NOT trigger rule 4
         assert_eq!(
-            kmap_resolve("model.layers.30.mlp.experts.5.gate_up_proj.weight", 64, false),
+            kmap_resolve(
+                "model.layers.30.mlp.experts.5.gate_up_proj.weight",
+                64,
+                false
+            ),
             QuantLevel::Base
         );
     }
@@ -8064,14 +9368,29 @@ mod tests {
     #[test]
     fn kmap_gguf_names() {
         // GGUF edge-layer FFN (dense) — promoted
-        assert_eq!(kmap_resolve("blk.0.ffn_gate.weight", 64, false), QuantLevel::Promote6);
-        assert_eq!(kmap_resolve("blk.63.ffn_gate.weight", 64, false), QuantLevel::Promote6);
+        assert_eq!(
+            kmap_resolve("blk.0.ffn_gate.weight", 64, false),
+            QuantLevel::Promote6
+        );
+        assert_eq!(
+            kmap_resolve("blk.63.ffn_gate.weight", 64, false),
+            QuantLevel::Promote6
+        );
         // GGUF edge-layer attn (dense) — NOT promoted
-        assert_eq!(kmap_resolve("blk.0.attn_q.weight", 64, false), QuantLevel::Base);
+        assert_eq!(
+            kmap_resolve("blk.0.attn_q.weight", 64, false),
+            QuantLevel::Base
+        );
         // GGUF edge-layer attn (MoE) — promoted
-        assert_eq!(kmap_resolve("blk.0.attn_q.weight", 64, true), QuantLevel::Promote6);
+        assert_eq!(
+            kmap_resolve("blk.0.attn_q.weight", 64, true),
+            QuantLevel::Promote6
+        );
         // GGUF middle-layer — base
-        assert_eq!(kmap_resolve("blk.30.ffn_gate.weight", 64, false), QuantLevel::Base);
+        assert_eq!(
+            kmap_resolve("blk.30.ffn_gate.weight", 64, false),
+            QuantLevel::Base
+        );
     }
 
     // ── Alternating mode tests ───────────────────────────────────────────
@@ -8087,7 +9406,7 @@ mod tests {
     #[test]
     fn positional_promote_stride3() {
         // Middle layers: every 3rd starting from idx 2
-        assert!(is_positional_promote(2, 40, 3));  // edge
+        assert!(is_positional_promote(2, 40, 3)); // edge
         assert!(!is_positional_promote(3, 40, 3));
         assert!(!is_positional_promote(4, 40, 3));
         assert!(is_positional_promote(5, 40, 3));
@@ -8100,15 +9419,30 @@ mod tests {
     fn kmap_alternating_moe_experts() {
         // MoE experts: promoted in positional layers, base in others
         assert_eq!(
-            kmap_resolve_mode("model.language_model.layers.0.mlp.experts.5.gate_up_proj.weight", 40, true, 1),
+            kmap_resolve_mode(
+                "model.language_model.layers.0.mlp.experts.5.gate_up_proj.weight",
+                40,
+                true,
+                1
+            ),
             QuantLevel::Promote6 // edge layer
         );
         assert_eq!(
-            kmap_resolve_mode("model.language_model.layers.5.mlp.experts.5.gate_up_proj.weight", 40, true, 1),
+            kmap_resolve_mode(
+                "model.language_model.layers.5.mlp.experts.5.gate_up_proj.weight",
+                40,
+                true,
+                1
+            ),
             QuantLevel::Promote6 // stride hit (5-2=3, 3%3==0)
         );
         assert_eq!(
-            kmap_resolve_mode("model.language_model.layers.3.mlp.experts.5.gate_up_proj.weight", 40, true, 1),
+            kmap_resolve_mode(
+                "model.language_model.layers.3.mlp.experts.5.gate_up_proj.weight",
+                40,
+                true,
+                1
+            ),
             QuantLevel::Base // not on stride
         );
     }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -246,7 +246,14 @@ impl DType {
         // (flow through rotate_x_mq_for, which applies x/=awq_scale when a sidecar is
         // attached) — see the doc block above. Enables AWQ×Lloyd composition once the
         // quantizer emits sidecars for the Lloyd arms.
-        matches!(self, DType::MQ4G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ3G256Lloyd | DType::MQ2G256Lloyd)
+        matches!(
+            self,
+            DType::MQ4G256
+                | DType::MQ3G256
+                | DType::MQ2G256
+                | DType::MQ3G256Lloyd
+                | DType::MQ2G256Lloyd
+        )
     }
 }
 
@@ -1217,6 +1224,7 @@ impl Gpu {
     /// Drop captured graph state after a live KV layout switch so the next
     /// forward captures the current K/V modes and kernarg blobs.
     pub fn invalidate_for_kv_mode_switch(&mut self) {
+        // bind_thread: skip — delegated to invalidate_graph_state().
         self.invalidate_graph_state();
     }
 

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -242,7 +242,11 @@ impl DType {
     /// quant time — this helper governs only whether the loader
     /// attaches an already-emitted sidecar.
     pub fn supports_awq_sidecar(self) -> bool {
-        matches!(self, DType::MQ4G256 | DType::MQ3G256)
+        // MQ3G256Lloyd / MQ2G256Lloyd added 2026-05-28: they are "forward-path-ready"
+        // (flow through rotate_x_mq_for, which applies x/=awq_scale when a sidecar is
+        // attached) — see the doc block above. Enables AWQ×Lloyd composition once the
+        // quantizer emits sidecars for the Lloyd arms.
+        matches!(self, DType::MQ4G256 | DType::MQ3G256 | DType::MQ2G256 | DType::MQ3G256Lloyd | DType::MQ2G256Lloyd)
     }
 }
 


### PR DESCRIPTION
## Summary
- enable AWQ calibration/scaling for MQ3, MQ2, MQ2-Lloyd, MQ3-Lloyd, and MQ6 quantizer arms
- clamp AWQ scales into an F16-safe range before writing scale metadata
- adjust dispatch dtype handling for the new AWQ-backed sub-4-bit paths

## Validation
- `git diff --check origin/master..HEAD`
- `cargo check -p hipfire-quantize --bins` (passes with existing warnings)
- `cargo check -p rdna-compute` (passes with existing warnings)