### PR TITLE
Ship 4 (MoE): deepseek4 MoE fully on MoeFamily — decode + prefill (Step 6 + 4.3), no qwen35

### DIFF
--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -2770,9 +2770,8 @@ fn ffn_routed(
             up_batch,
             rot_batch,
         };
-        let ctx = hipfire_dispatch::context::DispatchCtx::new(gpu);
         hipfire_runtime::llama::moe_family()
-            .run_bias_aware(&ctx, gpu, &moe_params)
+            .run_bias_aware(gpu, &moe_params)
             .map_err(|e| format!("ffn_routed l{layer_idx} dispatch: {e}"))?;
 
         return Ok(());

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -2737,68 +2737,43 @@ fn ffn_routed(
             .gate_bias
             .as_ref()
             .ok_or_else(|| format!("ffn_routed l{layer_idx}: gate_bias missing"))?;
-        gpu.deepseek4_moe_topk_bias_aware_f32(
-            scores_dev,
-            bias_dev,
-            topk_idx_dev,
-            topk_w_dev,
-            cfg.n_routed_experts as i32,
-            k_top as i32,
-            route_scale_override,
-        )
-        .map_err(|e| format!("deepseek4_moe_topk_bias_aware l{layer_idx}: {e:?}"))?;
-
         let gate_up_ptrs = layer.expert_gate_up_ptrs.as_ref().unwrap();
         let w2_ptrs = layer.expert_w2_ptrs.as_ref().unwrap();
         let gate_batch = state.moe_gate_batch.as_ref().unwrap();
         let up_batch = state.moe_up_batch.as_ref().unwrap();
         let rot_batch = state.moe_rot_batch.as_ref().unwrap();
 
-        // 1. Fused gate_up GEMV: one launch dispatches all k_top experts'
-        //    gate and up halves in parallel. M = 2*intermediate; the
-        //    kernel splits output rows by r<im → gate, r>=im → up.
-        gpu.deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed(
-            gate_up_ptrs,
-            topk_idx_dev,
-            ffn_x_rot,
-            gate_batch,
-            up_batch,
-            2 * im,
-            cfg.hidden_size,
+        // Bias-aware top-k select + the routed MQ2-Lloyd experts now run through
+        // the centralized MoE family (Ship 4.3): bias-aware top-k -> indexed
+        // gate_up -> batched silu*mul*clamp -> batched FWHT rotate -> indexed
+        // down with route-scaled residual accumulation into ffn_out. The router
+        // GEMV + sqrt_softplus (moe_route, above) and the shared expert
+        // (ffn_stub) stay model-owned; ffn_stub must have seeded ffn_out before
+        // this accumulates into it.
+        let moe_params = hipfire_dispatch::families::moe::MoeBiasAwareParams {
+            hidden: cfg.hidden_size,
+            mi: im,
             k_top,
-        )
-        .map_err(|e| format!("fused gate_up l{layer_idx}: {e:?}"))?;
-
-        // 2. Batched silu_clamp + batched FWHT rotate. Each kernel handles
-        //    all k_top streams in one launch (grid.y = k_top), replacing
-        //    2*k_top = 12 small launches with 2.
-        gpu.deepseek4_silu_mul_clamp_f32_batched(
-            gate_batch,
-            up_batch,
-            gate_batch,
-            im,
-            k_top,
-            cfg.swiglu_limit,
-        )
-        .map_err(|e| format!("deepseek4_silu_mul_clamp batched l{layer_idx}: {e:?}"))?;
-        gpu.rotate_x_mq_batched(gate_batch, rot_batch, im, k_top)
-            .map_err(|e| format!("rotate batched l{layer_idx}: {e:?}"))?;
-
-        // 3. Fused down GEMV: one launch atomicAdds
-        //      Σ_k topk_weights[k] * (W_down[expert_k] · rot_batch[k])
-        //    into ffn_out. Replaces k_top per-expert GEMV + scaled_add
-        //    pairs. The route_scale_override is baked into topk_weights.
-        gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed(
-            w2_ptrs,
-            topk_idx_dev,
-            topk_w_dev,
-            rot_batch,
+            n_exp: cfg.n_routed_experts,
+            route_scale: route_scale_override,
+            swiglu_limit: cfg.swiglu_limit,
+            batch_size: 1,
+            x_rot: ffn_x_rot,
             ffn_out,
-            cfg.hidden_size,
-            im,
-            k_top,
-        )
-        .map_err(|e| format!("fused down l{layer_idx}: {e:?}"))?;
+            scores: scores_dev,
+            gate_bias: bias_dev,
+            expert_gate_up_ptrs: gate_up_ptrs,
+            expert_down_ptrs: w2_ptrs,
+            topk_indices: topk_idx_dev,
+            topk_weights: topk_w_dev,
+            gate_batch,
+            up_batch,
+            rot_batch,
+        };
+        let ctx = hipfire_dispatch::context::DispatchCtx::new(gpu);
+        hipfire_runtime::llama::moe_family()
+            .run_bias_aware(&ctx, gpu, &moe_params)
+            .map_err(|e| format!("ffn_routed l{layer_idx} dispatch: {e}"))?;
 
         return Ok(());
     }

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -6486,12 +6486,12 @@ fn ffn_batched(
     gpu.sqrt_softplus_f32(&pbs.moe_scores_batch)
         .map_err(|e| format!("sqrt_softplus_f32 moe scores l{layer_idx}: {e:?}"))?;
 
-    if hash_routing {
-        // Hash routing: per-batch GPU-side tid2eid lookup + score gather
-        // + normalize + route_scale, all in one launch. Eliminates the
-        // d2h(scores) + CPU loop + 2× h2d (idx+w) round-trip that the
-        // legacy path used (which stalled the stream per hash layer).
-        // pbs.tokens already holds the chunk's token IDs as [B] i32.
+    // Routing + routed experts + combine now run through the centralized MoE
+    // family (Ship 4.3 prefill). The router GEMV + sqrt_softplus (above) and the
+    // shared expert stay model-owned; the family routes (hash or bias-aware),
+    // runs the experts (grouped GEMM at B>=gate, else scalar K4), and
+    // accumulates into ffn_out_batch (already holding the shared-expert output).
+    let routing = if hash_routing {
         if tokens.len() < batch_size {
             return Err(format!(
                 "ffn_batched l{layer_idx}: tokens len {} < batch_size {}",
@@ -6502,531 +6502,54 @@ fn ffn_batched(
         let tid2eid_dev = layer.tid2eid_dev.as_ref().ok_or_else(|| {
             format!(
                 "ffn_batched hash l{layer_idx}: tid2eid_dev missing (pre-FP4 \
-             quant skipped tid2eid; HFQ load_weights should still populate \
-             the device buffer)"
+                 quant skipped tid2eid; HFQ load_weights should still populate \
+                 the device buffer)"
             )
         })?;
-        gpu.hash_router_normalize_f32_batched(
-            tid2eid_dev,
-            &pbs.moe_scores_batch,
-            &pbs.tokens,
-            &pbs.moe_topk_indices_batch,
-            &pbs.moe_topk_weights_batch,
-            n_exp as i32,
-            k_top as i32,
-            route_scale,
-            batch_size as i32,
-        )
-        .map_err(|e| format!("hash_router_normalize_f32_batched l{layer_idx}: {e:?}"))?;
+        hipfire_dispatch::families::moe::MoePrefillRouting::Hash {
+            tid2eid: tid2eid_dev,
+            tokens: &pbs.tokens,
+        }
     } else {
         let gate_bias = layer
             .gate_bias
             .as_ref()
             .ok_or_else(|| format!("layer {layer_idx} gate.bias missing"))?;
-        // 10. Bias-aware top-K per batch row.
-        gpu.deepseek4_moe_topk_bias_aware_batched_f32(
-            &pbs.moe_scores_batch,
-            gate_bias,
-            &pbs.moe_topk_indices_batch,
-            &pbs.moe_topk_weights_batch,
-            n_exp as i32,
-            k_top as i32,
-            route_scale,
-            batch_size as i32,
-        )
-        .map_err(|e| format!("deepseek4_moe_topk_bias_aware_batched l{layer_idx}: {e:?}"))?;
-    }
+        hipfire_dispatch::families::moe::MoePrefillRouting::BiasAware { gate_bias }
+    };
 
-    // Gate 1 validation (2026-05-22): dump per-layer topk_indices to a
-    // file for routing-distribution analysis. Append mode — one
-    // [B, K_TOP] block of i32 per layer per chunk. Off by default.
-    if let Ok(path) = std::env::var("HIPFIRE_DEEPSEEK4_DUMP_TOPK") {
-        use std::io::Write;
-        let raw = gpu
-            .download_f32(&pbs.moe_topk_indices_batch)
-            .map_err(|e| format!("dump_topk download: {e:?}"))?;
-        // moe_topk_indices_batch is stored i32-in-F32-slots; reinterpret.
-        let n = batch_size * k_top;
-        let mut indices: Vec<i32> = Vec::with_capacity(n);
-        for i in 0..n {
-            indices.push(raw[i].to_bits() as i32);
-        }
-        let mut f = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|e| format!("dump_topk open {path}: {e:?}"))?;
-        // Header: layer_idx | batch_size | k_top — 3 i32s
-        let header = [layer_idx as i32, batch_size as i32, k_top as i32];
-        let header_bytes = unsafe { std::slice::from_raw_parts(header.as_ptr() as *const u8, 12) };
-        f.write_all(header_bytes)
-            .map_err(|e| format!("dump_topk write header: {e:?}"))?;
-        let data_bytes =
-            unsafe { std::slice::from_raw_parts(indices.as_ptr() as *const u8, indices.len() * 4) };
-        f.write_all(data_bytes)
-            .map_err(|e| format!("dump_topk write data: {e:?}"))?;
-    }
-
-    // Grouped MoE dispatch: DEFAULT-ON when chunk_size ≥ 128 (validated
-    // crossover on gfx1151, 2026-05-26 — see
-    // project_v4f_l2_bottleneck_2026_05_26 memory).
-    //
-    // Original gate at 256 was set 2026-05-22 (commit 29984e2) based on
-    // theoretical "Gate 1 tile-fill" reasoning, never empirically swept
-    // at lower batch sizes. 2026-05-26 PP_BATCH×gate sweep on
-    // deepseek-v4-flash.mq2lloyd (2100-token prompt, B=16..256, 3 trials
-    // per cell, fresh process) shows the actual crossover is between
-    // B=64 (tied: 40.84 scalar vs 40.29 grouped) and B=128 (grouped wins
-    // 46.02 vs 39.28 = +17.2%). Setting threshold at 128 captures the
-    // win without paying the small-batch padding-overhead cost (-22% at
-    // B=16, -11% at B=32).
-    //
-    // HIPFIRE_DEEPSEEK4_MOE_GROUPED_GATE overrides the threshold for
-    // future sweeps. HIPFIRE_DEEPSEEK4_MOE_GROUPED=0 forces the scalar
-    // path at any batch (used for A/B regression debugging).
-    let gate_threshold: usize = std::env::var("HIPFIRE_DEEPSEEK4_MOE_GROUPED_GATE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(128);
-    let use_grouped =
-        batch_size >= gate_threshold && std::env::var("HIPFIRE_DEEPSEEK4_MOE_GROUPED").as_deref() != Ok("0");
-
-    if use_grouped {
-        const BLOCK_M: usize = 16;
-        let m_total_max = batch_size * k_top + n_exp * BLOCK_M;
-
-        // Scatter (single launch): histogram + offsets + permute. Writes
-        // -1 sentinels into expert_tile_ids and sorted_slot_index for
-        // unused slots, so the grouped-GEMM can be launched at the
-        // worst-case tile count without a d2h sync on m_total.
-        gpu.moe_scatter_fused_k8(
-            &pbs.moe_topk_indices_batch,
-            &pbs.moe_expert_token_counts,
-            &pbs.moe_expert_offsets,
-            &pbs.moe_sorted_slot_index,
-            &pbs.moe_expert_tile_ids,
-            &pbs.moe_inverse_perm,
-            batch_size * k_top,
-            n_exp,
-            m_total_max,
-            BLOCK_M,
-        )
-        .map_err(|e| format!("moe_scatter_fused_k8 l{layer_idx}: {e:?}"))?;
-
-        // Grouped gate_up GEMM: M = 2*im (gate||up concat), K = hidden.
-        // x_row_div = k_top because X is per-token ffn_x_rot_batch [B, K].
-        //
-        // RECONCILED (#355 + #356) MQ2-Lloyd grouped MoE dispatch.
-        // 4-warp 64×16 variant (gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2) is
-        // the default ON for gfx11+ — #356 broadened the gate from gfx1151-only
-        // (#355) to gfx11||gfx12 (measured 83.8% vs 43.4% L2 hit, -9% kernel
-        // time on gfx1151). [REVIEWER NOTE: the broader gfx11||gfx12 default
-        // gate is #356's; #355 shipped gfx1151-only. Confirm on gfx11 dGPU.]
-        // Opt out via HIPFIRE_DEEPSEEK4_MOE_LLOYD_4W=0. Shape gate: gate_up
-        // M=2*im must be a multiple of 64, K=hidden a multiple of 256.
-        let use_lloyd_4w = match std::env::var("HIPFIRE_DEEPSEEK4_MOE_LLOYD_4W")
-            .as_deref()
-        {
-            Ok("0") => false,
-            Ok("1") => true,
-            _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
-        } && (2 * im) % 64 == 0
-          && hidden % 256 == 0;
-        // MMQ-style index-pack preload (#356). Reverted to OPT-IN: the preload
-        // hoisted only 8 of 16 weight packs, decoding half the MQ2 weights wrong
-        // → long-context attractor on DS4 mq2lloyd (root-caused by @nwoolmer on
-        // gfx1151; the corrected kernel measured flat, so no reason to default it).
-        let use_mmqload = use_lloyd_4w && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() == Ok("1");
-        // Barrier-free nosync variant (#356, opt in via =1).
-        let use_nosync = use_mmqload && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
-            .as_deref() == Ok("1");
-        // Research levers from #355 (all opt-in, default OFF). When set they
-        // take precedence over the mmqload/nosync default path.
-        // Lever 1 (HIPFIRE_DEEPSEEK4_MOE_N32=1): N_TILE=32 tile-pairing on the
-        // 4w kernel — decode the MQ2-Lloyd A-fragment once per same-expert tile
-        // pair, amortizing the dequant ALU across 2 token sub-tiles.
-        let n32_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_N32").as_deref() == Ok("1");
-        // Lever 2 (HIPFIRE_DEEPSEEK4_MOE_CND=1): cndmask dequant on the n16 4w
-        // kernel — shorter dependency chain, same occupancy.
-        let cnd_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_CND").as_deref() == Ok("1");
-        // Lever 3 (HIPFIRE_DEEPSEEK4_MOE_8W=1): 8-warp variant (shares staged X
-        // across 8 warps; same occupancy as 4w, ~half X-load traffic).
-        let eightw_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_8W").as_deref() == Ok("1");
-        if use_lloyd_4w && n32_env {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_n32(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_4w_k2_n32 gate_up l{layer_idx}: {e:?}"))?;
-        } else if use_lloyd_4w && cnd_env {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_cnd(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_4w_k2_cnd gate_up l{layer_idx}: {e:?}"))?;
-        } else if use_lloyd_4w && eightw_env {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_8w_k2(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_8w_k2 gate_up l{layer_idx}: {e:?}"))?;
-        } else if use_nosync {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_mmqload_nosync(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_nosync gate_up l{layer_idx}: {e:?}"))?;
-        } else if use_mmqload {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_mmqload(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_mmqload gate_up l{layer_idx}: {e:?}"))?;
-        } else if use_lloyd_4w {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_4w gate_up l{layer_idx}: {e:?}"))?;
-        } else {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_k2(
-                gate_up_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.ffn_x_rot_batch,
-                &pbs.moe_y_gate_up_grouped,
-                2 * im,
-                hidden,
-                k_top,
-                m_total_max,
-                batch_size,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped gate_up l{layer_idx}: {e:?}"))?;
-        }
-
-        // Phase D1 (2026-05-26): fused unscatter + SwiGLU + asymmetric
-        // clamp. One launch instead of two; eliminates `moe_up_batch`
-        // write traffic. Byte-identical output (verified A/B at temp=0).
-        // Measured perf at PP_BATCH=512 / 2.1k-tok prompt: -0.4% prefill —
-        // launch-overhead savings cancelled by per-thread overhead, per
-        // feedback_kernel_fusion. Default OFF; opt in via
-        // HIPFIRE_DEEPSEEK4_FUSED_UNSCATTER_SILU=1.
-        let use_fused_unscatter_silu = std::env::var(
-            "HIPFIRE_DEEPSEEK4_FUSED_UNSCATTER_SILU",
-        )
-        .map(|s| s != "0")
-        .unwrap_or(false);
-        if use_fused_unscatter_silu {
-            gpu.moe_unscatter_silu_clamp_k8(
-                &pbs.moe_y_gate_up_grouped,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_gate_batch,
-                im,
-                k_top,
-                m_total_max,
-                cfg.swiglu_limit,
-            )
-            .map_err(|e| format!("moe_unscatter_silu_clamp_k8 l{layer_idx}: {e:?}"))?;
-        } else {
-            // Unscatter [m_total × 2*im] → [B, k_top, im] gate + up. Padded
-            // slots are dropped (sorted_slot_index == -1 lanes).
-            gpu.moe_gate_up_unscatter_k8(
-                &pbs.moe_y_gate_up_grouped,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_gate_batch,
-                &pbs.moe_up_batch,
-                im,
-                k_top,
-                m_total_max,
-            )
-            .map_err(|e| format!("moe_gate_up_unscatter_k8 l{layer_idx}: {e:?}"))?;
-
-            // SwiGLU + clamp (unchanged from scalar path; reads gate,up writes gate).
-            gpu.deepseek4_silu_mul_clamp_f32_batched(
-                &pbs.moe_gate_batch,
-                &pbs.moe_up_batch,
-                &pbs.moe_gate_batch,
-                im,
-                batch_size * k_top,
-                cfg.swiglu_limit,
-            )
-            .map_err(|e| format!("silu_mul_clamp grouped routed l{layer_idx}: {e:?}"))?;
-        }
-
-        // FWHT rotate (unchanged).
-        gpu.rotate_x_mq_batched(
-            &pbs.moe_gate_batch,
-            &pbs.moe_rot_batch,
-            im,
-            batch_size * k_top,
-        )
-        .map_err(|e| format!("rotate_x_mq_batched grouped routed l{layer_idx}: {e:?}"))?;
-
-        // Grouped down GEMM: M = hidden, K = im. x_row_div = 1 because
-        // moe_rot_batch is [B × k_top, im] flat — sorted_slot_index[s]
-        // already yields the row index directly (b*k_top + krank).
-        // RECONCILED (#355 + #356): same 4w default + levers as gate_up above.
-        let use_lloyd_4w_down = match std::env::var("HIPFIRE_DEEPSEEK4_MOE_LLOYD_4W")
-            .as_deref()
-        {
-            Ok("0") => false,
-            Ok("1") => true,
-            _ => (gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12"))
-        } && hidden % 64 == 0
-          && im % 256 == 0;
-        // Opt-in (see use_mmqload above — same #356 long-context attractor).
-        let use_mmqload_down = use_lloyd_4w_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD")
-            .as_deref() == Ok("1");
-        let use_nosync_down = use_mmqload_down && std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC")
-            .as_deref() == Ok("1");
-        // n32_env / cnd_env / eightw_env reused from the gate_up block above.
-        if use_lloyd_4w_down && n32_env {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_n32(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_4w_k2_n32 down l{layer_idx}: {e:?}"))?;
-        } else if use_lloyd_4w_down && cnd_env {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_cnd(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_4w_k2_cnd down l{layer_idx}: {e:?}"))?;
-        } else if use_lloyd_4w_down && eightw_env {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_8w_k2(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_8w_k2 down l{layer_idx}: {e:?}"))?;
-        } else if use_nosync_down {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_mmqload_nosync(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_nosync down l{layer_idx}: {e:?}"))?;
-        } else if use_mmqload_down {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_mmqload(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_mmqload down l{layer_idx}: {e:?}"))?;
-        } else if use_lloyd_4w_down {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped_4w down l{layer_idx}: {e:?}"))?;
-        } else {
-            gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_k2(
-                w2_ptrs,
-                &pbs.moe_expert_tile_ids,
-                &pbs.moe_sorted_slot_index,
-                &pbs.moe_rot_batch,
-                &pbs.moe_y_down_grouped,
-                hidden,
-                im,
-                1,
-                m_total_max,
-                batch_size * k_top,
-            )
-            .map_err(|e| format!("gemm_mq2g256_lloyd_moe_grouped down l{layer_idx}: {e:?}"))?;
-        }
-
-        // Down-combine: per-(token, m) sum K_TOP slots via inverse_perm,
-        // weighted by topk_weights, accumulated into ffn_out_batch (the
-        // shared-expert output already lives there from step 6 above).
-        gpu.moe_down_combine_grouped_k8(
-            &pbs.moe_y_down_grouped,
-            &pbs.moe_inverse_perm,
-            &pbs.moe_topk_weights_batch,
-            &pbs.ffn_out_batch,
-            hidden,
-            k_top,
-            batch_size,
-        )
-        .map_err(|e| format!("moe_down_combine_grouped_k8 l{layer_idx}: {e:?}"))?;
-    } else {
-        // ── Scalar K4 path (chunk_size < 256, or grouped opt-out) ──
-
-        // 11. Routed expert gate_up (MQ2-Lloyd K4-unrolled indexed batched).
-        gpu.deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed_batched_k4(
-            gate_up_ptrs,
-            &pbs.moe_topk_indices_batch,
-            &pbs.ffn_x_rot_batch,
-            &pbs.moe_gate_batch,
-            &pbs.moe_up_batch,
-            2 * im,
-            hidden,
-            k_top,
-            batch_size,
-        )
-        .map_err(|e| format!("deepseek4_gemv_gate_up_batched_k4 l{layer_idx}: {e:?}"))?;
-
-        // 12. SwiGLU + clamp over B * k_top streams of length IM.
-        gpu.deepseek4_silu_mul_clamp_f32_batched(
-            &pbs.moe_gate_batch,
-            &pbs.moe_up_batch,
-            &pbs.moe_gate_batch,
-            im,
-            batch_size * k_top,
-            cfg.swiglu_limit,
-        )
-        .map_err(|e| format!("deepseek4_silu_mul_clamp_f32_batched routed l{layer_idx}: {e:?}"))?;
-
-        // 13. FWHT rotate B * k_top vectors of length IM.
-        gpu.rotate_x_mq_batched(
-            &pbs.moe_gate_batch,
-            &pbs.moe_rot_batch,
-            im,
-            batch_size * k_top,
-        )
-        .map_err(|e| format!("rotate_x_mq_batched routed l{layer_idx}: {e:?}"))?;
-
-        // 14. Routed expert down. Two paths:
-        //   - Deterministic (default): expanded write to [B×K_TOP×hidden] +
-        //     non-atomic combine. Bit-reproducible at temp=0; load-bearing
-        //     for spec-decode draft/verify accept (84% K=3 with this on,
-        //     38% with atomicAdd path — FP reduction-order variance makes
-        //     draft/verify logits drift, top1 diverges, spurious rejection).
-        //   - HIPFIRE_DEEPSEEK4_MOE_DETERMINISTIC=0 (faster ~5–10 % prefill, non-
-        //     deterministic): K4 + atomicAdd directly into ffn_out_batch.
-        //     Acceptable for plain decode benchmarking; do NOT use with
-        //     spec decode.
-        let deterministic =
-            std::env::var("HIPFIRE_DEEPSEEK4_MOE_DETERMINISTIC").as_deref() != Ok("0");
-        if deterministic {
-            gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_expanded_k4(
-                w2_ptrs,
-                &pbs.moe_topk_indices_batch,
-                &pbs.moe_rot_batch,
-                &pbs.moe_down_expert_outputs,
-                hidden,
-                im,
-                k_top,
-                batch_size,
-            )
-            .map_err(|e| format!("deepseek4_gemv_down_expanded_k4 l{layer_idx}: {e:?}"))?;
-            gpu.moe_down_combine_k8_batched(
-                &pbs.moe_down_expert_outputs,
-                &pbs.moe_topk_weights_batch,
-                &pbs.ffn_out_batch,
-                hidden,
-                k_top,
-                batch_size,
-            )
-            .map_err(|e| format!("moe_down_combine_k8_batched l{layer_idx}: {e:?}"))?;
-        } else {
-            gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed_batched_k4(
-                w2_ptrs,
-                &pbs.moe_topk_indices_batch,
-                &pbs.moe_topk_weights_batch,
-                &pbs.moe_rot_batch,
-                &pbs.ffn_out_batch,
-                hidden,
-                im,
-                k_top,
-                batch_size,
-            )
-            .map_err(|e| format!("deepseek4_gemv_down_batched_k4 l{layer_idx}: {e:?}"))?;
-        }
-    }
+    let moe_params = hipfire_dispatch::families::moe::MoeBiasAwarePrefillParams {
+        hidden,
+        mi: im,
+        n_exp,
+        k_top,
+        batch_size,
+        route_scale,
+        swiglu_limit: cfg.swiglu_limit,
+        layer_idx,
+        routing,
+        scores: &pbs.moe_scores_batch,
+        topk_indices: &pbs.moe_topk_indices_batch,
+        topk_weights: &pbs.moe_topk_weights_batch,
+        expert_gate_up_ptrs: gate_up_ptrs,
+        expert_down_ptrs: w2_ptrs,
+        x_rot: &pbs.ffn_x_rot_batch,
+        ffn_out: &pbs.ffn_out_batch,
+        expert_token_counts: &pbs.moe_expert_token_counts,
+        expert_offsets: &pbs.moe_expert_offsets,
+        sorted_slot_index: &pbs.moe_sorted_slot_index,
+        expert_tile_ids: &pbs.moe_expert_tile_ids,
+        inverse_perm: &pbs.moe_inverse_perm,
+        y_gate_up_grouped: &pbs.moe_y_gate_up_grouped,
+        y_down_grouped: &pbs.moe_y_down_grouped,
+        gate_batch: &pbs.moe_gate_batch,
+        up_batch: &pbs.moe_up_batch,
+        rot_batch: &pbs.moe_rot_batch,
+        down_expert_outputs: &pbs.moe_down_expert_outputs,
+    };
+    hipfire_runtime::llama::moe_family()
+        .run_bias_aware_prefill(gpu, &moe_params)
+        .map_err(|e| format!("ffn_batched l{layer_idx} dispatch: {e}"))?;
 
     Ok(())
 }

--- a/crates/hipfire-dispatch/src/families/moe.rs
+++ b/crates/hipfire-dispatch/src/families/moe.rs
@@ -269,9 +269,13 @@ impl MoeFamily {
     /// `params.scores`) and the shared expert (`ffn_stub`, which seeds
     /// `params.ffn_out`); this entry runs only the bias-aware top-k + routed
     /// MQ2-Lloyd expert sub-graph.
+    ///
+    /// Takes no `DispatchCtx`: the bias-aware path dispatches fixed MQ2-Lloyd
+    /// kernels with no arch-gated sub-dispatch, so building a `DispatchCtx`
+    /// per layer per token (an uncached `FeatureFlags::from_env` parse) would
+    /// be pure waste on the decode hot path.
     pub fn run_bias_aware(
         &self,
-        _ctx: &DispatchCtx,
         gpu: &mut rdna_compute::Gpu,
         params: &MoeBiasAwareParams,
     ) -> Result<(), DispatchError> {

--- a/crates/hipfire-dispatch/src/families/moe.rs
+++ b/crates/hipfire-dispatch/src/families/moe.rs
@@ -165,6 +165,50 @@ pub struct MoeParams<'a> {
     pub down_expanded: &'a GpuTensor,
 }
 
+// ── DeepSeek-V4 bias-aware decode parameters ───────────
+
+/// Parameters for the deepseek4 bias-aware MoE decode arm (k=6, MQ2-Lloyd routed
+/// experts). Kept distinct from [`MoeParams`] because the ds4 sub-graph has no
+/// fused gate-side and no shared-expert block: the shared expert is a separate
+/// model-owned step (`ffn_stub`) that runs first and seeds `ffn_out`, and this
+/// arm's routed-down kernel atomic-accumulates into that same buffer.
+///
+/// `scores` is the post-`sqrt_softplus(gate·x)` router output — the model owns
+/// the router GEMV + activation. Selection adds `gate_bias` while the routing
+/// weights use the *unbiased* `scores`; the bias-aware kernel handles that
+/// two-score semantic and folds in `route_scale`, all in one launch. The model
+/// pre-rotates the activation, so `x_rot` is consumed as-is (no re-rotation).
+pub struct MoeBiasAwareParams<'a> {
+    // dims / config scalars
+    pub hidden: usize,
+    pub mi: usize,
+    pub k_top: usize,
+    pub n_exp: usize,
+    pub route_scale: f32,
+    pub swiglu_limit: f32,
+    /// Token-batch width. Decode = 1. A value > 1 must route to the grouped
+    /// prefill executor (Step 8), never this decode arm — guarded in the executor.
+    pub batch_size: usize,
+    // activations / residual
+    /// FWHT-rotated activation (model pre-rotates; this arm does not re-rotate).
+    pub x_rot: &'a GpuTensor,
+    /// Residual stream the routed-down kernel atomic-accumulates into. The
+    /// model's shared-expert step must have run first to seed this buffer.
+    pub ffn_out: &'a GpuTensor,
+    // router
+    pub scores: &'a GpuTensor,    // post-sqrt_softplus gate·x (weights use these)
+    pub gate_bias: &'a GpuTensor, // per-expert routing bias (selection only)
+    // routed expert pointer tables
+    pub expert_gate_up_ptrs: &'a GpuTensor,
+    pub expert_down_ptrs: &'a GpuTensor,
+    // scratch buffers (model-owned)
+    pub topk_indices: &'a GpuTensor,
+    pub topk_weights: &'a GpuTensor,
+    pub gate_batch: &'a GpuTensor,
+    pub up_batch: &'a GpuTensor,
+    pub rot_batch: &'a GpuTensor,
+}
+
 // ── Family ─────────────────────────────────────────────
 
 pub struct MoeFamily {
@@ -216,6 +260,22 @@ impl MoeFamily {
         params: &MoeParams,
     ) -> Result<(), DispatchError> {
         crate::pipeline::run_moe_decode(gpu, params)
+    }
+
+    /// Run a single-token deepseek4 bias-aware MoE decode step (k=6, MQ2-Lloyd
+    /// routed experts). Delegates to [`crate::pipeline::run_moe_decode_bias_aware`].
+    ///
+    /// The model owns the router GEMV + `sqrt_softplus` (producing
+    /// `params.scores`) and the shared expert (`ffn_stub`, which seeds
+    /// `params.ffn_out`); this entry runs only the bias-aware top-k + routed
+    /// MQ2-Lloyd expert sub-graph.
+    pub fn run_bias_aware(
+        &self,
+        _ctx: &DispatchCtx,
+        gpu: &mut rdna_compute::Gpu,
+        params: &MoeBiasAwareParams,
+    ) -> Result<(), DispatchError> {
+        crate::pipeline::run_moe_decode_bias_aware(gpu, params)
     }
 }
 

--- a/crates/hipfire-dispatch/src/families/moe.rs
+++ b/crates/hipfire-dispatch/src/families/moe.rs
@@ -209,6 +209,64 @@ pub struct MoeBiasAwareParams<'a> {
     pub rot_batch: &'a GpuTensor,
 }
 
+// ── DeepSeek-V4 batched/prefill MoE parameters ─────────
+
+/// Router-selection mode for the batched/prefill MoE path. DeepSeek-V4 uses
+/// static hash routing for the first `num_hash_layers` layers and bias-aware
+/// top-k for the rest; the executor branches on this.
+pub enum MoePrefillRouting<'a> {
+    /// Bias-aware batched top-k (select on `scores + gate_bias`, weight on the
+    /// unbiased `scores`, normalize, `*route_scale`).
+    BiasAware { gate_bias: &'a GpuTensor },
+    /// Static `tid2eid` hash routing (layers `0..num_hash_layers`). `tokens` is
+    /// the device-side `[B]` i32 token-id buffer.
+    Hash { tid2eid: &'a GpuTensor, tokens: &'a GpuTensor },
+}
+
+/// Parameters for the deepseek4 batched/prefill MoE (k=6, MQ2-Lloyd). The
+/// model owns RMSNorm, the shared expert, the router GEMV + `sqrt_softplus`
+/// (producing `scores`); this arm runs routing → routed experts → combine,
+/// accumulating into `ffn_out` (the shared expert already seeded it).
+///
+/// Picks the grouped-GEMM path when `batch_size >= HIPFIRE_DEEPSEEK4_MOE_GROUPED_GATE`
+/// (default 128), else the scalar K4 indexed path — mirroring `ffn_batched`.
+pub struct MoeBiasAwarePrefillParams<'a> {
+    // dims / config scalars
+    pub hidden: usize,
+    pub mi: usize,
+    pub n_exp: usize,
+    pub k_top: usize,
+    pub batch_size: usize,
+    pub route_scale: f32,
+    pub swiglu_limit: f32,
+    pub layer_idx: usize, // for the optional HIPFIRE_DEEPSEEK4_DUMP_TOPK header
+    // routing
+    pub routing: MoePrefillRouting<'a>,
+    pub scores: &'a GpuTensor,       // post-sqrt_softplus moe_scores_batch [B, n_exp]
+    pub topk_indices: &'a GpuTensor, // [B, k_top] (routing out, expert in)
+    pub topk_weights: &'a GpuTensor, // [B, k_top]
+    // routed expert pointer tables
+    pub expert_gate_up_ptrs: &'a GpuTensor,
+    pub expert_down_ptrs: &'a GpuTensor,
+    // activation / residual
+    pub x_rot: &'a GpuTensor,        // ffn_x_rot_batch [B, hidden]
+    pub ffn_out: &'a GpuTensor,      // ffn_out_batch [B, hidden] (accumulate target)
+    // grouped-path scratch
+    pub expert_token_counts: &'a GpuTensor,
+    pub expert_offsets: &'a GpuTensor,
+    pub sorted_slot_index: &'a GpuTensor,
+    pub expert_tile_ids: &'a GpuTensor,
+    pub inverse_perm: &'a GpuTensor,
+    pub y_gate_up_grouped: &'a GpuTensor,
+    pub y_down_grouped: &'a GpuTensor,
+    // shared scratch (grouped + scalar)
+    pub gate_batch: &'a GpuTensor,
+    pub up_batch: &'a GpuTensor,
+    pub rot_batch: &'a GpuTensor,
+    // scalar-path scratch (expanded deterministic down)
+    pub down_expert_outputs: &'a GpuTensor,
+}
+
 // ── Family ─────────────────────────────────────────────
 
 pub struct MoeFamily {
@@ -280,6 +338,20 @@ impl MoeFamily {
         params: &MoeBiasAwareParams,
     ) -> Result<(), DispatchError> {
         crate::pipeline::run_moe_decode_bias_aware(gpu, params)
+    }
+
+    /// Run a batched/prefill deepseek4 MoE step (k=6, MQ2-Lloyd): routing
+    /// (bias-aware or hash) → routed experts (grouped GEMM when
+    /// `batch_size >= gate`, else scalar K4 indexed) → combine, accumulating
+    /// into `params.ffn_out`. Delegates to
+    /// [`crate::pipeline::run_moe_prefill_bias_aware`]. The model owns RMSNorm,
+    /// the shared expert, and the router GEMV + `sqrt_softplus`.
+    pub fn run_bias_aware_prefill(
+        &self,
+        gpu: &mut rdna_compute::Gpu,
+        params: &MoeBiasAwarePrefillParams,
+    ) -> Result<(), DispatchError> {
+        crate::pipeline::run_moe_prefill_bias_aware(gpu, params)
     }
 }
 

--- a/crates/hipfire-dispatch/src/families/moe.rs
+++ b/crates/hipfire-dispatch/src/families/moe.rs
@@ -8,11 +8,11 @@
 //!
 //! # Current status
 //!
-//! MoE dispatch is **model-specific** — expert compute is orchestrated through
-//! per-model `moe_ffn_decode_with_scratch` paths (e.g. `qwen35`) that manage
-//! their own per-expert GEMV loops, scatter/gather, and softmax top-k routing.
-//! This family exists as a future entry point for fused grouped-expert kernels.
-//! Today, `run()` returns `UnsupportedVariant` with a clear explanation.
+//! `run()` is the centralized single-token MoE decode entry — it delegates to
+//! [`crate::pipeline::run_moe_decode`] (the GPU top-K fast path plus the generic
+//! CPU-top-K fallback). The model marshals its weights/scratch into `MoeParams`;
+//! scratch stays model-owned. Grouped-GEMM prefill is a future arm (gated on
+//! `ShapeInfo.batch_size`).
 
 use rdna_compute::DType;
 use rdna_compute::GpuTensor;
@@ -200,24 +200,22 @@ impl MoeFamily {
         self.registry.resolve(key, ctx, shape)
     }
 
-    /// Run a MoE expert operation.
+    /// Run a single-token MoE decode step through the centralized executor.
     ///
-    /// Currently returns `UnsupportedVariant` because expert dispatch is
-    /// model-specific — it lives in per-model `moe_ffn_decode_with_scratch`
-    /// paths that handle per-expert GEMV loops, routing, and scratch layout.
-    /// This is a placeholder for when fused grouped-expert kernels land.
+    /// Delegates to [`crate::pipeline::run_moe_decode`], which dispatches the
+    /// GPU top-K fast path (k=8 with an indexable routed dtype ∈ {MQ4G256,
+    /// MQ6G256, ParoQ4G128}) or the generic CPU-top-K fallback (k != 8 or a
+    /// non-indexable routed dtype). Scratch stays model-owned; the model
+    /// marshals it into `params`. `ctx` is currently unused (the executor
+    /// builds its own `DispatchCtx` where a GEMV sub-dispatch needs one) but is
+    /// kept for signature parity with the other families.
     pub fn run(
         &self,
         _ctx: &DispatchCtx,
-        _gpu: &mut rdna_compute::Gpu,
-        _params: &MoeParams,
+        gpu: &mut rdna_compute::Gpu,
+        params: &MoeParams,
     ) -> Result<(), DispatchError> {
-        Err(DispatchError::UnsupportedVariant {
-            family: "moe",
-            variant: "all",
-            arch: "",
-            quant: "",
-        })
+        crate::pipeline::run_moe_decode(gpu, params)
     }
 }
 

--- a/crates/hipfire-dispatch/src/pipeline/mod.rs
+++ b/crates/hipfire-dispatch/src/pipeline/mod.rs
@@ -519,6 +519,243 @@ pub fn run_moe_decode_bias_aware(
     Ok(())
 }
 
+/// MQ2-Lloyd grouped-GEMM kernel variant (deepseek4 research levers; default
+/// `Lloyd4w` on gfx11+, `Base` otherwise). Selected once per gate_up/down call.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum GroupedLloydVariant {
+    N32,
+    Cnd,
+    EightW,
+    Nosync,
+    Mmqload,
+    Lloyd4w,
+    Base,
+}
+
+/// Mirror of `ffn_batched`'s grouped-GEMM if/else-if ladder (priority order:
+/// n32 > cnd > 8w > nosync > mmqload > 4w > base). `n32`/`cnd`/`eightw` apply
+/// only on the 4w path; `use_nosync` ⊂ `use_mmqload` ⊂ `use_lloyd_4w`.
+fn select_grouped_lloyd_variant(
+    use_lloyd_4w: bool,
+    n32: bool,
+    cnd: bool,
+    eightw: bool,
+    use_mmqload: bool,
+    use_nosync: bool,
+) -> GroupedLloydVariant {
+    if use_lloyd_4w && n32 {
+        GroupedLloydVariant::N32
+    } else if use_lloyd_4w && cnd {
+        GroupedLloydVariant::Cnd
+    } else if use_lloyd_4w && eightw {
+        GroupedLloydVariant::EightW
+    } else if use_nosync {
+        GroupedLloydVariant::Nosync
+    } else if use_mmqload {
+        GroupedLloydVariant::Mmqload
+    } else if use_lloyd_4w {
+        GroupedLloydVariant::Lloyd4w
+    } else {
+        GroupedLloydVariant::Base
+    }
+}
+
+/// Dispatch one MQ2-Lloyd grouped GEMM. All seven variants share the signature
+/// `(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows)`, so
+/// this is called identically for gate_up (m=2*im, k=hidden, x_row_div=k_top,
+/// rows=B) and down (m=hidden, k=im, x_row_div=1, rows=B*k_top).
+#[allow(clippy::too_many_arguments)]
+fn dispatch_grouped_lloyd(
+    gpu: &mut Gpu,
+    variant: GroupedLloydVariant,
+    ptrs: &GpuTensor,
+    tile_ids: &GpuTensor,
+    slot_index: &GpuTensor,
+    x: &GpuTensor,
+    y: &GpuTensor,
+    m: usize,
+    k: usize,
+    x_row_div: usize,
+    m_total_max: usize,
+    rows: usize,
+) -> Result<(), DispatchError> {
+    use GroupedLloydVariant as V;
+    let r = match variant {
+        V::N32 => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_n32(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+        V::Cnd => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_cnd(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+        V::EightW => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_8w_k2(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+        V::Nosync => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_mmqload_nosync(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+        V::Mmqload => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_mmqload(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+        V::Lloyd4w => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+        V::Base => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_k2(ptrs, tile_ids, slot_index, x, y, m, k, x_row_div, m_total_max, rows),
+    };
+    r.map_err(|e| DispatchError::Hip(e.to_string()))
+}
+
+/// DeepSeek-V4 batched/prefill MoE executor. Transcribes the routed block of
+/// `hipfire-arch-deepseek4::forward::ffn_batched`: routing (hash or bias-aware)
+/// → routed experts (grouped GEMM when `batch_size >= gate`, else scalar K4
+/// indexed) → combine into `p.ffn_out` (the shared expert already seeded it).
+/// Router GEMV + `sqrt_softplus` and the shared expert stay model-owned.
+pub fn run_moe_prefill_bias_aware(
+    gpu: &mut Gpu,
+    p: &crate::families::moe::MoeBiasAwarePrefillParams,
+) -> Result<(), DispatchError> {
+    use crate::families::moe::MoePrefillRouting;
+    macro_rules! hip {
+        ($e:expr) => { $e.map_err(|e| DispatchError::Hip(e.to_string())) };
+    }
+    let (hidden, im, n_exp, k_top, batch_size) = (p.hidden, p.mi, p.n_exp, p.k_top, p.batch_size);
+
+    // ── Routing → topk_indices / topk_weights ────────────────────────────────
+    match &p.routing {
+        MoePrefillRouting::Hash { tid2eid, tokens } => {
+            hip!(gpu.hash_router_normalize_f32_batched(
+                tid2eid, p.scores, tokens,
+                p.topk_indices, p.topk_weights,
+                n_exp as i32, k_top as i32, p.route_scale, batch_size as i32,
+            ))?;
+        }
+        MoePrefillRouting::BiasAware { gate_bias } => {
+            hip!(gpu.deepseek4_moe_topk_bias_aware_batched_f32(
+                p.scores, gate_bias,
+                p.topk_indices, p.topk_weights,
+                n_exp as i32, k_top as i32, p.route_scale, batch_size as i32,
+            ))?;
+        }
+    }
+
+    // DIAG: dump per-layer topk indices ([B, k_top] i32) — off by default.
+    if let Ok(path) = std::env::var("HIPFIRE_DEEPSEEK4_DUMP_TOPK") {
+        use std::io::Write;
+        let raw = hip!(gpu.download_f32(p.topk_indices))?;
+        let n = batch_size * k_top;
+        let mut indices: Vec<i32> = Vec::with_capacity(n);
+        for i in 0..n {
+            indices.push(raw[i].to_bits() as i32);
+        }
+        let mut f = std::fs::OpenOptions::new().create(true).append(true).open(&path)
+            .map_err(|e| DispatchError::Hip(format!("dump_topk open {path}: {e:?}")))?;
+        let header = [p.layer_idx as i32, batch_size as i32, k_top as i32];
+        let header_bytes = unsafe { std::slice::from_raw_parts(header.as_ptr() as *const u8, 12) };
+        f.write_all(header_bytes).map_err(|e| DispatchError::Hip(format!("dump_topk header: {e:?}")))?;
+        let data_bytes = unsafe { std::slice::from_raw_parts(indices.as_ptr() as *const u8, indices.len() * 4) };
+        f.write_all(data_bytes).map_err(|e| DispatchError::Hip(format!("dump_topk data: {e:?}")))?;
+    }
+
+    // ── Grouped vs scalar gate ────────────────────────────────────────────────
+    let gate_threshold: usize = std::env::var("HIPFIRE_DEEPSEEK4_MOE_GROUPED_GATE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(128);
+    let use_grouped = batch_size >= gate_threshold
+        && std::env::var("HIPFIRE_DEEPSEEK4_MOE_GROUPED").as_deref() != Ok("0");
+
+    // Shared research levers (read once; default 4w on gfx11+).
+    let lloyd_4w_base = match std::env::var("HIPFIRE_DEEPSEEK4_MOE_LLOYD_4W").as_deref() {
+        Ok("0") => Some(false),
+        Ok("1") => Some(true),
+        _ => None,
+    };
+    let arch_4w = gpu.arch.starts_with("gfx11") || gpu.arch.starts_with("gfx12");
+    let n32 = std::env::var("HIPFIRE_DEEPSEEK4_MOE_N32").as_deref() == Ok("1");
+    let cnd = std::env::var("HIPFIRE_DEEPSEEK4_MOE_CND").as_deref() == Ok("1");
+    let eightw = std::env::var("HIPFIRE_DEEPSEEK4_MOE_8W").as_deref() == Ok("1");
+    let mmqload_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD").as_deref() == Ok("1");
+    let nosync_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC").as_deref() == Ok("1");
+
+    if use_grouped {
+        const BLOCK_M: usize = 16;
+        let m_total_max = batch_size * k_top + n_exp * BLOCK_M;
+
+        // Scatter: histogram + offsets + permute (single launch).
+        hip!(gpu.moe_scatter_fused_k8(
+            p.topk_indices, p.expert_token_counts, p.expert_offsets,
+            p.sorted_slot_index, p.expert_tile_ids, p.inverse_perm,
+            batch_size * k_top, n_exp, m_total_max, BLOCK_M,
+        ))?;
+
+        // Grouped gate_up GEMM (M=2*im, K=hidden, x_row_div=k_top, rows=B).
+        let use_lloyd_4w_gu = lloyd_4w_base.unwrap_or(arch_4w) && (2 * im) % 64 == 0 && hidden % 256 == 0;
+        let use_mmqload_gu = use_lloyd_4w_gu && mmqload_env;
+        let use_nosync_gu = use_mmqload_gu && nosync_env;
+        let v_gu = select_grouped_lloyd_variant(use_lloyd_4w_gu, n32, cnd, eightw, use_mmqload_gu, use_nosync_gu);
+        dispatch_grouped_lloyd(
+            gpu, v_gu, p.expert_gate_up_ptrs, p.expert_tile_ids, p.sorted_slot_index,
+            p.x_rot, p.y_gate_up_grouped, 2 * im, hidden, k_top, m_total_max, batch_size,
+        )?;
+
+        // Unscatter + SwiGLU·clamp.
+        let use_fused_unscatter_silu = std::env::var("HIPFIRE_DEEPSEEK4_FUSED_UNSCATTER_SILU")
+            .map(|s| s != "0")
+            .unwrap_or(false);
+        if use_fused_unscatter_silu {
+            hip!(gpu.moe_unscatter_silu_clamp_k8(
+                p.y_gate_up_grouped, p.sorted_slot_index, p.gate_batch,
+                im, k_top, m_total_max, p.swiglu_limit,
+            ))?;
+        } else {
+            hip!(gpu.moe_gate_up_unscatter_k8(
+                p.y_gate_up_grouped, p.sorted_slot_index, p.gate_batch, p.up_batch,
+                im, k_top, m_total_max,
+            ))?;
+            hip!(gpu.deepseek4_silu_mul_clamp_f32_batched(
+                p.gate_batch, p.up_batch, p.gate_batch, im, batch_size * k_top, p.swiglu_limit,
+            ))?;
+        }
+
+        // FWHT rotate.
+        hip!(gpu.rotate_x_mq_batched(p.gate_batch, p.rot_batch, im, batch_size * k_top))?;
+
+        // Grouped down GEMM (M=hidden, K=im, x_row_div=1, rows=B*k_top).
+        let use_lloyd_4w_dn = lloyd_4w_base.unwrap_or(arch_4w) && hidden % 64 == 0 && im % 256 == 0;
+        let use_mmqload_dn = use_lloyd_4w_dn && mmqload_env;
+        let use_nosync_dn = use_mmqload_dn && nosync_env;
+        let v_dn = select_grouped_lloyd_variant(use_lloyd_4w_dn, n32, cnd, eightw, use_mmqload_dn, use_nosync_dn);
+        dispatch_grouped_lloyd(
+            gpu, v_dn, p.expert_down_ptrs, p.expert_tile_ids, p.sorted_slot_index,
+            p.rot_batch, p.y_down_grouped, hidden, im, 1, m_total_max, batch_size * k_top,
+        )?;
+
+        // Down-combine: weighted Σ over k_top slots, per (token, m), into ffn_out.
+        hip!(gpu.moe_down_combine_grouped_k8(
+            p.y_down_grouped, p.inverse_perm, p.topk_weights, p.ffn_out,
+            hidden, k_top, batch_size,
+        ))?;
+    } else {
+        // ── Scalar K4 path (batch_size < gate, or grouped opt-out) ──
+        hip!(gpu.deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed_batched_k4(
+            p.expert_gate_up_ptrs, p.topk_indices, p.x_rot,
+            p.gate_batch, p.up_batch, 2 * im, hidden, k_top, batch_size,
+        ))?;
+        hip!(gpu.deepseek4_silu_mul_clamp_f32_batched(
+            p.gate_batch, p.up_batch, p.gate_batch, im, batch_size * k_top, p.swiglu_limit,
+        ))?;
+        hip!(gpu.rotate_x_mq_batched(p.gate_batch, p.rot_batch, im, batch_size * k_top))?;
+
+        // Down: deterministic expanded+combine (default; bit-reproducible for
+        // spec-decode) vs non-deterministic atomic-accumulate.
+        let deterministic =
+            std::env::var("HIPFIRE_DEEPSEEK4_MOE_DETERMINISTIC").as_deref() != Ok("0");
+        if deterministic {
+            hip!(gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_expanded_k4(
+                p.expert_down_ptrs, p.topk_indices, p.rot_batch, p.down_expert_outputs,
+                hidden, im, k_top, batch_size,
+            ))?;
+            hip!(gpu.moe_down_combine_k8_batched(
+                p.down_expert_outputs, p.topk_weights, p.ffn_out, hidden, k_top, batch_size,
+            ))?;
+        } else {
+            hip!(gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed_batched_k4(
+                p.expert_down_ptrs, p.topk_indices, p.topk_weights, p.rot_batch, p.ffn_out,
+                hidden, im, k_top, batch_size,
+            ))?;
+        }
+    }
+
+    Ok(())
+}
+
 pub fn dispatch_fused(
     gpu: &mut Gpu,
     key: KernelKey,

--- a/crates/hipfire-dispatch/src/pipeline/mod.rs
+++ b/crates/hipfire-dispatch/src/pipeline/mod.rs
@@ -465,6 +465,60 @@ fn run_moe_decode_cpu_fallback(
     Ok(())
 }
 
+/// DeepSeek-V4 bias-aware MoE decode executor. Transcribes the routed sub-graph
+/// of `hipfire-arch-deepseek4::forward::ffn_routed` (the fused
+/// `expert_gate_up_blob` branch): bias-aware top-k select → indexed MQ2-Lloyd
+/// gate_up → batched silu·mul·clamp → batched FWHT rotate → indexed MQ2-Lloyd
+/// down with route-scaled residual accumulation into `ffn_out`.
+///
+/// The router GEMV + `sqrt_softplus` (producing `p.scores`) and the shared
+/// expert stay model-owned — the shared expert seeds `p.ffn_out` and this arm
+/// accumulates into it, so the model must run it first. Decode only
+/// (`batch_size == 1`); batched prefill is the grouped executor (Step 8).
+pub fn run_moe_decode_bias_aware(
+    gpu: &mut Gpu,
+    p: &crate::families::moe::MoeBiasAwareParams,
+) -> Result<(), DispatchError> {
+    macro_rules! hip {
+        ($e:expr) => { $e.map_err(|e| DispatchError::Hip(e.to_string())) };
+    }
+    if p.batch_size != 1 {
+        return Err(DispatchError::UnsupportedVariant {
+            family: "moe", variant: "bias-aware-decode-requires-batch-1",
+            arch: "", quant: "",
+        });
+    }
+
+    // 1. Bias-aware top-K: select on (scores + bias), weight on the unbiased
+    //    scores, normalize, then fold in route_scale — all in one launch.
+    hip!(gpu.deepseek4_moe_topk_bias_aware_f32(
+        p.scores, p.gate_bias, p.topk_indices, p.topk_weights,
+        p.n_exp as i32, p.k_top as i32, p.route_scale,
+    ))?;
+
+    // 2. Indexed MQ2-Lloyd gate_up: all k_top experts in one launch
+    //    (M = 2*mi; the kernel splits rows r<mi → gate, r>=mi → up).
+    hip!(gpu.deepseek4_gemv_mq2g256_lloyd_moe_gate_up_indexed(
+        p.expert_gate_up_ptrs, p.topk_indices, p.x_rot,
+        p.gate_batch, p.up_batch, 2 * p.mi, p.hidden, p.k_top,
+    ))?;
+
+    // 3. Batched silu·mul·clamp (in-place into gate_batch) then batched FWHT rotate.
+    hip!(gpu.deepseek4_silu_mul_clamp_f32_batched(
+        p.gate_batch, p.up_batch, p.gate_batch, p.mi, p.k_top, p.swiglu_limit,
+    ))?;
+    hip!(gpu.rotate_x_mq_batched(p.gate_batch, p.rot_batch, p.mi, p.k_top))?;
+
+    // 4. Indexed MQ2-Lloyd down: atomic-accumulate Σ_k w_k·(W_down[e_k]·rot)
+    //    into ffn_out. route_scale is already baked into topk_weights.
+    hip!(gpu.deepseek4_gemv_mq2g256_lloyd_moe_down_residual_scaled_indexed(
+        p.expert_down_ptrs, p.topk_indices, p.topk_weights, p.rot_batch,
+        p.ffn_out, p.hidden, p.mi, p.k_top,
+    ))?;
+
+    Ok(())
+}
+
 pub fn dispatch_fused(
     gpu: &mut Gpu,
     key: KernelKey,

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -595,6 +595,16 @@ pub fn fused_qkv_family() -> &'static hipfire_dispatch::families::fused_qkv::Fus
     FUSED_QKV.get_or_init(hipfire_dispatch::families::fused_qkv::FusedQkvFamily::new)
 }
 
+/// Process-global [`MoeFamily`], mirroring [`gemv_family`]. The centralized MoE
+/// decode entry (Ship 4): arches route their per-layer MoE decode through
+/// `moe_family().run(..)` so expert dispatch lives in the dispatch crate rather
+/// than per-model kernel calls.
+pub fn moe_family() -> &'static hipfire_dispatch::families::moe::MoeFamily {
+    use std::sync::OnceLock;
+    static MOE: OnceLock<hipfire_dispatch::families::moe::MoeFamily> = OnceLock::new();
+    MOE.get_or_init(hipfire_dispatch::families::moe::MoeFamily::new)
+}
+
 pub use hipfire_dispatch::families::fused_qkv::FusedQkvParams;
 pub use hipfire_dispatch::families::gemv::{RotInput, RotateInputs, RotatedActivation};
 pub use hipfire_dispatch::context::DispatchCtx;


### PR DESCRIPTION
## Ship 4 (MoE) — deepseek4 MoE fully on MoeFamily (Step 6 + ds4 4.3 decode & prefill)

Part of the dispatch-unification program (#397) — centralizes MoE dispatch into `MoeFamily`. **Zero `qwen35.rs` contact**: per the Ship 3 ⊥ Ship 4 ownership split this is the no-overlap surface (the dispatch crate + the deepseek4 own crate). qwen35 decode wire-up (4.1) and qwen35 grouped-GEMM prefill (Step 8) wait for Ship 3.

Rebased onto staging tip `36d05d8f`. Net **−68 lines** — the sprawling inline ds4 routed blocks collapse into deduplicated family executors.

### Commits
- **Step 6 — `MoeFamily::run()` real + `moe_family()` accessor.** `run()` delegates to `pipeline::run_moe_decode` (GPU top-K + restored CPU-top-K fallback), killing the `UnsupportedVariant` stub. Adds `moe_family()` in `runtime::llama` (mirrors `gemv_family()`). qwen35 untouched (still calls the free `run_moe_decode`).
- **Ship 4.3 decode — bias-aware MoE decode onto the family.** `MoeBiasAwareParams` + `MoeFamily::run_bias_aware()` + `run_moe_decode_bias_aware()` — verbatim transcription of `ffn_routed`'s routed sub-graph (bias-aware top-k → indexed MQ2-Lloyd gate_up → silu·mul·clamp → FWHT rotate → indexed down, accumulate into `ffn_out`). Router GEMV + `sqrt_softplus` + shared expert stay model-owned.
- **perf — drop unused `DispatchCtx`** the bias-aware path ignored (uncached per-token `FeatureFlags::from_env`). Migration is perf-neutral by construction.
- **Ship 4.3 prefill — batched/prefill MoE onto the family.** `MoeBiasAwarePrefillParams` + `MoePrefillRouting{BiasAware,Hash}` + `MoeFamily::run_bias_aware_prefill()` + `run_moe_prefill_bias_aware()` — verbatim transcription of `ffn_batched`'s routed block: routing (hash or bias-aware batched top-k) → grouped GEMM (`batch_size >= gate`, default 128) or scalar K4 indexed → combine into `ffn_out`. The 7 MQ2-Lloyd grouped-GEMM research-lever variants (n32/cnd/8w/nosync/mmqload/4w/base) are deduplicated into a select+dispatch helper used for both gate_up and down; all env levers + the deterministic-vs-atomic down split are preserved. `ffn_batched` keeps RMSNorm + shared expert + router GEMV + `sqrt_softplus` model-owned.

### Validation (gfx1151)
- `cargo build` + `cargo test -p hipfire-dispatch` (84) + `-p hipfire-dispatch-tests` (58) green.
- **Decode coherence PASS** (`deepseek-v4-flash.mq2lloyd` + MTP addon; MTP spec-decode active so the routed path runs in prefill **and** draft/verify): cap → "…Paris.", reason → **9**.
- **Prefill coherence PASS — both paths**: **scalar** (B<128: cap=Paris, reason=9) and **grouped** (180-token prompt forced through the scatter → 7-variant grouped-GEMM → unscatter → combine path → coherent, on-topic output). No panic/loop/leak; clean load/unload.
- Behavior-preserving: identical kernels / args / order as the inline `ffn_routed` / `ffn_batched` paths (verified line-by-line).

### Deferred (out of scope here)
- **Dual-arch perf A/B** (`probe_commits.sh`-style on gfx1100 + gfx1201) per Phase 0.6 — this box is gfx1151. To be run by a reviewer before merge.
- qwen35 decode wire-up (4.1, adds `batch_size` to the shared `MoeParams` + swaps the call site) and Step 8 (qwen35 grouped prefill) — **wait for Ship 3** (one-file sequencing on `qwen35.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)