### PR TITLE
fix(cli): registry + CLI truth pass — published a3b repos, real 2b, honest help/errors

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -77,7 +77,7 @@ export interface HipfireConfig {
   // produce subtle output drift on certain prompt shapes that hide behind
   // higher peak tok/s — confounded debugging when DFlash was silently
   // on by default (auto). Opt in per-model with
-  // `hipfire config set-model <tag> dflash_mode on` once you've confirmed
+  // `hipfire config <tag> set dflash_mode on` once you've confirmed
   // the model + prompt shape on your hardware.
   //
   // A3B-specific rationale (kept for the `auto` path): A3B DFlash is a
@@ -234,8 +234,8 @@ const CONFIG_DEFAULTS: HipfireConfig = {
   mmq_screen_threshold: 0.10,
 
   // PFlash off by default. Operators opt in per target via:
-  //   hipfire config set-model <tag> prefill_compression auto
-  //   hipfire config set-model <tag> prefill_drafter ~/.hipfire/models/<drafter>.hfq
+  //   hipfire config <tag> set prefill_compression auto
+  //   hipfire config <tag> set prefill_drafter ~/.hipfire/models/<drafter>.hfq
   prefill_compression: "off",
   prefill_threshold: 32768,
   prefill_keep_ratio: 0.05,
@@ -564,7 +564,7 @@ function buildLoadMessage(path: string, tag?: string | null): any {
   const dflashAllowed = mode === "on" || (mode === "auto" && autoOn);
   if (!dflashAllowed) {
     if (mode === "auto" && isA3B) {
-      const hint = tag ? `config set-model ${tag} dflash_mode on` : `config set dflash_mode on`;
+      const hint = tag ? `config ${tag} set dflash_mode on` : `config set dflash_mode on`;
       console.error(`[hipfire] DFlash disabled for A3B target (dflash_mode=auto, no sidecar). Override with 'hipfire ${hint}'.`);
     } else if (mode === "off") {
       console.error(`[hipfire] DFlash disabled (dflash_mode=off).`);
@@ -5064,7 +5064,7 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
     },
     experimental_budget_alert: {
       label: "experimental_budget_alert",
-      desc: "show a one-line warning on startup when an experimental feature is enabled",
+      desc: "allow the budget_alert_at_tok / budget_alert_text generate params (research-only in-band nudge injected into the model's think stream — can leak into visible output). false = daemon ignores those params",
       options: ["true", "false"],
     },
     dflash_adaptive_b: {
@@ -5118,7 +5118,7 @@ function configTui(cfg: HipfireConfig, scope?: string | null): Promise<TuiExit> 
     },
     prompt_normalize: {
       label: "prompt_normalize",
-      desc: "collapse \\n{3,} → \\n\\n before encode (lifts τ +26.7% on PEP-8 code prompts; off by default)",
+      desc: "collapse \\n{3,} → \\n\\n before encode (+24% τ on PEP-8 code prompts; on by default — set false to keep raw whitespace)",
       options: ["true", "false"],
     },
     mmq_screen: {
@@ -5926,7 +5926,20 @@ switch (cmd) {
           + `  hipfire ps                 # check if running\n`
           + `  tail -f ${SERVE_LOG_FILE}  # follow log\n`);
         process.exit(0);
-      } else setHost(a);
+      }
+      // Model-tag-as-host guard: `hipfire serve qwen3.5:9b` used to silently
+      // bind to host "qwen3.5:9b" and fail later. A name:tag shape with a
+      // non-numeric port part (host:port matched above) — or anything that
+      // resolves in the registry — is a model tag, not a bind address.
+      else if (REGISTRY[resolveModelTag(a)] || /^[a-z0-9.-]+:[a-z0-9.-]+$/i.test(a)) {
+        console.error(`'${a}' looks like a model tag — \`hipfire serve\` takes [host] [port], not a model.`);
+        console.error(`The server loads models per-request (or pre-warms cfg.default_model). Instead:`);
+        console.error(`  hipfire run ${a} "hello"                # one-shot (uses running serve if any)`);
+        console.error(`  hipfire config set default_model ${a}   # make serve pre-warm this model`);
+        console.error(`  hipfire serve [host] [port]`);
+        process.exit(1);
+      }
+      else setHost(a);
     }
     host = host ?? cfg.host;
     port = port ?? cfg.port;
@@ -6011,12 +6024,12 @@ switch (cmd) {
   }
   case "run": {
     const model = rest[0];
-    if (!model) { console.error("Usage: hipfire run <model> [flags] [prompt]\n\nFlags:\n  --temp <float>           Temperature (default 0.3)\n  --top-p <float>          Top-p sampling (default 0.8)\n  --repeat-penalty <float> Repeat penalty (default 1.05)\n  --max-tokens <int>       Max tokens to generate (default 512)\n  --image <path>           Image for VL models\n  --system <text>          System prompt (overrides per-model default)\n\nExamples:\n  hipfire run qwen3.5:9b \"Hello\"\n  hipfire run qwen3.5:9b --temp 0.7 --max-tokens 256 \"Write a poem\"\n  hipfire run qwen3.5:4b --image photo.png \"Describe this\"\n  hipfire run qwen3.5:9b --system \"You are terse.\" \"Summarize quantum mechanics\""); process.exit(1); }
+    if (!model) { console.error("Usage: hipfire run <model> [flags] [prompt]\n\nFlags:\n  --temp <float>           Temperature (default 0.3)\n  --top-p <float>          Top-p sampling (default 0.8)\n  --repeat-penalty <float> Repeat penalty (default 1.05)\n  --max-tokens <int>       Max tokens to generate (default 4096)\n  --image <path>           Image for VL models\n  --system <text>          System prompt (overrides per-model default)\n\nExamples:\n  hipfire run qwen3.5:9b \"Hello\"\n  hipfire run qwen3.5:9b --temp 0.7 --max-tokens 256 \"Write a poem\"\n  hipfire run qwen3.5:4b --image photo.png \"Describe this\"\n  hipfire run qwen3.5:9b --system \"You are terse.\" \"Summarize quantum mechanics\""); process.exit(1); }
     // Parse --key value flags
     const flagDefs: Record<string, { default: number | string | undefined }> = {
       "--image": { default: undefined }, "--temp": { default: 0.3 },
       "--top-p": { default: 0.8 }, "--repeat-penalty": { default: 1.05 },
-      "--max-tokens": { default: 512 },
+      "--max-tokens": { default: 4096 },
       "--system": { default: undefined },
     };
     const stringFlags = new Set(["--image", "--system"]);
@@ -6649,6 +6662,11 @@ Examples:
   }
   case "rm": {
     const tag = rest[0] || "";
+    if (!tag) {
+      console.error("Usage: hipfire rm <model>   (e.g. hipfire rm qwen3.5:9b)");
+      console.error("  See installed models: hipfire list");
+      process.exit(1);
+    }
     const resolved = resolveModelTag(tag);
     const entry = REGISTRY[resolved];
     const path = entry ? join(MODELS_DIR, entry.file) : findModel(tag);
@@ -6657,6 +6675,8 @@ Examples:
       console.log(`Removed ${path}`);
     } else {
       console.error(`Model not found: ${tag}`);
+      console.error(`  See installed models: hipfire list`);
+      process.exit(1);
     }
     break;
   }
@@ -7217,6 +7237,14 @@ Examples:
     break;
   }
   default: {
+    // Unknown command: error to stderr + nonzero exit so scripts can detect
+    // the typo instead of parsing help text off a 0-exit stdout.
+    // `help`/`-h`/`--help` are explicit help requests, not typos.
+    if (cmd && !["help", "-h", "--help"].includes(cmd)) {
+      console.error(`Unknown command: ${cmd}`);
+      console.error(`Run \`hipfire help\` for the full command list.`);
+      process.exit(1);
+    }
     // First-run hint: if no config, no models, show a friendly setup tip.
     // (Only when invoked with no args — still show full help text below.)
     if (!cmd) {
@@ -7230,7 +7258,8 @@ Examples:
         console.log(`  1. Sanity-check your GPU:   \x1b[1mhipfire diag\x1b[0m`);
         console.log(`  2. Pull a model:            \x1b[1mhipfire pull qwen3.5:4b\x1b[0m`);
         console.log(`  3. Run your first prompt:   \x1b[1mhipfire run qwen3.5:4b "hello"\x1b[0m`);
-        console.log(`  4. Tweak settings:          \x1b[1mhipfire config\x1b[0m  (interactive)`);
+        console.log(`  4. Chat interactively:      \x1b[1mhipfire chat qwen3.5:4b\x1b[0m`);
+        console.log(`  5. Tweak settings:          \x1b[1mhipfire config\x1b[0m  (interactive)`);
         console.log(`\nFull command list:\n`);
       }
     }
@@ -7238,6 +7267,7 @@ Examples:
 
   pull <model>          Download model from HuggingFace
   run <model> [prompt]  Generate text (auto-pulls; uses running serve if any)
+  chat <model>          Interactive chat TUI (streaming, multi-turn; uses running serve if any)
   serve [host] [port] [-d]
                         Start OpenAI-compatible server (-d = background daemon)
   stop                  Stop the background serve daemon

--- a/cli/registry.json
+++ b/cli/registry.json
@@ -1,90 +1,301 @@
 {
-  "_comment": "hipfire model registry. Loaded by cli/index.ts at startup. Keep entry shape: { repo, file, size_gb, min_vram_gb, desc }. Empty repo = local-only (pull short-circuits with a clear message instead of 404'ing). Aliases are simple string→string redirects through the resolver.",
+  "_comment": "hipfire model registry. Loaded by cli/index.ts at startup. Keep entry shape: { repo, file, size_gb, min_vram_gb, desc }. Empty repo = local-only (pull short-circuits with a clear message instead of 404'ing). Aliases are simple string\u2192string redirects through the resolver.",
   "models": {
-    "qwen3.5:0.8b":     { "repo": "schuttdev/hipfire-qwen3.5-0.8b", "file": "qwen3.5-0.8b.mq4",   "size_gb": 0.55, "min_vram_gb": 1,  "desc": "386 / 5100 tok/s" },
-    "qwen3.5:4b":       { "repo": "schuttdev/hipfire-qwen3.5-4b",   "file": "qwen3.5-4b.mq4",     "size_gb": 2.6,  "min_vram_gb": 4,  "desc": "169 / 1900 tok/s" },
-    "qwen3.5:9b":       { "repo": "schuttdev/hipfire-qwen3.5-9b",   "file": "qwen3.5-9b.mq4",     "size_gb": 5.3,  "min_vram_gb": 6,  "desc": "125 / 1720 tok/s" },
-    "qwen3.5:27b":      { "repo": "schuttdev/hipfire-qwen3.5-27b",  "file": "qwen3.5-27b.mq4",    "size_gb": 15.0, "min_vram_gb": 16, "desc": "45 / 489 tok/s, 16GB+" },
-
-    "qwen3.5:35b-a3b":  { "repo": "schuttdev/hipfire-qwen3.5-35b-a3b", "file": "qwen3.5-35b-a3b.mq4", "size_gb": 19.7, "min_vram_gb": 22, "desc": "MoE 35B/3B-active, 115 tok/s" },
-    "deepseek-v4-flash": { "repo": "nwoolmer/hipfire-deepseek-v4-flash", "file": "deepseek-v4-flash.mq2lloyd", "size_gb": 82, "min_vram_gb": 96, "mtp": { "file": "deepseek-v4-flash-mtp.mq2lloyd" }, "desc": "DeepSeek V4 Flash, MQ2-Lloyd routed-expert MoE (arch_id=9). Includes MTP sidecar for K=2 spec-decode (+29% TG on code)." },
-    "qwen3.6:35b-a3b":  { "repo": "schuttdev/hipfire-qwen3.6-35b-a3b", "file": "qwen3.6-35b-a3b.mq4", "size_gb": 22.9, "min_vram_gb": 24, "desc": "MoE 35B/3B-active refresh, 148 tok/s" },
-
-    "qwen3.6:27b":      { "repo": "schuttdev/hipfire-qwen3.6-27b",  "file": "qwen3.6-27b.mq4",    "size_gb": 15.0, "min_vram_gb": 16, "desc": "44 tok/s AR / 185 tok/s w/ draft on code", "triattn": { "file": "qwen3.6-27b.mq4.triattn.blended_v3.bin" } },
-
-    "qwen3.5:0.8b-mq6": { "repo": "schuttdev/hipfire-qwen3.5-0.8b", "file": "qwen3.5-0.8b.mq6",   "size_gb": 0.67, "min_vram_gb": 2,  "desc": "MQ6, higher quality" },
-    "qwen3.5:4b-mq6":   { "repo": "schuttdev/hipfire-qwen3.5-4b",   "file": "qwen3.5-4b.mq6",     "size_gb": 3.5,  "min_vram_gb": 5,  "desc": "MQ6, higher quality" },
-    "qwen3.5:9b-mq6":   { "repo": "schuttdev/hipfire-qwen3.5-9b",   "file": "qwen3.5-9b.mq6",     "size_gb": 7.3,  "min_vram_gb": 8,  "desc": "MQ6, higher quality" },
-    "qwen3.5:27b-mq6":  { "repo": "schuttdev/hipfire-qwen3.5-27b",  "file": "qwen3.5-27b.mq6",    "size_gb": 21.4, "min_vram_gb": 24, "desc": "MQ6, higher quality" },
-
-    "qwen3.5:9b-mq3":   { "repo": "schuttdev/hipfire-qwen3.5-9b",   "file": "qwen3.5-9b.mq3",     "size_gb": 4.0,  "min_vram_gb": 6,  "desc": "MQ3 alpha (3.25 bpw, gfx11/gfx12). Smaller than MQ4, comparable decode. Quality eval pending — see issue #113. Sub-9B MQ3 not shipped — see #114." },
-    "qwen3.5:27b-mq3":  { "repo": "schuttdev/hipfire-qwen3.5-27b",  "file": "qwen3.5-27b.mq3",    "size_gb": 10.7, "min_vram_gb": 12, "desc": "MQ3 alpha — fits 128K asym3 ctx on 24 GB (MQ4 OOMs at ~98K). gfx11/gfx12 only." },
-    "qwen3.6:27b-mq3":  { "repo": "schuttdev/hipfire-qwen3.6-27b",  "file": "qwen3.6-27b.mq3",    "size_gb": 10.7, "min_vram_gb": 12, "desc": "MQ3 alpha — fits 128K asym3 ctx on 24 GB. Pairs well with mq4 DFlash draft (126 tok/s τ=7.0)." },
-
-    "qwen3.5:27b-draft-mq3": { "repo": "schuttdev/hipfire-qwen3.5-27b", "file": "qwen35-27b-dflash-mq3.hfq", "size_gb": 0.67, "min_vram_gb": 12, "desc": "MQ3 DFlash draft for qwen3.5:27b — 671 MB vs 920 MB MQ4 draft. ~30% lower τ on code prompts; trades draft VRAM for ctx fit." },
-    "qwen3.6:27b-draft-mq3": { "repo": "schuttdev/hipfire-qwen3.6-27b", "file": "qwen36-27b-dflash-mq3.hfq", "size_gb": 0.67, "min_vram_gb": 12, "desc": "MQ3 DFlash draft for qwen3.6:27b. Pairs with target/mq3 or target/mq4." },
-
-    "qwen3:0.6b":       { "repo": "schuttdev/hipfire-qwen3-0.6b",   "file": "qwen3-0.6b.hf4",     "size_gb": 0.4,  "min_vram_gb": 1,  "desc": "standard attention" },
-    "qwen3:8b":         { "repo": "schuttdev/hipfire-qwen3-8b",     "file": "qwen3-8b.hf4",       "size_gb": 4.1,  "min_vram_gb": 6,  "desc": "60 tok/s, standard attention" },
-
-    "qwen3.5:2b":       { "repo": "schuttdev/hipfire-qwen3.5-2b",   "file": "qwen3.5-2b.hf4",     "size_gb": 1.3,  "min_vram_gb": 2,  "desc": "2B, HF4 (legacy 4-bit format)" },
-    "qwen3.5:2b-hf6":   { "repo": "schuttdev/hipfire-qwen3.5-2b",   "file": "qwen3.5-2b.hf6",     "size_gb": 1.6,  "min_vram_gb": 3,  "desc": "2B, HF6 (legacy 6-bit), higher quality" },
-
-    "qwen3.5:9b-draft":  { "repo": "schuttdev/hipfire-qwen3.5-9b",  "file": "qwen35-9b-dflash-mq4.hfq",  "size_gb": 0.55, "min_vram_gb": 6,  "desc": "DFlash draft for qwen3.5:9b — pairs with target for 2-3× decode on code/instruct" },
-    "qwen3.5:27b-draft": { "repo": "schuttdev/hipfire-qwen3.5-27b", "file": "qwen35-27b-dflash-mq4.hfq", "size_gb": 0.92, "min_vram_gb": 16, "desc": "DFlash draft for qwen3.5:27b — pairs with target for 4× decode on code (212 tok/s peak)" },
-    "qwen3.6:27b-draft": { "repo": "schuttdev/hipfire-qwen3.6-27b", "file": "qwen36-27b-dflash-mq4.hfq", "size_gb": 0.92, "min_vram_gb": 16, "desc": "DFlash draft for qwen3.6:27b — pairs with target for ~4× decode on code (refreshed 2026-04-27 from z-lab@0919688)" },
-
-    "carnice:9b":        { "repo": "schuttdev/hipfire-carnice-9b",  "file": "carnice-9b.mq4",  "size_gb": 5.0, "min_vram_gb": 6,  "desc": "Hermes tool-use, MQ4" },
-    "carnice:27b":       { "repo": "schuttdev/hipfire-carnice-27b", "file": "carnice-27b.mq4", "size_gb": 15.0, "min_vram_gb": 16, "desc": "Hermes 27B tool-use, MQ4" },
-    "carnice:9b-mq6":    { "repo": "schuttdev/hipfire-carnice-9b",  "file": "carnice-9b.mq6",  "size_gb": 7.3, "min_vram_gb": 8,  "desc": "Hermes tool-use, MQ6 higher quality" },
-    "carnice:27b-mq6":   { "repo": "schuttdev/hipfire-carnice-27b", "file": "carnice-27b.mq6", "size_gb": 21.4, "min_vram_gb": 24, "desc": "Hermes 27B, MQ6 higher quality" },
-
-    "qwopus:9b":         { "repo": "schuttdev/hipfire-qwopus-9b",  "file": "qwopus-9b.mq4",  "size_gb": 5.3, "min_vram_gb": 6,  "desc": "Qwopus3.5 v3, MQ4" },
-    "qwopus:4b":         { "repo": "schuttdev/hipfire-qwopus-4b",  "file": "qwopus-4b.mq4",  "size_gb": 2.6, "min_vram_gb": 4,  "desc": "Qwopus3.5 v3, 4B MQ4" },
-    "qwopus:27b":        { "repo": "schuttdev/hipfire-qwopus-27b", "file": "qwopus-27b.mq4", "size_gb": 15.0, "min_vram_gb": 16, "desc": "Qwopus3.5 v3, 27B MQ4" },
-    "qwopus:9b-mq6":     { "repo": "schuttdev/hipfire-qwopus-9b",  "file": "qwopus-9b.mq6",  "size_gb": 7.3, "min_vram_gb": 8,  "desc": "Qwopus3.5 v3, MQ6 higher quality" },
-    "qwopus:4b-mq6":     { "repo": "schuttdev/hipfire-qwopus-4b",  "file": "qwopus-4b.mq6",  "size_gb": 3.8, "min_vram_gb": 5,  "desc": "Qwopus3.5 v3, 4B MQ6" },
-    "qwopus:27b-mq6":    { "repo": "schuttdev/hipfire-qwopus-27b", "file": "qwopus-27b.mq6", "size_gb": 21.4, "min_vram_gb": 24, "desc": "Qwopus3.5 v3, 27B MQ6" }
+    "qwen3.5:0.8b": {
+      "repo": "schuttdev/hipfire-qwen3.5-0.8b",
+      "file": "qwen3.5-0.8b.mq4",
+      "size_gb": 0.55,
+      "min_vram_gb": 1,
+      "desc": "386 / 5100 tok/s"
+    },
+    "qwen3.5:4b": {
+      "repo": "schuttdev/hipfire-qwen3.5-4b",
+      "file": "qwen3.5-4b.mq4",
+      "size_gb": 2.6,
+      "min_vram_gb": 4,
+      "desc": "169 / 1900 tok/s"
+    },
+    "qwen3.5:9b": {
+      "repo": "schuttdev/hipfire-qwen3.5-9b",
+      "file": "qwen3.5-9b.mq4",
+      "size_gb": 5.3,
+      "min_vram_gb": 6,
+      "desc": "125 / 1720 tok/s"
+    },
+    "qwen3.5:27b": {
+      "repo": "schuttdev/hipfire-qwen3.5-27b",
+      "file": "qwen3.5-27b.mq4",
+      "size_gb": 15.0,
+      "min_vram_gb": 16,
+      "desc": "45 / 489 tok/s, 16GB+"
+    },
+    "qwen3.5:35b-a3b": {
+      "repo": "schuttdev/hipfire-qwen3.5-35b-a3b",
+      "file": "qwen3.5-35b-a3b.mq4",
+      "size_gb": 19.7,
+      "min_vram_gb": 22,
+      "desc": "MoE 35B/3B-active, 115 tok/s"
+    },
+    "deepseek-v4-flash": {
+      "repo": "nwoolmer/hipfire-deepseek-v4-flash",
+      "file": "deepseek-v4-flash.mq2lloyd",
+      "size_gb": 82,
+      "min_vram_gb": 96,
+      "mtp": {
+        "file": "deepseek-v4-flash-mtp.mq2lloyd"
+      },
+      "desc": "DeepSeek V4 Flash, MQ2-Lloyd routed-expert MoE (arch_id=9). Includes MTP sidecar for K=2 spec-decode (+29% TG on code)."
+    },
+    "qwen3.6:35b-a3b": {
+      "repo": "schuttdev/hipfire-qwen3.6-35b-a3b",
+      "file": "qwen3.6-35b-a3b.mq4",
+      "size_gb": 22.9,
+      "min_vram_gb": 24,
+      "desc": "MoE 35B/3B-active refresh, 148 tok/s"
+    },
+    "qwen3.6:27b": {
+      "repo": "schuttdev/hipfire-qwen3.6-27b",
+      "file": "qwen3.6-27b.mq4",
+      "size_gb": 15.0,
+      "min_vram_gb": 16,
+      "desc": "44 tok/s AR / 185 tok/s w/ draft on code",
+      "triattn": {
+        "file": "qwen3.6-27b.mq4.triattn.blended_v3.bin"
+      }
+    },
+    "qwen3.5:0.8b-mq6": {
+      "repo": "schuttdev/hipfire-qwen3.5-0.8b",
+      "file": "qwen3.5-0.8b.mq6",
+      "size_gb": 0.67,
+      "min_vram_gb": 2,
+      "desc": "MQ6, higher quality"
+    },
+    "qwen3.5:4b-mq6": {
+      "repo": "schuttdev/hipfire-qwen3.5-4b",
+      "file": "qwen3.5-4b.mq6",
+      "size_gb": 3.5,
+      "min_vram_gb": 5,
+      "desc": "MQ6, higher quality"
+    },
+    "qwen3.5:9b-mq6": {
+      "repo": "schuttdev/hipfire-qwen3.5-9b",
+      "file": "qwen3.5-9b.mq6",
+      "size_gb": 7.3,
+      "min_vram_gb": 8,
+      "desc": "MQ6, higher quality"
+    },
+    "qwen3.5:27b-mq6": {
+      "repo": "schuttdev/hipfire-qwen3.5-27b",
+      "file": "qwen3.5-27b.mq6",
+      "size_gb": 21.4,
+      "min_vram_gb": 24,
+      "desc": "MQ6, higher quality"
+    },
+    "qwen3.5:9b-mq3": {
+      "repo": "schuttdev/hipfire-qwen3.5-9b",
+      "file": "qwen3.5-9b.mq3",
+      "size_gb": 4.0,
+      "min_vram_gb": 6,
+      "desc": "MQ3 alpha (3.25 bpw, gfx11/gfx12). Smaller than MQ4, comparable decode. Quality eval pending \u2014 see issue #113. Sub-9B MQ3 not shipped \u2014 see #114."
+    },
+    "qwen3.5:27b-mq3": {
+      "repo": "schuttdev/hipfire-qwen3.5-27b",
+      "file": "qwen3.5-27b.mq3",
+      "size_gb": 10.7,
+      "min_vram_gb": 12,
+      "desc": "MQ3 alpha \u2014 fits 128K asym3 ctx on 24 GB (MQ4 OOMs at ~98K). gfx11/gfx12 only."
+    },
+    "qwen3.6:27b-mq3": {
+      "repo": "schuttdev/hipfire-qwen3.6-27b",
+      "file": "qwen3.6-27b.mq3",
+      "size_gb": 10.7,
+      "min_vram_gb": 12,
+      "desc": "MQ3 alpha \u2014 fits 128K asym3 ctx on 24 GB. Pairs well with mq4 DFlash draft (126 tok/s \u03c4=7.0)."
+    },
+    "qwen3.5:27b-draft-mq3": {
+      "repo": "schuttdev/hipfire-qwen3.5-27b",
+      "file": "qwen35-27b-dflash-mq3.hfq",
+      "size_gb": 0.67,
+      "min_vram_gb": 12,
+      "desc": "MQ3 DFlash draft for qwen3.5:27b \u2014 671 MB vs 920 MB MQ4 draft. ~30% lower \u03c4 on code prompts; trades draft VRAM for ctx fit."
+    },
+    "qwen3.6:27b-draft-mq3": {
+      "repo": "schuttdev/hipfire-qwen3.6-27b",
+      "file": "qwen36-27b-dflash-mq3.hfq",
+      "size_gb": 0.67,
+      "min_vram_gb": 12,
+      "desc": "MQ3 DFlash draft for qwen3.6:27b. Pairs with target/mq3 or target/mq4."
+    },
+    "qwen3:0.6b": {
+      "repo": "schuttdev/hipfire-qwen3-0.6b",
+      "file": "qwen3-0.6b.hf4",
+      "size_gb": 0.4,
+      "min_vram_gb": 1,
+      "desc": "standard attention"
+    },
+    "qwen3:8b": {
+      "repo": "schuttdev/hipfire-qwen3-8b",
+      "file": "qwen3-8b.hf4",
+      "size_gb": 4.1,
+      "min_vram_gb": 6,
+      "desc": "60 tok/s, standard attention"
+    },
+    "qwen3.5:2b": {
+      "repo": "schuttdev/hipfire-qwen3.5-2b",
+      "file": "qwen3.5-2b.hf4",
+      "size_gb": 1.3,
+      "min_vram_gb": 2,
+      "desc": "2B, HF4 (legacy 4-bit format)"
+    },
+    "qwen3.5:2b-hf6": {
+      "repo": "schuttdev/hipfire-qwen3.5-2b",
+      "file": "qwen3.5-2b.hf6",
+      "size_gb": 1.6,
+      "min_vram_gb": 3,
+      "desc": "2B, HF6 (legacy 6-bit), higher quality"
+    },
+    "qwen3.5:9b-draft": {
+      "repo": "schuttdev/hipfire-qwen3.5-9b",
+      "file": "qwen35-9b-dflash-mq4.hfq",
+      "size_gb": 0.55,
+      "min_vram_gb": 6,
+      "desc": "DFlash draft for qwen3.5:9b \u2014 pairs with target for 2-3\u00d7 decode on code/instruct"
+    },
+    "qwen3.5:27b-draft": {
+      "repo": "schuttdev/hipfire-qwen3.5-27b",
+      "file": "qwen35-27b-dflash-mq4.hfq",
+      "size_gb": 0.92,
+      "min_vram_gb": 16,
+      "desc": "DFlash draft for qwen3.5:27b \u2014 pairs with target for 4\u00d7 decode on code (212 tok/s peak)"
+    },
+    "qwen3.6:27b-draft": {
+      "repo": "schuttdev/hipfire-qwen3.6-27b",
+      "file": "qwen36-27b-dflash-mq4.hfq",
+      "size_gb": 0.92,
+      "min_vram_gb": 16,
+      "desc": "DFlash draft for qwen3.6:27b \u2014 pairs with target for ~4\u00d7 decode on code (refreshed 2026-04-27 from z-lab@0919688)"
+    },
+    "carnice:9b": {
+      "repo": "schuttdev/hipfire-carnice-9b",
+      "file": "carnice-9b.mq4",
+      "size_gb": 5.0,
+      "min_vram_gb": 6,
+      "desc": "Hermes tool-use, MQ4"
+    },
+    "carnice:27b": {
+      "repo": "schuttdev/hipfire-carnice-27b",
+      "file": "carnice-27b.mq4",
+      "size_gb": 15.0,
+      "min_vram_gb": 16,
+      "desc": "Hermes 27B tool-use, MQ4"
+    },
+    "carnice:9b-mq6": {
+      "repo": "schuttdev/hipfire-carnice-9b",
+      "file": "carnice-9b.mq6",
+      "size_gb": 7.3,
+      "min_vram_gb": 8,
+      "desc": "Hermes tool-use, MQ6 higher quality"
+    },
+    "carnice:27b-mq6": {
+      "repo": "schuttdev/hipfire-carnice-27b",
+      "file": "carnice-27b.mq6",
+      "size_gb": 21.4,
+      "min_vram_gb": 24,
+      "desc": "Hermes 27B, MQ6 higher quality"
+    },
+    "qwopus:9b": {
+      "repo": "schuttdev/hipfire-qwopus-9b",
+      "file": "qwopus-9b.mq4",
+      "size_gb": 5.3,
+      "min_vram_gb": 6,
+      "desc": "Qwopus3.5 v3, MQ4"
+    },
+    "qwopus:4b": {
+      "repo": "schuttdev/hipfire-qwopus-4b",
+      "file": "qwopus-4b.mq4",
+      "size_gb": 2.6,
+      "min_vram_gb": 4,
+      "desc": "Qwopus3.5 v3, 4B MQ4"
+    },
+    "qwopus:27b": {
+      "repo": "schuttdev/hipfire-qwopus-27b",
+      "file": "qwopus-27b.mq4",
+      "size_gb": 15.0,
+      "min_vram_gb": 16,
+      "desc": "Qwopus3.5 v3, 27B MQ4"
+    },
+    "qwopus:9b-mq6": {
+      "repo": "schuttdev/hipfire-qwopus-9b",
+      "file": "qwopus-9b.mq6",
+      "size_gb": 7.3,
+      "min_vram_gb": 8,
+      "desc": "Qwopus3.5 v3, MQ6 higher quality"
+    },
+    "qwopus:4b-mq6": {
+      "repo": "schuttdev/hipfire-qwopus-4b",
+      "file": "qwopus-4b.mq6",
+      "size_gb": 3.8,
+      "min_vram_gb": 5,
+      "desc": "Qwopus3.5 v3, 4B MQ6"
+    },
+    "qwopus:27b-mq6": {
+      "repo": "schuttdev/hipfire-qwopus-27b",
+      "file": "qwopus-27b.mq6",
+      "size_gb": 21.4,
+      "min_vram_gb": 24,
+      "desc": "Qwopus3.5 v3, 27B MQ6"
+    },
+    "lfm2.5:350m": {
+      "repo": "hipfire-models/hipfire-LFM2.5-350M",
+      "file": "lfm2.5-350m.mq4",
+      "size_gb": 0.23,
+      "min_vram_gb": 2,
+      "desc": "LFM2.5 350M dense (MQ4, embedded chat template)"
+    },
+    "lfm2.5:8b-a1b": {
+      "repo": "hipfire-models/hipfire-LFM2.5-8B-A1B",
+      "file": "lfm2.5-8b-a1b.mq4",
+      "size_gb": 4.9,
+      "min_vram_gb": 7,
+      "desc": "LFM2.5 8B-A1B MoE (MQ4, jinja-validated)"
+    }
   },
   "aliases": {
-    "qwen3.5":         "qwen3.5:4b",
-    "qwen3.5:latest":  "qwen3.5:9b",
-    "qwen3.5:small":   "qwen3.5:0.8b",
-    "qwen3.5:large":   "qwen3.5:27b",
-    "qwen3.6":         "qwen3.6:35b-a3b",
-    "qwen3.6:a3b":     "qwen3.6:35b-a3b",
-    "qwen3":           "qwen3:8b",
-    "carnice":         "carnice:9b",
-    "qwopus":          "qwopus:9b",
-    "deepseek4":       "deepseek-v4-flash",
-    "deepseek-v4":     "deepseek-v4-flash",
-
+    "qwen3.5": "qwen3.5:4b",
+    "qwen3.5:latest": "qwen3.5:9b",
+    "qwen3.5:small": "qwen3.5:0.8b",
+    "qwen3.5:large": "qwen3.5:27b",
+    "qwen3.6": "qwen3.6:35b-a3b",
+    "qwen3.6:a3b": "qwen3.6:35b-a3b",
+    "qwen3": "qwen3:8b",
+    "carnice": "carnice:9b",
+    "qwopus": "qwopus:9b",
+    "deepseek4": "deepseek-v4-flash",
+    "deepseek-v4": "deepseek-v4-flash",
     "qwen3.5:0.8b-mq4": "qwen3.5:0.8b",
-    "qwen3.5:4b-mq4":   "qwen3.5:4b",
-    "qwen3.5:9b-mq4":   "qwen3.5:9b",
-    "qwen3.5:27b-mq4":  "qwen3.5:27b",
+    "qwen3.5:4b-mq4": "qwen3.5:4b",
+    "qwen3.5:9b-mq4": "qwen3.5:9b",
+    "qwen3.5:27b-mq4": "qwen3.5:27b",
     "qwen3.5:0.8b-hf4": "qwen3.5:0.8b",
-    "qwen3.5:2b-hf4":   "qwen3.5:2b",
-    "qwen3.5:4b-hf4":   "qwen3.5:4b",
-    "qwen3.5:9b-hf4":   "qwen3.5:9b",
-    "qwen3.5:27b-hf4":  "qwen3.5:27b",
+    "qwen3.5:2b-hf4": "qwen3.5:2b",
+    "qwen3.5:4b-hf4": "qwen3.5:4b",
+    "qwen3.5:9b-hf4": "qwen3.5:9b",
+    "qwen3.5:27b-hf4": "qwen3.5:27b",
     "qwen3.5:0.8b-hf6": "qwen3.5:0.8b-mq6",
-    "qwen3.5:4b-hf6":   "qwen3.5:4b-mq6",
-    "qwen3.5:9b-hf6":   "qwen3.5:9b-mq6",
-    "qwen3.5:27b-hf6":  "qwen3.5:27b-mq6",
-
-    "qwopus:9b-hf4":  "qwopus:9b",
-    "qwopus:4b-hf4":  "qwopus:4b",
+    "qwen3.5:4b-hf6": "qwen3.5:4b-mq6",
+    "qwen3.5:9b-hf6": "qwen3.5:9b-mq6",
+    "qwen3.5:27b-hf6": "qwen3.5:27b-mq6",
+    "qwopus:9b-hf4": "qwopus:9b",
+    "qwopus:4b-hf4": "qwopus:4b",
     "qwopus:27b-hf4": "qwopus:27b",
-    "qwopus:9b-mq4":  "qwopus:9b",
-    "qwopus:4b-mq4":  "qwopus:4b",
+    "qwopus:9b-mq4": "qwopus:9b",
+    "qwopus:4b-mq4": "qwopus:4b",
     "qwopus:27b-mq4": "qwopus:27b",
-
-    "qwen3.5-9b:draft":   "qwen3.5:9b-draft",
-    "qwen3.5-27b:draft":  "qwen3.5:27b-draft",
-    "qwen3.6-27b:draft":  "qwen3.6:27b-draft",
-    "qwen3.5:9b:draft":   "qwen3.5:9b-draft",
-    "qwen3.5:27b:draft":  "qwen3.5:27b-draft",
-    "qwen3.6:27b:draft":  "qwen3.6:27b-draft"
+    "qwen3.5-9b:draft": "qwen3.5:9b-draft",
+    "qwen3.5-27b:draft": "qwen3.5:27b-draft",
+    "qwen3.6-27b:draft": "qwen3.6:27b-draft",
+    "qwen3.5:9b:draft": "qwen3.5:9b-draft",
+    "qwen3.5:27b:draft": "qwen3.5:27b-draft",
+    "qwen3.6:27b:draft": "qwen3.6:27b-draft"
   }
 }

--- a/cli/registry.json
+++ b/cli/registry.json
@@ -6,9 +6,9 @@
     "qwen3.5:9b":       { "repo": "schuttdev/hipfire-qwen3.5-9b",   "file": "qwen3.5-9b.mq4",     "size_gb": 5.3,  "min_vram_gb": 6,  "desc": "125 / 1720 tok/s" },
     "qwen3.5:27b":      { "repo": "schuttdev/hipfire-qwen3.5-27b",  "file": "qwen3.5-27b.mq4",    "size_gb": 15.0, "min_vram_gb": 16, "desc": "45 / 489 tok/s, 16GB+" },
 
-    "qwen3.5:35b-a3b":  { "repo": "", "file": "qwen3.5-35b-a3b.mq4", "size_gb": 18.7, "min_vram_gb": 22, "desc": "MoE 35B/3B-active, 115 tok/s — LOCAL ONLY (no HF repo yet)" },
+    "qwen3.5:35b-a3b":  { "repo": "schuttdev/hipfire-qwen3.5-35b-a3b", "file": "qwen3.5-35b-a3b.mq4", "size_gb": 19.7, "min_vram_gb": 22, "desc": "MoE 35B/3B-active, 115 tok/s" },
     "deepseek-v4-flash": { "repo": "nwoolmer/hipfire-deepseek-v4-flash", "file": "deepseek-v4-flash.mq2lloyd", "size_gb": 82, "min_vram_gb": 96, "mtp": { "file": "deepseek-v4-flash-mtp.mq2lloyd" }, "desc": "DeepSeek V4 Flash, MQ2-Lloyd routed-expert MoE (arch_id=9). Includes MTP sidecar for K=2 spec-decode (+29% TG on code)." },
-    "qwen3.6:35b-a3b":  { "repo": "schuttdev/hipfire-qwen3.6-35b-a3b", "file": "qwen3.6-35b-a3b.mq4", "size_gb": 18.7, "min_vram_gb": 22, "desc": "MoE 35B/3B-active refresh, 148 tok/s" },
+    "qwen3.6:35b-a3b":  { "repo": "schuttdev/hipfire-qwen3.6-35b-a3b", "file": "qwen3.6-35b-a3b.mq4", "size_gb": 22.9, "min_vram_gb": 24, "desc": "MoE 35B/3B-active refresh, 148 tok/s" },
 
     "qwen3.6:27b":      { "repo": "schuttdev/hipfire-qwen3.6-27b",  "file": "qwen3.6-27b.mq4",    "size_gb": 15.0, "min_vram_gb": 16, "desc": "44 tok/s AR / 185 tok/s w/ draft on code", "triattn": { "file": "qwen3.6-27b.mq4.triattn.blended_v3.bin" } },
 
@@ -26,6 +26,9 @@
 
     "qwen3:0.6b":       { "repo": "schuttdev/hipfire-qwen3-0.6b",   "file": "qwen3-0.6b.hf4",     "size_gb": 0.4,  "min_vram_gb": 1,  "desc": "standard attention" },
     "qwen3:8b":         { "repo": "schuttdev/hipfire-qwen3-8b",     "file": "qwen3-8b.hf4",       "size_gb": 4.1,  "min_vram_gb": 6,  "desc": "60 tok/s, standard attention" },
+
+    "qwen3.5:2b":       { "repo": "schuttdev/hipfire-qwen3.5-2b",   "file": "qwen3.5-2b.hf4",     "size_gb": 1.3,  "min_vram_gb": 2,  "desc": "2B, HF4 (legacy 4-bit format)" },
+    "qwen3.5:2b-hf6":   { "repo": "schuttdev/hipfire-qwen3.5-2b",   "file": "qwen3.5-2b.hf6",     "size_gb": 1.6,  "min_vram_gb": 3,  "desc": "2B, HF6 (legacy 6-bit), higher quality" },
 
     "qwen3.5:9b-draft":  { "repo": "schuttdev/hipfire-qwen3.5-9b",  "file": "qwen35-9b-dflash-mq4.hfq",  "size_gb": 0.55, "min_vram_gb": 6,  "desc": "DFlash draft for qwen3.5:9b — pairs with target for 2-3× decode on code/instruct" },
     "qwen3.5:27b-draft": { "repo": "schuttdev/hipfire-qwen3.5-27b", "file": "qwen35-27b-dflash-mq4.hfq", "size_gb": 0.92, "min_vram_gb": 16, "desc": "DFlash draft for qwen3.5:27b — pairs with target for 4× decode on code (212 tok/s peak)" },
@@ -61,12 +64,11 @@
     "qwen3.5:9b-mq4":   "qwen3.5:9b",
     "qwen3.5:27b-mq4":  "qwen3.5:27b",
     "qwen3.5:0.8b-hf4": "qwen3.5:0.8b",
-    "qwen3.5:2b-hf4":   "qwen3.5:4b",
+    "qwen3.5:2b-hf4":   "qwen3.5:2b",
     "qwen3.5:4b-hf4":   "qwen3.5:4b",
     "qwen3.5:9b-hf4":   "qwen3.5:9b",
     "qwen3.5:27b-hf4":  "qwen3.5:27b",
     "qwen3.5:0.8b-hf6": "qwen3.5:0.8b-mq6",
-    "qwen3.5:2b-hf6":   "qwen3.5:4b-mq6",
     "qwen3.5:4b-hf6":   "qwen3.5:4b-mq6",
     "qwen3.5:9b-hf6":   "qwen3.5:9b-mq6",
     "qwen3.5:27b-hf6":  "qwen3.5:27b-mq6",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,7 +33,7 @@ quote it: `hipfire run qwen3.5:9b "What's 2+2?"`.
 | `hipfire config` | Interactive TUI for global config (`~/.hipfire/config.json`). |
 | `hipfire config <tag>` | Per-model overlay (`~/.hipfire/per_model_config.json`). Rows show `(inherited)` vs `(overridden)`. |
 | `hipfire config set <key> <val>` | Non-interactive set. |
-| `hipfire config view` | Print effective config + all overlays. |
+| `hipfire config list` | Print effective config. Prefix with a tag (`hipfire config <tag> list`) for the per-model overlay. |
 
 Full key list and tradeoffs in [CONFIG.md](CONFIG.md).
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -13,12 +13,13 @@ sizes when you want more headroom; pull with the `:<size>-mq6` suffix.
 | Tag | File | VRAM floor | Notes |
 |---|---|---|---|
 | `qwen3.5:0.8b` | 0.55 GB | 1 GB | Tiny, hybrid DeltaNet + FullAttn |
+| `qwen3.5:2b` | 1.3 GB | 2 GB | 2B, HF4 (legacy 4-bit format; `-hf6` variant available) |
 | `qwen3.5:4b` | 2.6 GB | 4 GB | Best speed/quality balance |
 | `qwen3.5:9b` | 5.3 GB | 6 GB | Default `serve` pre-warm |
 | `qwen3.5:27b` | 15 GB | 16 GB | Needs 16 GB+ VRAM |
-| `qwen3.5:35b-a3b` | 18.7 GB | 22 GB | MoE 35B / 3B-active. Local-only (no HF repo yet). |
+| `qwen3.5:35b-a3b` | 19.7 GB | 22 GB | MoE 35B / 3B-active |
 | `qwen3.6:27b` | 15 GB | 16 GB | 3.6 refresh, same hybrid arch as 3.5 |
-| `qwen3.6:35b-a3b` | 18.7 GB | 22 GB | 3.6 MoE refresh. Local-only. |
+| `qwen3.6:35b-a3b` | 22.9 GB | 24 GB | 3.6 MoE refresh |
 | `deepseek-v4-flash` | 82 GB | 96 GB | DeepSeek V4 Flash (arch_id=9): MQ2-Lloyd routed-expert MoE, Q8_0 attn KV, Hyper-Connections + compressed-KV indexer + tail-only RoPE. `hipfire pull` also fetches the MTP sidecar for K=2 spec-decode (+29% TG on code). |
 
 Higher-quality variants:
@@ -170,7 +171,7 @@ Cap how many tokens the model may emit before `</think>` closes. 0
 
 ```bash
 hipfire config set max_think_tokens 4096                  # global
-hipfire config set-model qwen3.6:35b-a3b max_think_tokens 1024  # per-model
+hipfire config qwen3.6:35b-a3b set max_think_tokens 1024  # per-model
 ```
 
 Per-model settings take precedence; the registry pre-applies sane caps


### PR DESCRIPTION
Task #46 — registry + CLI stop-the-bleeding: fix broken entries + user-facing lies.

## Registry (`cli/registry.json`) — every changed URL curl-verified 302 on HF

| Entry | Before | After |
|---|---|---|
| `qwen3.5:35b-a3b` | `repo: ""`, desc "LOCAL ONLY (no HF repo yet)", 18.7 GB | `schuttdev/hipfire-qwen3.5-35b-a3b` (live since 2026-05-07), 19.7 GB (x-linked-size 19663624448) |
| `qwen3.6:35b-a3b` | 18.7 GB, min_vram 22 | 22.9 GB (actual HF mq4 = 22855051520 B), min_vram 24 — a 22.9 GB file cannot fit a 22 GB budget |
| `qwen3.5:2b-hf4` alias | → `qwen3.5:4b` (wrong model) | → new real `qwen3.5:2b` entry (`schuttdev/hipfire-qwen3.5-2b`, qwen3.5-2b.hf4, 1.3 GB) |
| `qwen3.5:2b-hf6` alias | → `qwen3.5:4b-mq6` (wrong model) | promoted to real entry (qwen3.5-2b.hf6, 1.6 GB) |

qwen3.5-2b dense is a supported arch per the MODELS.md support matrix (arch_id=5 row).

## CLI truth fixes (`cli/index.ts`)

- **help**: `chat` was shipped but absent from the command list and first-run setup — added to both.
- **unknown command**: printed full help to stdout with exit 0; now `Unknown command: X` on stderr + exit 1 (`help`/`-h`/`--help` still exit 0).
- **serve model-tag-as-host**: `hipfire serve qwen3.5:9b` silently bound host `"qwen3.5:9b"`. Now detects tag shape (`^[a-z0-9.-]+:[a-z0-9.-]+$`, after host:port matched earlier) or registry/alias hits, prints `hipfire run` / `config set default_model` hint, exit 1. `host:port`, `[v6]:port`, bare host/port parsing unchanged.
- **run usage**: claimed `--max-tokens` default 512; actual default is 4096 (bumped 2026-05-28). Usage text + dead flagDef fixed.
- **dflash A3B hint** (`:567`): suggested `config set-model <tag> dflash_mode on` — `set-model` does not exist; real syntax `config <tag> set dflash_mode on` (also fixed in comments and MODELS.md).
- **config TUI descriptions**: `experimental_budget_alert` described a nonexistent "startup warning" — now describes the real `budget_alert_at_tok`/`budget_alert_text` param gate. `prompt_normalize` claimed "off by default" — it is ON by default since 2026-04-26.
- **rm**: usage on missing arg; `hipfire list` hint + exit 1 on not-found (was exit 0).

## Docs

- `docs/MODELS.md`: 2b row added, a3b sizes corrected, stale "Local-only" notes dropped, `set-model` example fixed.
- `docs/CLI.md`: `hipfire config view` never existed → `hipfire config list`.

## Validation

- `bun test` in `cli/`: 126/126 pass
- `bun cli/index.ts help` shows `chat`, exit 0
- `bun cli/index.ts badcmd` → stderr, exit 1
- `bun cli/index.ts serve qwen3.5:9b` and `serve qwen3.5` (bare alias) → hint, exit 1
- `bun cli/index.ts serve 0.0.0.0:11435 --help` → parses host:port, exit 0
- `bun cli/index.ts rm` / `rm not-a-model` → usage/hint, exit 1
- registry JSON parses; all 36 alias targets resolve to model entries
- curl -I on all 3 changed download URLs → HTTP 302 with expected x-linked-size

🤖 Generated with [Claude Code](https://claude.com/claude-code)