### PR TITLE
chore(scripts): harden cleanup and benchmark argument handling

### DIFF
--- a/scripts/pflash-gate.sh
+++ b/scripts/pflash-gate.sh
@@ -29,7 +29,7 @@
 # Hooks into scripts/coherence-gate.sh as a follow-up stage.
 
 set -u
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 2
 
 BASELINE="scripts/pflash-baselines/gfx1100-2026-05-02.json"
 TOLERANCE_PCT=10
@@ -150,11 +150,11 @@ run_fixture() {
         *multi*)     maxgen="$MAXGEN_MULTI" ;;
         *longcode*|*longprose*) maxgen="$MAXGEN_LONG" ;;
     esac
-    local extra="--pretok"
+    local -a extra=(--pretok)
     if [ "$mode" = "pflash" ]; then
-        extra="$extra --pflash $DRAFTER --keep-ratio 0.30 --block-size 64"
+        extra+=(--pflash "$DRAFTER" --keep-ratio 0.30 --block-size 64)
     fi
-    "$EXE" "$TARGET" "$fixture" --maxgen "$maxgen" --asym3 $extra 2>&1
+    "$EXE" "$TARGET" "$fixture" --maxgen "$maxgen" --asym3 "${extra[@]}" 2>&1
 }
 
 extract_total() {

--- a/scripts/pflash-niah-bench.sh
+++ b/scripts/pflash-niah-bench.sh
@@ -47,7 +47,7 @@
 # users, thermal). Re-run from a quiet box.
 
 set -u
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 2
 
 EXE="./target/release/examples/pflash_niah_bench"
 TARGET=""
@@ -114,13 +114,13 @@ stat_line() {
 }
 
 run_once() {
-    local extra=""
-    [ "$PRETOK" = "1" ] && extra="$extra --pretok"
+    local -a extra=()
+    [ "$PRETOK" = "1" ] && extra+=(--pretok)
     if [ -n "$DRAFTER" ]; then
-        extra="$extra --pflash $DRAFTER --keep-ratio $KEEP_RATIO --block-size $BLOCK_SIZE"
+        extra+=(--pflash "$DRAFTER" --keep-ratio "$KEEP_RATIO" --block-size "$BLOCK_SIZE")
     fi
     local out
-    out=$("$EXE" "$TARGET" "$FIXTURE" --maxgen "$MAXGEN" $KV_MODE $extra 2>&1)
+    out=$("$EXE" "$TARGET" "$FIXTURE" --maxgen "$MAXGEN" "$KV_MODE" "${extra[@]}" 2>&1)
     local pass=0
     grep -q "^PASS:" <<< "$out" && pass=1
     local compress prefill decode ttft total

--- a/scripts/quant_cohort.sh
+++ b/scripts/quant_cohort.sh
@@ -70,7 +70,7 @@ usage() {
     echo "usage: $0 <cohort-label> <bf16-ref-dir-or-file> <variant-spec.tsv> [flags...]"
     echo
     echo "variant-spec.tsv format (TAB-separated):"
-    echo "  <variant-name>\t<hfq-path>\t<arch>"
+    printf '  <variant-name>\t<hfq-path>\t<arch>\n'
     echo
     echo "Optional flags: --kldref PATH, --max-chunks N, --kv-mode MODE, --scoring-mode MODE"
 }
@@ -245,7 +245,7 @@ while IFS=$'\t' read -r VARIANT HFQ_PATH ARCH; do
 
     # ─── 1. Per-tensor MSE ──────────────────────────────────────────────
     echo "  [1/4] per-tensor MSE..."
-    ./target/release/examples/quant_quality_mse "$ST_DIR" "$HFQ_PATH" 2>&1 > "${PV}.mse.txt" \
+    ./target/release/examples/quant_quality_mse "$ST_DIR" "$HFQ_PATH" > "${PV}.mse.txt" 2>&1 \
         || { echo "    (MSE run failed; output captured anyway)"; }
 
     # Extract the aggregate 4-bit MSE (mean over qts ∈ {13, 21, 24} == MQ4/HFP4/MFP4).
@@ -296,6 +296,7 @@ else:
 
         # GPU lock — eval_hipfire takes hours; coordinate with other jobs.
         if [ -f "scripts/gpu-lock.sh" ]; then
+            # shellcheck disable=SC1091
             source scripts/gpu-lock.sh
             gpu_acquire "quant_cohort-${LABEL}-${VARIANT}" 2>&1 | tail -1 || true
         fi

--- a/tests/e2e_bump_reload.sh
+++ b/tests/e2e_bump_reload.sh
@@ -6,11 +6,17 @@ MODEL=${MODEL:-qwen3.5:0.8b}
 LOG=$(mktemp)
 HIPFIRE_MODEL="$MODEL" bun cli/index.ts serve "$PORT" > "$LOG" 2>&1 &
 PID=$!
-trap "kill -TERM $PID 2>/dev/null; wait $PID 2>/dev/null; rm -f $LOG" EXIT
+# shellcheck disable=SC2329 # invoked by trap
+cleanup() {
+  kill -TERM "${PID:-}" 2>/dev/null || true
+  wait "${PID:-}" 2>/dev/null || true
+  rm -f -- "${LOG:-}"
+}
+trap cleanup EXIT
 
-for i in $(seq 1 90); do
+for _ in $(seq 1 90); do
   if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then break; fi
-  if ! kill -0 $PID 2>/dev/null; then echo "serve died"; tail "$LOG"; exit 1; fi
+  if ! kill -0 "$PID" 2>/dev/null; then echo "serve died"; tail "$LOG"; exit 1; fi
   sleep 1
 done
 

--- a/tests/e2e_kv_budget.sh
+++ b/tests/e2e_kv_budget.sh
@@ -14,12 +14,18 @@ LOG=$(mktemp)
 echo "=== booting serve on :$PORT (log $LOG) ==="
 HIPFIRE_MODEL="$MODEL" bun cli/index.ts serve "$PORT" > "$LOG" 2>&1 &
 PID=$!
-trap "kill -TERM $PID 2>/dev/null; wait $PID 2>/dev/null; rm -f $LOG" EXIT
+# shellcheck disable=SC2329 # invoked by trap
+cleanup() {
+  kill -TERM "${PID:-}" 2>/dev/null || true
+  wait "${PID:-}" 2>/dev/null || true
+  rm -f -- "${LOG:-}"
+}
+trap cleanup EXIT
 
 # Wait for health
 for i in $(seq 1 90); do
   if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then echo "ready after ${i}s"; break; fi
-  if ! kill -0 $PID 2>/dev/null; then
+  if ! kill -0 "$PID" 2>/dev/null; then
     echo "FAIL: serve exited prematurely"
     tail -30 "$LOG"
     exit 1
@@ -44,7 +50,7 @@ PAY=$(jq -cn --arg sys "$SYS" --arg m "$MODEL" \
 B=$(curl -sf -X POST "http://localhost:$PORT/v1/chat/completions" -H "Content-Type: application/json" --max-time 120 -d "$PAY")
 echo "$B" | jq '{finish: .choices[0].finish_reason, tokens: .usage.completion_tokens, error: .error}'
 if echo "$B" | jq -e '.error' >/dev/null; then
-  echo "FAIL B — got error: $(echo $B | jq -r .error)"; fail=$((fail+1))
+  echo "FAIL B — got error: $(echo "$B" | jq -r .error)"; fail=$((fail+1))
 fi
 
 echo "=== C: short follow-up (should reuse loaded model) ==="

--- a/tests/e2e_kv_reject.sh
+++ b/tests/e2e_kv_reject.sh
@@ -35,11 +35,17 @@ JSON
 
 HOME="$TMPCFG" HIPFIRE_MODEL="$MODEL" bun cli/index.ts serve "$PORT" > "$LOG" 2>&1 &
 PID=$!
-trap "kill -TERM $PID 2>/dev/null; wait $PID 2>/dev/null; rm -rf $TMPCFG $LOG /tmp/qg_N.json" EXIT
+# shellcheck disable=SC2329 # invoked by trap
+cleanup() {
+  kill -TERM "${PID:-}" 2>/dev/null || true
+  wait "${PID:-}" 2>/dev/null || true
+  rm -rf -- "${TMPCFG:-}" "${LOG:-}" /tmp/qg_N.json
+}
+trap cleanup EXIT
 
-for i in $(seq 1 90); do
+for _ in $(seq 1 90); do
   if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then break; fi
-  if ! kill -0 $PID 2>/dev/null; then echo "serve died"; tail "$LOG"; exit 1; fi
+  if ! kill -0 "$PID" 2>/dev/null; then echo "serve died"; tail "$LOG"; exit 1; fi
   sleep 1
 done
 

--- a/tests/e2e_run_reject.sh
+++ b/tests/e2e_run_reject.sh
@@ -14,7 +14,11 @@
 set -uo pipefail
 MODEL=${MODEL:-qwen3.5:0.8b}
 TMPCFG=$(mktemp -d)
-trap "rm -rf $TMPCFG" EXIT
+# shellcheck disable=SC2329 # invoked by trap
+cleanup() {
+  rm -rf -- "${TMPCFG:-}"
+}
+trap cleanup EXIT
 
 # Isolated HOME; only config.json differs, models/bin are symlinked.
 mkdir -p "$TMPCFG/.hipfire"


### PR DESCRIPTION
Split out from the older conflicted cleanup PR #303.

This keeps only the script-hardening pieces that still apply cleanly on current master:
- quote cleanup paths and PIDs in e2e trap handlers
- use arrays for PFlash benchmark optional arguments
- fix quant cohort logging redirection and shellcheck source annotation

Validation:
- git diff --check origin/master...HEAD
- bash -n scripts/quant_cohort.sh scripts/pflash-gate.sh scripts/pflash-niah-bench.sh tests/e2e_bump_reload.sh tests/e2e_kv_budget.sh tests/e2e_kv_reject.sh tests/e2e_run_reject.sh
- shellcheck scripts/quant_cohort.sh scripts/pflash-gate.sh scripts/pflash-niah-bench.sh tests/e2e_bump_reload.sh tests/e2e_kv_budget.sh tests/e2e_kv_reject.sh tests/e2e_run_reject.sh