### PR TITLE
test(qwen35): cover MoE prefill admission matrix

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -7778,6 +7778,103 @@ fn paro_batched_admit_enabled_from_env(value: Option<&str>) -> bool {
     value != Some("0")
 }
 
+#[derive(Debug, Clone, Copy)]
+struct MoePrefillDtypes {
+    router: DType,
+    shared_expert_scalar_gate: DType,
+    shared_expert_gate: DType,
+    shared_expert_up: DType,
+    shared_expert_down: DType,
+    expert_gate_up: DType,
+    expert_down: DType,
+    expert_gate_up_uniform: bool,
+    expert_down_uniform: bool,
+}
+
+impl MoePrefillDtypes {
+    #[cfg(test)]
+    fn uniform(dtype: DType) -> Self {
+        Self {
+            router: dtype,
+            shared_expert_scalar_gate: dtype,
+            shared_expert_gate: dtype,
+            shared_expert_up: dtype,
+            shared_expert_down: dtype,
+            expert_gate_up: dtype,
+            expert_down: dtype,
+            expert_gate_up_uniform: true,
+            expert_down_uniform: true,
+        }
+    }
+
+    fn from_ffn(ffn: &MoeFfnWeights) -> Option<Self> {
+        let first = ffn.experts.first()?;
+        Some(Self {
+            router: ffn.router.gpu_dtype,
+            shared_expert_scalar_gate: ffn.shared_expert_gate.gpu_dtype,
+            shared_expert_gate: ffn.shared_expert.gate.gpu_dtype,
+            shared_expert_up: ffn.shared_expert.up.gpu_dtype,
+            shared_expert_down: ffn.shared_expert.down.gpu_dtype,
+            expert_gate_up: first.gate_up.gpu_dtype,
+            expert_down: first.down.gpu_dtype,
+            expert_gate_up_uniform: ffn
+                .experts
+                .iter()
+                .all(|e| e.gate_up.gpu_dtype == first.gate_up.gpu_dtype),
+            expert_down_uniform: ffn
+                .experts
+                .iter()
+                .all(|e| e.down.gpu_dtype == first.down.gpu_dtype),
+        })
+    }
+}
+
+fn moe_prefill_topk_shape_supported(k_top: usize, num_experts: usize) -> bool {
+    k_top == 8 && num_experts <= 1024
+}
+
+fn moe_ffn_batched_admissible_for_dtypes(
+    dtypes: &MoePrefillDtypes,
+    admit_mq6: bool,
+    admit_paro: bool,
+) -> bool {
+    let router_ok = matches!(dtypes.router, DType::MQ4G256 | DType::Q8_0 | DType::F32);
+    let shared_gate_ok = matches!(
+        dtypes.shared_expert_scalar_gate,
+        DType::MQ4G256 | DType::Q8_0 | DType::F32
+    );
+    if !(router_ok && shared_gate_ok && dtypes.expert_gate_up_uniform && dtypes.expert_down_uniform)
+    {
+        return false;
+    }
+
+    if admit_paro
+        && dtypes.shared_expert_gate == DType::ParoQ4G128
+        && dtypes.shared_expert_up == DType::ParoQ4G128
+        && dtypes.shared_expert_down == DType::ParoQ4G128
+        && dtypes.expert_gate_up == DType::ParoQ4G128
+        && dtypes.expert_down == DType::ParoQ4G128
+    {
+        return true;
+    }
+
+    if admit_mq6 {
+        let shared_gu_dt = dtypes.shared_expert_gate;
+        let shared_gu_ok = matches!(shared_gu_dt, DType::MQ4G256 | DType::MQ6G256)
+            && dtypes.shared_expert_up == shared_gu_dt;
+        let shared_dn_ok = matches!(dtypes.shared_expert_down, DType::MQ4G256 | DType::MQ6G256);
+        let experts_ok = matches!(dtypes.expert_gate_up, DType::MQ4G256 | DType::MQ6G256)
+            && matches!(dtypes.expert_down, DType::MQ4G256 | DType::MQ6G256);
+        shared_gu_ok && shared_dn_ok && experts_ok
+    } else {
+        dtypes.shared_expert_gate == DType::MQ4G256
+            && dtypes.shared_expert_up == DType::MQ4G256
+            && dtypes.shared_expert_down == DType::MQ4G256
+            && dtypes.expert_gate_up == DType::MQ4G256
+            && dtypes.expert_down == DType::MQ4G256
+    }
+}
+
 /// Threshold below which batching overhead isn't worth the alloc + per-layer
 /// dispatch — single-token prefill must not take the batched path.
 const MIN_BATCH: usize = 2;
@@ -7803,7 +7900,8 @@ pub fn prefill_batch_pbs_eligible(
     let force_fallback = std::env::var("HIPFIRE_PREFILL_BATCHED").ok().as_deref() == Some("0");
     // MoE batched path requires K_TOP=8 (hard-coded in the indexed kernels) and
     // num_experts ≤ 1024 (bound of the batched top-K shared mem).
-    let moe_topk_ok = config.num_experts_per_tok == 8 && config.num_experts <= 1024;
+    let moe_topk_ok =
+        moe_prefill_topk_shape_supported(config.num_experts_per_tok, config.num_experts);
     let admit_mq6 = mq6_batched_admit_enabled_from_env(
         std::env::var("HIPFIRE_MOE_MQ6_ADMIT").ok().as_deref(),
         arch,
@@ -7862,18 +7960,9 @@ fn mq6_batched_admit_enabled_from_env(value: Option<&str>, arch: &str) -> bool {
 }
 
 fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights, admit_mq6: bool) -> bool {
-    // F32 router/shared_gate admit (PARO checkpoints — router is FP16-dense,
-    // expanded to F32 on GPU; shared_expert_gate likewise. See
-    // load_fp16_weight_from_source at qwen35.rs:1177). The dispatch arms in
-    // prefill_moe_ffn_body_batched route F32 through gemm_f32_batched.
-    let router_ok = matches!(
-        ffn.router.gpu_dtype,
-        DType::MQ4G256 | DType::Q8_0 | DType::F32
-    );
-    let shared_gate_ok = matches!(
-        ffn.shared_expert_gate.gpu_dtype,
-        DType::MQ4G256 | DType::Q8_0 | DType::F32
-    );
+    let Some(dtypes) = MoePrefillDtypes::from_ffn(ffn) else {
+        return false;
+    };
 
     // PARO admit is default-on. Set HIPFIRE_PARO_BATCHED=0 to force the old
     // fallback path while bisecting or debugging.
@@ -7886,49 +7975,8 @@ fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights, admit_mq6: bool) -> bool {
     let admit_paro = *PARO_ADMIT.get_or_init(|| {
         paro_batched_admit_enabled_from_env(std::env::var("HIPFIRE_PARO_BATCHED").ok().as_deref())
     });
-    if admit_paro {
-        let paro_ok = router_ok
-            && shared_gate_ok
-            && matches!(ffn.shared_expert.gate.gpu_dtype, DType::ParoQ4G128)
-            && matches!(ffn.shared_expert.up.gpu_dtype, DType::ParoQ4G128)
-            && matches!(ffn.shared_expert.down.gpu_dtype, DType::ParoQ4G128)
-            && ffn.experts.iter().all(|e| {
-                e.gate_up.gpu_dtype == DType::ParoQ4G128 && e.down.gpu_dtype == DType::ParoQ4G128
-            });
-        if paro_ok {
-            return true;
-        }
-    }
 
-    if admit_mq6 {
-        // Per-projection MQ4 OR MQ6 admit.
-        let shared_gu_dt = ffn.shared_expert.gate.gpu_dtype;
-        let shared_gu_ok = matches!(shared_gu_dt, DType::MQ4G256 | DType::MQ6G256)
-            && ffn.shared_expert.up.gpu_dtype == shared_gu_dt;
-        let shared_dn_ok = matches!(
-            ffn.shared_expert.down.gpu_dtype,
-            DType::MQ4G256 | DType::MQ6G256
-        );
-        let experts_gu = ffn.experts[0].gate_up.gpu_dtype;
-        let experts_dn = ffn.experts[0].down.gpu_dtype;
-        let experts_ok = matches!(experts_gu, DType::MQ4G256 | DType::MQ6G256)
-            && matches!(experts_dn, DType::MQ4G256 | DType::MQ6G256)
-            && ffn
-                .experts
-                .iter()
-                .all(|e| e.gate_up.gpu_dtype == experts_gu && e.down.gpu_dtype == experts_dn);
-        router_ok && shared_gate_ok && shared_gu_ok && shared_dn_ok && experts_ok
-    } else {
-        // Strict MQ4 (pre-fan-out behavior).
-        router_ok
-            && shared_gate_ok
-            && ffn.shared_expert.gate.gpu_dtype == DType::MQ4G256
-            && ffn.shared_expert.up.gpu_dtype == DType::MQ4G256
-            && ffn.shared_expert.down.gpu_dtype == DType::MQ4G256
-            && ffn.experts.iter().all(|e| {
-                e.gate_up.gpu_dtype == DType::MQ4G256 && e.down.gpu_dtype == DType::MQ4G256
-            })
-    }
+    moe_ffn_batched_admissible_for_dtypes(&dtypes, admit_mq6, admit_paro)
 }
 
 /// Batched MoE FFN for `forward_prefill_chunk`. Takes the post-attention
@@ -16421,6 +16469,73 @@ mod tests {
         assert!(paro_batched_admit_enabled_from_env(Some("1")));
         assert!(paro_batched_admit_enabled_from_env(Some("surprise")));
         assert!(!paro_batched_admit_enabled_from_env(Some("0")));
+    }
+
+    #[test]
+    fn moe_prefill_topk_shape_requires_k8_and_bounded_experts() {
+        assert!(moe_prefill_topk_shape_supported(8, 256));
+        assert!(moe_prefill_topk_shape_supported(8, 1024));
+        assert!(!moe_prefill_topk_shape_supported(4, 256));
+        assert!(!moe_prefill_topk_shape_supported(8, 1025));
+    }
+
+    #[test]
+    fn moe_prefill_admits_mq4_as_known_good_control() {
+        let dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        assert!(moe_ffn_batched_admissible_for_dtypes(&dtypes, false, false));
+    }
+
+    #[test]
+    fn moe_prefill_rejects_mq3_before_admission_work() {
+        let mut dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        dtypes.expert_gate_up = DType::MQ3G256;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+
+        let mut dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        dtypes.shared_expert_down = DType::MQ3G256;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+    }
+
+    #[test]
+    fn moe_prefill_mq6_requires_explicit_admission() {
+        let mut dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        dtypes.shared_expert_scalar_gate = DType::Q8_0;
+        dtypes.shared_expert_gate = DType::MQ6G256;
+        dtypes.shared_expert_up = DType::MQ6G256;
+        dtypes.shared_expert_down = DType::MQ6G256;
+        dtypes.expert_gate_up = DType::MQ6G256;
+        dtypes.expert_down = DType::MQ6G256;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(
+            &dtypes, false, false
+        ));
+        assert!(moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+    }
+
+    #[test]
+    fn moe_prefill_rejects_nonuniform_expert_projections() {
+        let mut dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        dtypes.expert_gate_up_uniform = false;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+
+        let mut dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        dtypes.expert_down_uniform = false;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+    }
+
+    #[test]
+    fn moe_prefill_shared_gate_up_must_be_one_dtype() {
+        let mut dtypes = MoePrefillDtypes::uniform(DType::MQ4G256);
+        dtypes.shared_expert_up = DType::MQ6G256;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+    }
+
+    #[test]
+    fn moe_prefill_admits_paro_when_enabled() {
+        let mut dtypes = MoePrefillDtypes::uniform(DType::ParoQ4G128);
+        dtypes.router = DType::F32;
+        dtypes.shared_expert_scalar_gate = DType::F32;
+        assert!(!moe_ffn_batched_admissible_for_dtypes(&dtypes, true, false));
+        assert!(moe_ffn_batched_admissible_for_dtypes(&dtypes, true, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refactors the qwen35 MoE batched-prefill admission predicate into a small dtype helper and adds focused no-GPU unit coverage for the current admission matrix.

This keeps the existing MQ6 arch/env policy intact; the helper receives the already-computed MQ6 admission boolean from `prefill_batch_pbs_eligible`.

## Scope

- Adds `MoePrefillDtypes` to snapshot the MoE FFN dtype shape.
- Extracts `moe_prefill_topk_shape_supported`.
- Extracts `moe_ffn_batched_admissible_for_dtypes` for direct unit coverage.
- Adds tests for MQ4 control, MQ3 rejection, MQ6 gate behavior, Paro admission, top-k shape, and expert dtype uniformity.

## Validation

- `git diff --check`
- `cargo test -p hipfire-arch-qwen35 --lib moe_prefill`
- `cargo check -p hipfire-arch-qwen35 --lib`
- Commit hook short coherence battery:
  - `/tmp/coherence-20260605-163238.md` no hard errors
  - `/tmp/coherence-dflash-20260605-163254.md` 27B models absent, skipped without hard error
  - agentic gate skipped because A3B models absent
  - speed gate skipped because 4B model absent