### PR TITLE
feat(reap): generic MoE REAP keep-map loader (SP1) across deepseek4/qwen35/lfm2moe/minimax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ version = "0.2.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +112,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,10 +147,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hip-bridge"
@@ -144,6 +200,7 @@ version = "0.2.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",
@@ -288,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hipfire-reap"
+version = "0.2.0"
+dependencies = [
+ "hipfire-runtime",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "hipfire-runtime"
 version = "0.2.0"
 dependencies = [
@@ -326,6 +392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,7 +419,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -355,6 +429,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -371,6 +451,18 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "md5"
@@ -450,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +558,16 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -485,6 +593,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -551,6 +665,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +745,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,10 +784,171 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ version = "0.2.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ version = "0.1.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/redline",
     "crates/hipfire-dispatch",
     "crates/hipfire-dispatch-tests",
+    "crates/hipfire-reap",
 ]
 
 [workspace.package]

--- a/crates/hipfire-arch-deepseek4/Cargo.toml
+++ b/crates/hipfire-arch-deepseek4/Cargo.toml
@@ -17,6 +17,7 @@ rdna-compute = { path = "../rdna-compute" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
+hipfire-reap = { path = "../hipfire-reap" }
 
 [features]
 

--- a/crates/hipfire-arch-deepseek4/examples/deepseek4_perplexity.rs
+++ b/crates/hipfire-arch-deepseek4/examples/deepseek4_perplexity.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Nick Woolmer
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Perplexity / NLL eval for DeepSeek V4 Flash (ds4, arch_id=9).
+//!
+//! The qwen `perplexity` example hardcodes `qwen35::forward_scratch`; this is
+//! the ds4 analog. ds4 manages its own KV/SWA/indexer/compressor cache inside
+//! `DeepseekV4State`, so there is no external `KvCache` — we just loop
+//! `decode_step`, which returns the host logits for each position.
+//!
+//! Usage:
+//!   deepseek4_perplexity <model.hfq> <corpus.txt> \
+//!       [--ctx 2048] [--warmup 8] [--offset 0] [--dump-logits <path>]
+//!
+//! Set `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` to evaluate the REAP-pruned
+//! (e.g. 162B / 144-expert) variant of the SAME quant — the loader keeps only
+//! the mapped experts. Run twice (off / on) for a full-vs-pruned comparison.
+//!
+//! `--dump-logits <path>` writes per-scored-position full-vocab logits for an
+//! offline KLD comparison between two runs (same corpus/offset/ctx/warmup):
+//!   magic "DS4PPL01"(8) | vocab:u32 | n_scored:u32 |
+//!   then n_scored × { pos:u32, target:u32, logits:[f32; vocab] }
+
+use hipfire_arch_deepseek4::{forward::decode_step, DeepseekV4};
+use hipfire_runtime::arch::Architecture;
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::tokenizer::Tokenizer;
+use rdna_compute::Gpu;
+use std::io::Write;
+use std::path::Path;
+use std::time::Instant;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let model_path = args
+        .next()
+        .expect("usage: deepseek4_perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N] [--dump-logits PATH]");
+    let corpus_path = args
+        .next()
+        .expect("usage: deepseek4_perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N] [--dump-logits PATH]");
+
+    let mut ctx_len: usize = 2048;
+    let mut warmup: usize = 8;
+    let mut offset: usize = 0;
+    let mut dump_logits: Option<String> = None;
+    while let Some(flag) = args.next() {
+        let val = args.next().expect("flag missing value");
+        match flag.as_str() {
+            "--ctx" => ctx_len = val.parse().unwrap(),
+            "--warmup" => warmup = val.parse().unwrap(),
+            "--offset" => offset = val.parse().unwrap(),
+            "--dump-logits" => dump_logits = Some(val),
+            _ => panic!("unknown flag: {flag}"),
+        }
+    }
+    assert!(ctx_len > warmup + 4, "ctx must exceed warmup by enough to score");
+
+    let want_bytes = (offset + ctx_len) * 8;
+    let raw = std::fs::read(&corpus_path).expect("read corpus");
+    let take = want_bytes.min(raw.len());
+    let corpus = String::from_utf8_lossy(&raw[..take]).to_string();
+    eprintln!("Corpus: {} bytes (of {}) from {corpus_path}", corpus.len(), raw.len());
+
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let cfg = DeepseekV4::config_from_hfq(&hfq).expect("config");
+    let tokenizer =
+        Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer from HFQ metadata");
+    eprintln!(
+        "Model arch_id={} n_layers={} n_routed_experts={} (keep-map {})",
+        DeepseekV4::arch_id(),
+        cfg.num_hidden_layers,
+        cfg.n_routed_experts,
+        if cfg.reap_keep.is_some() { "ACTIVE" } else { "off" },
+    );
+
+    eprintln!("Tokenizing...");
+    let t_tok = Instant::now();
+    let all_tokens: Vec<u32> = tokenizer.encode(&corpus);
+    eprintln!(
+        "Tokenized: {} tokens in {:.2}s",
+        all_tokens.len(),
+        t_tok.elapsed().as_secs_f64()
+    );
+
+    let end = (offset + ctx_len).min(all_tokens.len());
+    if end <= offset + warmup + 4 {
+        panic!("not enough tokens past offset={offset} for warmup={warmup} + scoring");
+    }
+    let window = &all_tokens[offset..end];
+    eprintln!(
+        "Window: offset={offset} ctx={} (warmup {warmup}, scoring {})",
+        window.len(),
+        window.len() - warmup - 1
+    );
+
+    let mut gpu = Gpu::init().expect("GPU init");
+    eprintln!("GPU: {}", gpu.arch.clone());
+    eprintln!("Loading weights from {model_path}...");
+    let t_load = Instant::now();
+    let mut state = DeepseekV4::new_state(&mut gpu, &cfg).expect("new_state");
+    let weights = DeepseekV4::load_weights(&mut hfq, &cfg, &mut gpu).expect("load_weights");
+    eprintln!("Loaded in {:.1}s", t_load.elapsed().as_secs_f64());
+
+    // Optional KLD logit dump.
+    let mut dump = dump_logits.as_ref().map(|p| {
+        let f = std::fs::File::create(p).expect("create dump-logits file");
+        let w = std::io::BufWriter::new(f);
+        eprintln!("Dumping full-vocab logits to {p}");
+        w
+    });
+    let scored_total = (window.len() - 1).saturating_sub(warmup);
+    if let Some(w) = dump.as_mut() {
+        w.write_all(b"DS4PPL01").unwrap();
+        w.write_all(&(0u32).to_le_bytes()).unwrap(); // vocab placeholder (patched at end)
+        w.write_all(&(scored_total as u32).to_le_bytes()).unwrap();
+    }
+
+    let mut total_nll: f64 = 0.0;
+    let mut scored: usize = 0;
+    let mut vocab_seen: u32 = 0;
+    let t0 = Instant::now();
+
+    for (pos, &tok) in window.iter().enumerate().take(window.len() - 1) {
+        let logits = decode_step(&cfg, &weights, &mut state, &mut gpu, tok, pos as u32)
+            .expect("decode_step");
+        if pos < warmup {
+            continue;
+        }
+        let target = window[pos + 1] as usize;
+        let nll = neg_log_softmax_at(&logits, target);
+        if !nll.is_finite() {
+            eprintln!("  warn: non-finite NLL at pos={pos} target={target}, skipping");
+            continue;
+        }
+        total_nll += nll as f64;
+        scored += 1;
+
+        if let Some(w) = dump.as_mut() {
+            vocab_seen = logits.len() as u32;
+            w.write_all(&(pos as u32).to_le_bytes()).unwrap();
+            w.write_all(&(target as u32).to_le_bytes()).unwrap();
+            let bytes: &[u8] = bytemuck_cast(&logits);
+            w.write_all(bytes).unwrap();
+        }
+
+        if scored == 1 || scored % 128 == 0 {
+            let avg_nll = total_nll / scored as f64;
+            let elapsed = t0.elapsed().as_secs_f64();
+            let rate = scored as f64 / elapsed.max(1e-9);
+            eprintln!(
+                "  pos={:5} scored={:5} nll/tok={:.4} ppl={:.3} ({:.2} tok/s)",
+                pos,
+                scored,
+                avg_nll,
+                avg_nll.exp(),
+                rate,
+            );
+        }
+    }
+
+    if let Some(mut w) = dump {
+        w.flush().unwrap();
+        drop(w);
+        // Patch the vocab field (offset 8) now that we know it.
+        if let Some(p) = dump_logits.as_ref() {
+            if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(p) {
+                use std::io::Seek;
+                f.seek(std::io::SeekFrom::Start(8)).unwrap();
+                f.write_all(&vocab_seen.to_le_bytes()).unwrap();
+            }
+        }
+    }
+
+    let avg_nll = if scored > 0 { total_nll / scored as f64 } else { 0.0 };
+    let ppl = avg_nll.exp();
+    let elapsed = t0.elapsed().as_secs_f64();
+    println!();
+    println!("Model:    {model_path}");
+    println!("Corpus:   {corpus_path}");
+    println!(
+        "Variant:  {}",
+        if cfg.reap_keep.is_some() {
+            format!("REAP keep-map ({} experts/layer)", cfg.n_routed_experts)
+        } else {
+            format!("full ({} experts/layer)", cfg.n_routed_experts)
+        }
+    );
+    println!("Tokens:   offset={offset} ctx={} warmup={warmup}", window.len());
+    println!("Scored:   {scored}");
+    println!("NLL/tok:  {avg_nll:.10}");
+    println!("PPL:      {ppl:.4}");
+    println!(
+        "Elapsed:  {:.1}s ({:.2} tok/s)",
+        elapsed,
+        scored as f64 / elapsed.max(1e-9)
+    );
+}
+
+fn neg_log_softmax_at(logits: &[f32], target: usize) -> f32 {
+    if target >= logits.len() {
+        return f32::NAN;
+    }
+    let mut max = f32::NEG_INFINITY;
+    for &v in logits {
+        if v > max {
+            max = v;
+        }
+    }
+    let mut sum = 0.0f64;
+    for &v in logits {
+        sum += ((v - max) as f64).exp();
+    }
+    let log_sum = max as f64 + sum.ln();
+    (log_sum - logits[target] as f64) as f32
+}
+
+/// Reinterpret &[f32] as &[u8] (little-endian host) for the logit dump.
+fn bytemuck_cast(v: &[f32]) -> &[u8] {
+    // SAFETY: f32 has no padding; we only read it as bytes for a binary dump
+    // consumed on the same host (little-endian).
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/hipfire-arch-deepseek4/src/arch.rs
+++ b/crates/hipfire-arch-deepseek4/src/arch.rs
@@ -167,7 +167,23 @@ impl DeepseekV4 {
         n_exp: usize,
         layer: &mut DeepseekV4LayerWeights,
         shard: Option<(&hipfire_runtime::tp_shard::ShardConfig, usize)>,
+        keep: Option<&[u32]>,
     ) -> Result<(), String> {
+        // REAP keep-map: compact slot `e` loads ORIGINAL expert `src(e)`.
+        // `keep = None` ⇒ identity (slot == original index), byte-identical
+        // to the full load. `n_exp` is the COMPACT count (kept) when active.
+        if keep.is_some() && shard.is_some() {
+            return Err("deepseek4: REAP keep-map + EP sharding are mutually exclusive".into());
+        }
+        if let Some(k) = keep {
+            if k.len() != n_exp {
+                return Err(format!(
+                    "deepseek4: {prefix} keep slice len {} != n_exp {n_exp}",
+                    k.len()
+                ));
+            }
+        }
+        let src = |slot: usize| -> usize { keep.map(|k| k[slot] as usize).unwrap_or(slot) };
         // EP shard: precompute owned set + compact-slot mapping. `shard = None`
         // ⇒ every expert owned, `local_of_global[e] == e`, n_owned == n_exp →
         // identical layout to the unsharded path.
@@ -188,7 +204,7 @@ impl DeepseekV4 {
         // Vec, then one upload. Non-owned experts are read for stride
         // validation, then dropped (never uploaded — the EP memory win).
         {
-            let name0 = format!("{prefix}.ffn.experts.0.w2.weight");
+            let name0 = format!("{prefix}.ffn.experts.{}.w2.weight", src(0));
             let (info0, _b0) = hfq
                 .tensor_data_pread(&name0)
                 .ok_or_else(|| format!("deepseek4: missing {name0}"))?;
@@ -205,7 +221,7 @@ impl DeepseekV4 {
                 if !owns(e) {
                     continue;
                 }
-                let name = format!("{prefix}.ffn.experts.{e}.w2.weight");
+                let name = format!("{prefix}.ffn.experts.{}.w2.weight", src(e));
                 let (info, bytes) = hfq
                     .tensor_data_pread(&name)
                     .ok_or_else(|| format!("deepseek4: missing {name}"))?;
@@ -249,8 +265,8 @@ impl DeepseekV4 {
         // gate_up (combined w1 ‖ w3): per-expert pread, pack ONLY owned, single
         // upload. Non-owned ptr → a shared ZEROED dummy gate_up buffer.
         {
-            let w1_0 = format!("{prefix}.ffn.experts.0.w1.weight");
-            let w3_0 = format!("{prefix}.ffn.experts.0.w3.weight");
+            let w1_0 = format!("{prefix}.ffn.experts.{}.w1.weight", src(0));
+            let w3_0 = format!("{prefix}.ffn.experts.{}.w3.weight", src(0));
             let (w1_info0, _b1) = hfq
                 .tensor_data_pread(&w1_0)
                 .ok_or_else(|| format!("deepseek4: missing {w1_0}"))?;
@@ -277,14 +293,14 @@ impl DeepseekV4 {
                 if !owns(e) {
                     continue;
                 }
-                let w1_name = format!("{prefix}.ffn.experts.{e}.w1.weight");
+                let w1_name = format!("{prefix}.ffn.experts.{}.w1.weight", src(e));
                 {
                     let (_, w1_bytes) = hfq
                         .tensor_data_pread(&w1_name)
                         .ok_or_else(|| format!("deepseek4: missing {w1_name}"))?;
                     combined.extend_from_slice(&w1_bytes);
                 }
-                let w3_name = format!("{prefix}.ffn.experts.{e}.w3.weight");
+                let w3_name = format!("{prefix}.ffn.experts.{}.w3.weight", src(e));
                 {
                     let (_, w3_bytes) = hfq
                         .tensor_data_pread(&w3_name)
@@ -363,6 +379,86 @@ impl DeepseekV4 {
             .collect();
         gpu.upload_f32(&f32_vals, &shape)
             .map_err(|e| format!("deepseek4: upload f16→f32 '{name}' failed: {e:?}"))
+    }
+
+    /// REAP keep-map variant of `upload_quant_or_f16`: byte row-gather only
+    /// the kept output rows (experts) before upload. Exact for row-major,
+    /// row-independent quant (F16 / Q8 / MQ*-G256) — each row's quant blocks
+    /// are self-contained, so a byte gather preserves the original encoding.
+    fn upload_quant_or_f16_keep(
+        hfq: &HfqFile,
+        gpu: &mut Gpu,
+        name: &str,
+        keep: &[u32],
+    ) -> Result<rdna_compute::GpuTensor, String> {
+        let (info, bytes) = hfq
+            .tensor_data_pread(name)
+            .ok_or_else(|| format!("deepseek4: tensor '{name}' missing in HFQ"))?;
+        let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
+        if orig_rows == 0 || bytes.len() % orig_rows != 0 {
+            return Err(format!(
+                "deepseek4: '{name}' row-gather: {orig_rows} rows don't divide {} bytes",
+                bytes.len()
+            ));
+        }
+        let rowstride = bytes.len() / orig_rows;
+        let mut sub = Vec::with_capacity(rowstride * keep.len());
+        for &oe in keep {
+            let oe = oe as usize;
+            if oe >= orig_rows {
+                return Err(format!("deepseek4: '{name}' keep idx {oe} >= rows {orig_rows}"));
+            }
+            sub.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
+        }
+        let mut shape: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+        shape[0] = keep.len();
+        let mut t = gpu
+            .upload_raw(&sub, &shape)
+            .map_err(|e| format!("deepseek4: upload keep-subset '{name}' failed: {e:?}"))?;
+        match info.quant_type {
+            1 => t.dtype = rdna_compute::DType::F16,
+            3 => t.dtype = rdna_compute::DType::Q8_0,
+            _ => {}
+        }
+        Ok(t)
+    }
+
+    /// REAP keep-map variant of `upload_global_f16_as_f32`: gather kept rows
+    /// of an F16 `[n_orig, ..]` (or `[n_orig]`) tensor, then decode to F32.
+    fn upload_global_f16_as_f32_keep(
+        hfq: &HfqFile,
+        gpu: &mut Gpu,
+        name: &str,
+        keep: &[u32],
+    ) -> Result<rdna_compute::GpuTensor, String> {
+        let (info, bytes) = hfq
+            .tensor_data_pread(name)
+            .ok_or_else(|| format!("deepseek4: tensor '{name}' missing in HFQ"))?;
+        let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
+        if orig_rows == 0 || bytes.len() % (orig_rows * 2) != 0 {
+            return Err(format!(
+                "deepseek4: '{name}' f16 keep-gather: {orig_rows} rows × 2B don't divide {} bytes",
+                bytes.len()
+            ));
+        }
+        let per_row = bytes.len() / (orig_rows * 2); // f16 elems per row
+        let mut f32_vals: Vec<f32> = Vec::with_capacity(per_row * keep.len());
+        for &oe in keep {
+            let oe = oe as usize;
+            if oe >= orig_rows {
+                return Err(format!("deepseek4: '{name}' keep idx {oe} >= rows {orig_rows}"));
+            }
+            let base = oe * per_row * 2;
+            for j in 0..per_row {
+                let lo = bytes[base + j * 2];
+                let hi = bytes[base + j * 2 + 1];
+                f32_vals.push(hipfire_runtime::llama::f16_to_f32(u16::from_le_bytes([lo, hi])));
+            }
+        }
+        let mut shape: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+        shape[0] = keep.len();
+        gpu.upload_f32(&f32_vals, &shape)
+            .map_err(|e| format!("deepseek4: upload f16→f32 keep '{name}' failed: {e:?}"))
     }
 
     pub fn load_weights_host_only_walk(
@@ -493,12 +589,18 @@ impl DeepseekV4 {
                     return Err(format!("deepseek4: layer {l} missing shared '{suffix}'"));
                 }
             }
-            // Routed experts: 256 × {w1, w2, w3}.
+            // Routed experts: kept × {w1, w2, w3}. `n_routed_experts` is the
+            // kept count under a REAP keep-map; remap slot → original index.
             for e in 0..cfg.n_routed_experts {
+                let e_src = cfg
+                    .reap_keep
+                    .as_ref()
+                    .map(|r| r.keep[l][e] as usize)
+                    .unwrap_or(e);
                 for proj in &["w1", "w2", "w3"] {
-                    let name = format!("layers.{l}.ffn.experts.{e}.{proj}.weight");
+                    let name = format!("layers.{l}.ffn.experts.{e_src}.{proj}.weight");
                     if hfq.find_tensor_info(&name).is_none() {
-                        return Err(format!("deepseek4: layer {l} expert {e} missing '{proj}'"));
+                        return Err(format!("deepseek4: layer {l} expert {e_src} missing '{proj}'"));
                     }
                 }
             }
@@ -902,17 +1004,22 @@ impl DeepseekV4 {
             // of actual quant. For Q8F16 routers (deepseek4-q8-mtp) that meant
             // reading Q8 bytes as MQ4 blocks → NaN logits at layer 3+
             // (the first non-hash layer that runs moe_route).
-            layer.gate_weight = Some(Self::upload_quant_or_f16(
-                hfq,
-                gpu,
-                &format!("layers.{l}.ffn.gate.weight"),
-            )?);
+            let gate_name = format!("layers.{l}.ffn.gate.weight");
+            layer.gate_weight = Some(match cfg.reap_keep.as_ref() {
+                Some(rk) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, &rk.keep[l])?,
+                None => Self::upload_quant_or_f16(hfq, gpu, &gate_name)?,
+            });
             if l >= cfg.num_hash_layers {
                 // Store F32 on GPU (was F16 on disk) so the bias can
                 // either be added on-device or downloaded once for CPU
                 // topk. Also cache host-side for the CPU-routing path.
                 let bias_name = format!("layers.{l}.ffn.gate.bias");
-                let bias_gpu = Self::upload_global_f16_as_f32(hfq, gpu, &bias_name)?;
+                let bias_gpu = match cfg.reap_keep.as_ref() {
+                    Some(rk) => {
+                        Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, &rk.keep[l])?
+                    }
+                    None => Self::upload_global_f16_as_f32(hfq, gpu, &bias_name)?,
+                };
                 layer.gate_bias_host = gpu
                     .download_f32(&bias_gpu)
                     .map_err(|e| format!("d2h gate_bias l{l}: {e:?}"))?;
@@ -923,7 +1030,18 @@ impl DeepseekV4 {
                 // at quant time, in which case forward falls back to
                 // shared-only on hash layers (current default behaviour).
                 let tid_name = format!("layers.{l}.ffn.gate.tid2eid");
-                if let Some((info, bytes)) = hfq.tensor_data_pread(&tid_name) {
+                if let Some((info, file_bytes)) = hfq.tensor_data_pread(&tid_name) {
+                    // Under a REAP keep-map the hash table is REMAPPED (pruned
+                    // experts redirected to kept ones, in 0..kept slot space);
+                    // read the sidecar table instead of the file's original.
+                    let bytes: Vec<u8> = match cfg.reap_keep.as_ref() {
+                        Some(rk) => {
+                            let p = rk.tid2eid_path(l);
+                            std::fs::read(&p)
+                                .map_err(|e| format!("deepseek4: REAP tid2eid read {p:?}: {e}"))?
+                        }
+                        None => file_bytes.to_vec(),
+                    };
                     if bytes.len() % 4 == 0 {
                         let vals: Vec<u32> = bytes
                             .chunks_exact(4)
@@ -991,11 +1109,17 @@ impl DeepseekV4 {
         if mtp_present {
             let load_mtp = std::env::var("HIPFIRE_DEEPSEEK4_LOAD_MTP")
                 .map(|s| s != "0")
-                .unwrap_or(true);
+                .unwrap_or(true)
+                && cfg.reap_keep.is_none();
             if !load_mtp {
                 eprintln!(
-                    "deepseek4: HFQ contains MTP layer but \
-                    HIPFIRE_DEEPSEEK4_LOAD_MTP=0 — skipping MTP upload"
+                    "deepseek4: skipping MTP upload ({})",
+                    if cfg.reap_keep.is_some() {
+                        "REAP keep-map active — MTP unused for PPL/KLD and would \
+                         need separate keep handling"
+                    } else {
+                        "HIPFIRE_DEEPSEEK4_LOAD_MTP=0"
+                    }
                 );
             } else {
                 eprintln!(
@@ -1221,6 +1345,7 @@ impl DeepseekV4 {
                     continue;
                 }
                 let n_exp = cfg.n_routed_experts;
+                let keep = cfg.reap_keep.as_ref().map(|r| r.keep[l].as_slice());
                 Self::upload_layer_routed_experts(
                     hfq,
                     gpu,
@@ -1228,6 +1353,7 @@ impl DeepseekV4 {
                     n_exp,
                     layer,
                     shard,
+                    keep,
                 )?;
             }
         }
@@ -1253,6 +1379,7 @@ impl DeepseekV4 {
                     cfg.n_routed_experts,
                     mtp,
                     shard,
+                    None, // MTP not loaded under REAP keep-map (see load_mtp guard)
                 )?;
             }
         }

--- a/crates/hipfire-arch-deepseek4/src/arch.rs
+++ b/crates/hipfire-arch-deepseek4/src/arch.rs
@@ -394,26 +394,10 @@ impl DeepseekV4 {
         let (info, bytes) = hfq
             .tensor_data_pread(name)
             .ok_or_else(|| format!("deepseek4: tensor '{name}' missing in HFQ"))?;
-        let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
-        if orig_rows == 0 || bytes.len() % orig_rows != 0 {
-            return Err(format!(
-                "deepseek4: '{name}' row-gather: {orig_rows} rows don't divide {} bytes",
-                bytes.len()
-            ));
-        }
-        let rowstride = bytes.len() / orig_rows;
-        let mut sub = Vec::with_capacity(rowstride * keep.len());
-        for &oe in keep {
-            let oe = oe as usize;
-            if oe >= orig_rows {
-                return Err(format!("deepseek4: '{name}' keep idx {oe} >= rows {orig_rows}"));
-            }
-            sub.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
-        }
-        let mut shape: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
-        shape[0] = keep.len();
+        let shape_usize: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+        let (new_shape, sub) = hipfire_reap::gather::gather_rows(&shape_usize, &bytes, keep)?;
         let mut t = gpu
-            .upload_raw(&sub, &shape)
+            .upload_raw(&sub, &new_shape)
             .map_err(|e| format!("deepseek4: upload keep-subset '{name}' failed: {e:?}"))?;
         match info.quant_type {
             1 => t.dtype = rdna_compute::DType::F16,
@@ -591,12 +575,9 @@ impl DeepseekV4 {
             }
             // Routed experts: kept × {w1, w2, w3}. `n_routed_experts` is the
             // kept count under a REAP keep-map; remap slot → original index.
+            let ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
             for e in 0..cfg.n_routed_experts {
-                let e_src = cfg
-                    .reap_keep
-                    .as_ref()
-                    .map(|r| r.keep[l][e] as usize)
-                    .unwrap_or(e);
+                let e_src = ep.as_ref().map(|p| p.src(e)).unwrap_or(e);
                 for proj in &["w1", "w2", "w3"] {
                     let name = format!("layers.{l}.ffn.experts.{e_src}.{proj}.weight");
                     if hfq.find_tensor_info(&name).is_none() {
@@ -1004,9 +985,14 @@ impl DeepseekV4 {
             // of actual quant. For Q8F16 routers (deepseek4-q8-mtp) that meant
             // reading Q8 bytes as MQ4 blocks → NaN logits at layer 3+
             // (the first non-hash layer that runs moe_route).
+            // Per-layer keep slice (None ⇒ keep-all / no plan ⇒ full upload).
+            let keep_l: Option<Vec<u32>> = cfg
+                .reap_keep
+                .as_ref()
+                .and_then(|r| r.expert_plan(l).keep().map(|k| k.to_vec()));
             let gate_name = format!("layers.{l}.ffn.gate.weight");
-            layer.gate_weight = Some(match cfg.reap_keep.as_ref() {
-                Some(rk) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, &rk.keep[l])?,
+            layer.gate_weight = Some(match keep_l.as_deref() {
+                Some(keep) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, keep)?,
                 None => Self::upload_quant_or_f16(hfq, gpu, &gate_name)?,
             });
             if l >= cfg.num_hash_layers {
@@ -1014,9 +1000,9 @@ impl DeepseekV4 {
                 // either be added on-device or downloaded once for CPU
                 // topk. Also cache host-side for the CPU-routing path.
                 let bias_name = format!("layers.{l}.ffn.gate.bias");
-                let bias_gpu = match cfg.reap_keep.as_ref() {
-                    Some(rk) => {
-                        Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, &rk.keep[l])?
+                let bias_gpu = match keep_l.as_deref() {
+                    Some(keep) => {
+                        Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, keep)?
                     }
                     None => Self::upload_global_f16_as_f32(hfq, gpu, &bias_name)?,
                 };
@@ -1035,8 +1021,8 @@ impl DeepseekV4 {
                     // experts redirected to kept ones, in 0..kept slot space);
                     // read the sidecar table instead of the file's original.
                     let bytes: Vec<u8> = match cfg.reap_keep.as_ref() {
-                        Some(rk) => {
-                            let p = rk.tid2eid_path(l);
+                        Some(plan) => {
+                            let p = crate::deepseek4::Ds4ReapHook::tid2eid_path(plan, l);
                             std::fs::read(&p)
                                 .map_err(|e| format!("deepseek4: REAP tid2eid read {p:?}: {e}"))?
                         }
@@ -1345,7 +1331,10 @@ impl DeepseekV4 {
                     continue;
                 }
                 let n_exp = cfg.n_routed_experts;
-                let keep = cfg.reap_keep.as_ref().map(|r| r.keep[l].as_slice());
+                let keep = cfg
+                    .reap_keep
+                    .as_ref()
+                    .and_then(|r| r.expert_plan(l).keep());
                 Self::upload_layer_routed_experts(
                     hfq,
                     gpu,

--- a/crates/hipfire-arch-deepseek4/src/arch.rs
+++ b/crates/hipfire-arch-deepseek4/src/arch.rs
@@ -18,6 +18,7 @@
 use crate::deepseek4::{
     DeepseekV4Config, DeepseekV4LayerWeights, DeepseekV4State, DeepseekV4Weights,
 };
+use hipfire_reap::hook::ReapArchHook;
 use hipfire_runtime::arch::Architecture;
 use hipfire_runtime::hfq::HfqFile;
 use rdna_compute::Gpu;
@@ -986,12 +987,9 @@ impl DeepseekV4 {
             // reading Q8 bytes as MQ4 blocks → NaN logits at layer 3+
             // (the first non-hash layer that runs moe_route).
             // Per-layer keep slice (None ⇒ keep-all / no plan ⇒ full upload).
-            let keep_l: Option<Vec<u32>> = cfg
-                .reap_keep
-                .as_ref()
-                .and_then(|r| r.expert_plan(l).keep().map(|k| k.to_vec()));
+            let ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
             let gate_name = format!("layers.{l}.ffn.gate.weight");
-            layer.gate_weight = Some(match keep_l.as_deref() {
+            layer.gate_weight = Some(match ep.as_ref().and_then(|p| p.keep()) {
                 Some(keep) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, keep)?,
                 None => Self::upload_quant_or_f16(hfq, gpu, &gate_name)?,
             });
@@ -1000,7 +998,7 @@ impl DeepseekV4 {
                 // either be added on-device or downloaded once for CPU
                 // topk. Also cache host-side for the CPU-routing path.
                 let bias_name = format!("layers.{l}.ffn.gate.bias");
-                let bias_gpu = match keep_l.as_deref() {
+                let bias_gpu = match ep.as_ref().and_then(|p| p.keep()) {
                     Some(keep) => {
                         Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, keep)?
                     }
@@ -1022,7 +1020,8 @@ impl DeepseekV4 {
                     // read the sidecar table instead of the file's original.
                     let bytes: Vec<u8> = match cfg.reap_keep.as_ref() {
                         Some(plan) => {
-                            let p = crate::deepseek4::Ds4ReapHook::tid2eid_path(plan, l);
+                            let p = crate::deepseek4::Ds4ReapHook
+                                .sidecar_path(plan, &format!("tid2eid_l{l}.i32"));
                             std::fs::read(&p)
                                 .map_err(|e| format!("deepseek4: REAP tid2eid read {p:?}: {e}"))?
                         }

--- a/crates/hipfire-arch-deepseek4/src/deepseek4.rs
+++ b/crates/hipfire-arch-deepseek4/src/deepseek4.rs
@@ -106,7 +106,7 @@ pub struct DeepseekV4Config {
     /// of an existing full quant — no re-quant. Not (de)serialized;
     /// populated at load time from the sidecar.
     #[serde(skip)]
-    pub reap_keep: Option<std::sync::Arc<ReapKeepMap>>,
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 /// Raw upstream JSON shape — only the fields we read. Used to drive
@@ -223,107 +223,45 @@ impl DeepseekV4Config {
             num_hash_layers: raw.num_hash_layers,
             reap_keep: None,
         };
-        // Optional REAP keep-map: emulate a pruned expert pool (e.g. 162B
+        // Optional REAP plan: emulate a pruned expert pool (e.g. 162B
         // 256→144) by partial-loading this full quant. Read BEFORE the
         // n_routed_experts override so validation sees the original count.
-        if let Ok(dir) = std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP") {
-            let km = ReapKeepMap::load(&dir, config.num_hidden_layers, config.n_routed_experts)?;
+        // New generic env HIPFIRE_REAP_PLAN=<dir> (reap_plan.json); legacy
+        // HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir> (keep_by_layer.json) is still
+        // honored as a keep-only alias via ReapPlan::load_any.
+        let reap_dir = std::env::var("HIPFIRE_REAP_PLAN")
+            .ok()
+            .or_else(|| std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP").ok());
+        if let Some(dir) = reap_dir {
+            let plan = hipfire_reap::plan::ReapPlan::load_any(
+                &dir,
+                config.num_hidden_layers,
+                config.n_routed_experts,
+            )?;
             eprintln!(
-                "deepseek4: REAP keep-map ACTIVE — keeping {} of {} routed experts/layer; sidecar {dir}",
-                km.kept_per_layer, config.n_routed_experts
+                "deepseek4: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+                plan.kept_per_layer(),
+                config.n_routed_experts
             );
-            config.n_routed_experts = km.kept_per_layer;
-            config.reap_keep = Some(std::sync::Arc::new(km));
+            config.n_routed_experts = plan.kept_per_layer();
+            config.reap_keep = Some(std::sync::Arc::new(plan));
         }
         Ok(config)
     }
 }
 
-/// REAP keep-map: per-layer list of kept routed-expert indices (in compact
-/// slot order) plus the sidecar dir holding remapped hash-router `tid2eid`
-/// tables. Built by tooling from a REAP `reap_plan.json` + the pruned
-/// checkpoint. Activated via `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>`.
-#[derive(Debug)]
-pub struct ReapKeepMap {
-    pub kept_per_layer: usize,
-    pub num_layers: usize,
-    pub original_experts: usize,
-    /// `keep[l][slot]` = original expert index loaded into compact slot `slot`.
-    pub keep: Vec<Vec<u32>>,
-    pub sidecar_dir: std::path::PathBuf,
-}
+/// DeepSeek-V4-specific REAP extras. The generic `hipfire-reap` plan owns the
+/// keep-map; this hook owns the arch-specific sidecar layout — here, the
+/// remapped hash-router `tid2eid` tables that live alongside the plan dir.
+pub struct Ds4ReapHook;
 
-impl ReapKeepMap {
-    /// Load `<dir>/keep_by_layer.json` and validate against the model's
-    /// layer/expert counts (passed BEFORE n_routed_experts is overridden).
-    pub fn load(
-        dir: &str,
-        num_layers_expected: usize,
-        orig_experts_expected: usize,
-    ) -> Result<Self, String> {
-        let path = std::path::Path::new(dir).join("keep_by_layer.json");
-        let txt = std::fs::read_to_string(&path)
-            .map_err(|e| format!("deepseek4: REAP keep-map read {path:?}: {e}"))?;
-        let v: serde_json::Value = serde_json::from_str(&txt)
-            .map_err(|e| format!("deepseek4: REAP keep-map parse {path:?}: {e}"))?;
-        let kept = v["kept_per_layer"]
-            .as_u64()
-            .ok_or("deepseek4: REAP keep-map missing kept_per_layer")? as usize;
-        let orig = v["original_experts"]
-            .as_u64()
-            .unwrap_or(orig_experts_expected as u64) as usize;
-        if orig != orig_experts_expected {
-            return Err(format!(
-                "deepseek4: REAP keep-map original_experts {orig} != model n_routed_experts {orig_experts_expected}"
-            ));
-        }
-        let keep_arr = v["keep"]
-            .as_array()
-            .ok_or("deepseek4: REAP keep-map missing `keep` array")?;
-        if keep_arr.len() != num_layers_expected {
-            return Err(format!(
-                "deepseek4: REAP keep-map has {} layers, model has {num_layers_expected}",
-                keep_arr.len()
-            ));
-        }
-        let mut keep = Vec::with_capacity(keep_arr.len());
-        for (l, row) in keep_arr.iter().enumerate() {
-            let r = row
-                .as_array()
-                .ok_or_else(|| format!("deepseek4: REAP keep layer {l} not an array"))?;
-            if r.len() != kept {
-                return Err(format!(
-                    "deepseek4: REAP keep layer {l} has {} entries, expected {kept}",
-                    r.len()
-                ));
-            }
-            let mut v32 = Vec::with_capacity(kept);
-            for x in r {
-                let idx = x
-                    .as_u64()
-                    .ok_or_else(|| format!("deepseek4: REAP keep layer {l} non-integer index"))?
-                    as u32;
-                if idx as usize >= orig {
-                    return Err(format!(
-                        "deepseek4: REAP keep layer {l} index {idx} >= original_experts {orig}"
-                    ));
-                }
-                v32.push(idx);
-            }
-            keep.push(v32);
-        }
-        Ok(Self {
-            kept_per_layer: kept,
-            num_layers: num_layers_expected,
-            original_experts: orig,
-            keep,
-            sidecar_dir: std::path::PathBuf::from(dir),
-        })
-    }
+impl hipfire_reap::hook::ReapArchHook for Ds4ReapHook {}
 
-    /// Path to the remapped hash-router `tid2eid` table for a hash layer.
-    pub fn tid2eid_path(&self, layer: usize) -> std::path::PathBuf {
-        self.sidecar_dir.join(format!("tid2eid_l{layer}.i32"))
+impl Ds4ReapHook {
+    /// Path to the remapped hash-router `tid2eid` table for a hash layer,
+    /// inside the plan dir. Preserves the legacy `tid2eid_l{layer}.i32` name.
+    pub fn tid2eid_path(plan: &hipfire_reap::plan::ReapPlan, layer: usize) -> std::path::PathBuf {
+        plan.dir.join(format!("tid2eid_l{layer}.i32"))
     }
 }
 

--- a/crates/hipfire-arch-deepseek4/src/deepseek4.rs
+++ b/crates/hipfire-arch-deepseek4/src/deepseek4.rs
@@ -96,6 +96,17 @@ pub struct DeepseekV4Config {
 
     // ── hash-routing (DeepSeek V4-only) ─────────────────────────────────
     pub num_hash_layers: usize,
+
+    // ── REAP keep-map (optional expert-pruning emulation) ───────────────
+    /// When set (via `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>`), the loader
+    /// keeps only `keep[l]` of the original routed experts per layer,
+    /// packed into compact slots `0..kept_per_layer`, and overrides
+    /// `n_routed_experts` to that kept count. Lets us emulate a
+    /// REAP-pruned checkpoint (e.g. 0xSero 162B, 256→144) by partial-load
+    /// of an existing full quant — no re-quant. Not (de)serialized;
+    /// populated at load time from the sidecar.
+    #[serde(skip)]
+    pub reap_keep: Option<std::sync::Arc<ReapKeepMap>>,
 }
 
 /// Raw upstream JSON shape — only the fields we read. Used to drive
@@ -170,7 +181,7 @@ impl DeepseekV4Config {
             .ok_or_else(|| "deepseek4: metadata_json missing `config` wrapper".to_string())?;
         let raw: RawDeepseekV4Config = serde_json::from_value(inner.clone())
             .map_err(|e| format!("deepseek4: parsing inner config failed: {e}"))?;
-        Ok(DeepseekV4Config {
+        let mut config = DeepseekV4Config {
             vocab_size: raw.vocab_size,
             hidden_size: raw.hidden_size,
             num_hidden_layers: raw.num_hidden_layers,
@@ -210,7 +221,109 @@ impl DeepseekV4Config {
             sliding_window: raw.sliding_window,
             num_nextn_predict_layers: raw.num_nextn_predict_layers,
             num_hash_layers: raw.num_hash_layers,
+            reap_keep: None,
+        };
+        // Optional REAP keep-map: emulate a pruned expert pool (e.g. 162B
+        // 256→144) by partial-loading this full quant. Read BEFORE the
+        // n_routed_experts override so validation sees the original count.
+        if let Ok(dir) = std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP") {
+            let km = ReapKeepMap::load(&dir, config.num_hidden_layers, config.n_routed_experts)?;
+            eprintln!(
+                "deepseek4: REAP keep-map ACTIVE — keeping {} of {} routed experts/layer; sidecar {dir}",
+                km.kept_per_layer, config.n_routed_experts
+            );
+            config.n_routed_experts = km.kept_per_layer;
+            config.reap_keep = Some(std::sync::Arc::new(km));
+        }
+        Ok(config)
+    }
+}
+
+/// REAP keep-map: per-layer list of kept routed-expert indices (in compact
+/// slot order) plus the sidecar dir holding remapped hash-router `tid2eid`
+/// tables. Built by tooling from a REAP `reap_plan.json` + the pruned
+/// checkpoint. Activated via `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>`.
+#[derive(Debug)]
+pub struct ReapKeepMap {
+    pub kept_per_layer: usize,
+    pub num_layers: usize,
+    pub original_experts: usize,
+    /// `keep[l][slot]` = original expert index loaded into compact slot `slot`.
+    pub keep: Vec<Vec<u32>>,
+    pub sidecar_dir: std::path::PathBuf,
+}
+
+impl ReapKeepMap {
+    /// Load `<dir>/keep_by_layer.json` and validate against the model's
+    /// layer/expert counts (passed BEFORE n_routed_experts is overridden).
+    pub fn load(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = std::path::Path::new(dir).join("keep_by_layer.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("deepseek4: REAP keep-map read {path:?}: {e}"))?;
+        let v: serde_json::Value = serde_json::from_str(&txt)
+            .map_err(|e| format!("deepseek4: REAP keep-map parse {path:?}: {e}"))?;
+        let kept = v["kept_per_layer"]
+            .as_u64()
+            .ok_or("deepseek4: REAP keep-map missing kept_per_layer")? as usize;
+        let orig = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if orig != orig_experts_expected {
+            return Err(format!(
+                "deepseek4: REAP keep-map original_experts {orig} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let keep_arr = v["keep"]
+            .as_array()
+            .ok_or("deepseek4: REAP keep-map missing `keep` array")?;
+        if keep_arr.len() != num_layers_expected {
+            return Err(format!(
+                "deepseek4: REAP keep-map has {} layers, model has {num_layers_expected}",
+                keep_arr.len()
+            ));
+        }
+        let mut keep = Vec::with_capacity(keep_arr.len());
+        for (l, row) in keep_arr.iter().enumerate() {
+            let r = row
+                .as_array()
+                .ok_or_else(|| format!("deepseek4: REAP keep layer {l} not an array"))?;
+            if r.len() != kept {
+                return Err(format!(
+                    "deepseek4: REAP keep layer {l} has {} entries, expected {kept}",
+                    r.len()
+                ));
+            }
+            let mut v32 = Vec::with_capacity(kept);
+            for x in r {
+                let idx = x
+                    .as_u64()
+                    .ok_or_else(|| format!("deepseek4: REAP keep layer {l} non-integer index"))?
+                    as u32;
+                if idx as usize >= orig {
+                    return Err(format!(
+                        "deepseek4: REAP keep layer {l} index {idx} >= original_experts {orig}"
+                    ));
+                }
+                v32.push(idx);
+            }
+            keep.push(v32);
+        }
+        Ok(Self {
+            kept_per_layer: kept,
+            num_layers: num_layers_expected,
+            original_experts: orig,
+            keep,
+            sidecar_dir: std::path::PathBuf::from(dir),
         })
+    }
+
+    /// Path to the remapped hash-router `tid2eid` table for a hash layer.
+    pub fn tid2eid_path(&self, layer: usize) -> std::path::PathBuf {
+        self.sidecar_dir.join(format!("tid2eid_l{layer}.i32"))
     }
 }
 

--- a/crates/hipfire-arch-deepseek4/src/deepseek4.rs
+++ b/crates/hipfire-arch-deepseek4/src/deepseek4.rs
@@ -257,14 +257,6 @@ pub struct Ds4ReapHook;
 
 impl hipfire_reap::hook::ReapArchHook for Ds4ReapHook {}
 
-impl Ds4ReapHook {
-    /// Path to the remapped hash-router `tid2eid` table for a hash layer,
-    /// inside the plan dir. Preserves the legacy `tid2eid_l{layer}.i32` name.
-    pub fn tid2eid_path(plan: &hipfire_reap::plan::ReapPlan, layer: usize) -> std::path::PathBuf {
-        plan.dir.join(format!("tid2eid_l{layer}.i32"))
-    }
-}
-
 /// Per-layer GPU-resident weights. Slots match DeepSeek V4 shipped tensor
 /// inventory; each is `Option<GpuTensor>` so partial-upload paths
 /// (host walk only / minimal upload / full upload) can populate

--- a/crates/hipfire-arch-lfm2moe/Cargo.toml
+++ b/crates/hipfire-arch-lfm2moe/Cargo.toml
@@ -11,6 +11,7 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 rdna-compute = { path = "../rdna-compute" }
 hip-bridge = { path = "../hip-bridge" }
+hipfire-reap = { path = "../hipfire-reap" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/hipfire-arch-lfm2moe/src/config.rs
+++ b/crates/hipfire-arch-lfm2moe/src/config.rs
@@ -56,6 +56,14 @@ pub struct Lfm2MoeConfig {
     pub tie_word_embeddings: bool,
     /// Per-layer mixer choice (length == num_hidden_layers).
     pub layer_types: Vec<MixerKind>,
+
+    /// Optional REAP keep-map: emulate a pruned routed-expert pool by
+    /// partial-loading this full quant (load only the kept experts under
+    /// remapped names, gather the router's expert rows to the kept set).
+    /// Populated at config time from `HIPFIRE_REAP_PLAN=<dir>`; `None` ⇒
+    /// no pruning (today's behavior, byte-identical to baseline). Not
+    /// (de)serialized — `Lfm2MoeConfig` derives only `Clone`/`Debug`.
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 #[derive(Deserialize)]
@@ -138,6 +146,44 @@ fn default_routed_scale() -> f32 {
     1.0
 }
 
+/// Apply an optional REAP keep-map to a freshly parsed `Lfm2MoeConfig`.
+///
+/// Reads `HIPFIRE_REAP_PLAN=<dir>` (lfm2moe has no legacy env alias). When
+/// set, loads `<dir>/reap_plan.json` (or the legacy `keep_by_layer.json`)
+/// via `ReapPlan::load_any`, validating against the ORIGINAL routed-expert
+/// count (`config.num_experts`) BEFORE overriding it to the kept count.
+/// This emulates a pruned expert pool by partial-loading the full quant:
+/// only kept experts are loaded (under remapped names) and the router's
+/// expert rows are gathered to the kept set in the MoE loader.
+///
+/// No env ⇒ no-op (`config.reap_keep` stays `None`); the MoE loader then
+/// takes the literal original full-load path — byte-identical to baseline.
+pub fn apply_reap_plan(config: &mut Lfm2MoeConfig) -> Result<(), String> {
+    let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
+        return Ok(());
+    };
+    // MoE-only feature: a dense (num_experts==0) checkpoint has no routed
+    // experts to prune. Refuse rather than silently divide-by-zero / mislead.
+    if config.num_experts == 0 {
+        return Err(format!(
+            "lfm2moe: HIPFIRE_REAP_PLAN={dir} set but this is a dense (num_experts==0) checkpoint"
+        ));
+    }
+    let plan = hipfire_reap::plan::ReapPlan::load_any(
+        &dir,
+        config.num_hidden_layers,
+        config.num_experts,
+    )?;
+    eprintln!(
+        "lfm2moe: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.num_experts
+    );
+    config.num_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+    Ok(())
+}
+
 impl Lfm2MoeConfig {
     pub fn from_hfq(hfq: &HfqFile) -> Result<Self, String> {
         let wrapper: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
@@ -145,7 +191,18 @@ impl Lfm2MoeConfig {
         let inner = wrapper
             .get("config")
             .ok_or_else(|| "lfm2moe: metadata_json missing `config` wrapper".to_string())?;
-        Self::from_config_value(inner)
+        let mut config = Self::from_config_value(inner)?;
+        // Apply the optional REAP keep-map HERE, inside the single public HFQ
+        // config entry point, so it is IMPOSSIBLE to bypass. `from_hfq` is the
+        // ONLY public HFQ→config path — the daemon (daemon.rs) and every
+        // example (infer/kld/graph_parity/dump) call it directly; there is no
+        // `Architecture` trait shim for lfm2moe to wire it into separately.
+        // Applied AFTER parse so validation sees the ORIGINAL num_experts;
+        // overrides num_experts to the kept count when active. No env ⇒ no-op
+        // (baseline behavior, byte-identical). `?`-propagates a malformed plan
+        // (REAP is opt-in: a bad plan must hard-fail, never silently no-op).
+        apply_reap_plan(&mut config)?;
+        Ok(config)
     }
 
     /// Parse from a raw `config.json` Value (the inner `config` blob).
@@ -222,6 +279,7 @@ impl Lfm2MoeConfig {
             routed_scaling_factor: raw.routed_scaling_factor,
             tie_word_embeddings: raw.tie_word_embeddings,
             layer_types,
+            reap_keep: None,
         })
     }
 

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -162,8 +162,10 @@ fn load_wt(
 /// for any row-independent quant (every per-expert row is self-contained — its
 /// own scale/zero/codebook live in the row), which holds for every quant_type
 /// `wt_from_raw` accepts. `keep` MUST be in compact slot order and `m` MUST
-/// equal `keep.len()`. Reads owned bytes via the same `read_tensor` helper as
-/// the non-keep path (pread-based `tensor_data_vec`), so no fresh-alloc API.
+/// equal `keep.len()`. Reads owned bytes via `hfq.tensor_data_vec` directly
+/// (bypassing the `read_tensor` wrapper) to retain `info.shape` for deriving
+/// the original row count — the non-keep path uses `read_tensor`, which
+/// discards `info`.
 fn load_wt_keep(
     hfq: &HfqFile,
     gpu: &mut Gpu,
@@ -494,7 +496,7 @@ impl Lfm2MoeWeights {
                 // index loaded into slot (slot==e on the no-keep identity path).
                 let mut experts = Vec::with_capacity(n_exp);
                 for slot in 0..n_exp {
-                    let e = reap_ep.as_ref().map(|p| p.src(slot)).unwrap_or(slot);
+                    let e = reap_ep.as_ref().map(|ep| ep.src(slot)).unwrap_or(slot);
                     let ep = format!("{p}.feed_forward.experts.{e}");
                     let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                     let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -87,6 +87,49 @@ fn load_f32(
         .map_err(|e| format!("lfm2moe: upload {name}: {e:?}"))
 }
 
+/// REAP keep variant of [`load_f32`] for a 1-D per-expert vector (the MoE
+/// `expert_bias`, shape `[orig_experts]`): gather the kept elements BEFORE
+/// dequant, then upload as `[keep.len()]`. Each element is one expert's bias,
+/// fully self-contained (F16/F32 are trivially row-independent; Q8_0's 32-elem
+/// blocks would NOT be element-gatherable, but expert_bias ships as F16/F32 —
+/// guarded below). `m` MUST equal `keep.len()`.
+fn load_f32_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    keep: &[u32],
+) -> Result<GpuTensor, String> {
+    debug_assert_eq!(m, keep.len(), "load_f32_keep: m must equal keep.len()");
+    let (qt, data) = read_tensor(hfq, name)?;
+    // Per-element width for the row-gather. Q8_0 packs 32 elems/block, so a
+    // single bias element is not a whole row — refuse rather than corrupt.
+    let elem_bytes = match qt {
+        1 => 2, // F16
+        2 => 4, // F32
+        other => {
+            return Err(format!(
+                "lfm2moe: expert_bias {name} keep-gather needs F16/F32, got qt={other}"
+            ))
+        }
+    };
+    let orig = data.len() / elem_bytes;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("lfm2moe: expert_bias row-gather '{name}': {e}"))?;
+    let f32_data: Vec<f32> = match qt {
+        1 => sub
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        _ => sub
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    };
+    gpu.upload_f32(&f32_data, &[m])
+        .map_err(|e| format!("lfm2moe: upload {name}: {e:?}"))
+}
+
 /// Minimal Q8_0 dequant (32-elem blocks: little-endian f16 scale + 32 int8).
 fn dequant_q8_0(data: &[u8]) -> Vec<f32> {
     let mut out = Vec::with_capacity(data.len() / 34 * 32);
@@ -108,6 +151,38 @@ fn load_wt(
 ) -> Result<WeightTensor, String> {
     let (qt, data) = read_tensor(hfq, name)?;
     wt_from_raw(gpu, qt, &data, m, k).map_err(|e| format!("lfm2moe: load_wt {name}: {e}"))
+}
+
+/// REAP keep variant of [`load_wt`]: gather the tensor's first-axis rows (one
+/// row per ORIGINAL expert) down to `keep` BEFORE quant decode, then build the
+/// `WeightTensor` from the gathered bytes with `m = keep.len()`.
+///
+/// Only used for the MoE router (`feed_forward.gate.weight`, shape
+/// `[orig_experts, hidden]`) under an active keep-map. `gather_rows` is exact
+/// for any row-independent quant (every per-expert row is self-contained — its
+/// own scale/zero/codebook live in the row), which holds for every quant_type
+/// `wt_from_raw` accepts. `keep` MUST be in compact slot order and `m` MUST
+/// equal `keep.len()`. Reads owned bytes via the same `read_tensor` helper as
+/// the non-keep path (pread-based `tensor_data_vec`), so no fresh-alloc API.
+fn load_wt_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+    keep: &[u32],
+) -> Result<WeightTensor, String> {
+    debug_assert_eq!(m, keep.len(), "load_wt_keep: m must equal keep.len()");
+    let (info, data) = hfq
+        .tensor_data_vec(name)
+        .ok_or_else(|| format!("lfm2moe: tensor not found in HFQ: {name}"))?;
+    // The on-disk first-axis length is the ORIGINAL expert count; gather_rows
+    // derives the rowstride from shape[0] and selects the kept rows.
+    let orig = *info.shape.first().unwrap_or(&0) as usize;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("lfm2moe: router row-gather '{name}': {e}"))?;
+    wt_from_raw(gpu, info.quant_type, &sub, m, k)
+        .map_err(|e| format!("lfm2moe: load_wt_keep {name}: {e}"))
 }
 
 /// quant_type → DType mapping (mirrors minimax::wt_from_raw); uploads raw
@@ -370,18 +445,56 @@ impl Lfm2MoeWeights {
                 )?;
                 Ffn::Dense(DenseFfn { w1, w3, w2 })
             } else {
-                let router = load_wt(
-                    hfq,
-                    gpu,
-                    &format!("{p}.feed_forward.gate.weight"),
-                    n_exp,
-                    hidden,
-                )?;
-                let expert_bias =
-                    load_f32(hfq, gpu, &format!("{p}.feed_forward.expert_bias"), &[n_exp])?;
+                // REAP keep-map for this layer (None ⇒ no pruning / identity).
+                // When a keep is present, `n_exp == cfg.num_experts` is already
+                // the KEPT count (overridden in apply_reap_plan); the router and
+                // expert loops below load only the kept original experts, in
+                // compact slot order.
+                let reap_ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
+                let keep_l = reap_ep.as_ref().and_then(|e| e.keep());
+
+                // Router: hidden → n_exp. Under a keep, gather the router's
+                // expert rows (`[orig_experts, hidden]`) down to the kept set so
+                // it emits logits only for kept experts, in compact slot order.
+                // No keep ⇒ the literal original full load.
+                let router = match keep_l {
+                    Some(keep) => load_wt_keep(
+                        hfq,
+                        gpu,
+                        &format!("{p}.feed_forward.gate.weight"),
+                        n_exp,
+                        hidden,
+                        keep,
+                    )?,
+                    None => load_wt(
+                        hfq,
+                        gpu,
+                        &format!("{p}.feed_forward.gate.weight"),
+                        n_exp,
+                        hidden,
+                    )?,
+                };
+                // expert_bias is a 1-D [orig_experts] F32 vector indexed by
+                // expert; under a keep it must also be gathered to the kept set
+                // (parallel to the router rows). No keep ⇒ literal original load.
+                let expert_bias = match keep_l {
+                    Some(keep) => load_f32_keep(
+                        hfq,
+                        gpu,
+                        &format!("{p}.feed_forward.expert_bias"),
+                        n_exp,
+                        keep,
+                    )?,
+                    None => {
+                        load_f32(hfq, gpu, &format!("{p}.feed_forward.expert_bias"), &[n_exp])?
+                    }
+                };
                 // Byte-fuse w1‖w3 → gate_up [2*moe_inter, hidden]; w2 → down.
+                // Iterate compact slots `0..n_exp`; `e` = the ORIGINAL expert
+                // index loaded into slot (slot==e on the no-keep identity path).
                 let mut experts = Vec::with_capacity(n_exp);
-                for e in 0..n_exp {
+                for slot in 0..n_exp {
+                    let e = reap_ep.as_ref().map(|p| p.src(slot)).unwrap_or(slot);
                     let ep = format!("{p}.feed_forward.experts.{e}");
                     let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                     let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
@@ -392,16 +505,26 @@ impl Lfm2MoeWeights {
                     let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
                     let mut down = wt_from_raw(gpu, qt2, &w2, hidden, moe_inter)
                         .map_err(|e2| format!("lfm2moe: down L{l}E{e}: {e2}"))?;
-                    // AWQ scales: shared per layer, emitted once on expert 0 by the
+                    // AWQ scales: LAYER-SHARED, emitted once on expert 0 by the
                     // quantizer (full port of minimax 3c676d00 BOTH-projection AWQ).
-                    // Attach the gate_up scale (len hidden) to expert 0's gate_up and
-                    // the down scale (len moe_inter) to expert 0's down; the forward
+                    // The scale tensors are NOT expert-indexed — their names are
+                    // `{p}.feed_forward.awq_scale_{gate_up,down}.weight` and their
+                    // lengths are `hidden` / `moe_inter` (per-projection dims, NOT
+                    // per-expert), so they are INVARIANT under a REAP keep and load
+                    // UNCHANGED. We attach them to the representative FIRST COMPACT
+                    // SLOT (`slot == 0`, i.e. `experts[0]`) — the same slot the
+                    // forward reads from — regardless of which original expert it
+                    // maps to. Gate on `slot == 0` (not `e == 0`): under a keep the
+                    // original expert 0 may be pruned, so `e == 0` could never fire
+                    // (dropping the scale) or fire on a non-representative slot.
+                    // Attach the gate_up scale (len hidden) to slot 0's gate_up and
+                    // the down scale (len moe_inter) to slot 0's down; the forward
                     // reads both from experts[0] and divides x/s in the unrotated
                     // basis via the AWQ-aware rotate_x_mq_for (gate_up input) and
                     // fused_silu_mul_rotate_mq_batched_for (post-SwiGLU intermediate
                     // for down). down (w2) is the most quant-sensitive proj, so its
                     // AWQ is the whole point. No-op on non-AWQ files.
-                    if e == 0 {
+                    if slot == 0 {
                         gate_up.awq_scale = load_lfm2_awq_scale(
                             hfq,
                             gpu,

--- a/crates/hipfire-arch-minimax/Cargo.toml
+++ b/crates/hipfire-arch-minimax/Cargo.toml
@@ -18,5 +18,6 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
+hipfire-reap = { path = "../hipfire-reap" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -173,6 +173,9 @@ pub fn apply_reap_plan(config: &mut MiniMaxConfig) -> Result<(), String> {
     let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
         return Ok(());
     };
+    if config.num_local_experts == 0 {
+        return Err(format!("minimax: HIPFIRE_REAP_PLAN={dir} set but num_local_experts == 0 (not a MoE checkpoint)"));
+    }
     let plan = hipfire_reap::plan::ReapPlan::load_any(
         &dir,
         config.num_hidden_layers,
@@ -306,6 +309,8 @@ fn load_norm_keep(
 ) -> Result<GpuTensor, String> {
     debug_assert_eq!(m, keep.len(), "minimax load_norm_keep: m must equal keep.len()");
     let (qt, data) = read_tensor(hfq, name)?;
+    // Per-element width for the row-gather. Q8_0 packs 32 elems/block, so a
+    // single bias element is not a whole row — refuse rather than corrupt.
     let elem_bytes = match qt {
         1 => 2, // F16
         2 => 4, // F32

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -43,6 +43,11 @@ pub struct MiniMaxConfig {
     pub scoring_func: String,
     /// MTP draft modules (spec-decode; 0 for the base forward / this ckpt).
     pub num_mtp_modules: usize,
+    /// Optional REAP keep-map: emulate a pruned expert pool by partial-loading
+    /// this full quant. Populated at config time from `HIPFIRE_REAP_PLAN=<dir>`;
+    /// `None` ⇒ no pruning (literal original full load, byte-identical to
+    /// baseline). Not (de)serialized — set in `apply_reap_plan`.
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 #[derive(Deserialize)]
@@ -103,7 +108,7 @@ impl MiniMaxConfig {
         let head_dim = raw
             .head_dim
             .unwrap_or(raw.hidden_size / raw.num_attention_heads);
-        Ok(MiniMaxConfig {
+        let mut config = MiniMaxConfig {
             vocab_size: raw.vocab_size,
             hidden_size: raw.hidden_size,
             num_hidden_layers: raw.num_hidden_layers,
@@ -121,7 +126,23 @@ impl MiniMaxConfig {
             use_routing_bias: raw.use_routing_bias,
             scoring_func: raw.scoring_func,
             num_mtp_modules: raw.num_mtp_modules,
-        })
+            reap_keep: None,
+        };
+        // Apply the optional REAP keep-map HERE, inside the single public config
+        // entry point, so it is IMPOSSIBLE to bypass. Every caller funnels
+        // through `MiniMaxConfig::from_hfq` — the daemon (via the `Architecture`
+        // trait's `config_from_hfq`, which just delegates here) AND every
+        // example (`infer_minimax`, `ep_minimax`, `dump_minimax_hidden_states`,
+        // `debug_minimax_batch`) which call `MiniMaxConfig::from_hfq` directly,
+        // never through the trait. Wiring REAP only in the trait shim would
+        // silently ignore HIPFIRE_REAP_PLAN on all the direct callers. The trait
+        // impl therefore does NOT re-apply (double-apply ⇒ kept-of-kept ⇒
+        // load_any validation error). `from_hfq` returns `Result`, so a
+        // malformed plan propagates cleanly via `?` (REAP is opt-in ⇒ a user who
+        // explicitly set HIPFIRE_REAP_PLAN MUST hard-fail). With no env var,
+        // `apply_reap_plan` is a no-op (Ok), so baseline behavior is unchanged.
+        apply_reap_plan(&mut config)?;
+        Ok(config)
     }
 
     /// q projection output width (n_heads * head_dim).
@@ -132,6 +153,39 @@ impl MiniMaxConfig {
     pub fn kv_dim(&self) -> usize {
         self.num_key_value_heads * self.head_dim
     }
+}
+
+/// Apply an optional REAP keep-map to a freshly parsed `MiniMaxConfig`.
+///
+/// Reads `HIPFIRE_REAP_PLAN=<dir>` (minimax has no legacy env alias). When set,
+/// loads `<dir>/reap_plan.json` (or the legacy `keep_by_layer.json`) via
+/// `ReapPlan::load_any`, validating against the ORIGINAL local-expert count
+/// (`config.num_local_experts`) BEFORE overriding it to the kept count. This
+/// emulates a pruned expert pool by partial-loading the full quant: only kept
+/// experts are packed into the per-layer blob (under remapped names) and the
+/// router's expert rows + routing bias are gathered to the kept set in
+/// `MiniMaxWeights::load`.
+///
+/// No env ⇒ no-op (`config.reap_keep` stays `None`); the loader then takes the
+/// literal original full-load path — byte-identical to baseline. REAP and EP
+/// sharding are MUTUALLY EXCLUSIVE; that guard lives in `MiniMaxWeights::load`.
+pub fn apply_reap_plan(config: &mut MiniMaxConfig) -> Result<(), String> {
+    let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
+        return Ok(());
+    };
+    let plan = hipfire_reap::plan::ReapPlan::load_any(
+        &dir,
+        config.num_hidden_layers,
+        config.num_local_experts,
+    )?;
+    eprintln!(
+        "minimax: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.num_local_experts
+    );
+    config.num_local_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+    Ok(())
 }
 
 // ───────────────────────── HFQ load helpers ─────────────────────────
@@ -206,6 +260,76 @@ fn load_wt(
 ) -> Result<WeightTensor, String> {
     let (qt, data) = read_tensor(hfq, name)?;
     wt_from_raw(gpu, qt, &data, m, k).map_err(|e| format!("minimax: load_wt {name}: {e}"))
+}
+
+/// REAP keep variant of [`load_wt`]: gather the tensor's first-axis rows (one
+/// row per ORIGINAL expert) down to `keep` BEFORE quant decode, then build the
+/// `WeightTensor` with `m = keep.len()`. Only used for the MoE router
+/// (`block_sparse_moe.gate.weight`, shape `[orig_experts, hidden]`) under an
+/// active keep-map: it then emits logits only for kept experts, in compact slot
+/// order. `gather_rows` is exact for any row-independent quant (each per-expert
+/// row carries its own scale/zero/codebook), which holds for every quant_type
+/// `wt_from_raw` accepts. Reads owned bytes via `tensor_data_vec` to retain
+/// `info.shape` for the original row count. `keep` MUST be compact-slot-ordered
+/// and `m` MUST equal `keep.len()`.
+fn load_wt_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+    keep: &[u32],
+) -> Result<WeightTensor, String> {
+    debug_assert_eq!(m, keep.len(), "minimax load_wt_keep: m must equal keep.len()");
+    let (info, data) = hfq
+        .tensor_data_vec(name)
+        .ok_or_else(|| format!("minimax: tensor not found in HFQ: {name}"))?;
+    let orig = *info.shape.first().unwrap_or(&0) as usize;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("minimax: router row-gather '{name}': {e}"))?;
+    wt_from_raw(gpu, info.quant_type, &sub, m, k)
+        .map_err(|e| format!("minimax: load_wt_keep {name}: {e}"))
+}
+
+/// REAP keep variant of [`load_norm`] for a 1-D per-expert F16/F32 vector (the
+/// router's `e_score_correction_bias` `[orig_experts]`). Gathers the kept rows
+/// (parallel to the router weight rows) so the per-expert routing bias aligns
+/// with the gathered router logits. `gather_rows` over a 1-D shape is an exact
+/// element select. Refuses block-packed quant (a single bias element is not a
+/// whole quant block) — only F16/F32 1-D vectors can be element-gathered.
+fn load_norm_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    keep: &[u32],
+) -> Result<GpuTensor, String> {
+    debug_assert_eq!(m, keep.len(), "minimax load_norm_keep: m must equal keep.len()");
+    let (qt, data) = read_tensor(hfq, name)?;
+    let elem_bytes = match qt {
+        1 => 2, // F16
+        2 => 4, // F32
+        other => {
+            return Err(format!(
+                "minimax: routing_bias {name} keep-gather needs F16/F32, got qt={other}"
+            ))
+        }
+    };
+    let orig = data.len() / elem_bytes;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("minimax: routing_bias row-gather '{name}': {e}"))?;
+    let f32_data: Vec<f32> = match qt {
+        1 => sub
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        _ => sub
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    };
+    gpu.upload_f32(&f32_data, &[m])
+        .map_err(|e| format!("minimax: upload routing_bias {name}: {e:?}"))
 }
 
 /// quant_type → DType mapping (subset used by MiniMax HFQ files; mirrors
@@ -299,6 +423,16 @@ impl MiniMaxWeights {
         let inter = cfg.intermediate_size;
         let n_exp = cfg.num_local_experts;
 
+        // REAP keep-map and EP sharding are MUTUALLY EXCLUSIVE: REAP emulates a
+        // pruned pool by partial-loading kept experts into the compact blob (so
+        // `n_exp` is already the kept count and the pointer table spans only
+        // kept slots), while EP-shard packs only rank-owned experts and routes
+        // non-owned ones to a shared zeroed dummy. Combining them would
+        // double-remap the slot space. Mirror deepseek4's guard and refuse.
+        if cfg.reap_keep.is_some() && shard.is_some() {
+            return Err("minimax: REAP keep-map + EP sharding are mutually exclusive".into());
+        }
+
         // Globals.
         let (_qt, embed_bytes) = read_tensor(hfq, "model.embed_tokens.weight")?;
         let embed = gpu
@@ -348,20 +482,56 @@ impl MiniMaxWeights {
                 q_dim,
             )?;
 
-            let router = load_wt(
-                hfq,
-                gpu,
-                &format!("{p}.block_sparse_moe.gate.weight"),
-                n_exp,
-                hidden,
-            )?;
-            // e_score_correction_bias: [n_exp] F16 → F32 (kept F16 in HFQ).
-            let routing_bias = load_norm(
-                hfq,
-                gpu,
-                &format!("{p}.block_sparse_moe.e_score_correction_bias"),
-                &[n_exp],
-            )?;
+            // REAP keep-map for this layer (None ⇒ no pruning / identity load).
+            // When a keep is present, `n_exp == cfg.num_local_experts` is already
+            // the KEPT count (overridden in apply_reap_plan); the router, routing
+            // bias, and expert-pack loop below load only the kept original
+            // experts, in compact slot order. (EP-shard is excluded above, so the
+            // keep path never coexists with the non-owned-zero path.)
+            let reap_ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
+            let keep_l = reap_ep.as_ref().and_then(|e| e.keep());
+
+            // Router: hidden → n_exp. Under a keep, gather the router's expert
+            // rows (`[orig_experts, hidden]`) down to the kept set so it emits
+            // logits only for kept experts, in compact slot order. No keep ⇒ the
+            // literal original full load (byte-identical to baseline).
+            let router = match keep_l {
+                Some(keep) => load_wt_keep(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.gate.weight"),
+                    n_exp,
+                    hidden,
+                    keep,
+                )?,
+                None => load_wt(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.gate.weight"),
+                    n_exp,
+                    hidden,
+                )?,
+            };
+            // e_score_correction_bias: [n_exp] F16 → F32 (kept F16 in HFQ). This
+            // is a PER-EXPERT routing bias added to the router logits for top-k
+            // selection; under a keep it MUST be row-gathered to the kept set in
+            // the same compact slot order as the router weight, else the bias
+            // mis-aligns with the gathered logits. No keep ⇒ literal original.
+            let routing_bias = match keep_l {
+                Some(keep) => load_norm_keep(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.e_score_correction_bias"),
+                    n_exp,
+                    keep,
+                )?,
+                None => load_norm(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.e_score_correction_bias"),
+                    &[n_exp],
+                )?,
+            };
 
             // Routed experts: pack ALL experts of this layer into ONE gate_up
             // blob + ONE down blob (deepseek4 `upload_layer_routed_experts`
@@ -386,13 +556,22 @@ impl MiniMaxWeights {
             let owns = |e: usize| shard.map(|(s, rank)| s.owns_expert(rank, e)).unwrap_or(true);
             let mut local_of_global = vec![usize::MAX; n_exp];
             let mut n_owned = 0usize;
-            for e in 0..n_exp {
+            // Iterate COMPACT slots `0..n_exp`. `e` = the ORIGINAL expert index
+            // loaded into this slot: under a REAP keep it is `src(slot)` (read the
+            // kept experts in compact order); with no keep it is `slot` itself, so
+            // the loop is byte-identical to the original literal pack (and the
+            // EP-shard path is unchanged — REAP excludes sharding, so when a keep
+            // is active `shard` is None and `owns(e)` is always true). `owns` /
+            // `local_of_global` stay indexed by the original id `e` (== slot on
+            // the no-keep path), preserving shard semantics exactly.
+            for slot in 0..n_exp {
+                let e = reap_ep.as_ref().map(|ep| ep.src(slot)).unwrap_or(slot);
                 let ep = format!("{p}.block_sparse_moe.experts.{e}");
                 let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                 let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
                 let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
                 let gu_len = w1.len() + w3.len();
-                if e == 0 {
+                if slot == 0 {
                     gu_stride = gu_len;
                     dn_stride = w2.len();
                     qt_gu = qt1;
@@ -407,7 +586,15 @@ impl MiniMaxWeights {
                     ));
                 }
                 if owns(e) {
-                    local_of_global[e] = n_owned;
+                    // `local_of_global` is indexed by the KERNEL ROUTING INDEX —
+                    // the slot the router/topk emits, which the device pointer
+                    // table is built over below. With EP-shard that index is the
+                    // GLOBAL expert id `e`; with REAP (shard excluded) the router
+                    // is gathered to compact slots, so the routing index is the
+                    // COMPACT SLOT. On the plain path `e == slot`, so both agree
+                    // and the table is identity (byte-identical to baseline).
+                    let route = if shard.is_some() { e } else { slot };
+                    local_of_global[route] = n_owned;
                     n_owned += 1;
                     gu_combined.extend_from_slice(&w1);
                     gu_combined.extend_from_slice(&w3);

--- a/crates/hipfire-arch-qwen35/Cargo.toml
+++ b/crates/hipfire-arch-qwen35/Cargo.toml
@@ -16,6 +16,7 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
+hipfire-reap = { path = "../hipfire-reap" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/hipfire-arch-qwen35/src/arch.rs
+++ b/crates/hipfire-arch-qwen35/src/arch.rs
@@ -62,8 +62,13 @@ impl Architecture for Qwen35 {
     }
 
     fn config_from_hfq(hfq: &HfqFile) -> Result<Self::Config, String> {
-        qwen35_config_from_hfq(hfq)
-            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())
+        let mut config = qwen35_config_from_hfq(hfq)
+            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())?;
+        // Optional REAP keep-map (HIPFIRE_REAP_PLAN). Applied AFTER parse so
+        // validation sees the original n_routed_experts; overrides num_experts
+        // to the kept count when active. No env ⇒ no-op (baseline behavior).
+        crate::qwen35::apply_reap_plan(&mut config)?;
+        Ok(config)
     }
 
     fn load_weights(

--- a/crates/hipfire-arch-qwen35/src/arch.rs
+++ b/crates/hipfire-arch-qwen35/src/arch.rs
@@ -62,13 +62,13 @@ impl Architecture for Qwen35 {
     }
 
     fn config_from_hfq(hfq: &HfqFile) -> Result<Self::Config, String> {
-        let mut config = qwen35_config_from_hfq(hfq)
-            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())?;
-        // Optional REAP keep-map (HIPFIRE_REAP_PLAN). Applied AFTER parse so
-        // validation sees the original n_routed_experts; overrides num_experts
-        // to the kept count when active. No env ⇒ no-op (baseline behavior).
-        crate::qwen35::apply_reap_plan(&mut config)?;
-        Ok(config)
+        // REAP is applied INSIDE `qwen35_config_from_hfq` (the public free fn)
+        // so every caller — trait or direct — gets it; do NOT re-apply here,
+        // or the keep-map would be applied twice (double-overriding num_experts
+        // to kept-of-kept, which would then fail load_any's kept-count
+        // validation against the original count).
+        qwen35_config_from_hfq(hfq)
+            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())
     }
 
     fn load_weights(

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -193,6 +193,14 @@ pub struct Qwen35Config {
     /// to `u64::MAX` (no eviction — tested when VRAM is unlimited or we just
     /// want to verify the routing path works without eviction pressure).
     pub vram_budget_bytes: u64,
+
+    /// Optional REAP keep-map: emulate a pruned routed-expert pool by
+    /// partial-loading this full quant (load only the kept experts under
+    /// remapped names, gather the router's expert rows to the kept set).
+    /// Populated at config time from `HIPFIRE_REAP_PLAN=<dir>`; `None` ⇒
+    /// no pruning (today's behavior, byte-identical to baseline). Not
+    /// (de)serialized — `Qwen35Config` does not derive serde.
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
@@ -346,7 +354,44 @@ pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
         // a follow-up commit). When false, no behavior change vs main.
         paged_experts: false,
         vram_budget_bytes: u64::MAX,
+        reap_keep: None,
     })
+}
+
+/// Apply an optional REAP keep-map to a freshly parsed `Qwen35Config`.
+///
+/// Reads `HIPFIRE_REAP_PLAN=<dir>` (qwen35 has no legacy env alias). When
+/// set, loads `<dir>/reap_plan.json` (or the legacy `keep_by_layer.json`)
+/// via `ReapPlan::load_any`, validating against the ORIGINAL routed-expert
+/// count (`config.num_experts`) BEFORE overriding it to the kept count.
+/// This emulates a pruned expert pool by partial-loading the full quant:
+/// only kept experts are loaded (under remapped names) and the router's
+/// expert rows are gathered to the kept set in `load_moe_ffn`.
+///
+/// No env ⇒ no-op (`config.reap_keep` stays `None`); the MoE loader then
+/// takes the literal original full-load path — byte-identical to baseline.
+/// Only the HFQ MoE path (`load_moe_ffn`) honors the keep-map; the
+/// ParoQuant path does not (see `paro_load_moe_ffn`).
+pub fn apply_reap_plan(config: &mut Qwen35Config) -> Result<(), String> {
+    let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
+        return Ok(());
+    };
+    // MoE-only feature: a dense (num_experts==0) checkpoint has no routed
+    // experts to prune. Refuse rather than silently divide-by-zero / mislead.
+    if config.num_experts == 0 {
+        return Err(format!(
+            "qwen35: HIPFIRE_REAP_PLAN={dir} set but this is a dense (num_experts==0) checkpoint"
+        ));
+    }
+    let plan = hipfire_reap::plan::ReapPlan::load_any(&dir, config.n_layers, config.num_experts)?;
+    eprintln!(
+        "qwen35: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.num_experts
+    );
+    config.num_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+    Ok(())
 }
 
 /// Parse Qwen35Config from a SafetensorsSource (or any ModelSource).
@@ -487,6 +532,7 @@ pub fn config_from_safetensors(source: &dyn ModelSource) -> Option<Qwen35Config>
         norm_topk_prob,
         paged_experts: false,
         vram_budget_bytes: u64::MAX,
+        reap_keep: None,
     })
 }
 
@@ -1599,6 +1645,63 @@ fn load_weight_tensor(
         }
         Ok(wt)
     }
+}
+
+/// REAP keep variant of [`load_weight_tensor`]: gather the tensor's first-axis
+/// rows (one row per original expert) down to `keep` BEFORE quant decode, then
+/// build the `WeightTensor` from the gathered bytes with `m = keep.len()`.
+///
+/// Only used for the MoE router (`mlp.gate.weight`, shape `[orig_experts, k]`)
+/// under an active keep-map. `gather_rows` is exact for any row-independent
+/// quant (every per-expert row is self-contained — its own scale/zero/codebook
+/// live in the row), which is true for every quant_type this loader accepts.
+/// `keep` MUST equal the compact slot order, and `m` MUST equal `keep.len()`.
+///
+/// The AWQ sidecar (when present) is indexed by `k` (the input/hidden
+/// dimension), shared across all expert rows, so it is loaded UNCHANGED —
+/// row selection does not touch it.
+fn load_weight_tensor_keep(
+    hfq: &HfqFile,
+    gpu: &Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+    keep: &[u32],
+) -> HipResult<WeightTensor> {
+    debug_assert_eq!(
+        m,
+        keep.len(),
+        "load_weight_tensor_keep: m ({m}) must equal keep.len() ({})",
+        keep.len()
+    );
+    // Resolve via the same name-candidate logic as the non-keep path, taking
+    // owned bytes so the gather + AWQ-sidecar reads don't fight a borrow.
+    // `HfqTensorInfo` is not Clone, so pull out the scalars we need (quant
+    // type + on-disk row count) while the borrow is live.
+    let mut matched: Option<String> = None;
+    let mut found: Option<(u8, usize, Vec<u8>)> = None;
+    for candidate in qwen35_tensor_name_candidates(name) {
+        if let Some((info, buf)) = hfq.tensor_data_vec(&candidate) {
+            let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
+            matched = Some(candidate);
+            found = Some((info.quant_type, orig_rows, buf));
+            break;
+        }
+    }
+    let (quant_type, orig_rows, bytes) =
+        found.unwrap_or_else(|| panic!("tensor not found: {name}"));
+    // Row-gather to the kept set. The on-disk row count is the ORIGINAL expert
+    // count (= bytes.len() / rowstride); gather_rows derives it from shape[0].
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig_rows], &bytes, keep)
+        .map_err(|e| HipError::new(0, &format!("qwen35: router row-gather '{name}': {e}")))?;
+    let mut wt = load_weight_tensor_raw(gpu, quant_type, &sub, m, k)?;
+    if wt.gpu_dtype.supports_awq_sidecar() {
+        wt.awq_scale = matched
+            .as_deref()
+            .and_then(|mn| load_awq_scale_for(hfq, gpu, mn, k))
+            .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
+    }
+    Ok(wt)
 }
 
 // ─── ParoQuant AWQ → HFQ4G128 repack ────────────────────────────────────────
@@ -4284,8 +4387,31 @@ fn load_moe_ffn(
     let mi = config.moe_intermediate_size;
     let smi = config.shared_expert_intermediate_size;
 
+    // REAP keep-map for this layer (None ⇒ no pruning / identity). When a
+    // keep is present, `n_exp == config.num_experts` is already the KEPT
+    // count; the router and expert loops below load only the kept rows.
+    let ep = config
+        .reap_keep
+        .as_ref()
+        .map(|r| r.expert_plan(layer_idx as usize));
+
     // Router: hidden_size → num_experts. Precision-sensitive but small.
-    let router = load_weight_tensor(hfq, gpu, &format!("{p}.mlp.gate.weight"), n_exp, config.dim)?;
+    // Under a keep, gather the router's expert rows (`[orig_experts, dim]`)
+    // down to the kept set so it emits logits only for kept experts, in
+    // compact slot order. No keep ⇒ the literal original full load.
+    let router = match ep.as_ref().and_then(|e| e.keep()) {
+        Some(keep) => load_weight_tensor_keep(
+            hfq,
+            gpu,
+            &format!("{p}.mlp.gate.weight"),
+            n_exp,
+            config.dim,
+            keep,
+        )?,
+        None => {
+            load_weight_tensor(hfq, gpu, &format!("{p}.mlp.gate.weight"), n_exp, config.dim)?
+        }
+    };
 
     // Shared expert (always-on, contributes to every token). Unlike routed
     // experts, gate_proj + up_proj are stored separately in the safetensors
@@ -4326,8 +4452,16 @@ fn load_moe_ffn(
     // Routed experts — quantizer wrote per-expert tensors named
     // `{p}.mlp.experts.{X}.gate_up_proj.weight` (shape [2*moe_intermediate, hidden_size])
     // and `{p}.mlp.experts.{X}.down_proj.weight` (shape [hidden_size, moe_intermediate]).
-    let mut experts = Vec::with_capacity(n_exp);
-    for x in 0..n_exp {
+    //
+    // REAP keep-map: `n_exp` is already the KEPT count (config.num_experts was
+    // overridden in apply_reap_plan). Iterate compact slots and load only the
+    // kept original experts under their remapped names (`ep` computed above).
+    // No keep ⇒ identity (slot==original index, `n_slots == n_exp`) — the
+    // literal original loop.
+    let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
+    let mut experts = Vec::with_capacity(n_slots);
+    for slot in 0..n_slots {
+        let x = ep.as_ref().map(|e| e.src(slot)).unwrap_or(slot);
         let gate_up = load_weight_tensor(
             hfq,
             gpu,

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -323,7 +323,7 @@ pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
 
-    Some(Qwen35Config {
+    let mut config = Qwen35Config {
         dim,
         n_layers,
         vocab_size,
@@ -355,7 +355,31 @@ pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
         paged_experts: false,
         vram_budget_bytes: u64::MAX,
         reap_keep: None,
-    })
+    };
+
+    // Apply the optional REAP keep-map HERE, inside the single public config
+    // entry point, so it is IMPOSSIBLE to bypass. `config_from_hfq` has ~50
+    // direct callers (daemon, perplexity example, every bench/profile example)
+    // that never go through the `Architecture` trait shim; wiring REAP only in
+    // the trait impl would silently ignore HIPFIRE_REAP_PLAN on all of them
+    // (including the deferred identity NLL gate, which the perplexity example
+    // drives via this public fn). The trait impl therefore does NOT re-apply.
+    //
+    // Error policy: this fn returns `Option<Qwen35Config>`, shared by ~50
+    // callers that mostly `.expect()`/`.ok_or()` the Option — converting to
+    // `Result<_, String>` would be an invasive, churny signature change across
+    // all of them. REAP is OPT-IN (env-gated), so a malformed plan when the
+    // user explicitly set HIPFIRE_REAP_PLAN MUST hard-fail, never silently
+    // no-op or get swallowed into a `None` that callers misread as "bad
+    // metadata". We therefore hard-exit on Err with a clear FATAL message
+    // rather than collapsing the error into `None`. With no env var,
+    // apply_reap_plan is a no-op (Ok), so baseline behavior is unchanged.
+    if let Err(e) = apply_reap_plan(&mut config) {
+        eprintln!("FATAL: HIPFIRE_REAP_PLAN: {e}");
+        std::process::exit(1);
+    }
+
+    Some(config)
 }
 
 /// Apply an optional REAP keep-map to a freshly parsed `Qwen35Config`.
@@ -1674,28 +1698,29 @@ fn load_weight_tensor_keep(
         "load_weight_tensor_keep: m ({m}) must equal keep.len() ({})",
         keep.len()
     );
-    // Resolve via the same name-candidate logic as the non-keep path, taking
-    // owned bytes so the gather + AWQ-sidecar reads don't fight a borrow.
-    // `HfqTensorInfo` is not Clone, so pull out the scalars we need (quant
-    // type + on-disk row count) while the borrow is live.
-    let mut matched: Option<String> = None;
-    let mut found: Option<(u8, usize, Vec<u8>)> = None;
-    for candidate in qwen35_tensor_name_candidates(name) {
-        if let Some((info, buf)) = hfq.tensor_data_vec(&candidate) {
-            let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
-            matched = Some(candidate);
-            found = Some((info.quant_type, orig_rows, buf));
-            break;
-        }
-    }
-    let (quant_type, orig_rows, bytes) =
-        found.unwrap_or_else(|| panic!("tensor not found: {name}"));
+    // Resolve via the shared `qwen35_tensor_data_vec` helper (same candidate
+    // logic as the non-keep path; it preads + fadvise_dontneeds internally and
+    // returns OWNED bytes, so the gather + AWQ-sidecar reads don't fight a
+    // borrow). `orig_rows` is the on-disk first-axis length = original expert
+    // count. The matched (prefixed) candidate name is resolved separately for
+    // the AWQ sidecar lookup via a metadata-only existence check, since the
+    // helper doesn't surface which candidate it hit.
+    let (info, bytes) =
+        qwen35_tensor_data_vec(hfq, name).unwrap_or_else(|| panic!("tensor not found: {name}"));
+    let quant_type = info.quant_type;
+    let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
     // Row-gather to the kept set. The on-disk row count is the ORIGINAL expert
     // count (= bytes.len() / rowstride); gather_rows derives it from shape[0].
     let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig_rows], &bytes, keep)
         .map_err(|e| HipError::new(0, &format!("qwen35: router row-gather '{name}': {e}")))?;
     let mut wt = load_weight_tensor_raw(gpu, quant_type, &sub, m, k)?;
     if wt.gpu_dtype.supports_awq_sidecar() {
+        // Resolve the matched candidate name (metadata only) so the AWQ sidecar
+        // is looked up under the same prefix the weight resolved to; fall back
+        // to the bare `name`. Mirrors the non-keep `load_weight_tensor`.
+        let matched = qwen35_tensor_name_candidates(name)
+            .into_iter()
+            .find(|c| hfq.find_tensor_info(c).is_some());
         wt.awq_scale = matched
             .as_deref()
             .and_then(|mn| load_awq_scale_for(hfq, gpu, mn, k))
@@ -4454,13 +4479,14 @@ fn load_moe_ffn(
     // and `{p}.mlp.experts.{X}.down_proj.weight` (shape [hidden_size, moe_intermediate]).
     //
     // REAP keep-map: `n_exp` is already the KEPT count (config.num_experts was
-    // overridden in apply_reap_plan). Iterate compact slots and load only the
-    // kept original experts under their remapped names (`ep` computed above).
-    // No keep ⇒ identity (slot==original index, `n_slots == n_exp`) — the
-    // literal original loop.
-    let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
-    let mut experts = Vec::with_capacity(n_slots);
-    for slot in 0..n_slots {
+    // overridden in apply_reap_plan), and under a keep `ExpertPlan::n_slots`
+    // also equals the kept count — so `n_exp` is the slot count on both the
+    // keep and no-keep paths. Iterate compact slots `0..n_exp` (matching ds4's
+    // `0..n_routed_experts`) and load only the kept original experts under
+    // their remapped names via `ep.src(slot)`. No keep ⇒ identity (slot ==
+    // original index) — the literal original loop.
+    let mut experts = Vec::with_capacity(n_exp);
+    for slot in 0..n_exp {
         let x = ep.as_ref().map(|e| e.src(slot)).unwrap_or(slot);
         let gate_up = load_weight_tensor(
             hfq,

--- a/crates/hipfire-reap/Cargo.toml
+++ b/crates/hipfire-reap/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hipfire-reap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+rdna-compute = { path = "../rdna-compute" }
+serde_json = { version = "1", features = ["preserve_order"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/hipfire-reap/Cargo.toml
+++ b/crates/hipfire-reap/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [dependencies]
 hipfire-runtime = { path = "../hipfire-runtime" }
-rdna-compute = { path = "../rdna-compute" }
 serde_json = { version = "1", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/crates/hipfire-reap/src/gather.rs
+++ b/crates/hipfire-reap/src/gather.rs
@@ -1,0 +1,57 @@
+/// Gather kept rows from a row-major tensor's raw bytes. `shape[0]` is the
+/// row count (e.g. experts); every row must be `bytes.len()/shape[0]` bytes.
+/// Returns `(new_shape, gathered_bytes)`. Exact for row-independent quant.
+pub fn gather_rows(shape: &[usize], bytes: &[u8], keep: &[u32]) -> Result<(Vec<usize>, Vec<u8>), String> {
+    let orig_rows = *shape.first().unwrap_or(&0);
+    if orig_rows == 0 || bytes.len() % orig_rows != 0 {
+        return Err(format!(
+            "reap: row-gather: {orig_rows} rows don't divide {} bytes",
+            bytes.len()
+        ));
+    }
+    let rowstride = bytes.len() / orig_rows;
+    let mut out = Vec::with_capacity(rowstride * keep.len());
+    for &oe in keep {
+        let oe = oe as usize;
+        if oe >= orig_rows {
+            return Err(format!("reap: row-gather keep idx {oe} >= rows {orig_rows}"));
+        }
+        out.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
+    }
+    let mut new_shape = shape.to_vec();
+    new_shape[0] = keep.len();
+    Ok((new_shape, out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gathers_subset_in_order() {
+        // 4 rows × 3 bytes
+        let bytes: Vec<u8> = vec![0,0,0, 1,1,1, 2,2,2, 3,3,3];
+        let (shape, out) = gather_rows(&[4, 3], &bytes, &[2, 0, 3]).unwrap();
+        assert_eq!(shape, vec![3, 3]);
+        assert_eq!(out, vec![2,2,2, 0,0,0, 3,3,3]);
+    }
+
+    #[test]
+    fn identity_keep_is_byte_identical() {
+        let bytes: Vec<u8> = (0..24).collect();
+        let (_, out) = gather_rows(&[4, 6], &bytes, &[0, 1, 2, 3]).unwrap();
+        assert_eq!(out, bytes);
+    }
+
+    #[test]
+    fn errors_on_indivisible_rows() {
+        let err = gather_rows(&[3, 2], &[0, 1, 2, 3, 4], &[0]).unwrap_err();
+        assert!(err.contains("don't divide"), "got: {err}");
+    }
+
+    #[test]
+    fn errors_on_out_of_range_keep() {
+        let err = gather_rows(&[2, 2], &[0, 1, 2, 3], &[5]).unwrap_err();
+        assert!(err.contains("keep idx 5 >= rows 2"), "got: {err}");
+    }
+}

--- a/crates/hipfire-reap/src/hook.rs
+++ b/crates/hipfire-reap/src/hook.rs
@@ -1,0 +1,14 @@
+use crate::plan::ReapPlan;
+
+/// Arch-specific REAP extras. Default impls are no-ops so arches that need
+/// nothing (qwen35, lfm2moe, minimax) don't implement anything.
+pub trait ReapArchHook {
+    /// Path to an arch sidecar file inside the plan dir, if the arch uses one.
+    fn sidecar_path(&self, plan: &ReapPlan, name: &str) -> std::path::PathBuf {
+        plan.dir.join(name)
+    }
+    /// Whether this layer's auxiliary head (e.g. ds4 MTP) is skipped under reap.
+    fn skip_aux_head(&self, _plan: &ReapPlan, _layer: usize) -> bool {
+        false
+    }
+}

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -2,7 +2,9 @@
 //! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
 
 pub mod gather;
+pub mod hook;
 pub mod plan;
 pub mod source;
 
+pub use hook::ReapArchHook;
 pub use source::{ExpertPlan, TensorSource};

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -1,0 +1,2 @@
+//! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
+//! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -1,2 +1,4 @@
 //! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
 //! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+
+pub mod plan;

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -1,4 +1,5 @@
 //! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
 //! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
 
+pub mod gather;
 pub mod plan;

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -3,3 +3,6 @@
 
 pub mod gather;
 pub mod plan;
+pub mod source;
+
+pub use source::{ExpertPlan, TensorSource};

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -47,6 +47,7 @@ pub struct ReapPlan {
 }
 
 impl ReapPlan {
+    /// Returns 0 if keep is Some with an empty outer vec (cannot arise from load()).
     pub fn kept_per_layer(&self) -> usize {
         match &self.keep {
             Some(k) => k.first().map(|r| r.len()).unwrap_or(0),
@@ -137,10 +138,18 @@ impl ReapPlan {
                 let role = Role::parse(
                     o["role"].as_str().ok_or_else(|| format!("reap: quant_override[{i}] missing role"))?,
                 )?;
-                let experts: Vec<u32> = o["experts"]
-                    .as_array()
-                    .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect())
-                    .unwrap_or_default();
+                let experts: Vec<u32> = if let Some(a) = o["experts"].as_array() {
+                    a.iter().enumerate().map(|(j, x)| {
+                        let n = x.as_u64()
+                            .ok_or_else(|| format!("reap: quant_override[{i}] experts[{j}] not an integer"))? as u32;
+                        if n as usize >= original_experts {
+                            return Err(format!("reap: quant_override[{i}] expert {n} >= original_experts {original_experts}"));
+                        }
+                        Ok(n)
+                    }).collect::<Result<Vec<_>, String>>()?
+                } else {
+                    Vec::new()
+                };
                 if !experts.is_empty() && role != Role::RoutedExperts {
                     return Err(format!(
                         "reap: quant_override[{i}] lists experts but role is not routed_experts"
@@ -223,5 +232,25 @@ mod tests {
         let d = write_plan(r#"{"original_experts":4,"num_layers":3,"keep":{"per_layer":[[0,1]]}}"#);
         let err = ReapPlan::load(d.path().to_str().unwrap(), 3, 4).unwrap_err();
         assert!(err.contains("keep.per_layer has 1 layers"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_non_integer_override_expert() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"routed_experts","experts":[1,"bad"],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("not an integer"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_out_of_range_override_expert() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"routed_experts","experts":[9],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains(">= original_experts 4"), "got: {err}");
     }
 }

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -1,0 +1,227 @@
+use std::path::{Path, PathBuf};
+
+/// One selective-requant edit (applied in SP2+; parsed & validated now).
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuantOverride {
+    pub layer: usize,
+    pub role: Role,
+    /// Only meaningful for `Role::RoutedExperts`; empty ⇒ whole role at this layer.
+    pub experts: Vec<u32>,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    RoutedExperts,
+    SharedExpert,
+    Attention,
+    Router,
+    LmHead,
+    Embed,
+}
+
+impl Role {
+    pub fn parse(s: &str) -> Result<Role, String> {
+        Ok(match s {
+            "routed_experts" => Role::RoutedExperts,
+            "shared_expert" => Role::SharedExpert,
+            "attention" => Role::Attention,
+            "router" => Role::Router,
+            "lm_head" => Role::LmHead,
+            "embed" => Role::Embed,
+            other => return Err(format!("reap: unknown role '{other}'")),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReapPlan {
+    pub model_arch: Option<String>,
+    pub num_layers: usize,
+    pub original_experts: usize,
+    /// `keep[l][slot]` = original expert index in compact slot `slot`.
+    /// `None` ⇒ no pruning (keep all `original_experts`).
+    pub keep: Option<Vec<Vec<u32>>>,
+    pub quant_overrides: Vec<QuantOverride>,
+    pub dir: PathBuf,
+}
+
+impl ReapPlan {
+    pub fn kept_per_layer(&self) -> usize {
+        match &self.keep {
+            Some(k) => k.first().map(|r| r.len()).unwrap_or(0),
+            None => self.original_experts,
+        }
+    }
+
+    /// Load `<dir>/reap_plan.json`, validating against the model's layer/expert
+    /// counts (passed BEFORE any n_routed_experts override).
+    pub fn load(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = Path::new(dir).join("reap_plan.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: read {path:?}: {e}"))?;
+        let v: serde_json::Value =
+            serde_json::from_str(&txt).map_err(|e| format!("reap: parse {path:?}: {e}"))?;
+
+        let original_experts = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if original_experts != orig_experts_expected {
+            return Err(format!(
+                "reap: original_experts {original_experts} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let num_layers = v["num_layers"].as_u64().unwrap_or(num_layers_expected as u64) as usize;
+        if num_layers != num_layers_expected {
+            return Err(format!(
+                "reap: num_layers {num_layers} != model num_hidden_layers {num_layers_expected}"
+            ));
+        }
+
+        let keep = match v["keep"]["per_layer"].as_array() {
+            None => None,
+            Some(arr) => {
+                if arr.len() != num_layers_expected {
+                    return Err(format!(
+                        "reap: keep.per_layer has {} layers, model has {num_layers_expected}",
+                        arr.len()
+                    ));
+                }
+                let kept = arr.first().and_then(|r| r.as_array()).map(|r| r.len()).unwrap_or(0);
+                let mut out = Vec::with_capacity(arr.len());
+                for (l, row) in arr.iter().enumerate() {
+                    let r = row
+                        .as_array()
+                        .ok_or_else(|| format!("reap: keep layer {l} not an array"))?;
+                    if r.len() != kept {
+                        return Err(format!(
+                            "reap: keep layer {l} has {} entries, expected {kept}",
+                            r.len()
+                        ));
+                    }
+                    let mut v32 = Vec::with_capacity(kept);
+                    for x in r {
+                        let idx = x
+                            .as_u64()
+                            .ok_or_else(|| format!("reap: keep layer {l} non-integer index"))?
+                            as u32;
+                        if idx as usize >= original_experts {
+                            return Err(format!(
+                                "reap: keep layer {l} index {idx} >= original_experts {original_experts}"
+                            ));
+                        }
+                        v32.push(idx);
+                    }
+                    out.push(v32);
+                }
+                Some(out)
+            }
+        };
+
+        let mut quant_overrides = Vec::new();
+        if let Some(arr) = v["quant_overrides"].as_array() {
+            for (i, o) in arr.iter().enumerate() {
+                let layer = o["layer"]
+                    .as_u64()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing layer"))?
+                    as usize;
+                if layer >= num_layers_expected {
+                    return Err(format!(
+                        "reap: quant_override[{i}] layer {layer} >= num_layers {num_layers_expected}"
+                    ));
+                }
+                let role = Role::parse(
+                    o["role"].as_str().ok_or_else(|| format!("reap: quant_override[{i}] missing role"))?,
+                )?;
+                let experts: Vec<u32> = o["experts"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect())
+                    .unwrap_or_default();
+                if !experts.is_empty() && role != Role::RoutedExperts {
+                    return Err(format!(
+                        "reap: quant_override[{i}] lists experts but role is not routed_experts"
+                    ));
+                }
+                let tier = o["tier"]
+                    .as_str()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing tier"))?
+                    .to_string();
+                quant_overrides.push(QuantOverride { layer, role, experts, tier });
+            }
+        }
+
+        Ok(ReapPlan {
+            model_arch: v["model_arch"].as_str().map(|s| s.to_string()),
+            num_layers: num_layers_expected,
+            original_experts,
+            keep,
+            quant_overrides,
+            dir: PathBuf::from(dir),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_plan(json: &str) -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(d.path().join("reap_plan.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        d
+    }
+
+    #[test]
+    fn keep_all_when_keep_absent() {
+        let d = write_plan(r#"{"original_experts":8,"num_layers":2}"#);
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 8).unwrap();
+        assert!(p.keep.is_none());
+        assert_eq!(p.kept_per_layer(), 8);
+    }
+
+    #[test]
+    fn parses_keep_and_overrides() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":2,
+                "keep":{"per_layer":[[0,2,3],[1,2,3]]},
+                "quant_overrides":[{"layer":1,"role":"routed_experts","experts":[2],"tier":"mq3lloyd"}]}"#,
+        );
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 4).unwrap();
+        assert_eq!(p.kept_per_layer(), 3);
+        assert_eq!(p.keep.as_ref().unwrap()[0], vec![0, 2, 3]);
+        assert_eq!(p.quant_overrides.len(), 1);
+        assert_eq!(p.quant_overrides[0].tier, "mq3lloyd");
+    }
+
+    #[test]
+    fn rejects_out_of_range_index() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,"keep":{"per_layer":[[0,9]]}}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("index 9 >= original_experts 4"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_experts_on_non_routed_role() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"attention","experts":[1],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("not routed_experts"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_layer_count_mismatch() {
+        let d = write_plan(r#"{"original_experts":4,"num_layers":3,"keep":{"per_layer":[[0,1]]}}"#);
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 3, 4).unwrap_err();
+        assert!(err.contains("keep.per_layer has 1 layers"), "got: {err}");
+    }
+}

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -172,6 +172,95 @@ impl ReapPlan {
             dir: PathBuf::from(dir),
         })
     }
+
+    /// Load `<dir>/reap_plan.json` if present, else fall back to a legacy
+    /// `<dir>/keep_by_layer.json` (keep-only; no overrides). Lets old
+    /// deepseek4 sidecars keep working through the generic loader.
+    pub fn load_any(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        if Path::new(dir).join("reap_plan.json").exists() {
+            return Self::load(dir, num_layers_expected, orig_experts_expected);
+        }
+        Self::load_legacy_keepmap(dir, num_layers_expected, orig_experts_expected)
+    }
+
+    /// Load the legacy `<dir>/keep_by_layer.json` schema (top-level
+    /// `kept_per_layer:u64`, optional `original_experts:u64`, and
+    /// `keep: [[u32; kept]; num_layers]`) and produce a keep-only
+    /// `ReapPlan`. Validation mirrors the old `ReapKeepMap::load`: the
+    /// `original_experts` must match the model, layer count must match,
+    /// each row length must equal `kept_per_layer`, and every index must
+    /// be `< original_experts`.
+    pub fn load_legacy_keepmap(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = Path::new(dir).join("keep_by_layer.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: legacy keep-map read {path:?}: {e}"))?;
+        let v: serde_json::Value = serde_json::from_str(&txt)
+            .map_err(|e| format!("reap: legacy keep-map parse {path:?}: {e}"))?;
+
+        let kept = v["kept_per_layer"]
+            .as_u64()
+            .ok_or("reap: legacy keep-map missing kept_per_layer")? as usize;
+        let original_experts = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if original_experts != orig_experts_expected {
+            return Err(format!(
+                "reap: legacy keep-map original_experts {original_experts} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let keep_arr = v["keep"]
+            .as_array()
+            .ok_or("reap: legacy keep-map missing `keep` array")?;
+        if keep_arr.len() != num_layers_expected {
+            return Err(format!(
+                "reap: legacy keep-map has {} layers, model has {num_layers_expected}",
+                keep_arr.len()
+            ));
+        }
+        let mut keep = Vec::with_capacity(keep_arr.len());
+        for (l, row) in keep_arr.iter().enumerate() {
+            let r = row
+                .as_array()
+                .ok_or_else(|| format!("reap: legacy keep layer {l} not an array"))?;
+            if r.len() != kept {
+                return Err(format!(
+                    "reap: legacy keep layer {l} has {} entries, expected {kept}",
+                    r.len()
+                ));
+            }
+            let mut v32 = Vec::with_capacity(kept);
+            for x in r {
+                let idx = x
+                    .as_u64()
+                    .ok_or_else(|| format!("reap: legacy keep layer {l} non-integer index"))?
+                    as u32;
+                if idx as usize >= original_experts {
+                    return Err(format!(
+                        "reap: legacy keep layer {l} index {idx} >= original_experts {original_experts}"
+                    ));
+                }
+                v32.push(idx);
+            }
+            keep.push(v32);
+        }
+
+        Ok(ReapPlan {
+            model_arch: None,
+            num_layers: num_layers_expected,
+            original_experts,
+            keep: Some(keep),
+            quant_overrides: Vec::new(),
+            dir: PathBuf::from(dir),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -184,6 +273,23 @@ mod tests {
         let mut f = std::fs::File::create(d.path().join("reap_plan.json")).unwrap();
         f.write_all(json.as_bytes()).unwrap();
         d
+    }
+
+    fn write_legacy(json: &str) -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(d.path().join("keep_by_layer.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        d
+    }
+
+    #[test]
+    fn loads_legacy_keepmap() {
+        let d = write_legacy(
+            r#"{"kept_per_layer":2,"original_experts":4,"keep":[[0,3],[1,2]]}"#,
+        );
+        let p = ReapPlan::load_any(d.path().to_str().unwrap(), 2, 4).unwrap();
+        assert_eq!(p.kept_per_layer(), 2);
+        assert_eq!(p.keep.as_ref().unwrap()[0], vec![0, 3]);
     }
 
     #[test]

--- a/crates/hipfire-reap/src/source.rs
+++ b/crates/hipfire-reap/src/source.rs
@@ -37,6 +37,7 @@ impl<'a> ExpertPlan<'a> {
         self.keep
     }
     /// Original expert index for a compact slot (identity when no keep map).
+    /// Panics if slot >= n_slots(full); callers must iterate 0..n_slots(full).
     pub fn src(&self, slot: usize) -> usize {
         self.keep.map(|k| k[slot] as usize).unwrap_or(slot)
     }

--- a/crates/hipfire-reap/src/source.rs
+++ b/crates/hipfire-reap/src/source.rs
@@ -1,0 +1,75 @@
+use crate::plan::ReapPlan;
+use hipfire_runtime::hfq::{HfqFile, HfqTensorInfo};
+
+/// Overlay-then-base tensor resolver. SP1: overlay is always None (base only);
+/// SP3 adds the overlay HfqFile and prefers it when it holds `name`.
+pub struct TensorSource<'a> {
+    pub base: &'a HfqFile,
+    pub overlay: Option<&'a HfqFile>,
+}
+
+impl<'a> TensorSource<'a> {
+    pub fn new(base: &'a HfqFile) -> Self {
+        TensorSource { base, overlay: None }
+    }
+
+    /// Resolve a tensor by name: overlay first (SP3), else base.
+    /// Returns `(&HfqTensorInfo, Vec<u8>)` using `tensor_data_vec` for
+    /// owned bytes (avoids RefCell borrow and works on all platforms).
+    pub fn tensor(&self, name: &str) -> Option<(&'a HfqTensorInfo, Vec<u8>)> {
+        if let Some(ov) = self.overlay {
+            if let Some(hit) = ov.tensor_data_vec(name) {
+                return Some(hit);
+            }
+        }
+        self.base.tensor_data_vec(name)
+    }
+}
+
+/// Per-(layer, role) plan slice the arch loader consumes at its expert loop.
+pub struct ExpertPlan<'a> {
+    /// `keep[slot]` = original expert index for compact slot. `None` ⇒ identity.
+    keep: Option<&'a [u32]>,
+}
+
+impl<'a> ExpertPlan<'a> {
+    pub fn keep(&self) -> Option<&'a [u32]> {
+        self.keep
+    }
+    /// Original expert index for a compact slot (identity when no keep map).
+    pub fn src(&self, slot: usize) -> usize {
+        self.keep.map(|k| k[slot] as usize).unwrap_or(slot)
+    }
+    /// Number of compact expert slots for this layer.
+    pub fn n_slots(&self, full: usize) -> usize {
+        self.keep.map(|k| k.len()).unwrap_or(full)
+    }
+}
+
+impl ReapPlan {
+    /// Build the per-layer expert plan (routed experts). `None`-keep ⇒ identity.
+    pub fn expert_plan(&self, layer: usize) -> ExpertPlan<'_> {
+        ExpertPlan {
+            keep: self.keep.as_ref().map(|k| k[layer].as_slice()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // ExpertPlan::src/n_slots are pure; test them without an HfqFile.
+    #[test]
+    fn identity_src_when_no_keep() {
+        let ep = ExpertPlan { keep: None };
+        assert_eq!(ep.src(5), 5);
+        assert_eq!(ep.n_slots(8), 8);
+    }
+    #[test]
+    fn remaps_src_with_keep() {
+        let k = vec![3u32, 1, 0];
+        let ep = ExpertPlan { keep: Some(&k) };
+        assert_eq!(ep.src(0), 3);
+        assert_eq!(ep.n_slots(8), 3);
+    }
+}

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
@@ -1,0 +1,808 @@
+# Generic MoE REAP — Sub-project 1: Generic Keep-Map Loader — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the DeepSeek-V4-specific REAP keep-map loader into a model-agnostic `hipfire-reap` crate and wire it into all 4 MoE arches present on the base (`deepseek4`, `qwen35`, `lfm2moe`, `minimax`), preserving the byte-identical default-off / keep-all-identity guarantee.
+
+**Architecture:** A new `hipfire-reap` crate owns plan parsing (`ReapPlan`), an overlay-then-base tensor resolver (`TensorSource`), an exact byte row-gather (`gather_rows`), and a per-(layer,role) `ExpertPlan` the arch loaders consume at their existing expert-enumeration seam. Arch-specific oddities (deepseek4 `tid2eid`/MTP) stay in the arch crate behind a `ReapArchHook`. Quant-override/overlay *application* and mixed dispatch are SP2–SP4; this plan ships pruning + the overlay-aware resolver plumbing only (tier table is parsed and threaded, but every tier resolves to the base dtype until SP2).
+
+**Tech Stack:** Rust, `serde_json`, the in-repo `hipfire-runtime` (`HfqFile`, `Gpu`, `DType`, `GpuTensor`). Tests via `cargo test -p hipfire-reap` and arch-level identity NLL checks via existing `examples/deepseek4_perplexity.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` (§1, §4 SP1 gates).
+
+**Scope note:** `cohere2moe` is in-flight on `nw_cohere2moe_support` and not on this base; it gets the identical Task-9-style wiring once merged. SP2 (mixed dispatch), SP3 (overlay application), SP4 (bake) get their own plans authored after this lands.
+
+---
+
+### Task 1: Scaffold the `hipfire-reap` crate
+
+**Files:**
+- Create: `crates/hipfire-reap/Cargo.toml`
+- Create: `crates/hipfire-reap/src/lib.rs`
+- Modify: `Cargo.toml` (workspace `members`)
+
+- [ ] **Step 1: Create the crate manifest**
+
+`crates/hipfire-reap/Cargo.toml`:
+```toml
+[package]
+name = "hipfire-reap"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+rdna_compute = { path = "../../rdna_compute" }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
+```
+(Verify the exact `rdna_compute` relative path and `serde_json`/`tempfile` versions against a sibling crate's `Cargo.toml`, e.g. `crates/hipfire-arch-deepseek4/Cargo.toml`; match whatever the workspace already pins.)
+
+- [ ] **Step 2: Create a placeholder lib so the crate compiles**
+
+`crates/hipfire-reap/src/lib.rs`:
+```rust
+//! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
+//! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+```
+
+- [ ] **Step 3: Register the crate in the workspace**
+
+In the root `Cargo.toml` `[workspace] members = [...]` list, add `"crates/hipfire-reap"` (alphabetically near the other `crates/hipfire-*` entries). Confirm the list style (some workspaces glob `crates/*`; if so, no edit needed — check first).
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `cargo build -p hipfire-reap`
+Expected: compiles clean (an unused-crate warning is fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-reap/Cargo.toml crates/hipfire-reap/src/lib.rs Cargo.toml
+git commit -m "feat(reap): scaffold hipfire-reap crate"
+```
+
+---
+
+### Task 2: `ReapPlan` — parse & validate `reap_plan.json`
+
+This generalizes `ReapKeepMap::load` (currently `crates/hipfire-arch-deepseek4/src/deepseek4.rs:256-328`) — same validation, but model-agnostic and extended with the optional `quant_overrides` manifest. Pruning is optional (`keep` may be absent ⇒ keep-all).
+
+**Files:**
+- Create: `crates/hipfire-reap/src/plan.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs` (add `pub mod plan;`)
+- Test: inline `#[cfg(test)]` in `plan.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `pub mod plan;` to `lib.rs`, then create `crates/hipfire-reap/src/plan.rs`:
+```rust
+use std::path::{Path, PathBuf};
+
+/// One selective-requant edit (applied in SP2+; parsed & validated now).
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuantOverride {
+    pub layer: usize,
+    pub role: Role,
+    /// Only meaningful for `Role::RoutedExperts`; empty ⇒ whole role at this layer.
+    pub experts: Vec<u32>,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    RoutedExperts,
+    SharedExpert,
+    Attention,
+    Router,
+    LmHead,
+    Embed,
+}
+
+impl Role {
+    pub fn parse(s: &str) -> Result<Role, String> {
+        Ok(match s {
+            "routed_experts" => Role::RoutedExperts,
+            "shared_expert" => Role::SharedExpert,
+            "attention" => Role::Attention,
+            "router" => Role::Router,
+            "lm_head" => Role::LmHead,
+            "embed" => Role::Embed,
+            other => return Err(format!("reap: unknown role '{other}'")),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReapPlan {
+    pub model_arch: Option<String>,
+    pub num_layers: usize,
+    pub original_experts: usize,
+    /// `keep[l][slot]` = original expert index in compact slot `slot`.
+    /// `None` ⇒ no pruning (keep all `original_experts`).
+    pub keep: Option<Vec<Vec<u32>>>,
+    pub quant_overrides: Vec<QuantOverride>,
+    pub dir: PathBuf,
+}
+
+impl ReapPlan {
+    pub fn kept_per_layer(&self) -> usize {
+        match &self.keep {
+            Some(k) => k.first().map(|r| r.len()).unwrap_or(0),
+            None => self.original_experts,
+        }
+    }
+
+    /// Load `<dir>/reap_plan.json`, validating against the model's layer/expert
+    /// counts (passed BEFORE any n_routed_experts override).
+    pub fn load(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = Path::new(dir).join("reap_plan.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: read {path:?}: {e}"))?;
+        let v: serde_json::Value =
+            serde_json::from_str(&txt).map_err(|e| format!("reap: parse {path:?}: {e}"))?;
+
+        let original_experts = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if original_experts != orig_experts_expected {
+            return Err(format!(
+                "reap: original_experts {original_experts} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let num_layers = v["num_layers"].as_u64().unwrap_or(num_layers_expected as u64) as usize;
+        if num_layers != num_layers_expected {
+            return Err(format!(
+                "reap: num_layers {num_layers} != model num_hidden_layers {num_layers_expected}"
+            ));
+        }
+
+        let keep = match v["keep"]["per_layer"].as_array() {
+            None => None,
+            Some(arr) => {
+                if arr.len() != num_layers_expected {
+                    return Err(format!(
+                        "reap: keep.per_layer has {} layers, model has {num_layers_expected}",
+                        arr.len()
+                    ));
+                }
+                let kept = arr.first().and_then(|r| r.as_array()).map(|r| r.len()).unwrap_or(0);
+                let mut out = Vec::with_capacity(arr.len());
+                for (l, row) in arr.iter().enumerate() {
+                    let r = row
+                        .as_array()
+                        .ok_or_else(|| format!("reap: keep layer {l} not an array"))?;
+                    if r.len() != kept {
+                        return Err(format!(
+                            "reap: keep layer {l} has {} entries, expected {kept}",
+                            r.len()
+                        ));
+                    }
+                    let mut v32 = Vec::with_capacity(kept);
+                    for x in r {
+                        let idx = x
+                            .as_u64()
+                            .ok_or_else(|| format!("reap: keep layer {l} non-integer index"))?
+                            as u32;
+                        if idx as usize >= original_experts {
+                            return Err(format!(
+                                "reap: keep layer {l} index {idx} >= original_experts {original_experts}"
+                            ));
+                        }
+                        v32.push(idx);
+                    }
+                    out.push(v32);
+                }
+                Some(out)
+            }
+        };
+
+        let mut quant_overrides = Vec::new();
+        if let Some(arr) = v["quant_overrides"].as_array() {
+            for (i, o) in arr.iter().enumerate() {
+                let layer = o["layer"]
+                    .as_u64()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing layer"))?
+                    as usize;
+                if layer >= num_layers_expected {
+                    return Err(format!(
+                        "reap: quant_override[{i}] layer {layer} >= num_layers {num_layers_expected}"
+                    ));
+                }
+                let role = Role::parse(
+                    o["role"].as_str().ok_or_else(|| format!("reap: quant_override[{i}] missing role"))?,
+                )?;
+                let experts: Vec<u32> = o["experts"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect())
+                    .unwrap_or_default();
+                if !experts.is_empty() && role != Role::RoutedExperts {
+                    return Err(format!(
+                        "reap: quant_override[{i}] lists experts but role is not routed_experts"
+                    ));
+                }
+                let tier = o["tier"]
+                    .as_str()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing tier"))?
+                    .to_string();
+                quant_overrides.push(QuantOverride { layer, role, experts, tier });
+            }
+        }
+
+        Ok(ReapPlan {
+            model_arch: v["model_arch"].as_str().map(|s| s.to_string()),
+            num_layers: num_layers_expected,
+            original_experts,
+            keep,
+            quant_overrides,
+            dir: PathBuf::from(dir),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_plan(json: &str) -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(d.path().join("reap_plan.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        d
+    }
+
+    #[test]
+    fn keep_all_when_keep_absent() {
+        let d = write_plan(r#"{"original_experts":8,"num_layers":2}"#);
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 8).unwrap();
+        assert!(p.keep.is_none());
+        assert_eq!(p.kept_per_layer(), 8);
+    }
+
+    #[test]
+    fn parses_keep_and_overrides() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":2,
+                "keep":{"per_layer":[[0,2,3],[1,2,3]]},
+                "quant_overrides":[{"layer":1,"role":"routed_experts","experts":[2],"tier":"mq3lloyd"}]}"#,
+        );
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 4).unwrap();
+        assert_eq!(p.kept_per_layer(), 3);
+        assert_eq!(p.keep.as_ref().unwrap()[0], vec![0, 2, 3]);
+        assert_eq!(p.quant_overrides.len(), 1);
+        assert_eq!(p.quant_overrides[0].tier, "mq3lloyd");
+    }
+
+    #[test]
+    fn rejects_out_of_range_index() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,"keep":{"per_layer":[[0,9]]}}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("index 9 >= original_experts 4"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_experts_on_non_routed_role() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"attention","experts":[1],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("not routed_experts"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_layer_count_mismatch() {
+        let d = write_plan(r#"{"original_experts":4,"num_layers":3,"keep":{"per_layer":[[0,1]]}}"#);
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 3, 4).unwrap_err();
+        assert!(err.contains("keep.per_layer has 1 layers"), "got: {err}");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile-first)**
+
+Run: `cargo test -p hipfire-reap plan::`
+Expected: passes once written — but first confirm `tempfile` is a dev-dep (Task 1). If it doesn't compile, fix the manifest, not the test.
+
+- [ ] **Step 3: (impl already inline above) Run tests to verify they pass**
+
+Run: `cargo test -p hipfire-reap plan::`
+Expected: 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/hipfire-reap/src/plan.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): ReapPlan json parse + validation"
+```
+
+---
+
+### Task 3: `gather_rows` — exact byte row-gather
+
+Generalizes `upload_quant_or_f16_keep`'s gather math (`crates/hipfire-arch-deepseek4/src/arch.rs:384-424`) into a pure, GPU-free function returning gathered bytes + new shape. Exact for row-independent quant (F16/Q8/MQ*-G256); rows that don't divide the byte length are a hard error.
+
+**Files:**
+- Create: `crates/hipfire-reap/src/gather.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs` (`pub mod gather;`)
+
+- [ ] **Step 1: Write the failing tests**
+
+`crates/hipfire-reap/src/gather.rs`:
+```rust
+/// Gather kept rows from a row-major tensor's raw bytes. `shape[0]` is the
+/// row count (e.g. experts); every row must be `bytes.len()/shape[0]` bytes.
+/// Returns `(new_shape, gathered_bytes)`. Exact for row-independent quant.
+pub fn gather_rows(shape: &[usize], bytes: &[u8], keep: &[u32]) -> Result<(Vec<usize>, Vec<u8>), String> {
+    let orig_rows = *shape.first().unwrap_or(&0);
+    if orig_rows == 0 || bytes.len() % orig_rows != 0 {
+        return Err(format!(
+            "reap: row-gather: {orig_rows} rows don't divide {} bytes",
+            bytes.len()
+        ));
+    }
+    let rowstride = bytes.len() / orig_rows;
+    let mut out = Vec::with_capacity(rowstride * keep.len());
+    for &oe in keep {
+        let oe = oe as usize;
+        if oe >= orig_rows {
+            return Err(format!("reap: row-gather keep idx {oe} >= rows {orig_rows}"));
+        }
+        out.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
+    }
+    let mut new_shape = shape.to_vec();
+    new_shape[0] = keep.len();
+    Ok((new_shape, out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gathers_subset_in_order() {
+        // 4 rows × 3 bytes
+        let bytes: Vec<u8> = vec![0,0,0, 1,1,1, 2,2,2, 3,3,3];
+        let (shape, out) = gather_rows(&[4, 3], &bytes, &[2, 0, 3]).unwrap();
+        assert_eq!(shape, vec![3, 3]);
+        assert_eq!(out, vec![2,2,2, 0,0,0, 3,3,3]);
+    }
+
+    #[test]
+    fn identity_keep_is_byte_identical() {
+        let bytes: Vec<u8> = (0..24).collect();
+        let (_, out) = gather_rows(&[4, 6], &bytes, &[0, 1, 2, 3]).unwrap();
+        assert_eq!(out, bytes);
+    }
+
+    #[test]
+    fn errors_on_indivisible_rows() {
+        let err = gather_rows(&[3, 2], &[0, 1, 2, 3, 4], &[0]).unwrap_err();
+        assert!(err.contains("don't divide"), "got: {err}");
+    }
+
+    #[test]
+    fn errors_on_out_of_range_keep() {
+        let err = gather_rows(&[2, 2], &[0, 1, 2, 3], &[5]).unwrap_err();
+        assert!(err.contains("keep idx 5 >= rows 2"), "got: {err}");
+    }
+}
+```
+Add `pub mod gather;` to `lib.rs`.
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo test -p hipfire-reap gather::`
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/gather.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): exact byte row-gather primitive"
+```
+
+---
+
+### Task 4: `TensorSource` + `ExpertPlan` — the loader-facing API
+
+`TensorSource` wraps a base `&HfqFile` (overlay handle is `None` in SP1; the field exists so SP3 slots in without changing call sites). `ExpertPlan` is what an arch asks for per (layer, role): the optional keep slice and a tier resolver (always base dtype in SP1).
+
+**Files:**
+- Create: `crates/hipfire-reap/src/source.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs` (`pub mod source;`, re-exports)
+
+- [ ] **Step 1: Write the source module + a unit test for the keep accessor**
+
+`crates/hipfire-reap/src/source.rs`:
+```rust
+use crate::plan::ReapPlan;
+use hipfire_runtime::hfq::HfqFile; // adjust path to wherever HfqFile is exported
+
+/// Overlay-then-base tensor resolver. SP1: overlay is always None (base only);
+/// SP3 adds the overlay HfqFile and prefers it when it holds `name`.
+pub struct TensorSource<'a> {
+    pub base: &'a HfqFile,
+    pub overlay: Option<&'a HfqFile>,
+}
+
+impl<'a> TensorSource<'a> {
+    pub fn new(base: &'a HfqFile) -> Self {
+        TensorSource { base, overlay: None }
+    }
+
+    /// Resolve a tensor by name: overlay first (SP3), else base.
+    pub fn tensor(&self, name: &str) -> Option<(hipfire_runtime::hfq::TensorInfo, Vec<u8>)> {
+        if let Some(ov) = self.overlay {
+            if let Some(hit) = ov.tensor_data_pread(name) {
+                return Some(hit);
+            }
+        }
+        self.base.tensor_data_pread(name)
+    }
+}
+
+/// Per-(layer, role) plan slice the arch loader consumes at its expert loop.
+pub struct ExpertPlan<'a> {
+    /// `keep[slot]` = original expert index for compact slot. `None` ⇒ identity.
+    keep: Option<&'a [u32]>,
+}
+
+impl<'a> ExpertPlan<'a> {
+    pub fn keep(&self) -> Option<&'a [u32]> {
+        self.keep
+    }
+    /// Original expert index for a compact slot (identity when no keep map).
+    pub fn src(&self, slot: usize) -> usize {
+        self.keep.map(|k| k[slot] as usize).unwrap_or(slot)
+    }
+    /// Number of compact expert slots for this layer.
+    pub fn n_slots(&self, full: usize) -> usize {
+        self.keep.map(|k| k.len()).unwrap_or(full)
+    }
+}
+
+impl ReapPlan {
+    /// Build the per-layer expert plan (routed experts). `None`-keep ⇒ identity.
+    pub fn expert_plan(&self, layer: usize) -> ExpertPlan<'_> {
+        ExpertPlan {
+            keep: self.keep.as_ref().map(|k| k[layer].as_slice()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // ExpertPlan::src/n_slots are pure; test them without an HfqFile.
+    #[test]
+    fn identity_src_when_no_keep() {
+        let ep = ExpertPlan { keep: None };
+        assert_eq!(ep.src(5), 5);
+        assert_eq!(ep.n_slots(8), 8);
+    }
+    #[test]
+    fn remaps_src_with_keep() {
+        let k = vec![3u32, 1, 0];
+        let ep = ExpertPlan { keep: Some(&k) };
+        assert_eq!(ep.src(0), 3);
+        assert_eq!(ep.n_slots(8), 3);
+    }
+}
+```
+**Before running:** confirm the real module paths for `HfqFile`, `TensorInfo`, and `tensor_data_pread`'s return type by grepping the deepseek4 loader (it calls `hfq.tensor_data_pread(&name)` returning `Option<(info, bytes)>`). Fix the `use` and the `tensor()` signature to match the actual types (the return is likely `(&TensorInfo, Vec<u8>)` or owned — match it; the test only exercises the pure `ExpertPlan` methods, so it compiles regardless of the exact HfqFile signature once the `use` resolves).
+
+Add `pub mod source;` and `pub use source::{ExpertPlan, TensorSource};` to `lib.rs`.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p hipfire-reap source::`
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/source.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): TensorSource + ExpertPlan loader API"
+```
+
+---
+
+### Task 5: `ReapArchHook` trait for arch-specific extras
+
+Lets the arch crate inject its own sidecar handling (deepseek4 `tid2eid` remap, MTP-skip) without `hipfire-reap` knowing about it.
+
+**Files:**
+- Create: `crates/hipfire-reap/src/hook.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs`
+
+- [ ] **Step 1: Define the trait**
+
+`crates/hipfire-reap/src/hook.rs`:
+```rust
+use crate::plan::ReapPlan;
+
+/// Arch-specific REAP extras. Default impls are no-ops so arches that need
+/// nothing (qwen35, lfm2moe, minimax) don't implement anything.
+pub trait ReapArchHook {
+    /// Path to an arch sidecar file inside the plan dir, if the arch uses one.
+    fn sidecar_path(&self, plan: &ReapPlan, name: &str) -> std::path::PathBuf {
+        plan.dir.join(name)
+    }
+    /// Whether this layer's auxiliary head (e.g. ds4 MTP) is skipped under reap.
+    fn skip_aux_head(&self, _plan: &ReapPlan, _layer: usize) -> bool {
+        false
+    }
+}
+```
+Add `pub mod hook;` and `pub use hook::ReapArchHook;` to `lib.rs`.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cargo build -p hipfire-reap`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/hook.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): ReapArchHook trait for arch-specific extras"
+```
+
+---
+
+### Task 6: Re-point deepseek4 onto `hipfire-reap` (the lift)
+
+Replace the in-crate `ReapKeepMap` + `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` path with `ReapPlan`/`HIPFIRE_REAP_PLAN`, keeping the old env var as a back-compat alias that loads a `keep`-only plan. The existing `upload_quant_or_f16_keep`/`upload_global_f16_as_f32_keep` GPU helpers stay (they wrap `gather_rows`'s math + an upload); we only swap their byte-gather core to call `hipfire_reap::gather::gather_rows` so there is one source of truth.
+
+**Files:**
+- Modify: `crates/hipfire-arch-deepseek4/Cargo.toml` (add `hipfire-reap` dep)
+- Modify: `crates/hipfire-arch-deepseek4/src/deepseek4.rs:100-236` (env hook, field type) and `:242-328` (delete `ReapKeepMap`)
+- Modify: `crates/hipfire-arch-deepseek4/src/arch.rs:384-424` (gather core → `gather_rows`)
+
+- [ ] **Step 1: Add the dependency**
+
+In `crates/hipfire-arch-deepseek4/Cargo.toml` `[dependencies]`, add:
+```toml
+hipfire-reap = { path = "../hipfire-reap" }
+```
+
+- [ ] **Step 2: Swap the env hook (deepseek4.rs ~229-236)**
+
+Replace the block that reads `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` and builds `ReapKeepMap` with one that prefers `HIPFIRE_REAP_PLAN` and falls back to the old var:
+```rust
+// REAP plan: emulate a pruned expert pool by partial-load. New generic env
+// HIPFIRE_REAP_PLAN=<dir> (reap_plan.json); legacy HIPFIRE_DEEPSEEK4_REAP_KEEPMAP
+// (keep_by_layer.json) still honored as a keep-only alias.
+let reap_dir = std::env::var("HIPFIRE_REAP_PLAN")
+    .ok()
+    .or_else(|| std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP").ok());
+if let Some(dir) = reap_dir {
+    let plan = hipfire_reap::plan::ReapPlan::load_any(
+        &dir,
+        config.num_hidden_layers,
+        config.n_routed_experts,
+    )?;
+    eprintln!(
+        "deepseek4: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.n_routed_experts
+    );
+    config.n_routed_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+}
+```
+Change the `reap_keep` field type (deepseek4.rs ~109) from `Option<Arc<ReapKeepMap>>` to `Option<Arc<hipfire_reap::plan::ReapPlan>>`. Update all readers of `.reap_keep` (the arch.rs upload sites and the `tid2eid_path` caller) to use `plan.keep` / the `ExpertPlan` accessors and the `ReapArchHook` for `tid2eid_path` (move `tid2eid_path` onto a small ds4 `ReapArchHook` impl).
+
+- [ ] **Step 3: Add `ReapPlan::load_any` (keep-only-alias loader)**
+
+In `crates/hipfire-reap/src/plan.rs`, add a helper that accepts either `reap_plan.json` or a legacy `keep_by_layer.json` in the dir:
+```rust
+impl ReapPlan {
+    /// Load `reap_plan.json` if present, else a legacy `keep_by_layer.json`
+    /// (keep-only; no overrides). Lets old ds4 sidecars keep working.
+    pub fn load_any(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        if Path::new(dir).join("reap_plan.json").exists() {
+            return Self::load(dir, num_layers_expected, orig_experts_expected);
+        }
+        Self::load_legacy_keepmap(dir, num_layers_expected, orig_experts_expected)
+    }
+}
+```
+Add `load_legacy_keepmap` that reads `keep_by_layer.json` (the old schema: `kept_per_layer`, `original_experts`, `keep`) and produces a `ReapPlan` with `keep: Some(...)`, `quant_overrides: vec![]`. Reuse the existing validation logic. Add a unit test mirroring an existing legacy sidecar shape.
+
+- [ ] **Step 4: Swap the gather core in arch.rs (~404-412)**
+
+Inside `upload_quant_or_f16_keep`, replace the manual `rowstride`/loop with:
+```rust
+let shape_usize: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+let (new_shape, sub) = hipfire_reap::gather::gather_rows(&shape_usize, &bytes, keep)?;
+```
+then upload `sub`/`new_shape` as before, preserving the `info.quant_type` → `t.dtype` mapping. Do the analogous swap is NOT needed for `upload_global_f16_as_f32_keep` (it decodes f16→f32 element-wise; leave it, or refactor to call `gather_rows` then decode — optional, keep behavior identical).
+
+- [ ] **Step 5: Build + run the ds4 identity check**
+
+Run: `cargo build -p hipfire-arch-deepseek4 && cargo test -p hipfire-reap`
+Then the identity NLL gate (the existing keep-all-256 sidecar): rebuild the ds4 perplexity example and confirm a keep-all `reap_plan.json` reproduces the no-plan baseline NLL to 10 decimals (use the existing `scripts/reap/build_keepall_sidecar.py`, regenerated to emit `reap_plan.json`, or point `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` at the legacy sidecar to exercise `load_legacy_keepmap`).
+Expected: identical NLL — the lift is behavior-preserving.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hipfire-arch-deepseek4 crates/hipfire-reap
+git commit -m "refactor(ds4): lift REAP onto hipfire-reap; HIPFIRE_REAP_PLAN + legacy alias"
+```
+
+---
+
+### Task 7: Wire `qwen35` (buffer arch)
+
+Buffer arch: experts are individual `ExpertWeights { gate_up, down }` (`crates/hipfire-arch-qwen35/src/qwen35.rs:4331-4346`). Pruning = iterate compact slots and load only kept experts by remapped name; router logits get a `gather_rows` on the per-expert rows.
+
+**Files:**
+- Modify: `crates/hipfire-arch-qwen35/Cargo.toml` (add `hipfire-reap`)
+- Modify: `crates/hipfire-arch-qwen35/src/qwen35.rs` (MoE loader ~4320-4380, config/env hook, router load)
+
+- [ ] **Step 1: Add dependency + thread the plan**
+
+Add `hipfire-reap = { path = "../hipfire-reap" }`. Locate where qwen35 reads its config/builds weights; add the same `HIPFIRE_REAP_PLAN` env read as ds4 (Task 6 Step 2), storing `Option<Arc<ReapPlan>>` on the config/weights struct, and override the routed-expert count (`n_routed_experts`/equivalent) to `plan.kept_per_layer()` when active.
+
+- [ ] **Step 2: Write the failing identity test**
+
+Add an arch-level test (or reuse the qwen35 perplexity/eval example) asserting a keep-all plan reproduces baseline logits for a small qwen35-MoE fixture. If no tiny fixture exists, gate this as a manual NLL check documented in the task and add a `#[test]` that at least exercises the loader path with a keep-all plan on a toy-sized config (skip if no fixture; note it).
+
+- [ ] **Step 3: Implement the loop change**
+
+Replace the expert loop (`for x in 0..n_exp`) with compact-slot iteration:
+```rust
+let plan = config.reap_keep.as_ref();
+let ep = plan.map(|p| p.expert_plan(layer_idx));
+let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
+for slot in 0..n_slots {
+    let x = ep.as_ref().map(|e| e.src(slot)).unwrap_or(slot);
+    let gate_up = load_weight_tensor(hfq, gpu, &format!("{p}.mlp.experts.{x}.gate_up_proj.weight"), 2 * mi, config.dim)?;
+    let down = load_weight_tensor(hfq, gpu, &format!("{p}.mlp.experts.{x}.down_proj.weight"), config.dim, mi)?;
+    experts.push(ExpertWeights { gate_up, down });
+}
+```
+For the **router** (`{p}.mlp.gate.weight` or equivalent, `[n_exp, dim]`): when `ep` has a keep, read its bytes, `gather_rows(&[n_exp, dim_stride], &bytes, keep)`, and upload the gathered subset so the router emits logits only for kept experts. (Find the exact router tensor name in the qwen35 loader and match its existing upload.)
+
+- [ ] **Step 4: Build + identity check**
+
+Run: `cargo build -p hipfire-arch-qwen35`, then the keep-all NLL check.
+Expected: baseline reproduced.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-arch-qwen35
+git commit -m "feat(qwen35): generic REAP keep-map loader wiring"
+```
+
+---
+
+### Task 8: Wire `lfm2moe` (buffer arch, fused-at-load gate_up)
+
+Same buffer-arch pattern as qwen35, but gate_up is fused from `w1`/`w3` at load (`crates/hipfire-arch-lfm2moe/src/lfm2moe.rs:345-454`) and per-layer AWQ scales hang off `experts[0]`.
+
+**Files:**
+- Modify: `crates/hipfire-arch-lfm2moe/Cargo.toml` (add `hipfire-reap`)
+- Modify: `crates/hipfire-arch-lfm2moe/src/lfm2moe.rs:345-454` + config/env hook
+
+- [ ] **Step 1: Add dependency + env hook + count override** (as Task 7 Step 1).
+
+- [ ] **Step 2: Convert the expert loop to compact slots**
+
+In the `MoeFfnWeights::load` expert loop, replace `e` with `slot`/`src` exactly as Task 7 Step 3, applying `src` to the `{prefix}.feed_forward.experts.{src}.{w1,w3,w2}.weight` names. Keep the w1‖w3 fuse unchanged (it operates per expert). **AWQ caveat:** the shared per-layer AWQ scale read from `experts[0]` must read from `experts[src(0)]`'s scale tensor — confirm the AWQ scale is layer-shared (same for all experts) or per-expert; if per-expert, gather it under keep. Document which, in the commit.
+
+- [ ] **Step 3: Router gather** as Task 7 Step 3 (find lfm2moe's router/gate tensor).
+
+- [ ] **Step 4: Build + identity check**
+
+Run: `cargo build -p hipfire-arch-lfm2moe`, then keep-all NLL check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-arch-lfm2moe
+git commit -m "feat(lfm2moe): generic REAP keep-map loader wiring"
+```
+
+---
+
+### Task 9: Wire `minimax` (blob arch, like deepseek4)
+
+Blob arch: all experts packed into single `gu_combined`/`dn_combined` blobs with a stride pointer table (`crates/hipfire-arch-minimax/src/minimax.rs:280-517`). Pruning = pack only kept experts' bytes via `src(slot)`, mirroring ds4's `upload_layer_routed_experts` change.
+
+**Files:**
+- Modify: `crates/hipfire-arch-minimax/Cargo.toml` (add `hipfire-reap`)
+- Modify: `crates/hipfire-arch-minimax/src/minimax.rs:280-517` + config/env hook
+
+- [ ] **Step 1: Add dependency + env hook + count override** (as Task 7 Step 1). MiniMax already has EP-shard logic; assert reap and EP-shard are mutually exclusive (mirror ds4 arch.rs's guard: error if both a keep plan and a shard config are present).
+
+- [ ] **Step 2: Pack only kept experts**
+
+In the blob-build loops (the `for e in 0..n_exp` that `extend_from_slice` w1/w3/w2 bytes), iterate compact slots and read `experts.{src(slot)}`:
+```rust
+let ep = config.reap_keep.as_ref().map(|p| p.expert_plan(layer_idx));
+let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
+for slot in 0..n_slots {
+    let e = ep.as_ref().map(|x| x.src(slot)).unwrap_or(slot);
+    // ... read experts.{e}.w1/w3/w2, extend into gu_combined/dn_combined ...
+}
+```
+The stride pointer table is then built over `n_slots` compact entries (unchanged math). **EP-shard:** since reap and EP-shard are mutually exclusive (Step 1), the non-owned-zero path is untouched when reap is active.
+
+- [ ] **Step 3: Router gather** (minimax router/gate `[n_exp, dim]`) as Task 7 Step 3.
+
+- [ ] **Step 4: Build + identity check**
+
+Run: `cargo build -p hipfire-arch-minimax`, then keep-all NLL check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-arch-minimax
+git commit -m "feat(minimax): generic REAP keep-map loader wiring"
+```
+
+---
+
+### Task 10: Cross-arch regression gate + end-to-end smoke
+
+**Files:**
+- Create: `crates/hipfire-reap/tests/identity_gate.md` (documented manual gate runner) or extend `scripts/reap/`
+- Modify: `scripts/reap/build_keepall_sidecar.py` → emit `reap_plan.json` (generic)
+
+- [ ] **Step 1: Generalize the keep-all sidecar builder**
+
+Update `scripts/reap/build_keepall_sidecar.py` to write a generic `reap_plan.json` with `keep.per_layer = [[0..N-1]] * num_layers` for a given (num_layers, n_experts), arch-agnostic.
+
+- [ ] **Step 2: Run the identity gate on every wired arch**
+
+For each of ds4, qwen35, lfm2moe, minimax with an available MoE checkpoint: load with `HIPFIRE_REAP_PLAN=<keepall dir>` and confirm logits/NLL match the no-plan baseline to 10 decimals. Record results in `scripts/reap/README.md`.
+Expected: all 4 reproduce baseline (the machinery is an exact no-op under keep-all).
+
+- [ ] **Step 3: ds4 end-to-end smoke**
+
+Reproduce the known K144 result through the new generic path: full-256 PPL ≈ 7.56 vs pruned-144 ≈ 17.73 on wikitext2 ctx=1024 (existing `scripts/reap/run_ppl_kld.sh`, regenerated keep-map as `reap_plan.json`).
+Expected: matches the pre-lift numbers — no regression.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/reap crates/hipfire-reap/tests
+git commit -m "test(reap): cross-arch keep-all identity gate + ds4 K144 smoke"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§1, §4-SP1):**
+- `hipfire-reap` crate + `ReapPlan`/`TensorSource`/`gather_rows`/`ExpertPlan`/`ReapArchHook` → Tasks 1–5. ✓
+- Overlay-then-base resolver present but overlay=None until SP3 → `TensorSource.overlay` field, Task 4. ✓
+- Blob-arch per-tier sub-blob packing → **deferred to SP2** (this plan packs kept experts into the *existing single* blob; multi-tier sub-blobs need the dtype table from SP2). Noted in Architecture. ✓ (pruning-only is correct for SP1.)
+- All 4 base arches wired → Tasks 6–9; cohere2moe on-merge noted. ✓
+- Byte-identical / keep-all identity gate → Tasks 6 Step 5, 10. ✓
+- `gather_rows` exactness + `ReapPlan` validation unit tests → Tasks 2, 3. ✓
+- Legacy env alias → Task 6 Step 3. ✓
+
+**Placeholder scan:** Tasks 7–9 Step 2 reference "find the exact router tensor name" / "if no fixture exists" — these are genuine per-arch lookups the implementer must do at the seam; each gives the file:line and the transform pattern with concrete code, not hand-waving. Acceptable (the unknown is a tensor *name* in a known file, not missing logic).
+
+**Type consistency:** `ReapPlan` (fields `keep: Option<Vec<Vec<u32>>>`, `quant_overrides`, `dir`), `ExpertPlan::{src,n_slots,keep}`, `gather_rows(shape,bytes,keep)->(Vec<usize>,Vec<u8>)`, `TensorSource::{new,tensor,overlay}`, `ReapArchHook` — names used consistently across Tasks 4–10. `config.reap_keep: Option<Arc<ReapPlan>>` used identically in Tasks 6–9. ✓
+
+**Known follow-ups (SP2+):** mixed-tier sub-blob packing, `per_expert_quant` dtype table, overlay application (`TensorSource.overlay = Some(...)`), bake. Each gets its own plan.

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
@@ -10,6 +10,13 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` (§1, §4 SP1 gates).
 
+> ⛔ **GPU EMBARGO (2026-06-11):** the GPU is in use by separate cohere work. Do **NOT** run any
+> step that loads a model on the GPU: no `examples/daemon`, no perplexity/NLL/PPL/KLD runs, no
+> `cargo run`, and no `cargo test` on the arch crates (they may init the GPU). Allowed: editing
+> code, `cargo build -p <crate>` (compile only — kernels JIT at runtime, not build time), and
+> `cargo test -p hipfire-reap` (pure-CPU unit tests). Steps marked **[GPU — DEFERRED]** must be
+> left unchecked with a note; implement the code they verify, but do not execute them.
+
 **Scope note:** `cohere2moe` is in-flight on `nw_cohere2moe_support` and not on this base; it gets the identical Task-9-style wiring once merged. SP2 (mixed dispatch), SP3 (overlay application), SP4 (bake) get their own plans authored after this lands.
 
 ---
@@ -633,11 +640,15 @@ let (new_shape, sub) = hipfire_reap::gather::gather_rows(&shape_usize, &bytes, k
 ```
 then upload `sub`/`new_shape` as before, preserving the `info.quant_type` → `t.dtype` mapping. Do the analogous swap is NOT needed for `upload_global_f16_as_f32_keep` (it decodes f16→f32 element-wise; leave it, or refactor to call `gather_rows` then decode — optional, keep behavior identical).
 
-- [ ] **Step 5: Build + run the ds4 identity check**
+- [ ] **Step 5a: Build + CPU tests (run now)**
 
 Run: `cargo build -p hipfire-arch-deepseek4 && cargo test -p hipfire-reap`
-Then the identity NLL gate (the existing keep-all-256 sidecar): rebuild the ds4 perplexity example and confirm a keep-all `reap_plan.json` reproduces the no-plan baseline NLL to 10 decimals (use the existing `scripts/reap/build_keepall_sidecar.py`, regenerated to emit `reap_plan.json`, or point `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` at the legacy sidecar to exercise `load_legacy_keepmap`).
-Expected: identical NLL — the lift is behavior-preserving.
+Expected: compiles; `hipfire-reap` unit tests (incl. the new `load_legacy_keepmap` test) pass.
+
+- [ ] **Step 5b: [GPU — DEFERRED] ds4 identity NLL gate**
+
+The identity NLL gate (existing keep-all-256 sidecar): confirm a keep-all `reap_plan.json` reproduces the no-plan baseline NLL to 10 decimals (use `scripts/reap/build_keepall_sidecar.py` regenerated to emit `reap_plan.json`, or point `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` at the legacy sidecar to exercise `load_legacy_keepmap`).
+**Do NOT run under the GPU embargo** — leave unchecked; note "deferred: GPU in use". The lift must be behavior-preserving; this is the gate to run once the GPU frees.
 
 - [ ] **Step 6: Commit**
 
@@ -680,10 +691,10 @@ for slot in 0..n_slots {
 ```
 For the **router** (`{p}.mlp.gate.weight` or equivalent, `[n_exp, dim]`): when `ep` has a keep, read its bytes, `gather_rows(&[n_exp, dim_stride], &bytes, keep)`, and upload the gathered subset so the router emits logits only for kept experts. (Find the exact router tensor name in the qwen35 loader and match its existing upload.)
 
-- [ ] **Step 4: Build + identity check**
+- [ ] **Step 4: Build (run now) + [GPU — DEFERRED] identity check**
 
-Run: `cargo build -p hipfire-arch-qwen35`, then the keep-all NLL check.
-Expected: baseline reproduced.
+Run: `cargo build -p hipfire-arch-qwen35` (compile only).
+The keep-all NLL check is **[GPU — DEFERRED]** under the embargo — leave unchecked, note "deferred: GPU in use".
 
 - [ ] **Step 5: Commit**
 
@@ -710,9 +721,10 @@ In the `MoeFfnWeights::load` expert loop, replace `e` with `slot`/`src` exactly 
 
 - [ ] **Step 3: Router gather** as Task 7 Step 3 (find lfm2moe's router/gate tensor).
 
-- [ ] **Step 4: Build + identity check**
+- [ ] **Step 4: Build (run now) + [GPU — DEFERRED] identity check**
 
-Run: `cargo build -p hipfire-arch-lfm2moe`, then keep-all NLL check.
+Run: `cargo build -p hipfire-arch-lfm2moe` (compile only).
+Keep-all NLL check is **[GPU — DEFERRED]** — leave unchecked, note "deferred: GPU in use".
 
 - [ ] **Step 5: Commit**
 
@@ -748,9 +760,10 @@ The stride pointer table is then built over `n_slots` compact entries (unchanged
 
 - [ ] **Step 3: Router gather** (minimax router/gate `[n_exp, dim]`) as Task 7 Step 3.
 
-- [ ] **Step 4: Build + identity check**
+- [ ] **Step 4: Build (run now) + [GPU — DEFERRED] identity check**
 
-Run: `cargo build -p hipfire-arch-minimax`, then keep-all NLL check.
+Run: `cargo build -p hipfire-arch-minimax` (compile only).
+Keep-all NLL check is **[GPU — DEFERRED]** — leave unchecked, note "deferred: GPU in use".
 
 - [ ] **Step 5: Commit**
 
@@ -771,21 +784,22 @@ git commit -m "feat(minimax): generic REAP keep-map loader wiring"
 
 Update `scripts/reap/build_keepall_sidecar.py` to write a generic `reap_plan.json` with `keep.per_layer = [[0..N-1]] * num_layers` for a given (num_layers, n_experts), arch-agnostic.
 
-- [ ] **Step 2: Run the identity gate on every wired arch**
+- [ ] **Step 2: [GPU — DEFERRED] Run the identity gate on every wired arch**
 
 For each of ds4, qwen35, lfm2moe, minimax with an available MoE checkpoint: load with `HIPFIRE_REAP_PLAN=<keepall dir>` and confirm logits/NLL match the no-plan baseline to 10 decimals. Record results in `scripts/reap/README.md`.
-Expected: all 4 reproduce baseline (the machinery is an exact no-op under keep-all).
+**Do NOT run under the GPU embargo** — leave unchecked, note "deferred: GPU in use". Expected (when run): all 4 reproduce baseline (exact no-op under keep-all).
 
-- [ ] **Step 3: ds4 end-to-end smoke**
+- [ ] **Step 3: [GPU — DEFERRED] ds4 end-to-end smoke**
 
 Reproduce the known K144 result through the new generic path: full-256 PPL ≈ 7.56 vs pruned-144 ≈ 17.73 on wikitext2 ctx=1024 (existing `scripts/reap/run_ppl_kld.sh`, regenerated keep-map as `reap_plan.json`).
-Expected: matches the pre-lift numbers — no regression.
+**Do NOT run under the GPU embargo** — leave unchecked, note "deferred: GPU in use". Expected (when run): matches pre-lift numbers — no regression.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Commit the (Python/script) changes**
 
+Step 1 (CPU, the `build_keepall_sidecar.py` generalization) is runnable now; Steps 2–3 are deferred. Commit what's done:
 ```bash
 git add scripts/reap crates/hipfire-reap/tests
-git commit -m "test(reap): cross-arch keep-all identity gate + ds4 K144 smoke"
+git commit -m "test(reap): generalize keep-all sidecar builder; cross-arch identity gate (GPU-deferred)"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+++ b/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
@@ -1,0 +1,232 @@
+# Generic MoE REAP — selective expert pruning + selective re-quant
+
+**Date:** 2026-06-11
+**Branch:** `nw_generic_moe_reap` (worktree `~/repos/hipfire-reap`, based off `nw_reap162b_keepmap` @ `43ed446d`)
+**Author:** Nick Woolmer
+
+## Problem
+
+The existing REAP loader (`43ed446d`, branch `nw_reap162b_keepmap`) is **DeepSeek-V4-specific**.
+It lets us emulate a REAP-pruned checkpoint (e.g. 0xSero 162B, 256→144 experts) by
+partial-loading the kept experts from an existing full mq2-lloyd quant — no re-quant —
+via an env-gated keep-map sidecar (`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP`). It validated cleanly
+(keep-all identity reproduces baseline NLL to 10 decimals) and produced the K144 finding
+(full PPL 7.56 vs pruned 17.73).
+
+We want two generalizations:
+
+1. **Generic across all MoE archs.** Any user should be able to selectively reap any MoE
+   model — `deepseek4`, `qwen35`, `cohere2moe`, `lfm2moe`, `minimax` — not just ds4.
+2. **Lightweight selective re-quant.** Selectively up- or down-quant specific layers/experts
+   *without* re-quantizing the whole model, to iterate and fine-tune a quant config cheaply.
+
+## Prior art (reuse, don't duplicate)
+
+- **Existing ds4 REAP loader** (`43ed446d`): `ReapKeepMap` + `from_hfq` env hook in `deepseek4.rs`;
+  per-expert byte row-gather `upload_quant_or_f16_keep` + hash `tid2eid` remap in `arch.rs`;
+  `examples/deepseek4_perplexity.rs` + `scripts/reap/`. This is the foundation we lift.
+- **Mixed-precision K-map** (`docs/superpowers/specs/2026-05-08-mixed-quant-kmap-design.md`,
+  implemented in `hipfire-quantize/src/main.rs`: `enum QuantLevel`, `kmap_resolve_mode`,
+  `Promote6`). This is the *build-time, heuristic* mixed-precision path (tensor role/layer/MoE →
+  level → one new `.hfq`). Our `quant_overrides` is the *explicit, manual* counterpart, and
+  `reap bake` reuses the quantizer's per-format encoders + K-map machinery rather than
+  reimplementing quant math. **Distinction:** K-map promotes by *tensor role* (lm_head, router,
+  edge layers) where tensors are already separately dispatched; our novel runtime work is mixing
+  tiers *among routed experts within a single layer's expert pool*, which needs new dispatch.
+
+## Non-goals
+
+- New mixed-type MoE GEMV kernels (we bucket existing single-tier kernels instead).
+- Prefill grouped-GEMM support for mixed-tier layers (decode/scoring is the target; see §2 scope honesty).
+- Combining REAP with EP (expert-parallel) sharding — kept mutually exclusive, as today.
+
+## Artifacts & contract
+
+Two artifacts per experiment, plus an activation env var.
+
+### A. `reap_plan.json` — metadata/contract (no weight bytes)
+
+```jsonc
+{
+  "version": 1,
+  "model_arch": "deepseek4",        // optional; validated against detected arch
+  "original_experts": 256,          // base per-layer routed count; validated pre-override
+  "num_layers": 43,
+
+  "keep": {                         // OPTIONAL — omit ⇒ no pruning (keep all)
+    "per_layer": [[0,1,5, /* … */ ], /* … */ ]   // kept ORIGINAL indices, compact-slot order
+  },
+
+  "quant_overrides": [              // OPTIONAL — manifest of re-quantized tensors
+    { "layer": 20, "role": "routed_experts", "experts": [7,12], "tier": "mq3lloyd" },
+    { "layer": 41, "role": "attention",                          "tier": "q8"       }
+  ],
+
+  "arch": { "deepseek4": { "tid2eid_layers": [0,1,2] } }  // arch-specific extras
+}
+```
+
+- `role` ∈ `routed_experts | shared_expert | attention | router | lm_head | embed`.
+- `experts` is valid only for `role: routed_experts` (absent ⇒ whole role at that layer).
+- `tier` is a quant-format name the quantizer understands (`q8`, `f16`, `mq2lloyd`,
+  `mq3lloyd`, `mq4lloyd`, `hfq4g256`, `hfq6g256`, …).
+
+### B. `overlay.hfq` — small HFQ sidecar with only the re-quantized tensors
+
+Keyed by the **same tensor names** as the base file (`{prefix}.ffn.experts.7.w1.weight`, …).
+Built by `hipfire reap quant`. Cheap because only targeted tensors are re-quantized.
+
+### Loader resolution rule (the heart of it)
+
+When fetching tensor `N`: check `overlay.hfq` first, else base `.hfq`; then apply keep-gather.
+Dispatch reads each expert's effective tier from the plan to bucket kernels. This reuses the
+existing tensor-by-name HFQ lookup, so all 5 arches get overlay support at the same seam they
+already load from.
+
+### Activation
+
+`HIPFIRE_REAP_PLAN=<dir>` (dir holds `reap_plan.json` + optional `overlay.hfq` + arch sidecars),
+generalizing today's `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP`. Default-off ⇒ untouched base load.
+The old env var is kept as a thin alias (parses into a `keep`-only plan) for back-compat with
+existing ds4 sidecars.
+
+## Decomposition (4 sub-projects, dependency order)
+
+1. **Generic reap keep-map loader** — `hipfire-reap` crate + `ExpertLoaderHook` seam across all
+   5 arches. Independent; extends existing code.
+2. **Mixed-quant dispatch** — `MoeDtypes` per-expert tier vectors + bucketed dispatch. Prereq for
+   per-expert/mixed quant at runtime.
+3. **Load-time quant overlay** — `overlay.hfq` spliced over base at load (fast iterate loop).
+   Depends on 2.
+4. **Offline bake** — quantizer writes a standalone `.hfq` from plan + overlay. Depends on 1+3
+   plan format.
+
+---
+
+## §1 — `hipfire-reap` crate & loader seam (sub-project 1)
+
+**New crate `hipfire-reap`** (deps: `hipfire-runtime` for `HfqFile`/`Gpu`/`DType`; depended on by
+each arch crate). Owns all model-agnostic logic so arch crates stay thin.
+
+- **`ReapPlan`** — parse + validate `reap_plan.json`. Generalizes the ds4 `ReapKeepMap`
+  validation (layer count, `original_experts`, in-range indices, role/expert misuse). Resolves
+  the optional `overlay.hfq` handle.
+- **`TensorSource`** — overlay-then-base resolution: `fn tensor(name) -> (info, bytes)`. Replaces
+  raw `hfq.tensor_data_pread(name)` in arch loaders.
+- **`gather_rows(info, bytes, keep) -> (info', bytes')`** — generalized, arch-free version of ds4
+  `upload_quant_or_f16_keep`. Exact byte gather for row-independent quant (F16/Q8/MQ*-G256);
+  errors on row-coupled formats. Used for router gate/bias and any expert-pruned role.
+- **`ExpertPlan { keep: Option<&[u32]>, tier_of_slot: impl Fn(usize) -> DType }`** per (layer,
+  role) — what the arch loader asks `hipfire-reap` for.
+- **`ReapArchHook`** — callback the plan invokes for arch-specific bits (ds4 `tid2eid` remap +
+  MTP-skip). Only ds4 implements it; `hipfire-reap` never learns about it.
+
+**The seam in each arch** is the existing expert-enumeration loop
+(`for e in 0..n_exp { … pread(experts.{e}…) … }`). It becomes: iterate compact slots, resolve
+`src = keep[slot]`, fetch via `TensorSource`, group the upload **by tier**:
+
+- **Blob-packing arches (deepseek4 `arch.rs:163-333`, minimax `minimax.rs:280-517`):** build
+  **one sub-blob per quant tier present in the layer** instead of one blob/layer. Each expert's
+  pointer-table slot points into its tier's sub-blob (pointer table is already per-expert → no
+  kernel change). Uniform-tier layer ⇒ one sub-blob ⇒ byte-identical to today.
+- **Buffer arches (qwen35 `qwen35.rs:4331-4435`, cohere2moe `cohere2moe.rs:188-237`, lfm2moe
+  `lfm2moe.rs:345-454`):** already one `WeightTensor` (+ `gpu_dtype`) per expert → mixed tiers
+  naturally representable; only change is recording the per-expert tier for dispatch.
+
+**Byte-identical guarantee:** no plan ⇒ original path unchanged. Keep-all + no overrides ⇒ gather
+is identity and single-tier sub-blob equals today's blob. The identity-sidecar test becomes the
+cross-arch regression gate.
+
+**Files touched:** new `crates/hipfire-reap/`; `arch.rs`/`*.rs` expert loops in all 5 arch crates;
+`deepseek4.rs` env hook → delegate to `hipfire-reap` + register `ReapArchHook`.
+
+---
+
+## §2 — Mixed-quant dispatch (sub-project 2)
+
+Today `MoeDtypes` (`hipfire-dispatch/src/families/moe.rs:41-50`) carries one `routed_gate_up`/
+`routed_down` `DType` sampled from `expert[0]`; `pipeline/mod.rs:207-435` branches monolithically.
+
+- **Extend `MoeDtypes`** with `per_expert_gate_up: Option<Vec<DType>>` and
+  `per_expert_down: Option<Vec<DType>>`. `None` ⇒ today's uniform path, untouched. `Some(v)` ⇒
+  mixed path. Arch `MoeDtypes` builder fills these from the `ExpertPlan` tier table only when the
+  layer is actually mixed.
+- **`MoeResolution::resolve`** gains `mixed: bool`. Set ⇒ **bucketed path**: group the layer's
+  top-k selected experts by tier; for each tier call the existing single-tier
+  `gemv_*_moe_*_indexed` kernel over that tier's sub-blob + remapped compact indices, accumulating
+  into the same output. 2-3 tiers ⇒ 2-3 launches/layer; uniform layers never enter this path.
+- **Index remapping:** each bucket gets a compact index list (selected experts of that tier) +
+  the tier sub-blob pointer table from §1 — the kernel sees the contiguous-stride layout it
+  already expects. **No kernel signature changes.**
+- **Both decode sites covered:** generic `run_moe_decode` (`pipeline/mod.rs:207`) *and* ds4
+  `run_moe_decode_bias_aware` (`pipeline/mod.rs:604`) / `ffn_hash_routed`
+  (`deepseek4/forward.rs:3505`). The memory flags these as two separate dispatch sites (the
+  all-NaN gotcha) — the bucketing helper lives in `hipfire-dispatch`; both call it.
+
+**Scope honesty:** this targets decode/scoring (PPL/KLD, serve-decode). Prefill grouped-GEMM
+kernels stay single-tier per layer; a mixed layer falls back to per-tier grouped calls, or if a
+tier lacks a prefill kernel (e.g. mq3) that layer is **decode-only** — matching the current mq3
+"score-not-serve" limitation. Spec calls this out; no silent degradation.
+
+---
+
+## §3 — Quant tooling: overlays & bake (sub-projects 3 & 4)
+
+**`hipfire reap quant`** (build an overlay): reads the base `.hfq`; for each `quant_overrides`
+entry re-quantizes only the targeted tensors to `tier`, writing them into `overlay.hfq` under
+their original names. Reuses existing per-format encoders + the K-map `kmap_resolve_mode` path in
+`hipfire-quantize/src/main.rs` — no new quant math. Re-quanting "layer 20 experts 7,12" is
+seconds, not full-model hours. This is the fast iterate loop.
+
+- Per-expert `routed_experts` with `experts: [...]` ⇒ only those experts' `w1/w3/w2` (or
+  `gate_up_proj/down_proj`) rows are re-quantized; the loader tier table marks those slots so §1
+  packs them into the right tier sub-blob and §2 buckets them.
+- Whole-role overrides (attention/router/lm_head/embed) replace the single tensor wholesale.
+
+**`hipfire reap bake`** (freeze to standalone `.hfq`): consumes the same `reap_plan.json` +
+`overlay.hfq` and writes an ordinary servable `.hfq`:
+- pruned experts dropped, kept experts renumbered to compact slots (byte row-gather → disk);
+- overlay tensors written in place of base counterparts;
+- arch sidecars (ds4 `tid2eid`) folded into file metadata so the baked model needs no plan/env at
+  load.
+
+Result loads through the normal path, no env var. Overlay = iterate; bake = freeze once happy.
+Both consume one plan, so what you tuned is exactly what you bake.
+
+---
+
+## §4 — Testing & validation
+
+Per-sub-project gates, anchored on the **identity invariant** (keep-all + no overrides reproduces
+baseline NLL to 10 decimals).
+
+- **SP1 (generic loader):** identity-sidecar test → **cross-arch regression gate**: each of the 5
+  MoE arches must reproduce its no-plan baseline logits (bit-for-bit, or NLL to 10 decimals) under
+  a keep-all plan. Unit tests on `ReapPlan` validation (bad layer counts, out-of-range indices,
+  role/expert misuse) and `gather_rows` exactness (gathered subset == direct per-row reads, for
+  F16/Q8/MQ*-G256).
+- **SP2 (mixed dispatch):** **bucketing-equivalence test** — a layer whose experts are all one
+  tier, routed through the *mixed* path, must match the uniform path exactly (bucketing is a no-op
+  decomposition before any real mixing). Run on both `run_moe_decode` and ds4 bias-aware/hash
+  paths.
+- **SP3 (overlay):** overlay re-quantizing a tensor **to the tier it already is** must reproduce
+  base load (plumbing exact when re-quant is a no-op). Then a real down-quant (one layer mq2→mq3)
+  shows the expected small, *localized* NLL shift via the generalized `scripts/reap` PPL/KLD
+  harness.
+- **SP4 (bake):** baked model must produce **identical logits to the same plan applied via overlay
+  at load** (bake == freeze the overlay path). Baked file loads with no env var and serves through
+  the normal path.
+
+**End-to-end smoke:** reproduce the existing 162B K144 result (full 7.56 vs pruned 17.73 PPL)
+through the new *generic* ds4 path — confirms no regression from the lift.
+
+Each gate is a written assertion before the code (TDD-friendly).
+
+## Open questions / risks
+
+- **`gather_rows` on row-coupled quant:** must hard-error (not silently corrupt) for any format
+  whose rows aren't self-contained. Enumerate which current formats are row-independent up front.
+- **Tier sub-blob count blow-up:** pathological plans (many tiers/layer) multiply sub-blobs +
+  launches. Cap/ warn beyond N tiers per layer.
+- **K-map ↔ overrides precedence:** if a baked model is produced with both `--kmap` and a reap
+  plan, define precedence (proposed: explicit `quant_overrides` win over heuristic `kmap_resolve`).

--- a/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+++ b/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
@@ -16,7 +16,10 @@ via an env-gated keep-map sidecar (`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP`). It validat
 We want two generalizations:
 
 1. **Generic across all MoE archs.** Any user should be able to selectively reap any MoE
-   model — `deepseek4`, `qwen35`, `cohere2moe`, `lfm2moe`, `minimax` — not just ds4.
+   model — not just ds4. Target archs present on the integration base are `deepseek4`,
+   `qwen35`, `lfm2moe`, `minimax`. **`cohere2moe` is currently in-flight on branch
+   `nw_cohere2moe_support` and not yet on master** — it gets the *identical* one-call
+   `ExpertLoaderHook` wiring once it merges; we do not build on that moving branch here.
 2. **Lightweight selective re-quant.** Selectively up- or down-quant specific layers/experts
    *without* re-quantizing the whole model, to iterate and fine-tune a quant config cheaply.
 

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -1,0 +1,55 @@
+# REAP keep-map test harness (DeepSeek V4)
+
+Evaluate a **REAP-pruned** DeepSeek-V4 variant (e.g. 0xSero `DeepSeek-V4-Flash-162B`,
+256→144 routed experts) **without re-quantizing** — by partial-loading the kept
+experts out of an existing full quant (`deepseek-v4-flash.mq2lloyd`).
+
+A REAP prune is a *pure expert selection*: the kept experts (and the router rows
+for them) are byte-identical to the full model; only the hash-router `tid2eid`
+tables (layers 0–2) are remapped. So the loader can keep only `keep[l]` experts
+per layer, packed into compact slots `0..kept`, and reproduce the pruned model
+exactly from the full quant.
+
+## Loader hook
+
+`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` activates the keep-map in the ds4 loader
+(`crates/hipfire-arch-deepseek4/src/{deepseek4.rs,arch.rs}`). Default-off ⇒ the
+load path is byte-identical (validated: a keep-all-256 identity sidecar
+reproduces the full baseline NLL to 10 decimals). When active: `n_routed_experts`
+→ kept count; expert blob loads `experts.{keep[l][slot]}`; Q8 gate + F16 bias rows
+are gathered to `keep[l]`; hash `tid2eid` is read from the sidecar. All exact byte
+ops — no dequant.
+
+## Workflow
+
+```bash
+# 1. Build the keep-map sidecar from the pruned repo's reap_plan.json + safetensors
+python3 scripts/reap/build_reap_keepmap.py
+#    -> /data/hipfire-models/reap_keepmap_162B_k144/{keep_by_layer.json, tid2eid_l{0,1,2}.i32}
+
+# 2. (optional) Identity sidecar to validate the machinery is an exact no-op
+python3 scripts/reap/build_keepall_sidecar.py
+#    HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=/data/hipfire-models/reap_keepall_256 ... must == full PPL
+
+# 3. Build the PPL harness
+cargo build --release -p hipfire-arch-deepseek4 --example deepseek4_perplexity
+
+# 4. Run full-vs-pruned PPL + KLD
+scripts/reap/run_ppl_kld.sh 1024 8
+```
+
+`deepseek4_perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N] [--dump-logits PATH]`
+computes NLL/PPL via `decode_step`; `--dump-logits` writes per-position full-vocab
+logits (`DS4PPL01` format) for `kld_compare.py` (stdlib-only — this box's numpy is
+broken). Set the keep-map env var to score the pruned variant; unset for the full
+baseline.
+
+## Result (0xSero 162B, K144, mq2-lloyd, wikitext2, ctx=1024)
+
+| | full-256 | pruned-144 |
+|---|---|---|
+| PPL | 7.56 | 17.73 |
+| NLL/tok | 2.023 | 2.875 |
+
+KL(full‖pruned) = 1.14 nats, KL(pruned‖full) = 1.64, top-1 agreement = 57.6%.
+The K144 checkpoint is heavily degraded (experimental, partial calibration).

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -1,8 +1,13 @@
-# REAP keep-map test harness (DeepSeek V4)
+# REAP keep-map test harness (generic MoE)
 
-Evaluate a **REAP-pruned** DeepSeek-V4 variant (e.g. 0xSero `DeepSeek-V4-Flash-162B`,
+Evaluate a **REAP-pruned** MoE variant (e.g. 0xSero `DeepSeek-V4-Flash-162B`,
 256→144 routed experts) **without re-quantizing** — by partial-loading the kept
 experts out of an existing full quant (`deepseek-v4-flash.mq2lloyd`).
+
+The keep-map loader is now **arch-generic** (crate `hipfire-reap`), wired into
+`deepseek4`, `qwen35`, `lfm2moe`, `minimax`. Activate on any of them with
+`HIPFIRE_REAP_PLAN=<dir>` (a `reap_plan.json`). `cohere2moe` gets the same wiring
+once it merges to master. See `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md`.
 
 A REAP prune is a *pure expert selection*: the kept experts (and the router rows
 for them) are byte-identical to the full model; only the hash-router `tid2eid`
@@ -12,13 +17,18 @@ exactly from the full quant.
 
 ## Loader hook
 
-`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` activates the keep-map in the ds4 loader
-(`crates/hipfire-arch-deepseek4/src/{deepseek4.rs,arch.rs}`). Default-off ⇒ the
-load path is byte-identical (validated: a keep-all-256 identity sidecar
-reproduces the full baseline NLL to 10 decimals). When active: `n_routed_experts`
-→ kept count; expert blob loads `experts.{keep[l][slot]}`; Q8 gate + F16 bias rows
-are gathered to `keep[l]`; hash `tid2eid` is read from the sidecar. All exact byte
-ops — no dequant.
+`HIPFIRE_REAP_PLAN=<dir>` activates the generic keep-map (any wired MoE arch); for
+ds4, the legacy `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` still works as an alias
+(loads a keep-only plan from `keep_by_layer.json`). Default-off ⇒ the load path is
+byte-identical. When active: routed-expert count → kept count; each kept expert is
+loaded/packed from `experts.{keep[l][slot]}`; router/gate (+ per-expert bias, ds4
+hash `tid2eid`) rows are gathered to `keep[l]` via the shared `gather_rows`. All
+exact byte ops — no dequant. REAP and EP-sharding are mutually exclusive.
+
+> ⚠️ The cross-arch **keep-all identity gate** and the ds4 **K144 PPL/KLD smoke**
+> below are **GPU-deferred** (the box's GPU is in use). The loader code compiles and
+> all `hipfire-reap` CPU unit tests pass; the 10-decimal NLL gate must be run once
+> the GPU frees. See the SP1 plan's GPU-embargo note.
 
 ## Workflow
 
@@ -27,9 +37,13 @@ ops — no dequant.
 python3 scripts/reap/build_reap_keepmap.py
 #    -> /data/hipfire-models/reap_keepmap_162B_k144/{keep_by_layer.json, tid2eid_l{0,1,2}.i32}
 
-# 2. (optional) Identity sidecar to validate the machinery is an exact no-op
-python3 scripts/reap/build_keepall_sidecar.py
-#    HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=/data/hipfire-models/reap_keepall_256 ... must == full PPL
+# 2. (optional) Keep-all identity plan to validate the machinery is an exact no-op.
+#    Generic (any arch): emits reap_plan.json for HIPFIRE_REAP_PLAN.
+python3 scripts/reap/build_keepall_sidecar.py --num-layers <L> --num-experts <E> \
+        --arch <name> --out /data/hipfire-models/reap_keepall_<E>
+#    ds4 convenience (also emits tid2eid + legacy keep_by_layer.json):
+python3 scripts/reap/build_keepall_sidecar.py --ds4
+#    Then HIPFIRE_REAP_PLAN=<out> must reproduce that arch's no-plan baseline NLL.
 
 # 3. Build the PPL harness
 cargo build --release -p hipfire-arch-deepseek4 --example deepseek4_perplexity

--- a/scripts/reap/build_keepall_sidecar.py
+++ b/scripts/reap/build_keepall_sidecar.py
@@ -1,17 +1,31 @@
 #!/usr/bin/env python3
-# Identity sidecar: keep ALL 256 experts (no pruning), ORIGINAL tid2eid.
-# If the keep-map machinery is correct, running with this must reproduce the
-# full-256 (no-keep-map) PPL exactly — isolates machinery bugs from REAP cost.
-import struct, json, os
+# Keep-ALL identity plan: keep every expert (no pruning). If the generic REAP
+# machinery is correct, loading any MoE arch with HIPFIRE_REAP_PLAN=<out> must
+# reproduce that arch's no-plan baseline NLL to ~10 decimals — isolating
+# machinery bugs from REAP pruning cost. Arch-agnostic.
+#
+# Usage:
+#   build_keepall_sidecar.py --num-layers N --num-experts E --out DIR [--arch NAME]
+#   # ds4 convenience (also emits hash-layer tid2eid sidecars + legacy
+#   # keep_by_layer.json so the HIPFIRE_DEEPSEEK4_REAP_KEEPMAP alias path is
+#   # exercised too):
+#   build_keepall_sidecar.py --ds4 [--out DIR]
+#
+# Emits <out>/reap_plan.json (new generic schema). In --ds4 mode also emits
+# tid2eid_l{L}.i32 (identity, original) and the legacy keep_by_layer.json.
+import argparse, json, os, struct
 
 HUB = "/home/nick/.cache/huggingface/hub"
-OUT = "/data/hipfire-models/reap_keepall_256"
+
+
 def snap(m):
     base = os.path.join(HUB, m, "snapshots")
     return os.path.join(base, sorted(os.listdir(base))[0])
-ORIG = snap("models--deepseek-ai--DeepSeek-V4-Flash")
+
 
 _hc = {}
+
+
 def header_for(root, shard):
     k = (root, shard)
     if k not in _hc:
@@ -19,29 +33,86 @@ def header_for(root, shard):
             n = struct.unpack("<Q", f.read(8))[0]
             _hc[k] = (json.loads(f.read(n)), 8 + n)
     return _hc[k]
+
+
 def read_tensor(root, wm, name):
-    shard = wm[name]; hdr, base = header_for(root, shard); meta = hdr[name]
+    shard = wm[name]
+    hdr, base = header_for(root, shard)
+    meta = hdr[name]
     s, e = meta["data_offsets"]
     with open(os.path.join(root, shard), "rb") as f:
-        f.seek(base + s); return meta["dtype"], meta["shape"], f.read(e - s)
+        f.seek(base + s)
+        return meta["dtype"], meta["shape"], f.read(e - s)
 
-wm = json.load(open(os.path.join(ORIG, "model.safetensors.index.json")))["weight_map"]
-ORIG_EXP, NLAY, HASH = 256, 43, [0, 1, 2]
-os.makedirs(OUT, exist_ok=True)
-keep = [list(range(ORIG_EXP)) for _ in range(NLAY)]
-json.dump({"kept_per_layer": ORIG_EXP, "num_layers": NLAY, "num_hash_layers": len(HASH),
-           "original_experts": ORIG_EXP, "keep": keep},
-          open(os.path.join(OUT, "keep_by_layer.json"), "w"))
 
-DT = {"I64": (8, "<q"), "I32": (4, "<i"), "U32": (4, "<I")}
-for L in HASH:
-    dt, shape, data = read_tensor(ORIG, wm, f"layers.{L}.ffn.gate.tid2eid")
-    esz, fmt = DT[dt]
-    n = 1
-    for s in shape: n *= s
-    vals = [struct.unpack_from(fmt, data, i*esz)[0] for i in range(n)]
-    assert 0 <= min(vals) and max(vals) < ORIG_EXP, f"L{L} range {min(vals)}..{max(vals)}"
-    with open(os.path.join(OUT, f"tid2eid_l{L}.i32"), "wb") as f:
-        f.write(b"".join(struct.pack("<i", v) for v in vals))
-    print(f"  L{L}: orig tid2eid {dt}{shape} range [{min(vals)},{max(vals)}] -> i32 OK")
-print(f"keep-all sidecar written to {OUT}")
+def write_plan(out, arch, num_layers, num_experts):
+    """Write the generic keep-all reap_plan.json (ReapPlan::load schema)."""
+    os.makedirs(out, exist_ok=True)
+    keep = [list(range(num_experts)) for _ in range(num_layers)]
+    plan = {
+        "version": 1,
+        "original_experts": num_experts,
+        "num_layers": num_layers,
+        "keep": {"per_layer": keep},
+    }
+    if arch:
+        plan["model_arch"] = arch
+    with open(os.path.join(out, "reap_plan.json"), "w") as f:
+        json.dump(plan, f)
+    print(f"keep-all reap_plan.json ({num_layers}L x {num_experts}E"
+          f"{', arch=' + arch if arch else ''}) -> {out}")
+
+
+def write_ds4_extras(out, orig_snapshot, num_layers, num_experts, hash_layers):
+    """ds4-only: identity tid2eid sidecars + legacy keep_by_layer.json."""
+    wm = json.load(open(os.path.join(orig_snapshot, "model.safetensors.index.json")))["weight_map"]
+    # Legacy alias schema (load_legacy_keepmap / HIPFIRE_DEEPSEEK4_REAP_KEEPMAP).
+    keep = [list(range(num_experts)) for _ in range(num_layers)]
+    json.dump(
+        {"kept_per_layer": num_experts, "num_layers": num_layers,
+         "num_hash_layers": len(hash_layers), "original_experts": num_experts, "keep": keep},
+        open(os.path.join(out, "keep_by_layer.json"), "w"),
+    )
+    DT = {"I64": (8, "<q"), "I32": (4, "<i"), "U32": (4, "<I")}
+    for L in hash_layers:
+        dt, shape, data = read_tensor(orig_snapshot, wm, f"layers.{L}.ffn.gate.tid2eid")
+        esz, fmt = DT[dt]
+        n = 1
+        for s in shape:
+            n *= s
+        vals = [struct.unpack_from(fmt, data, i * esz)[0] for i in range(n)]
+        assert 0 <= min(vals) and max(vals) < num_experts, f"L{L} range {min(vals)}..{max(vals)}"
+        with open(os.path.join(out, f"tid2eid_l{L}.i32"), "wb") as f:
+            f.write(b"".join(struct.pack("<i", v) for v in vals))
+        print(f"  L{L}: orig tid2eid {dt}{shape} range [{min(vals)},{max(vals)}] -> i32 OK")
+    print(f"ds4 legacy keep_by_layer.json + tid2eid sidecars -> {out}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Build a keep-all identity REAP plan.")
+    ap.add_argument("--num-layers", type=int, help="number of MoE layers")
+    ap.add_argument("--num-experts", type=int, help="routed experts per layer (original count)")
+    ap.add_argument("--arch", default=None, help="optional model_arch tag for the plan")
+    ap.add_argument("--out", default=None, help="output dir for the plan")
+    ap.add_argument("--ds4", action="store_true",
+                    help="DeepSeek-V4-Flash convenience: 43L x 256E + tid2eid + legacy sidecar")
+    ap.add_argument("--ds4-model", default="models--deepseek-ai--DeepSeek-V4-Flash",
+                    help="HF hub dir name for the ds4 original (for tid2eid)")
+    ap.add_argument("--hash-layers", default="0,1,2", help="ds4 hash layer indices (comma-sep)")
+    args = ap.parse_args()
+
+    if args.ds4:
+        num_layers = args.num_layers or 43
+        num_experts = args.num_experts or 256
+        out = args.out or "/data/hipfire-models/reap_keepall_256"
+        hash_layers = [int(x) for x in args.hash_layers.split(",") if x != ""]
+        write_plan(out, "deepseek4", num_layers, num_experts)
+        write_ds4_extras(out, snap(args.ds4_model), num_layers, num_experts, hash_layers)
+    else:
+        if args.num_layers is None or args.num_experts is None or args.out is None:
+            ap.error("--num-layers, --num-experts and --out are required (or use --ds4)")
+        write_plan(args.out, args.arch, args.num_layers, args.num_experts)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reap/build_keepall_sidecar.py
+++ b/scripts/reap/build_keepall_sidecar.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Identity sidecar: keep ALL 256 experts (no pruning), ORIGINAL tid2eid.
+# If the keep-map machinery is correct, running with this must reproduce the
+# full-256 (no-keep-map) PPL exactly — isolates machinery bugs from REAP cost.
+import struct, json, os
+
+HUB = "/home/nick/.cache/huggingface/hub"
+OUT = "/data/hipfire-models/reap_keepall_256"
+def snap(m):
+    base = os.path.join(HUB, m, "snapshots")
+    return os.path.join(base, sorted(os.listdir(base))[0])
+ORIG = snap("models--deepseek-ai--DeepSeek-V4-Flash")
+
+_hc = {}
+def header_for(root, shard):
+    k = (root, shard)
+    if k not in _hc:
+        with open(os.path.join(root, shard), "rb") as f:
+            n = struct.unpack("<Q", f.read(8))[0]
+            _hc[k] = (json.loads(f.read(n)), 8 + n)
+    return _hc[k]
+def read_tensor(root, wm, name):
+    shard = wm[name]; hdr, base = header_for(root, shard); meta = hdr[name]
+    s, e = meta["data_offsets"]
+    with open(os.path.join(root, shard), "rb") as f:
+        f.seek(base + s); return meta["dtype"], meta["shape"], f.read(e - s)
+
+wm = json.load(open(os.path.join(ORIG, "model.safetensors.index.json")))["weight_map"]
+ORIG_EXP, NLAY, HASH = 256, 43, [0, 1, 2]
+os.makedirs(OUT, exist_ok=True)
+keep = [list(range(ORIG_EXP)) for _ in range(NLAY)]
+json.dump({"kept_per_layer": ORIG_EXP, "num_layers": NLAY, "num_hash_layers": len(HASH),
+           "original_experts": ORIG_EXP, "keep": keep},
+          open(os.path.join(OUT, "keep_by_layer.json"), "w"))
+
+DT = {"I64": (8, "<q"), "I32": (4, "<i"), "U32": (4, "<I")}
+for L in HASH:
+    dt, shape, data = read_tensor(ORIG, wm, f"layers.{L}.ffn.gate.tid2eid")
+    esz, fmt = DT[dt]
+    n = 1
+    for s in shape: n *= s
+    vals = [struct.unpack_from(fmt, data, i*esz)[0] for i in range(n)]
+    assert 0 <= min(vals) and max(vals) < ORIG_EXP, f"L{L} range {min(vals)}..{max(vals)}"
+    with open(os.path.join(OUT, f"tid2eid_l{L}.i32"), "wb") as f:
+        f.write(b"".join(struct.pack("<i", v) for v in vals))
+    print(f"  L{L}: orig tid2eid {dt}{shape} range [{min(vals)},{max(vals)}] -> i32 OK")
+print(f"keep-all sidecar written to {OUT}")

--- a/scripts/reap/build_reap_keepmap.py
+++ b/scripts/reap/build_reap_keepmap.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Build the REAP keep-map sidecar for the keep-map-aware ds4 loader.
+# Output:
+#   $OUT/keep_by_layer.json   - {kept_per_layer, num_layers, num_hash_layers, original_experts, keep:[[...]]}
+#   $OUT/tid2eid_l{0,1,2}.i32 - sero's remapped hash tables, raw LE int32, shape [129280,6]
+#   $OUT/MANIFEST.txt         - provenance
+import json, struct, os, sys
+
+HUB = "/home/nick/.cache/huggingface/hub"
+OUT = "/data/hipfire-models/reap_keepmap_162B_k144"
+def snap(m):
+    base = os.path.join(HUB, m, "snapshots")
+    return os.path.join(base, sorted(os.listdir(base))[0])
+SERO = snap("models--0xSero--DeepSeek-V4-Flash-162B")
+
+# ---- dependency-free safetensors reader ----
+_hc = {}
+def header_for(root, shard):
+    key = (root, shard)
+    if key not in _hc:
+        with open(os.path.join(root, shard), "rb") as f:
+            n = struct.unpack("<Q", f.read(8))[0]
+            hdr = json.loads(f.read(n))
+        _hc[key] = (hdr, 8 + n)
+    return _hc[key]
+def read_tensor(root, wm, name):
+    if name not in wm:
+        return None
+    shard = wm[name]
+    hdr, base = header_for(root, shard)
+    meta = hdr[name]
+    s, e = meta["data_offsets"]
+    with open(os.path.join(root, shard), "rb") as f:
+        f.seek(base + s); data = f.read(e - s)
+    return meta["dtype"], meta["shape"], data
+
+wm = json.load(open(os.path.join(SERO, "model.safetensors.index.json")))["weight_map"]
+plan = json.load(open(os.path.join(SERO, "reap_plan.json")))
+keep = plan["keep_maps"]["keep_by_layer"]
+kept = plan["kept_experts_per_layer"]          # 144
+orig = plan["original_experts_per_layer"]      # 256
+hashL = plan["hash_routed_layers"]             # [0,1,2]
+nlay = len(keep)                               # 43
+
+# ---- validate keep map ----
+keep_list = []
+for L in range(nlay):
+    k = keep[str(L)]
+    assert len(k) == kept, f"layer {L}: {len(k)} != {kept}"
+    assert len(set(k)) == kept, f"layer {L}: duplicates"
+    assert min(k) >= 0 and max(k) < orig, f"layer {L}: idx out of range"
+    keep_list.append(k)
+print(f"keep map OK: {nlay} layers x {kept} kept (of {orig}); hash layers {hashL}")
+
+os.makedirs(OUT, exist_ok=True)
+with open(os.path.join(OUT, "keep_by_layer.json"), "w") as f:
+    json.dump({"kept_per_layer": kept, "num_layers": nlay,
+               "num_hash_layers": len(hashL), "original_experts": orig,
+               "keep": keep_list}, f)
+
+# ---- tid2eid for hash layers, from sero (already remapped, 0..kept-1 space) ----
+DT = {"I64": (8, "<q"), "I32": (4, "<i"), "I16": (2, "<h"), "U32": (4, "<I")}
+for L in hashL:
+    t = read_tensor(SERO, wm, f"layers.{L}.ffn.gate.tid2eid")
+    assert t is not None, f"layer {L}: sero missing tid2eid"
+    dt, shape, data = t
+    assert dt in DT, f"layer {L}: unexpected tid2eid dtype {dt}"
+    esz, fmt = DT[dt]
+    n = 1
+    for s in shape: n *= s
+    assert len(data) == n * esz, f"layer {L}: size mismatch"
+    vals = struct.unpack("<" + fmt[1] * n, data) if False else [struct.unpack_from(fmt, data, i*esz)[0] for i in range(n)]
+    vmin, vmax = min(vals), max(vals)
+    assert vmin >= 0 and vmax < kept, f"layer {L}: tid2eid range [{vmin},{vmax}] not in [0,{kept-1}] (NOT slot space!)"
+    out = b"".join(struct.pack("<i", v) for v in vals)
+    with open(os.path.join(OUT, f"tid2eid_l{L}.i32"), "wb") as f:
+        f.write(out)
+    print(f"  layer {L}: tid2eid {dt}{shape} range [{vmin},{vmax}] -> {len(out)}B i32  OK (slot space)")
+
+with open(os.path.join(OUT, "MANIFEST.txt"), "w") as f:
+    f.write(f"source: {SERO}\nbase: {plan['base_model_id']}\n"
+            f"target: {plan['target_label']}\nkept_per_layer: {kept}\n"
+            f"num_layers: {nlay}\nhash_layers: {hashL}\n")
+print(f"\nsidecar written to {OUT}")
+for fn in sorted(os.listdir(OUT)):
+    print(f"  {fn}  ({os.path.getsize(os.path.join(OUT, fn))}B)")

--- a/scripts/reap/kld_compare.py
+++ b/scripts/reap/kld_compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# stdlib-only KLD comparator for two DS4PPL01 logit dumps (no numpy).
+#   usage: kld_stdlib.py <full.logits> <pruned.logits>
+# A = full (reference P), B = pruned (Q).
+import struct, sys, math
+from array import array
+
+def open_dump(p):
+    f = open(p, "rb")
+    assert f.read(8) == b"DS4PPL01", f"{p}: bad magic"
+    vocab = struct.unpack("<I", f.read(4))[0]
+    n = struct.unpack("<I", f.read(4))[0]
+    return f, vocab, n
+
+A, B = sys.argv[1], sys.argv[2]
+fa, va, na = open_dump(A)
+fb, vb, nb = open_dump(B)
+assert va == vb and na == nb, f"mismatch vocab {va}/{vb} n {na}/{nb}"
+V = va
+exp, log, fsum = math.exp, math.log, math.fsum
+
+skl_pq = skl_qp = 0.0
+top1 = 0
+for i in range(na):
+    pa, ta = struct.unpack("<II", fa.read(8))
+    xP = array("f"); xP.frombytes(fa.read(V * 4))
+    pb, tb = struct.unpack("<II", fb.read(8))
+    xQ = array("f"); xQ.frombytes(fb.read(V * 4))
+    assert pa == pb and ta == tb, f"misalign at {i}: pos {pa}/{pb} tgt {ta}/{tb}"
+
+    mP = max(xP); mQ = max(xQ)          # C-level
+    eP = [exp(v - mP) for v in xP]
+    eQ = [exp(v - mQ) for v in xQ]
+    sP = fsum(eP); sQ = fsum(eQ)
+    lseP = mP + log(sP); lseQ = mQ + log(sQ)
+    # KL(P||Q) = (lseQ-lseP) + sum_i P_i (xP_i - xQ_i);  P_i = eP_i / sP
+    accp = fsum(ep * (xp - xq) for ep, xp, xq in zip(eP, xP, xQ))
+    accq = fsum(eq * (xq - xp) for eq, xp, xq in zip(eQ, xP, xQ))
+    skl_pq += (lseQ - lseP) + accp / sP
+    skl_qp += (lseP - lseQ) + accq / sQ
+    if xP.index(mP) == xQ.index(mQ):
+        top1 += 1
+    if (i + 1) % 128 == 0:
+        sys.stderr.write(f"  {i+1}/{na} KL(f||p)={skl_pq/(i+1):.4f}\n")
+
+print(f"positions:               {na}")
+print(f"mean KL(full || pruned): {skl_pq/na:.6f} nats")
+print(f"mean KL(pruned || full): {skl_qp/na:.6f} nats")
+print(f"top-1 argmax agreement:  {top1}/{na} = {100*top1/na:.2f}%")

--- a/scripts/reap/run_ppl_kld.sh
+++ b/scripts/reap/run_ppl_kld.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Full vs REAP-pruned ds4 PPL + KLD comparison (same corpus/offset/ctx/warmup).
+#   usage: scripts/reap/run_ppl_kld.sh [CTX=1024] [WARMUP=8]
+# Requires: target/release/examples/deepseek4_perplexity built, and the keep-map
+# sidecar at $KEEPMAP (see build_reap_keepmap.py). Edit MODEL/CORPUS/KEEPMAP for
+# your box.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+CTX="${1:-1024}"; WARMUP="${2:-8}"
+MODEL="${MODEL:-/data/hipfire-models/deepseek-v4-flash.mq2lloyd}"
+CORPUS="${CORPUS:-benchmarks/quality-baselines/slice/wikitext2-1024s-2048ctx.txt}"
+KEEPMAP="${KEEPMAP:-/data/hipfire-models/reap_keepmap_162B_k144}"
+BIN=./target/release/examples/deepseek4_perplexity
+OUT="${OUT:-/data/hipfire-models/reap_ppl_kld_ctx${CTX}}"
+mkdir -p "$OUT"
+FILT='pre-compiled blob|recompiling'
+
+echo "===== FULL-256 (keep-map OFF) ctx=$CTX ====="
+"$BIN" "$MODEL" "$CORPUS" --ctx "$CTX" --warmup "$WARMUP" \
+    --dump-logits "$OUT/full.logits" 2>&1 | grep -vE "$FILT" | tee "$OUT/full.log"
+
+echo "===== PRUNED-144 (keep-map ON) ctx=$CTX ====="
+HIPFIRE_DEEPSEEK4_REAP_KEEPMAP="$KEEPMAP" "$BIN" "$MODEL" "$CORPUS" --ctx "$CTX" --warmup "$WARMUP" \
+    --dump-logits "$OUT/pruned.logits" 2>&1 | grep -vE "$FILT" | tee "$OUT/pruned.log"
+
+echo "===== KLD (full vs pruned) ====="
+python3 scripts/reap/kld_compare.py "$OUT/full.logits" "$OUT/pruned.logits" | tee "$OUT/kld.txt"
+
+echo "===== SUMMARY (ctx=$CTX) ====="
+fp=$(grep '^PPL:' "$OUT/full.log" | awk '{print $2}')
+pp=$(grep '^PPL:' "$OUT/pruned.log" | awk '{print $2}')
+echo "full-256 PPL=$fp   pruned-144 PPL=$pp"
+# Free the large logit dumps once KLD is computed (keep logs + kld.txt).
+rm -f "$OUT/full.logits" "$OUT/pruned.logits"
+echo "(logit dumps removed; logs + kld.txt kept in $OUT)"


### PR DESCRIPTION
## Summary

Generalizes the DeepSeek-V4-specific REAP keep-map loader into a model-agnostic **`hipfire-reap`** crate and wires it into 4 MoE arches — **deepseek4, qwen35, lfm2moe, minimax** — so any of them can be selectively **expert-pruned** (emulate a REAP checkpoint) by partial-loading the kept experts from an existing quant, **no re-quantization**. Default-off ⇒ byte-identical load.

This is **Sub-project 1** of a larger design (spec + plan included in the diff under `docs/superpowers/`). SP2–4 (mixed-quant bucketed dispatch, load-time quant overlay, offline bake) are scoped but not in this PR; their seams (`TensorSource.overlay`, `ReapPlan.quant_overrides`) are threaded but inert.

> **Stacking note:** this branch is stacked on the unmerged `nw_reap162b_keepmap` (commit `43ed446d`), so this PR also bundles that ds4 REAP foundation + the spec/plan docs. Review the `hipfire-reap` crate + the 4 arch wirings as the SP1 contribution.

## What's in it

- **`crates/hipfire-reap`** (new): `ReapPlan` (parse/validate `reap_plan.json` + legacy `keep_by_layer.json` alias), `gather_rows` (exact byte row-gather for row-independent quant), `TensorSource`/`ExpertPlan` loader API, `ReapArchHook`. 14 CPU unit tests.
- **4 arch wirings**: each applies the plan at its single public HFQ→config entry point (`HIPFIRE_REAP_PLAN=<dir>`), overrides routed-expert count to the kept count, loads/packs only kept experts via `src(slot)`, and gathers router (+ per-expert routing bias) rows to the kept set. REAP and EP-sharding are mutually exclusive (ds4/minimax guard).
- **Tooling**: generalized `scripts/reap/build_keepall_sidecar.py` (emits generic `reap_plan.json`), updated README.

## ⚠️ Verification status

- ✅ **CPU**: all 5 crates build clean; `cargo test -p hipfire-reap` 14/14.
- ⛔ **GPU-DEFERRED (owed)**: the keep-all **identity NLL gate** (keep-all reproduces each arch's no-plan baseline to ~10 decimals — the safety net for the lift) and the ds4 **K144 PPL/KLD smoke** were NOT run (GPU in use by separate cohere work during development). **These must pass before relying on this in production.**

## Follow-ups (recorded, not in this PR)

- Run the GPU identity gate on all 4 arches + ds4 K144 smoke + legacy-alias check.
- qwen35 EP post-load transform (`shard_all_moe_layers`) lacks the ds4/minimax REAP+EP mutual-exclusion guard (pre-existing footgun).
- qwen35 ParoQuant path (`paro_load_moe_ffn`) doesn't honor the keep-map (HFQ path only).
- `cohere2moe` gets the identical wiring once it merges to master.

## Test plan

- [ ] `cargo test -p hipfire-reap` (CPU) — green
- [ ] keep-all `reap_plan.json` reproduces no-plan baseline NLL to 10 decimals on each of deepseek4/qwen35/lfm2moe/minimax (GPU)
- [ ] ds4 K144: full-256 PPL ≈7.56 vs pruned-144 ≈17.73 through the generic path (GPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)