### PR TITLE
chore(scripts): harden Python diagnostic imports

### DIFF
--- a/benchmarks/quality-baselines/harness/kldref_format.py
+++ b/benchmarks/quality-baselines/harness/kldref_format.py
@@ -121,7 +121,8 @@ def read_block(f, header: KldRefHeader) -> TokenBlock:
     off += header.top_k * 4
     top_log_probs = list(struct.unpack_from(f"<{header.top_k}f", raw, off))
     off += header.top_k * 4
-    (sum_p_residual,) = struct.unpack_from("<f", raw, off); off += 4
+    (sum_p_residual,) = struct.unpack_from("<f", raw, off)
+    off += 4
     # last 4 bytes are reserved_pad — ignored
     return TokenBlock(
         top_indices=top_indices, top_log_probs=top_log_probs,
@@ -203,7 +204,10 @@ def write_per_seq_kld(
         f.write(SEQKLD_MAGIC)
         f.write(struct.pack("<III", version, n_chunk, 0))
         if version == 2:
-            for m, p, n in zip(mean_kld_per_seq, p99_kld_per_seq, mean_nll_per_seq):
+            nll_per_seq = mean_nll_per_seq
+            if nll_per_seq is None:
+                raise AssertionError("version 2 requires mean_nll_per_seq")
+            for m, p, n in zip(mean_kld_per_seq, p99_kld_per_seq, nll_per_seq):
                 f.write(struct.pack("<ddd", m, p, n))
         else:
             for m, p in zip(mean_kld_per_seq, p99_kld_per_seq):

--- a/scripts/dflash_diag_config.py
+++ b/scripts/dflash_diag_config.py
@@ -38,13 +38,12 @@ import argparse
 import sys
 from pathlib import Path
 
-import torch
 from safetensors.torch import load_file
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / ".dflash-reference"))
 
-from dflash.model import DFlashDraftModel  # noqa: E402
+from dflash.model import DFlashDraftModel  # type: ignore[import-not-found]  # noqa: E402
 
 
 def parse_args():
@@ -93,7 +92,7 @@ def instantiate_and_dump(args, tc):
     cfg = mod.build_draft_config(tc, args.draft_layers, args.block_size,
                                  mask_token_id=151935)
     print("\n" + "=" * 72)
-    print(f"Draft config (from build_draft_config):")
+    print("Draft config (from build_draft_config):")
     print(f"  type               = {type(cfg).__name__}")
     print(f"  num_hidden_layers  = {cfg.num_hidden_layers}")
     print(f"  hidden_size        = {cfg.hidden_size}")
@@ -167,7 +166,7 @@ def load_and_compare(our_path, other_path, ref_shapes):
         if missing_theirs:
             print(f"  missing in checkpoint ({len(missing_theirs)}): {missing_theirs[:5]}")
         if not shape_mismatch and not extra_theirs and not missing_theirs:
-            print(f"  ✓ keys + shapes match model → draft loadable")
+            print("  ✓ keys + shapes match model → draft loadable")
 
 
 def main():

--- a/scripts/dflash_diag_iter1_tau.py
+++ b/scripts/dflash_diag_iter1_tau.py
@@ -41,7 +41,7 @@ import torch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / ".dflash-reference"))
 
-from dflash.model import DFlashDraftModel, extract_context_feature, sample  # noqa: E402
+from dflash.model import DFlashDraftModel, extract_context_feature, sample  # type: ignore[import-not-found]  # noqa: E402
 
 
 def parse_args():
@@ -134,7 +134,7 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     dtype = torch.bfloat16
 
-    from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+    from transformers import AutoModelForCausalLM, AutoTokenizer
     from safetensors.torch import load_file
 
     print(f"[target] loading {args.target_repo}...")

--- a/scripts/dflash_diag_zlab_loss.py
+++ b/scripts/dflash_diag_zlab_loss.py
@@ -43,7 +43,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / ".dflash-reference"))
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from dflash.model import DFlashDraftModel, extract_context_feature  # noqa: E402
+from dflash.model import DFlashDraftModel, extract_context_feature  # type: ignore[import-not-found]  # noqa: E402
 
 
 def parse_args():

--- a/scripts/dflash_ref_spec_test.py
+++ b/scripts/dflash_ref_spec_test.py
@@ -12,10 +12,20 @@ with our Qwen3.5 target (e.g. cache layout, position_ids, etc).
 
 If this gives τ>1, our tau_probe has a reproducible bug to find.
 """
-import sys, torch
-sys.path.insert(0, "/root/hipfire/.dflash-reference")
-from dflash.model import DFlashDraftModel
+import os
+import sys
+from pathlib import Path
+
+import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DFLASH_REFERENCE = Path(os.environ.get("HIPFIRE_DFLASH_REFERENCE", REPO_ROOT / ".dflash-reference"))
+if not (DFLASH_REFERENCE / "dflash" / "model.py").exists():
+    raise SystemExit(f"missing DFlash reference at {DFLASH_REFERENCE}")
+sys.path.insert(0, str(DFLASH_REFERENCE))
+
+from dflash.model import DFlashDraftModel  # type: ignore[import-not-found]  # noqa: E402
 
 device = torch.device("cuda")
 dtype = torch.bfloat16
@@ -24,7 +34,7 @@ print("[target] loading...", flush=True)
 tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-4B")
 target = AutoModelForCausalLM.from_pretrained(
     "Qwen/Qwen3.5-4B", torch_dtype=dtype, attn_implementation="eager",
-).to(device)
+).to(device)  # type: ignore[arg-type]
 target.eval()
 
 print("[draft] loading z-lab 4B DFlash...", flush=True)
@@ -57,6 +67,6 @@ try:
     gen = tok.decode(gen_ids, skip_special_tokens=False)
     print(f"[out] shape={out.shape}  new_len={len(gen_ids)}", flush=True)
     print(f"[gen] {gen[:400]!r}", flush=True)
-except Exception as e:
+except Exception:
     import traceback
     traceback.print_exc()

--- a/scripts/dflash_spec_debug.py
+++ b/scripts/dflash_spec_debug.py
@@ -9,13 +9,23 @@
 The goal: figure out why the draft+target loop produces 'useruser...'
 while target.generate alone produces '<think>\\nThinking Process:'.
 """
-import sys, torch
-sys.path.insert(0, "/root/hipfire/scripts")
-sys.path.insert(0, "/root/hipfire/.dflash-reference")
-from dflash_train_poc import build_draft_config
-from dflash.model import DFlashDraftModel, extract_context_feature, sample
+import os
+import sys
+from pathlib import Path
+
+import torch
 from safetensors.torch import load_file
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, DynamicCache
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DFLASH_REFERENCE = Path(os.environ.get("HIPFIRE_DFLASH_REFERENCE", REPO_ROOT / ".dflash-reference"))
+if not (DFLASH_REFERENCE / "dflash" / "model.py").exists():
+    raise SystemExit(f"missing DFlash reference at {DFLASH_REFERENCE}")
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(DFLASH_REFERENCE))
+
+from dflash_train_poc import build_draft_config  # noqa: E402
+from dflash.model import DFlashDraftModel, extract_context_feature, sample  # type: ignore[import-not-found]  # noqa: E402
 
 device = torch.device("cuda")
 dtype = torch.bfloat16
@@ -25,15 +35,21 @@ tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-4B")
 tgt_cfg = AutoConfig.from_pretrained("Qwen/Qwen3.5-4B")
 target = AutoModelForCausalLM.from_pretrained(
     "Qwen/Qwen3.5-4B", torch_dtype=dtype, attn_implementation="eager",
-).to(device)
+).to(device)  # type: ignore[arg-type]
 target.eval()
 
 print("[draft] loading z-lab weights...", flush=True)
 cfg = build_draft_config(tgt_cfg, 5, 16, 248070, match_zlab_arch=True)
 draft = DFlashDraftModel(cfg).to(device=device, dtype=dtype)
 sd = load_file(
-    "/root/.cache/huggingface/hub/models--z-lab--Qwen3.5-4B-DFlash/snapshots/"
-    "96899cc270945f554998309580b08a04a05a3187/model.safetensors"
+    os.environ.get(
+        "HIPFIRE_DFLASH_ZLAB_SAFETENSORS",
+        str(
+            Path.home()
+            / ".cache/huggingface/hub/models--z-lab--Qwen3.5-4B-DFlash/snapshots"
+            / "96899cc270945f554998309580b08a04a05a3187/model.safetensors"
+        ),
+    )
 )
 miss, unex = draft.load_state_dict(sd, strict=False)
 print(f"[draft]   missing={len(miss)} unexpected={len(unex)}", flush=True)
@@ -117,7 +133,7 @@ def debug_spec(max_cycles=3, B=16):
         pkv_t.crop(start)
         th = extract_context_feature(o.hidden_states, draft.target_layer_ids)[:, :al+1, :]
 
-    print(f"\n=== FINAL DECODE ===", flush=True)
+    print("\n=== FINAL DECODE ===", flush=True)
     print(f"out[{num_in}:{start+1}] = {tok.decode(out[0, num_in:start+1].cpu().tolist(), skip_special_tokens=False)!r}", flush=True)
 
 debug_spec(max_cycles=3)

--- a/scripts/dflash_train_poc.py
+++ b/scripts/dflash_train_poc.py
@@ -62,7 +62,6 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import os
 import random
 import sys
 import time
@@ -78,7 +77,7 @@ from torch.optim.lr_scheduler import LambdaLR
 # `pip install -e` it (avoids transformers-version conflicts).
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / ".dflash-reference"))
-from dflash.model import DFlashDraftModel, build_target_layer_ids, extract_context_feature  # noqa: E402
+from dflash.model import DFlashDraftModel, build_target_layer_ids, extract_context_feature  # type: ignore[import-not-found]  # noqa: E402
 
 
 def parse_args() -> argparse.Namespace:
@@ -168,7 +167,7 @@ def tau_probe(draft, target, tokenizer, prompt: str, max_new: int, device):
     try:
         # Patch spec_generate to also return acceptance_lengths via a hack:
         # we re-run the decode logic inline to capture τ cheaply.
-        from dflash.model import extract_context_feature, sample
+        from dflash.model import extract_context_feature, sample  # type: ignore[import-not-found]
         from transformers import DynamicCache
 
         num_input = input_ids.shape[1]
@@ -305,7 +304,7 @@ def build_draft_config(target_config, draft_layers: int, block_size: int, mask_t
     # embeddings, intermediate_size=9728. Keeps hidden_size from target (the
     # fc layer needs len(target_layer_ids) * target.hidden_size → draft.hidden_size
     # match — z-lab's 2560 matches Qwen3.5-4B target's 2560).
-    attn_overrides = {}
+    attn_overrides: dict[str, int] = {}
     if match_zlab_arch:
         attn_overrides.update(
             num_attention_heads=32,
@@ -392,7 +391,7 @@ def main() -> int:
         args.target_repo,
         torch_dtype=dtype,
         attn_implementation="eager",   # safer on ROCm; swap to sdpa once verified
-    ).to(device)
+    ).to(device)  # type: ignore[arg-type]
     target.eval()
     for p in target.parameters():
         p.requires_grad_(False)
@@ -559,7 +558,6 @@ def main() -> int:
             #       * attends to noise q'_j ONLY IF q'_j is in the same block k
             #         (bidirectional within-block; no cross-block leakage).
             q_len = K * B
-            k_len_total = L + q_len
             q_block = torch.arange(q_len, device=device) // B                   # [q_len] which block
             q_anchor = anchors[b][q_block]                                      # [q_len] abs anchor of q
             # Context visibility: [q_len, L] — j < anchor(q)
@@ -726,7 +724,7 @@ def main() -> int:
         "batch_size": args.batch_size,
     }, indent=2))
     print(f"[done] final HF-format draft at {final_dir}", flush=True)
-    print(f"[done] convert to .hfq with:", flush=True)
+    print("[done] convert to .hfq with:", flush=True)
     print(f"       target/release/dflash_convert --input {final_dir} "
           f"--output {final_dir}.hfq --mq4", flush=True)
     return 0

--- a/tests/test_kernel_atlas.py
+++ b/tests/test_kernel_atlas.py
@@ -12,6 +12,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 ATLAS_PATH = REPO_ROOT / "scripts" / "kernel_atlas.py"
 
 spec = importlib.util.spec_from_file_location("kernel_atlas", ATLAS_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"failed to load kernel_atlas module from {ATLAS_PATH}")
 kernel_atlas = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(kernel_atlas)
 


### PR DESCRIPTION
Split out from the older conflicted cleanup PR #303.

This keeps the Python diagnostic portability fixes that still apply cleanly on current master:
- avoid hard-coded /root/hipfire DFlash reference paths
- allow HIPFIRE_DFLASH_REFERENCE and HIPFIRE_DFLASH_ZLAB_SAFETENSORS overrides
- keep optional DFlash reference imports explicit for type checkers
- guard dynamic kernel_atlas test import setup

Validation:
- git diff --check origin/master...HEAD
- python3 -m py_compile benchmarks/quality-baselines/harness/kldref_format.py scripts/dflash_diag_config.py scripts/dflash_diag_iter1_tau.py scripts/dflash_diag_zlab_loss.py scripts/dflash_ref_spec_test.py scripts/dflash_spec_debug.py scripts/dflash_train_poc.py tests/test_kernel_atlas.py
- python3 -m unittest tests.test_kernel_atlas