### PR TITLE
docs(readme): v0.2.1 refresh — small-model quickstart, supported-arch table, RDNA4 numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,62 @@ LLM inference for AMD RDNA GPUs. Rust + HIP. Single binary. No Python
 in the hot path. Ollama-style UX.
 
 ```bash
-hipfire pull qwen3.5:9b
-hipfire run  qwen3.5:9b "What is the capital of France?"
-hipfire serve -d        # background daemon, OpenAI-compatible API on 0.0.0.0:11435
+hipfire pull lfm2.5:1.2b   # 1.25 GB — small dense model, fast first token
+hipfire serve -d           # background daemon, OpenAI-compatible API on 0.0.0.0:11435
+hipfire chat lfm2.5:1.2b   # interactive chat (auto-starts serve if it isn't running)
 ```
 
-Current release: **v0.2.1** — dispatch unification (#397). DeepSeek V4 Flash support landed in v0.2.0. See [CHANGELOG.md](CHANGELOG.md).
+One-shot prompts and bigger models work the same way:
+
+```bash
+hipfire pull qwen3.5:9b
+hipfire run  qwen3.5:9b "What is the capital of France?"
+```
+
+Current release: **v0.2.1** — dispatch unification (#397). DeepSeek V4
+Flash support landed in v0.2.0. See [CHANGELOG.md](CHANGELOG.md).
+Curated weights live on Hugging Face at
+[huggingface.co/hipfire-models](https://huggingface.co/hipfire-models)
+(newer publishes) and the legacy per-model repos the registry still
+points at.
 
 Discord: <https://discord.gg/F3BaywB8Rs>
+
+## v0.2.1 highlights
+
+- **Dispatch unification (#397).** Every GEMV / GEMM / attention / MoE /
+  rotation / fused projection across all seven architecture crates now
+  resolves through typed kernel families with per-(arch × dtype) tables —
+  adding a dense quant is a table entry plus a kernel file, no model
+  code. Forward-as-pipeline lowered decode is default-on everywhere, and
+  GPU-free coverage gates assert dispatch plans for the whole fleet
+  including RDNA4.
+- **Multi-GPU expert-parallel serving.** `hipfire serve --tp N` shards
+  DeepSeek V4 Flash / MiniMax-M2 experts across N GPUs, with DSML
+  tool-call render/parse on the EP serve path.
+- **RDNA4 F16 fix.** A broken `gemm_f16_tiled` fallback was corrupting
+  ds4's DSA compressor on gfx12 — F16 GEMVs now route through WMMA on
+  RDNA4 (restoring ds4 EP tool-calling), and the rewritten fallback
+  kernel is correct and up to 13.8× faster.
+- **Jinja chat templates default-on** (HF-byte-exact tool rendering),
+  plus q8 error-feedback DeltaNet state by default.
+
+## Supported architectures
+
+| Family | Pull tags | Notes |
+|---|---|---|
+| Qwen 3.5 / 3.6 dense | `qwen3.5:0.8b` … `qwen3.5:27b`, `qwen3.6:27b` | Hybrid DeltaNet + FullAttn; DFlash spec-decode draft tags for 9B/27B |
+| Qwen 3.5 / 3.6 MoE | `qwen3.5:35b-a3b`, `qwen3.6:35b-a3b` | 35B total / 3B active |
+| LFM2.5 family | `lfm2.5:350m`, `lfm2.5:1.2b`, `lfm2.5:1.2b-thinking`, `lfm2.5:8b-a1b` | LiquidAI hybrid conv + GQA, dense and MoE; published under [hipfire-models](https://huggingface.co/hipfire-models) |
+| DeepSeek V4 Flash | `deepseek-v4-flash` | MQ2-Lloyd routed-expert MoE + MTP spec-decode; tool calls; multi-GPU `hipfire serve --tp 4` |
+| MiniMax-M2 | BYO (`hipfire quantize`) | Interleaved thinking, prefix caching, EP serve arm |
+| Qwen2 | BYO (`hipfire quantize`) | Plain Qwen2 decoder (e.g. 1.5B class) |
+| dots.ocr | BYO (`hipfire quantize`) | Qwen2-VL-family layout-extraction VLM — image → structured OCR |
+| LLaMA family | `qwen3:0.6b`, `qwen3:8b`, BYO GGUF | Standard-attention loader path |
+| Gemma 4 | — | In integration (`feat/gemma4-integrate`) — not on master yet |
+
+See [docs/MODELS.md](docs/MODELS.md) for the full curated registry
+(MQ6 variants, drafts, fine-tunes) and bring-your-own-model flows.
 
 ## Why
 
@@ -25,7 +73,8 @@ runtime.
 
 ## Headline numbers — 7900 XTX (gfx1100)
 
-Decode tok/s, default config (asym3 KV, FlashAttention auto):
+Decode tok/s, default config (measured at asym3 KV — perf-equivalent
+to today's `fwht3` per-arch default; FlashAttention auto):
 
 | Model | hipfire decode | hipfire prefill (peak) | vs ollama Q4_K_M |
 |---|---:|---:|---:|
@@ -39,6 +88,14 @@ on 27B HumanEval/53** (4.45× over AR), **372 tok/s peak on 9B**.
 DFlash speedup is genre-conditional — see
 [docs/BENCHMARKS.md](docs/BENCHMARKS.md) for the full per-genre table
 and the cross-arch matrix (RDNA1 / RDNA2 / APU / MI300X).
+
+### RDNA4 (gfx1201, Radeon AI PRO R9700)
+
+| Model | Config | Decode tok/s |
+|---|---|---:|
+| Qwen2 1.5B HFQ4 | single GPU | **266** |
+| DeepSeek V4 Flash (82 GB MQ2-Lloyd) | 4× R9700, `hipfire serve --tp 4` (EP) | **25.6** |
+| Gemma 4 12B MQ4 | single GPU (integration branch, pre-merge) | **~47** |
 
 CASK-based KV cache eviction lets you run long-context prompts without
 OOM: generate a sidecar with `hipfire sidecar-gen <model>` and enable


### PR DESCRIPTION
## What

README.md refresh for v0.2.1. Every claim was verified against master (`e2d21ae2`) before landing:

- **Quickstart** now leads with the small-model first-token UX: `hipfire pull lfm2.5:1.2b` → `hipfire serve -d` → `hipfire chat lfm2.5:1.2b` (1.25 GB Q8; registry entry `hipfire-models/hipfire-LFM2.5-1.2B`; `chat` auto-starts serve — `cli/chat.ts:120`). The qwen3.5:9b `run` one-liner stays as the second example.
- **v0.2.1 highlights** section condensed from CHANGELOG.md: #397 dispatch unification (typed kernel families, per-(arch × dtype) tables, forward-as-pipeline default-on for all seven arch crates), EP multi-GPU serving (`hipfire serve --tp N`, DSML render/parse on the EP path), the gfx12 F16 GEMV fix (`245ae3fe` — restores ds4 EP tool-calling on RDNA4; `gemm_f16_tiled` rewrite up to 13.8× faster, `8bd96035`), jinja chat templates default-on + q8 EF DeltaNet state.
- **Supported architectures** table matching the daemon's actual arch_id dispatch (0/1 llama-family, 5/6 qwen3.5/3.6 dense+MoE, 7 qwen2, 8 dots.ocr, 9 ds4, 10 minimax, 11 LFM2.5) and the live `cli/registry.json` pull tags. MiniMax / Qwen2 / dots.ocr marked BYO (`hipfire quantize`) — no registry tags exist for them. Gemma 4 marked **in integration** (`feat/gemma4-integrate`, not on master).
- **RDNA4 (gfx1201) perf table** with committed evidence for each row:
  - Qwen2 1.5B HFQ4 — **266 tok/s** (commit `e0e3cfa3`, byte-parity A/B on gfx1201, 266.7 both paths)
  - DeepSeek V4 Flash — **25.6 tok/s** decode on 4× R9700 EP (`hipfire serve --tp 4`; merge `12d2fc57` fleet validation)
  - Gemma 4 12B MQ4 — **~47 tok/s** (integration branch, pre-merge; flagged as such)
- **Stale claim fixed:** "default config (asym3 KV …)" — the per-arch default is now `fwht3`/`fwht2` (`cli/index.ts` `archDefaults`). Reworded to match the BENCHMARKS.md KV-mode note (asym3-measured, perf-equivalent to fwht3).
- **hipfire-models HF org** linked from the release blurb and the LFM2.5 row: https://huggingface.co/hipfire-models

## Verification trail

| Claim | Evidence |
|---|---|
| `lfm2.5:1.2b` pull tag | `cli/registry.json` (`hipfire-models/hipfire-LFM2.5-1.2B`, 1.25 GB Q8) |
| `hipfire chat` exists + auto-serve | `cli/index.ts:6068`, `cli/chat.ts:116-130` |
| `serve --tp N` EP (ds4/MiniMax) | `cli/index.ts:5887-5921`, commits `c993f2a2`/`fa8e222e`/`250a2e75` |
| ds4 EP tool-calling on gfx1201 | `245ae3fe` + `81366a90` + CHANGELOG v0.2.1 |
| Daemon arch coverage | `crates/hipfire-runtime/examples/daemon.rs` arch_id arms (5/6/7/8/9/10/11, 0/1) |
| gemma4 not on master | no `crates/hipfire-arch-gemma4` in master tree; lives on `feat/gemma4-integrate` |
| 266 / 25.6 / ~47 tok/s | `e0e3cfa3` / `12d2fc57` / gemma4 branch commit bodies (44.8–50.7 range) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)