### PR TITLE
ci: add no-GPU validation workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,9 +18,11 @@
 
 ## Test plan
 
+- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
 - [ ] `cargo build --release --workspace --features deltanet` clean
 - [ ] `cargo test --lib --workspace --features deltanet` passes
 - [ ] If kernel/dispatch changed: `./scripts/coherence-gate.sh` clean
+- [ ] If spec-decode changed: `./scripts/coherence-gate-dflash.sh` clean
 - [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines
 
 ## Architecture-trait change?

--- a/.github/workflows/no-gpu-ci.yml
+++ b/.github/workflows/no-gpu-ci.yml
@@ -1,0 +1,32 @@
+name: no-gpu-ci
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  no-gpu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Install Python test dependencies
+        run: python -m pip install --upgrade pytest numpy
+
+      - name: Install Bun dependencies
+        working-directory: cli
+        run: bun install --frozen-lockfile
+
+      - name: Run no-GPU checks
+        run: ./scripts/no-gpu-ci.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,30 @@ cd hipfire
 cargo build --release --features deltanet --example daemon -p hipfire-runtime
 cargo build --release --features deltanet --example test_kernels -p hipfire-runtime
 cargo build --release -p hipfire-quantize
+./scripts/install-hooks.sh
 ```
 
 Requires Rust 1.75+ and ROCm 6+ (the dev workflow needs `hipcc` for
 kernel JIT). Pre-compiled kernel blobs ship for gfx1010 / gfx1030 /
 gfx1100 / gfx1200; other arches JIT-compile on first load.
+
+`scripts/install-hooks.sh` is idempotent; it sets
+`core.hooksPath=.githooks` and makes the local pre-commit hook
+executable.
+
+### No-GPU CI subset
+
+The default CI path intentionally avoids AMD GPU access and model
+downloads:
+
+```bash
+./scripts/no-gpu-ci.sh
+```
+
+It runs `cargo check --workspace --examples`, no-GPU Rust unit tests,
+CPU Python tests, the env/docs drift check, and Bun tests/typecheck
+when Bun is installed. GPU coherence and speed gates remain required
+for kernel, dispatch, quant, forward-pass, and spec-decode changes.
 
 ### GPU kernel correctness check
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,12 @@ attribute the corresponding inventions per [AGENTS.md](AGENTS.md).
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Any change to kernels, quant
-formats, dispatch, fusion, rotation, rmsnorm, or the spec-decode path
-must pass `./scripts/coherence-gate-dflash.sh` before commit. The
-canonical correctness gate is per-arch channel-test; the speed-gate
-catches regressions on the baseline arch. Don't bypass either with
-`--no-verify` — see
+See [CONTRIBUTING.md](CONTRIBUTING.md). Install local hooks with
+`./scripts/install-hooks.sh`. The no-GPU CI subset is
+`./scripts/no-gpu-ci.sh`; it does not replace the hardware gates. Any
+change to kernels, quant formats, dispatch, fusion, rotation, rmsnorm,
+or the spec-decode path must pass `./scripts/coherence-gate-dflash.sh`
+before commit. The canonical correctness gate is per-arch channel-test;
+the speed-gate catches regressions on the baseline arch. Don't bypass
+either with `--no-verify` — see
 [methodology/perf-benchmarking.md](docs/methodology/perf-benchmarking.md).

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -5,10 +5,8 @@
     "": {
       "name": "cli",
       "devDependencies": {
-        "@types/bun": "latest",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
+        "@types/bun": "1.3.11",
+        "typescript": "^5.9.3",
       },
     },
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,10 +3,12 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
-  "devDependencies": {
-    "@types/bun": "latest"
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
   },
-  "peerDependencies": {
-    "typescript": "^5"
+  "devDependencies": {
+    "@types/bun": "1.3.11",
+    "typescript": "^5.9.3"
   }
 }

--- a/scripts/check-env-docs.py
+++ b/scripts/check-env-docs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "env-vars.md"
+REFERENCE_DOCS = [ROOT / "AGENTS.md", ROOT / "README.md", ROOT / "CONTRIBUTING.md"]
+
+
+def env_vars(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    return set(re.findall(r"\bHIPFIRE_[A-Z0-9_]+\b", text))
+
+
+def main() -> int:
+    canonical = DOC.read_text(encoding="utf-8", errors="ignore")
+    missing: list[tuple[str, str]] = []
+    for path in REFERENCE_DOCS:
+        for name in sorted(env_vars(path)):
+            if name not in canonical:
+                missing.append((path.relative_to(ROOT).as_posix(), name))
+
+    if missing:
+        print("docs/env-vars.md is missing HIPFIRE_* vars referenced by top-level docs:")
+        for path, name in missing:
+            print(f"  {path}: {name}")
+        return 1
+
+    print("env-docs: top-level HIPFIRE_* references are covered by docs/env-vars.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if [ ! -d .githooks ]; then
+    echo "install-hooks: .githooks directory is missing" >&2
+    exit 1
+fi
+
+git config core.hooksPath .githooks
+
+if [ -f .githooks/pre-commit ]; then
+    chmod +x .githooks/pre-commit
+fi
+
+echo "install-hooks: core.hooksPath=$(git config core.hooksPath)"

--- a/scripts/no-gpu-ci.sh
+++ b/scripts/no-gpu-ci.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== Rust check =="
+cargo check --workspace --examples
+
+echo "== Rust no-GPU unit tests =="
+cargo test -p rdna-compute --lib
+cargo test -p hipfire-arch-qwen35 --lib moe_prefill
+
+echo "== Python CPU tests =="
+python3 -m pytest tests scripts/test_astrea.py
+
+echo "== Env/docs drift check =="
+python3 scripts/check-env-docs.py
+
+if command -v bun >/dev/null 2>&1; then
+    echo "== Bun tests/typecheck =="
+    (
+        cd cli
+        bun install --frozen-lockfile
+        bun test
+        bun run typecheck
+    )
+else
+    echo "no-gpu-ci: bun not found; skipping Bun checks" >&2
+fi


### PR DESCRIPTION
## Summary

Adds a no-GPU CI workflow and local script for checks that can run without AMD GPU access or model downloads. Also documents the local hook installer and adds the no-GPU check to the PR template.

## Scope

- Adds `.github/workflows/no-gpu-ci.yml`.
- Adds `scripts/no-gpu-ci.sh`, `scripts/check-env-docs.py`, and `scripts/install-hooks.sh`.
- Adds CLI Bun `test`/`typecheck` scripts with pinned dev dependencies.
- Updates README/CONTRIBUTING/PR template references.

## Validation

- `git diff --check`
- `bash -n scripts/no-gpu-ci.sh scripts/install-hooks.sh && python3 -m py_compile scripts/check-env-docs.py`
- `python3 scripts/check-env-docs.py`
- `./scripts/no-gpu-ci.sh`