### PR TITLE
fix(runtime): accept no for prompt normalization opt-out

### DIFF
--- a/crates/hipfire-runtime/src/config.rs
+++ b/crates/hipfire-runtime/src/config.rs
@@ -67,15 +67,10 @@ impl RuntimeConfig {
             prompt_heat_json,
             prompt_heat_limit,
             dflash_draft: std::env::var("HIPFIRE_DFLASH_DRAFT").ok(),
-            dflash_mode: std::env::var("HIPFIRE_DFLASH_MODE")
-                .unwrap_or_else(|_| "off".to_string()),
+            dflash_mode: std::env::var("HIPFIRE_DFLASH_MODE").unwrap_or_else(|_| "off".to_string()),
             draft_f16: std::env::var("HIPFIRE_DRAFT_F16").ok().as_deref() != Some("0"),
-            draft_gemm_dump: std::env::var("HIPFIRE_DRAFT_GEMM_DUMP")
-                .ok()
-                .as_deref() == Some("1"),
-            draft_subphase: std::env::var("HIPFIRE_DRAFT_SUBPHASE")
-                .ok()
-                .as_deref() == Some("1"),
+            draft_gemm_dump: std::env::var("HIPFIRE_DRAFT_GEMM_DUMP").ok().as_deref() == Some("1"),
+            draft_subphase: std::env::var("HIPFIRE_DRAFT_SUBPHASE").ok().as_deref() == Some("1"),
             ddtree_budget: std::env::var("HIPFIRE_DDTREE_BUDGET")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -84,9 +79,7 @@ impl RuntimeConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(8),
-            prefill_batched: std::env::var("HIPFIRE_PREFILL_BATCHED")
-                .ok()
-                .as_deref() != Some("0"),
+            prefill_batched: std::env::var("HIPFIRE_PREFILL_BATCHED").ok().as_deref() != Some("0"),
             flash_partials_batch: std::env::var("HIPFIRE_FLASH_PARTIALS_BATCH")
                 .ok()
                 .and_then(|s| s.parse::<usize>().ok()),
@@ -99,16 +92,14 @@ impl RuntimeConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(256),
             devices: std::env::var("HIPFIRE_DEVICES").ok(),
-            allow_mixed_arch: std::env::var("HIPFIRE_ALLOW_MIXED_ARCH")
-                .ok()
-                .as_deref() == Some("1"),
+            allow_mixed_arch: std::env::var("HIPFIRE_ALLOW_MIXED_ARCH").ok().as_deref()
+                == Some("1"),
             uniform_vram_tolerance_gb: std::env::var("HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB")
                 .ok()
                 .and_then(|s| s.parse().ok()),
             lm_head_f16: std::env::var("HIPFIRE_LM_HEAD_F16")
                 .unwrap_or_else(|_| "auto".to_string()),
-            mtp_mode: std::env::var("HIPFIRE_MTP_MODE")
-                .unwrap_or_else(|_| "auto".to_string()),
+            mtp_mode: std::env::var("HIPFIRE_MTP_MODE").unwrap_or_else(|_| "auto".to_string()),
             mtp_k: std::env::var("HIPFIRE_MTP_K")
                 .ok()
                 .and_then(|v| v.parse().ok())

--- a/crates/hipfire-runtime/src/config.rs
+++ b/crates/hipfire-runtime/src/config.rs
@@ -48,7 +48,7 @@ pub fn init() {
 impl RuntimeConfig {
     pub fn from_env() -> Self {
         let normalize_prompt = match std::env::var("HIPFIRE_NORMALIZE_PROMPT").ok().as_deref() {
-            Some("0") | Some("false") | Some("off") => false,
+            Some("0") | Some("false") | Some("off") | Some("no") => false,
             _ => true,
         };
 
@@ -113,6 +113,29 @@ impl RuntimeConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(3),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuntimeConfig;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn normalize_prompt_accepts_no_as_false() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("HIPFIRE_NORMALIZE_PROMPT").ok();
+        std::env::set_var("HIPFIRE_NORMALIZE_PROMPT", "no");
+
+        let cfg = RuntimeConfig::from_env();
+        assert!(!cfg.normalize_prompt);
+
+        match prev {
+            Some(value) => std::env::set_var("HIPFIRE_NORMALIZE_PROMPT", value),
+            None => std::env::remove_var("HIPFIRE_NORMALIZE_PROMPT"),
         }
     }
 }

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -25,8 +25,7 @@ use std::sync::OnceLock;
 /// the priority the reference encoders use, so chunking boundaries
 /// match HF tokenizers' Split-then-ByteLevel pipeline byte-for-byte
 /// (verified against locked niah_4k token md5).
-const GPT2_PRETOK_PATTERN: &str =
-    r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+";
+const GPT2_PRETOK_PATTERN: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+";
 
 fn gpt2_pretok_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
@@ -190,12 +189,12 @@ fn resolve_merges(
         result_buf.clear();
         result_buf.push_str(l_str);
         result_buf.push_str(r_str);
-        let result =
-            token_to_id.get(result_buf.as_str()).copied().ok_or_else(|| {
-                TokenizerError::MissingMergeResult {
-                    rank,
-                    expected: result_buf.clone(),
-                }
+        let result = token_to_id
+            .get(result_buf.as_str())
+            .copied()
+            .ok_or_else(|| TokenizerError::MissingMergeResult {
+                rank,
+                expected: result_buf.clone(),
             })?;
         merges.push(result);
         // First-rank-wins on duplicate `(left_id, right_id)` pairs:
@@ -237,9 +236,11 @@ impl Tokenizer {
     /// Load tokenizer from GGUF metadata.
     pub fn from_gguf(gguf: &GgufFile) -> Result<Self, TokenizerError> {
         // Read vocabulary
-        let tokens_meta = gguf
-            .meta("tokenizer.ggml.tokens")
-            .ok_or(TokenizerError::MetadataMissing { field: "tokenizer.ggml.tokens" })?;
+        let tokens_meta =
+            gguf.meta("tokenizer.ggml.tokens")
+                .ok_or(TokenizerError::MetadataMissing {
+                    field: "tokenizer.ggml.tokens",
+                })?;
         let vocab: Vec<String> = match tokens_meta {
             MetaValue::Array(arr) => arr
                 .iter()
@@ -248,7 +249,11 @@ impl Tokenizer {
                     _ => String::new(),
                 })
                 .collect(),
-            _ => return Err(TokenizerError::MetadataMissing { field: "tokenizer.ggml.tokens" }),
+            _ => {
+                return Err(TokenizerError::MetadataMissing {
+                    field: "tokenizer.ggml.tokens",
+                })
+            }
         };
 
         let mut token_to_id = HashMap::with_capacity(vocab.len());
@@ -280,7 +285,7 @@ impl Tokenizer {
         let bos_id = gguf.meta_u32("tokenizer.ggml.bos_token_id").unwrap_or(1);
         let eos_id = gguf.meta_u32("tokenizer.ggml.eos_token_id").unwrap_or(2);
         let endoftext = token_to_id.get("<|endoftext|>").copied();
-        let im_end    = token_to_id.get("<|im_end|>").copied();
+        let im_end = token_to_id.get("<|im_end|>").copied();
         let eot_id = match (endoftext, im_end) {
             (Some(et), Some(ie)) if et != eos_id && ie == eos_id => Some(et),
             (Some(et), _) if et != eos_id => Some(et),
@@ -295,7 +300,10 @@ impl Tokenizer {
         let mut special_tokens: Vec<(String, u32)> = Vec::new();
         for (i, tok) in vocab.iter().enumerate() {
             if (tok.starts_with("<|") && tok.ends_with("|>"))
-                || (tok.starts_with("<") && tok.ends_with(">") && tok.len() > 3 && !tok.contains(' '))
+                || (tok.starts_with("<")
+                    && tok.ends_with(">")
+                    && tok.len() > 3
+                    && !tok.contains(' '))
             {
                 special_tokens.push((tok.clone(), i as u32));
             }
@@ -333,19 +341,19 @@ impl Tokenizer {
             .get("model")
             .ok_or(TokenizerError::MetadataMissing { field: "model" })?;
 
-        let vocab_map = model
-            .get("vocab")
-            .and_then(|v| v.as_object())
-            .ok_or(TokenizerError::MetadataMissing { field: "model.vocab" })?;
+        let vocab_map = model.get("vocab").and_then(|v| v.as_object()).ok_or(
+            TokenizerError::MetadataMissing {
+                field: "model.vocab",
+            },
+        )?;
         let vocab_size = vocab_map.len();
 
         let mut vocab = vec![String::new(); vocab_size + 100];
         let mut token_to_id = HashMap::with_capacity(vocab_size);
         for (token, id_val) in vocab_map {
-            let id = id_val
-                .as_u64()
-                .ok_or(TokenizerError::MetadataMissing { field: "model.vocab[*]: non-integer id" })?
-                as u32;
+            let id = id_val.as_u64().ok_or(TokenizerError::MetadataMissing {
+                field: "model.vocab[*]: non-integer id",
+            })? as u32;
             if (id as usize) >= vocab.len() {
                 vocab.resize(id as usize + 1, String::new());
             }
@@ -410,10 +418,14 @@ impl Tokenizer {
         }
         special_tokens.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
 
-        let bos_id = token_to_id.get("<|endoftext|>").copied()
+        let bos_id = token_to_id
+            .get("<|endoftext|>")
+            .copied()
             .or_else(|| token_to_id.get("<s>").copied())
             .unwrap_or(1);
-        let eos_id = token_to_id.get("<|im_end|>").copied()
+        let eos_id = token_to_id
+            .get("<|im_end|>")
+            .copied()
             .or_else(|| token_to_id.get("<|endoftext|>").copied())
             .or_else(|| token_to_id.get("</s>").copied())
             .unwrap_or(2);
@@ -475,7 +487,9 @@ impl Tokenizer {
         if let Some(gguf_meta) = meta.get("gguf_meta") {
             return Self::from_gguf_meta_json(gguf_meta);
         }
-        Err(TokenizerError::MetadataMissing { field: "tokenizer | gguf_meta" })
+        Err(TokenizerError::MetadataMissing {
+            field: "tokenizer | gguf_meta",
+        })
     }
 
     /// Load tokenizer from a JSON-serialized GGUF metadata tree. Mirrors
@@ -486,7 +500,9 @@ impl Tokenizer {
         let tokens_arr = meta
             .get("tokenizer.ggml.tokens")
             .and_then(|v| v.as_array())
-            .ok_or(TokenizerError::MetadataMissing { field: "tokenizer.ggml.tokens" })?;
+            .ok_or(TokenizerError::MetadataMissing {
+                field: "tokenizer.ggml.tokens",
+            })?;
         let vocab: Vec<String> = tokens_arr
             .iter()
             .map(|v| v.as_str().unwrap_or("").to_string())
@@ -541,7 +557,10 @@ impl Tokenizer {
         let mut special_tokens: Vec<(String, u32)> = Vec::new();
         for (i, tok) in vocab.iter().enumerate() {
             if (tok.starts_with("<|") && tok.ends_with("|>"))
-                || (tok.starts_with("<") && tok.ends_with(">") && tok.len() > 3 && !tok.contains(' '))
+                || (tok.starts_with("<")
+                    && tok.ends_with(">")
+                    && tok.len() > 3
+                    && !tok.contains(' '))
             {
                 special_tokens.push((tok.clone(), i as u32));
             }
@@ -584,7 +603,8 @@ impl Tokenizer {
     /// when the token is not registered as a special token in this
     /// tokenizer (e.g. an older Qwen vocab without `<tool_call>`).
     pub fn special_token_id(&self, content: &str) -> Option<u32> {
-        self.special_tokens.iter()
+        self.special_tokens
+            .iter()
             .find(|(s, _)| s == content)
             .map(|(_, id)| *id)
     }
@@ -837,7 +857,10 @@ impl Tokenizer {
             .byte_to_id
             .as_ref()
             .expect("encode_gpt2_chunk called on non-GPT2 tokenizer");
-        let mut syms: Vec<u32> = chunk_bytes.iter().map(|&b| byte_to_id[b as usize]).collect();
+        let mut syms: Vec<u32> = chunk_bytes
+            .iter()
+            .map(|&b| byte_to_id[b as usize])
+            .collect();
         let n = syms.len();
         if n == 0 {
             return;
@@ -881,7 +904,6 @@ impl Tokenizer {
         for i in 0..n - 1 {
             push_pair(&mut heap, &syms, &gen, i, i + 1);
         }
-
 
         // 6. Main merge loop. Each pop is O(log N); validation is O(1);
         // splice is O(1); two pushes are O(log N). Total O(N log N).
@@ -1029,10 +1051,7 @@ fn byte_to_gpt2_char(b: u8) -> char {
 /// Reverse of byte_to_gpt2_char.
 fn gpt2_char_to_byte(c: char) -> Option<u8> {
     let c = c as u32;
-    if (0x21..=0x7E).contains(&c)
-        || (0xA1..=0xAC).contains(&c)
-        || (0xAE..=0xFF).contains(&c)
-    {
+    if (0x21..=0x7E).contains(&c) || (0xA1..=0xAC).contains(&c) || (0xAE..=0xFF).contains(&c) {
         Some(c as u8)
     } else if c >= 256 && c < 256 + 68 {
         GPT2_OFFSET_TO_BYTE.get((c - 256) as usize).copied()
@@ -1047,9 +1066,8 @@ static GPT2_BYTE_TO_OFFSET: [u8; 256] = {
     let mut n = 0u8;
     let mut b = 0u16;
     while b < 256 {
-        let is_printable = (b >= 0x21 && b <= 0x7E)
-            || (b >= 0xA1 && b <= 0xAC)
-            || (b >= 0xAE && b <= 0xFF);
+        let is_printable =
+            (b >= 0x21 && b <= 0x7E) || (b >= 0xA1 && b <= 0xAC) || (b >= 0xAE && b <= 0xFF);
         if !is_printable {
             table[b as usize] = n;
             n += 1;
@@ -1065,9 +1083,8 @@ static GPT2_OFFSET_TO_BYTE: [u8; 68] = {
     let mut n = 0usize;
     let mut b = 0u16;
     while b < 256 {
-        let is_printable = (b >= 0x21 && b <= 0x7E)
-            || (b >= 0xA1 && b <= 0xAC)
-            || (b >= 0xAE && b <= 0xFF);
+        let is_printable =
+            (b >= 0x21 && b <= 0x7E) || (b >= 0xA1 && b <= 0xAC) || (b >= 0xAE && b <= 0xFF);
         if !is_printable {
             table[n] = b as u8;
             n += 1;
@@ -1193,7 +1210,11 @@ impl Tokenizer {
     fn rank_of(&self, id: u32, table: &HashMap<u32, usize>) -> Option<usize> {
         table.get(&id).copied().or_else(|| {
             let s = self.vocab.get(id as usize)?;
-            if s.len() <= 1 { Some(0) } else { None }
+            if s.len() <= 1 {
+                Some(0)
+            } else {
+                None
+            }
         })
     }
 
@@ -1217,33 +1238,60 @@ impl Tokenizer {
             s.push_str(",\"tokens\":");
             s.push_str(&ids.len().to_string());
             s.push_str(",\"summary\":{");
-            s.push_str(&format!("\"base\":{},\"hot\":{},\"warm\":{},\"cold\":{},\"frozen\":{},\"special\":{}",
-                counts[0], counts[1], counts[2], counts[3], counts[4], counts[5]));
+            s.push_str(&format!(
+                "\"base\":{},\"hot\":{},\"warm\":{},\"cold\":{},\"frozen\":{},\"special\":{}",
+                counts[0], counts[1], counts[2], counts[3], counts[4], counts[5]
+            ));
             s.push_str("},\"positions\":[");
             for (pos, &id) in ids.iter().enumerate() {
-                if pos > 0 { s.push(','); }
+                if pos > 0 {
+                    s.push(',');
+                }
                 let rank = self.rank_of(id, &table);
-                let decoded = self.decode(&[id]).replace('\\', "\\\\").replace('"', "\\\"")
-                    .replace('\n', "\\n").replace('\t', "\\t").replace('\r', "\\r");
-                s.push_str(&format!("{{\"pos\":{pos},\"id\":{id},\"rank\":{},\"text\":\"{decoded}\"}}",
-                    rank.map(|r| r.to_string()).unwrap_or_else(|| "null".to_string())));
+                let decoded = self
+                    .decode(&[id])
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n")
+                    .replace('\t', "\\t")
+                    .replace('\r', "\\r");
+                s.push_str(&format!(
+                    "{{\"pos\":{pos},\"id\":{id},\"rank\":{},\"text\":\"{decoded}\"}}",
+                    rank.map(|r| r.to_string())
+                        .unwrap_or_else(|| "null".to_string())
+                ));
             }
             s.push_str("]}");
             println!("{s}");
             return;
         }
         let limit: usize = crate::config::get().prompt_heat_limit;
-        eprintln!("[token-heat] prompt={} bytes  tokens={}", text.len(), ids.len());
-        eprintln!("[token-heat] {:>4}  {:>6}  {:>7}  {:7}  {}", "pos", "id", "rank", "class", "decoded");
+        eprintln!(
+            "[token-heat] prompt={} bytes  tokens={}",
+            text.len(),
+            ids.len()
+        );
+        eprintln!(
+            "[token-heat] {:>4}  {:>6}  {:>7}  {:7}  {}",
+            "pos", "id", "rank", "class", "decoded"
+        );
         for (pos, &id) in ids.iter().take(limit).enumerate() {
             let rank = self.rank_of(id, &table);
             let class = HeatClass::from_rank(rank);
             let display = self.decode(&[id]).replace('\n', "\\n").replace('\t', "\\t");
-            let rank_str = rank.map(|r| r.to_string()).unwrap_or_else(|| "-".to_string());
-            eprintln!("[token-heat] {pos:>4}  {id:>6}  {rank_str:>7}  {}  {display:?}", class.label());
+            let rank_str = rank
+                .map(|r| r.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            eprintln!(
+                "[token-heat] {pos:>4}  {id:>6}  {rank_str:>7}  {}  {display:?}",
+                class.label()
+            );
         }
         if ids.len() > limit {
-            eprintln!("[token-heat] ... ({} more tokens omitted)", ids.len() - limit);
+            eprintln!(
+                "[token-heat] ... ({} more tokens omitted)",
+                ids.len() - limit
+            );
         }
         eprintln!("[token-heat] summary: BASE={} ({:.0}%)  HOT={} ({:.0}%)  WARM={} ({:.0}%)  COLD={} ({:.0}%)  FROZEN={} ({:.0}%)  SPECIAL={} ({:.0}%)",
             counts[0], 100.0*counts[0] as f32/total as f32,
@@ -1254,7 +1302,10 @@ impl Tokenizer {
             counts[5], 100.0*counts[5] as f32/total as f32);
         let cold_frac = (counts[3] + counts[4]) as f32 / total as f32;
         if cold_frac > 0.05 {
-            eprintln!("[token-heat] WARNING: {:.1}% cold tokens — likely τ depressor", 100.0 * cold_frac);
+            eprintln!(
+                "[token-heat] WARNING: {:.1}% cold tokens — likely τ depressor",
+                100.0 * cold_frac
+            );
         }
     }
 }
@@ -1531,7 +1582,13 @@ mod bpe_tests {
         // Final symbol list: ["hello"] → [id 7]
         let tok = synth(
             &["h", "e", "l", "o", "he", "ll", "hell", "hello", "lo"],
-            &[("h", "e"), ("l", "l"), ("he", "ll"), ("hell", "o"), ("l", "o")],
+            &[
+                ("h", "e"),
+                ("l", "l"),
+                ("he", "ll"),
+                ("hell", "o"),
+                ("l", "o"),
+            ],
         );
         assert_eq!(tok.encode_gpt2_bpe("hello"), vec![7]);
     }
@@ -1542,7 +1599,13 @@ mod bpe_tests {
         // Init ["l","o","l"] → after merge ["lo","l"] → [id 8, id 2].
         let tok = synth(
             &["h", "e", "l", "o", "he", "ll", "hell", "hello", "lo"],
-            &[("h", "e"), ("l", "l"), ("he", "ll"), ("hell", "o"), ("l", "o")],
+            &[
+                ("h", "e"),
+                ("l", "l"),
+                ("he", "ll"),
+                ("hell", "o"),
+                ("l", "o"),
+            ],
         );
         assert_eq!(tok.encode_gpt2_bpe("lol"), vec![8, 2]);
     }
@@ -1552,7 +1615,13 @@ mod bpe_tests {
         // "ho" — no ("h","o") merge in the table; output is the two byte tokens.
         let tok = synth(
             &["h", "e", "l", "o", "he", "ll", "hell", "hello", "lo"],
-            &[("h", "e"), ("l", "l"), ("he", "ll"), ("hell", "o"), ("l", "o")],
+            &[
+                ("h", "e"),
+                ("l", "l"),
+                ("he", "ll"),
+                ("hell", "o"),
+                ("l", "o"),
+            ],
         );
         assert_eq!(tok.encode_gpt2_bpe("ho"), vec![0, 3]);
     }
@@ -1570,10 +1639,7 @@ mod bpe_tests {
         // first → ["ab","a","b","a"] → ("a","b") at (1,2) → ["ab","ab","a"] →
         // now ("ab","a") at (1,2) rank 1 → ["ab","aba"]. No more merges.
         // Expected: [id of "ab", id of "aba"].
-        let tok = synth(
-            &["a", "b", "ab", "aba"],
-            &[("a", "b"), ("ab", "a")],
-        );
+        let tok = synth(&["a", "b", "ab", "aba"], &[("a", "b"), ("ab", "a")]);
         assert_eq!(tok.encode_gpt2_bpe("ababa"), vec![2, 3]);
     }
 
@@ -1590,10 +1656,7 @@ mod bpe_tests {
         // and many stale heap entries (each merge invalidates ≤ 2 prior
         // entries via the gen tag). Verifies we don't panic, deadlock, or
         // produce a non-decreasing-length output for a known shape.
-        let tok = synth(
-            &["a", "aa", "aaaa"],
-            &[("a", "a"), ("aa", "aa")],
-        );
+        let tok = synth(&["a", "aa", "aaaa"], &[("a", "a"), ("aa", "aa")]);
         let input = "a".repeat(1024);
         let out = tok.encode_gpt2_bpe(&input);
         // 1024 bytes → 512 "aa" pairs (rank 0) → 256 "aaaa" (rank 1). No
@@ -1665,7 +1728,12 @@ mod consistency_tests {
             Ok(_) => panic!("expected Err, got Ok"),
         };
         match err {
-            TokenizerError::MissingMergeOperand { rank: 0, missing_side: Side::Left, ref left, ref right } => {
+            TokenizerError::MissingMergeOperand {
+                rank: 0,
+                missing_side: Side::Left,
+                ref left,
+                ref right,
+            } => {
                 assert_eq!(left, "a");
                 assert_eq!(right, "b");
             }
@@ -1682,7 +1750,11 @@ mod consistency_tests {
             Ok(_) => panic!("expected Err, got Ok"),
         };
         match err {
-            TokenizerError::MissingMergeOperand { rank: 0, missing_side: Side::Right, .. } => {}
+            TokenizerError::MissingMergeOperand {
+                rank: 0,
+                missing_side: Side::Right,
+                ..
+            } => {}
             other => panic!("expected MissingMergeOperand{{Right}}, got {other:?}"),
         }
     }
@@ -1697,7 +1769,10 @@ mod consistency_tests {
             Ok(_) => panic!("expected Err, got Ok"),
         };
         match err {
-            TokenizerError::MissingMergeResult { rank: 0, ref expected } => {
+            TokenizerError::MissingMergeResult {
+                rank: 0,
+                ref expected,
+            } => {
                 assert_eq!(expected, "ab");
             }
             other => panic!("expected MissingMergeResult, got {other:?}"),
@@ -1715,7 +1790,10 @@ mod consistency_tests {
             Ok(_) => panic!("expected Err, got Ok"),
         };
         match err {
-            TokenizerError::MissingByteSymbol { byte: 0x41, char: 'A' } => {}
+            TokenizerError::MissingByteSymbol {
+                byte: 0x41,
+                char: 'A',
+            } => {}
             other => panic!("expected MissingByteSymbol{{0x41,'A'}}, got {other:?}"),
         }
     }
@@ -1739,8 +1817,8 @@ mod consistency_tests {
         // byte_to_gpt2_char maps printable ASCII to itself, so the
         // byte chars *are* "A" and "B".
         let meta = gpt2_meta_full_bytes(None, &["AB"], &["A B"]);
-        let tok = Tokenizer::from_gguf_meta_json(&meta)
-            .expect("consistent GPT-2 vocab should succeed");
+        let tok =
+            Tokenizer::from_gguf_meta_json(&meta).expect("consistent GPT-2 vocab should succeed");
         assert!(tok.byte_to_id.is_some());
         assert_eq!(tok.merges.len(), 1);
         // Merge resolved to ids: A → 0x41, B → 0x42, AB → 256 (first extra).
@@ -1879,10 +1957,7 @@ mod prompt_norm_tests {
 
     #[test]
     fn multiple_independent_runs() {
-        assert_eq!(
-            collapse_newline_runs("a\n\n\nb\n\n\n\nc"),
-            "a\n\nb\n\nc"
-        );
+        assert_eq!(collapse_newline_runs("a\n\n\nb\n\n\n\nc"), "a\n\nb\n\nc");
     }
 
     #[test]
@@ -1953,10 +2028,7 @@ mod prompt_norm_tests {
     #[test]
     fn line_endings_mixed_crlf_and_lf() {
         // git-attributes mishap: some lines CRLF, some LF.
-        assert_eq!(
-            normalize_line_endings("a\r\nb\nc\r\nd"),
-            "a\nb\nc\nd"
-        );
+        assert_eq!(normalize_line_endings("a\r\nb\nc\r\nd"), "a\nb\nc\nd");
     }
 
     #[test]
@@ -2017,7 +2089,7 @@ mod prompt_norm_tests {
         assert!(!needs_nbsp_replace("a b"));
         // Other Latin-1 chars starting with 0xC2 must not false-positive.
         assert!(!needs_nbsp_replace("caf\u{00E9}")); // é = 0xC3 0xA9
-        assert!(!needs_nbsp_replace("\u{00A2}"));    // ¢ = 0xC2 0xA2
+        assert!(!needs_nbsp_replace("\u{00A2}")); // ¢ = 0xC2 0xA2
     }
 
     // ---- strip_trailing_line_ws ----
@@ -2077,10 +2149,7 @@ mod prompt_norm_tests {
             "\tdef foo():\n\t\treturn 1\n"
         );
         // Mixed tab + space indentation also round-trips.
-        assert_eq!(
-            strip_trailing_line_ws("\t \tx = 1\n"),
-            "\t \tx = 1\n"
-        );
+        assert_eq!(strip_trailing_line_ws("\t \tx = 1\n"), "\t \tx = 1\n");
         // Trailing tabs at end of line still get stripped.
         assert_eq!(strip_trailing_line_ws("a\tb\t\nc"), "a\tb\nc");
     }
@@ -2088,10 +2157,7 @@ mod prompt_norm_tests {
     #[test]
     fn strip_blank_line_with_indent() {
         // Whitespace-only "blank" line between code blocks — strip the indent.
-        assert_eq!(
-            strip_trailing_line_ws("a\n    \nb"),
-            "a\n\nb"
-        );
+        assert_eq!(strip_trailing_line_ws("a\n    \nb"), "a\n\nb");
     }
 
     #[test]

--- a/crates/hipfire-runtime/src/tokenizer.rs
+++ b/crates/hipfire-runtime/src/tokenizer.rs
@@ -1391,7 +1391,7 @@ pub fn strip_trailing_line_ws(s: &str) -> String {
 /// disabled; `Cow::Owned` only on actual rewrite. Each step in the pipeline
 /// is itself a no-op fast-path when its trigger pattern is absent.
 pub fn maybe_normalize_prompt(s: &str) -> std::borrow::Cow<'_, str> {
-    // Default ON. Explicit "0" / "false" / "off" opts out (parsed once in
+    // Default ON. Explicit "0" / "false" / "off" / "no" opts out (parsed once in
     // RuntimeConfig::from_env). Delegates to the flag-parameterized core so the
     // pipeline is unit-testable without the memoized `config::get()` singleton.
     normalize_prompt_with(s, crate::config::get().normalize_prompt)


### PR DESCRIPTION
## Summary
- treat `HIPFIRE_NORMALIZE_PROMPT=no` the same as `0`, `false`, and `off`
- update the tokenizer comment so the documented opt-out spellings match runtime parsing
- add a focused runtime config unit test for the `no` spelling

## Validation
- `git diff --check`
- `cargo test -p hipfire-runtime --lib normalize_prompt_accepts_no_as_false`
- `cargo test -p hipfire-runtime --lib normalize_prompt`

Note: Rust tests pass with existing warnings in `hip-bridge`, `rdna-compute`, `hipfire-runtime`, and arch crates.