### PR TITLE
feat(runtime): add HIP wait scheduling knob

### DIFF
--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -151,6 +151,7 @@ pub struct HipRuntime {
     // Device management
     fn_get_device_count: unsafe extern "C" fn(*mut c_int) -> u32,
     fn_set_device: unsafe extern "C" fn(c_int) -> u32,
+    fn_set_device_flags: unsafe extern "C" fn(c_uint) -> u32,
     fn_get_device: unsafe extern "C" fn(*mut c_int) -> u32,
 
     // Multi-device / peer access
@@ -307,6 +308,11 @@ impl HipRuntime {
                     unsafe extern "C" fn(*mut c_int) -> u32
                 ),
                 fn_set_device: load_fn!(lib, "hipSetDevice", unsafe extern "C" fn(c_int) -> u32),
+                fn_set_device_flags: load_fn!(
+                    lib,
+                    "hipSetDeviceFlags",
+                    unsafe extern "C" fn(c_uint) -> u32
+                ),
                 fn_get_device: load_fn!(
                     lib,
                     "hipGetDevice",
@@ -573,6 +579,16 @@ impl HipRuntime {
     pub fn set_device(&self, id: i32) -> HipResult<()> {
         let code = unsafe { (self.fn_set_device)(id) };
         self.check(code, "hipSetDevice")
+    }
+
+    /// Set HIP device scheduling flags before the device context is created.
+    ///
+    /// HIP uses these flags to choose how host sync calls wait for GPU work:
+    /// spin is lowest-latency but consumes a CPU core; yield/blocking are more
+    /// cooperative with the OS and reduce CPU pressure during long prefill.
+    pub fn set_device_flags(&self, flags: u32) -> HipResult<()> {
+        let code = unsafe { (self.fn_set_device_flags)(flags as c_uint) };
+        self.check(code, "hipSetDeviceFlags")
     }
 
     pub fn current_device(&self) -> HipResult<i32> {

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -433,6 +433,26 @@ impl Gpu {
                 &format!("device id {id} out of range (count={count})"),
             ));
         }
+        if let Ok(mode) = std::env::var("HIPFIRE_HIP_WAIT") {
+            let mode_lc = mode.to_ascii_lowercase();
+            let flags = match mode_lc.as_str() {
+                "auto" => Some(0x00),
+                "spin" => Some(0x01),
+                "yield" => Some(0x02),
+                "block" | "blocking" | "blocking_sync" => Some(0x04),
+                "" => None,
+                other => {
+                    eprintln!(
+                        "WARNING: unknown HIPFIRE_HIP_WAIT={other:?}; expected auto|spin|yield|blocking"
+                    );
+                    None
+                }
+            };
+            if let Some(flags) = flags {
+                hip.set_device_flags(flags)?;
+                eprintln!("[hipfire] HIP wait mode: {mode_lc}");
+            }
+        }
         // set_device must precede try_init_rocblas — rocBLAS captures the
         // currently-bound device into its handle.
         hip.set_device(id)?;


### PR DESCRIPTION
## Summary
- expose HIP device scheduling flags through the bridge layer
- add a dispatch-side environment knob for HIP wait scheduling behavior

## Validation
- `git diff --check origin/master..HEAD`
- `cargo check -p hip-bridge` (passes with existing warning)
- `cargo check -p rdna-compute` (passes with existing warnings)