### PR TITLE
feat(dflash): add MQ6 draft conversion and dispatch

### DIFF
--- a/crates/hipfire-quantize/src/bin/dflash_convert.rs
+++ b/crates/hipfire-quantize/src/bin/dflash_convert.rs
@@ -65,8 +65,8 @@ impl SafetensorsFile {
         let header_len = u64::from_le_bytes(mmap[0..8].try_into().unwrap()) as usize;
         let header_json = std::str::from_utf8(&mmap[8..8 + header_len])
             .expect("safetensors header is not valid utf8");
-        let raw: serde_json::Value = serde_json::from_str(header_json)
-            .expect("safetensors header JSON parse failed");
+        let raw: serde_json::Value =
+            serde_json::from_str(header_json).expect("safetensors header JSON parse failed");
         let mut tensors = HashMap::new();
         if let serde_json::Value::Object(map) = raw {
             for (k, v) in map {
@@ -195,7 +195,9 @@ fn f32_slice_to_f32_bytes(f32_data: &[f32]) -> Vec<u8> {
 /// fwht_forward_256 in rdna_compute: signs1 → butterfly → scale → signs2.
 fn cpu_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
     assert!(x.len() == 256);
-    for i in 0..256 { x[i] *= signs1[i]; }
+    for i in 0..256 {
+        x[i] *= signs1[i];
+    }
     let mut stride = 1;
     while stride < 256 {
         let mut i = 0;
@@ -211,17 +213,25 @@ fn cpu_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
         stride <<= 1;
     }
     let scale = 0.0625; // 1/sqrt(256) = 1/16
-    for i in 0..256 { x[i] *= scale * signs2[i]; }
+    for i in 0..256 {
+        x[i] *= scale * signs2[i];
+    }
 }
 
 /// Generate FWHT sign table matching the engine's gen_fwht_signs.
 /// Standard MQ4 seeds are 42 (signs1) and 1042 (signs2).
 fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     let mut state = seed;
-    (0..n).map(|_| {
-        state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
-        if (state >> 16) & 1 == 1 { 1.0f32 } else { -1.0f32 }
-    }).collect()
+    (0..n)
+        .map(|_| {
+            state = state.wrapping_mul(1103515245).wrapping_add(12345) & 0x7fffffff;
+            if (state >> 16) & 1 == 1 {
+                1.0f32
+            } else {
+                -1.0f32
+            }
+        })
+        .collect()
 }
 
 /// MagnumQuant MQ3-G256: FWHT-rotated 3-bit quantization.
@@ -457,9 +467,8 @@ fn resolve_model_path(input: &str) -> String {
             let org = parts[0];
             let name = parts[1];
             let home = std::env::var("HOME").unwrap_or_default();
-            let cache_root = format!(
-                "{home}/.cache/huggingface/hub/models--{org}--{name}/snapshots"
-            );
+            let cache_root =
+                format!("{home}/.cache/huggingface/hub/models--{org}--{name}/snapshots");
             if let Ok(entries) = std::fs::read_dir(&cache_root) {
                 for e in entries.flatten() {
                     let p = e.path();
@@ -489,11 +498,7 @@ fn is_norm_tensor(name: &str) -> bool {
 
 fn parse_int_array(json: &serde_json::Value) -> Vec<i64> {
     json.as_array()
-        .map(|a| {
-            a.iter()
-                .filter_map(|v| v.as_i64())
-                .collect()
-        })
+        .map(|a| a.iter().filter_map(|v| v.as_i64()).collect())
         .unwrap_or_default()
 }
 
@@ -648,13 +653,31 @@ fn main() {
     );
 
     // Metadata JSON for the HFQ file.
-    let draft_dtype = if keep_f32 { "f32" } else if use_mq3 { "mq3" } else if use_mq4 { "mq4" } else if use_mq6 { "mq6" } else { "f16" };
+    let draft_dtype = if keep_f32 {
+        "f32"
+    } else if use_mq3 {
+        "mq3"
+    } else if use_mq4 {
+        "mq4"
+    } else if use_mq6 {
+        "mq6"
+    } else {
+        "f16"
+    };
     // FWHT sign tables for MQ rotation. Seeds 42/1042 match the engine's
     // `rdna_compute::Gpu::ensure_mq_signs()` so quantized weights here can
     // be dequantized/used correctly on GPU at inference.
     let needs_fwht = use_mq3 || use_mq4 || use_mq6;
-    let signs1: Vec<f32> = if needs_fwht { gen_fwht_signs(42, 256) } else { Vec::new() };
-    let signs2: Vec<f32> = if needs_fwht { gen_fwht_signs(1042, 256) } else { Vec::new() };
+    let signs1: Vec<f32> = if needs_fwht {
+        gen_fwht_signs(42, 256)
+    } else {
+        Vec::new()
+    };
+    let signs2: Vec<f32> = if needs_fwht {
+        gen_fwht_signs(1042, 256)
+    } else {
+        Vec::new()
+    };
     let metadata = serde_json::json!({
         "architecture": "dflash",
         "config": config,
@@ -684,7 +707,10 @@ fn main() {
         .inspect(|p| eprintln!("  loading: {}", p.display()))
         .map(|p| SafetensorsFile::open(p).expect("safetensors open failed"))
         .collect();
-    assert!(!st_files.is_empty(), "no .safetensors files found in input dir");
+    assert!(
+        !st_files.is_empty(),
+        "no .safetensors files found in input dir"
+    );
 
     let mut name_to_file: Vec<(String, usize)> = Vec::new();
     for (fi, st) in st_files.iter().enumerate() {
@@ -700,7 +726,9 @@ fn main() {
     let mut total_bytes_out = 0usize;
 
     for (name, fi) in &name_to_file {
-        let (meta, raw) = st_files[*fi].tensor_data(name).expect("tensor lookup failed");
+        let (meta, raw) = st_files[*fi]
+            .tensor_data(name)
+            .expect("tensor lookup failed");
         let n_elements: usize = meta.shape.iter().product();
         total_params += n_elements as u64;
 
@@ -747,7 +775,10 @@ fn main() {
         total_params as f64 / 1e9,
         hfq_tensors.len()
     );
-    eprintln!("  total out  : {:.2} MiB", total_bytes_out as f64 / (1024.0 * 1024.0));
+    eprintln!(
+        "  total out  : {:.2} MiB",
+        total_bytes_out as f64 / (1024.0 * 1024.0)
+    );
 
     if let Some(parent) = output_path.parent() {
         if !parent.as_os_str().is_empty() {

--- a/crates/hipfire-quantize/src/bin/dflash_convert.rs
+++ b/crates/hipfire-quantize/src/bin/dflash_convert.rs
@@ -189,7 +189,7 @@ fn f32_slice_to_f32_bytes(f32_data: &[f32]) -> Vec<u8> {
     out
 }
 
-// ─── FWHT + MQ4 quantization ──────────────────────────────────────────────
+// ─── FWHT + MQ quantization ───────────────────────────────────────────────
 
 /// CPU-side FWHT on a 256-element group. Matches the GPU-side
 /// fwht_forward_256 in rdna_compute: signs1 → butterfly → scale → signs2.
@@ -311,6 +311,50 @@ fn quantize_mq4g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8>
     output
 }
 
+/// MagnumQuant MQ6-G256: FWHT-rotated 6-bit quantization.
+/// 200 bytes per 256 weights (0.781 B/w). Same binary layout as HFQ6-G256.
+fn quantize_mq6g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+    let group_size = 256;
+    let block_bytes = 200;
+    let n = f32_data.len();
+    let n_blocks = (n + group_size - 1) / group_size;
+    let mut output = vec![0u8; n_blocks * block_bytes];
+
+    for b in 0..n_blocks {
+        let start = b * group_size;
+        let end = (start + group_size).min(n);
+
+        let mut group = [0.0f32; 256];
+        let actual_len = end - start;
+        group[..actual_len].copy_from_slice(&f32_data[start..end]);
+        cpu_fwht_256(&mut group, signs1, signs2);
+
+        let min_val = group.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max_val = group.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let range = max_val - min_val;
+        let scale = if range > 0.0 { range / 63.0 } else { 1.0 };
+        let inv_scale = if range > 0.0 { 1.0 / scale } else { 0.0 };
+
+        let out_off = b * block_bytes;
+        output[out_off..out_off + 4].copy_from_slice(&scale.to_le_bytes());
+        output[out_off + 4..out_off + 8].copy_from_slice(&min_val.to_le_bytes());
+
+        for i in (0..256).step_by(4) {
+            let q0 = (((group[i] - min_val) * inv_scale + 0.5) as u8).min(63);
+            let q1 = (((group[i + 1] - min_val) * inv_scale + 0.5) as u8).min(63);
+            let q2 = (((group[i + 2] - min_val) * inv_scale + 0.5) as u8).min(63);
+            let q3 = (((group[i + 3] - min_val) * inv_scale + 0.5) as u8).min(63);
+
+            let byte_off = 8 + (i / 4) * 3;
+            output[out_off + byte_off] = q0 | (q1 << 6);
+            output[out_off + byte_off + 1] = (q1 >> 2) | (q2 << 4);
+            output[out_off + byte_off + 2] = (q2 >> 4) | (q3 << 2);
+        }
+    }
+
+    output
+}
+
 // ─── HFQ File Format ──────────────────────────────────────────────────────
 
 const HFQ_MAGIC: &[u8; 4] = b"HFQM";
@@ -325,6 +369,7 @@ enum QuantType {
     F16 = 1,
     F32 = 2,
     MQ4G256 = 13,
+    MQ6G256 = 15,
     MQ3G256 = 17,
 }
 
@@ -460,6 +505,7 @@ fn main() {
     let mut output_path: Option<String> = None;
     let mut keep_f32 = false;
     let mut use_mq4 = false;
+    let mut use_mq6 = false;
     let mut use_mq3 = false;
 
     let mut i = 1;
@@ -481,13 +527,17 @@ fn main() {
                 use_mq4 = true;
                 i += 1;
             }
+            "--mq6" => {
+                use_mq6 = true;
+                i += 1;
+            }
             "--mq3" => {
                 use_mq3 = true;
                 i += 1;
             }
             "-h" | "--help" => {
                 eprintln!(
-                    "Usage: dflash_convert --input <dir_or_hf_id> --output <file.hfq> [--keep-f32 | --mq4 | --mq3]"
+                    "Usage: dflash_convert --input <dir_or_hf_id> --output <file.hfq> [--keep-f32 | --mq3 | --mq4 | --mq6]"
                 );
                 std::process::exit(0);
             }
@@ -497,9 +547,9 @@ fn main() {
             }
         }
     }
-    let n_format_flags = (keep_f32 as u8) + (use_mq4 as u8) + (use_mq3 as u8);
+    let n_format_flags = (keep_f32 as u8) + (use_mq3 as u8) + (use_mq4 as u8) + (use_mq6 as u8);
     if n_format_flags > 1 {
-        eprintln!("--keep-f32, --mq4, and --mq3 are mutually exclusive");
+        eprintln!("--keep-f32, --mq3, --mq4, and --mq6 are mutually exclusive");
         std::process::exit(1);
     }
 
@@ -514,10 +564,12 @@ fn main() {
     eprintln!("  output: {}", output_path.display());
     let dtype_desc = if keep_f32 {
         "F32"
-    } else if use_mq4 {
-        "MQ4-G256 (weights), F32 (norms)"
     } else if use_mq3 {
         "MQ3-G256 (weights), F32 (norms)"
+    } else if use_mq4 {
+        "MQ4-G256 (weights), F32 (norms)"
+    } else if use_mq6 {
+        "MQ6-G256 (weights), F32 (norms)"
     } else {
         "F16 (weights), F32 (norms)"
     };
@@ -596,11 +648,11 @@ fn main() {
     );
 
     // Metadata JSON for the HFQ file.
-    let draft_dtype = if keep_f32 { "f32" } else if use_mq4 { "mq4" } else if use_mq3 { "mq3" } else { "f16" };
-    // FWHT sign tables for MQ4 rotation. Seeds 42/1042 match the engine's
+    let draft_dtype = if keep_f32 { "f32" } else if use_mq3 { "mq3" } else if use_mq4 { "mq4" } else if use_mq6 { "mq6" } else { "f16" };
+    // FWHT sign tables for MQ rotation. Seeds 42/1042 match the engine's
     // `rdna_compute::Gpu::ensure_mq_signs()` so quantized weights here can
     // be dequantized/used correctly on GPU at inference.
-    let needs_fwht = use_mq4 || use_mq3;
+    let needs_fwht = use_mq3 || use_mq4 || use_mq6;
     let signs1: Vec<f32> = if needs_fwht { gen_fwht_signs(42, 256) } else { Vec::new() };
     let signs2: Vec<f32> = if needs_fwht { gen_fwht_signs(1042, 256) } else { Vec::new() };
     let metadata = serde_json::json!({
@@ -657,9 +709,9 @@ fn main() {
         // Classification rules:
         //   norms → always F32 (small, precision-critical).
         //   other (projections) → F32 if --keep-f32,
-        //                         MQ4-G256 if --mq4 (and innermost ≥ 256 divisible),
+        //                         MQ{3,4,6}-G256 if requested (and N ≥ 256),
         //                         else F16.
-        // MQ4 divisibility: quantize_mq4g256 pads the final partial group with
+        // MQ divisibility: quantizers pad the final partial group with
         // zeros. That's safe for weights since the padded lanes are never read
         // at inference. We still require N ≥ 256 to ensure a full first group
         // (per-group scale/min carries meaning).
@@ -670,6 +722,9 @@ fn main() {
         } else if use_mq4 && n_elements >= 256 {
             let q = quantize_mq4g256(&f32_data, &signs1, &signs2);
             (QuantType::MQ4G256, 256u32, q)
+        } else if use_mq6 && n_elements >= 256 {
+            let q = quantize_mq6g256(&f32_data, &signs1, &signs2);
+            (QuantType::MQ6G256, 256u32, q)
         } else if use_mq3 && n_elements >= 256 {
             let q = quantize_mq3g256(&f32_data, &signs1, &signs2);
             (QuantType::MQ3G256, 256u32, q)

--- a/crates/hipfire-runtime/examples/dflash_spec_demo.rs
+++ b/crates/hipfire-runtime/examples/dflash_spec_demo.rs
@@ -619,7 +619,7 @@ fn main() {
         &mut gpu, &draft_cfg, draft_scratch_b, ctx_capacity, draft_weights.has_mq,
     ).expect("alloc draft scratch");
     if draft_weights.has_mq {
-        eprintln!("draft: MQ4 weights detected, FWHT rotation scratch enabled");
+        eprintln!("draft: MQ weights detected, FWHT rotation scratch enabled");
     }
 
     // ── Check vocab compatibility ─────────────────────────────────────

--- a/crates/hipfire-runtime/examples/dflash_spec_demo.rs
+++ b/crates/hipfire-runtime/examples/dflash_spec_demo.rs
@@ -57,23 +57,29 @@ fn main() {
 
 #[cfg(feature = "deltanet")]
 fn main() {
-    use hipfire_runtime::cask::CaskCtx;
-    use hipfire_runtime::dflash::{DflashConfig, DflashScratch, DflashWeights};
-    use hipfire_runtime::hfq::HfqFile;
     use hipfire_arch_qwen35::qwen35::LayerType;
     use hipfire_arch_qwen35::speculative::{
         self, DeltaNetSnapshot, HiddenStateRingBuffer, ModelSlot, ModelSlotConfig, SpecStats,
     };
+    use hipfire_runtime::cask::CaskCtx;
+    use hipfire_runtime::dflash::{DflashConfig, DflashScratch, DflashWeights};
+    use hipfire_runtime::hfq::HfqFile;
     use hipfire_runtime::tokenizer::Tokenizer;
     use hipfire_runtime::triattn::{EvictionCtx, EvictionResult, TriAttnCenters};
     use std::path::Path;
     use std::time::Instant;
 
-    enum CaskPolicy { Plain(EvictionCtx), Cask(CaskCtx) }
+    enum CaskPolicy {
+        Plain(EvictionCtx),
+        Cask(CaskCtx),
+    }
     impl CaskPolicy {
-        fn maybe_evict(&self, gpu: &mut rdna_compute::Gpu, kv: &mut hipfire_runtime::llama::KvCache, physical: usize)
-            -> hip_bridge::HipResult<Option<EvictionResult>>
-        {
+        fn maybe_evict(
+            &self,
+            gpu: &mut rdna_compute::Gpu,
+            kv: &mut hipfire_runtime::llama::KvCache,
+            physical: usize,
+        ) -> hip_bridge::HipResult<Option<EvictionResult>> {
             match self {
                 CaskPolicy::Plain(c) => c.maybe_evict(gpu, kv, physical),
                 CaskPolicy::Cask(c) => c.maybe_evict(gpu, kv, physical),
@@ -147,26 +153,26 @@ fn main() {
     // acceptance on repetition-heavy content). No kernel work; hybrid-arch
     // safe (pure linear verify, no tree state forking).
     let mut pld_enabled: bool = false;
-    let mut pld_min_extract: usize = 3;  // matcher floor; ≥3 tokens to record a match
-    let mut pld_max_extract: usize = 8;  // paper cap
-    let mut pld_ngrams: Vec<usize> = vec![5, 4, 3];  // paper defaults
-    // Goose §4.3 bypass-mode confidence gate: only USE a PLD match when
-    // it's confident enough to beat DFlash. Paper uses consensus ≥ 2
-    // (at least two n-gram lengths agree on first token) and chain length
-    // ≥ 8. 0 disables the gate (use every matcher hit — useful for
-    // diagnostics; usually a net loss on content where DFlash is strong).
+    let mut pld_min_extract: usize = 3; // matcher floor; ≥3 tokens to record a match
+    let mut pld_max_extract: usize = 8; // paper cap
+    let mut pld_ngrams: Vec<usize> = vec![5, 4, 3]; // paper defaults
+                                                    // Goose §4.3 bypass-mode confidence gate: only USE a PLD match when
+                                                    // it's confident enough to beat DFlash. Paper uses consensus ≥ 2
+                                                    // (at least two n-gram lengths agree on first token) and chain length
+                                                    // ≥ 8. 0 disables the gate (use every matcher hit — useful for
+                                                    // diagnostics; usually a net loss on content where DFlash is strong).
     let mut pld_min_consensus: usize = 2;
-    let mut pld_min_chain: usize = 5;  // conservative: below paper's 8 but still filters noise
-    // DDTree (Ringel & Romano 2026): tree-structured verification built from
-    // DFlash per-position draft marginals. Per-path DFS verify (no batched
-    // tree attention) — slower per cycle but correct on hybrid arch. Spike
-    // measurement: does τ improve with the tree structure?
+    let mut pld_min_chain: usize = 5; // conservative: below paper's 8 but still filters noise
+                                      // DDTree (Ringel & Romano 2026): tree-structured verification built from
+                                      // DFlash per-position draft marginals. Per-path DFS verify (no batched
+                                      // tree attention) — slower per cycle but correct on hybrid arch. Spike
+                                      // measurement: does τ improve with the tree structure?
     let mut ddtree_enabled: bool = false;
-    let mut ddtree_budget: usize = 16;  // paper uses 60; cheaper spike default
-    let mut ddtree_topk: usize = 8;     // paper uses B-1 * budget_fanout; small k keeps tree shallow
-    // --ddtree-batched: use spec_step_ddtree_batched (single tree-attention
-    // forward) instead of the per-path DFS. Requires FA batched path (Q8 /
-    // asym3 / asym4 KV). Tree-exact on FA side, linear-replay on GDN.
+    let mut ddtree_budget: usize = 16; // paper uses 60; cheaper spike default
+    let mut ddtree_topk: usize = 8; // paper uses B-1 * budget_fanout; small k keeps tree shallow
+                                    // --ddtree-batched: use spec_step_ddtree_batched (single tree-attention
+                                    // forward) instead of the per-path DFS. Requires FA batched path (Q8 /
+                                    // asym3 / asym4 KV). Tree-exact on FA side, linear-replay on GDN.
     let mut ddtree_batched: bool = false;
     // --ddtree-path-c={phase1|phase2}: dispatch through `spec_step_ddtree_path_c`
     // (PRD docs/plans/ddtree-path-c-main-path-first-from-lucebox.prd).
@@ -300,12 +306,15 @@ fn main() {
             "--adaptive-b-range" => {
                 // Format: "MIN:MAX" e.g. "8:20". Both inclusive.
                 let v = &args[i + 1];
-                let (lo, hi) = v.split_once(':').unwrap_or_else(||
-                    panic!("--adaptive-b-range expects MIN:MAX, got {v:?}"));
+                let (lo, hi) = v
+                    .split_once(':')
+                    .unwrap_or_else(|| panic!("--adaptive-b-range expects MIN:MAX, got {v:?}"));
                 adaptive_b_min = lo.parse().expect("--adaptive-b-range MIN");
                 adaptive_b_max = hi.parse().expect("--adaptive-b-range MAX");
-                assert!(adaptive_b_min >= 2 && adaptive_b_max >= adaptive_b_min,
-                    "--adaptive-b-range invalid: {adaptive_b_min}..{adaptive_b_max}");
+                assert!(
+                    adaptive_b_min >= 2 && adaptive_b_max >= adaptive_b_min,
+                    "--adaptive-b-range invalid: {adaptive_b_min}..{adaptive_b_max}"
+                );
                 i += 2;
             }
             "--ngram" => {
@@ -335,7 +344,11 @@ fn main() {
             "--pld-ngrams" => {
                 pld_ngrams = args[i + 1]
                     .split(',')
-                    .map(|s| s.trim().parse::<usize>().expect("--pld-ngrams: comma-separated positive ints"))
+                    .map(|s| {
+                        s.trim()
+                            .parse::<usize>()
+                            .expect("--pld-ngrams: comma-separated positive ints")
+                    })
                     .collect();
                 // Sort descending — longest-first is required by the matcher.
                 pld_ngrams.sort_by(|a, b| b.cmp(a));
@@ -458,8 +471,10 @@ fn main() {
     // Each row is (label, raw_prompt, row_max_tokens). row_max_tokens
     // defaults to the global --max if the manifest line omits it.
     let prompts: Vec<(String, String, usize)> = if let Some(pf) = prompts_file.as_ref() {
-        let raw = std::fs::read_to_string(pf)
-            .unwrap_or_else(|e| { eprintln!("--prompts-file: read {pf}: {e}"); std::process::exit(1); });
+        let raw = std::fs::read_to_string(pf).unwrap_or_else(|e| {
+            eprintln!("--prompts-file: read {pf}: {e}");
+            std::process::exit(1);
+        });
         let mut out = Vec::new();
         for (idx, line) in raw.lines().enumerate() {
             let trimmed = line.trim();
@@ -469,13 +484,23 @@ fn main() {
             let v: serde_json::Value = match serde_json::from_str(trimmed) {
                 Ok(v) => v,
                 Err(e) => {
-                    eprintln!("[prompts-file] skipping line {}: invalid JSON: {e}", idx + 1);
+                    eprintln!(
+                        "[prompts-file] skipping line {}: invalid JSON: {e}",
+                        idx + 1
+                    );
                     continue;
                 }
             };
-            let label = v.get("label").and_then(|x| x.as_str()).unwrap_or("").to_string();
+            let label = v
+                .get("label")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
             if label.contains("@@@") || label.contains('\n') {
-                eprintln!("[prompts-file] skipping line {}: label must not contain '@@@' or newline", idx + 1);
+                eprintln!(
+                    "[prompts-file] skipping line {}: label must not contain '@@@' or newline",
+                    idx + 1
+                );
                 continue;
             }
             let p = match v.get("prompt").and_then(|x| x.as_str()) {
@@ -485,7 +510,9 @@ fn main() {
                     continue;
                 }
             };
-            let m = v.get("max").and_then(|x| x.as_u64())
+            let m = v
+                .get("max")
+                .and_then(|x| x.as_u64())
                 .map(|x| x as usize)
                 .unwrap_or(max_tokens);
             out.push((label, p, m));
@@ -496,8 +523,10 @@ fn main() {
         }
         out
     } else if let Some(pf) = prompt_file.as_ref() {
-        let p = std::fs::read_to_string(pf)
-            .unwrap_or_else(|e| { eprintln!("--prompt-file: read {pf}: {e}"); std::process::exit(1); });
+        let p = std::fs::read_to_string(pf).unwrap_or_else(|e| {
+            eprintln!("--prompt-file: read {pf}: {e}");
+            std::process::exit(1);
+        });
         vec![(String::new(), p, max_tokens)]
     } else {
         let p = prompt.unwrap_or_else(|| {
@@ -512,8 +541,11 @@ fn main() {
     eprintln!("target: {target_path}");
     eprintln!("draft:  {draft_path}");
     if multi_row {
-        eprintln!("prompts: {} rows from {}", prompts.len(),
-            prompts_file.as_deref().unwrap_or("--prompt"));
+        eprintln!(
+            "prompts: {} rows from {}",
+            prompts.len(),
+            prompts_file.as_deref().unwrap_or("--prompt")
+        );
     }
     if let Some(n) = ctx_slice {
         eprintln!("ctx_slice: last {n} positions only (bisect mode)");
@@ -554,7 +586,10 @@ fn main() {
     // to the next power of 2 and waste the room the draft needs.
     // Compute adaptive-B scratch ceiling early so KV + ring-buffer sizing
     // upstream of the draft-load accounts for the max possible B we'll use.
-    let cfg_block_size_for_slot = draft_cfg.block_size.max(if adaptive_b { adaptive_b_max } else { 0 });
+    let cfg_block_size_for_slot =
+        draft_cfg
+            .block_size
+            .max(if adaptive_b { adaptive_b_max } else { 0 });
     let mut slot_cfg = ModelSlotConfig::default();
     slot_cfg.max_seq = ctx_capacity + cfg_block_size_for_slot + 16;
     slot_cfg.kv_mode = match kv_mode_str.as_str() {
@@ -566,14 +601,16 @@ fn main() {
         "fwht3" => hipfire_arch_qwen35::speculative::KvMode::Fwht3,
         "fwht2" => hipfire_arch_qwen35::speculative::KvMode::Fwht2,
         other => {
-            eprintln!("unknown --kv-mode: {other}. Valid: q8, asym4, asym3, asym2, fwht4, fwht3, fwht2");
+            eprintln!(
+                "unknown --kv-mode: {other}. Valid: q8, asym4, asym3, asym2, fwht4, fwht3, fwht2"
+            );
             std::process::exit(1);
         }
     };
     eprintln!("kv_mode: {:?}", slot_cfg.kv_mode);
     let t1 = Instant::now();
-    let mut target =
-        ModelSlot::load(&mut gpu, Path::new(&target_path), "target", slot_cfg).expect("load target");
+    let mut target = ModelSlot::load(&mut gpu, Path::new(&target_path), "target", slot_cfg)
+        .expect("load target");
     eprintln!("target loaded in {:.2}s", t1.elapsed().as_secs_f64());
     vram_report(&gpu.hip, "after target load");
 
@@ -616,8 +653,13 @@ fn main() {
         );
     }
     let mut draft_scratch = DflashScratch::new_with_mq(
-        &mut gpu, &draft_cfg, draft_scratch_b, ctx_capacity, draft_weights.has_mq,
-    ).expect("alloc draft scratch");
+        &mut gpu,
+        &draft_cfg,
+        draft_scratch_b,
+        ctx_capacity,
+        draft_weights.has_mq,
+    )
+    .expect("alloc draft scratch");
     if draft_weights.has_mq {
         eprintln!("draft: MQ weights detected, FWHT rotation scratch enabled");
     }
@@ -651,13 +693,14 @@ fn main() {
     // DDTree needs a SECOND snapshot for the post-seed branch point (shared
     // across all DFS paths in a cycle). Allocate unconditionally — a single
     // DeltaNetSnapshot is cheap (~100 MB on 9B) and unused if --ddtree is off.
-    let mut post_seed_snap = DeltaNetSnapshot::new_for(&mut gpu, &target.dn_state).expect("post-seed snap");
+    let mut post_seed_snap =
+        DeltaNetSnapshot::new_for(&mut gpu, &target.dn_state).expect("post-seed snap");
     // Path C Phase 2 auxiliary snapshots. Allocated unconditionally, used
     // only when --ddtree-path-c=phase2. See speculative::Phase2Snapshots.
-    let mut path_c_parent_pre_snap = DeltaNetSnapshot::new_for(&mut gpu, &target.dn_state)
-        .expect("path-c parent-pre snap");
-    let mut path_c_main_end_snap = DeltaNetSnapshot::new_for(&mut gpu, &target.dn_state)
-        .expect("path-c main-end snap");
+    let mut path_c_parent_pre_snap =
+        DeltaNetSnapshot::new_for(&mut gpu, &target.dn_state).expect("path-c parent-pre snap");
+    let mut path_c_main_end_snap =
+        DeltaNetSnapshot::new_for(&mut gpu, &target.dn_state).expect("path-c main-end snap");
     // GdnTape: per-LA-layer (q, k, v, α, β) innovation tape — sized for B
     // positions, allocated once and reused every spec step. Enables the
     // rollback path to replay GDN recurrence without re-running the target.
@@ -668,8 +711,11 @@ fn main() {
     // or plain DFlash.
     let tape_max_n = draft_scratch_b.max(1 + ddtree_budget);
     let mut gdn_tape = hipfire_arch_qwen35::speculative::GdnTape::new_for_config(
-        &mut gpu, &target.config, tape_max_n,
-    ).expect("alloc gdn tape");
+        &mut gpu,
+        &target.config,
+        tape_max_n,
+    )
+    .expect("alloc gdn tape");
     // DdtreeScratch: persistent attention-bias buffer for batched tree verify.
     // One allocation at startup (sized for max_budget), reused every cycle —
     // avoids the per-cycle malloc+htod+free churn that dominated early wall-
@@ -684,7 +730,10 @@ fn main() {
         let vd = target.config.linear_num_value_heads * target.config.linear_value_head_dim;
         kd * 2 + vd
     };
-    let ddtree_n_fa_layers = target.config.layer_types.iter()
+    let ddtree_n_fa_layers = target
+        .config
+        .layer_types
+        .iter()
         .filter(|t| **t == hipfire_arch_qwen35::qwen35::LayerType::FullAttention)
         .count();
     let ddtree_scratch = hipfire_arch_qwen35::speculative::DdtreeScratch::new(
@@ -694,7 +743,8 @@ fn main() {
         target.config.head_dim,
         ddtree_qkv_dim,
         ddtree_n_fa_layers,
-    ).expect("alloc ddtree scratch");
+    )
+    .expect("alloc ddtree scratch");
     // VerifyScratch: persistent per-cycle tensors (final_hidden, logits,
     // rotation scratch, argmax buf). Sized to max_n = max(block_size,
     // 1 + ddtree_budget) to cover plain DFlash and DDTree. Drops ~8
@@ -708,7 +758,8 @@ fn main() {
         target.config.vocab_size,
         target.weights.output.k,
         &target.config,
-    ).expect("alloc verify scratch");
+    )
+    .expect("alloc verify scratch");
     let mut target_hidden_host: Vec<f32> =
         Vec::with_capacity(ctx_capacity * draft_cfg.num_extract() * draft_cfg.hidden);
 
@@ -727,8 +778,18 @@ fn main() {
     // would need an explicit reset hook; today it doesn't have one.
     let cask_policy: Option<CaskPolicy> = if let Some(path) = cask_sidecar.as_ref() {
         let centers = TriAttnCenters::load(Path::new(path)).expect("load cask sidecar");
-        let fa_layer_ids: Vec<usize> = target.config.layer_types.iter().enumerate()
-            .filter_map(|(i, t)| if *t == LayerType::FullAttention { Some(i) } else { None })
+        let fa_layer_ids: Vec<usize> = target
+            .config
+            .layer_types
+            .iter()
+            .enumerate()
+            .filter_map(|(i, t)| {
+                if *t == LayerType::FullAttention {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
             .collect();
         let n_rot = (target.config.head_dim as f32 * target.config.partial_rotary_factor) as usize;
         // Ensure target KV has enough headroom for budget+beta+B+margin. The
@@ -741,19 +802,35 @@ fn main() {
             cask_budget + cask_beta + draft_scratch_b + 4,
         );
         let base = EvictionCtx::new(
-            &mut gpu, &centers, fa_layer_ids,
-            cask_budget, cask_beta,
-            target.config.n_heads, target.config.n_kv_heads, target.config.head_dim,
-            n_rot, target.config.rope_theta, target.kv_cache.max_seq,
-        ).expect("build EvictionCtx for FlashCASK");
+            &mut gpu,
+            &centers,
+            fa_layer_ids,
+            cask_budget,
+            cask_beta,
+            target.config.n_heads,
+            target.config.n_kv_heads,
+            target.config.head_dim,
+            n_rot,
+            target.config.rope_theta,
+            target.kv_cache.max_seq,
+        )
+        .expect("build EvictionCtx for FlashCASK");
         Some(if use_cask {
-            eprintln!("FlashCASK: CASK α={:.2} m={} budget={} β={}", cask_core_frac, cask_fold_m, cask_budget, cask_beta);
+            eprintln!(
+                "FlashCASK: CASK α={:.2} m={} budget={} β={}",
+                cask_core_frac, cask_fold_m, cask_budget, cask_beta
+            );
             CaskPolicy::Cask(CaskCtx::new(base, cask_core_frac, cask_fold_m))
         } else {
-            eprintln!("FlashCASK: TriAttention (plain) budget={} β={}", cask_budget, cask_beta);
+            eprintln!(
+                "FlashCASK: TriAttention (plain) budget={} β={}",
+                cask_budget, cask_beta
+            );
             CaskPolicy::Plain(base)
         })
-    } else { None };
+    } else {
+        None
+    };
 
     // ── Per-row loop ──────────────────────────────────────────────────
     // Issue #173: when --prompts-file is used, run multiple prompts
@@ -819,15 +896,25 @@ fn main() {
             chat.extend_from_slice(&asst);
             chat.extend_from_slice(&nl);
             prompt_tokens = chat;
-            eprintln!("chatml wrapping enabled: prompt is {} tokens after wrap", prompt_tokens.len());
+            eprintln!(
+                "chatml wrapping enabled: prompt is {} tokens after wrap",
+                prompt_tokens.len()
+            );
         }
         if prompt_normalized.len() < 2000 {
             eprintln!("prompt: {:?}", prompt_normalized);
         } else {
             eprintln!("prompt: <{} chars elided>", prompt_normalized.len());
         }
-        eprintln!("prompt tokens ({}): {}", prompt_tokens.len(),
-            if prompt_tokens.len() < 64 { format!("{:?}", prompt_tokens) } else { format!("[{} tokens]", prompt_tokens.len()) });
+        eprintln!(
+            "prompt tokens ({}): {}",
+            prompt_tokens.len(),
+            if prompt_tokens.len() < 64 {
+                format!("{:?}", prompt_tokens)
+            } else {
+                format!("[{} tokens]", prompt_tokens.len())
+            }
+        );
 
         // ── Optional PFlash compression ───────────────────────────────
         // Single-prompt only for now. --prompts-file + --pflash is rejected
@@ -837,7 +924,8 @@ fn main() {
         let pflash_source_tokens = prompt_tokens.len();
         if let Some(pflash_drafter_path) = pflash_path.as_ref() {
             use hipfire_arch_qwen35::pflash::{
-                self, BypassReason, PflashConfig, PflashDecision, PflashMode, PflashState, RequestKind,
+                self, BypassReason, PflashConfig, PflashDecision, PflashMode, PflashState,
+                RequestKind,
             };
             let cfg = PflashConfig {
                 mode: PflashMode::Always,
@@ -853,11 +941,17 @@ fn main() {
             let drafter_max_kv = prompt_tokens.len() + 64;
             let t_load = Instant::now();
             pflash::load_drafter(
-                &mut state, &mut gpu, Path::new(pflash_drafter_path), &tokenizer, drafter_max_kv,
-            ).expect("pflash: load drafter");
+                &mut state,
+                &mut gpu,
+                Path::new(pflash_drafter_path),
+                &tokenizer,
+                drafter_max_kv,
+            )
+            .expect("pflash: load drafter");
             eprintln!(
                 "pflash drafter loaded: {:.2}s | tokenizer_compat={}",
-                t_load.elapsed().as_secs_f64(), state.tokenizer_compat
+                t_load.elapsed().as_secs_f64(),
+                state.tokenizer_compat
             );
             if !state.tokenizer_compat {
                 eprintln!("FAIL: pflash drafter tokenizer incompatible with target");
@@ -867,27 +961,45 @@ fn main() {
 
             let t_compress = Instant::now();
             let decision = pflash::maybe_compress_prompt(
-                &mut gpu, &mut state, &cfg, &prompt_tokens, RequestKind::Text, &[],
-            ).expect("pflash: maybe_compress_prompt");
+                &mut gpu,
+                &mut state,
+                &cfg,
+                &prompt_tokens,
+                RequestKind::Text,
+                &[],
+            )
+            .expect("pflash: maybe_compress_prompt");
             pflash_compress_ms = t_compress.elapsed().as_millis();
 
             prompt_tokens = match decision {
                 PflashDecision::Compressed(cp) => {
                     eprintln!(
                         "pflash compress: {} ms (score={}ms select={}ms gather={}ms)",
-                        pflash_compress_ms, cp.timings.score_ms, cp.timings.select_ms, cp.timings.gather_ms
+                        pflash_compress_ms,
+                        cp.timings.score_ms,
+                        cp.timings.select_ms,
+                        cp.timings.gather_ms
                     );
                     eprintln!(
                         "pflash kept:    {} -> {} tokens (ratio {:.3})",
-                        cp.source_tokens, cp.kept_tokens,
+                        cp.source_tokens,
+                        cp.kept_tokens,
                         cp.kept_tokens as f32 / cp.source_tokens.max(1) as f32
                     );
                     eprintln!("pflash spans:   {} ranges", cp.kept_spans.len());
                     pflash_kept_tokens = cp.kept_tokens;
                     cp.token_ids
                 }
-                PflashDecision::Bypass { reason: BypassReason::BelowThreshold { source_tokens: st, threshold } } => {
-                    eprintln!("pflash bypass (BelowThreshold {st} < {threshold}); running full prefill");
+                PflashDecision::Bypass {
+                    reason:
+                        BypassReason::BelowThreshold {
+                            source_tokens: st,
+                            threshold,
+                        },
+                } => {
+                    eprintln!(
+                        "pflash bypass (BelowThreshold {st} < {threshold}); running full prefill"
+                    );
                     prompt_tokens
                 }
                 PflashDecision::Bypass { reason } => {
@@ -906,144 +1018,167 @@ fn main() {
         // existing decode-loop body keeps working unchanged.
         let max_tokens = row_max_tokens;
 
-    // ── Prefill: seed target_hidden via per-token forward_with_hidden ──
-    eprintln!("seeding target_hidden from prompt ({} tokens)...", prompt_tokens.len());
-    let t2 = Instant::now();
-    speculative::seed_target_hidden_from_prompt(
-        &mut gpu,
-        &mut target,
-        &mut hidden_rb,
-        &mut target_hidden_host,
-        &prompt_tokens,
-    )
-    .expect("seed target hidden");
-    // Mirror the prompt rows from the hidden ring buffer straight into
-    // draft_scratch.target_hidden on GPU. This primes the GPU-resident
-    // path in spec_step_dflash (ctx_slice=None) so it doesn't need to
-    // round-trip target_hidden through the CPU shadow each cycle.
-    speculative::scatter_hidden_block_to_interleaved(
-        &gpu,
-        &hidden_rb,
-        &draft_scratch.target_hidden,
-        0,
-        prompt_tokens.len(), // block_size: seed wrote prompt_len contiguous slots
-        prompt_tokens.len(), // n_rows:     keep all of them
-    )
-    .expect("seed scatter");
-    draft_scratch.uploaded_target_hidden_rows = prompt_tokens.len();
-    // Seed per-row absolute positions for the draft's cross-attention RoPE.
-    // Pre-eviction these match [0..prompt_len) exactly, so FlashCASK-free runs
-    // stay byte-identical to the old contiguous-range behaviour.
-    draft_scratch.target_hidden_abs_positions =
-        (0..prompt_tokens.len() as i32).collect();
-    let prefill_secs = t2.elapsed().as_secs_f64();
-    let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
-    eprintln!("prefill in {:.2}s ({:.1} tok/s)", prefill_secs, prefill_tok_s);
-    vram_report(&gpu.hip, "after_prefill");
+        // ── Prefill: seed target_hidden via per-token forward_with_hidden ──
+        eprintln!(
+            "seeding target_hidden from prompt ({} tokens)...",
+            prompt_tokens.len()
+        );
+        let t2 = Instant::now();
+        speculative::seed_target_hidden_from_prompt(
+            &mut gpu,
+            &mut target,
+            &mut hidden_rb,
+            &mut target_hidden_host,
+            &prompt_tokens,
+        )
+        .expect("seed target hidden");
+        // Mirror the prompt rows from the hidden ring buffer straight into
+        // draft_scratch.target_hidden on GPU. This primes the GPU-resident
+        // path in spec_step_dflash (ctx_slice=None) so it doesn't need to
+        // round-trip target_hidden through the CPU shadow each cycle.
+        speculative::scatter_hidden_block_to_interleaved(
+            &gpu,
+            &hidden_rb,
+            &draft_scratch.target_hidden,
+            0,
+            prompt_tokens.len(), // block_size: seed wrote prompt_len contiguous slots
+            prompt_tokens.len(), // n_rows:     keep all of them
+        )
+        .expect("seed scatter");
+        draft_scratch.uploaded_target_hidden_rows = prompt_tokens.len();
+        // Seed per-row absolute positions for the draft's cross-attention RoPE.
+        // Pre-eviction these match [0..prompt_len) exactly, so FlashCASK-free runs
+        // stay byte-identical to the old contiguous-range behaviour.
+        draft_scratch.target_hidden_abs_positions = (0..prompt_tokens.len() as i32).collect();
+        let prefill_secs = t2.elapsed().as_secs_f64();
+        let prefill_tok_s = prompt_tokens.len() as f64 / prefill_secs.max(1e-9);
+        eprintln!(
+            "prefill in {:.2}s ({:.1} tok/s)",
+            prefill_secs, prefill_tok_s
+        );
+        vram_report(&gpu.hip, "after_prefill");
 
-    // Post-prefill eviction: if the prompt already filled past the
-    // threshold, compact once before decoding so the spec loop starts at
-    // budget-sized physical state. cask_policy is built once before the
-    // for-loop; the rejection of --prompts-file + --cask-sidecar
-    // guarantees this only runs in single-prompt mode.
-    let mut position: usize = prompt_tokens.len();
-    if let Some(ref p) = cask_policy {
-        if let Some(ev) = p.maybe_evict(&mut gpu, &mut target.kv_cache, position)
-            .expect("post-prefill cask evict") {
-            let pre_phys = position;
-            eprintln!(
-                "FlashCASK: post-prefill compact {} -> {} (compact_offset={})",
-                pre_phys, ev.new_physical, target.kv_cache.compact_offset,
-            );
-            position = ev.new_physical;
-            // Mirror the KV eviction into the draft's target_hidden so
-            // draft/target see the same windowed context.
-            if !ev.retain_mask.is_empty() {
-                speculative::apply_eviction_retain_to_draft(
-                    &mut gpu,
-                    &mut draft_scratch,
-                    &ev.retain_mask,
-                    draft_cfg.num_extract(),
-                    draft_cfg.hidden,
-                    pre_phys,
-                ).expect("mirror eviction to draft (post-prefill)");
+        // Post-prefill eviction: if the prompt already filled past the
+        // threshold, compact once before decoding so the spec loop starts at
+        // budget-sized physical state. cask_policy is built once before the
+        // for-loop; the rejection of --prompts-file + --cask-sidecar
+        // guarantees this only runs in single-prompt mode.
+        let mut position: usize = prompt_tokens.len();
+        if let Some(ref p) = cask_policy {
+            if let Some(ev) = p
+                .maybe_evict(&mut gpu, &mut target.kv_cache, position)
+                .expect("post-prefill cask evict")
+            {
+                let pre_phys = position;
+                eprintln!(
+                    "FlashCASK: post-prefill compact {} -> {} (compact_offset={})",
+                    pre_phys, ev.new_physical, target.kv_cache.compact_offset,
+                );
+                position = ev.new_physical;
+                // Mirror the KV eviction into the draft's target_hidden so
+                // draft/target see the same windowed context.
+                if !ev.retain_mask.is_empty() {
+                    speculative::apply_eviction_retain_to_draft(
+                        &mut gpu,
+                        &mut draft_scratch,
+                        &ev.retain_mask,
+                        draft_cfg.num_extract(),
+                        draft_cfg.hidden,
+                        pre_phys,
+                    )
+                    .expect("mirror eviction to draft (post-prefill)");
+                }
             }
         }
-    }
 
-    // ── Initial seed_token: target's greedy pick after prefill ───────
-    // Target state is at position `prompt_len` after seed_target_hidden_from_prompt.
-    // Its scratch.logits at this point corresponds to the LAST prompt token's output —
-    // i.e., the prediction for position prompt_len. Argmax = first emitted token.
-    let first_logits = gpu.download_f32(&target.scratch.logits).expect("download logits");
-    let first_token = first_logits
-        .iter()
-        .enumerate()
-        .fold((0u32, f32::NEG_INFINITY), |(best, bv), (i, &v)| {
-            if v > bv {
-                (i as u32, v)
-            } else {
-                (best, bv)
-            }
-        })
-        .0;
+        // ── Initial seed_token: target's greedy pick after prefill ───────
+        // Target state is at position `prompt_len` after seed_target_hidden_from_prompt.
+        // Its scratch.logits at this point corresponds to the LAST prompt token's output —
+        // i.e., the prediction for position prompt_len. Argmax = first emitted token.
+        let first_logits = gpu
+            .download_f32(&target.scratch.logits)
+            .expect("download logits");
+        let first_token = first_logits
+            .iter()
+            .enumerate()
+            .fold((0u32, f32::NEG_INFINITY), |(best, bv), (i, &v)| {
+                if v > bv {
+                    (i as u32, v)
+                } else {
+                    (best, bv)
+                }
+            })
+            .0;
 
-    // ── Decode loop ───────────────────────────────────────────────────
-    let mut emitted: Vec<u32> = vec![first_token];
-    // `position` was already declared above (it may have been advanced by a
-    // post-prefill CASK eviction). Keep it as-is.
-    let mut seed_token: u32 = first_token;
+        // ── Decode loop ───────────────────────────────────────────────────
+        let mut emitted: Vec<u32> = vec![first_token];
+        // `position` was already declared above (it may have been advanced by a
+        // post-prefill CASK eviction). Keep it as-is.
+        let mut seed_token: u32 = first_token;
 
-    // Loop-break cycle detector (HIPFIRE_DFLASH_LOOP_BREAK=stop|escalate|temp).
-    // After each commit, hash the trailing 32-token window. Hit = the
-    // model has entered a structural repeat (block-level attractor — the
-    // kind that slips past the first-128-tok coherence gate).
-    //
-    // Modes:
-    //   stop (=1, default): track consecutive hits; once >= STOP_AFTER
-    //     terminate decode as if EOS was emitted. Simple, gracefully
-    //     stops degeneration.
-    //   escalate: on each STOP_AFTER threshold trigger, bump runtime
-    //     repeat_penalty by RP_STEP (cap at RP_MAX). The bumped RP
-    //     penalizes the loop's vocabulary; gen continues. After
-    //     RECOVERY_CYCLES cycles with no hits, decay RP back toward
-    //     baseline. Terminate only if MAX_ESCALATIONS hit (RP cap reached
-    //     AND the bumped value still loops).
-    //   temp: legacy diagnostic — bump temp on each hit, reset on miss.
-    //     Empirically bounces the model between attractors.
-    //
-    // Detection cost: one DefaultHasher pass over 32 u32s per cycle (~ns).
-    // Memory: HashSet<u64>, ≤ max_tokens / 12 entries (~125 for max=1500).
-    let loop_break_raw = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK").ok();
-    let loop_break_mode: &str = match loop_break_raw.as_deref() {
-        Some("temp") => "temp",
-        Some("escalate") | Some("recover") => "escalate",
-        Some("stop") | Some("1") | Some("on") | Some("true") => "stop",
-        _ => "off",
-    };
-    let loop_break_on = loop_break_mode != "off";
-    let loop_break_temp: f32 = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_TEMP")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(1.0);
-    let loop_break_stop_after: usize = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_STOP_AFTER")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(3);
-    let loop_break_rp_step: f32 = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_RP_STEP")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(0.10);
-    let loop_break_rp_max: f32 = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_RP_MAX")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(1.30);
-    let loop_break_recovery: usize = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_RECOVERY")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(32);
-    let loop_break_max_escalations: usize = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_MAX_ESCALATIONS")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(4);
-    const LOOP_BREAK_WINDOW: usize = 32;
-    let mut runtime_temp: f32 = temp;
-    let mut runtime_repeat_penalty: f32 = repeat_penalty;
-    let mut loop_break_hits: usize = 0;
-    let mut loop_break_consecutive: usize = 0;
-    let mut loop_break_escalations: usize = 0;
-    let mut loop_break_clean_streak: usize = 0;
-    let mut window_hashes: std::collections::HashSet<u64> = std::collections::HashSet::new();
-    if loop_break_on {
-        match loop_break_mode {
+        // Loop-break cycle detector (HIPFIRE_DFLASH_LOOP_BREAK=stop|escalate|temp).
+        // After each commit, hash the trailing 32-token window. Hit = the
+        // model has entered a structural repeat (block-level attractor — the
+        // kind that slips past the first-128-tok coherence gate).
+        //
+        // Modes:
+        //   stop (=1, default): track consecutive hits; once >= STOP_AFTER
+        //     terminate decode as if EOS was emitted. Simple, gracefully
+        //     stops degeneration.
+        //   escalate: on each STOP_AFTER threshold trigger, bump runtime
+        //     repeat_penalty by RP_STEP (cap at RP_MAX). The bumped RP
+        //     penalizes the loop's vocabulary; gen continues. After
+        //     RECOVERY_CYCLES cycles with no hits, decay RP back toward
+        //     baseline. Terminate only if MAX_ESCALATIONS hit (RP cap reached
+        //     AND the bumped value still loops).
+        //   temp: legacy diagnostic — bump temp on each hit, reset on miss.
+        //     Empirically bounces the model between attractors.
+        //
+        // Detection cost: one DefaultHasher pass over 32 u32s per cycle (~ns).
+        // Memory: HashSet<u64>, ≤ max_tokens / 12 entries (~125 for max=1500).
+        let loop_break_raw = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK").ok();
+        let loop_break_mode: &str = match loop_break_raw.as_deref() {
+            Some("temp") => "temp",
+            Some("escalate") | Some("recover") => "escalate",
+            Some("stop") | Some("1") | Some("on") | Some("true") => "stop",
+            _ => "off",
+        };
+        let loop_break_on = loop_break_mode != "off";
+        let loop_break_temp: f32 = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_TEMP")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1.0);
+        let loop_break_stop_after: usize = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_STOP_AFTER")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3);
+        let loop_break_rp_step: f32 = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_RP_STEP")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.10);
+        let loop_break_rp_max: f32 = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_RP_MAX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1.30);
+        let loop_break_recovery: usize = std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_RECOVERY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(32);
+        let loop_break_max_escalations: usize =
+            std::env::var("HIPFIRE_DFLASH_LOOP_BREAK_MAX_ESCALATIONS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(4);
+        const LOOP_BREAK_WINDOW: usize = 32;
+        let mut runtime_temp: f32 = temp;
+        let mut runtime_repeat_penalty: f32 = repeat_penalty;
+        let mut loop_break_hits: usize = 0;
+        let mut loop_break_consecutive: usize = 0;
+        let mut loop_break_escalations: usize = 0;
+        let mut loop_break_clean_streak: usize = 0;
+        let mut window_hashes: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        if loop_break_on {
+            match loop_break_mode {
             "stop" => eprintln!(
                 "[loop-break] enabled: mode=stop window={LOOP_BREAK_WINDOW} stop_after={loop_break_stop_after}"
             ),
@@ -1056,917 +1191,973 @@ fn main() {
                 "[loop-break] enabled: mode=temp window={LOOP_BREAK_WINDOW} bump_temp={loop_break_temp} (canonical temp={temp})"
             ),
         }
-    }
+        }
 
-    // SpecStats histogram must fit the max accept_len we'll ever see, so
-    // size by draft_scratch_b (which accounts for adaptive_b_max).
-    let mut stats = SpecStats::new(draft_scratch_b);
+        // SpecStats histogram must fit the max accept_len we'll ever see, so
+        // size by draft_scratch_b (which accounts for adaptive_b_max).
+        let mut stats = SpecStats::new(draft_scratch_b);
 
-    if adaptive_b && draft_scratch_b != draft_cfg.block_size {
-        eprintln!(
+        if adaptive_b && draft_scratch_b != draft_cfg.block_size {
+            eprintln!(
             "decoding (max {max_tokens} tokens, adaptive-B range {adaptive_b_min}..={adaptive_b_max}, draft trained at {})...",
             draft_cfg.block_size,
         );
-    } else {
-        eprintln!("decoding (max {max_tokens} tokens, block_size {})...", draft_cfg.block_size);
-    }
-
-    // Rolling τ window for live emit + future adaptive routing decisions.
-    // τ_window[i] = accepted draft tokens in cycle i. Running mean over the
-    // last N cycles is a good proxy for whether the draft is keeping up.
-    const TAU_WINDOW: usize = 8;
-    let mut accepts_window: std::collections::VecDeque<usize> =
-        std::collections::VecDeque::with_capacity(TAU_WINDOW);
-    let live_tau = std::env::var("DFLASH_LIVE_TAU").is_ok();
-
-    let mut rng_state: u64 = seed | 1; // xorshift state must be non-zero
-    if temp > 0.0 {
-        eprintln!("temp sampling: T={temp}, seed={seed}");
-        if cactus_delta > 0.0 {
+        } else {
             eprintln!(
-                "cactus: δ={cactus_delta} (bumped acceptance γ* = min(q + √(2·δ·q·(1−q)), 1))"
+                "decoding (max {max_tokens} tokens, block_size {})...",
+                draft_cfg.block_size
             );
         }
-    } else if cactus_delta > 0.0 {
-        eprintln!("cactus_delta={cactus_delta} ignored at temp=0 (greedy path has no distribution)");
-    }
-    // N-gram cache: built incrementally from committed output each iter.
-    // Seeded from the prompt so multi-turn repetitions in the prompt get
-    // cached. min_count gates how aggressive overrides are.
-    let mut ngram_cache = if ngram {
-        let mut c = hipfire_arch_qwen35::speculative::NgramCache::new(ngram_min_count);
-        c.observe_many(&prompt_tokens);
-        eprintln!(
-            "ngram cache: bigrams seeded from prompt, min_count={ngram_min_count}"
-        );
-        Some(c)
-    } else {
-        None
-    };
-    // PLD matcher: stateless, scans (prompt ++ emitted) suffix each cycle.
-    let pld_matcher = if pld_enabled {
-        let m = hipfire_arch_qwen35::speculative::PldMatcher {
-            ngram_lens: pld_ngrams.clone(),
-            max_extract: pld_max_extract,
-            min_extract: pld_min_extract,
-        };
-        eprintln!(
-            "pld: enabled (ngrams={:?}, min_extract={}, max_extract={})",
-            m.ngram_lens, m.min_extract, m.max_extract
-        );
-        Some(m)
-    } else {
-        None
-    };
-    // PLD stats: hits = cycles where a spine was substituted for DFlash;
-    // accepted_from_pld = accepted count on those cycles (for τ_pld).
-    let mut pld_hits: usize = 0;
-    let mut pld_accepted: usize = 0;
 
-    if ddtree_enabled {
+        // Rolling τ window for live emit + future adaptive routing decisions.
+        // τ_window[i] = accepted draft tokens in cycle i. Running mean over the
+        // last N cycles is a good proxy for whether the draft is keeping up.
+        const TAU_WINDOW: usize = 8;
+        let mut accepts_window: std::collections::VecDeque<usize> =
+            std::collections::VecDeque::with_capacity(TAU_WINDOW);
+        let live_tau = std::env::var("DFLASH_LIVE_TAU").is_ok();
+
+        let mut rng_state: u64 = seed | 1; // xorshift state must be non-zero
         if temp > 0.0 {
+            eprintln!("temp sampling: T={temp}, seed={seed}");
+            if cactus_delta > 0.0 {
+                eprintln!(
+                    "cactus: δ={cactus_delta} (bumped acceptance γ* = min(q + √(2·δ·q·(1−q)), 1))"
+                );
+            }
+        } else if cactus_delta > 0.0 {
             eprintln!(
-                "WARNING: --ddtree with temp>0 falls back to greedy on the verify side for \
-                this spike (rejection-sampling integration is deferred)."
+                "cactus_delta={cactus_delta} ignored at temp=0 (greedy path has no distribution)"
             );
         }
-        if pld_enabled {
-            eprintln!("WARNING: --pld is ignored when --ddtree is enabled.");
-        }
-        if ddtree_batched {
+        // N-gram cache: built incrementally from committed output each iter.
+        // Seeded from the prompt so multi-turn repetitions in the prompt get
+        // cached. min_count gates how aggressive overrides are.
+        let mut ngram_cache = if ngram {
+            let mut c = hipfire_arch_qwen35::speculative::NgramCache::new(ngram_min_count);
+            c.observe_many(&prompt_tokens);
+            eprintln!("ngram cache: bigrams seeded from prompt, min_count={ngram_min_count}");
+            Some(c)
+        } else {
+            None
+        };
+        // PLD matcher: stateless, scans (prompt ++ emitted) suffix each cycle.
+        let pld_matcher = if pld_enabled {
+            let m = hipfire_arch_qwen35::speculative::PldMatcher {
+                ngram_lens: pld_ngrams.clone(),
+                max_extract: pld_max_extract,
+                min_extract: pld_min_extract,
+            };
             eprintln!(
+                "pld: enabled (ngrams={:?}, min_extract={}, max_extract={})",
+                m.ngram_lens, m.min_extract, m.max_extract
+            );
+            Some(m)
+        } else {
+            None
+        };
+        // PLD stats: hits = cycles where a spine was substituted for DFlash;
+        // accepted_from_pld = accepted count on those cycles (for τ_pld).
+        let mut pld_hits: usize = 0;
+        let mut pld_accepted: usize = 0;
+
+        if ddtree_enabled {
+            if temp > 0.0 {
+                eprintln!(
+                    "WARNING: --ddtree with temp>0 falls back to greedy on the verify side for \
+                this spike (rejection-sampling integration is deferred)."
+                );
+            }
+            if pld_enabled {
+                eprintln!("WARNING: --pld is ignored when --ddtree is enabled.");
+            }
+            if ddtree_batched {
+                eprintln!(
                 "ddtree: enabled (budget={}, topk={}; BATCHED tree verify via FA tree-attention mask + GDN linear replay)",
                 ddtree_budget, ddtree_topk,
             );
-        } else {
-            eprintln!(
+            } else {
+                eprintln!(
                 "ddtree: enabled (budget={}, topk={}; per-path DFS verify, ~{}× DFlash per-cycle cost)",
                 ddtree_budget,
                 ddtree_topk,
                 ddtree_budget / (draft_cfg.block_size.saturating_sub(1).max(1)),
             );
+            }
         }
-    }
 
-    // HIPFIRE_PROFILE=1: enable per-kernel profiling for `--profile-cycles N`
-    // worth of cycles (default 5) starting at cycle 1 (after a warm-up cycle
-    // 0 to settle the JIT). Prints kernel breakdown after the limit.
-    let do_profile = std::env::var("HIPFIRE_PROFILE").ok().as_deref() == Some("1");
-    let profile_cycles_target: usize = std::env::var("HIPFIRE_PROFILE_CYCLES")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(5);
-    let mut profile_cycle_count: usize = 0;
-    let mut profile_armed = false;
+        // HIPFIRE_PROFILE=1: enable per-kernel profiling for `--profile-cycles N`
+        // worth of cycles (default 5) starting at cycle 1 (after a warm-up cycle
+        // 0 to settle the JIT). Prints kernel breakdown after the limit.
+        let do_profile = std::env::var("HIPFIRE_PROFILE").ok().as_deref() == Some("1");
+        let profile_cycles_target: usize = std::env::var("HIPFIRE_PROFILE_CYCLES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(5);
+        let mut profile_cycle_count: usize = 0;
+        let mut profile_armed = false;
 
-    // ── AR baseline branch: skip DFlash, pure greedy AR via target ───
-    // Used to confirm whether the prompt + target alone are coherent.
-    // Same tokenization, same model, same greedy; isolates DFlash vs model.
-    if ar_baseline {
-        eprintln!("AR-BASELINE MODE: pure greedy target decode (no DFlash)");
-        let t_ar = Instant::now();
-        let mut ar_first_tok_secs: Option<f64> = None;
-        // Position already advanced to prompt_tokens.len() during prefill.
-        // seed_token = target's argmax at position `prompt_len` (first emit).
-        let mut cur_token = seed_token;
+        // ── AR baseline branch: skip DFlash, pure greedy AR via target ───
+        // Used to confirm whether the prompt + target alone are coherent.
+        // Same tokenization, same model, same greedy; isolates DFlash vs model.
+        if ar_baseline {
+            eprintln!("AR-BASELINE MODE: pure greedy target decode (no DFlash)");
+            let t_ar = Instant::now();
+            let mut ar_first_tok_secs: Option<f64> = None;
+            // Position already advanced to prompt_tokens.len() during prefill.
+            // seed_token = target's argmax at position `prompt_len` (first emit).
+            let mut cur_token = seed_token;
+            while emitted.len() < max_tokens {
+                if position >= ctx_capacity {
+                    eprintln!("hit ctx_capacity {}; stopping", ctx_capacity);
+                    break;
+                }
+                hipfire_arch_qwen35::qwen35::forward_scratch(
+                    &mut gpu,
+                    &target.weights,
+                    &target.config,
+                    cur_token,
+                    position,
+                    &mut target.kv_cache,
+                    &mut target.dn_state,
+                    &target.scratch,
+                )
+                .expect("ar forward");
+                let lg = gpu.download_f32(&target.scratch.logits).expect("logits");
+                let next = lg
+                    .iter()
+                    .enumerate()
+                    .fold((0u32, f32::NEG_INFINITY), |(best, bv), (i, &v)| {
+                        if v > bv {
+                            (i as u32, v)
+                        } else {
+                            (best, bv)
+                        }
+                    })
+                    .0;
+                emitted.push(next);
+                if ar_first_tok_secs.is_none() {
+                    ar_first_tok_secs = Some(t_ar.elapsed().as_secs_f64());
+                }
+                position += 1;
+                if let Some(ref p) = cask_policy {
+                    if let Some(ev) = p
+                        .maybe_evict(&mut gpu, &mut target.kv_cache, position)
+                        .expect("ar cask evict")
+                    {
+                        // AR baseline doesn't touch draft state — no mirror needed.
+                        position = ev.new_physical;
+                    }
+                }
+                if tokenizer.is_terminator(next) {
+                    eprintln!("eos (id={next})");
+                    break;
+                }
+                cur_token = next;
+            }
+            let ar_elapsed = t_ar.elapsed().as_secs_f64();
+            let text = tokenizer.decode(&emitted);
+            eprintln!("--- AR-BASELINE OUTPUT ---");
+            println!("{text}");
+            eprintln!("--------------------------");
+            eprintln!(
+                "emitted: {} tokens in {:.2}s  ({:.2} tok/s)",
+                emitted.len(),
+                ar_elapsed,
+                emitted.len() as f64 / ar_elapsed
+            );
+            eprintln!("AR tokens: {:?}", emitted);
+            // Mirror BENCH METRICS block from the DFlash path so downstream
+            // bench harnesses (scripts/bench_humaneval_dflash.py) can extract
+            // prefill_tok_s + ttft_ms + decode stats from AR runs too.
+            let ar_ttft_ms = (prefill_secs + ar_first_tok_secs.unwrap_or(0.0)) * 1000.0;
+            let (vram_free_bytes, vram_total_bytes) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+            let vram_used_mb = ((vram_total_bytes.saturating_sub(vram_free_bytes)) as f64
+                / (1024.0 * 1024.0)) as u64;
+            let vram_total_mb = (vram_total_bytes as f64 / (1024.0 * 1024.0)) as u64;
+            eprintln!("=== BENCH METRICS ===");
+            eprintln!("prompt_tokens: {}", prompt_tokens.len());
+            eprintln!("prefill_secs: {:.4}", prefill_secs);
+            eprintln!("prefill_tok_s: {:.2}", prefill_tok_s);
+            eprintln!("ttft_ms: {:.2}", ar_ttft_ms);
+            eprintln!("decode_tokens_emitted: {}", emitted.len());
+            eprintln!("decode_secs: {:.4}", ar_elapsed);
+            eprintln!(
+                "decode_tok_s: {:.2}",
+                emitted.len() as f64 / ar_elapsed.max(1e-9)
+            );
+            eprintln!("decode_tau: 1.0000");
+            eprintln!("decode_accept_rate: 1.0000");
+            eprintln!("vram_used_mb: {}", vram_used_mb);
+            eprintln!("vram_total_mb: {}", vram_total_mb);
+            eprintln!("=====================");
+            // End-of-row for the AR-baseline path. In single-prompt mode this
+            // is the last iteration, so `continue` falls out of the one-row loop
+            // just like the historical `return`. In --prompts-file mode it lets
+            // the resident bench proceed to the next row.
+            if multi_row {
+                eprintln!("@@@ ROW {row_idx} END @@@");
+            }
+            continue;
+        }
+
+        // HIPFIRE_HOST_TIMING=1: dump per-cycle host-side wall-clock breakdown
+        // (launch overhead vs D2D/D2H/H2D vs other host work) by diffing the
+        // hip-bridge launch_counters around each cycle.
+        let host_timing = std::env::var("HIPFIRE_HOST_TIMING").ok().as_deref() == Some("1");
+        let mut per_cycle_wall_us: Vec<u64> = Vec::new();
+        let mut per_cycle_api_us: Vec<(u64, u64, u64, u64, u64, u64, u64, u64, u64)> = Vec::new();
+        // columns: launch, h2d, d2h, d2d, memset, stream_sync, event_sync, device_sync, graph_launch
+
+        // HIPFIRE_DPM_WARMUP_SECS: run a memset loop on a 256 MB scratch before
+        // the decode timer starts, to pin the GPU at high DPM. See dispatch.rs
+        // `dpm_warmup` for rationale — between-process DPM variance has been
+        // observed at 7× wall-clock (52 ms vs 358 ms/cycle on the same bench),
+        // which is orders of magnitude more than the ±10-15% noise band our
+        // methodology doc calls out. Default 0 (disabled) for backward compat.
+        if let Ok(secs_str) = std::env::var("HIPFIRE_DPM_WARMUP_SECS") {
+            let secs: f32 = secs_str.parse().unwrap_or(0.0);
+            if secs > 0.0 {
+                gpu.dpm_warmup(secs).expect("dpm warmup");
+            }
+        }
+
+        // (Seed-oracle + ddtree-meta counter resets moved to the per-row reset
+        // block at the top of the multi-prompt loop — see issue #173.)
+
+        // Adaptive-B state: tracks current B between cycles, plus a cooldown
+        // counter and a histogram for end-of-run reporting.
+        let mut current_adaptive_b: usize = draft_cfg.block_size;
+        let mut adaptive_b_cycles_since_change: usize = 0;
+        let mut adaptive_b_histogram: std::collections::HashMap<usize, u32> =
+            std::collections::HashMap::new();
+        let mut adaptive_b_changes: u32 = 0;
+        const ADAPTIVE_B_STEP: usize = 2;
+        const ADAPTIVE_B_COOLDOWN: usize = 3;
+        // Hysteresis thresholds on util = EWMA(accept_len) / (current_B - 1):
+        //   util > UP   → draft keeps up, stretch B further.
+        //   util < DOWN → draft lags, shrink B to cut verify cost.
+        // Gap between the two prevents flapping at one util value.
+        //
+        // Measured util ceilings at fixed-B16 (2026-04-24 3-run median):
+        //   code  τ≈7.68 / (B-1=15) = 0.51
+        //   prose τ≈1.65 / 15 = 0.11
+        //   instr τ≈1.82 / 15 = 0.12
+        // UP=0.70 never triggers — B never grows past start. UP=0.45 picks up
+        // code's high-confidence stretches without firing on prose/instr, where
+        // shrinking is the right move. Env override for tuning:
+        //   HIPFIRE_ADAPTIVE_B_UP=0.XX / HIPFIRE_ADAPTIVE_B_DOWN=0.XX
+        let adaptive_b_up: f64 = std::env::var("HIPFIRE_ADAPTIVE_B_UP")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.45);
+        let adaptive_b_down: f64 = std::env::var("HIPFIRE_ADAPTIVE_B_DOWN")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.25);
+
+        let t_decode = Instant::now();
+        // TTFT capture: production-realistic measure excluding DPM warmup
+        // (which inflates wall-clock by HIPFIRE_DPM_WARMUP_SECS during benches).
+        // Reported value = prefill_ms + first_cycle_ms, taken from t_decode
+        // (set AFTER warmup) plus the previously-recorded prefill_secs.
+        let mut ttft_ms: Option<f64> = None;
         while emitted.len() < max_tokens {
-            if position >= ctx_capacity {
+            if position + draft_scratch_b >= ctx_capacity {
                 eprintln!("hit ctx_capacity {}; stopping", ctx_capacity);
                 break;
             }
-            hipfire_arch_qwen35::qwen35::forward_scratch(
-                &mut gpu,
-                &target.weights,
-                &target.config,
-                cur_token,
-                position,
-                &mut target.kv_cache,
-                &mut target.dn_state,
-                &target.scratch,
-            ).expect("ar forward");
-            let lg = gpu.download_f32(&target.scratch.logits).expect("logits");
-            let next = lg.iter().enumerate().fold((0u32, f32::NEG_INFINITY), |(best, bv), (i, &v)| {
-                if v > bv { (i as u32, v) } else { (best, bv) }
-            }).0;
-            emitted.push(next);
-            if ar_first_tok_secs.is_none() {
-                ar_first_tok_secs = Some(t_ar.elapsed().as_secs_f64());
+            // Per-cycle host timing snapshot (before the step).
+            let (
+                wall_start,
+                l_start,
+                htod_start,
+                dtoh_start,
+                dtod_start,
+                memset_start,
+                ssync_start,
+                esync_start,
+                dsync_start,
+                glaunch_start,
+            ) = if host_timing {
+                use hip_bridge::launch_counters as lc;
+                (
+                    Instant::now(),
+                    lc::launch_kernel::time_ns(),
+                    lc::memcpy_htod::time_ns(),
+                    lc::memcpy_dtoh::time_ns(),
+                    lc::memcpy_dtod::time_ns(),
+                    lc::memset::time_ns(),
+                    lc::stream_sync::time_ns(),
+                    lc::event_sync::time_ns(),
+                    lc::device_sync::time_ns(),
+                    lc::graph_launch::time_ns(),
+                )
+            } else {
+                (Instant::now(), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            };
+            if do_profile && stats.cycles == 1 && !profile_armed {
+                // First cycle was the JIT warm-up. Arm profiling now and drain
+                // after `profile_cycles_target` more cycles.
+                rdna_compute::profile::start();
+                profile_armed = true;
             }
-            position += 1;
-            if let Some(ref p) = cask_policy {
-                if let Some(ev) = p.maybe_evict(&mut gpu, &mut target.kv_cache, position)
-                    .expect("ar cask evict") {
-                    // AR baseline doesn't touch draft state — no mirror needed.
-                    position = ev.new_physical;
-                }
-            }
-            if tokenizer.is_terminator(next) {
-                eprintln!("eos (id={next})");
-                break;
-            }
-            cur_token = next;
-        }
-        let ar_elapsed = t_ar.elapsed().as_secs_f64();
-        let text = tokenizer.decode(&emitted);
-        eprintln!("--- AR-BASELINE OUTPUT ---");
-        println!("{text}");
-        eprintln!("--------------------------");
-        eprintln!("emitted: {} tokens in {:.2}s  ({:.2} tok/s)",
-                  emitted.len(), ar_elapsed, emitted.len() as f64 / ar_elapsed);
-        eprintln!("AR tokens: {:?}", emitted);
-        // Mirror BENCH METRICS block from the DFlash path so downstream
-        // bench harnesses (scripts/bench_humaneval_dflash.py) can extract
-        // prefill_tok_s + ttft_ms + decode stats from AR runs too.
-        let ar_ttft_ms = (prefill_secs + ar_first_tok_secs.unwrap_or(0.0)) * 1000.0;
-        let (vram_free_bytes, vram_total_bytes) = gpu.hip.get_vram_info().unwrap_or((0, 0));
-        let vram_used_mb = ((vram_total_bytes.saturating_sub(vram_free_bytes)) as f64 / (1024.0 * 1024.0)) as u64;
-        let vram_total_mb = (vram_total_bytes as f64 / (1024.0 * 1024.0)) as u64;
-        eprintln!("=== BENCH METRICS ===");
-        eprintln!("prompt_tokens: {}", prompt_tokens.len());
-        eprintln!("prefill_secs: {:.4}", prefill_secs);
-        eprintln!("prefill_tok_s: {:.2}", prefill_tok_s);
-        eprintln!("ttft_ms: {:.2}", ar_ttft_ms);
-        eprintln!("decode_tokens_emitted: {}", emitted.len());
-        eprintln!("decode_secs: {:.4}", ar_elapsed);
-        eprintln!("decode_tok_s: {:.2}", emitted.len() as f64 / ar_elapsed.max(1e-9));
-        eprintln!("decode_tau: 1.0000");
-        eprintln!("decode_accept_rate: 1.0000");
-        eprintln!("vram_used_mb: {}", vram_used_mb);
-        eprintln!("vram_total_mb: {}", vram_total_mb);
-        eprintln!("=====================");
-        // End-of-row for the AR-baseline path. In single-prompt mode this
-        // is the last iteration, so `continue` falls out of the one-row loop
-        // just like the historical `return`. In --prompts-file mode it lets
-        // the resident bench proceed to the next row.
-        if multi_row {
-            eprintln!("@@@ ROW {row_idx} END @@@");
-        }
-        continue;
-    }
-
-    // HIPFIRE_HOST_TIMING=1: dump per-cycle host-side wall-clock breakdown
-    // (launch overhead vs D2D/D2H/H2D vs other host work) by diffing the
-    // hip-bridge launch_counters around each cycle.
-    let host_timing = std::env::var("HIPFIRE_HOST_TIMING").ok().as_deref() == Some("1");
-    let mut per_cycle_wall_us: Vec<u64> = Vec::new();
-    let mut per_cycle_api_us: Vec<(u64, u64, u64, u64, u64, u64, u64, u64, u64)> = Vec::new();
-    // columns: launch, h2d, d2h, d2d, memset, stream_sync, event_sync, device_sync, graph_launch
-
-    // HIPFIRE_DPM_WARMUP_SECS: run a memset loop on a 256 MB scratch before
-    // the decode timer starts, to pin the GPU at high DPM. See dispatch.rs
-    // `dpm_warmup` for rationale — between-process DPM variance has been
-    // observed at 7× wall-clock (52 ms vs 358 ms/cycle on the same bench),
-    // which is orders of magnitude more than the ±10-15% noise band our
-    // methodology doc calls out. Default 0 (disabled) for backward compat.
-    if let Ok(secs_str) = std::env::var("HIPFIRE_DPM_WARMUP_SECS") {
-        let secs: f32 = secs_str.parse().unwrap_or(0.0);
-        if secs > 0.0 {
-            gpu.dpm_warmup(secs).expect("dpm warmup");
-        }
-    }
-
-    // (Seed-oracle + ddtree-meta counter resets moved to the per-row reset
-    // block at the top of the multi-prompt loop — see issue #173.)
-
-    // Adaptive-B state: tracks current B between cycles, plus a cooldown
-    // counter and a histogram for end-of-run reporting.
-    let mut current_adaptive_b: usize = draft_cfg.block_size;
-    let mut adaptive_b_cycles_since_change: usize = 0;
-    let mut adaptive_b_histogram: std::collections::HashMap<usize, u32> =
-        std::collections::HashMap::new();
-    let mut adaptive_b_changes: u32 = 0;
-    const ADAPTIVE_B_STEP: usize = 2;
-    const ADAPTIVE_B_COOLDOWN: usize = 3;
-    // Hysteresis thresholds on util = EWMA(accept_len) / (current_B - 1):
-    //   util > UP   → draft keeps up, stretch B further.
-    //   util < DOWN → draft lags, shrink B to cut verify cost.
-    // Gap between the two prevents flapping at one util value.
-    //
-    // Measured util ceilings at fixed-B16 (2026-04-24 3-run median):
-    //   code  τ≈7.68 / (B-1=15) = 0.51
-    //   prose τ≈1.65 / 15 = 0.11
-    //   instr τ≈1.82 / 15 = 0.12
-    // UP=0.70 never triggers — B never grows past start. UP=0.45 picks up
-    // code's high-confidence stretches without firing on prose/instr, where
-    // shrinking is the right move. Env override for tuning:
-    //   HIPFIRE_ADAPTIVE_B_UP=0.XX / HIPFIRE_ADAPTIVE_B_DOWN=0.XX
-    let adaptive_b_up: f64 = std::env::var("HIPFIRE_ADAPTIVE_B_UP")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(0.45);
-    let adaptive_b_down: f64 = std::env::var("HIPFIRE_ADAPTIVE_B_DOWN")
-        .ok().and_then(|s| s.parse().ok()).unwrap_or(0.25);
-
-    let t_decode = Instant::now();
-    // TTFT capture: production-realistic measure excluding DPM warmup
-    // (which inflates wall-clock by HIPFIRE_DPM_WARMUP_SECS during benches).
-    // Reported value = prefill_ms + first_cycle_ms, taken from t_decode
-    // (set AFTER warmup) plus the previously-recorded prefill_secs.
-    let mut ttft_ms: Option<f64> = None;
-    while emitted.len() < max_tokens {
-        if position + draft_scratch_b >= ctx_capacity {
-            eprintln!("hit ctx_capacity {}; stopping", ctx_capacity);
-            break;
-        }
-        // Per-cycle host timing snapshot (before the step).
-        let (
-            wall_start,
-            l_start,
-            htod_start,
-            dtoh_start,
-            dtod_start,
-            memset_start,
-            ssync_start,
-            esync_start,
-            dsync_start,
-            glaunch_start,
-        ) = if host_timing {
-            use hip_bridge::launch_counters as lc;
-            (
-                Instant::now(),
-                lc::launch_kernel::time_ns(),
-                lc::memcpy_htod::time_ns(),
-                lc::memcpy_dtoh::time_ns(),
-                lc::memcpy_dtod::time_ns(),
-                lc::memset::time_ns(),
-                lc::stream_sync::time_ns(),
-                lc::event_sync::time_ns(),
-                lc::device_sync::time_ns(),
-                lc::graph_launch::time_ns(),
-            )
-        } else {
-            (Instant::now(), 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        };
-        if do_profile && stats.cycles == 1 && !profile_armed {
-            // First cycle was the JIT warm-up. Arm profiling now and drain
-            // after `profile_cycles_target` more cycles.
-            rdna_compute::profile::start();
-            profile_armed = true;
-        }
-        if do_profile && profile_armed
-            && stats.cycles >= 1 + profile_cycles_target
-            && profile_cycle_count == 0
-        {
-            profile_cycle_count = stats.cycles - 1;
-            if let Some(entries) = rdna_compute::profile::stop() {
-                use std::collections::HashMap;
-                let mut by_kernel: HashMap<&str, (f64, usize, usize)> = HashMap::new();
-                for e in &entries {
-                    let entry = by_kernel.entry(e.kernel).or_insert((0.0, 0, 0));
-                    entry.0 += e.time_us;
-                    entry.1 += 1;
-                    entry.2 += e.bytes;
-                }
-                let mut kerns: Vec<_> = by_kernel.into_iter().collect();
-                kerns.sort_by(|a, b| b.1.0.partial_cmp(&a.1.0).unwrap());
-                let total_us: f64 = kerns.iter().map(|(_, (t, _, _))| t).sum();
-                eprintln!(
+            if do_profile
+                && profile_armed
+                && stats.cycles >= 1 + profile_cycles_target
+                && profile_cycle_count == 0
+            {
+                profile_cycle_count = stats.cycles - 1;
+                if let Some(entries) = rdna_compute::profile::stop() {
+                    use std::collections::HashMap;
+                    let mut by_kernel: HashMap<&str, (f64, usize, usize)> = HashMap::new();
+                    for e in &entries {
+                        let entry = by_kernel.entry(e.kernel).or_insert((0.0, 0, 0));
+                        entry.0 += e.time_us;
+                        entry.1 += 1;
+                        entry.2 += e.bytes;
+                    }
+                    let mut kerns: Vec<_> = by_kernel.into_iter().collect();
+                    kerns.sort_by(|a, b| b.1 .0.partial_cmp(&a.1 .0).unwrap());
+                    let total_us: f64 = kerns.iter().map(|(_, (t, _, _))| t).sum();
+                    eprintln!(
                     "\n=== PROFILE ({} kernel calls over {} cycles, {:.1}ms total kernel time) ===",
                     entries.len(), profile_cycle_count, total_us / 1000.0,
                 );
-                eprintln!(
-                    "  {:50} {:>6} {:>10} {:>10} {:>7} {:>10}",
-                    "kernel", "calls", "total_ms", "us/call", "%", "MB",
-                );
-                for (kern, (us, n, bytes)) in &kerns {
-                    if *us / total_us < 0.005 { continue; } // skip <0.5%
                     eprintln!(
-                        "  {kern:50} {n:>6} {:>10.2} {:>10.0} {:>6.1}% {:>10.1}",
-                        us / 1000.0,
-                        us / *n as f64,
-                        us / total_us * 100.0,
-                        *bytes as f64 / 1.0e6,
+                        "  {:50} {:>6} {:>10} {:>10} {:>7} {:>10}",
+                        "kernel", "calls", "total_ms", "us/call", "%", "MB",
                     );
+                    for (kern, (us, n, bytes)) in &kerns {
+                        if *us / total_us < 0.005 {
+                            continue;
+                        } // skip <0.5%
+                        eprintln!(
+                            "  {kern:50} {n:>6} {:>10.2} {:>10.0} {:>6.1}% {:>10.1}",
+                            us / 1000.0,
+                            us / *n as f64,
+                            us / total_us * 100.0,
+                            *bytes as f64 / 1.0e6,
+                        );
+                    }
                 }
             }
-        }
-        // Adaptive-B scheduler (Task #93 Phase B replacement — 2026-04-24).
-        //
-        // Online rule, no training. Tracks recent EWMA(accept_len), divides
-        // by current_B-1 to get "utilization". When draft is over-performing
-        // (util > UP), bump B — amortize verify over more positions. When
-        // draft is under-performing (util < DOWN), shrink B — cut verify
-        // cost, let τ recover. Hysteresis + cooldown prevent flapping.
-        //
-        // adaptive_b_min/max default to 8..=16 (pre-2026-04-24 behaviour
-        // bounded by the draft's trained block_size). User can widen with
-        // --adaptive-b-range MIN:MAX; scratches upstream pre-sized for MAX.
-        let block_override = if adaptive_b {
-            if accepts_window.len() >= 4 && adaptive_b_cycles_since_change >= ADAPTIVE_B_COOLDOWN {
-                let ewma: f64 = accepts_window.iter().copied().sum::<usize>() as f64
-                    / accepts_window.len() as f64;
-                let util = ewma / (current_adaptive_b.saturating_sub(1).max(1)) as f64;
-                if util > adaptive_b_up
-                    && current_adaptive_b + ADAPTIVE_B_STEP <= adaptive_b_max
+            // Adaptive-B scheduler (Task #93 Phase B replacement — 2026-04-24).
+            //
+            // Online rule, no training. Tracks recent EWMA(accept_len), divides
+            // by current_B-1 to get "utilization". When draft is over-performing
+            // (util > UP), bump B — amortize verify over more positions. When
+            // draft is under-performing (util < DOWN), shrink B — cut verify
+            // cost, let τ recover. Hysteresis + cooldown prevent flapping.
+            //
+            // adaptive_b_min/max default to 8..=16 (pre-2026-04-24 behaviour
+            // bounded by the draft's trained block_size). User can widen with
+            // --adaptive-b-range MIN:MAX; scratches upstream pre-sized for MAX.
+            let block_override = if adaptive_b {
+                if accepts_window.len() >= 4
+                    && adaptive_b_cycles_since_change >= ADAPTIVE_B_COOLDOWN
                 {
-                    current_adaptive_b += ADAPTIVE_B_STEP;
-                    adaptive_b_cycles_since_change = 0;
-                    adaptive_b_changes += 1;
-                } else if util < adaptive_b_down
-                    && current_adaptive_b >= adaptive_b_min + ADAPTIVE_B_STEP
-                {
-                    current_adaptive_b -= ADAPTIVE_B_STEP;
-                    adaptive_b_cycles_since_change = 0;
-                    adaptive_b_changes += 1;
+                    let ewma: f64 = accepts_window.iter().copied().sum::<usize>() as f64
+                        / accepts_window.len() as f64;
+                    let util = ewma / (current_adaptive_b.saturating_sub(1).max(1)) as f64;
+                    if util > adaptive_b_up
+                        && current_adaptive_b + ADAPTIVE_B_STEP <= adaptive_b_max
+                    {
+                        current_adaptive_b += ADAPTIVE_B_STEP;
+                        adaptive_b_cycles_since_change = 0;
+                        adaptive_b_changes += 1;
+                    } else if util < adaptive_b_down
+                        && current_adaptive_b >= adaptive_b_min + ADAPTIVE_B_STEP
+                    {
+                        current_adaptive_b -= ADAPTIVE_B_STEP;
+                        adaptive_b_cycles_since_change = 0;
+                        adaptive_b_changes += 1;
+                    }
                 }
-            }
-            adaptive_b_cycles_since_change += 1;
-            *adaptive_b_histogram.entry(current_adaptive_b).or_insert(0) += 1;
-            Some(current_adaptive_b)
-        } else {
-            None
-        };
-        // PLD lookup: context = prompt ++ emitted (everything committed so
-        // far). The matcher finds a suffix self-match and extracts up to
-        // pld_max_extract continuation tokens. `pld_spine` is passed as a
-        // borrowed slice — when Some, spec_step_dflash bypasses the
-        // DFlash forward entirely for this cycle.
-        let pld_match = pld_matcher.as_ref().and_then(|m| {
-            // Build context = prompt ++ emitted ++ seed_token, making sure
-            // the context suffix ENDS at seed_token — the matcher predicts
-            // what follows the suffix, and block[1..] lives right after
-            // seed_token. At cycle K≥1, emitted[-1] is already seed_token
-            // (pushed as the prior cycle's bonus) so we skip the extra push;
-            // at cycle 0 (emitted empty) we need to append it explicitly.
-            let mut ctx = Vec::with_capacity(prompt_tokens.len() + emitted.len() + 1);
-            ctx.extend_from_slice(&prompt_tokens);
-            ctx.extend_from_slice(&emitted);
-            if ctx.last() != Some(&seed_token) {
-                ctx.push(seed_token);
-            }
-            m.lookup(&ctx)
-        });
-        // Goose §4.3 bypass-mode gate: only use PLD if both consensus AND
-        // chain length clear their thresholds. Weaker matches are a net loss
-        // when DFlash is strong (repetition-heavy content where literal
-        // 3-gram matches predict the wrong number/variable in a list).
-        let pld_spine: Option<&[u32]> = pld_match.as_ref().and_then(|m| {
-            if m.consensus >= pld_min_consensus && m.tokens.len() >= pld_min_chain {
-                Some(m.tokens.as_slice())
+                adaptive_b_cycles_since_change += 1;
+                *adaptive_b_histogram.entry(current_adaptive_b).or_insert(0) += 1;
+                Some(current_adaptive_b)
             } else {
                 None
-            }
-        });
-        let used_pld = pld_spine.is_some();
-        if used_pld {
-            pld_hits += 1;
-        }
-        let step = if ddtree_enabled {
-            if let Some(phase) = ddtree_path_c_phase.as_deref() {
-                let phase2_snaps = if phase == "phase2" {
-                    Some(speculative::Phase2Snapshots {
-                        parent_pre_snap: &mut path_c_parent_pre_snap,
-                        main_end_snap: &mut path_c_main_end_snap,
-                    })
+            };
+            // PLD lookup: context = prompt ++ emitted (everything committed so
+            // far). The matcher finds a suffix self-match and extracts up to
+            // pld_max_extract continuation tokens. `pld_spine` is passed as a
+            // borrowed slice — when Some, spec_step_dflash bypasses the
+            // DFlash forward entirely for this cycle.
+            let pld_match = pld_matcher.as_ref().and_then(|m| {
+                // Build context = prompt ++ emitted ++ seed_token, making sure
+                // the context suffix ENDS at seed_token — the matcher predicts
+                // what follows the suffix, and block[1..] lives right after
+                // seed_token. At cycle K≥1, emitted[-1] is already seed_token
+                // (pushed as the prior cycle's bonus) so we skip the extra push;
+                // at cycle 0 (emitted empty) we need to append it explicitly.
+                let mut ctx = Vec::with_capacity(prompt_tokens.len() + emitted.len() + 1);
+                ctx.extend_from_slice(&prompt_tokens);
+                ctx.extend_from_slice(&emitted);
+                if ctx.last() != Some(&seed_token) {
+                    ctx.push(seed_token);
+                }
+                m.lookup(&ctx)
+            });
+            // Goose §4.3 bypass-mode gate: only use PLD if both consensus AND
+            // chain length clear their thresholds. Weaker matches are a net loss
+            // when DFlash is strong (repetition-heavy content where literal
+            // 3-gram matches predict the wrong number/variable in a list).
+            let pld_spine: Option<&[u32]> = pld_match.as_ref().and_then(|m| {
+                if m.consensus >= pld_min_consensus && m.tokens.len() >= pld_min_chain {
+                    Some(m.tokens.as_slice())
                 } else {
                     None
-                };
-                speculative::spec_step_ddtree_path_c(
-                    &mut gpu,
-                    &mut target,
-                    &draft_weights,
-                    &draft_cfg,
-                    &mut draft_scratch,
-                    &mut hidden_rb,
-                    &mut target_hidden_host,
-                    &mut target_snap,
-                    &mut gdn_tape,
-                    &verify_scratch,
-                    position,
-                    seed_token,
-                    ctx_slice,
-                    ddtree_budget,
-                    ddtree_topk,
-                    phase2_snaps,
-                )
-                .expect("ddtree-path-c spec step")
-            } else if ddtree_batched {
-                speculative::spec_step_ddtree_batched(
-                    &mut gpu,
-                    &mut target,
-                    &draft_weights,
-                    &draft_cfg,
-                    &mut draft_scratch,
-                    &mut hidden_rb,
-                    &mut target_hidden_host,
-                    &mut target_snap,
-                    &mut post_seed_snap,
-                    &mut gdn_tape,
-                    &ddtree_scratch,
-                    &verify_scratch,
-                    position,
-                    seed_token,
-                    ctx_slice,
-                    ddtree_budget,
-                    ddtree_topk,
-                )
-                .expect("ddtree-batched spec step")
-            } else {
-                speculative::spec_step_ddtree(
-                    &mut gpu,
-                    &mut target,
-                    &draft_weights,
-                    &draft_cfg,
-                    &mut draft_scratch,
-                    &mut hidden_rb,
-                    &mut target_hidden_host,
-                    &mut target_snap,
-                    &mut post_seed_snap,
-                    &mut gdn_tape,
-                    &verify_scratch,
-                    position,
-                    seed_token,
-                    ctx_slice,
-                    ddtree_budget,
-                    ddtree_topk,
-                )
-                .expect("ddtree spec step")
+                }
+            });
+            let used_pld = pld_spine.is_some();
+            if used_pld {
+                pld_hits += 1;
             }
-        } else {
-            speculative::spec_step_dflash(
-                &mut gpu,
-                &mut target,
-                &draft_weights,
-                &draft_cfg,
-                &mut draft_scratch,
-                &mut hidden_rb,
-                &mut target_hidden_host,
-                &mut target_snap,
-                &verify_scratch,
-                position,
-                seed_token,
-                ctx_slice,
-                if no_tape { None } else { Some(&mut gdn_tape) },
-                runtime_temp,
-                &mut rng_state,
-                block_override,
-                ngram_cache.as_ref(),
-                &emitted,
-                cactus_delta,
-                pld_spine,
-                runtime_repeat_penalty,
-                repeat_window,
-            )
-            .expect("spec step")
-        };
-        if used_pld {
-            pld_accepted += step.accepted;
-        }
+            let step = if ddtree_enabled {
+                if let Some(phase) = ddtree_path_c_phase.as_deref() {
+                    let phase2_snaps = if phase == "phase2" {
+                        Some(speculative::Phase2Snapshots {
+                            parent_pre_snap: &mut path_c_parent_pre_snap,
+                            main_end_snap: &mut path_c_main_end_snap,
+                        })
+                    } else {
+                        None
+                    };
+                    speculative::spec_step_ddtree_path_c(
+                        &mut gpu,
+                        &mut target,
+                        &draft_weights,
+                        &draft_cfg,
+                        &mut draft_scratch,
+                        &mut hidden_rb,
+                        &mut target_hidden_host,
+                        &mut target_snap,
+                        &mut gdn_tape,
+                        &verify_scratch,
+                        position,
+                        seed_token,
+                        ctx_slice,
+                        ddtree_budget,
+                        ddtree_topk,
+                        phase2_snaps,
+                    )
+                    .expect("ddtree-path-c spec step")
+                } else if ddtree_batched {
+                    speculative::spec_step_ddtree_batched(
+                        &mut gpu,
+                        &mut target,
+                        &draft_weights,
+                        &draft_cfg,
+                        &mut draft_scratch,
+                        &mut hidden_rb,
+                        &mut target_hidden_host,
+                        &mut target_snap,
+                        &mut post_seed_snap,
+                        &mut gdn_tape,
+                        &ddtree_scratch,
+                        &verify_scratch,
+                        position,
+                        seed_token,
+                        ctx_slice,
+                        ddtree_budget,
+                        ddtree_topk,
+                    )
+                    .expect("ddtree-batched spec step")
+                } else {
+                    speculative::spec_step_ddtree(
+                        &mut gpu,
+                        &mut target,
+                        &draft_weights,
+                        &draft_cfg,
+                        &mut draft_scratch,
+                        &mut hidden_rb,
+                        &mut target_hidden_host,
+                        &mut target_snap,
+                        &mut post_seed_snap,
+                        &mut gdn_tape,
+                        &verify_scratch,
+                        position,
+                        seed_token,
+                        ctx_slice,
+                        ddtree_budget,
+                        ddtree_topk,
+                    )
+                    .expect("ddtree spec step")
+                }
+            } else {
+                speculative::spec_step_dflash(
+                    &mut gpu,
+                    &mut target,
+                    &draft_weights,
+                    &draft_cfg,
+                    &mut draft_scratch,
+                    &mut hidden_rb,
+                    &mut target_hidden_host,
+                    &mut target_snap,
+                    &verify_scratch,
+                    position,
+                    seed_token,
+                    ctx_slice,
+                    if no_tape { None } else { Some(&mut gdn_tape) },
+                    runtime_temp,
+                    &mut rng_state,
+                    block_override,
+                    ngram_cache.as_ref(),
+                    &emitted,
+                    cactus_delta,
+                    pld_spine,
+                    runtime_repeat_penalty,
+                    repeat_window,
+                )
+                .expect("spec step")
+            };
+            if used_pld {
+                pld_accepted += step.accepted;
+            }
 
-        // Per-cycle debug for the first N cycles.
-        if stats.cycles < debug_cycles {
-            eprintln!(
-                "[cycle {}] pos={} seed={} committed={:?} bonus={} accepted={} τ={:.3}",
-                stats.cycles,
-                position,
-                seed_token,
-                step.committed.iter().skip(1).take(4).collect::<Vec<_>>(),
-                step.bonus_token,
-                step.accepted,
-                step.accepted as f64,
-            );
-            // Decode the first few committed tokens for visibility.
-            let preview: Vec<u32> = step.committed.iter().skip(1).copied().collect();
-            let tx = tokenizer.decode(&preview);
-            eprintln!("  decoded-committed[1..]: {:?}", tx);
-        }
+            // Per-cycle debug for the first N cycles.
+            if stats.cycles < debug_cycles {
+                eprintln!(
+                    "[cycle {}] pos={} seed={} committed={:?} bonus={} accepted={} τ={:.3}",
+                    stats.cycles,
+                    position,
+                    seed_token,
+                    step.committed.iter().skip(1).take(4).collect::<Vec<_>>(),
+                    step.bonus_token,
+                    step.accepted,
+                    step.accepted as f64,
+                );
+                // Decode the first few committed tokens for visibility.
+                let preview: Vec<u32> = step.committed.iter().skip(1).copied().collect();
+                let tx = tokenizer.decode(&preview);
+                eprintln!("  decoded-committed[1..]: {:?}", tx);
+            }
 
-        // Populate n-gram cache from newly committed tokens. `step.committed`
-        // is [seed, accepted draft tokens, bonus]; we record all consecutive
-        // triples within the committed span plus the join with prior context.
-        if let Some(ref mut ng) = ngram_cache {
-            // The 2 tokens right before step.committed[0] are the last 2 of
-            // `emitted` (since seed_token == prev iter's bonus = last emitted).
-            // Walk windows across (tail-2 of emitted ++ step.committed).
-            let tail_len = emitted.len().min(2);
-            let mut window: Vec<u32> = Vec::with_capacity(tail_len + step.committed.len());
-            window.extend_from_slice(&emitted[emitted.len() - tail_len..]);
-            window.extend_from_slice(&step.committed);
-            ng.observe_many(&window);
-        }
-        stats.record(&step);
+            // Populate n-gram cache from newly committed tokens. `step.committed`
+            // is [seed, accepted draft tokens, bonus]; we record all consecutive
+            // triples within the committed span plus the join with prior context.
+            if let Some(ref mut ng) = ngram_cache {
+                // The 2 tokens right before step.committed[0] are the last 2 of
+                // `emitted` (since seed_token == prev iter's bonus = last emitted).
+                // Walk windows across (tail-2 of emitted ++ step.committed).
+                let tail_len = emitted.len().min(2);
+                let mut window: Vec<u32> = Vec::with_capacity(tail_len + step.committed.len());
+                window.extend_from_slice(&emitted[emitted.len() - tail_len..]);
+                window.extend_from_slice(&step.committed);
+                ng.observe_many(&window);
+            }
+            stats.record(&step);
 
-        // Per-cycle host timing snapshot (after the step).
-        if host_timing {
-            use hip_bridge::launch_counters as lc;
-            let wall_us = wall_start.elapsed().as_micros() as u64;
-            let launch_us = (lc::launch_kernel::time_ns() - l_start) / 1000;
-            let htod_us = (lc::memcpy_htod::time_ns() - htod_start) / 1000;
-            let dtoh_us = (lc::memcpy_dtoh::time_ns() - dtoh_start) / 1000;
-            let dtod_us = (lc::memcpy_dtod::time_ns() - dtod_start) / 1000;
-            let memset_us = (lc::memset::time_ns() - memset_start) / 1000;
-            let ssync_us = (lc::stream_sync::time_ns() - ssync_start) / 1000;
-            let esync_us = (lc::event_sync::time_ns() - esync_start) / 1000;
-            let dsync_us = (lc::device_sync::time_ns() - dsync_start) / 1000;
-            let glaunch_us = (lc::graph_launch::time_ns() - glaunch_start) / 1000;
-            per_cycle_wall_us.push(wall_us);
-            per_cycle_api_us.push((
-                launch_us, htod_us, dtoh_us, dtod_us, memset_us,
-                ssync_us, esync_us, dsync_us, glaunch_us,
-            ));
-        }
+            // Per-cycle host timing snapshot (after the step).
+            if host_timing {
+                use hip_bridge::launch_counters as lc;
+                let wall_us = wall_start.elapsed().as_micros() as u64;
+                let launch_us = (lc::launch_kernel::time_ns() - l_start) / 1000;
+                let htod_us = (lc::memcpy_htod::time_ns() - htod_start) / 1000;
+                let dtoh_us = (lc::memcpy_dtoh::time_ns() - dtoh_start) / 1000;
+                let dtod_us = (lc::memcpy_dtod::time_ns() - dtod_start) / 1000;
+                let memset_us = (lc::memset::time_ns() - memset_start) / 1000;
+                let ssync_us = (lc::stream_sync::time_ns() - ssync_start) / 1000;
+                let esync_us = (lc::event_sync::time_ns() - esync_start) / 1000;
+                let dsync_us = (lc::device_sync::time_ns() - dsync_start) / 1000;
+                let glaunch_us = (lc::graph_launch::time_ns() - glaunch_start) / 1000;
+                per_cycle_wall_us.push(wall_us);
+                per_cycle_api_us.push((
+                    launch_us, htod_us, dtoh_us, dtod_us, memset_us, ssync_us, esync_us, dsync_us,
+                    glaunch_us,
+                ));
+            }
 
-        // Rolling τ.
-        if accepts_window.len() == TAU_WINDOW {
-            accepts_window.pop_front();
-        }
-        accepts_window.push_back(step.accepted);
-        if live_tau {
-            let win_tau: f64 = accepts_window.iter().copied().sum::<usize>() as f64
-                / accepts_window.len() as f64;
-            let cum_tau: f64 = stats.accepted_tokens as f64 / stats.cycles as f64;
-            eprintln!(
-                "[cycle {:3}] accepted={:2} seed={:5} τ_win={:.2} τ_cum={:.2} position={}",
-                stats.cycles, step.accepted, seed_token, win_tau, cum_tau, position,
-            );
-        }
+            // Rolling τ.
+            if accepts_window.len() == TAU_WINDOW {
+                accepts_window.pop_front();
+            }
+            accepts_window.push_back(step.accepted);
+            if live_tau {
+                let win_tau: f64 = accepts_window.iter().copied().sum::<usize>() as f64
+                    / accepts_window.len() as f64;
+                let cum_tau: f64 = stats.accepted_tokens as f64 / stats.cycles as f64;
+                eprintln!(
+                    "[cycle {:3}] accepted={:2} seed={:5} τ_win={:.2} τ_cum={:.2} position={}",
+                    stats.cycles, step.accepted, seed_token, win_tau, cum_tau, position,
+                );
+            }
 
-        // `step.committed[0]` is the seed_token (already emitted). Emit [1..].
-        for (&tok, _) in step.committed.iter().skip(1).zip(0..) {
-            emitted.push(tok);
-        }
-        if ttft_ms.is_none() && step.committed.len() > 1 {
-            // Use t_decode (post-warmup) + prefill_secs so the reported
-            // TTFT is what a serving-mode client would actually see.
-            let first_cycle_ms = t_decode.elapsed().as_secs_f64() * 1000.0;
-            ttft_ms = Some(prefill_secs * 1000.0 + first_cycle_ms);
-        }
+            // `step.committed[0]` is the seed_token (already emitted). Emit [1..].
+            for (&tok, _) in step.committed.iter().skip(1).zip(0..) {
+                emitted.push(tok);
+            }
+            if ttft_ms.is_none() && step.committed.len() > 1 {
+                // Use t_decode (post-warmup) + prefill_secs so the reported
+                // TTFT is what a serving-mode client would actually see.
+                let first_cycle_ms = t_decode.elapsed().as_secs_f64() * 1000.0;
+                ttft_ms = Some(prefill_secs * 1000.0 + first_cycle_ms);
+            }
 
-        // Loop-break cycle detector: hash trailing 32-token window, look
-        // up in known-hash set. Hit = repeating block. The shift-by-cycle
-        // (each iter advances ~12 tokens, window=32) means consecutive
-        // windows overlap heavily but yield distinct hashes; only a true
-        // verbatim repeat re-hashes to a previously-seen value.
-        let mut loop_break_force_stop = false;
-        if loop_break_on && emitted.len() >= LOOP_BREAK_WINDOW {
-            use std::hash::{Hash, Hasher};
-            let tail = &emitted[emitted.len() - LOOP_BREAK_WINDOW..];
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            tail.hash(&mut hasher);
-            let h = hasher.finish();
-            let hit = window_hashes.contains(&h);
-            if hit {
-                loop_break_hits += 1;
-                loop_break_consecutive += 1;
-                loop_break_clean_streak = 0;
-                let trigger = loop_break_consecutive >= loop_break_stop_after;
-                match loop_break_mode {
-                    "stop" => {
-                        if trigger {
-                            eprintln!(
+            // Loop-break cycle detector: hash trailing 32-token window, look
+            // up in known-hash set. Hit = repeating block. The shift-by-cycle
+            // (each iter advances ~12 tokens, window=32) means consecutive
+            // windows overlap heavily but yield distinct hashes; only a true
+            // verbatim repeat re-hashes to a previously-seen value.
+            let mut loop_break_force_stop = false;
+            if loop_break_on && emitted.len() >= LOOP_BREAK_WINDOW {
+                use std::hash::{Hash, Hasher};
+                let tail = &emitted[emitted.len() - LOOP_BREAK_WINDOW..];
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                tail.hash(&mut hasher);
+                let h = hasher.finish();
+                let hit = window_hashes.contains(&h);
+                if hit {
+                    loop_break_hits += 1;
+                    loop_break_consecutive += 1;
+                    loop_break_clean_streak = 0;
+                    let trigger = loop_break_consecutive >= loop_break_stop_after;
+                    match loop_break_mode {
+                        "stop" => {
+                            if trigger {
+                                eprintln!(
                                 "[loop-break] cycle {} pos {}: {} consecutive repeats → terminating decode (synthetic EOS); total_hits={}",
                                 stats.cycles, position, loop_break_consecutive, loop_break_hits
                             );
-                            loop_break_force_stop = true;
-                        } else {
-                            eprintln!(
+                                loop_break_force_stop = true;
+                            } else {
+                                eprintln!(
                                 "[loop-break] cycle {} pos {}: window repeat ({}/{} consecutive)",
                                 stats.cycles, position, loop_break_consecutive, loop_break_stop_after
                             );
+                            }
                         }
-                    }
-                    "escalate" => {
-                        if trigger {
-                            // Either escalate RP or give up if escalation
-                            // ladder exhausted (max bumps reached AND the
-                            // bumped value still loops).
-                            if loop_break_escalations >= loop_break_max_escalations
-                                || runtime_repeat_penalty >= loop_break_rp_max - 1e-4
-                            {
-                                eprintln!(
+                        "escalate" => {
+                            if trigger {
+                                // Either escalate RP or give up if escalation
+                                // ladder exhausted (max bumps reached AND the
+                                // bumped value still loops).
+                                if loop_break_escalations >= loop_break_max_escalations
+                                    || runtime_repeat_penalty >= loop_break_rp_max - 1e-4
+                                {
+                                    eprintln!(
                                     "[loop-break] cycle {} pos {}: escalation exhausted (rp={:.2} after {} bumps) → terminating; total_hits={}",
                                     stats.cycles, position, runtime_repeat_penalty,
                                     loop_break_escalations, loop_break_hits
                                 );
-                                loop_break_force_stop = true;
-                            } else {
-                                let prev_rp = runtime_repeat_penalty;
-                                runtime_repeat_penalty = (runtime_repeat_penalty + loop_break_rp_step)
-                                    .min(loop_break_rp_max);
-                                if runtime_repeat_penalty < 1.0 + loop_break_rp_step {
-                                    runtime_repeat_penalty = 1.0 + loop_break_rp_step;
-                                }
-                                loop_break_escalations += 1;
-                                loop_break_consecutive = 0;
-                                // Wipe the hash set so the bumped RP gets
-                                // a fresh judgment window — otherwise the
-                                // same stale tokens trigger immediately.
-                                window_hashes.clear();
-                                eprintln!(
+                                    loop_break_force_stop = true;
+                                } else {
+                                    let prev_rp = runtime_repeat_penalty;
+                                    runtime_repeat_penalty = (runtime_repeat_penalty
+                                        + loop_break_rp_step)
+                                        .min(loop_break_rp_max);
+                                    if runtime_repeat_penalty < 1.0 + loop_break_rp_step {
+                                        runtime_repeat_penalty = 1.0 + loop_break_rp_step;
+                                    }
+                                    loop_break_escalations += 1;
+                                    loop_break_consecutive = 0;
+                                    // Wipe the hash set so the bumped RP gets
+                                    // a fresh judgment window — otherwise the
+                                    // same stale tokens trigger immediately.
+                                    window_hashes.clear();
+                                    eprintln!(
                                     "[loop-break] cycle {} pos {}: ESCALATE rp {:.2} → {:.2} (bump {}/{}); total_hits={}",
                                     stats.cycles, position, prev_rp, runtime_repeat_penalty,
                                     loop_break_escalations, loop_break_max_escalations, loop_break_hits
                                 );
-                            }
-                        } else {
-                            eprintln!(
+                                }
+                            } else {
+                                eprintln!(
                                 "[loop-break] cycle {} pos {}: window repeat ({}/{} consecutive, rp={:.2})",
                                 stats.cycles, position, loop_break_consecutive,
                                 loop_break_stop_after, runtime_repeat_penalty
                             );
+                            }
                         }
-                    }
-                    _ => {
-                        // legacy temp-bump mode
-                        runtime_temp = loop_break_temp;
-                        eprintln!(
+                        _ => {
+                            // legacy temp-bump mode
+                            runtime_temp = loop_break_temp;
+                            eprintln!(
                             "[loop-break] cycle {} pos {}: window repeat → temp={} for next cycle (count={})",
                             stats.cycles, position, loop_break_temp, loop_break_hits
                         );
+                        }
                     }
-                }
-            } else {
-                loop_break_consecutive = 0;
-                loop_break_clean_streak += 1;
-                if loop_break_mode == "temp" {
-                    runtime_temp = temp;
-                }
-                // Escalate-mode RP decay: after RECOVERY cycles of clean
-                // output, halve the gap toward baseline. Repeat each
-                // RECOVERY cycles until back at baseline. Lets the model
-                // regain natural entropy once the basin is escaped.
-                if loop_break_mode == "escalate"
-                    && runtime_repeat_penalty > repeat_penalty + 1e-4
-                    && loop_break_clean_streak > 0
-                    && loop_break_clean_streak % loop_break_recovery == 0
-                {
-                    let prev_rp = runtime_repeat_penalty;
-                    runtime_repeat_penalty =
-                        repeat_penalty + (runtime_repeat_penalty - repeat_penalty) * 0.5;
-                    if runtime_repeat_penalty < repeat_penalty + 0.01 {
-                        runtime_repeat_penalty = repeat_penalty;
-                        loop_break_escalations = loop_break_escalations.saturating_sub(1);
+                } else {
+                    loop_break_consecutive = 0;
+                    loop_break_clean_streak += 1;
+                    if loop_break_mode == "temp" {
+                        runtime_temp = temp;
                     }
-                    eprintln!(
+                    // Escalate-mode RP decay: after RECOVERY cycles of clean
+                    // output, halve the gap toward baseline. Repeat each
+                    // RECOVERY cycles until back at baseline. Lets the model
+                    // regain natural entropy once the basin is escaped.
+                    if loop_break_mode == "escalate"
+                        && runtime_repeat_penalty > repeat_penalty + 1e-4
+                        && loop_break_clean_streak > 0
+                        && loop_break_clean_streak % loop_break_recovery == 0
+                    {
+                        let prev_rp = runtime_repeat_penalty;
+                        runtime_repeat_penalty =
+                            repeat_penalty + (runtime_repeat_penalty - repeat_penalty) * 0.5;
+                        if runtime_repeat_penalty < repeat_penalty + 0.01 {
+                            runtime_repeat_penalty = repeat_penalty;
+                            loop_break_escalations = loop_break_escalations.saturating_sub(1);
+                        }
+                        eprintln!(
                         "[loop-break] cycle {} pos {}: clean for {} cycles → DECAY rp {:.2} → {:.2}",
                         stats.cycles, position, loop_break_clean_streak, prev_rp, runtime_repeat_penalty
                     );
+                    }
+                }
+                window_hashes.insert(h);
+            }
+
+            if loop_break_force_stop {
+                eprintln!("eos");
+                break;
+            }
+
+            // Advance position + pick next seed (= bonus_token).
+            position += step.accepted + 1;
+            seed_token = step.bonus_token;
+
+            // FlashCASK eviction. Fires when target.kv_cache physical hits
+            // budget+β. compact_offset is maintained on the cache so the next
+            // cycle's target.forward_scratch uses the right RoPE phase.
+            if let Some(ref p) = cask_policy {
+                if let Some(ev) = p
+                    .maybe_evict(&mut gpu, &mut target.kv_cache, position)
+                    .expect("spec cask evict")
+                {
+                    let pre_phys = position;
+                    position = ev.new_physical;
+                    // Mirror the KV eviction into the draft's target_hidden view.
+                    // Empty retain_mask (CASK m-fold path) → skip; draft keeps the
+                    // pre-eviction buffer, the old τ-collapse behaviour still
+                    // applies there until m-fold gets a compatible draft mirror.
+                    if !ev.retain_mask.is_empty() {
+                        speculative::apply_eviction_retain_to_draft(
+                            &mut gpu,
+                            &mut draft_scratch,
+                            &ev.retain_mask,
+                            draft_cfg.num_extract(),
+                            draft_cfg.hidden,
+                            pre_phys,
+                        )
+                        .expect("mirror eviction to draft");
+                    }
                 }
             }
-            window_hashes.insert(h);
+
+            // Stop on any terminator (eos_id OR eot_id). Checking only eos_id
+            // misses `<|endoftext|>` when running --no-chatml on a raw-text draft
+            // — see findings/dflash-benchmark-2026-04-24.md §3.5 (post-EOT
+            // attractor loop). `is_terminator` covers both.
+            if step
+                .committed
+                .iter()
+                .skip(1)
+                .any(|&t| tokenizer.is_terminator(t))
+            {
+                eprintln!("eos");
+                break;
+            }
         }
+        let elapsed = t_decode.elapsed().as_secs_f64();
+        let tok_s = emitted.len() as f64 / elapsed;
 
-        if loop_break_force_stop {
-            eprintln!("eos");
-            break;
-        }
-
-        // Advance position + pick next seed (= bonus_token).
-        position += step.accepted + 1;
-        seed_token = step.bonus_token;
-
-        // FlashCASK eviction. Fires when target.kv_cache physical hits
-        // budget+β. compact_offset is maintained on the cache so the next
-        // cycle's target.forward_scratch uses the right RoPE phase.
+        // ── Report ────────────────────────────────────────────────────────
+        let text = tokenizer.decode(&emitted);
+        eprintln!("--- OUTPUT ---");
+        println!("{text}");
+        eprintln!("--------------");
+        eprintln!(
+            "emitted: {} tokens in {:.2}s  ({:.2} tok/s)",
+            emitted.len(),
+            elapsed,
+            tok_s
+        );
+        eprintln!(
+            "cycles: {}  committed: {}  accepted: {}  τ={:.3}  mean_committed={:.3}",
+            stats.cycles,
+            stats.committed_tokens,
+            stats.accepted_tokens,
+            stats.tau(),
+            stats.mean_committed(),
+        );
         if let Some(ref p) = cask_policy {
-            if let Some(ev) = p.maybe_evict(&mut gpu, &mut target.kv_cache, position)
-                .expect("spec cask evict") {
-                let pre_phys = position;
-                position = ev.new_physical;
-                // Mirror the KV eviction into the draft's target_hidden view.
-                // Empty retain_mask (CASK m-fold path) → skip; draft keeps the
-                // pre-eviction buffer, the old τ-collapse behaviour still
-                // applies there until m-fold gets a compatible draft mirror.
-                if !ev.retain_mask.is_empty() {
-                    speculative::apply_eviction_retain_to_draft(
-                        &mut gpu,
-                        &mut draft_scratch,
-                        &ev.retain_mask,
-                        draft_cfg.num_extract(),
-                        draft_cfg.hidden,
-                        pre_phys,
-                    ).expect("mirror eviction to draft");
-                }
+            eprintln!(
+                "FlashCASK: {} evictions  final compact_offset={}",
+                p.eviction_count(),
+                target.kv_cache.compact_offset,
+            );
+        }
+        let accept_rate = if stats.cycles > 0 {
+            stats.accepted_tokens as f32 / (stats.cycles * (draft_cfg.block_size - 1)) as f32
+        } else {
+            0.0
+        };
+
+        // ── BENCH METRICS (machine-parseable) ─────────────────────────────────
+        // Single source of truth for downstream submission scripts (LMX,
+        // benchmarks/results/*.py). Keep flat key=value lines so a simple regex
+        // pulls each field; do not change format without updating callers.
+        // hip.get_vram_info returns (free_bytes, total_bytes) — see line 356.
+        let (vram_free_bytes, vram_total_bytes) = gpu.hip.get_vram_info().unwrap_or((0, 0));
+        let vram_used_mb =
+            ((vram_total_bytes.saturating_sub(vram_free_bytes)) as f64 / (1024.0 * 1024.0)) as u64;
+        let vram_total_mb = (vram_total_bytes as f64 / (1024.0 * 1024.0)) as u64;
+        eprintln!("=== BENCH METRICS ===");
+        eprintln!("prompt_tokens: {}", prompt_tokens.len());
+        if pflash_path.is_some() {
+            eprintln!("pflash_source_tokens: {pflash_source_tokens}");
+            eprintln!("pflash_kept_tokens: {pflash_kept_tokens}");
+            eprintln!("pflash_compress_ms: {pflash_compress_ms}");
+            if pflash_source_tokens > 0 {
+                eprintln!(
+                    "pflash_ratio: {:.3}",
+                    pflash_kept_tokens as f32 / pflash_source_tokens as f32
+                );
             }
         }
-
-        // Stop on any terminator (eos_id OR eot_id). Checking only eos_id
-        // misses `<|endoftext|>` when running --no-chatml on a raw-text draft
-        // — see findings/dflash-benchmark-2026-04-24.md §3.5 (post-EOT
-        // attractor loop). `is_terminator` covers both.
-        if step.committed.iter().skip(1).any(|&t| tokenizer.is_terminator(t)) {
-            eprintln!("eos");
-            break;
+        eprintln!("prefill_secs: {:.4}", prefill_secs);
+        eprintln!("prefill_tok_s: {:.2}", prefill_tok_s);
+        eprintln!("ttft_ms: {:.2}", ttft_ms.unwrap_or(0.0));
+        eprintln!("decode_tokens_emitted: {}", emitted.len());
+        eprintln!("decode_secs: {:.4}", elapsed);
+        eprintln!("decode_tok_s: {:.2}", tok_s);
+        eprintln!("decode_tau: {:.4}", stats.tau());
+        eprintln!("decode_accept_rate: {:.4}", accept_rate);
+        eprintln!("vram_used_mb: {}", vram_used_mb);
+        eprintln!("vram_total_mb: {}", vram_total_mb);
+        eprintln!("=====================");
+        eprintln!("accept_rate (accepted / (cycles × (B-1))): {accept_rate:.3}");
+        eprintln!(
+            "histogram: {:?}",
+            stats.acceptance_hist.iter().enumerate().collect::<Vec<_>>()
+        );
+        // DDTree meta-verifier pruner stats — only meaningful under --ddtree-*
+        // with HIPFIRE_DDTREE_LOGW_CUTOFF set. Cycles == 0 on pure-DFlash runs.
+        let meta = hipfire_arch_qwen35::speculative::read_ddtree_meta_stats();
+        if meta.cycles > 0 {
+            let mean_nodes = meta.total_nodes as f32 / meta.cycles as f32;
+            eprintln!(
+                "ddtree-meta: cycles={} mean_nodes={:.2} min={} max={} (cutoff={:?})",
+                meta.cycles,
+                mean_nodes,
+                meta.min_nodes,
+                meta.max_nodes,
+                std::env::var("HIPFIRE_DDTREE_LOGW_CUTOFF").unwrap_or_else(|_| "off".to_string()),
+            );
         }
-    }
-    let elapsed = t_decode.elapsed().as_secs_f64();
-    let tok_s = emitted.len() as f64 / elapsed;
-
-    // ── Report ────────────────────────────────────────────────────────
-    let text = tokenizer.decode(&emitted);
-    eprintln!("--- OUTPUT ---");
-    println!("{text}");
-    eprintln!("--------------");
-    eprintln!(
-        "emitted: {} tokens in {:.2}s  ({:.2} tok/s)",
-        emitted.len(),
-        elapsed,
-        tok_s
-    );
-    eprintln!(
-        "cycles: {}  committed: {}  accepted: {}  τ={:.3}  mean_committed={:.3}",
-        stats.cycles,
-        stats.committed_tokens,
-        stats.accepted_tokens,
-        stats.tau(),
-        stats.mean_committed(),
-    );
-    if let Some(ref p) = cask_policy {
-        eprintln!(
-            "FlashCASK: {} evictions  final compact_offset={}",
-            p.eviction_count(),
-            target.kv_cache.compact_offset,
-        );
-    }
-    let accept_rate = if stats.cycles > 0 {
-        stats.accepted_tokens as f32 / (stats.cycles * (draft_cfg.block_size - 1)) as f32
-    } else {
-        0.0
-    };
-
-    // ── BENCH METRICS (machine-parseable) ─────────────────────────────────
-    // Single source of truth for downstream submission scripts (LMX,
-    // benchmarks/results/*.py). Keep flat key=value lines so a simple regex
-    // pulls each field; do not change format without updating callers.
-    // hip.get_vram_info returns (free_bytes, total_bytes) — see line 356.
-    let (vram_free_bytes, vram_total_bytes) = gpu.hip.get_vram_info().unwrap_or((0, 0));
-    let vram_used_mb = ((vram_total_bytes.saturating_sub(vram_free_bytes)) as f64 / (1024.0 * 1024.0)) as u64;
-    let vram_total_mb = (vram_total_bytes as f64 / (1024.0 * 1024.0)) as u64;
-    eprintln!("=== BENCH METRICS ===");
-    eprintln!("prompt_tokens: {}", prompt_tokens.len());
-    if pflash_path.is_some() {
-        eprintln!("pflash_source_tokens: {pflash_source_tokens}");
-        eprintln!("pflash_kept_tokens: {pflash_kept_tokens}");
-        eprintln!("pflash_compress_ms: {pflash_compress_ms}");
-        if pflash_source_tokens > 0 {
-            eprintln!("pflash_ratio: {:.3}",
-                pflash_kept_tokens as f32 / pflash_source_tokens as f32);
+        // Adaptive-B usage report — only meaningful when --adaptive-b is on.
+        if adaptive_b && !adaptive_b_histogram.is_empty() {
+            let mut buckets: Vec<(usize, u32)> =
+                adaptive_b_histogram.iter().map(|(&b, &c)| (b, c)).collect();
+            buckets.sort_by_key(|(b, _)| *b);
+            let total: u32 = buckets.iter().map(|(_, c)| *c).sum();
+            let mean_b: f32 = buckets
+                .iter()
+                .map(|(b, c)| (*b as f32) * (*c as f32))
+                .sum::<f32>()
+                / total.max(1) as f32;
+            let dist: String = buckets
+                .iter()
+                .map(|(b, c)| format!("B={b}:{:.1}%", *c as f32 * 100.0 / total.max(1) as f32))
+                .collect::<Vec<_>>()
+                .join(" ");
+            eprintln!(
+                "adaptive-b: range={}..={} mean_B={:.2} changes={} dist=[{}]",
+                adaptive_b_min, adaptive_b_max, mean_b, adaptive_b_changes, dist,
+            );
         }
-    }
-    eprintln!("prefill_secs: {:.4}", prefill_secs);
-    eprintln!("prefill_tok_s: {:.2}", prefill_tok_s);
-    eprintln!("ttft_ms: {:.2}", ttft_ms.unwrap_or(0.0));
-    eprintln!("decode_tokens_emitted: {}", emitted.len());
-    eprintln!("decode_secs: {:.4}", elapsed);
-    eprintln!("decode_tok_s: {:.2}", tok_s);
-    eprintln!("decode_tau: {:.4}", stats.tau());
-    eprintln!("decode_accept_rate: {:.4}", accept_rate);
-    eprintln!("vram_used_mb: {}", vram_used_mb);
-    eprintln!("vram_total_mb: {}", vram_total_mb);
-    eprintln!("=====================");
-    eprintln!("accept_rate (accepted / (cycles × (B-1))): {accept_rate:.3}");
-    eprintln!(
-        "histogram: {:?}",
-        stats.acceptance_hist.iter().enumerate().collect::<Vec<_>>()
-    );
-    // DDTree meta-verifier pruner stats — only meaningful under --ddtree-*
-    // with HIPFIRE_DDTREE_LOGW_CUTOFF set. Cycles == 0 on pure-DFlash runs.
-    let meta = hipfire_arch_qwen35::speculative::read_ddtree_meta_stats();
-    if meta.cycles > 0 {
-        let mean_nodes = meta.total_nodes as f32 / meta.cycles as f32;
-        eprintln!(
-            "ddtree-meta: cycles={} mean_nodes={:.2} min={} max={} (cutoff={:?})",
-            meta.cycles, mean_nodes, meta.min_nodes, meta.max_nodes,
-            std::env::var("HIPFIRE_DDTREE_LOGW_CUTOFF").unwrap_or_else(|_| "off".to_string()),
-        );
-    }
-    // Adaptive-B usage report — only meaningful when --adaptive-b is on.
-    if adaptive_b && !adaptive_b_histogram.is_empty() {
-        let mut buckets: Vec<(usize, u32)> = adaptive_b_histogram.iter()
-            .map(|(&b, &c)| (b, c)).collect();
-        buckets.sort_by_key(|(b, _)| *b);
-        let total: u32 = buckets.iter().map(|(_, c)| *c).sum();
-        let mean_b: f32 = buckets.iter()
-            .map(|(b, c)| (*b as f32) * (*c as f32))
-            .sum::<f32>() / total.max(1) as f32;
-        let dist: String = buckets.iter()
-            .map(|(b, c)| format!("B={b}:{:.1}%", *c as f32 * 100.0 / total.max(1) as f32))
-            .collect::<Vec<_>>().join(" ");
-        eprintln!(
-            "adaptive-b: range={}..={} mean_B={:.2} changes={} dist=[{}]",
-            adaptive_b_min, adaptive_b_max, mean_b, adaptive_b_changes, dist,
-        );
-    }
-    // Task #93 Phase B seed-prediction oracle. Zero cycles = pure-AR or tree
-    // paths that didn't invoke spec_step_dflash; skip in that case.
-    let s = hipfire_arch_qwen35::speculative::read_seed_oracle_stats();
-    if s.total > 0 {
-        let denom = s.total as f32;
-        eprintln!(
+        // Task #93 Phase B seed-prediction oracle. Zero cycles = pure-AR or tree
+        // paths that didn't invoke spec_step_dflash; skip in that case.
+        let s = hipfire_arch_qwen35::speculative::read_seed_oracle_stats();
+        if s.total > 0 {
+            let denom = s.total as f32;
+            eprintln!(
             "seed-oracle: cycles={} full_accept={} mean_accept_len={:.3} | rej_match={:.3} tail_match={:.3} anypos_match={:.3}",
             s.total, s.full_accept, s.accept_len_sum as f32 / denom,
             s.rej_match as f32 / denom,
             s.tail_match as f32 / denom,
             s.anypos_match as f32 / denom,
         );
-    }
-    if host_timing && !per_cycle_wall_us.is_empty() {
-        // Skip first 2 cycles (JIT warm-up), summarize the rest as mean / median.
-        let skip = 2.min(per_cycle_wall_us.len().saturating_sub(1));
-        let wall: Vec<u64> = per_cycle_wall_us.iter().skip(skip).copied().collect();
-        let api: Vec<(u64, u64, u64, u64, u64, u64, u64, u64, u64)> =
-            per_cycle_api_us.iter().skip(skip).copied().collect();
-        let n = wall.len().max(1);
-        let mean_wall = wall.iter().sum::<u64>() / n as u64;
-        let mean_launch = api.iter().map(|x| x.0).sum::<u64>() / n as u64;
-        let mean_htod = api.iter().map(|x| x.1).sum::<u64>() / n as u64;
-        let mean_dtoh = api.iter().map(|x| x.2).sum::<u64>() / n as u64;
-        let mean_dtod = api.iter().map(|x| x.3).sum::<u64>() / n as u64;
-        let mean_memset = api.iter().map(|x| x.4).sum::<u64>() / n as u64;
-        let mean_ssync = api.iter().map(|x| x.5).sum::<u64>() / n as u64;
-        let mean_esync = api.iter().map(|x| x.6).sum::<u64>() / n as u64;
-        let mean_dsync = api.iter().map(|x| x.7).sum::<u64>() / n as u64;
-        let mean_glaunch = api.iter().map(|x| x.8).sum::<u64>() / n as u64;
-        let tracked = mean_launch + mean_htod + mean_dtoh + mean_dtod + mean_memset
-            + mean_ssync + mean_esync + mean_dsync + mean_glaunch;
-        let untracked = mean_wall.saturating_sub(tracked);
-        // Cumulative counts — post-run totals divided by elapsed cycles give
-        // mean per-cycle API call counts. Helpful for isolating which op is
-        // the hot path (few-but-fat vs many-but-thin).
-        use hip_bridge::launch_counters as lc;
-        let total_cycles = per_cycle_wall_us.len() as u64;
-        let n_launch = lc::launch_kernel::count() / total_cycles.max(1);
-        let n_htod = lc::memcpy_htod::count() / total_cycles.max(1);
-        let n_dtoh = lc::memcpy_dtoh::count() / total_cycles.max(1);
-        let n_dtod = lc::memcpy_dtod::count() / total_cycles.max(1);
-        let n_memset = lc::memset::count() / total_cycles.max(1);
-        let n_ssync = lc::stream_sync::count() / total_cycles.max(1);
-        let n_glaunch = lc::graph_launch::count() / total_cycles.max(1);
-        let b_dtoh = lc::memcpy_dtoh::bytes() / total_cycles.max(1);
-        let b_memset = lc::memset::bytes() / total_cycles.max(1);
-        eprintln!(
+        }
+        if host_timing && !per_cycle_wall_us.is_empty() {
+            // Skip first 2 cycles (JIT warm-up), summarize the rest as mean / median.
+            let skip = 2.min(per_cycle_wall_us.len().saturating_sub(1));
+            let wall: Vec<u64> = per_cycle_wall_us.iter().skip(skip).copied().collect();
+            let api: Vec<(u64, u64, u64, u64, u64, u64, u64, u64, u64)> =
+                per_cycle_api_us.iter().skip(skip).copied().collect();
+            let n = wall.len().max(1);
+            let mean_wall = wall.iter().sum::<u64>() / n as u64;
+            let mean_launch = api.iter().map(|x| x.0).sum::<u64>() / n as u64;
+            let mean_htod = api.iter().map(|x| x.1).sum::<u64>() / n as u64;
+            let mean_dtoh = api.iter().map(|x| x.2).sum::<u64>() / n as u64;
+            let mean_dtod = api.iter().map(|x| x.3).sum::<u64>() / n as u64;
+            let mean_memset = api.iter().map(|x| x.4).sum::<u64>() / n as u64;
+            let mean_ssync = api.iter().map(|x| x.5).sum::<u64>() / n as u64;
+            let mean_esync = api.iter().map(|x| x.6).sum::<u64>() / n as u64;
+            let mean_dsync = api.iter().map(|x| x.7).sum::<u64>() / n as u64;
+            let mean_glaunch = api.iter().map(|x| x.8).sum::<u64>() / n as u64;
+            let tracked = mean_launch
+                + mean_htod
+                + mean_dtoh
+                + mean_dtod
+                + mean_memset
+                + mean_ssync
+                + mean_esync
+                + mean_dsync
+                + mean_glaunch;
+            let untracked = mean_wall.saturating_sub(tracked);
+            // Cumulative counts — post-run totals divided by elapsed cycles give
+            // mean per-cycle API call counts. Helpful for isolating which op is
+            // the hot path (few-but-fat vs many-but-thin).
+            use hip_bridge::launch_counters as lc;
+            let total_cycles = per_cycle_wall_us.len() as u64;
+            let n_launch = lc::launch_kernel::count() / total_cycles.max(1);
+            let n_htod = lc::memcpy_htod::count() / total_cycles.max(1);
+            let n_dtoh = lc::memcpy_dtoh::count() / total_cycles.max(1);
+            let n_dtod = lc::memcpy_dtod::count() / total_cycles.max(1);
+            let n_memset = lc::memset::count() / total_cycles.max(1);
+            let n_ssync = lc::stream_sync::count() / total_cycles.max(1);
+            let n_glaunch = lc::graph_launch::count() / total_cycles.max(1);
+            let b_dtoh = lc::memcpy_dtoh::bytes() / total_cycles.max(1);
+            let b_memset = lc::memset::bytes() / total_cycles.max(1);
+            eprintln!(
             "host timing (mean over {} cycles, µs): wall={}\n  launch={} (n={}) h2d={} (n={}) d2h={} (n={}, {}KB) d2d={} (n={}) memset={} (n={}, {}MB) glaunch={} (n={})\n  ssync={} (n={}) esync={} dsync={} → other={}",
             n, mean_wall,
             mean_launch, n_launch, mean_htod, n_htod, mean_dtoh, n_dtoh, b_dtoh / 1024,
             mean_dtod, n_dtod, mean_memset, n_memset, b_memset / (1024*1024), mean_glaunch, n_glaunch,
             mean_ssync, n_ssync, mean_esync, mean_dsync, untracked,
         );
-    }
-    eprintln!("DFlash tokens: {:?}", emitted);
-    if pld_matcher.is_some() {
-        let hit_rate = if stats.cycles > 0 {
-            pld_hits as f32 / stats.cycles as f32
-        } else {
-            0.0
-        };
-        let tau_pld = if pld_hits > 0 {
-            pld_accepted as f32 / pld_hits as f32
-        } else {
-            0.0
-        };
-        let tau_dflash = if stats.cycles > pld_hits {
-            (stats.accepted_tokens - pld_accepted) as f32
-                / (stats.cycles - pld_hits) as f32
-        } else {
-            0.0
-        };
-        eprintln!(
-            "pld: hits={}/{} ({:.1}%)  τ_pld={:.3}  τ_dflash={:.3}",
-            pld_hits,
-            stats.cycles,
-            hit_rate * 100.0,
-            tau_pld,
-            tau_dflash,
-        );
-    }
+        }
+        eprintln!("DFlash tokens: {:?}", emitted);
+        if pld_matcher.is_some() {
+            let hit_rate = if stats.cycles > 0 {
+                pld_hits as f32 / stats.cycles as f32
+            } else {
+                0.0
+            };
+            let tau_pld = if pld_hits > 0 {
+                pld_accepted as f32 / pld_hits as f32
+            } else {
+                0.0
+            };
+            let tau_dflash = if stats.cycles > pld_hits {
+                (stats.accepted_tokens - pld_accepted) as f32 / (stats.cycles - pld_hits) as f32
+            } else {
+                0.0
+            };
+            eprintln!(
+                "pld: hits={}/{} ({:.1}%)  τ_pld={:.3}  τ_dflash={:.3}",
+                pld_hits,
+                stats.cycles,
+                hit_rate * 100.0,
+                tau_pld,
+                tau_dflash,
+            );
+        }
         // ── End of per-row loop body ──────────────────────────────
         if multi_row {
             eprintln!("@@@ ROW {row_idx} END @@@");

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -90,9 +90,10 @@ impl DflashConfig {
         let intermediate = df.get("intermediate_size").and_then(|v| v.as_u64())? as usize;
         let n_heads = df.get("num_attention_heads").and_then(|v| v.as_u64())? as usize;
         let n_kv_heads = df.get("num_key_value_heads").and_then(|v| v.as_u64())? as usize;
-        let head_dim = df.get("head_dim").and_then(|v| v.as_u64()).unwrap_or(
-            (hidden / n_heads) as u64,
-        ) as usize;
+        let head_dim = df
+            .get("head_dim")
+            .and_then(|v| v.as_u64())
+            .unwrap_or((hidden / n_heads) as u64) as usize;
         let vocab_size = df.get("vocab_size").and_then(|v| v.as_u64())? as usize;
         let norm_eps = df
             .get("rms_norm_eps")
@@ -110,9 +111,7 @@ impl DflashConfig {
             .iter()
             .filter_map(|v| v.as_u64().map(|x| x as usize))
             .collect();
-        let num_target_layers = df
-            .get("num_target_layers")
-            .and_then(|v| v.as_u64())? as usize;
+        let num_target_layers = df.get("num_target_layers").and_then(|v| v.as_u64())? as usize;
 
         Some(DflashConfig {
             n_layers,
@@ -135,24 +134,24 @@ impl DflashConfig {
 // ─── Weights ───────────────────────────────────────────────────────────────
 
 pub struct DflashLayerWeights {
-    pub attn_norm: GpuTensor,        // [hidden] — F32, RMSNorm weight
-    pub wq: WeightTensor,            // [q_dim, hidden]
-    pub wk: WeightTensor,            // [kv_dim, hidden]
-    pub wv: WeightTensor,            // [kv_dim, hidden]
-    pub wo: WeightTensor,            // [hidden, q_dim]
-    pub q_norm: GpuTensor,           // [head_dim] — F32
-    pub k_norm: GpuTensor,           // [head_dim] — F32
-    pub ffn_norm: GpuTensor,         // [hidden] — F32
-    pub w_gate: WeightTensor,        // [intermediate, hidden]
-    pub w_up: WeightTensor,          // [intermediate, hidden]
-    pub w_down: WeightTensor,        // [hidden, intermediate]
+    pub attn_norm: GpuTensor, // [hidden] — F32, RMSNorm weight
+    pub wq: WeightTensor,     // [q_dim, hidden]
+    pub wk: WeightTensor,     // [kv_dim, hidden]
+    pub wv: WeightTensor,     // [kv_dim, hidden]
+    pub wo: WeightTensor,     // [hidden, q_dim]
+    pub q_norm: GpuTensor,    // [head_dim] — F32
+    pub k_norm: GpuTensor,    // [head_dim] — F32
+    pub ffn_norm: GpuTensor,  // [hidden] — F32
+    pub w_gate: WeightTensor, // [intermediate, hidden]
+    pub w_up: WeightTensor,   // [intermediate, hidden]
+    pub w_down: WeightTensor, // [hidden, intermediate]
 }
 
 pub struct DflashWeights {
     /// `fc`: Linear(num_extract × hidden → hidden). Shape: [hidden, num_extract × hidden].
     pub fc: WeightTensor,
-    pub hidden_norm: GpuTensor,    // [hidden] — F32
-    pub norm: GpuTensor,           // [hidden] — F32, final output norm
+    pub hidden_norm: GpuTensor, // [hidden] — F32
+    pub norm: GpuTensor,        // [hidden] — F32, final output norm
     pub layers: Vec<DflashLayerWeights>,
     /// True when at least one matrix weight is MQ4G256 — drives whether
     /// the draft_forward path needs to allocate FWHT rotation scratches.
@@ -160,7 +159,12 @@ pub struct DflashWeights {
 }
 
 /// Load a F32-only tensor (norms, embedding-shaped scalars). Always F32 on GPU.
-fn hfq_tensor_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: Vec<usize>) -> HipResult<GpuTensor> {
+fn hfq_tensor_f32(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    shape: Vec<usize>,
+) -> HipResult<GpuTensor> {
     let (info, data) = hfq
         .tensor_data(name)
         .unwrap_or_else(|| panic!("dflash tensor missing: {name}"));
@@ -198,7 +202,13 @@ fn hfq_tensor_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: Vec<usize>) -
 /// the unaligned byte length; for MQ formats we skip shape verification (the
 /// quantized bytes are not a function of m*k alone — group padding can add
 /// up to 255 trailing bytes per row group).
-fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> HipResult<WeightTensor> {
+fn hfq_weight(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+) -> HipResult<WeightTensor> {
     let (info, data) = hfq
         .tensor_data(name)
         .unwrap_or_else(|| panic!("dflash tensor missing: {name}"));
@@ -213,9 +223,21 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
             // A/B comparison.
             let use_f16 = crate::config::get().draft_f16;
             if use_f16 {
-                assert_eq!(data.len(), m * k * 2, "dflash {name} F16 byte-size mismatch");
+                assert_eq!(
+                    data.len(),
+                    m * k * 2,
+                    "dflash {name} F16 byte-size mismatch"
+                );
                 let buf = gpu.upload_raw(data, &[m * k])?;
-                Ok(WeightTensor { buf, gpu_dtype: DType::F16, m, k, row_stride: 0, paro: None, awq_scale: None })
+                Ok(WeightTensor {
+                    buf,
+                    gpu_dtype: DType::F16,
+                    m,
+                    k,
+                    row_stride: 0,
+                    paro: None,
+                    awq_scale: None,
+                })
             } else {
                 let f32_data: Vec<f32> = data
                     .chunks_exact(2)
@@ -223,7 +245,15 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
                     .collect();
                 assert_eq!(f32_data.len(), m * k, "dflash {name} F16 size mismatch");
                 let buf = gpu.upload_f32(&f32_data, &[m * k])?;
-                Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, paro: None, awq_scale: None })
+                Ok(WeightTensor {
+                    buf,
+                    gpu_dtype: DType::F32,
+                    m,
+                    k,
+                    row_stride: 0,
+                    paro: None,
+                    awq_scale: None,
+                })
             }
         }
         2 => {
@@ -233,26 +263,58 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
                 .collect();
             assert_eq!(f32_data.len(), m * k, "dflash {name} F32 size mismatch");
             let buf = gpu.upload_f32(&f32_data, &[m * k])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::F32, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::F32,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         13 => {
             // MQ4-G256: 136 bytes per 256 weights. The buffer is opaque to
             // the engine; the gemm_hfq4g256 kernel reads it directly.
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::MQ4G256,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         15 => {
             // MQ6-G256: 200 bytes per 256 weights. Same opaque-buffer pattern
             // as MQ4/MQ3; dispatch rotates activations and calls HFQ6 GEMM.
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ6G256, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::MQ6G256,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         17 => {
             // MQ3-G256: 104 bytes per 256 weights. Same opaque-buffer pattern
             // as MQ4. Dispatch path (`gemm_dispatch`) routes through
             // `rotate_x_mq_batched` + `gemm_hfq3g256_batched_lmhead`.
             let buf = gpu.upload_raw(data, &[data.len()])?;
-            Ok(WeightTensor { buf, gpu_dtype: DType::MQ3G256, m, k, row_stride: 0, paro: None, awq_scale: None })
+            Ok(WeightTensor {
+                buf,
+                gpu_dtype: DType::MQ3G256,
+                m,
+                k,
+                row_stride: 0,
+                paro: None,
+                awq_scale: None,
+            })
         }
         q => panic!("dflash: unsupported matrix quant_type {q} for {name}"),
     }?;
@@ -269,7 +331,13 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
 
 impl DflashWeights {
     pub fn load(gpu: &mut Gpu, hfq: &HfqFile, cfg: &DflashConfig) -> HipResult<Self> {
-        let fc = hfq_weight(hfq, gpu, "fc.weight", cfg.hidden, cfg.num_extract() * cfg.hidden)?;
+        let fc = hfq_weight(
+            hfq,
+            gpu,
+            "fc.weight",
+            cfg.hidden,
+            cfg.num_extract() * cfg.hidden,
+        )?;
         let hidden_norm = hfq_tensor_f32(hfq, gpu, "hidden_norm.weight", vec![cfg.hidden])?;
         let norm = hfq_tensor_f32(hfq, gpu, "norm.weight", vec![cfg.hidden])?;
 
@@ -277,17 +345,79 @@ impl DflashWeights {
         for i in 0..cfg.n_layers {
             let p = format!("layers.{i}");
             let layer = DflashLayerWeights {
-                attn_norm: hfq_tensor_f32(hfq, gpu, &format!("{p}.input_layernorm.weight"), vec![cfg.hidden])?,
-                wq: hfq_weight(hfq, gpu, &format!("{p}.self_attn.q_proj.weight"), cfg.q_dim(), cfg.hidden)?,
-                wk: hfq_weight(hfq, gpu, &format!("{p}.self_attn.k_proj.weight"), cfg.kv_dim(), cfg.hidden)?,
-                wv: hfq_weight(hfq, gpu, &format!("{p}.self_attn.v_proj.weight"), cfg.kv_dim(), cfg.hidden)?,
-                wo: hfq_weight(hfq, gpu, &format!("{p}.self_attn.o_proj.weight"), cfg.hidden, cfg.q_dim())?,
-                q_norm: hfq_tensor_f32(hfq, gpu, &format!("{p}.self_attn.q_norm.weight"), vec![cfg.head_dim])?,
-                k_norm: hfq_tensor_f32(hfq, gpu, &format!("{p}.self_attn.k_norm.weight"), vec![cfg.head_dim])?,
-                ffn_norm: hfq_tensor_f32(hfq, gpu, &format!("{p}.post_attention_layernorm.weight"), vec![cfg.hidden])?,
-                w_gate: hfq_weight(hfq, gpu, &format!("{p}.mlp.gate_proj.weight"), cfg.intermediate, cfg.hidden)?,
-                w_up: hfq_weight(hfq, gpu, &format!("{p}.mlp.up_proj.weight"), cfg.intermediate, cfg.hidden)?,
-                w_down: hfq_weight(hfq, gpu, &format!("{p}.mlp.down_proj.weight"), cfg.hidden, cfg.intermediate)?,
+                attn_norm: hfq_tensor_f32(
+                    hfq,
+                    gpu,
+                    &format!("{p}.input_layernorm.weight"),
+                    vec![cfg.hidden],
+                )?,
+                wq: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.self_attn.q_proj.weight"),
+                    cfg.q_dim(),
+                    cfg.hidden,
+                )?,
+                wk: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.self_attn.k_proj.weight"),
+                    cfg.kv_dim(),
+                    cfg.hidden,
+                )?,
+                wv: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.self_attn.v_proj.weight"),
+                    cfg.kv_dim(),
+                    cfg.hidden,
+                )?,
+                wo: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.self_attn.o_proj.weight"),
+                    cfg.hidden,
+                    cfg.q_dim(),
+                )?,
+                q_norm: hfq_tensor_f32(
+                    hfq,
+                    gpu,
+                    &format!("{p}.self_attn.q_norm.weight"),
+                    vec![cfg.head_dim],
+                )?,
+                k_norm: hfq_tensor_f32(
+                    hfq,
+                    gpu,
+                    &format!("{p}.self_attn.k_norm.weight"),
+                    vec![cfg.head_dim],
+                )?,
+                ffn_norm: hfq_tensor_f32(
+                    hfq,
+                    gpu,
+                    &format!("{p}.post_attention_layernorm.weight"),
+                    vec![cfg.hidden],
+                )?,
+                w_gate: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.mlp.gate_proj.weight"),
+                    cfg.intermediate,
+                    cfg.hidden,
+                )?,
+                w_up: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.mlp.up_proj.weight"),
+                    cfg.intermediate,
+                    cfg.hidden,
+                )?,
+                w_down: hfq_weight(
+                    hfq,
+                    gpu,
+                    &format!("{p}.mlp.down_proj.weight"),
+                    cfg.hidden,
+                    cfg.intermediate,
+                )?,
             };
             layers.push(layer);
         }
@@ -296,7 +426,12 @@ impl DflashWeights {
             .chain(layers.iter().flat_map(|l| {
                 [&l.wq, &l.wk, &l.wv, &l.wo, &l.w_gate, &l.w_up, &l.w_down].into_iter()
             }))
-            .any(|w| matches!(w.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256));
+            .any(|w| {
+                matches!(
+                    w.gpu_dtype,
+                    DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256
+                )
+            });
         if has_mq {
             // MQ dispatch needs the engine's FWHT sign tables uploaded
             // (matches `gemv_mq4g256_with_rotate`'s setup).
@@ -345,32 +480,32 @@ pub struct DflashScratch {
     pub max_ctx_len: usize,
 
     // Block-sized activations (B rows).
-    pub x: GpuTensor,              // [B, hidden] — hidden state rolled across layers
-    pub x_norm: GpuTensor,         // [B, hidden]
-    pub q: GpuTensor,              // [B, q_dim]
-    pub k_noise: GpuTensor,        // [B, kv_dim]
-    pub v_noise: GpuTensor,        // [B, kv_dim]
-    pub gate: GpuTensor,           // [B, intermediate]
-    pub up: GpuTensor,             // [B, intermediate]
-    pub gate_up: GpuTensor,        // [B, intermediate]
-    pub attn_out: GpuTensor,       // [B, q_dim]
-    pub attn_proj: GpuTensor,      // [B, hidden]
-    pub residual_attn: GpuTensor,  // [B, hidden]
-    pub residual_ffn: GpuTensor,   // [B, hidden]
+    pub x: GpuTensor,             // [B, hidden] — hidden state rolled across layers
+    pub x_norm: GpuTensor,        // [B, hidden]
+    pub q: GpuTensor,             // [B, q_dim]
+    pub k_noise: GpuTensor,       // [B, kv_dim]
+    pub v_noise: GpuTensor,       // [B, kv_dim]
+    pub gate: GpuTensor,          // [B, intermediate]
+    pub up: GpuTensor,            // [B, intermediate]
+    pub gate_up: GpuTensor,       // [B, intermediate]
+    pub attn_out: GpuTensor,      // [B, q_dim]
+    pub attn_proj: GpuTensor,     // [B, hidden]
+    pub residual_attn: GpuTensor, // [B, hidden]
+    pub residual_ffn: GpuTensor,  // [B, hidden]
 
     // Context activations (L rows), where L ≤ max_ctx_len.
-    pub target_hidden: GpuTensor,        // [L, num_extract × hidden]
-    pub target_hidden_proj: GpuTensor,   // [L, hidden]
-    pub k_ctx: GpuTensor,                // [L, kv_dim]
-    pub v_ctx: GpuTensor,                // [L, kv_dim]
+    pub target_hidden: GpuTensor,      // [L, num_extract × hidden]
+    pub target_hidden_proj: GpuTensor, // [L, hidden]
+    pub k_ctx: GpuTensor,              // [L, kv_dim]
+    pub v_ctx: GpuTensor,              // [L, kv_dim]
 
     // Concatenated K/V (L + B rows).
-    pub k_cat: GpuTensor,                // [L + B, kv_dim]
-    pub v_cat: GpuTensor,                // [L + B, kv_dim]
+    pub k_cat: GpuTensor, // [L + B, kv_dim]
+    pub v_cat: GpuTensor, // [L + B, kv_dim]
 
     // Positions (i32).
-    pub positions_q: GpuTensor,          // [B]       i32
-    pub positions_k: GpuTensor,          // [L + B]   i32
+    pub positions_q: GpuTensor, // [B]       i32
+    pub positions_k: GpuTensor, // [L + B]   i32
 
     // FWHT rotation scratch for MQ4 weight paths. Sized to the largest
     // single-call requirement: max(max_ctx × num_extract*hidden,
@@ -511,28 +646,28 @@ impl DflashScratch {
             max_block_size: b,
             max_ctx_len: l,
 
-            x:             gpu.alloc_tensor(&[b * h], DType::F32)?,
-            x_norm:        gpu.alloc_tensor(&[b * h], DType::F32)?,
-            q:             gpu.alloc_tensor(&[b * qd], DType::F32)?,
-            k_noise:       gpu.alloc_tensor(&[b * kvd], DType::F32)?,
-            v_noise:       gpu.alloc_tensor(&[b * kvd], DType::F32)?,
-            gate:          gpu.alloc_tensor(&[b * inter], DType::F32)?,
-            up:            gpu.alloc_tensor(&[b * inter], DType::F32)?,
-            gate_up:       gpu.alloc_tensor(&[b * inter], DType::F32)?,
-            attn_out:      gpu.alloc_tensor(&[b * qd], DType::F32)?,
-            attn_proj:     gpu.alloc_tensor(&[b * h], DType::F32)?,
+            x: gpu.alloc_tensor(&[b * h], DType::F32)?,
+            x_norm: gpu.alloc_tensor(&[b * h], DType::F32)?,
+            q: gpu.alloc_tensor(&[b * qd], DType::F32)?,
+            k_noise: gpu.alloc_tensor(&[b * kvd], DType::F32)?,
+            v_noise: gpu.alloc_tensor(&[b * kvd], DType::F32)?,
+            gate: gpu.alloc_tensor(&[b * inter], DType::F32)?,
+            up: gpu.alloc_tensor(&[b * inter], DType::F32)?,
+            gate_up: gpu.alloc_tensor(&[b * inter], DType::F32)?,
+            attn_out: gpu.alloc_tensor(&[b * qd], DType::F32)?,
+            attn_proj: gpu.alloc_tensor(&[b * h], DType::F32)?,
             residual_attn: gpu.alloc_tensor(&[b * h], DType::F32)?,
-            residual_ffn:  gpu.alloc_tensor(&[b * h], DType::F32)?,
+            residual_ffn: gpu.alloc_tensor(&[b * h], DType::F32)?,
 
-            target_hidden:      gpu.alloc_tensor(&[l * ne * h], DType::F32)?,
+            target_hidden: gpu.alloc_tensor(&[l * ne * h], DType::F32)?,
             target_hidden_proj: gpu.alloc_tensor(&[l * h], DType::F32)?,
-            k_ctx:              gpu.alloc_tensor(&[l * kvd], DType::F32)?,
-            v_ctx:              gpu.alloc_tensor(&[l * kvd], DType::F32)?,
+            k_ctx: gpu.alloc_tensor(&[l * kvd], DType::F32)?,
+            v_ctx: gpu.alloc_tensor(&[l * kvd], DType::F32)?,
 
             k_cat: gpu.alloc_tensor(&[tot * kvd], DType::F32)?,
             v_cat: gpu.alloc_tensor(&[tot * kvd], DType::F32)?,
 
-            positions_q: gpu.alloc_tensor(&[b],   DType::F32)?,
+            positions_q: gpu.alloc_tensor(&[b], DType::F32)?,
             positions_k: gpu.alloc_tensor(&[tot], DType::F32)?,
 
             mq_x_rot,
@@ -639,11 +774,15 @@ fn gemm_dispatch(
     // draft GEMM triage. Cached via OnceLock so the fast path pays a single
     // atomic load per call rather than an env lookup.
     static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let dump = *DUMP.get_or_init(|| {
-        crate::config::get().draft_gemm_dump
-    });
-    if dump { gpu.hip.device_synchronize()?; }
-    let t0 = if dump { Some(std::time::Instant::now()) } else { None };
+    let dump = *DUMP.get_or_init(|| crate::config::get().draft_gemm_dump);
+    if dump {
+        gpu.hip.device_synchronize()?;
+    }
+    let t0 = if dump {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     let result = match w.gpu_dtype {
         DType::F32 => gpu.gemm_f32_batched(x, &w.buf, y, batch, w.k, w.m),
         DType::F16 => gpu.gemm_f16_batched_lmhead(&w.buf, x, y, w.m, w.k, batch),
@@ -667,11 +806,15 @@ fn gemm_dispatch(
                 // the `x /= awq_scale` + FWHT kernel; otherwise falls
                 // through to the plain `rotate_x_mq_batched` and is
                 // numerically identical to the prior dispatch.
-                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
+                if let Err(e) =
+                    crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n)
+                {
                     chunked = Err(e);
                     break;
                 }
-                if let Err(e) = gpu.gemm_hfq4g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n) {
+                if let Err(e) =
+                    gpu.gemm_hfq4g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n)
+                {
                     chunked = Err(e);
                     break;
                 }
@@ -708,11 +851,15 @@ fn gemm_dispatch(
                 // `hfq_weight`) now actually receive the `x /= s` divide
                 // before the HFQ3 GEMM; pre-fix this silently produced
                 // wrong drafts on AWQ-calibrated drafters.
-                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
+                if let Err(e) =
+                    crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n)
+                {
                     chunked = Err(e);
                     break;
                 }
-                if let Err(e) = gpu.gemm_hfq3g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n) {
+                if let Err(e) =
+                    gpu.gemm_hfq3g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n)
+                {
                     chunked = Err(e);
                     break;
                 }
@@ -734,11 +881,15 @@ fn gemm_dispatch(
                 let x_chunk = x.sub_offset(row * w.k, n * w.k);
                 let y_chunk = y.sub_offset(row * w.m, n * w.m);
                 let rot_view = scratch.sub_offset(0, n * w.k);
-                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
+                if let Err(e) =
+                    crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n)
+                {
                     chunked = Err(e);
                     break;
                 }
-                if let Err(e) = gpu.gemm_hfq6g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n) {
+                if let Err(e) =
+                    gpu.gemm_hfq6g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n)
+                {
                     chunked = Err(e);
                     break;
                 }
@@ -761,8 +912,16 @@ fn gemm_dispatch(
         };
         let bytes = weight_bytes + batch * w.k * 4 + batch * w.m * 4 * 2;
         let gbs = (bytes as f64) / (us.max(1) as f64) / 1000.0;
-        eprintln!("[draft-gemm] dtype={:?} M={} K={} B={} us={} bytes={}KB GB/s={:.1}",
-            w.gpu_dtype, w.m, w.k, batch, us, bytes / 1024, gbs);
+        eprintln!(
+            "[draft-gemm] dtype={:?} M={} K={} B={} us={} bytes={}KB GB/s={:.1}",
+            w.gpu_dtype,
+            w.m,
+            w.k,
+            batch,
+            us,
+            bytes / 1024,
+            gbs
+        );
     }
     result
 }
@@ -777,9 +936,7 @@ fn begin_draft_ffn_graph_capture(gpu: &mut Gpu) -> HipResult<()> {
     gpu.hip.stream_begin_capture(stream, 0)
 }
 
-fn end_draft_ffn_graph_capture(
-    gpu: &mut Gpu,
-) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
+fn end_draft_ffn_graph_capture(gpu: &mut Gpu) -> HipResult<(Graph, GraphExec, Vec<Vec<u8>>)> {
     gpu.graphs.capture_mode = false;
     let stream = gpu.active_stream.as_ref().unwrap();
     let graph = gpu.hip.stream_end_capture(stream)?;
@@ -810,21 +967,36 @@ fn draft_ffn_layer(
     if graph_safe {
         gpu.memcpy_dtod_auto(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
     } else {
-        gpu.hip.memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+        gpu.hip
+            .memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
     }
 
-    gpu.rmsnorm_batched(
-        &scratch.x,
-        &layer.ffn_norm,
+    gpu.rmsnorm_batched(&scratch.x, &layer.ffn_norm, &scratch.x_norm, b, h, eps)?;
+    gemm_dispatch(
+        gpu,
         &scratch.x_norm,
+        &layer.w_gate,
+        &scratch.gate,
         b,
-        h,
-        eps,
+        scratch.mq_x_rot.as_ref(),
     )?;
-    gemm_dispatch(gpu, &scratch.x_norm, &layer.w_gate, &scratch.gate, b, scratch.mq_x_rot.as_ref())?;
-    gemm_dispatch(gpu, &scratch.x_norm, &layer.w_up,   &scratch.up,   b, scratch.mq_x_rot.as_ref())?;
+    gemm_dispatch(
+        gpu,
+        &scratch.x_norm,
+        &layer.w_up,
+        &scratch.up,
+        b,
+        scratch.mq_x_rot.as_ref(),
+    )?;
     gpu.silu_mul_f32(&scratch.gate, &scratch.up, &scratch.gate_up)?;
-    gemm_dispatch(gpu, &scratch.gate_up, &layer.w_down, &scratch.x, b, scratch.mq_x_rot.as_ref())?;
+    gemm_dispatch(
+        gpu,
+        &scratch.gate_up,
+        &layer.w_down,
+        &scratch.x,
+        b,
+        scratch.mq_x_rot.as_ref(),
+    )?;
     if graph_safe {
         gpu.add_f32_graph_safe(&scratch.residual_ffn, &scratch.x, &scratch.x)
     } else {
@@ -871,7 +1043,9 @@ fn draft_ffn_layer_maybe_graph(
         let stream = gpu.active_stream.as_ref().unwrap();
         let entry = scratch.draft_ffn_graphs[layer_idx]
             .get(&b)
-            .unwrap_or_else(|| panic!("missing captured draft FFN graph for layer={layer_idx} b={b}"));
+            .unwrap_or_else(|| {
+                panic!("missing captured draft FFN graph for layer={layer_idx} b={b}")
+            });
         gpu.hip.graph_launch(&entry.1, stream)
     } else {
         abort_draft_ffn_graph_capture(gpu);
@@ -881,17 +1055,15 @@ fn draft_ffn_layer_maybe_graph(
 
 /// Upload f32 slice into a GPU tensor (bytes via memcpy_htod).
 fn upload_slice_f32(gpu: &Gpu, dst: &GpuTensor, data: &[f32]) -> HipResult<()> {
-    let bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
-    };
+    let bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     gpu.hip.memcpy_htod(&dst.buf, bytes)
 }
 
 /// Upload i32 slice into a GPU tensor (interpreted as i32 by kernels).
 fn upload_slice_i32(gpu: &Gpu, dst: &GpuTensor, data: &[i32]) -> HipResult<()> {
-    let bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4)
-    };
+    let bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     gpu.hip.memcpy_htod(&dst.buf, bytes)
 }
 
@@ -1009,10 +1181,7 @@ pub fn draft_forward_opts(
         let prev = scratch.uploaded_target_hidden_rows;
         // Full-upload conditions: first call, reset flagged, caller shrank
         // the context, or the slice length suggests ctx_slice (unusual l).
-        if prev == 0
-            || prev > l
-            || th_slice.len() != expected_full_len
-        {
+        if prev == 0 || prev > l || th_slice.len() != expected_full_len {
             upload_slice_f32(gpu, &scratch.target_hidden, th_slice)?;
             scratch.uploaded_target_hidden_rows = l;
         } else if prev < l {
@@ -1020,13 +1189,10 @@ pub fn draft_forward_opts(
             // prev * row_f32 * 4 of scratch.target_hidden.
             let tail = &th_slice[prev * row_f32..];
             let dst_byte_off = prev * row_f32 * 4;
-            let src_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
-                    tail.as_ptr() as *const u8,
-                    tail.len() * 4,
-                )
-            };
-            gpu.hip.memcpy_htod_offset(&scratch.target_hidden.buf, dst_byte_off, src_bytes)?;
+            let src_bytes: &[u8] =
+                unsafe { std::slice::from_raw_parts(tail.as_ptr() as *const u8, tail.len() * 4) };
+            gpu.hip
+                .memcpy_htod_offset(&scratch.target_hidden.buf, dst_byte_off, src_bytes)?;
             scratch.uploaded_target_hidden_rows = l;
         }
         // prev == l: nothing new to upload (wouldn't happen in practice
@@ -1059,8 +1225,12 @@ pub fn draft_forward_opts(
     if delta > 0 {
         let src_offset_elems = cached_rows * ne * h;
         let dst_offset_elems = cached_rows * h;
-        let th_slice = scratch.target_hidden.sub_offset(src_offset_elems, delta * ne * h);
-        let thp_slice = scratch.target_hidden_proj.sub_offset(dst_offset_elems, delta * h);
+        let th_slice = scratch
+            .target_hidden
+            .sub_offset(src_offset_elems, delta * ne * h);
+        let thp_slice = scratch
+            .target_hidden_proj
+            .sub_offset(dst_offset_elems, delta * h);
         gemm_dispatch(
             gpu,
             &th_slice,
@@ -1069,14 +1239,7 @@ pub fn draft_forward_opts(
             delta,
             scratch.mq_x_rot.as_ref(),
         )?;
-        gpu.rmsnorm_batched(
-            &thp_slice,
-            &weights.hidden_norm,
-            &thp_slice,
-            delta,
-            h,
-            eps,
-        )?;
+        gpu.rmsnorm_batched(&thp_slice, &weights.hidden_norm, &thp_slice, delta, h, eps)?;
     }
 
     // HIPFIRE_DRAFT_SUBPHASE=1: per-layer-section timing inside draft_forward.
@@ -1100,37 +1263,56 @@ pub fn draft_forward_opts(
     let mut us_attn_kernel: u128 = 0;
     let mut us_ffn_gemm: u128 = 0;
     let mut us_concat: u128 = 0;
-    if dbg { gpu.hip.device_synchronize()?; }
+    if dbg {
+        gpu.hip.device_synchronize()?;
+    }
 
     // ── 2. Per-layer decoder ─────────────────────────────────────────────
     for li in 0..cfg.n_layers {
         let layer = &weights.layers[li];
 
         // Residual.
-        gpu.hip.memcpy_dtod(&scratch.residual_attn.buf, &scratch.x.buf, (b * h) * 4)?;
+        gpu.hip
+            .memcpy_dtod(&scratch.residual_attn.buf, &scratch.x.buf, (b * h) * 4)?;
 
         // attn_norm.
-        gpu.rmsnorm_batched(
-            &scratch.x,
-            &layer.attn_norm,
-            &scratch.x_norm,
-            b,
-            h,
-            eps,
-        )?;
+        gpu.rmsnorm_batched(&scratch.x, &layer.attn_norm, &scratch.x_norm, b, h, eps)?;
 
         let t0 = if dbg {
             gpu.hip.device_synchronize()?;
             Some(std::time::Instant::now())
-        } else { None };
+        } else {
+            None
+        };
 
         // Q/K/V projections — dispatched on each weight's dtype.
         // Q and K/V noise (over the B block positions) must be computed
         // every cycle. K_ctx and V_ctx (over the L context positions)
         // are *incrementally* cached — see the per-layer block below.
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.wq, &scratch.q,       b, scratch.mq_x_rot.as_ref())?;
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.wk, &scratch.k_noise, b, scratch.mq_x_rot.as_ref())?;
-        gemm_dispatch(gpu, &scratch.x_norm, &layer.wv, &scratch.v_noise, b, scratch.mq_x_rot.as_ref())?;
+        gemm_dispatch(
+            gpu,
+            &scratch.x_norm,
+            &layer.wq,
+            &scratch.q,
+            b,
+            scratch.mq_x_rot.as_ref(),
+        )?;
+        gemm_dispatch(
+            gpu,
+            &scratch.x_norm,
+            &layer.wk,
+            &scratch.k_noise,
+            b,
+            scratch.mq_x_rot.as_ref(),
+        )?;
+        gemm_dispatch(
+            gpu,
+            &scratch.x_norm,
+            &layer.wv,
+            &scratch.v_noise,
+            b,
+            scratch.mq_x_rot.as_ref(),
+        )?;
 
         // K_ctx / V_ctx — same wk/wv weights but projected over the L
         // accepted-context rows of target_hidden_proj. INCREMENTAL PATH:
@@ -1152,13 +1334,36 @@ pub fn draft_forward_opts(
         if delta > 0 {
             let src_offset_elems = cached_rows * h;
             let dst_offset_elems = cached_rows * kvd;
-            let thp_slice = scratch.target_hidden_proj.sub_offset(src_offset_elems, delta * h);
+            let thp_slice = scratch
+                .target_hidden_proj
+                .sub_offset(src_offset_elems, delta * h);
             let k_slot = k_cache_layer.sub_offset(dst_offset_elems, delta * kvd);
             let v_slot = v_cache_layer.sub_offset(dst_offset_elems, delta * kvd);
-            gemm_dispatch(gpu, &thp_slice, &layer.wk, &k_slot, delta, scratch.mq_x_rot.as_ref())?;
-            gemm_dispatch(gpu, &thp_slice, &layer.wv, &v_slot, delta, scratch.mq_x_rot.as_ref())?;
+            gemm_dispatch(
+                gpu,
+                &thp_slice,
+                &layer.wk,
+                &k_slot,
+                delta,
+                scratch.mq_x_rot.as_ref(),
+            )?;
+            gemm_dispatch(
+                gpu,
+                &thp_slice,
+                &layer.wv,
+                &v_slot,
+                delta,
+                scratch.mq_x_rot.as_ref(),
+            )?;
             // Per-head RMSNorm on K delta rows only. batch = delta × n_kv_heads.
-            gpu.rmsnorm_batched(&k_slot, &layer.k_norm, &k_slot, delta * cfg.n_kv_heads, hd, eps)?;
+            gpu.rmsnorm_batched(
+                &k_slot,
+                &layer.k_norm,
+                &k_slot,
+                delta * cfg.n_kv_heads,
+                hd,
+                eps,
+            )?;
         }
 
         if let Some(t) = t0 {
@@ -1167,28 +1372,58 @@ pub fn draft_forward_opts(
         }
         let t1 = if dbg {
             Some(std::time::Instant::now())
-        } else { None };
+        } else {
+            None
+        };
 
         // Concat K = [K_ctx_cached | K_noise] → k_cat [L + B, kv_dim].
         // The cached K prefix is already post-k_norm (applied incrementally
         // above); the noise tail still needs k_norm applied below.
-        let ctx_bytes   = (l * kvd) * 4;
+        let ctx_bytes = (l * kvd) * 4;
         let noise_bytes = (b * kvd) * 4;
-        gpu.hip.memcpy_dtod_at(&scratch.k_cat.buf, 0,          &k_cache_layer.buf,   0, ctx_bytes)?;
-        gpu.hip.memcpy_dtod_at(&scratch.k_cat.buf, ctx_bytes,  &scratch.k_noise.buf, 0, noise_bytes)?;
-        gpu.hip.memcpy_dtod_at(&scratch.v_cat.buf, 0,          &v_cache_layer.buf,   0, ctx_bytes)?;
-        gpu.hip.memcpy_dtod_at(&scratch.v_cat.buf, ctx_bytes,  &scratch.v_noise.buf, 0, noise_bytes)?;
+        gpu.hip
+            .memcpy_dtod_at(&scratch.k_cat.buf, 0, &k_cache_layer.buf, 0, ctx_bytes)?;
+        gpu.hip.memcpy_dtod_at(
+            &scratch.k_cat.buf,
+            ctx_bytes,
+            &scratch.k_noise.buf,
+            0,
+            noise_bytes,
+        )?;
+        gpu.hip
+            .memcpy_dtod_at(&scratch.v_cat.buf, 0, &v_cache_layer.buf, 0, ctx_bytes)?;
+        gpu.hip.memcpy_dtod_at(
+            &scratch.v_cat.buf,
+            ctx_bytes,
+            &scratch.v_noise.buf,
+            0,
+            noise_bytes,
+        )?;
 
         // Per-head RMSNorm on Q: each of B*n_heads rows, size head_dim,
         // weight [head_dim].
-        gpu.rmsnorm_batched(&scratch.q, &layer.q_norm, &scratch.q, b * cfg.n_heads, hd, eps)?;
+        gpu.rmsnorm_batched(
+            &scratch.q,
+            &layer.q_norm,
+            &scratch.q,
+            b * cfg.n_heads,
+            hd,
+            eps,
+        )?;
         // Per-head RMSNorm on the NOISE tail of K_cat only — the cached
         // prefix was already normed when it was inserted into the layer's
         // k_ctx_cached. batch = B × n_kv_heads, applied to the last B rows
         // of k_cat.
         {
             let noise_slot = scratch.k_cat.sub_offset(l * kvd, b * kvd);
-            gpu.rmsnorm_batched(&noise_slot, &layer.k_norm, &noise_slot, b * cfg.n_kv_heads, hd, eps)?;
+            gpu.rmsnorm_batched(
+                &noise_slot,
+                &layer.k_norm,
+                &noise_slot,
+                b * cfg.n_kv_heads,
+                hd,
+                eps,
+            )?;
         }
 
         // RoPE. rope_batched_f32 expects q and k at the SAME batch size,
@@ -1198,8 +1433,8 @@ pub fn draft_forward_opts(
         // (scratch.k_noise is shape-compatible; n_heads_k=0 skips its loop).
         gpu.rope_batched_f32(
             &scratch.q,
-            &scratch.k_noise,      // ignored because n_heads_k = 0
-            &scratch.positions_q,  // [B]
+            &scratch.k_noise,     // ignored because n_heads_k = 0
+            &scratch.positions_q, // [B]
             cfg.n_heads,
             0,
             hd,
@@ -1208,9 +1443,9 @@ pub fn draft_forward_opts(
         )?;
         // Call 2: rotate K_cat with positions_k. n_heads_q = 0 skips Q.
         gpu.rope_batched_f32(
-            &scratch.q,            // ignored because n_heads_q = 0
+            &scratch.q, // ignored because n_heads_q = 0
             &scratch.k_cat,
-            &scratch.positions_k,  // [L + B]
+            &scratch.positions_k, // [L + B]
             0,
             cfg.n_kv_heads,
             hd,
@@ -1224,7 +1459,9 @@ pub fn draft_forward_opts(
         }
         let t2 = if dbg {
             Some(std::time::Instant::now())
-        } else { None };
+        } else {
+            None
+        };
 
         // Attention: Q [B, n_heads, hd] × K [tot, n_kv_heads, hd]^T → scores
         // (with GQA expansion) → softmax → @V.
@@ -1243,10 +1480,21 @@ pub fn draft_forward_opts(
             gpu.hip.device_synchronize()?;
             us_attn_kernel += t.elapsed().as_micros();
         }
-        let t3 = if dbg { Some(std::time::Instant::now()) } else { None };
+        let t3 = if dbg {
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
 
         // attn_proj = attn_out @ wo^T → [B, hidden]
-        gemm_dispatch(gpu, &scratch.attn_out, &layer.wo, &scratch.attn_proj, b, scratch.mq_x_rot.as_ref())?;
+        gemm_dispatch(
+            gpu,
+            &scratch.attn_out,
+            &layer.wo,
+            &scratch.attn_proj,
+            b,
+            scratch.mq_x_rot.as_ref(),
+        )?;
 
         // x = residual_attn + attn_proj
         gpu.add_f32(&scratch.residual_attn, &scratch.attn_proj, &scratch.x)?;
@@ -1254,18 +1502,8 @@ pub fn draft_forward_opts(
         // Fixed-shape FFN tail. MoE DFlash can optionally capture this as a
         // per-layer/per-B hipGraph; the attention/context work above is left
         // direct because `ctx_len` changes every accepted cycle.
-        let graph_ffn_active =
-            graph_ffn && !dbg && !crate::config::get().draft_gemm_dump;
-        draft_ffn_layer_maybe_graph(
-            gpu,
-            layer,
-            scratch,
-            li,
-            b,
-            h,
-            eps,
-            graph_ffn_active,
-        )?;
+        let graph_ffn_active = graph_ffn && !dbg && !crate::config::get().draft_gemm_dump;
+        draft_ffn_layer_maybe_graph(gpu, layer, scratch, li, b, h, eps, graph_ffn_active)?;
         // 2026-04-21: tried target's fused gemm_gate_up_hfq4g256 here (shared
         // FP16-X convert + interleaved gate/up GEMMs). Byte-exact A/B neutral
         // on 27B HumanEval (median 76.47 fused vs 76.74 baseline; ±7 % run-to-

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -32,7 +32,7 @@ use hip_bridge::{Graph, GraphExec, HipResult};
 use rdna_compute::{DType, Gpu, GpuTensor};
 use std::collections::{HashMap, HashSet};
 
-/// Max rows per call into `gemm_dispatch` for the MQ4/MQ3 (FWHT-rotated)
+/// Max rows per call into `gemm_dispatch` for the MQ (FWHT-rotated)
 /// path. The activation rotation scratch (`DflashScratch.mq_x_rot`) is
 /// sized to this many rows × `max(inter, q_dim, num_extract * hidden)`,
 /// regardless of context length. Calls with `batch > MQ_X_ROT_CHUNK_ROWS`
@@ -191,9 +191,11 @@ fn hfq_tensor_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, shape: Vec<usize>) -
 ///   1  (F16)      → lifted to F32 on GPU (legacy path).
 ///   2  (F32)      → uploaded as F32.
 ///   13 (MQ4-G256) → uploaded raw, kernel dispatch will FWHT-rotate x at use.
+///   15 (MQ6-G256) → uploaded raw, kernel dispatch will FWHT-rotate x at use.
+///   17 (MQ3-G256) → uploaded raw, kernel dispatch will FWHT-rotate x at use.
 ///
 /// `shape = [m, k]` so m=output_dim and k=input_dim. The HFQ index stores
-/// the unaligned byte length; for MQ4 we skip shape verification (the
+/// the unaligned byte length; for MQ formats we skip shape verification (the
 /// quantized bytes are not a function of m*k alone — group padding can add
 /// up to 255 trailing bytes per row group).
 fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> HipResult<WeightTensor> {
@@ -238,6 +240,12 @@ fn hfq_weight(hfq: &HfqFile, gpu: &mut Gpu, name: &str, m: usize, k: usize) -> H
             // the engine; the gemm_hfq4g256 kernel reads it directly.
             let buf = gpu.upload_raw(data, &[data.len()])?;
             Ok(WeightTensor { buf, gpu_dtype: DType::MQ4G256, m, k, row_stride: 0, paro: None, awq_scale: None })
+        }
+        15 => {
+            // MQ6-G256: 200 bytes per 256 weights. Same opaque-buffer pattern
+            // as MQ4/MQ3; dispatch rotates activations and calls HFQ6 GEMM.
+            let buf = gpu.upload_raw(data, &[data.len()])?;
+            Ok(WeightTensor { buf, gpu_dtype: DType::MQ6G256, m, k, row_stride: 0, paro: None, awq_scale: None })
         }
         17 => {
             // MQ3-G256: 104 bytes per 256 weights. Same opaque-buffer pattern
@@ -288,9 +296,9 @@ impl DflashWeights {
             .chain(layers.iter().flat_map(|l| {
                 [&l.wq, &l.wk, &l.wv, &l.wo, &l.w_gate, &l.w_up, &l.w_down].into_iter()
             }))
-            .any(|w| matches!(w.gpu_dtype, DType::MQ4G256 | DType::MQ3G256));
+            .any(|w| matches!(w.gpu_dtype, DType::MQ4G256 | DType::MQ6G256 | DType::MQ3G256));
         if has_mq {
-            // The MQ4 dispatch needs the engine's FWHT sign tables uploaded
+            // MQ dispatch needs the engine's FWHT sign tables uploaded
             // (matches `gemv_mq4g256_with_rotate`'s setup).
             gpu.ensure_mq_signs()?;
         }
@@ -609,7 +617,7 @@ impl DflashScratch {
 ///   w.buf [m × k]  weight, format depends on w.gpu_dtype
 ///   y [batch × m]  F32 output
 ///
-/// For MQ4-G256, the kernel needs the input FWHT-rotated. We do that into
+/// For MQ-G256, the kernel needs the input FWHT-rotated. We do that into
 /// `mq_x_rot` (sized to the per-call max in `DflashScratch`), then call the
 /// HFQ4-G256 GEMM kernel against the pre-rotated weights.
 fn gemm_dispatch(
@@ -712,6 +720,32 @@ fn gemm_dispatch(
             }
             chunked
         }
+        DType::MQ6G256 => {
+            // Mirrors the MQ4/MQ3 path: pre-rotate x via FWHT, then dispatch
+            // the HFQ6 batched lm_head WMMA kernel. Chunked symmetrically with
+            // the other MQ formats.
+            let scratch = mq_x_rot.expect("MQ6 dispatch requires mq_x_rot scratch");
+            let max_chunk = (scratch.shape[0] / w.k).max(1);
+            gpu.scratch.fp16_x_source_ptr = std::ptr::null_mut();
+            let mut chunked: HipResult<()> = Ok(());
+            let mut row = 0;
+            while row < batch {
+                let n = std::cmp::min(max_chunk, batch - row);
+                let x_chunk = x.sub_offset(row * w.k, n * w.k);
+                let y_chunk = y.sub_offset(row * w.m, n * w.m);
+                let rot_view = scratch.sub_offset(0, n * w.k);
+                if let Err(e) = crate::llama::rotate_x_mq_batched_for(gpu, w, &x_chunk, &rot_view, w.k, n) {
+                    chunked = Err(e);
+                    break;
+                }
+                if let Err(e) = gpu.gemm_hfq6g256_batched_lmhead(&w.buf, &rot_view, &y_chunk, w.m, w.k, n) {
+                    chunked = Err(e);
+                    break;
+                }
+                row += n;
+            }
+            chunked
+        }
         other => panic!("dflash gemm_dispatch: unsupported weight dtype {:?}", other),
     };
     if let Some(t) = t0 {
@@ -720,8 +754,10 @@ fn gemm_dispatch(
         let weight_bytes = match w.gpu_dtype {
             DType::F32 => w.m * w.k * 4,
             DType::F16 => w.m * w.k * 2,
-            // HFQ4/MQ4: 136B per group of 256
-            _ => w.m * (w.k / 256).max(1) * 136,
+            DType::MQ3G256 => w.m * (w.k / 256).max(1) * 104,
+            DType::HFQ4G256 | DType::MQ4G256 => w.m * (w.k / 256).max(1) * 136,
+            DType::MQ6G256 => w.m * (w.k / 256).max(1) * 200,
+            _ => w.m * w.k,
         };
         let bytes = weight_bytes + batch * w.k * 4 + batch * w.m * 4 * 2;
         let gbs = (bytes as f64) / (us.max(1) as f64) / 1000.0;


### PR DESCRIPTION
## Summary
- add `--mq6` support to `dflash_convert` with MQ6-G256 packing and HFQ quant type metadata
- load MQ6 DFlash draft weights as raw MQ6 tensors and include them in MQ draft detection/sign setup
- route MQ6 draft GEMMs through the FWHT rotation path and HFQ6 batched lm-head dispatch

## Validation
- `git diff --check origin/master..HEAD`
- `cargo check -p hipfire-quantize --bin dflash_convert`
- `cargo check -p hipfire-runtime --example dflash_spec_demo`

Note: the runtime check passes with existing warnings in `hip-bridge`, `rdna-compute`, `hipfire-runtime`, and arch crates.