### PR TITLE
feat(reap): selective re-quant — overlay (SP4a) + load-time splice (SP3) + bake (SP4b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ version = "0.2.0"
 dependencies = [
  "byteorder",
  "hipfire-reap",
+ "hipfire-runtime",
  "memmap2",
  "rayon",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ version = "0.2.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +112,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,10 +147,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hip-bridge"
@@ -144,6 +200,7 @@ version = "0.2.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",
@@ -288,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hipfire-reap"
+version = "0.2.0"
+dependencies = [
+ "hipfire-runtime",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "hipfire-runtime"
 version = "0.2.0"
 dependencies = [
@@ -326,6 +392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,7 +419,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -355,6 +429,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -371,6 +451,18 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "md5"
@@ -450,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +558,16 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -485,6 +593,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -551,6 +665,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +745,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,10 +784,171 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ version = "0.2.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ version = "0.1.0"
 dependencies = [
  "hip-bridge",
  "hipfire-dispatch",
+ "hipfire-reap",
  "hipfire-runtime",
  "rdna-compute",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,10 +341,12 @@ name = "hipfire-quantize"
 version = "0.2.0"
 dependencies = [
  "byteorder",
+ "hipfire-reap",
  "memmap2",
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/redline",
     "crates/hipfire-dispatch",
     "crates/hipfire-dispatch-tests",
+    "crates/hipfire-reap",
 ]
 
 [workspace.package]

--- a/crates/hipfire-arch-deepseek4/Cargo.toml
+++ b/crates/hipfire-arch-deepseek4/Cargo.toml
@@ -17,6 +17,7 @@ rdna-compute = { path = "../rdna-compute" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
+hipfire-reap = { path = "../hipfire-reap" }
 
 [features]
 

--- a/crates/hipfire-arch-deepseek4/examples/deepseek4_perplexity.rs
+++ b/crates/hipfire-arch-deepseek4/examples/deepseek4_perplexity.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Nick Woolmer
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Perplexity / NLL eval for DeepSeek V4 Flash (ds4, arch_id=9).
+//!
+//! The qwen `perplexity` example hardcodes `qwen35::forward_scratch`; this is
+//! the ds4 analog. ds4 manages its own KV/SWA/indexer/compressor cache inside
+//! `DeepseekV4State`, so there is no external `KvCache` — we just loop
+//! `decode_step`, which returns the host logits for each position.
+//!
+//! Usage:
+//!   deepseek4_perplexity <model.hfq> <corpus.txt> \
+//!       [--ctx 2048] [--warmup 8] [--offset 0] [--dump-logits <path>]
+//!
+//! Set `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` to evaluate the REAP-pruned
+//! (e.g. 162B / 144-expert) variant of the SAME quant — the loader keeps only
+//! the mapped experts. Run twice (off / on) for a full-vs-pruned comparison.
+//!
+//! `--dump-logits <path>` writes per-scored-position full-vocab logits for an
+//! offline KLD comparison between two runs (same corpus/offset/ctx/warmup):
+//!   magic "DS4PPL01"(8) | vocab:u32 | n_scored:u32 |
+//!   then n_scored × { pos:u32, target:u32, logits:[f32; vocab] }
+
+use hipfire_arch_deepseek4::{forward::decode_step, DeepseekV4};
+use hipfire_runtime::arch::Architecture;
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::tokenizer::Tokenizer;
+use rdna_compute::Gpu;
+use std::io::Write;
+use std::path::Path;
+use std::time::Instant;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let model_path = args
+        .next()
+        .expect("usage: deepseek4_perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N] [--dump-logits PATH]");
+    let corpus_path = args
+        .next()
+        .expect("usage: deepseek4_perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N] [--dump-logits PATH]");
+
+    let mut ctx_len: usize = 2048;
+    let mut warmup: usize = 8;
+    let mut offset: usize = 0;
+    let mut dump_logits: Option<String> = None;
+    while let Some(flag) = args.next() {
+        let val = args.next().expect("flag missing value");
+        match flag.as_str() {
+            "--ctx" => ctx_len = val.parse().unwrap(),
+            "--warmup" => warmup = val.parse().unwrap(),
+            "--offset" => offset = val.parse().unwrap(),
+            "--dump-logits" => dump_logits = Some(val),
+            _ => panic!("unknown flag: {flag}"),
+        }
+    }
+    assert!(ctx_len > warmup + 4, "ctx must exceed warmup by enough to score");
+
+    let want_bytes = (offset + ctx_len) * 8;
+    let raw = std::fs::read(&corpus_path).expect("read corpus");
+    let take = want_bytes.min(raw.len());
+    let corpus = String::from_utf8_lossy(&raw[..take]).to_string();
+    eprintln!("Corpus: {} bytes (of {}) from {corpus_path}", corpus.len(), raw.len());
+
+    let mut hfq = HfqFile::open(Path::new(&model_path)).expect("open model");
+    let cfg = DeepseekV4::config_from_hfq(&hfq).expect("config");
+    let tokenizer =
+        Tokenizer::from_hfq_metadata(&hfq.metadata_json).expect("tokenizer from HFQ metadata");
+    eprintln!(
+        "Model arch_id={} n_layers={} n_routed_experts={} (keep-map {})",
+        DeepseekV4::arch_id(),
+        cfg.num_hidden_layers,
+        cfg.n_routed_experts,
+        if cfg.reap_keep.is_some() { "ACTIVE" } else { "off" },
+    );
+
+    eprintln!("Tokenizing...");
+    let t_tok = Instant::now();
+    let all_tokens: Vec<u32> = tokenizer.encode(&corpus);
+    eprintln!(
+        "Tokenized: {} tokens in {:.2}s",
+        all_tokens.len(),
+        t_tok.elapsed().as_secs_f64()
+    );
+
+    let end = (offset + ctx_len).min(all_tokens.len());
+    if end <= offset + warmup + 4 {
+        panic!("not enough tokens past offset={offset} for warmup={warmup} + scoring");
+    }
+    let window = &all_tokens[offset..end];
+    eprintln!(
+        "Window: offset={offset} ctx={} (warmup {warmup}, scoring {})",
+        window.len(),
+        window.len() - warmup - 1
+    );
+
+    let mut gpu = Gpu::init().expect("GPU init");
+    eprintln!("GPU: {}", gpu.arch.clone());
+    eprintln!("Loading weights from {model_path}...");
+    let t_load = Instant::now();
+    let mut state = DeepseekV4::new_state(&mut gpu, &cfg).expect("new_state");
+    let weights = DeepseekV4::load_weights(&mut hfq, &cfg, &mut gpu).expect("load_weights");
+    eprintln!("Loaded in {:.1}s", t_load.elapsed().as_secs_f64());
+
+    // Optional KLD logit dump.
+    let mut dump = dump_logits.as_ref().map(|p| {
+        let f = std::fs::File::create(p).expect("create dump-logits file");
+        let w = std::io::BufWriter::new(f);
+        eprintln!("Dumping full-vocab logits to {p}");
+        w
+    });
+    let scored_total = (window.len() - 1).saturating_sub(warmup);
+    if let Some(w) = dump.as_mut() {
+        w.write_all(b"DS4PPL01").unwrap();
+        w.write_all(&(0u32).to_le_bytes()).unwrap(); // vocab placeholder (patched at end)
+        w.write_all(&(scored_total as u32).to_le_bytes()).unwrap();
+    }
+
+    let mut total_nll: f64 = 0.0;
+    let mut scored: usize = 0;
+    let mut vocab_seen: u32 = 0;
+    let t0 = Instant::now();
+
+    for (pos, &tok) in window.iter().enumerate().take(window.len() - 1) {
+        let logits = decode_step(&cfg, &weights, &mut state, &mut gpu, tok, pos as u32)
+            .expect("decode_step");
+        if pos < warmup {
+            continue;
+        }
+        let target = window[pos + 1] as usize;
+        let nll = neg_log_softmax_at(&logits, target);
+        if !nll.is_finite() {
+            eprintln!("  warn: non-finite NLL at pos={pos} target={target}, skipping");
+            continue;
+        }
+        total_nll += nll as f64;
+        scored += 1;
+
+        if let Some(w) = dump.as_mut() {
+            vocab_seen = logits.len() as u32;
+            w.write_all(&(pos as u32).to_le_bytes()).unwrap();
+            w.write_all(&(target as u32).to_le_bytes()).unwrap();
+            let bytes: &[u8] = bytemuck_cast(&logits);
+            w.write_all(bytes).unwrap();
+        }
+
+        if scored == 1 || scored % 128 == 0 {
+            let avg_nll = total_nll / scored as f64;
+            let elapsed = t0.elapsed().as_secs_f64();
+            let rate = scored as f64 / elapsed.max(1e-9);
+            eprintln!(
+                "  pos={:5} scored={:5} nll/tok={:.4} ppl={:.3} ({:.2} tok/s)",
+                pos,
+                scored,
+                avg_nll,
+                avg_nll.exp(),
+                rate,
+            );
+        }
+    }
+
+    if let Some(mut w) = dump {
+        w.flush().unwrap();
+        drop(w);
+        // Patch the vocab field (offset 8) now that we know it.
+        if let Some(p) = dump_logits.as_ref() {
+            if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(p) {
+                use std::io::Seek;
+                f.seek(std::io::SeekFrom::Start(8)).unwrap();
+                f.write_all(&vocab_seen.to_le_bytes()).unwrap();
+            }
+        }
+    }
+
+    let avg_nll = if scored > 0 { total_nll / scored as f64 } else { 0.0 };
+    let ppl = avg_nll.exp();
+    let elapsed = t0.elapsed().as_secs_f64();
+    println!();
+    println!("Model:    {model_path}");
+    println!("Corpus:   {corpus_path}");
+    println!(
+        "Variant:  {}",
+        if cfg.reap_keep.is_some() {
+            format!("REAP keep-map ({} experts/layer)", cfg.n_routed_experts)
+        } else {
+            format!("full ({} experts/layer)", cfg.n_routed_experts)
+        }
+    );
+    println!("Tokens:   offset={offset} ctx={} warmup={warmup}", window.len());
+    println!("Scored:   {scored}");
+    println!("NLL/tok:  {avg_nll:.10}");
+    println!("PPL:      {ppl:.4}");
+    println!(
+        "Elapsed:  {:.1}s ({:.2} tok/s)",
+        elapsed,
+        scored as f64 / elapsed.max(1e-9)
+    );
+}
+
+fn neg_log_softmax_at(logits: &[f32], target: usize) -> f32 {
+    if target >= logits.len() {
+        return f32::NAN;
+    }
+    let mut max = f32::NEG_INFINITY;
+    for &v in logits {
+        if v > max {
+            max = v;
+        }
+    }
+    let mut sum = 0.0f64;
+    for &v in logits {
+        sum += ((v - max) as f64).exp();
+    }
+    let log_sum = max as f64 + sum.ln();
+    (log_sum - logits[target] as f64) as f32
+}
+
+/// Reinterpret &[f32] as &[u8] (little-endian host) for the logit dump.
+fn bytemuck_cast(v: &[f32]) -> &[u8] {
+    // SAFETY: f32 has no padding; we only read it as bytes for a binary dump
+    // consumed on the same host (little-endian).
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, v.len() * 4) }
+}

--- a/crates/hipfire-arch-deepseek4/src/arch.rs
+++ b/crates/hipfire-arch-deepseek4/src/arch.rs
@@ -167,7 +167,23 @@ impl DeepseekV4 {
         n_exp: usize,
         layer: &mut DeepseekV4LayerWeights,
         shard: Option<(&hipfire_runtime::tp_shard::ShardConfig, usize)>,
+        keep: Option<&[u32]>,
     ) -> Result<(), String> {
+        // REAP keep-map: compact slot `e` loads ORIGINAL expert `src(e)`.
+        // `keep = None` ⇒ identity (slot == original index), byte-identical
+        // to the full load. `n_exp` is the COMPACT count (kept) when active.
+        if keep.is_some() && shard.is_some() {
+            return Err("deepseek4: REAP keep-map + EP sharding are mutually exclusive".into());
+        }
+        if let Some(k) = keep {
+            if k.len() != n_exp {
+                return Err(format!(
+                    "deepseek4: {prefix} keep slice len {} != n_exp {n_exp}",
+                    k.len()
+                ));
+            }
+        }
+        let src = |slot: usize| -> usize { keep.map(|k| k[slot] as usize).unwrap_or(slot) };
         // EP shard: precompute owned set + compact-slot mapping. `shard = None`
         // ⇒ every expert owned, `local_of_global[e] == e`, n_owned == n_exp →
         // identical layout to the unsharded path.
@@ -188,7 +204,7 @@ impl DeepseekV4 {
         // Vec, then one upload. Non-owned experts are read for stride
         // validation, then dropped (never uploaded — the EP memory win).
         {
-            let name0 = format!("{prefix}.ffn.experts.0.w2.weight");
+            let name0 = format!("{prefix}.ffn.experts.{}.w2.weight", src(0));
             let (info0, _b0) = hfq
                 .tensor_data_pread(&name0)
                 .ok_or_else(|| format!("deepseek4: missing {name0}"))?;
@@ -205,7 +221,7 @@ impl DeepseekV4 {
                 if !owns(e) {
                     continue;
                 }
-                let name = format!("{prefix}.ffn.experts.{e}.w2.weight");
+                let name = format!("{prefix}.ffn.experts.{}.w2.weight", src(e));
                 let (info, bytes) = hfq
                     .tensor_data_pread(&name)
                     .ok_or_else(|| format!("deepseek4: missing {name}"))?;
@@ -249,8 +265,8 @@ impl DeepseekV4 {
         // gate_up (combined w1 ‖ w3): per-expert pread, pack ONLY owned, single
         // upload. Non-owned ptr → a shared ZEROED dummy gate_up buffer.
         {
-            let w1_0 = format!("{prefix}.ffn.experts.0.w1.weight");
-            let w3_0 = format!("{prefix}.ffn.experts.0.w3.weight");
+            let w1_0 = format!("{prefix}.ffn.experts.{}.w1.weight", src(0));
+            let w3_0 = format!("{prefix}.ffn.experts.{}.w3.weight", src(0));
             let (w1_info0, _b1) = hfq
                 .tensor_data_pread(&w1_0)
                 .ok_or_else(|| format!("deepseek4: missing {w1_0}"))?;
@@ -277,14 +293,14 @@ impl DeepseekV4 {
                 if !owns(e) {
                     continue;
                 }
-                let w1_name = format!("{prefix}.ffn.experts.{e}.w1.weight");
+                let w1_name = format!("{prefix}.ffn.experts.{}.w1.weight", src(e));
                 {
                     let (_, w1_bytes) = hfq
                         .tensor_data_pread(&w1_name)
                         .ok_or_else(|| format!("deepseek4: missing {w1_name}"))?;
                     combined.extend_from_slice(&w1_bytes);
                 }
-                let w3_name = format!("{prefix}.ffn.experts.{e}.w3.weight");
+                let w3_name = format!("{prefix}.ffn.experts.{}.w3.weight", src(e));
                 {
                     let (_, w3_bytes) = hfq
                         .tensor_data_pread(&w3_name)
@@ -363,6 +379,86 @@ impl DeepseekV4 {
             .collect();
         gpu.upload_f32(&f32_vals, &shape)
             .map_err(|e| format!("deepseek4: upload f16→f32 '{name}' failed: {e:?}"))
+    }
+
+    /// REAP keep-map variant of `upload_quant_or_f16`: byte row-gather only
+    /// the kept output rows (experts) before upload. Exact for row-major,
+    /// row-independent quant (F16 / Q8 / MQ*-G256) — each row's quant blocks
+    /// are self-contained, so a byte gather preserves the original encoding.
+    fn upload_quant_or_f16_keep(
+        hfq: &HfqFile,
+        gpu: &mut Gpu,
+        name: &str,
+        keep: &[u32],
+    ) -> Result<rdna_compute::GpuTensor, String> {
+        let (info, bytes) = hfq
+            .tensor_data_pread(name)
+            .ok_or_else(|| format!("deepseek4: tensor '{name}' missing in HFQ"))?;
+        let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
+        if orig_rows == 0 || bytes.len() % orig_rows != 0 {
+            return Err(format!(
+                "deepseek4: '{name}' row-gather: {orig_rows} rows don't divide {} bytes",
+                bytes.len()
+            ));
+        }
+        let rowstride = bytes.len() / orig_rows;
+        let mut sub = Vec::with_capacity(rowstride * keep.len());
+        for &oe in keep {
+            let oe = oe as usize;
+            if oe >= orig_rows {
+                return Err(format!("deepseek4: '{name}' keep idx {oe} >= rows {orig_rows}"));
+            }
+            sub.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
+        }
+        let mut shape: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+        shape[0] = keep.len();
+        let mut t = gpu
+            .upload_raw(&sub, &shape)
+            .map_err(|e| format!("deepseek4: upload keep-subset '{name}' failed: {e:?}"))?;
+        match info.quant_type {
+            1 => t.dtype = rdna_compute::DType::F16,
+            3 => t.dtype = rdna_compute::DType::Q8_0,
+            _ => {}
+        }
+        Ok(t)
+    }
+
+    /// REAP keep-map variant of `upload_global_f16_as_f32`: gather kept rows
+    /// of an F16 `[n_orig, ..]` (or `[n_orig]`) tensor, then decode to F32.
+    fn upload_global_f16_as_f32_keep(
+        hfq: &HfqFile,
+        gpu: &mut Gpu,
+        name: &str,
+        keep: &[u32],
+    ) -> Result<rdna_compute::GpuTensor, String> {
+        let (info, bytes) = hfq
+            .tensor_data_pread(name)
+            .ok_or_else(|| format!("deepseek4: tensor '{name}' missing in HFQ"))?;
+        let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
+        if orig_rows == 0 || bytes.len() % (orig_rows * 2) != 0 {
+            return Err(format!(
+                "deepseek4: '{name}' f16 keep-gather: {orig_rows} rows × 2B don't divide {} bytes",
+                bytes.len()
+            ));
+        }
+        let per_row = bytes.len() / (orig_rows * 2); // f16 elems per row
+        let mut f32_vals: Vec<f32> = Vec::with_capacity(per_row * keep.len());
+        for &oe in keep {
+            let oe = oe as usize;
+            if oe >= orig_rows {
+                return Err(format!("deepseek4: '{name}' keep idx {oe} >= rows {orig_rows}"));
+            }
+            let base = oe * per_row * 2;
+            for j in 0..per_row {
+                let lo = bytes[base + j * 2];
+                let hi = bytes[base + j * 2 + 1];
+                f32_vals.push(hipfire_runtime::llama::f16_to_f32(u16::from_le_bytes([lo, hi])));
+            }
+        }
+        let mut shape: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+        shape[0] = keep.len();
+        gpu.upload_f32(&f32_vals, &shape)
+            .map_err(|e| format!("deepseek4: upload f16→f32 keep '{name}' failed: {e:?}"))
     }
 
     pub fn load_weights_host_only_walk(
@@ -493,12 +589,18 @@ impl DeepseekV4 {
                     return Err(format!("deepseek4: layer {l} missing shared '{suffix}'"));
                 }
             }
-            // Routed experts: 256 × {w1, w2, w3}.
+            // Routed experts: kept × {w1, w2, w3}. `n_routed_experts` is the
+            // kept count under a REAP keep-map; remap slot → original index.
             for e in 0..cfg.n_routed_experts {
+                let e_src = cfg
+                    .reap_keep
+                    .as_ref()
+                    .map(|r| r.keep[l][e] as usize)
+                    .unwrap_or(e);
                 for proj in &["w1", "w2", "w3"] {
-                    let name = format!("layers.{l}.ffn.experts.{e}.{proj}.weight");
+                    let name = format!("layers.{l}.ffn.experts.{e_src}.{proj}.weight");
                     if hfq.find_tensor_info(&name).is_none() {
-                        return Err(format!("deepseek4: layer {l} expert {e} missing '{proj}'"));
+                        return Err(format!("deepseek4: layer {l} expert {e_src} missing '{proj}'"));
                     }
                 }
             }
@@ -902,17 +1004,22 @@ impl DeepseekV4 {
             // of actual quant. For Q8F16 routers (deepseek4-q8-mtp) that meant
             // reading Q8 bytes as MQ4 blocks → NaN logits at layer 3+
             // (the first non-hash layer that runs moe_route).
-            layer.gate_weight = Some(Self::upload_quant_or_f16(
-                hfq,
-                gpu,
-                &format!("layers.{l}.ffn.gate.weight"),
-            )?);
+            let gate_name = format!("layers.{l}.ffn.gate.weight");
+            layer.gate_weight = Some(match cfg.reap_keep.as_ref() {
+                Some(rk) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, &rk.keep[l])?,
+                None => Self::upload_quant_or_f16(hfq, gpu, &gate_name)?,
+            });
             if l >= cfg.num_hash_layers {
                 // Store F32 on GPU (was F16 on disk) so the bias can
                 // either be added on-device or downloaded once for CPU
                 // topk. Also cache host-side for the CPU-routing path.
                 let bias_name = format!("layers.{l}.ffn.gate.bias");
-                let bias_gpu = Self::upload_global_f16_as_f32(hfq, gpu, &bias_name)?;
+                let bias_gpu = match cfg.reap_keep.as_ref() {
+                    Some(rk) => {
+                        Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, &rk.keep[l])?
+                    }
+                    None => Self::upload_global_f16_as_f32(hfq, gpu, &bias_name)?,
+                };
                 layer.gate_bias_host = gpu
                     .download_f32(&bias_gpu)
                     .map_err(|e| format!("d2h gate_bias l{l}: {e:?}"))?;
@@ -923,7 +1030,18 @@ impl DeepseekV4 {
                 // at quant time, in which case forward falls back to
                 // shared-only on hash layers (current default behaviour).
                 let tid_name = format!("layers.{l}.ffn.gate.tid2eid");
-                if let Some((info, bytes)) = hfq.tensor_data_pread(&tid_name) {
+                if let Some((info, file_bytes)) = hfq.tensor_data_pread(&tid_name) {
+                    // Under a REAP keep-map the hash table is REMAPPED (pruned
+                    // experts redirected to kept ones, in 0..kept slot space);
+                    // read the sidecar table instead of the file's original.
+                    let bytes: Vec<u8> = match cfg.reap_keep.as_ref() {
+                        Some(rk) => {
+                            let p = rk.tid2eid_path(l);
+                            std::fs::read(&p)
+                                .map_err(|e| format!("deepseek4: REAP tid2eid read {p:?}: {e}"))?
+                        }
+                        None => file_bytes.to_vec(),
+                    };
                     if bytes.len() % 4 == 0 {
                         let vals: Vec<u32> = bytes
                             .chunks_exact(4)
@@ -991,11 +1109,17 @@ impl DeepseekV4 {
         if mtp_present {
             let load_mtp = std::env::var("HIPFIRE_DEEPSEEK4_LOAD_MTP")
                 .map(|s| s != "0")
-                .unwrap_or(true);
+                .unwrap_or(true)
+                && cfg.reap_keep.is_none();
             if !load_mtp {
                 eprintln!(
-                    "deepseek4: HFQ contains MTP layer but \
-                    HIPFIRE_DEEPSEEK4_LOAD_MTP=0 — skipping MTP upload"
+                    "deepseek4: skipping MTP upload ({})",
+                    if cfg.reap_keep.is_some() {
+                        "REAP keep-map active — MTP unused for PPL/KLD and would \
+                         need separate keep handling"
+                    } else {
+                        "HIPFIRE_DEEPSEEK4_LOAD_MTP=0"
+                    }
                 );
             } else {
                 eprintln!(
@@ -1221,6 +1345,7 @@ impl DeepseekV4 {
                     continue;
                 }
                 let n_exp = cfg.n_routed_experts;
+                let keep = cfg.reap_keep.as_ref().map(|r| r.keep[l].as_slice());
                 Self::upload_layer_routed_experts(
                     hfq,
                     gpu,
@@ -1228,6 +1353,7 @@ impl DeepseekV4 {
                     n_exp,
                     layer,
                     shard,
+                    keep,
                 )?;
             }
         }
@@ -1253,6 +1379,7 @@ impl DeepseekV4 {
                     cfg.n_routed_experts,
                     mtp,
                     shard,
+                    None, // MTP not loaded under REAP keep-map (see load_mtp guard)
                 )?;
             }
         }

--- a/crates/hipfire-arch-deepseek4/src/arch.rs
+++ b/crates/hipfire-arch-deepseek4/src/arch.rs
@@ -394,26 +394,10 @@ impl DeepseekV4 {
         let (info, bytes) = hfq
             .tensor_data_pread(name)
             .ok_or_else(|| format!("deepseek4: tensor '{name}' missing in HFQ"))?;
-        let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
-        if orig_rows == 0 || bytes.len() % orig_rows != 0 {
-            return Err(format!(
-                "deepseek4: '{name}' row-gather: {orig_rows} rows don't divide {} bytes",
-                bytes.len()
-            ));
-        }
-        let rowstride = bytes.len() / orig_rows;
-        let mut sub = Vec::with_capacity(rowstride * keep.len());
-        for &oe in keep {
-            let oe = oe as usize;
-            if oe >= orig_rows {
-                return Err(format!("deepseek4: '{name}' keep idx {oe} >= rows {orig_rows}"));
-            }
-            sub.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
-        }
-        let mut shape: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
-        shape[0] = keep.len();
+        let shape_usize: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+        let (new_shape, sub) = hipfire_reap::gather::gather_rows(&shape_usize, &bytes, keep)?;
         let mut t = gpu
-            .upload_raw(&sub, &shape)
+            .upload_raw(&sub, &new_shape)
             .map_err(|e| format!("deepseek4: upload keep-subset '{name}' failed: {e:?}"))?;
         match info.quant_type {
             1 => t.dtype = rdna_compute::DType::F16,
@@ -591,12 +575,9 @@ impl DeepseekV4 {
             }
             // Routed experts: kept × {w1, w2, w3}. `n_routed_experts` is the
             // kept count under a REAP keep-map; remap slot → original index.
+            let ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
             for e in 0..cfg.n_routed_experts {
-                let e_src = cfg
-                    .reap_keep
-                    .as_ref()
-                    .map(|r| r.keep[l][e] as usize)
-                    .unwrap_or(e);
+                let e_src = ep.as_ref().map(|p| p.src(e)).unwrap_or(e);
                 for proj in &["w1", "w2", "w3"] {
                     let name = format!("layers.{l}.ffn.experts.{e_src}.{proj}.weight");
                     if hfq.find_tensor_info(&name).is_none() {
@@ -1004,9 +985,14 @@ impl DeepseekV4 {
             // of actual quant. For Q8F16 routers (deepseek4-q8-mtp) that meant
             // reading Q8 bytes as MQ4 blocks → NaN logits at layer 3+
             // (the first non-hash layer that runs moe_route).
+            // Per-layer keep slice (None ⇒ keep-all / no plan ⇒ full upload).
+            let keep_l: Option<Vec<u32>> = cfg
+                .reap_keep
+                .as_ref()
+                .and_then(|r| r.expert_plan(l).keep().map(|k| k.to_vec()));
             let gate_name = format!("layers.{l}.ffn.gate.weight");
-            layer.gate_weight = Some(match cfg.reap_keep.as_ref() {
-                Some(rk) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, &rk.keep[l])?,
+            layer.gate_weight = Some(match keep_l.as_deref() {
+                Some(keep) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, keep)?,
                 None => Self::upload_quant_or_f16(hfq, gpu, &gate_name)?,
             });
             if l >= cfg.num_hash_layers {
@@ -1014,9 +1000,9 @@ impl DeepseekV4 {
                 // either be added on-device or downloaded once for CPU
                 // topk. Also cache host-side for the CPU-routing path.
                 let bias_name = format!("layers.{l}.ffn.gate.bias");
-                let bias_gpu = match cfg.reap_keep.as_ref() {
-                    Some(rk) => {
-                        Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, &rk.keep[l])?
+                let bias_gpu = match keep_l.as_deref() {
+                    Some(keep) => {
+                        Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, keep)?
                     }
                     None => Self::upload_global_f16_as_f32(hfq, gpu, &bias_name)?,
                 };
@@ -1035,8 +1021,8 @@ impl DeepseekV4 {
                     // experts redirected to kept ones, in 0..kept slot space);
                     // read the sidecar table instead of the file's original.
                     let bytes: Vec<u8> = match cfg.reap_keep.as_ref() {
-                        Some(rk) => {
-                            let p = rk.tid2eid_path(l);
+                        Some(plan) => {
+                            let p = crate::deepseek4::Ds4ReapHook::tid2eid_path(plan, l);
                             std::fs::read(&p)
                                 .map_err(|e| format!("deepseek4: REAP tid2eid read {p:?}: {e}"))?
                         }
@@ -1345,7 +1331,10 @@ impl DeepseekV4 {
                     continue;
                 }
                 let n_exp = cfg.n_routed_experts;
-                let keep = cfg.reap_keep.as_ref().map(|r| r.keep[l].as_slice());
+                let keep = cfg
+                    .reap_keep
+                    .as_ref()
+                    .and_then(|r| r.expert_plan(l).keep());
                 Self::upload_layer_routed_experts(
                     hfq,
                     gpu,

--- a/crates/hipfire-arch-deepseek4/src/arch.rs
+++ b/crates/hipfire-arch-deepseek4/src/arch.rs
@@ -18,6 +18,7 @@
 use crate::deepseek4::{
     DeepseekV4Config, DeepseekV4LayerWeights, DeepseekV4State, DeepseekV4Weights,
 };
+use hipfire_reap::hook::ReapArchHook;
 use hipfire_runtime::arch::Architecture;
 use hipfire_runtime::hfq::HfqFile;
 use rdna_compute::Gpu;
@@ -986,12 +987,9 @@ impl DeepseekV4 {
             // reading Q8 bytes as MQ4 blocks → NaN logits at layer 3+
             // (the first non-hash layer that runs moe_route).
             // Per-layer keep slice (None ⇒ keep-all / no plan ⇒ full upload).
-            let keep_l: Option<Vec<u32>> = cfg
-                .reap_keep
-                .as_ref()
-                .and_then(|r| r.expert_plan(l).keep().map(|k| k.to_vec()));
+            let ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
             let gate_name = format!("layers.{l}.ffn.gate.weight");
-            layer.gate_weight = Some(match keep_l.as_deref() {
+            layer.gate_weight = Some(match ep.as_ref().and_then(|p| p.keep()) {
                 Some(keep) => Self::upload_quant_or_f16_keep(hfq, gpu, &gate_name, keep)?,
                 None => Self::upload_quant_or_f16(hfq, gpu, &gate_name)?,
             });
@@ -1000,7 +998,7 @@ impl DeepseekV4 {
                 // either be added on-device or downloaded once for CPU
                 // topk. Also cache host-side for the CPU-routing path.
                 let bias_name = format!("layers.{l}.ffn.gate.bias");
-                let bias_gpu = match keep_l.as_deref() {
+                let bias_gpu = match ep.as_ref().and_then(|p| p.keep()) {
                     Some(keep) => {
                         Self::upload_global_f16_as_f32_keep(hfq, gpu, &bias_name, keep)?
                     }
@@ -1022,7 +1020,8 @@ impl DeepseekV4 {
                     // read the sidecar table instead of the file's original.
                     let bytes: Vec<u8> = match cfg.reap_keep.as_ref() {
                         Some(plan) => {
-                            let p = crate::deepseek4::Ds4ReapHook::tid2eid_path(plan, l);
+                            let p = crate::deepseek4::Ds4ReapHook
+                                .sidecar_path(plan, &format!("tid2eid_l{l}.i32"));
                             std::fs::read(&p)
                                 .map_err(|e| format!("deepseek4: REAP tid2eid read {p:?}: {e}"))?
                         }

--- a/crates/hipfire-arch-deepseek4/src/deepseek4.rs
+++ b/crates/hipfire-arch-deepseek4/src/deepseek4.rs
@@ -106,7 +106,7 @@ pub struct DeepseekV4Config {
     /// of an existing full quant — no re-quant. Not (de)serialized;
     /// populated at load time from the sidecar.
     #[serde(skip)]
-    pub reap_keep: Option<std::sync::Arc<ReapKeepMap>>,
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 /// Raw upstream JSON shape — only the fields we read. Used to drive
@@ -223,107 +223,45 @@ impl DeepseekV4Config {
             num_hash_layers: raw.num_hash_layers,
             reap_keep: None,
         };
-        // Optional REAP keep-map: emulate a pruned expert pool (e.g. 162B
+        // Optional REAP plan: emulate a pruned expert pool (e.g. 162B
         // 256→144) by partial-loading this full quant. Read BEFORE the
         // n_routed_experts override so validation sees the original count.
-        if let Ok(dir) = std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP") {
-            let km = ReapKeepMap::load(&dir, config.num_hidden_layers, config.n_routed_experts)?;
+        // New generic env HIPFIRE_REAP_PLAN=<dir> (reap_plan.json); legacy
+        // HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir> (keep_by_layer.json) is still
+        // honored as a keep-only alias via ReapPlan::load_any.
+        let reap_dir = std::env::var("HIPFIRE_REAP_PLAN")
+            .ok()
+            .or_else(|| std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP").ok());
+        if let Some(dir) = reap_dir {
+            let plan = hipfire_reap::plan::ReapPlan::load_any(
+                &dir,
+                config.num_hidden_layers,
+                config.n_routed_experts,
+            )?;
             eprintln!(
-                "deepseek4: REAP keep-map ACTIVE — keeping {} of {} routed experts/layer; sidecar {dir}",
-                km.kept_per_layer, config.n_routed_experts
+                "deepseek4: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+                plan.kept_per_layer(),
+                config.n_routed_experts
             );
-            config.n_routed_experts = km.kept_per_layer;
-            config.reap_keep = Some(std::sync::Arc::new(km));
+            config.n_routed_experts = plan.kept_per_layer();
+            config.reap_keep = Some(std::sync::Arc::new(plan));
         }
         Ok(config)
     }
 }
 
-/// REAP keep-map: per-layer list of kept routed-expert indices (in compact
-/// slot order) plus the sidecar dir holding remapped hash-router `tid2eid`
-/// tables. Built by tooling from a REAP `reap_plan.json` + the pruned
-/// checkpoint. Activated via `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>`.
-#[derive(Debug)]
-pub struct ReapKeepMap {
-    pub kept_per_layer: usize,
-    pub num_layers: usize,
-    pub original_experts: usize,
-    /// `keep[l][slot]` = original expert index loaded into compact slot `slot`.
-    pub keep: Vec<Vec<u32>>,
-    pub sidecar_dir: std::path::PathBuf,
-}
+/// DeepSeek-V4-specific REAP extras. The generic `hipfire-reap` plan owns the
+/// keep-map; this hook owns the arch-specific sidecar layout — here, the
+/// remapped hash-router `tid2eid` tables that live alongside the plan dir.
+pub struct Ds4ReapHook;
 
-impl ReapKeepMap {
-    /// Load `<dir>/keep_by_layer.json` and validate against the model's
-    /// layer/expert counts (passed BEFORE n_routed_experts is overridden).
-    pub fn load(
-        dir: &str,
-        num_layers_expected: usize,
-        orig_experts_expected: usize,
-    ) -> Result<Self, String> {
-        let path = std::path::Path::new(dir).join("keep_by_layer.json");
-        let txt = std::fs::read_to_string(&path)
-            .map_err(|e| format!("deepseek4: REAP keep-map read {path:?}: {e}"))?;
-        let v: serde_json::Value = serde_json::from_str(&txt)
-            .map_err(|e| format!("deepseek4: REAP keep-map parse {path:?}: {e}"))?;
-        let kept = v["kept_per_layer"]
-            .as_u64()
-            .ok_or("deepseek4: REAP keep-map missing kept_per_layer")? as usize;
-        let orig = v["original_experts"]
-            .as_u64()
-            .unwrap_or(orig_experts_expected as u64) as usize;
-        if orig != orig_experts_expected {
-            return Err(format!(
-                "deepseek4: REAP keep-map original_experts {orig} != model n_routed_experts {orig_experts_expected}"
-            ));
-        }
-        let keep_arr = v["keep"]
-            .as_array()
-            .ok_or("deepseek4: REAP keep-map missing `keep` array")?;
-        if keep_arr.len() != num_layers_expected {
-            return Err(format!(
-                "deepseek4: REAP keep-map has {} layers, model has {num_layers_expected}",
-                keep_arr.len()
-            ));
-        }
-        let mut keep = Vec::with_capacity(keep_arr.len());
-        for (l, row) in keep_arr.iter().enumerate() {
-            let r = row
-                .as_array()
-                .ok_or_else(|| format!("deepseek4: REAP keep layer {l} not an array"))?;
-            if r.len() != kept {
-                return Err(format!(
-                    "deepseek4: REAP keep layer {l} has {} entries, expected {kept}",
-                    r.len()
-                ));
-            }
-            let mut v32 = Vec::with_capacity(kept);
-            for x in r {
-                let idx = x
-                    .as_u64()
-                    .ok_or_else(|| format!("deepseek4: REAP keep layer {l} non-integer index"))?
-                    as u32;
-                if idx as usize >= orig {
-                    return Err(format!(
-                        "deepseek4: REAP keep layer {l} index {idx} >= original_experts {orig}"
-                    ));
-                }
-                v32.push(idx);
-            }
-            keep.push(v32);
-        }
-        Ok(Self {
-            kept_per_layer: kept,
-            num_layers: num_layers_expected,
-            original_experts: orig,
-            keep,
-            sidecar_dir: std::path::PathBuf::from(dir),
-        })
-    }
+impl hipfire_reap::hook::ReapArchHook for Ds4ReapHook {}
 
-    /// Path to the remapped hash-router `tid2eid` table for a hash layer.
-    pub fn tid2eid_path(&self, layer: usize) -> std::path::PathBuf {
-        self.sidecar_dir.join(format!("tid2eid_l{layer}.i32"))
+impl Ds4ReapHook {
+    /// Path to the remapped hash-router `tid2eid` table for a hash layer,
+    /// inside the plan dir. Preserves the legacy `tid2eid_l{layer}.i32` name.
+    pub fn tid2eid_path(plan: &hipfire_reap::plan::ReapPlan, layer: usize) -> std::path::PathBuf {
+        plan.dir.join(format!("tid2eid_l{layer}.i32"))
     }
 }
 

--- a/crates/hipfire-arch-deepseek4/src/deepseek4.rs
+++ b/crates/hipfire-arch-deepseek4/src/deepseek4.rs
@@ -96,6 +96,17 @@ pub struct DeepseekV4Config {
 
     // ── hash-routing (DeepSeek V4-only) ─────────────────────────────────
     pub num_hash_layers: usize,
+
+    // ── REAP keep-map (optional expert-pruning emulation) ───────────────
+    /// When set (via `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>`), the loader
+    /// keeps only `keep[l]` of the original routed experts per layer,
+    /// packed into compact slots `0..kept_per_layer`, and overrides
+    /// `n_routed_experts` to that kept count. Lets us emulate a
+    /// REAP-pruned checkpoint (e.g. 0xSero 162B, 256→144) by partial-load
+    /// of an existing full quant — no re-quant. Not (de)serialized;
+    /// populated at load time from the sidecar.
+    #[serde(skip)]
+    pub reap_keep: Option<std::sync::Arc<ReapKeepMap>>,
 }
 
 /// Raw upstream JSON shape — only the fields we read. Used to drive
@@ -170,7 +181,7 @@ impl DeepseekV4Config {
             .ok_or_else(|| "deepseek4: metadata_json missing `config` wrapper".to_string())?;
         let raw: RawDeepseekV4Config = serde_json::from_value(inner.clone())
             .map_err(|e| format!("deepseek4: parsing inner config failed: {e}"))?;
-        Ok(DeepseekV4Config {
+        let mut config = DeepseekV4Config {
             vocab_size: raw.vocab_size,
             hidden_size: raw.hidden_size,
             num_hidden_layers: raw.num_hidden_layers,
@@ -210,7 +221,109 @@ impl DeepseekV4Config {
             sliding_window: raw.sliding_window,
             num_nextn_predict_layers: raw.num_nextn_predict_layers,
             num_hash_layers: raw.num_hash_layers,
+            reap_keep: None,
+        };
+        // Optional REAP keep-map: emulate a pruned expert pool (e.g. 162B
+        // 256→144) by partial-loading this full quant. Read BEFORE the
+        // n_routed_experts override so validation sees the original count.
+        if let Ok(dir) = std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP") {
+            let km = ReapKeepMap::load(&dir, config.num_hidden_layers, config.n_routed_experts)?;
+            eprintln!(
+                "deepseek4: REAP keep-map ACTIVE — keeping {} of {} routed experts/layer; sidecar {dir}",
+                km.kept_per_layer, config.n_routed_experts
+            );
+            config.n_routed_experts = km.kept_per_layer;
+            config.reap_keep = Some(std::sync::Arc::new(km));
+        }
+        Ok(config)
+    }
+}
+
+/// REAP keep-map: per-layer list of kept routed-expert indices (in compact
+/// slot order) plus the sidecar dir holding remapped hash-router `tid2eid`
+/// tables. Built by tooling from a REAP `reap_plan.json` + the pruned
+/// checkpoint. Activated via `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>`.
+#[derive(Debug)]
+pub struct ReapKeepMap {
+    pub kept_per_layer: usize,
+    pub num_layers: usize,
+    pub original_experts: usize,
+    /// `keep[l][slot]` = original expert index loaded into compact slot `slot`.
+    pub keep: Vec<Vec<u32>>,
+    pub sidecar_dir: std::path::PathBuf,
+}
+
+impl ReapKeepMap {
+    /// Load `<dir>/keep_by_layer.json` and validate against the model's
+    /// layer/expert counts (passed BEFORE n_routed_experts is overridden).
+    pub fn load(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = std::path::Path::new(dir).join("keep_by_layer.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("deepseek4: REAP keep-map read {path:?}: {e}"))?;
+        let v: serde_json::Value = serde_json::from_str(&txt)
+            .map_err(|e| format!("deepseek4: REAP keep-map parse {path:?}: {e}"))?;
+        let kept = v["kept_per_layer"]
+            .as_u64()
+            .ok_or("deepseek4: REAP keep-map missing kept_per_layer")? as usize;
+        let orig = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if orig != orig_experts_expected {
+            return Err(format!(
+                "deepseek4: REAP keep-map original_experts {orig} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let keep_arr = v["keep"]
+            .as_array()
+            .ok_or("deepseek4: REAP keep-map missing `keep` array")?;
+        if keep_arr.len() != num_layers_expected {
+            return Err(format!(
+                "deepseek4: REAP keep-map has {} layers, model has {num_layers_expected}",
+                keep_arr.len()
+            ));
+        }
+        let mut keep = Vec::with_capacity(keep_arr.len());
+        for (l, row) in keep_arr.iter().enumerate() {
+            let r = row
+                .as_array()
+                .ok_or_else(|| format!("deepseek4: REAP keep layer {l} not an array"))?;
+            if r.len() != kept {
+                return Err(format!(
+                    "deepseek4: REAP keep layer {l} has {} entries, expected {kept}",
+                    r.len()
+                ));
+            }
+            let mut v32 = Vec::with_capacity(kept);
+            for x in r {
+                let idx = x
+                    .as_u64()
+                    .ok_or_else(|| format!("deepseek4: REAP keep layer {l} non-integer index"))?
+                    as u32;
+                if idx as usize >= orig {
+                    return Err(format!(
+                        "deepseek4: REAP keep layer {l} index {idx} >= original_experts {orig}"
+                    ));
+                }
+                v32.push(idx);
+            }
+            keep.push(v32);
+        }
+        Ok(Self {
+            kept_per_layer: kept,
+            num_layers: num_layers_expected,
+            original_experts: orig,
+            keep,
+            sidecar_dir: std::path::PathBuf::from(dir),
         })
+    }
+
+    /// Path to the remapped hash-router `tid2eid` table for a hash layer.
+    pub fn tid2eid_path(&self, layer: usize) -> std::path::PathBuf {
+        self.sidecar_dir.join(format!("tid2eid_l{layer}.i32"))
     }
 }
 

--- a/crates/hipfire-arch-deepseek4/src/deepseek4.rs
+++ b/crates/hipfire-arch-deepseek4/src/deepseek4.rs
@@ -257,14 +257,6 @@ pub struct Ds4ReapHook;
 
 impl hipfire_reap::hook::ReapArchHook for Ds4ReapHook {}
 
-impl Ds4ReapHook {
-    /// Path to the remapped hash-router `tid2eid` table for a hash layer,
-    /// inside the plan dir. Preserves the legacy `tid2eid_l{layer}.i32` name.
-    pub fn tid2eid_path(plan: &hipfire_reap::plan::ReapPlan, layer: usize) -> std::path::PathBuf {
-        plan.dir.join(format!("tid2eid_l{layer}.i32"))
-    }
-}
-
 /// Per-layer GPU-resident weights. Slots match DeepSeek V4 shipped tensor
 /// inventory; each is `Option<GpuTensor>` so partial-upload paths
 /// (host walk only / minimal upload / full upload) can populate

--- a/crates/hipfire-arch-lfm2moe/Cargo.toml
+++ b/crates/hipfire-arch-lfm2moe/Cargo.toml
@@ -11,6 +11,7 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 rdna-compute = { path = "../rdna-compute" }
 hip-bridge = { path = "../hip-bridge" }
+hipfire-reap = { path = "../hipfire-reap" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/hipfire-arch-lfm2moe/src/config.rs
+++ b/crates/hipfire-arch-lfm2moe/src/config.rs
@@ -56,6 +56,14 @@ pub struct Lfm2MoeConfig {
     pub tie_word_embeddings: bool,
     /// Per-layer mixer choice (length == num_hidden_layers).
     pub layer_types: Vec<MixerKind>,
+
+    /// Optional REAP keep-map: emulate a pruned routed-expert pool by
+    /// partial-loading this full quant (load only the kept experts under
+    /// remapped names, gather the router's expert rows to the kept set).
+    /// Populated at config time from `HIPFIRE_REAP_PLAN=<dir>`; `None` ⇒
+    /// no pruning (today's behavior, byte-identical to baseline). Not
+    /// (de)serialized — `Lfm2MoeConfig` derives only `Clone`/`Debug`.
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 #[derive(Deserialize)]
@@ -138,6 +146,44 @@ fn default_routed_scale() -> f32 {
     1.0
 }
 
+/// Apply an optional REAP keep-map to a freshly parsed `Lfm2MoeConfig`.
+///
+/// Reads `HIPFIRE_REAP_PLAN=<dir>` (lfm2moe has no legacy env alias). When
+/// set, loads `<dir>/reap_plan.json` (or the legacy `keep_by_layer.json`)
+/// via `ReapPlan::load_any`, validating against the ORIGINAL routed-expert
+/// count (`config.num_experts`) BEFORE overriding it to the kept count.
+/// This emulates a pruned expert pool by partial-loading the full quant:
+/// only kept experts are loaded (under remapped names) and the router's
+/// expert rows are gathered to the kept set in the MoE loader.
+///
+/// No env ⇒ no-op (`config.reap_keep` stays `None`); the MoE loader then
+/// takes the literal original full-load path — byte-identical to baseline.
+pub fn apply_reap_plan(config: &mut Lfm2MoeConfig) -> Result<(), String> {
+    let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
+        return Ok(());
+    };
+    // MoE-only feature: a dense (num_experts==0) checkpoint has no routed
+    // experts to prune. Refuse rather than silently divide-by-zero / mislead.
+    if config.num_experts == 0 {
+        return Err(format!(
+            "lfm2moe: HIPFIRE_REAP_PLAN={dir} set but this is a dense (num_experts==0) checkpoint"
+        ));
+    }
+    let plan = hipfire_reap::plan::ReapPlan::load_any(
+        &dir,
+        config.num_hidden_layers,
+        config.num_experts,
+    )?;
+    eprintln!(
+        "lfm2moe: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.num_experts
+    );
+    config.num_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+    Ok(())
+}
+
 impl Lfm2MoeConfig {
     pub fn from_hfq(hfq: &HfqFile) -> Result<Self, String> {
         let wrapper: serde_json::Value = serde_json::from_str(&hfq.metadata_json)
@@ -145,7 +191,18 @@ impl Lfm2MoeConfig {
         let inner = wrapper
             .get("config")
             .ok_or_else(|| "lfm2moe: metadata_json missing `config` wrapper".to_string())?;
-        Self::from_config_value(inner)
+        let mut config = Self::from_config_value(inner)?;
+        // Apply the optional REAP keep-map HERE, inside the single public HFQ
+        // config entry point, so it is IMPOSSIBLE to bypass. `from_hfq` is the
+        // ONLY public HFQ→config path — the daemon (daemon.rs) and every
+        // example (infer/kld/graph_parity/dump) call it directly; there is no
+        // `Architecture` trait shim for lfm2moe to wire it into separately.
+        // Applied AFTER parse so validation sees the ORIGINAL num_experts;
+        // overrides num_experts to the kept count when active. No env ⇒ no-op
+        // (baseline behavior, byte-identical). `?`-propagates a malformed plan
+        // (REAP is opt-in: a bad plan must hard-fail, never silently no-op).
+        apply_reap_plan(&mut config)?;
+        Ok(config)
     }
 
     /// Parse from a raw `config.json` Value (the inner `config` blob).
@@ -222,6 +279,7 @@ impl Lfm2MoeConfig {
             routed_scaling_factor: raw.routed_scaling_factor,
             tie_word_embeddings: raw.tie_word_embeddings,
             layer_types,
+            reap_keep: None,
         })
     }
 

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -162,8 +162,10 @@ fn load_wt(
 /// for any row-independent quant (every per-expert row is self-contained — its
 /// own scale/zero/codebook live in the row), which holds for every quant_type
 /// `wt_from_raw` accepts. `keep` MUST be in compact slot order and `m` MUST
-/// equal `keep.len()`. Reads owned bytes via the same `read_tensor` helper as
-/// the non-keep path (pread-based `tensor_data_vec`), so no fresh-alloc API.
+/// equal `keep.len()`. Reads owned bytes via `hfq.tensor_data_vec` directly
+/// (bypassing the `read_tensor` wrapper) to retain `info.shape` for deriving
+/// the original row count — the non-keep path uses `read_tensor`, which
+/// discards `info`.
 fn load_wt_keep(
     hfq: &HfqFile,
     gpu: &mut Gpu,
@@ -494,7 +496,7 @@ impl Lfm2MoeWeights {
                 // index loaded into slot (slot==e on the no-keep identity path).
                 let mut experts = Vec::with_capacity(n_exp);
                 for slot in 0..n_exp {
-                    let e = reap_ep.as_ref().map(|p| p.src(slot)).unwrap_or(slot);
+                    let e = reap_ep.as_ref().map(|ep| ep.src(slot)).unwrap_or(slot);
                     let ep = format!("{p}.feed_forward.experts.{e}");
                     let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                     let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -87,6 +87,49 @@ fn load_f32(
         .map_err(|e| format!("lfm2moe: upload {name}: {e:?}"))
 }
 
+/// REAP keep variant of [`load_f32`] for a 1-D per-expert vector (the MoE
+/// `expert_bias`, shape `[orig_experts]`): gather the kept elements BEFORE
+/// dequant, then upload as `[keep.len()]`. Each element is one expert's bias,
+/// fully self-contained (F16/F32 are trivially row-independent; Q8_0's 32-elem
+/// blocks would NOT be element-gatherable, but expert_bias ships as F16/F32 —
+/// guarded below). `m` MUST equal `keep.len()`.
+fn load_f32_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    keep: &[u32],
+) -> Result<GpuTensor, String> {
+    debug_assert_eq!(m, keep.len(), "load_f32_keep: m must equal keep.len()");
+    let (qt, data) = read_tensor(hfq, name)?;
+    // Per-element width for the row-gather. Q8_0 packs 32 elems/block, so a
+    // single bias element is not a whole row — refuse rather than corrupt.
+    let elem_bytes = match qt {
+        1 => 2, // F16
+        2 => 4, // F32
+        other => {
+            return Err(format!(
+                "lfm2moe: expert_bias {name} keep-gather needs F16/F32, got qt={other}"
+            ))
+        }
+    };
+    let orig = data.len() / elem_bytes;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("lfm2moe: expert_bias row-gather '{name}': {e}"))?;
+    let f32_data: Vec<f32> = match qt {
+        1 => sub
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        _ => sub
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    };
+    gpu.upload_f32(&f32_data, &[m])
+        .map_err(|e| format!("lfm2moe: upload {name}: {e:?}"))
+}
+
 /// Minimal Q8_0 dequant (32-elem blocks: little-endian f16 scale + 32 int8).
 fn dequant_q8_0(data: &[u8]) -> Vec<f32> {
     let mut out = Vec::with_capacity(data.len() / 34 * 32);
@@ -108,6 +151,38 @@ fn load_wt(
 ) -> Result<WeightTensor, String> {
     let (qt, data) = read_tensor(hfq, name)?;
     wt_from_raw(gpu, qt, &data, m, k).map_err(|e| format!("lfm2moe: load_wt {name}: {e}"))
+}
+
+/// REAP keep variant of [`load_wt`]: gather the tensor's first-axis rows (one
+/// row per ORIGINAL expert) down to `keep` BEFORE quant decode, then build the
+/// `WeightTensor` from the gathered bytes with `m = keep.len()`.
+///
+/// Only used for the MoE router (`feed_forward.gate.weight`, shape
+/// `[orig_experts, hidden]`) under an active keep-map. `gather_rows` is exact
+/// for any row-independent quant (every per-expert row is self-contained — its
+/// own scale/zero/codebook live in the row), which holds for every quant_type
+/// `wt_from_raw` accepts. `keep` MUST be in compact slot order and `m` MUST
+/// equal `keep.len()`. Reads owned bytes via the same `read_tensor` helper as
+/// the non-keep path (pread-based `tensor_data_vec`), so no fresh-alloc API.
+fn load_wt_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+    keep: &[u32],
+) -> Result<WeightTensor, String> {
+    debug_assert_eq!(m, keep.len(), "load_wt_keep: m must equal keep.len()");
+    let (info, data) = hfq
+        .tensor_data_vec(name)
+        .ok_or_else(|| format!("lfm2moe: tensor not found in HFQ: {name}"))?;
+    // The on-disk first-axis length is the ORIGINAL expert count; gather_rows
+    // derives the rowstride from shape[0] and selects the kept rows.
+    let orig = *info.shape.first().unwrap_or(&0) as usize;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("lfm2moe: router row-gather '{name}': {e}"))?;
+    wt_from_raw(gpu, info.quant_type, &sub, m, k)
+        .map_err(|e| format!("lfm2moe: load_wt_keep {name}: {e}"))
 }
 
 /// quant_type → DType mapping (mirrors minimax::wt_from_raw); uploads raw
@@ -370,18 +445,56 @@ impl Lfm2MoeWeights {
                 )?;
                 Ffn::Dense(DenseFfn { w1, w3, w2 })
             } else {
-                let router = load_wt(
-                    hfq,
-                    gpu,
-                    &format!("{p}.feed_forward.gate.weight"),
-                    n_exp,
-                    hidden,
-                )?;
-                let expert_bias =
-                    load_f32(hfq, gpu, &format!("{p}.feed_forward.expert_bias"), &[n_exp])?;
+                // REAP keep-map for this layer (None ⇒ no pruning / identity).
+                // When a keep is present, `n_exp == cfg.num_experts` is already
+                // the KEPT count (overridden in apply_reap_plan); the router and
+                // expert loops below load only the kept original experts, in
+                // compact slot order.
+                let reap_ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
+                let keep_l = reap_ep.as_ref().and_then(|e| e.keep());
+
+                // Router: hidden → n_exp. Under a keep, gather the router's
+                // expert rows (`[orig_experts, hidden]`) down to the kept set so
+                // it emits logits only for kept experts, in compact slot order.
+                // No keep ⇒ the literal original full load.
+                let router = match keep_l {
+                    Some(keep) => load_wt_keep(
+                        hfq,
+                        gpu,
+                        &format!("{p}.feed_forward.gate.weight"),
+                        n_exp,
+                        hidden,
+                        keep,
+                    )?,
+                    None => load_wt(
+                        hfq,
+                        gpu,
+                        &format!("{p}.feed_forward.gate.weight"),
+                        n_exp,
+                        hidden,
+                    )?,
+                };
+                // expert_bias is a 1-D [orig_experts] F32 vector indexed by
+                // expert; under a keep it must also be gathered to the kept set
+                // (parallel to the router rows). No keep ⇒ literal original load.
+                let expert_bias = match keep_l {
+                    Some(keep) => load_f32_keep(
+                        hfq,
+                        gpu,
+                        &format!("{p}.feed_forward.expert_bias"),
+                        n_exp,
+                        keep,
+                    )?,
+                    None => {
+                        load_f32(hfq, gpu, &format!("{p}.feed_forward.expert_bias"), &[n_exp])?
+                    }
+                };
                 // Byte-fuse w1‖w3 → gate_up [2*moe_inter, hidden]; w2 → down.
+                // Iterate compact slots `0..n_exp`; `e` = the ORIGINAL expert
+                // index loaded into slot (slot==e on the no-keep identity path).
                 let mut experts = Vec::with_capacity(n_exp);
-                for e in 0..n_exp {
+                for slot in 0..n_exp {
+                    let e = reap_ep.as_ref().map(|p| p.src(slot)).unwrap_or(slot);
                     let ep = format!("{p}.feed_forward.experts.{e}");
                     let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                     let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
@@ -392,16 +505,26 @@ impl Lfm2MoeWeights {
                     let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
                     let mut down = wt_from_raw(gpu, qt2, &w2, hidden, moe_inter)
                         .map_err(|e2| format!("lfm2moe: down L{l}E{e}: {e2}"))?;
-                    // AWQ scales: shared per layer, emitted once on expert 0 by the
+                    // AWQ scales: LAYER-SHARED, emitted once on expert 0 by the
                     // quantizer (full port of minimax 3c676d00 BOTH-projection AWQ).
-                    // Attach the gate_up scale (len hidden) to expert 0's gate_up and
-                    // the down scale (len moe_inter) to expert 0's down; the forward
+                    // The scale tensors are NOT expert-indexed — their names are
+                    // `{p}.feed_forward.awq_scale_{gate_up,down}.weight` and their
+                    // lengths are `hidden` / `moe_inter` (per-projection dims, NOT
+                    // per-expert), so they are INVARIANT under a REAP keep and load
+                    // UNCHANGED. We attach them to the representative FIRST COMPACT
+                    // SLOT (`slot == 0`, i.e. `experts[0]`) — the same slot the
+                    // forward reads from — regardless of which original expert it
+                    // maps to. Gate on `slot == 0` (not `e == 0`): under a keep the
+                    // original expert 0 may be pruned, so `e == 0` could never fire
+                    // (dropping the scale) or fire on a non-representative slot.
+                    // Attach the gate_up scale (len hidden) to slot 0's gate_up and
+                    // the down scale (len moe_inter) to slot 0's down; the forward
                     // reads both from experts[0] and divides x/s in the unrotated
                     // basis via the AWQ-aware rotate_x_mq_for (gate_up input) and
                     // fused_silu_mul_rotate_mq_batched_for (post-SwiGLU intermediate
                     // for down). down (w2) is the most quant-sensitive proj, so its
                     // AWQ is the whole point. No-op on non-AWQ files.
-                    if e == 0 {
+                    if slot == 0 {
                         gate_up.awq_scale = load_lfm2_awq_scale(
                             hfq,
                             gpu,

--- a/crates/hipfire-arch-minimax/Cargo.toml
+++ b/crates/hipfire-arch-minimax/Cargo.toml
@@ -18,5 +18,6 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
+hipfire-reap = { path = "../hipfire-reap" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -173,6 +173,9 @@ pub fn apply_reap_plan(config: &mut MiniMaxConfig) -> Result<(), String> {
     let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
         return Ok(());
     };
+    if config.num_local_experts == 0 {
+        return Err(format!("minimax: HIPFIRE_REAP_PLAN={dir} set but num_local_experts == 0 (not a MoE checkpoint)"));
+    }
     let plan = hipfire_reap::plan::ReapPlan::load_any(
         &dir,
         config.num_hidden_layers,
@@ -306,6 +309,8 @@ fn load_norm_keep(
 ) -> Result<GpuTensor, String> {
     debug_assert_eq!(m, keep.len(), "minimax load_norm_keep: m must equal keep.len()");
     let (qt, data) = read_tensor(hfq, name)?;
+    // Per-element width for the row-gather. Q8_0 packs 32 elems/block, so a
+    // single bias element is not a whole row — refuse rather than corrupt.
     let elem_bytes = match qt {
         1 => 2, // F16
         2 => 4, // F32

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -43,6 +43,11 @@ pub struct MiniMaxConfig {
     pub scoring_func: String,
     /// MTP draft modules (spec-decode; 0 for the base forward / this ckpt).
     pub num_mtp_modules: usize,
+    /// Optional REAP keep-map: emulate a pruned expert pool by partial-loading
+    /// this full quant. Populated at config time from `HIPFIRE_REAP_PLAN=<dir>`;
+    /// `None` ⇒ no pruning (literal original full load, byte-identical to
+    /// baseline). Not (de)serialized — set in `apply_reap_plan`.
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 #[derive(Deserialize)]
@@ -103,7 +108,7 @@ impl MiniMaxConfig {
         let head_dim = raw
             .head_dim
             .unwrap_or(raw.hidden_size / raw.num_attention_heads);
-        Ok(MiniMaxConfig {
+        let mut config = MiniMaxConfig {
             vocab_size: raw.vocab_size,
             hidden_size: raw.hidden_size,
             num_hidden_layers: raw.num_hidden_layers,
@@ -121,7 +126,23 @@ impl MiniMaxConfig {
             use_routing_bias: raw.use_routing_bias,
             scoring_func: raw.scoring_func,
             num_mtp_modules: raw.num_mtp_modules,
-        })
+            reap_keep: None,
+        };
+        // Apply the optional REAP keep-map HERE, inside the single public config
+        // entry point, so it is IMPOSSIBLE to bypass. Every caller funnels
+        // through `MiniMaxConfig::from_hfq` — the daemon (via the `Architecture`
+        // trait's `config_from_hfq`, which just delegates here) AND every
+        // example (`infer_minimax`, `ep_minimax`, `dump_minimax_hidden_states`,
+        // `debug_minimax_batch`) which call `MiniMaxConfig::from_hfq` directly,
+        // never through the trait. Wiring REAP only in the trait shim would
+        // silently ignore HIPFIRE_REAP_PLAN on all the direct callers. The trait
+        // impl therefore does NOT re-apply (double-apply ⇒ kept-of-kept ⇒
+        // load_any validation error). `from_hfq` returns `Result`, so a
+        // malformed plan propagates cleanly via `?` (REAP is opt-in ⇒ a user who
+        // explicitly set HIPFIRE_REAP_PLAN MUST hard-fail). With no env var,
+        // `apply_reap_plan` is a no-op (Ok), so baseline behavior is unchanged.
+        apply_reap_plan(&mut config)?;
+        Ok(config)
     }
 
     /// q projection output width (n_heads * head_dim).
@@ -132,6 +153,39 @@ impl MiniMaxConfig {
     pub fn kv_dim(&self) -> usize {
         self.num_key_value_heads * self.head_dim
     }
+}
+
+/// Apply an optional REAP keep-map to a freshly parsed `MiniMaxConfig`.
+///
+/// Reads `HIPFIRE_REAP_PLAN=<dir>` (minimax has no legacy env alias). When set,
+/// loads `<dir>/reap_plan.json` (or the legacy `keep_by_layer.json`) via
+/// `ReapPlan::load_any`, validating against the ORIGINAL local-expert count
+/// (`config.num_local_experts`) BEFORE overriding it to the kept count. This
+/// emulates a pruned expert pool by partial-loading the full quant: only kept
+/// experts are packed into the per-layer blob (under remapped names) and the
+/// router's expert rows + routing bias are gathered to the kept set in
+/// `MiniMaxWeights::load`.
+///
+/// No env ⇒ no-op (`config.reap_keep` stays `None`); the loader then takes the
+/// literal original full-load path — byte-identical to baseline. REAP and EP
+/// sharding are MUTUALLY EXCLUSIVE; that guard lives in `MiniMaxWeights::load`.
+pub fn apply_reap_plan(config: &mut MiniMaxConfig) -> Result<(), String> {
+    let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
+        return Ok(());
+    };
+    let plan = hipfire_reap::plan::ReapPlan::load_any(
+        &dir,
+        config.num_hidden_layers,
+        config.num_local_experts,
+    )?;
+    eprintln!(
+        "minimax: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.num_local_experts
+    );
+    config.num_local_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+    Ok(())
 }
 
 // ───────────────────────── HFQ load helpers ─────────────────────────
@@ -206,6 +260,76 @@ fn load_wt(
 ) -> Result<WeightTensor, String> {
     let (qt, data) = read_tensor(hfq, name)?;
     wt_from_raw(gpu, qt, &data, m, k).map_err(|e| format!("minimax: load_wt {name}: {e}"))
+}
+
+/// REAP keep variant of [`load_wt`]: gather the tensor's first-axis rows (one
+/// row per ORIGINAL expert) down to `keep` BEFORE quant decode, then build the
+/// `WeightTensor` with `m = keep.len()`. Only used for the MoE router
+/// (`block_sparse_moe.gate.weight`, shape `[orig_experts, hidden]`) under an
+/// active keep-map: it then emits logits only for kept experts, in compact slot
+/// order. `gather_rows` is exact for any row-independent quant (each per-expert
+/// row carries its own scale/zero/codebook), which holds for every quant_type
+/// `wt_from_raw` accepts. Reads owned bytes via `tensor_data_vec` to retain
+/// `info.shape` for the original row count. `keep` MUST be compact-slot-ordered
+/// and `m` MUST equal `keep.len()`.
+fn load_wt_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+    keep: &[u32],
+) -> Result<WeightTensor, String> {
+    debug_assert_eq!(m, keep.len(), "minimax load_wt_keep: m must equal keep.len()");
+    let (info, data) = hfq
+        .tensor_data_vec(name)
+        .ok_or_else(|| format!("minimax: tensor not found in HFQ: {name}"))?;
+    let orig = *info.shape.first().unwrap_or(&0) as usize;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("minimax: router row-gather '{name}': {e}"))?;
+    wt_from_raw(gpu, info.quant_type, &sub, m, k)
+        .map_err(|e| format!("minimax: load_wt_keep {name}: {e}"))
+}
+
+/// REAP keep variant of [`load_norm`] for a 1-D per-expert F16/F32 vector (the
+/// router's `e_score_correction_bias` `[orig_experts]`). Gathers the kept rows
+/// (parallel to the router weight rows) so the per-expert routing bias aligns
+/// with the gathered router logits. `gather_rows` over a 1-D shape is an exact
+/// element select. Refuses block-packed quant (a single bias element is not a
+/// whole quant block) — only F16/F32 1-D vectors can be element-gathered.
+fn load_norm_keep(
+    hfq: &HfqFile,
+    gpu: &mut Gpu,
+    name: &str,
+    m: usize,
+    keep: &[u32],
+) -> Result<GpuTensor, String> {
+    debug_assert_eq!(m, keep.len(), "minimax load_norm_keep: m must equal keep.len()");
+    let (qt, data) = read_tensor(hfq, name)?;
+    let elem_bytes = match qt {
+        1 => 2, // F16
+        2 => 4, // F32
+        other => {
+            return Err(format!(
+                "minimax: routing_bias {name} keep-gather needs F16/F32, got qt={other}"
+            ))
+        }
+    };
+    let orig = data.len() / elem_bytes;
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig], &data, keep)
+        .map_err(|e| format!("minimax: routing_bias row-gather '{name}': {e}"))?;
+    let f32_data: Vec<f32> = match qt {
+        1 => sub
+            .chunks_exact(2)
+            .map(|c| f16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect(),
+        _ => sub
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    };
+    gpu.upload_f32(&f32_data, &[m])
+        .map_err(|e| format!("minimax: upload routing_bias {name}: {e:?}"))
 }
 
 /// quant_type → DType mapping (subset used by MiniMax HFQ files; mirrors
@@ -299,6 +423,16 @@ impl MiniMaxWeights {
         let inter = cfg.intermediate_size;
         let n_exp = cfg.num_local_experts;
 
+        // REAP keep-map and EP sharding are MUTUALLY EXCLUSIVE: REAP emulates a
+        // pruned pool by partial-loading kept experts into the compact blob (so
+        // `n_exp` is already the kept count and the pointer table spans only
+        // kept slots), while EP-shard packs only rank-owned experts and routes
+        // non-owned ones to a shared zeroed dummy. Combining them would
+        // double-remap the slot space. Mirror deepseek4's guard and refuse.
+        if cfg.reap_keep.is_some() && shard.is_some() {
+            return Err("minimax: REAP keep-map + EP sharding are mutually exclusive".into());
+        }
+
         // Globals.
         let (_qt, embed_bytes) = read_tensor(hfq, "model.embed_tokens.weight")?;
         let embed = gpu
@@ -348,20 +482,56 @@ impl MiniMaxWeights {
                 q_dim,
             )?;
 
-            let router = load_wt(
-                hfq,
-                gpu,
-                &format!("{p}.block_sparse_moe.gate.weight"),
-                n_exp,
-                hidden,
-            )?;
-            // e_score_correction_bias: [n_exp] F16 → F32 (kept F16 in HFQ).
-            let routing_bias = load_norm(
-                hfq,
-                gpu,
-                &format!("{p}.block_sparse_moe.e_score_correction_bias"),
-                &[n_exp],
-            )?;
+            // REAP keep-map for this layer (None ⇒ no pruning / identity load).
+            // When a keep is present, `n_exp == cfg.num_local_experts` is already
+            // the KEPT count (overridden in apply_reap_plan); the router, routing
+            // bias, and expert-pack loop below load only the kept original
+            // experts, in compact slot order. (EP-shard is excluded above, so the
+            // keep path never coexists with the non-owned-zero path.)
+            let reap_ep = cfg.reap_keep.as_ref().map(|r| r.expert_plan(l));
+            let keep_l = reap_ep.as_ref().and_then(|e| e.keep());
+
+            // Router: hidden → n_exp. Under a keep, gather the router's expert
+            // rows (`[orig_experts, hidden]`) down to the kept set so it emits
+            // logits only for kept experts, in compact slot order. No keep ⇒ the
+            // literal original full load (byte-identical to baseline).
+            let router = match keep_l {
+                Some(keep) => load_wt_keep(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.gate.weight"),
+                    n_exp,
+                    hidden,
+                    keep,
+                )?,
+                None => load_wt(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.gate.weight"),
+                    n_exp,
+                    hidden,
+                )?,
+            };
+            // e_score_correction_bias: [n_exp] F16 → F32 (kept F16 in HFQ). This
+            // is a PER-EXPERT routing bias added to the router logits for top-k
+            // selection; under a keep it MUST be row-gathered to the kept set in
+            // the same compact slot order as the router weight, else the bias
+            // mis-aligns with the gathered logits. No keep ⇒ literal original.
+            let routing_bias = match keep_l {
+                Some(keep) => load_norm_keep(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.e_score_correction_bias"),
+                    n_exp,
+                    keep,
+                )?,
+                None => load_norm(
+                    hfq,
+                    gpu,
+                    &format!("{p}.block_sparse_moe.e_score_correction_bias"),
+                    &[n_exp],
+                )?,
+            };
 
             // Routed experts: pack ALL experts of this layer into ONE gate_up
             // blob + ONE down blob (deepseek4 `upload_layer_routed_experts`
@@ -386,13 +556,22 @@ impl MiniMaxWeights {
             let owns = |e: usize| shard.map(|(s, rank)| s.owns_expert(rank, e)).unwrap_or(true);
             let mut local_of_global = vec![usize::MAX; n_exp];
             let mut n_owned = 0usize;
-            for e in 0..n_exp {
+            // Iterate COMPACT slots `0..n_exp`. `e` = the ORIGINAL expert index
+            // loaded into this slot: under a REAP keep it is `src(slot)` (read the
+            // kept experts in compact order); with no keep it is `slot` itself, so
+            // the loop is byte-identical to the original literal pack (and the
+            // EP-shard path is unchanged — REAP excludes sharding, so when a keep
+            // is active `shard` is None and `owns(e)` is always true). `owns` /
+            // `local_of_global` stay indexed by the original id `e` (== slot on
+            // the no-keep path), preserving shard semantics exactly.
+            for slot in 0..n_exp {
+                let e = reap_ep.as_ref().map(|ep| ep.src(slot)).unwrap_or(slot);
                 let ep = format!("{p}.block_sparse_moe.experts.{e}");
                 let (qt1, w1) = read_tensor(hfq, &format!("{ep}.w1.weight"))?;
                 let (_qt3, w3) = read_tensor(hfq, &format!("{ep}.w3.weight"))?;
                 let (qt2, w2) = read_tensor(hfq, &format!("{ep}.w2.weight"))?;
                 let gu_len = w1.len() + w3.len();
-                if e == 0 {
+                if slot == 0 {
                     gu_stride = gu_len;
                     dn_stride = w2.len();
                     qt_gu = qt1;
@@ -407,7 +586,15 @@ impl MiniMaxWeights {
                     ));
                 }
                 if owns(e) {
-                    local_of_global[e] = n_owned;
+                    // `local_of_global` is indexed by the KERNEL ROUTING INDEX —
+                    // the slot the router/topk emits, which the device pointer
+                    // table is built over below. With EP-shard that index is the
+                    // GLOBAL expert id `e`; with REAP (shard excluded) the router
+                    // is gathered to compact slots, so the routing index is the
+                    // COMPACT SLOT. On the plain path `e == slot`, so both agree
+                    // and the table is identity (byte-identical to baseline).
+                    let route = if shard.is_some() { e } else { slot };
+                    local_of_global[route] = n_owned;
                     n_owned += 1;
                     gu_combined.extend_from_slice(&w1);
                     gu_combined.extend_from_slice(&w3);

--- a/crates/hipfire-arch-qwen35/Cargo.toml
+++ b/crates/hipfire-arch-qwen35/Cargo.toml
@@ -16,6 +16,7 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
+hipfire-reap = { path = "../hipfire-reap" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/hipfire-arch-qwen35/src/arch.rs
+++ b/crates/hipfire-arch-qwen35/src/arch.rs
@@ -62,8 +62,13 @@ impl Architecture for Qwen35 {
     }
 
     fn config_from_hfq(hfq: &HfqFile) -> Result<Self::Config, String> {
-        qwen35_config_from_hfq(hfq)
-            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())
+        let mut config = qwen35_config_from_hfq(hfq)
+            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())?;
+        // Optional REAP keep-map (HIPFIRE_REAP_PLAN). Applied AFTER parse so
+        // validation sees the original n_routed_experts; overrides num_experts
+        // to the kept count when active. No env ⇒ no-op (baseline behavior).
+        crate::qwen35::apply_reap_plan(&mut config)?;
+        Ok(config)
     }
 
     fn load_weights(

--- a/crates/hipfire-arch-qwen35/src/arch.rs
+++ b/crates/hipfire-arch-qwen35/src/arch.rs
@@ -62,13 +62,13 @@ impl Architecture for Qwen35 {
     }
 
     fn config_from_hfq(hfq: &HfqFile) -> Result<Self::Config, String> {
-        let mut config = qwen35_config_from_hfq(hfq)
-            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())?;
-        // Optional REAP keep-map (HIPFIRE_REAP_PLAN). Applied AFTER parse so
-        // validation sees the original n_routed_experts; overrides num_experts
-        // to the kept count when active. No env ⇒ no-op (baseline behavior).
-        crate::qwen35::apply_reap_plan(&mut config)?;
-        Ok(config)
+        // REAP is applied INSIDE `qwen35_config_from_hfq` (the public free fn)
+        // so every caller — trait or direct — gets it; do NOT re-apply here,
+        // or the keep-map would be applied twice (double-overriding num_experts
+        // to kept-of-kept, which would then fail load_any's kept-count
+        // validation against the original count).
+        qwen35_config_from_hfq(hfq)
+            .ok_or_else(|| "qwen35: failed to parse config from HFQ metadata".to_string())
     }
 
     fn load_weights(

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -193,6 +193,14 @@ pub struct Qwen35Config {
     /// to `u64::MAX` (no eviction — tested when VRAM is unlimited or we just
     /// want to verify the routing path works without eviction pressure).
     pub vram_budget_bytes: u64,
+
+    /// Optional REAP keep-map: emulate a pruned routed-expert pool by
+    /// partial-loading this full quant (load only the kept experts under
+    /// remapped names, gather the router's expert rows to the kept set).
+    /// Populated at config time from `HIPFIRE_REAP_PLAN=<dir>`; `None` ⇒
+    /// no pruning (today's behavior, byte-identical to baseline). Not
+    /// (de)serialized — `Qwen35Config` does not derive serde.
+    pub reap_keep: Option<std::sync::Arc<hipfire_reap::plan::ReapPlan>>,
 }
 
 pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
@@ -346,7 +354,44 @@ pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
         // a follow-up commit). When false, no behavior change vs main.
         paged_experts: false,
         vram_budget_bytes: u64::MAX,
+        reap_keep: None,
     })
+}
+
+/// Apply an optional REAP keep-map to a freshly parsed `Qwen35Config`.
+///
+/// Reads `HIPFIRE_REAP_PLAN=<dir>` (qwen35 has no legacy env alias). When
+/// set, loads `<dir>/reap_plan.json` (or the legacy `keep_by_layer.json`)
+/// via `ReapPlan::load_any`, validating against the ORIGINAL routed-expert
+/// count (`config.num_experts`) BEFORE overriding it to the kept count.
+/// This emulates a pruned expert pool by partial-loading the full quant:
+/// only kept experts are loaded (under remapped names) and the router's
+/// expert rows are gathered to the kept set in `load_moe_ffn`.
+///
+/// No env ⇒ no-op (`config.reap_keep` stays `None`); the MoE loader then
+/// takes the literal original full-load path — byte-identical to baseline.
+/// Only the HFQ MoE path (`load_moe_ffn`) honors the keep-map; the
+/// ParoQuant path does not (see `paro_load_moe_ffn`).
+pub fn apply_reap_plan(config: &mut Qwen35Config) -> Result<(), String> {
+    let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") else {
+        return Ok(());
+    };
+    // MoE-only feature: a dense (num_experts==0) checkpoint has no routed
+    // experts to prune. Refuse rather than silently divide-by-zero / mislead.
+    if config.num_experts == 0 {
+        return Err(format!(
+            "qwen35: HIPFIRE_REAP_PLAN={dir} set but this is a dense (num_experts==0) checkpoint"
+        ));
+    }
+    let plan = hipfire_reap::plan::ReapPlan::load_any(&dir, config.n_layers, config.num_experts)?;
+    eprintln!(
+        "qwen35: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.num_experts
+    );
+    config.num_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+    Ok(())
 }
 
 /// Parse Qwen35Config from a SafetensorsSource (or any ModelSource).
@@ -487,6 +532,7 @@ pub fn config_from_safetensors(source: &dyn ModelSource) -> Option<Qwen35Config>
         norm_topk_prob,
         paged_experts: false,
         vram_budget_bytes: u64::MAX,
+        reap_keep: None,
     })
 }
 
@@ -1599,6 +1645,63 @@ fn load_weight_tensor(
         }
         Ok(wt)
     }
+}
+
+/// REAP keep variant of [`load_weight_tensor`]: gather the tensor's first-axis
+/// rows (one row per original expert) down to `keep` BEFORE quant decode, then
+/// build the `WeightTensor` from the gathered bytes with `m = keep.len()`.
+///
+/// Only used for the MoE router (`mlp.gate.weight`, shape `[orig_experts, k]`)
+/// under an active keep-map. `gather_rows` is exact for any row-independent
+/// quant (every per-expert row is self-contained — its own scale/zero/codebook
+/// live in the row), which is true for every quant_type this loader accepts.
+/// `keep` MUST equal the compact slot order, and `m` MUST equal `keep.len()`.
+///
+/// The AWQ sidecar (when present) is indexed by `k` (the input/hidden
+/// dimension), shared across all expert rows, so it is loaded UNCHANGED —
+/// row selection does not touch it.
+fn load_weight_tensor_keep(
+    hfq: &HfqFile,
+    gpu: &Gpu,
+    name: &str,
+    m: usize,
+    k: usize,
+    keep: &[u32],
+) -> HipResult<WeightTensor> {
+    debug_assert_eq!(
+        m,
+        keep.len(),
+        "load_weight_tensor_keep: m ({m}) must equal keep.len() ({})",
+        keep.len()
+    );
+    // Resolve via the same name-candidate logic as the non-keep path, taking
+    // owned bytes so the gather + AWQ-sidecar reads don't fight a borrow.
+    // `HfqTensorInfo` is not Clone, so pull out the scalars we need (quant
+    // type + on-disk row count) while the borrow is live.
+    let mut matched: Option<String> = None;
+    let mut found: Option<(u8, usize, Vec<u8>)> = None;
+    for candidate in qwen35_tensor_name_candidates(name) {
+        if let Some((info, buf)) = hfq.tensor_data_vec(&candidate) {
+            let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
+            matched = Some(candidate);
+            found = Some((info.quant_type, orig_rows, buf));
+            break;
+        }
+    }
+    let (quant_type, orig_rows, bytes) =
+        found.unwrap_or_else(|| panic!("tensor not found: {name}"));
+    // Row-gather to the kept set. The on-disk row count is the ORIGINAL expert
+    // count (= bytes.len() / rowstride); gather_rows derives it from shape[0].
+    let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig_rows], &bytes, keep)
+        .map_err(|e| HipError::new(0, &format!("qwen35: router row-gather '{name}': {e}")))?;
+    let mut wt = load_weight_tensor_raw(gpu, quant_type, &sub, m, k)?;
+    if wt.gpu_dtype.supports_awq_sidecar() {
+        wt.awq_scale = matched
+            .as_deref()
+            .and_then(|mn| load_awq_scale_for(hfq, gpu, mn, k))
+            .or_else(|| load_awq_scale_for(hfq, gpu, name, k));
+    }
+    Ok(wt)
 }
 
 // ─── ParoQuant AWQ → HFQ4G128 repack ────────────────────────────────────────
@@ -4284,8 +4387,31 @@ fn load_moe_ffn(
     let mi = config.moe_intermediate_size;
     let smi = config.shared_expert_intermediate_size;
 
+    // REAP keep-map for this layer (None ⇒ no pruning / identity). When a
+    // keep is present, `n_exp == config.num_experts` is already the KEPT
+    // count; the router and expert loops below load only the kept rows.
+    let ep = config
+        .reap_keep
+        .as_ref()
+        .map(|r| r.expert_plan(layer_idx as usize));
+
     // Router: hidden_size → num_experts. Precision-sensitive but small.
-    let router = load_weight_tensor(hfq, gpu, &format!("{p}.mlp.gate.weight"), n_exp, config.dim)?;
+    // Under a keep, gather the router's expert rows (`[orig_experts, dim]`)
+    // down to the kept set so it emits logits only for kept experts, in
+    // compact slot order. No keep ⇒ the literal original full load.
+    let router = match ep.as_ref().and_then(|e| e.keep()) {
+        Some(keep) => load_weight_tensor_keep(
+            hfq,
+            gpu,
+            &format!("{p}.mlp.gate.weight"),
+            n_exp,
+            config.dim,
+            keep,
+        )?,
+        None => {
+            load_weight_tensor(hfq, gpu, &format!("{p}.mlp.gate.weight"), n_exp, config.dim)?
+        }
+    };
 
     // Shared expert (always-on, contributes to every token). Unlike routed
     // experts, gate_proj + up_proj are stored separately in the safetensors
@@ -4326,8 +4452,16 @@ fn load_moe_ffn(
     // Routed experts — quantizer wrote per-expert tensors named
     // `{p}.mlp.experts.{X}.gate_up_proj.weight` (shape [2*moe_intermediate, hidden_size])
     // and `{p}.mlp.experts.{X}.down_proj.weight` (shape [hidden_size, moe_intermediate]).
-    let mut experts = Vec::with_capacity(n_exp);
-    for x in 0..n_exp {
+    //
+    // REAP keep-map: `n_exp` is already the KEPT count (config.num_experts was
+    // overridden in apply_reap_plan). Iterate compact slots and load only the
+    // kept original experts under their remapped names (`ep` computed above).
+    // No keep ⇒ identity (slot==original index, `n_slots == n_exp`) — the
+    // literal original loop.
+    let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
+    let mut experts = Vec::with_capacity(n_slots);
+    for slot in 0..n_slots {
+        let x = ep.as_ref().map(|e| e.src(slot)).unwrap_or(slot);
         let gate_up = load_weight_tensor(
             hfq,
             gpu,

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -323,7 +323,7 @@ pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
 
-    Some(Qwen35Config {
+    let mut config = Qwen35Config {
         dim,
         n_layers,
         vocab_size,
@@ -355,7 +355,31 @@ pub fn config_from_hfq(hfq: &HfqFile) -> Option<Qwen35Config> {
         paged_experts: false,
         vram_budget_bytes: u64::MAX,
         reap_keep: None,
-    })
+    };
+
+    // Apply the optional REAP keep-map HERE, inside the single public config
+    // entry point, so it is IMPOSSIBLE to bypass. `config_from_hfq` has ~50
+    // direct callers (daemon, perplexity example, every bench/profile example)
+    // that never go through the `Architecture` trait shim; wiring REAP only in
+    // the trait impl would silently ignore HIPFIRE_REAP_PLAN on all of them
+    // (including the deferred identity NLL gate, which the perplexity example
+    // drives via this public fn). The trait impl therefore does NOT re-apply.
+    //
+    // Error policy: this fn returns `Option<Qwen35Config>`, shared by ~50
+    // callers that mostly `.expect()`/`.ok_or()` the Option — converting to
+    // `Result<_, String>` would be an invasive, churny signature change across
+    // all of them. REAP is OPT-IN (env-gated), so a malformed plan when the
+    // user explicitly set HIPFIRE_REAP_PLAN MUST hard-fail, never silently
+    // no-op or get swallowed into a `None` that callers misread as "bad
+    // metadata". We therefore hard-exit on Err with a clear FATAL message
+    // rather than collapsing the error into `None`. With no env var,
+    // apply_reap_plan is a no-op (Ok), so baseline behavior is unchanged.
+    if let Err(e) = apply_reap_plan(&mut config) {
+        eprintln!("FATAL: HIPFIRE_REAP_PLAN: {e}");
+        std::process::exit(1);
+    }
+
+    Some(config)
 }
 
 /// Apply an optional REAP keep-map to a freshly parsed `Qwen35Config`.
@@ -1674,28 +1698,29 @@ fn load_weight_tensor_keep(
         "load_weight_tensor_keep: m ({m}) must equal keep.len() ({})",
         keep.len()
     );
-    // Resolve via the same name-candidate logic as the non-keep path, taking
-    // owned bytes so the gather + AWQ-sidecar reads don't fight a borrow.
-    // `HfqTensorInfo` is not Clone, so pull out the scalars we need (quant
-    // type + on-disk row count) while the borrow is live.
-    let mut matched: Option<String> = None;
-    let mut found: Option<(u8, usize, Vec<u8>)> = None;
-    for candidate in qwen35_tensor_name_candidates(name) {
-        if let Some((info, buf)) = hfq.tensor_data_vec(&candidate) {
-            let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
-            matched = Some(candidate);
-            found = Some((info.quant_type, orig_rows, buf));
-            break;
-        }
-    }
-    let (quant_type, orig_rows, bytes) =
-        found.unwrap_or_else(|| panic!("tensor not found: {name}"));
+    // Resolve via the shared `qwen35_tensor_data_vec` helper (same candidate
+    // logic as the non-keep path; it preads + fadvise_dontneeds internally and
+    // returns OWNED bytes, so the gather + AWQ-sidecar reads don't fight a
+    // borrow). `orig_rows` is the on-disk first-axis length = original expert
+    // count. The matched (prefixed) candidate name is resolved separately for
+    // the AWQ sidecar lookup via a metadata-only existence check, since the
+    // helper doesn't surface which candidate it hit.
+    let (info, bytes) =
+        qwen35_tensor_data_vec(hfq, name).unwrap_or_else(|| panic!("tensor not found: {name}"));
+    let quant_type = info.quant_type;
+    let orig_rows = *info.shape.first().unwrap_or(&0) as usize;
     // Row-gather to the kept set. The on-disk row count is the ORIGINAL expert
     // count (= bytes.len() / rowstride); gather_rows derives it from shape[0].
     let (_new_shape, sub) = hipfire_reap::gather::gather_rows(&[orig_rows], &bytes, keep)
         .map_err(|e| HipError::new(0, &format!("qwen35: router row-gather '{name}': {e}")))?;
     let mut wt = load_weight_tensor_raw(gpu, quant_type, &sub, m, k)?;
     if wt.gpu_dtype.supports_awq_sidecar() {
+        // Resolve the matched candidate name (metadata only) so the AWQ sidecar
+        // is looked up under the same prefix the weight resolved to; fall back
+        // to the bare `name`. Mirrors the non-keep `load_weight_tensor`.
+        let matched = qwen35_tensor_name_candidates(name)
+            .into_iter()
+            .find(|c| hfq.find_tensor_info(c).is_some());
         wt.awq_scale = matched
             .as_deref()
             .and_then(|mn| load_awq_scale_for(hfq, gpu, mn, k))
@@ -4454,13 +4479,14 @@ fn load_moe_ffn(
     // and `{p}.mlp.experts.{X}.down_proj.weight` (shape [hidden_size, moe_intermediate]).
     //
     // REAP keep-map: `n_exp` is already the KEPT count (config.num_experts was
-    // overridden in apply_reap_plan). Iterate compact slots and load only the
-    // kept original experts under their remapped names (`ep` computed above).
-    // No keep ⇒ identity (slot==original index, `n_slots == n_exp`) — the
-    // literal original loop.
-    let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
-    let mut experts = Vec::with_capacity(n_slots);
-    for slot in 0..n_slots {
+    // overridden in apply_reap_plan), and under a keep `ExpertPlan::n_slots`
+    // also equals the kept count — so `n_exp` is the slot count on both the
+    // keep and no-keep paths. Iterate compact slots `0..n_exp` (matching ds4's
+    // `0..n_routed_experts`) and load only the kept original experts under
+    // their remapped names via `ep.src(slot)`. No keep ⇒ identity (slot ==
+    // original index) — the literal original loop.
+    let mut experts = Vec::with_capacity(n_exp);
+    for slot in 0..n_exp {
         let x = ep.as_ref().map(|e| e.src(slot)).unwrap_or(slot);
         let gate_up = load_weight_tensor(
             hfq,

--- a/crates/hipfire-quantize/Cargo.toml
+++ b/crates/hipfire-quantize/Cargo.toml
@@ -13,3 +13,9 @@ hipfire-reap = { path = "../hipfire-reap" }
 
 [dev-dependencies]
 tempfile = "3"
+# CPU-only reader for the overlay round-trip test: HfqFile parses the .hfq
+# container header/index by name without touching the GPU (builds on CPU).
+# hipfire-quantize is a binary crate (no lib target), so the overlay
+# integration test lives in-module in reap_overlay.rs (it needs crate-internal
+# write_hfq / quantize_* access that a tests/ target can't reach).
+hipfire-runtime = { path = "../hipfire-runtime" }

--- a/crates/hipfire-quantize/Cargo.toml
+++ b/crates/hipfire-quantize/Cargo.toml
@@ -9,3 +9,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 byteorder = "1"
 rayon = "1"
+hipfire-reap = { path = "../hipfire-reap" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -12,6 +12,7 @@
 //! RDNA-native quantized weights.
 
 mod gguf_input;
+mod reap_overlay;
 
 use memmap2::Mmap;
 use std::collections::HashMap;
@@ -697,7 +698,7 @@ fn quantize_q4_as_q8(f32_data: &[f32]) -> Vec<u8> {
 /// Quantize F32 weights to Q8_0 format (compatible with GGML Q8_0).
 /// Block: f16 scale (2B) + 32 × int8 = 34 bytes per 32 elements (1.0625 bytes/weight).
 /// Symmetric quantization: scale = max(|w|) / 127, q = round(w / scale).
-fn quantize_q8f16(f32_data: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_q8f16(f32_data: &[f32]) -> Vec<u8> {
     let group_size = 32;
     let block_bytes = 34;
     let n = f32_data.len();
@@ -799,7 +800,7 @@ fn cpu_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
 }
 
 /// Generate FWHT sign table (matches engine's gen_fwht_signs).
-fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
+pub(crate) fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
     let mut state = seed;
     (0..n)
         .map(|_| {
@@ -816,7 +817,7 @@ fn gen_fwht_signs(seed: u32, n: usize) -> Vec<f32> {
 /// MagnumQuant HFQ4-G256: FWHT-rotated 4-bit quantization.
 /// Same binary format as HFQ4-G256 (136 bytes/group) — the rotation is baked
 /// into the weights. The GEMV kernel rotates x instead of inverse-rotating w.
-fn quantize_mq4g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_mq4g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
     let group_size = 256;
     let block_bytes = 136;
     let n = f32_data.len();
@@ -859,7 +860,7 @@ fn quantize_mq4g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8>
 /// MagnumQuant MQ6-G256: FWHT-rotated 6-bit quantization.
 /// Same binary format as HFQ6-G256 (200 bytes/group) — the rotation is baked
 /// into the weights. The GEMV kernel rotates x instead of inverse-rotating w.
-fn quantize_mq6g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_mq6g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
     let group_size = 256;
     let block_bytes = 200; // 8 (scale+zero) + 192 (packed 6-bit)
     let n = f32_data.len();
@@ -954,7 +955,7 @@ fn quantize_mq8g256(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8>
     output
 }
 
-fn quantize_hfq4g256(f32_data: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_hfq4g256(f32_data: &[f32]) -> Vec<u8> {
     let group_size = 256;
     let block_bytes = 136;
     let n = f32_data.len();
@@ -1673,7 +1674,7 @@ fn f32_to_fp16_bits(v: f32) -> u16 {
 /// Lloyd's algorithm. 16 B header (8 fp16) + 96 B packed 3-bit indices = 112 B/group
 /// (vs uniform MQ3's 104 B — only +7.7% bandwidth). Direct extension of MQ2-Lloyd
 /// with K=8; targets sub-9B MQ3 collapse rescue (#114) and 9B MQ3 → MQ4 ppl gap.
-fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
     use rayon::prelude::*;
     let group_size = 256;
     let block_bytes = 112;
@@ -1802,7 +1803,7 @@ fn quantize_mq3g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> V
 /// `benchmarks/results/devlog_20260506_lloyd_mq4_extension.md`) is that the
 /// 16-centroid placement narrows the MQ4 → MQ6 ppl gap at lower bandwidth
 /// than uniform MQ6 (200 B/group).
-fn quantize_mq4g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_mq4g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
     use rayon::prelude::*;
     let group_size = 256;
     let block_bytes = 160;
@@ -2395,7 +2396,7 @@ fn quantize_mq2g256_lloyd_gptq(
     output
 }
 
-fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_mq2g256_lloyd(f32_data: &[f32], signs1: &[f32], signs2: &[f32]) -> Vec<u8> {
     use rayon::prelude::*;
     let group_size = 256;
     let block_bytes = 72;
@@ -2915,7 +2916,7 @@ fn quantize_hfq2g128(f32_data: &[f32]) -> Vec<u8> {
 
 /// Quantize F32 weights to HFQ6-G256: 6-bit with 256-weight groups.
 /// Block: [f32 scale][f32 zero][192B packed 6-bit] = 200 bytes per 256 weights (0.78125 B/w).
-fn quantize_hfq6g256(f32_data: &[f32]) -> Vec<u8> {
+pub(crate) fn quantize_hfq6g256(f32_data: &[f32]) -> Vec<u8> {
     let group_size = 256;
     let block_bytes = 200; // 8 (scale+zero) + 192 (packed 6-bit)
     let n = f32_data.len();
@@ -3031,8 +3032,8 @@ const HFQ_MAGIC: &[u8; 4] = b"HFQM";
 const HFQ_VERSION: u32 = 1;
 
 #[repr(u8)]
-#[derive(Clone, Copy)]
-enum QuantType {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum QuantType {
     Q4F16G64 = 0,
     F16 = 1,
     F32 = 2,
@@ -3316,15 +3317,16 @@ fn kmap_resolve_mode(name: &str, n_layers: usize, is_moe: bool, kmap_mode: u8) -
     QuantLevel::Base
 }
 
-struct HfqTensor {
-    name: String,
-    quant_type: QuantType,
-    shape: Vec<u32>,
-    group_size: u32,
-    data: Vec<u8>,
+#[derive(Debug)]
+pub(crate) struct HfqTensor {
+    pub(crate) name: String,
+    pub(crate) quant_type: QuantType,
+    pub(crate) shape: Vec<u32>,
+    pub(crate) group_size: u32,
+    pub(crate) data: Vec<u8>,
     /// When data is spilled to disk, this holds the byte count.
     /// `data` is empty and the bytes live in the spill file.
-    spilled_len: u64,
+    pub(crate) spilled_len: u64,
 }
 
 /// Streaming tensor spill file. When the quantizer accumulates more than

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -4738,6 +4738,20 @@ fn main() {
         .iter()
         .position(|a| a == "--reap-arch")
         .and_then(|i| args.get(i + 1).cloned());
+    // SP4b bake mode. `--reap-bake <plan-dir>` runs the NORMAL whole-model
+    // quantize to completion BUT with a per-tensor override hook active: any
+    // tensor the plan's `quant_overrides` name is re-quantized to its override
+    // tier; every other tensor keeps its arch-specific default quant. The whole
+    // model is written via the usual `write_hfq` to `--reap-out` (or the normal
+    // `--format` output path). Mutually exclusive with `--reap-overlay`.
+    let reap_bake_dir: Option<String> = args
+        .iter()
+        .position(|a| a == "--reap-bake")
+        .and_then(|i| args.get(i + 1).cloned());
+    if reap_bake_dir.is_some() && reap_overlay_dir.is_some() {
+        eprintln!("reap: --reap-bake and --reap-overlay are mutually exclusive");
+        std::process::exit(1);
+    }
 
     // Optional imatrix (llama.cpp GGUF format with .in_sum2 / .counts per-tensor).
     // When provided, MQ2-Lloyd quantization uses per-column importance weights
@@ -5611,6 +5625,56 @@ fn main() {
         return;
     }
 
+    // ── SP4b: bake-mode setup ────────────────────────────────────────────────
+    // `--reap-bake <plan-dir>` keeps the normal whole-model quantize loop but
+    // activates the per-tensor override hook (at the top of the loop below).
+    // Resolve the plan + arch family up front; the loop reads `reap_bake_plan`
+    // and `reap_arch`. When bake is inactive these are unused / None and the
+    // loop is byte-identical to today. If `--reap-out` is given, the whole
+    // baked model is written there instead of the normal `--output` path.
+    let reap_bake_plan: Option<hipfire_reap::plan::ReapPlan> = match reap_bake_dir.as_deref() {
+        Some(plan_dir) => Some(
+            hipfire_reap::plan::ReapPlan::load_unchecked(plan_dir).unwrap_or_else(|e| {
+                eprintln!("reap bake: failed to load plan from {plan_dir}: {e}");
+                std::process::exit(1);
+            }),
+        ),
+        None => None,
+    };
+    // Arch family for tensor-name matching: explicit --reap-arch overrides the
+    // auto-detection from arch_id (only consulted when bake is active).
+    let reap_arch: reap_overlay::ReapArch = if reap_bake_plan.is_some() {
+        match reap_arch_flag.as_deref() {
+            Some(s) => reap_overlay::ReapArch::from_flag(s).unwrap_or_else(|e| {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }),
+            None => reap_overlay::ReapArch::from_arch_id(arch_id).unwrap_or_else(|| {
+                eprintln!(
+                    "reap bake: could not auto-detect arch family from arch_id={arch_id}; \
+                     pass --reap-arch <deepseek4|qwen35|lfm2moe|minimax>"
+                );
+                std::process::exit(1);
+            }),
+        }
+    } else {
+        // Placeholder (never read when reap_bake_plan is None).
+        reap_overlay::ReapArch::Qwen35
+    };
+    // Redirect the whole-model output to --reap-out when baking with that flag.
+    let bake_out_path = reap_bake_plan
+        .as_ref()
+        .and(reap_out.as_deref())
+        .map(Path::new);
+    let output_path: &Path = bake_out_path.unwrap_or(output_path);
+    if let Some(plan) = &reap_bake_plan {
+        eprintln!(
+            "REAP bake mode: arch={reap_arch:?}, {} quant_overrides, out={}",
+            plan.quant_overrides.len(),
+            output_path.display()
+        );
+    }
+
     // ── K-map pre-pass ──────────────────────────────────────────────────────
     // Build per-tensor quant level map. Gated to MoE models by default
     // (maintainer directive 2026-05-08): K-map's dense PPL effect is mixed
@@ -5786,6 +5850,39 @@ fn main() {
         let (meta, raw_data) = st_files[*file_idx].tensor_data(name).unwrap();
         let n_elements: usize = meta.shape.iter().product();
         total_params += n_elements as u64;
+
+        // ── SP4b: bake override hook ───────────────────────────────────────────
+        // When `--reap-bake` is active and the plan overrides this tensor,
+        // re-quantize it to the override tier and skip the arch-specific default
+        // branch below. Non-overridden tensors fall through UNCHANGED. The hook
+        // is entirely behind `if let Some(plan) = &reap_bake_plan`, so default
+        // mode (no `--reap-bake`) is byte-identical to before. Bookkeeping
+        // mirrors the arch branches: f32-decode → push → drop_tensor_pages →
+        // quantized_params → maybe_spill → continue.
+        if let Some(plan) = &reap_bake_plan {
+            if let Some(fmt) = reap_overlay::reap_override_for(name, reap_arch, plan) {
+                let f32 = tensor_to_f32_with_optional_fp8_scale(
+                    name, raw_data, meta, &fp8_scale_for, &st_files,
+                );
+                let shape: Vec<usize> = meta.shape.clone();
+                match reap_overlay::quantize_to_format(name, fmt, &f32, &shape) {
+                    Ok(t) => {
+                        eprintln!("  {:>8}: {} {:?} → {fmt}", "BAKE", name, meta.shape);
+                        hfq_tensors.push(t);
+                    }
+                    Err(e) => {
+                        eprintln!("reap bake: {e}");
+                        std::process::exit(2);
+                    }
+                }
+                quantized_params += n_elements as u64;
+                st_files[*file_idx].drop_tensor_pages(name);
+                if let Some(ref mut s) = spill {
+                    maybe_spill(&mut hfq_tensors, s, 2 * 1024 * 1024 * 1024);
+                }
+                continue;
+            }
+        }
 
         // ── LFM2.5 ingest (arch_id 11) ─────────────────────────────────────────
         // Routed experts (A1B only) → MQ4G256; expert_bias → F32; everything else

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -3397,6 +3397,57 @@ fn maybe_spill(tensors: &mut [HfqTensor], spill: &mut TensorSpill, threshold: us
     let _ = spill.flush();
 }
 
+/// The arch-correct config field naming the routed-expert count, as the arch's
+/// loader config parser reads it from the HFQ metadata `config` object:
+///   * deepseek4 → `n_routed_experts`
+///   * qwen3.5-moe / lfm2moe → `num_experts`
+///   * minimax → `num_local_experts`
+fn reap_expert_count_field(arch: reap_overlay::ReapArch) -> &'static str {
+    match arch {
+        reap_overlay::ReapArch::Deepseek4 => "n_routed_experts",
+        reap_overlay::ReapArch::Qwen35 => "num_experts",
+        reap_overlay::ReapArch::Lfm2Moe => "num_experts",
+        reap_overlay::ReapArch::Minimax => "num_local_experts",
+    }
+}
+
+/// Patch the HFQ metadata envelope's `config` so the routed-expert count reads
+/// `kept` (the pruned/compact count) for `arch`. The arch loaders parse the
+/// inner `config` object (qwen3.5 additionally descends into `config.text_config`
+/// when present), so patch the field WHEREVER it currently exists under `config`:
+/// at `config[field]` and, if present, at `config.text_config[field]`. Erroring
+/// (rather than silently no-op'ing) when the field is absent prevents shipping a
+/// baked model whose metadata still claims the original expert count.
+fn patch_expert_count_metadata(
+    metadata_json: &str,
+    arch: reap_overlay::ReapArch,
+    kept: usize,
+) -> Result<String, String> {
+    let field = reap_expert_count_field(arch);
+    let mut v: serde_json::Value = serde_json::from_str(metadata_json)
+        .map_err(|e| format!("metadata not valid JSON: {e}"))?;
+    let config = v
+        .get_mut("config")
+        .ok_or_else(|| "metadata missing `config` object".to_string())?;
+    let mut patched = false;
+    if config.get(field).is_some() {
+        config[field] = serde_json::json!(kept);
+        patched = true;
+    }
+    if let Some(tc) = config.get_mut("text_config") {
+        if tc.get(field).is_some() {
+            tc[field] = serde_json::json!(kept);
+            patched = true;
+        }
+    }
+    if !patched {
+        return Err(format!(
+            "expert-count field '{field}' not found under config (or config.text_config) for {arch:?}"
+        ));
+    }
+    serde_json::to_string(&v).map_err(|e| format!("re-serialize metadata: {e}"))
+}
+
 fn write_hfq(
     path: &Path,
     arch: u32,
@@ -5493,7 +5544,10 @@ fn main() {
         "tokenizer_config": tokenizer_config,
         "generation_config": generation_config,
     });
-    let metadata_json = serde_json::to_string(&metadata).unwrap();
+    // `mut` so the SP4b bake-prune path can patch the routed-expert count down to
+    // the kept count before write_hfq (so the baked model loads with the compact
+    // count and NO env var). Untouched in every non-prune path.
+    let mut metadata_json = serde_json::to_string(&metadata).unwrap();
 
     // Load all safetensors files
     let st_files: Vec<SafetensorsFile> = find_safetensors(input_dir)
@@ -5674,6 +5728,21 @@ fn main() {
             output_path.display()
         );
     }
+    // Is expert pruning active? (A bake plan with a per-layer keep-map.) When
+    // active, the loop's prune hook drops pruned per-expert tensors, the kept
+    // per-expert tensors are recorded in `bake_rename` for a post-loop renumber
+    // to compact slots, routers/biases are row-gathered to the kept set, and the
+    // output metadata's expert count is patched to `kept_per_layer`.
+    let bake_keep_active = reap_bake_plan
+        .as_ref()
+        .map(|p| p.keep.is_some())
+        .unwrap_or(false);
+    // original-name → compact-renamed-name for kept per-expert tensors
+    // (ds4 score layers / lfm2 / minimax). Applied as a post-loop rename pass so
+    // the per-expert quant branches keep using the ORIGINAL name to read source
+    // bytes, then we rewrite `HfqTensor.name` to the compact slot before write.
+    let mut bake_rename: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
 
     // ── K-map pre-pass ──────────────────────────────────────────────────────
     // Build per-tensor quant level map. Gated to MoE models by default
@@ -5850,6 +5919,116 @@ fn main() {
         let (meta, raw_data) = st_files[*file_idx].tensor_data(name).unwrap();
         let n_elements: usize = meta.shape.iter().product();
         total_params += n_elements as u64;
+
+        // ── SP4b: bake prune hook ──────────────────────────────────────────────
+        // BEFORE the override hook. When `--reap-bake`'s plan carries a keep-map,
+        // prune routed experts not in `keep[L]`, renumber kept experts to compact
+        // slots, and row-gather routers / per-expert biases to the kept set so the
+        // baked model loads with the compact expert count and NO load-time
+        // keep-map. `meta`/`raw_data` may be shadowed below with gathered owned
+        // copies so the override hook + arch branches transparently quantize the
+        // gathered tensor with the arch's normal encoder.
+        //
+        // Two owned holders are pre-declared so a gather can rebind the borrowed
+        // (`meta`, `raw_data`) to point at gathered data for the rest of the body.
+        let _gathered_meta: TensorMeta;
+        let _gathered_bytes: Vec<u8>;
+        let mut meta: &TensorMeta = meta;
+        let mut raw_data: &[u8] = raw_data;
+        if bake_keep_active {
+            // SAFETY of indexing: bake_keep_active ⇒ reap_bake_plan.keep is Some.
+            let plan = reap_bake_plan.as_ref().unwrap();
+            let keep = plan.keep.as_ref().unwrap();
+            let layer = reap_overlay::bake_layer_of(name);
+
+            // Per-arch routed-expert (per-expert-named) tensors: drop pruned,
+            // record kept→compact rename for the post-loop pass.
+            if reap_overlay::expert_index_of(name, reap_arch).is_some() {
+                let l = layer.unwrap_or_else(|| {
+                    eprintln!("reap bake: routed-expert tensor '{name}' has no parseable layer");
+                    std::process::exit(2);
+                });
+                // ds4 hash-layer guard: pruning layers 0..=2 requires a tid2eid
+                // remap to the compact expert space — not supported in bake.
+                if reap_arch == reap_overlay::ReapArch::Deepseek4 && l <= 2 {
+                    eprintln!(
+                        "reap bake: ds4 hash-layer (0-2) tid2eid remap not supported in bake; \
+                         use the load-time keep-map for pruned ds4 hash layers"
+                    );
+                    std::process::exit(2);
+                }
+                if l >= keep.len() {
+                    eprintln!("reap bake: layer {l} for '{name}' out of keep-map range");
+                    std::process::exit(2);
+                }
+                match reap_overlay::bake_expert_rename(name, reap_arch, l, &keep[l]) {
+                    None => {
+                        // Pruned expert: drop entirely.
+                        st_files[*file_idx].drop_tensor_pages(name);
+                        continue;
+                    }
+                    Some(new_name) => {
+                        if &new_name != name {
+                            bake_rename.insert(name.to_string(), new_name);
+                        }
+                        // Fall through: the arch branch quantizes the ORIGINAL
+                        // bytes; the post-loop pass renames the output tensor.
+                    }
+                }
+            } else if let Some(l) = layer {
+                // Router weight (`*.gate.weight`, shape `[orig_experts, hidden]`)
+                // and per-expert bias (`*.gate.bias` / `e_score_correction_bias` /
+                // `expert_bias`, shape `[orig_experts]`): row-gather to the kept
+                // set BEFORE quant so the baked router/bias emit only kept rows in
+                // compact-slot order (mirrors the loader's load-time gather).
+                let is_router_w = reap_overlay::is_reap_router_weight(name, reap_arch)
+                    && meta.shape.len() == 2
+                    && meta.shape[0] == plan.original_experts;
+                let is_expert_bias = reap_overlay::is_reap_expert_bias(name, reap_arch)
+                    && meta.shape.len() == 1
+                    && meta.shape[0] == plan.original_experts;
+                if is_router_w || is_expert_bias {
+                    // ds4 hash-layer guard also covers the router of layers 0..=2.
+                    if reap_arch == reap_overlay::ReapArch::Deepseek4 && l <= 2 {
+                        eprintln!(
+                            "reap bake: ds4 hash-layer (0-2) router/tid2eid remap not supported \
+                             in bake; use the load-time keep-map for pruned ds4 hash layers"
+                        );
+                        std::process::exit(2);
+                    }
+                    if l >= keep.len() {
+                        eprintln!("reap bake: layer {l} for router/bias '{name}' out of keep-map range");
+                        std::process::exit(2);
+                    }
+                    let keep_l = &keep[l];
+                    match hipfire_reap::gather::gather_rows(&meta.shape, raw_data, keep_l) {
+                        Ok((new_shape, gathered)) => {
+                            _gathered_meta = TensorMeta {
+                                dtype: meta.dtype.clone(),
+                                shape: new_shape,
+                                data_offsets: meta.data_offsets,
+                            };
+                            _gathered_bytes = gathered;
+                            eprintln!(
+                                "  {:>8}: {} {:?} → rows[{}] (kept {} of {})",
+                                "GATHER",
+                                name,
+                                meta.shape,
+                                keep_l.len(),
+                                keep_l.len(),
+                                plan.original_experts
+                            );
+                            meta = &_gathered_meta;
+                            raw_data = &_gathered_bytes;
+                        }
+                        Err(e) => {
+                            eprintln!("reap bake: router/bias gather '{name}': {e}");
+                            std::process::exit(2);
+                        }
+                    }
+                }
+            }
+        }
 
         // ── SP4b: bake override hook ───────────────────────────────────────────
         // When `--reap-bake` is active and the plan overrides this tensor,
@@ -6310,7 +6489,31 @@ fn main() {
                 );
             }
 
-            // Parallelize across the 256 expert slices via rayon. Each slice
+            // ── SP4b bake prune (3D-stacked experts) ───────────────────────────
+            // Qwen3.5-MoE (and any 3D-stacked MoE) ships routed experts as one
+            // `[n_experts, ...]` tensor that this branch splits per-expert. Under
+            // an active bake keep, emit ONLY kept slices, renumbered to compact
+            // slots: `slots[slot] = orig_expert`. The slice offset + imatrix
+            // lookup key off `orig`; the output name uses `slot`. No keep ⇒
+            // identity (`slots[i] = (i, i)`), byte-identical to baseline.
+            let bake_slots: Vec<(usize, usize)> = if bake_keep_active {
+                let plan = reap_bake_plan.as_ref().unwrap();
+                let keep = plan.keep.as_ref().unwrap();
+                let l = parent_layer.unwrap_or_else(|| {
+                    eprintln!("reap bake: 3D-stacked expert tensor '{name}' has no parseable layer");
+                    std::process::exit(2);
+                });
+                if l >= keep.len() {
+                    eprintln!("reap bake: layer {l} for stacked experts '{name}' out of keep-map range");
+                    std::process::exit(2);
+                }
+                keep[l].iter().enumerate().map(|(slot, &orig)| (slot, orig as usize)).collect()
+            } else {
+                (0..n_experts).map(|i| (i, i)).collect()
+            };
+            let n_out_experts = bake_slots.len();
+
+            // Parallelize across the expert slices via rayon. Each slice
             // dequant→FWHT→quant→pack is a CPU-bound, self-contained job.
             // The outer Rayon pool size is set in main() before this runs.
             use rayon::prelude::*;
@@ -6318,9 +6521,9 @@ fn main() {
             let parent_owned = parent.to_string();
             let inner_shape_clone = inner_shape.clone();
             let base_owned = base_name.to_string();
-            let mut new_tensors: Vec<HfqTensor> = (0..n_experts)
+            let mut new_tensors: Vec<HfqTensor> = bake_slots
                 .into_par_iter()
-                .map(|x| {
+                .map(|(slot, x)| {
                     let slice_off = x * inner_bytes;
                     let slice = &raw_data[slice_off..slice_off + inner_bytes];
                     let f32_slice = to_f32(slice, &dtype);
@@ -6381,7 +6584,7 @@ fn main() {
                         (q, QuantType::HFQ4G128, 128u32)
                     };
                     HfqTensor {
-                        name: format!("{parent_owned}{x}.{base_owned}.weight"),
+                        name: format!("{parent_owned}{slot}.{base_owned}.weight"),
                         quant_type: qt,
                         shape: inner_shape_clone.clone(),
                         group_size: gs,
@@ -6390,7 +6593,7 @@ fn main() {
                     }
                 })
                 .collect();
-            quantized_params += inner_n as u64 * n_experts as u64;
+            quantized_params += inner_n as u64 * n_out_experts as u64;
             // Single eprintln to summarize the whole expert sweep.
             let label = if expert_mq3lloyd_native {
                 "MQ3G256L"
@@ -6414,7 +6617,7 @@ fn main() {
                 "HFQ4G128"
             };
             let bytes_per = new_tensors.first().map(|t| t.data.len()).unwrap_or(0);
-            eprintln!("  {label:>8}: {parent_owned}{{0..{n_experts}}}.{base_owned}.weight {:?} (×{n_experts} experts || {:.1} KB/expert, parallel)",
+            eprintln!("  {label:>8}: {parent_owned}{{0..{n_out_experts}}}.{base_owned}.weight {:?} (×{n_out_experts} experts of {n_experts} || {:.1} KB/expert, parallel)",
                 inner_shape, bytes_per as f64 / 1024.0);
             hfq_tensors.append(&mut new_tensors);
             // Drop source pages and spill quantized data after each expert batch.
@@ -7546,6 +7749,40 @@ fn main() {
     eprintln!("  Mean quant error: {mean_quant_error:.8}");
     eprintln!("  Max quant error:  {max_quant_error:.8}");
     eprintln!("  Output size:      {:.1} MB", total_bytes as f64 / 1e6);
+
+    // ── SP4b: bake prune finalize (rename kept per-expert tensors + patch count) ──
+    // Applied only when a bake keep-map is active. Renames the per-expert-named
+    // kept tensors (ds4 score layers / lfm2 / minimax) recorded during the loop to
+    // their compact slots, then patches the output metadata's routed-expert count
+    // to `kept_per_layer` so the baked model loads standalone (no env var, no
+    // load-time keep-map). Spill preserves `.name`, so rename order vs. spill is
+    // irrelevant. (Qwen3.5 stacked experts + all routers/biases were already
+    // pruned/gathered in-loop.)
+    if bake_keep_active {
+        let plan = reap_bake_plan.as_ref().unwrap();
+        if !bake_rename.is_empty() {
+            for t in hfq_tensors.iter_mut() {
+                if let Some(new_name) = bake_rename.get(&t.name) {
+                    t.name = new_name.clone();
+                }
+            }
+            eprintln!(
+                "REAP bake: renamed {} kept per-expert tensors to compact slots",
+                bake_rename.len()
+            );
+        }
+        let kept = plan.kept_per_layer();
+        match patch_expert_count_metadata(&metadata_json, reap_arch, kept) {
+            Ok(patched) => {
+                metadata_json = patched;
+                eprintln!("REAP bake: patched output metadata expert count → {kept}");
+            }
+            Err(e) => {
+                eprintln!("reap bake: failed to patch expert-count metadata: {e}");
+                std::process::exit(2);
+            }
+        }
+    }
 
     // Write .hfq file
     eprintln!("\nWriting: {}", output_path.display());

--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -4720,6 +4720,25 @@ fn main() {
         .map(|i| args[i + 1].as_str())
         .unwrap_or("q8f16");
 
+    // SP4 selective re-quant overlay mode. `--reap-overlay <plan-dir>` activates
+    // it: instead of quantizing the whole model, only the tensors named by the
+    // plan's `quant_overrides` are decoded from the original safetensors and
+    // re-quantized into a small `overlay.hfq` (written to `--reap-out`).
+    // `--reap-arch` overrides the auto-detected arch family used for
+    // tensor-name matching. See reap_overlay.rs / SP4 plan Task 4.
+    let reap_overlay_dir: Option<String> = args
+        .iter()
+        .position(|a| a == "--reap-overlay")
+        .and_then(|i| args.get(i + 1).cloned());
+    let reap_out: Option<String> = args
+        .iter()
+        .position(|a| a == "--reap-out")
+        .and_then(|i| args.get(i + 1).cloned());
+    let reap_arch_flag: Option<String> = args
+        .iter()
+        .position(|a| a == "--reap-arch")
+        .and_then(|i| args.get(i + 1).cloned());
+
     // Optional imatrix (llama.cpp GGUF format with .in_sum2 / .counts per-tensor).
     // When provided, MQ2-Lloyd quantization uses per-column importance weights
     // to bias centroid placement. See `quantize_mq2g256_lloyd_weighted`.
@@ -4773,7 +4792,16 @@ fn main() {
         || format == "deepseek4-q8"
         || format == "deepseek4-source-precision"
         || format == "deepseek4-source"
-        || format == "deepseek4-mtp-precise";
+        || format == "deepseek4-mtp-precise"
+        || format == "deepseek4-mq4lloyd"
+        || format == "deepseek4-mq3lloyd";
+    // deepseek4-mq4lloyd / deepseek4-mq3lloyd: identical recipe to deepseek4-q8
+    // (non-expert 2D → Q8F16, norms/HC → F16) EXCEPT routed experts ship as
+    // MQ4G256Lloyd (qt=30, 160 B/group) resp. MQ3G256Lloyd (qt=20, 112 B/group)
+    // instead of MQ2G256Lloyd. Both require the matching MoE GEMV kernels in the
+    // ds4 forward (MQ3-Lloyd kernels pre-existed; MQ4-Lloyd added alongside).
+    let use_deepseek4_mq4_experts = format == "deepseek4-mq4lloyd";
+    let use_deepseek4_mq3_experts = format == "deepseek4-mq3lloyd";
     // deepseek4-mtp-precise: addon-only build (use with --include-prefix mtp.) that
     // keeps every mtp.0.* DENSE weight at F16 instead of Q8F16. Doubles the
     // addon size (~2 GB → ~3 GB) but eliminates Q8 quant noise on the MTP
@@ -5490,6 +5518,99 @@ fn main() {
         fp8_scale_for.len()
     );
 
+    // ── SP4: selective re-quant overlay mode ────────────────────────────────
+    // When `--reap-overlay <plan-dir>` is set, this branch fully replaces the
+    // normal whole-model quantize: it loads the reap plan, resolves the arch
+    // family (auto from arch_id, or `--reap-arch` override), then iterates the
+    // model tensors and — for ONLY the tensors the plan overrides — decodes
+    // f32 and re-quantizes via `quantize_to_format`. Non-matched tensors skip
+    // the (expensive) f32 decode entirely. The subset is written to
+    // `--reap-out` via the existing `write_hfq`, keyed by original tensor name
+    // so a load-time splice (SP3) can overlay them onto the base model.
+    if let Some(plan_dir) = reap_overlay_dir.as_deref() {
+        let reap_out_path = reap_out.as_deref().unwrap_or_else(|| {
+            eprintln!("--reap-overlay requires --reap-out <overlay.hfq path>");
+            std::process::exit(1);
+        });
+        // Resolve arch: explicit --reap-arch overrides the auto-detection.
+        let arch: reap_overlay::ReapArch = match reap_arch_flag.as_deref() {
+            Some(s) => reap_overlay::ReapArch::from_flag(s).unwrap_or_else(|e| {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }),
+            None => reap_overlay::ReapArch::from_arch_id(arch_id).unwrap_or_else(|| {
+                eprintln!(
+                    "reap overlay: could not auto-detect arch family from arch_id={arch_id}; \
+                     pass --reap-arch <deepseek4|qwen35|lfm2moe|minimax>"
+                );
+                std::process::exit(1);
+            }),
+        };
+        let plan = hipfire_reap::plan::ReapPlan::load_unchecked(plan_dir).unwrap_or_else(|e| {
+            eprintln!("reap overlay: failed to load plan from {plan_dir}: {e}");
+            std::process::exit(1);
+        });
+        eprintln!(
+            "REAP overlay mode: arch={arch:?}, {} quant_overrides, out={reap_out_path}",
+            plan.quant_overrides.len()
+        );
+
+        let mut hfq_tensors: Vec<HfqTensor> = Vec::new();
+        for (name, file_idx) in &all_tensors {
+            // Check the plan BEFORE decoding f32 — skipping the decode of
+            // non-matched tensors is the whole point of an overlay build.
+            if reap_overlay::reap_override_for(name, arch, &plan).is_none() {
+                continue;
+            }
+            let (meta, raw_data) = st_files[*file_idx].tensor_data(name).unwrap();
+            let f32 = tensor_to_f32_with_optional_fp8_scale(
+                name,
+                raw_data,
+                &meta,
+                &fp8_scale_for,
+                &st_files,
+            );
+            let shape: Vec<usize> = meta.shape.clone();
+            let tier = reap_overlay::reap_override_for(name, arch, &plan).unwrap();
+            match reap_overlay::quantize_to_format(name, tier, &f32, &shape) {
+                Ok(t) => {
+                    eprintln!("  overlay: {name} → {tier} ({} bytes)", t.data.len());
+                    hfq_tensors.push(t);
+                }
+                Err(e) => {
+                    eprintln!("reap overlay: {e}");
+                    std::process::exit(2);
+                }
+            }
+        }
+
+        if hfq_tensors.is_empty() {
+            eprintln!(
+                "reap overlay: no tensors matched the plan's quant_overrides \
+                 (check arch/layer/expert names)"
+            );
+            std::process::exit(1);
+        }
+
+        eprintln!(
+            "REAP overlay: {} tensors quantized; writing {reap_out_path}",
+            hfq_tensors.len()
+        );
+        write_hfq(
+            Path::new(reap_out_path),
+            arch_id,
+            &metadata_json,
+            &hfq_tensors,
+            None,
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("reap overlay: failed to write {reap_out_path}: {e}");
+            std::process::exit(2);
+        });
+        eprintln!("REAP overlay written: {reap_out_path}");
+        return;
+    }
+
     // ── K-map pre-pass ──────────────────────────────────────────────────────
     // Build per-tensor quant level map. Gated to MoE models by default
     // (maintainer directive 2026-05-08): K-map's dense PPL effect is mixed
@@ -5893,15 +6014,36 @@ fn main() {
                 let signs1 = gen_fwht_signs(42, 256);
                 let signs2 = gen_fwht_signs(1042, 256);
                 let unit_col_weights: Vec<f32> = vec![1.0; k];
-                let q = if use_mq4_mq2lloyd_gptq_all || use_mq4_mqlloyd_antirez_gptq {
-                    quantize_mq2g256_lloyd_gptq(&f32_data, &unit_col_weights, &signs1, &signs2)
-                } else {
-                    quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2)
-                };
+                let (q, expert_qt, expert_label): (Vec<u8>, QuantType, &str) =
+                    if use_deepseek4_mq4_experts {
+                        (
+                            quantize_mq4g256_lloyd(&f32_data, &signs1, &signs2),
+                            QuantType::MQ4G256Lloyd,
+                            "MQ4L-DeepSeek V4",
+                        )
+                    } else if use_deepseek4_mq3_experts {
+                        (
+                            quantize_mq3g256_lloyd(&f32_data, &signs1, &signs2),
+                            QuantType::MQ3G256Lloyd,
+                            "MQ3L-DeepSeek V4",
+                        )
+                    } else if use_mq4_mq2lloyd_gptq_all || use_mq4_mqlloyd_antirez_gptq {
+                        (
+                            quantize_mq2g256_lloyd_gptq(&f32_data, &unit_col_weights, &signs1, &signs2),
+                            QuantType::MQ2G256Lloyd,
+                            "MQ2L-DeepSeek V4",
+                        )
+                    } else {
+                        (
+                            quantize_mq2g256_lloyd(&f32_data, &signs1, &signs2),
+                            QuantType::MQ2G256Lloyd,
+                            "MQ2L-DeepSeek V4",
+                        )
+                    };
                 let shape: Vec<u32> = logical_shape.iter().map(|&s| s as u32).collect();
                 eprintln!(
                     "  {:>8}: {} storage{:?} → logical{:?} ({:.1} KB → {:.1} KB)",
-                    "MQ2L-DeepSeek V4",
+                    expert_label,
                     name,
                     meta.shape,
                     logical_shape,
@@ -5910,7 +6052,7 @@ fn main() {
                 );
                 hfq_tensors.push(HfqTensor {
                     name: name.to_string(),
-                    quant_type: QuantType::MQ2G256Lloyd,
+                    quant_type: expert_qt,
                     shape,
                     group_size: 256,
                     data: q,

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -164,6 +164,105 @@ pub fn reap_override_for<'a>(name: &str, arch: ReapArch, plan: &'a ReapPlan) -> 
     None
 }
 
+/// The per-arch routed-expert name segment and the weight-suffix predicate that
+/// together identify a routed-expert tensor. Shared by `tensor_matches` and
+/// `expert_index_of` (DRY).
+fn routed_expert_seg(arch: ReapArch) -> (&'static str, fn(&str) -> bool) {
+    match arch {
+        ReapArch::Deepseek4 => (
+            ".ffn.experts.",
+            |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
+        ),
+        ReapArch::Qwen35 => (
+            ".mlp.experts.",
+            |n| n.ends_with(".gate_up_proj.weight") || n.ends_with(".down_proj.weight"),
+        ),
+        ReapArch::Lfm2Moe => (
+            ".feed_forward.experts.",
+            |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
+        ),
+        ReapArch::Minimax => (
+            ".block_sparse_moe.experts.",
+            |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
+        ),
+    }
+}
+
+/// Parse the routed-expert index `E` out of a per-expert tensor name for `arch`,
+/// or `None` if the name is not a routed-expert weight tensor. The index is the
+/// first dotted token after the arch's expert segment (e.g.
+/// `layers.0.ffn.experts.7.w1.weight` → `7`). Shared by `tensor_matches` (override
+/// resolution) and `bake_expert_rename` (prune/renumber) so both agree on layout.
+///
+/// NOTE: Qwen3.5-MoE ships its routed experts as a single 3-D stacked tensor
+/// (`...mlp.experts.gate_up_proj`, no per-expert index in the *source* name) that
+/// the quantizer splits into per-expert names at quant time. This parser matches
+/// the *split* form (`...mlp.experts.{E}.gate_up_proj.weight`); the bake's prune
+/// of the stacked source happens in the split loop, not via this fn.
+pub fn expert_index_of(name: &str, arch: ReapArch) -> Option<u32> {
+    let (seg, w_ok) = routed_expert_seg(arch);
+    if !name.contains(seg) || !w_ok(name) {
+        return None;
+    }
+    let after = &name[name.find(seg).unwrap() + seg.len()..];
+    after.split('.').next().and_then(|s| s.parse().ok())
+}
+
+/// For a routed-expert tensor under an active keep, decide: drop it, or emit it
+/// renamed to its compact slot. Returns `None` to drop (the expert was pruned),
+/// `Some(new_name)` to keep (the original expert-index token replaced by its
+/// compact slot index). `keep_l` is `keep[layer]` — original expert indices in
+/// compact-slot order. Non-routed-expert names (no parseable index) return `None`;
+/// callers gate this fn on routed-expert tensors only.
+pub fn bake_expert_rename(name: &str, arch: ReapArch, _layer: usize, keep_l: &[u32]) -> Option<String> {
+    let e = expert_index_of(name, arch)?;
+    let slot = keep_l.iter().position(|&k| k == e)?;
+    // Replace the expert-index token `.{seg}{E}.` with `.{seg}{slot}.`. The
+    // segment ends with `.`, and the token is immediately followed by `.`, so a
+    // bounded replace of `{seg}{E}.` → `{seg}{slot}.` is unambiguous.
+    let (seg, _) = routed_expert_seg(arch);
+    let from = format!("{seg}{e}.");
+    let to = format!("{seg}{slot}.");
+    Some(name.replacen(&from, &to, 1))
+}
+
+/// Does `name` name the MoE router weight (`[orig_experts, hidden]`) for `arch`?
+/// Used by the bake prune to row-gather the router to the kept expert set. The
+/// caller additionally checks the tensor's shape[0] == original_experts so a
+/// shared-expert gate (`[1, hidden]`) can never be mistaken for the router.
+pub fn is_reap_router_weight(name: &str, arch: ReapArch) -> bool {
+    match arch {
+        ReapArch::Deepseek4 => name.ends_with(".ffn.gate.weight"),
+        ReapArch::Qwen35 => name.ends_with(".mlp.gate.weight"),
+        ReapArch::Lfm2Moe => name.ends_with(".feed_forward.gate.weight"),
+        ReapArch::Minimax => name.ends_with(".block_sparse_moe.gate.weight"),
+    }
+}
+
+/// Does `name` name the per-expert routing bias (`[orig_experts]`) for `arch`?
+/// Row-gathered alongside the router under a keep so the bias aligns with the
+/// gathered logits in compact-slot order.
+pub fn is_reap_expert_bias(name: &str, arch: ReapArch) -> bool {
+    match arch {
+        ReapArch::Deepseek4 => name.ends_with(".ffn.gate.bias"),
+        // Qwen3.5-MoE routing has no per-expert correction bias.
+        ReapArch::Qwen35 => false,
+        ReapArch::Lfm2Moe => name.ends_with(".feed_forward.expert_bias"),
+        ReapArch::Minimax => name.ends_with(".block_sparse_moe.e_score_correction_bias"),
+    }
+}
+
+/// Parse the layer index `L` from a tensor name's `layers.{L}.` segment, or
+/// `None` if absent. All four arches embed the layer this way (with or without a
+/// `model.`/`model.language_model.` prefix). Uses `rfind` so a `.layers.` deeper
+/// in the path (none expected) prefers the last occurrence.
+pub fn bake_layer_of(name: &str) -> Option<usize> {
+    let marker = "layers.";
+    let i = name.rfind(marker)?;
+    let rest = &name[i + marker.len()..];
+    rest.split('.').next().and_then(|s| s.parse().ok())
+}
+
 fn tensor_matches(name: &str, arch: ReapArch, ov: &QuantOverride) -> bool {
     // Layer gate: the name must reference `ov.layer`. All four arches embed the
     // layer index as `.layers.{L}.` or `layers.{L}.`.
@@ -173,35 +272,16 @@ fn tensor_matches(name: &str, arch: ReapArch, ov: &QuantOverride) -> bool {
     }
     match ov.role {
         Role::RoutedExperts => {
-            let (seg, w_ok): (&str, fn(&str) -> bool) = match arch {
-                ReapArch::Deepseek4 => (
-                    ".ffn.experts.",
-                    |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
-                ),
-                ReapArch::Qwen35 => (
-                    ".mlp.experts.",
-                    |n| n.ends_with(".gate_up_proj.weight") || n.ends_with(".down_proj.weight"),
-                ),
-                ReapArch::Lfm2Moe => (
-                    ".feed_forward.experts.",
-                    |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
-                ),
-                ReapArch::Minimax => (
-                    ".block_sparse_moe.experts.",
-                    |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
-                ),
-            };
+            let (seg, w_ok) = routed_expert_seg(arch);
             if !name.contains(seg) || !w_ok(name) {
                 return false;
             }
             if ov.experts.is_empty() {
                 return true; // whole role at this layer
             }
-            // expert index: the token right after `seg`. ds4 layout (verified
-            // against main.rs:5843 — `layers.L.ffn.experts.E.{w1,w2,w3}.weight`)
-            // makes the first dotted token after `seg` the expert index.
-            let after = &name[name.find(seg).unwrap() + seg.len()..];
-            let eidx: u32 = match after.split('.').next().and_then(|s| s.parse().ok()) {
+            // expert index via the shared parser (verified against
+            // main.rs — `layers.L.ffn.experts.E.{w1,w2,w3}.weight`).
+            let eidx = match expert_index_of(name, arch) {
                 Some(e) => e,
                 None => return false,
             };
@@ -385,6 +465,217 @@ mod bake_tests {
     }
 }
 
+#[cfg(test)]
+mod prune_tests {
+    use super::*;
+
+    #[test]
+    fn renames_kept_expert_to_compact_slot() {
+        // keep[0] = [0,2,3]; original expert 2 → compact slot 1.
+        let n = "layers.0.ffn.experts.2.w1.weight";
+        assert_eq!(
+            bake_expert_rename(n, ReapArch::Deepseek4, 0, &[0, 2, 3]),
+            Some("layers.0.ffn.experts.1.w1.weight".to_string())
+        );
+    }
+
+    #[test]
+    fn drops_pruned_expert() {
+        let n = "layers.0.ffn.experts.5.w1.weight";
+        assert_eq!(bake_expert_rename(n, ReapArch::Deepseek4, 0, &[0, 2, 3]), None);
+    }
+
+    #[test]
+    fn rename_keeps_slot0_identity() {
+        // expert 0 stays slot 0 (identity rename, still Some).
+        let n = "layers.7.ffn.experts.0.w2.weight";
+        assert_eq!(
+            bake_expert_rename(n, ReapArch::Deepseek4, 7, &[0, 4, 9]),
+            Some("layers.7.ffn.experts.0.w2.weight".to_string())
+        );
+    }
+
+    #[test]
+    fn expert_index_parses_per_arch() {
+        assert_eq!(
+            expert_index_of("layers.3.ffn.experts.12.w1.weight", ReapArch::Deepseek4),
+            Some(12)
+        );
+        assert_eq!(
+            expert_index_of(
+                "model.layers.3.mlp.experts.4.gate_up_proj.weight",
+                ReapArch::Qwen35
+            ),
+            Some(4)
+        );
+        assert_eq!(
+            expert_index_of(
+                "layers.1.feed_forward.experts.7.w3.weight",
+                ReapArch::Lfm2Moe
+            ),
+            Some(7)
+        );
+        assert_eq!(
+            expert_index_of(
+                "model.layers.2.block_sparse_moe.experts.31.w2.weight",
+                ReapArch::Minimax
+            ),
+            Some(31)
+        );
+        // Non-routed-expert tensors → None.
+        assert_eq!(
+            expert_index_of("layers.0.self_attn.q_proj.weight", ReapArch::Deepseek4),
+            None
+        );
+        assert_eq!(
+            expert_index_of("layers.0.ffn.gate.weight", ReapArch::Deepseek4),
+            None
+        );
+    }
+
+    #[test]
+    fn minimax_rename_renumbers() {
+        let n = "model.layers.2.block_sparse_moe.experts.9.w1.weight";
+        assert_eq!(
+            bake_expert_rename(n, ReapArch::Minimax, 2, &[1, 9, 13]),
+            Some("model.layers.2.block_sparse_moe.experts.1.w1.weight".to_string())
+        );
+    }
+
+    #[test]
+    fn layer_parse() {
+        assert_eq!(bake_layer_of("layers.0.ffn.experts.2.w1.weight"), Some(0));
+        assert_eq!(
+            bake_layer_of("model.language_model.layers.41.mlp.gate.weight"),
+            Some(41)
+        );
+        assert_eq!(bake_layer_of("model.embed_tokens.weight"), None);
+    }
+}
+
+/// SP4b Task 2 prune finalize: router/bias row-gather + metadata expert-count
+/// patch. These reach crate-internal `patch_expert_count_metadata` (in main.rs),
+/// hence the in-module placement (binary crate has no lib target).
+#[cfg(test)]
+mod bake_finalize_tests {
+    use super::*;
+    use crate::patch_expert_count_metadata;
+    use hipfire_reap::gather::gather_rows;
+
+    #[test]
+    fn router_gather_keeps_only_kept_rows() {
+        // Router weight [orig_experts=4, dim=2] of f32 (8 bytes/row). Keep {2,0}.
+        let dim = 2usize;
+        let orig = 4usize;
+        let mut bytes = Vec::new();
+        for e in 0..orig {
+            for d in 0..dim {
+                bytes.extend_from_slice(&((e * 10 + d) as f32).to_le_bytes());
+            }
+        }
+        let keep_l: Vec<u32> = vec![2, 0];
+        let (new_shape, gathered) = gather_rows(&[orig, dim], &bytes, &keep_l).unwrap();
+        // Row count == keep_l.len(); inner dim preserved.
+        assert_eq!(new_shape, vec![keep_l.len(), dim]);
+        assert_eq!(gathered.len(), keep_l.len() * dim * 4);
+        // Compact slot 0 = original expert 2's first element (2*10+0 = 20.0).
+        let slot0_e0 = f32::from_le_bytes(gathered[0..4].try_into().unwrap());
+        assert_eq!(slot0_e0, 20.0);
+        // Compact slot 1 = original expert 0's first element (0.0).
+        let slot1_e0 = f32::from_le_bytes(gathered[dim * 4..dim * 4 + 4].try_into().unwrap());
+        assert_eq!(slot1_e0, 0.0);
+    }
+
+    #[test]
+    fn router_bias_classification_per_arch() {
+        // Router weight names.
+        assert!(is_reap_router_weight("layers.5.ffn.gate.weight", ReapArch::Deepseek4));
+        assert!(is_reap_router_weight(
+            "model.layers.5.mlp.gate.weight",
+            ReapArch::Qwen35
+        ));
+        assert!(is_reap_router_weight(
+            "layers.5.feed_forward.gate.weight",
+            ReapArch::Lfm2Moe
+        ));
+        assert!(is_reap_router_weight(
+            "model.layers.5.block_sparse_moe.gate.weight",
+            ReapArch::Minimax
+        ));
+        // Shared-expert gate must NOT be classed as the router.
+        assert!(!is_reap_router_weight(
+            "model.layers.5.mlp.shared_expert_gate.weight",
+            ReapArch::Qwen35
+        ));
+        // Per-expert bias names.
+        assert!(is_reap_expert_bias("layers.5.ffn.gate.bias", ReapArch::Deepseek4));
+        assert!(is_reap_expert_bias(
+            "layers.5.feed_forward.expert_bias",
+            ReapArch::Lfm2Moe
+        ));
+        assert!(is_reap_expert_bias(
+            "model.layers.5.block_sparse_moe.e_score_correction_bias",
+            ReapArch::Minimax
+        ));
+        assert!(!is_reap_expert_bias("layers.5.ffn.gate.bias", ReapArch::Qwen35));
+    }
+
+    fn meta(config: &str) -> String {
+        format!(r#"{{"architecture":"x","config":{config},"tokenizer":"{{}}"}}"#)
+    }
+
+    #[test]
+    fn patches_ds4_n_routed_experts() {
+        let m = meta(r#"{"n_routed_experts":256,"hidden_size":7168}"#);
+        let out = patch_expert_count_metadata(&m, ReapArch::Deepseek4, 32).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["config"]["n_routed_experts"], 32);
+        assert_eq!(v["config"]["hidden_size"], 7168); // untouched
+    }
+
+    #[test]
+    fn patches_qwen35_num_experts_top_level() {
+        let m = meta(r#"{"num_experts":128}"#);
+        let out = patch_expert_count_metadata(&m, ReapArch::Qwen35, 64).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["config"]["num_experts"], 64);
+    }
+
+    #[test]
+    fn patches_qwen35_num_experts_in_text_config() {
+        // VL-style nested config: num_experts lives under text_config.
+        let m = meta(r#"{"text_config":{"num_experts":128}}"#);
+        let out = patch_expert_count_metadata(&m, ReapArch::Qwen35, 64).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["config"]["text_config"]["num_experts"], 64);
+    }
+
+    #[test]
+    fn patches_minimax_num_local_experts() {
+        let m = meta(r#"{"num_local_experts":64}"#);
+        let out = patch_expert_count_metadata(&m, ReapArch::Minimax, 16).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["config"]["num_local_experts"], 16);
+    }
+
+    #[test]
+    fn patches_lfm2_num_experts() {
+        let m = meta(r#"{"num_experts":32}"#);
+        let out = patch_expert_count_metadata(&m, ReapArch::Lfm2Moe, 8).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["config"]["num_experts"], 8);
+    }
+
+    #[test]
+    fn errors_when_field_absent() {
+        // ds4 expects n_routed_experts; a config without it must error (never
+        // silently ship the original count).
+        let m = meta(r#"{"hidden_size":7168}"#);
+        let err = patch_expert_count_metadata(&m, ReapArch::Deepseek4, 32).unwrap_err();
+        assert!(err.contains("n_routed_experts"), "got: {err}");
+    }
+}
+
 /// SP4 Task 4 integration test: `build_overlay` selection + byte-correctness,
 /// then a real `write_hfq` → `HfqFile` container round-trip.
 ///
@@ -423,6 +714,12 @@ mod integ {
 
     #[test]
     fn build_overlay_selects_and_byte_matches_then_round_trips() {
+        // This test calls `HfqFile::open`, which reads the process-global
+        // `HIPFIRE_REAP_PLAN`. Serialize against `sp4_overlay_to_sp3_load_end_to_end`
+        // (which sets/removes that env var) so a concurrent set can't leak a stray
+        // overlay into this `open` (was a latent flake before SP4b T2 added tests
+        // that perturbed scheduling).
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let arch = ReapArch::Deepseek4;
         let d = tempfile::tempdir().unwrap();
         let plan = plan_layer0_expert0_hfq4(d.path());

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -66,13 +66,65 @@ pub fn quantize_to_format(
 
 /// Detected arch family for tensor-name matching (the quantizer already knows
 /// the arch_id; pass the matching variant in).
-#[allow(dead_code)] // Lfm2Moe / Minimax constructed by Task 4 (CLI arch detection)
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ReapArch {
     Deepseek4,
     Qwen35,
     Lfm2Moe,
     Minimax,
+}
+
+impl ReapArch {
+    /// Parse the `--reap-arch <name>` flag value.
+    pub fn from_flag(s: &str) -> Result<ReapArch, String> {
+        match s {
+            "deepseek4" | "deepseek_v4" | "ds4" => Ok(ReapArch::Deepseek4),
+            "qwen35" | "qwen3_5_moe" | "qwen3.5" => Ok(ReapArch::Qwen35),
+            "lfm2moe" | "lfm2_moe" => Ok(ReapArch::Lfm2Moe),
+            "minimax" => Ok(ReapArch::Minimax),
+            other => Err(format!(
+                "reap: unknown --reap-arch '{other}' (expected deepseek4|qwen35|lfm2moe|minimax)"
+            )),
+        }
+    }
+
+    /// Best-effort auto-detection from the quantizer's resolved `arch_id`.
+    /// Minimax has no quantizer arch_id, so it is only reachable via the
+    /// explicit `--reap-arch minimax` flag.
+    pub fn from_arch_id(arch_id: u32) -> Option<ReapArch> {
+        match arch_id {
+            9 => Some(ReapArch::Deepseek4),
+            6 => Some(ReapArch::Qwen35),
+            11 => Some(ReapArch::Lfm2Moe),
+            _ => None,
+        }
+    }
+}
+
+/// Overlay driver: quantize ONLY the tensors the plan overrides.
+///
+/// `tensors` yields `(name, shape, f32_data)` for the model's tensors. The
+/// caller is responsible for skipping the (expensive) f32 decode of tensors
+/// that don't match the plan — `build_overlay` only quantizes what it's
+/// handed (and re-checks the match so a hand-built iterator can over-supply).
+/// Returns the subset of `HfqTensor`s to write into `overlay.hfq`.
+///
+/// `main.rs`'s overlay branch inlines this logic (to skip the f32 decode of
+/// non-matched tensors); this standalone driver is exercised by the
+/// `tests/reap_overlay_integ.rs` integration target, hence the allow.
+#[allow(dead_code)]
+pub fn build_overlay(
+    arch: ReapArch,
+    plan: &ReapPlan,
+    tensors: impl Iterator<Item = (String, Vec<usize>, Vec<f32>)>,
+) -> Result<Vec<HfqTensor>, String> {
+    let mut out = Vec::new();
+    for (name, shape, f32) in tensors {
+        if let Some(fmt) = reap_override_for(&name, arch, plan) {
+            out.push(quantize_to_format(&name, fmt, &f32, &shape)?);
+        }
+    }
+    Ok(out)
 }
 
 /// Resolve a tensor name to its override tier under `plan`, or None.
@@ -256,5 +308,95 @@ mod resolve_tests {
             reap_override_for("model.layers.40.self_attn.q_proj.weight", ReapArch::Qwen35, &p),
             None
         );
+    }
+}
+
+/// SP4 Task 4 integration test: `build_overlay` selection + byte-correctness,
+/// then a real `write_hfq` → `HfqFile` container round-trip.
+///
+/// This lives in-module (not under `tests/`) because `hipfire-quantize` is a
+/// binary crate with no library target — a `tests/` integration target can't
+/// reach the crate-internal `write_hfq` / `quantize_hfq4g256` / `HfqTensor`.
+/// `hipfire-runtime` (CPU-only HFQ container reader) is a dev-dependency.
+#[cfg(test)]
+mod integ {
+    use super::*;
+    use crate::{quantize_hfq4g256, write_hfq};
+    use hipfire_reap::plan::ReapPlan;
+    use hipfire_runtime::hfq::HfqFile;
+
+    fn plan_layer0_expert0_hfq4(dir: &std::path::Path) -> ReapPlan {
+        std::fs::write(
+            dir.join("reap_plan.json"),
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"routed_experts","experts":[0],"tier":"hfq4"}]}"#,
+        )
+        .unwrap();
+        ReapPlan::load_unchecked(dir.to_str().unwrap()).unwrap()
+    }
+
+    /// A 4x256 tensor's worth of varied f32 (matches the plan's matched tensor).
+    fn matched_f32() -> Vec<f32> {
+        (0..4 * 256).map(|i| ((i as f32) * 0.017).sin() * 3.0).collect()
+    }
+
+    #[test]
+    fn build_overlay_selects_and_byte_matches_then_round_trips() {
+        let arch = ReapArch::Deepseek4;
+        let d = tempfile::tempdir().unwrap();
+        let plan = plan_layer0_expert0_hfq4(d.path());
+
+        // 3 hand-built tensors: one matches (layer 0 routed expert 0), two don't
+        // (wrong expert, and an attention tensor not in the plan).
+        let matched_name = "layers.0.ffn.experts.0.w1.weight".to_string();
+        let matched = matched_f32();
+        let tensors = vec![
+            (matched_name.clone(), vec![4usize, 256], matched.clone()),
+            (
+                "layers.0.ffn.experts.1.w1.weight".to_string(),
+                vec![4usize, 256],
+                vec![0.5f32; 4 * 256],
+            ),
+            (
+                "layers.0.self_attn.q_proj.weight".to_string(),
+                vec![4usize, 256],
+                vec![1.0f32; 4 * 256],
+            ),
+        ];
+
+        let out = build_overlay(arch, &plan, tensors.into_iter()).unwrap();
+
+        // (a) exactly the 1 matched tensor is emitted.
+        assert_eq!(out.len(), 1, "only the matched tensor should be emitted");
+        assert_eq!(out[0].name, matched_name);
+        assert_eq!(out[0].quant_type, QuantType::HFQ4G256);
+        assert_eq!(out[0].shape, vec![4u32, 256]);
+
+        // (b) bytes equal a direct quantize_hfq4g256 of the matched f32.
+        let direct = quantize_hfq4g256(&matched);
+        assert_eq!(out[0].data, direct, "overlay bytes must equal direct encode");
+
+        // (c) write_hfq → HfqFile round-trip: retrievable by name, right qt.
+        let overlay_path = d.path().join("overlay.hfq");
+        // Minimal metadata object — write_hfq's container + HfqFile's JSON
+        // brace-scan both accept `{}`.
+        write_hfq(&overlay_path, 9, "{}", &out, None).unwrap();
+
+        let hf = HfqFile::open(&overlay_path).unwrap();
+        assert_eq!(hf.arch_id, 9);
+        let info = hf
+            .find_tensor_info(&matched_name)
+            .expect("matched tensor retrievable by name from overlay.hfq");
+        assert_eq!(info.quant_type, QuantType::HFQ4G256 as u8);
+        assert_eq!(info.shape, vec![4u32, 256]);
+        // The non-matched tensors must be absent from the overlay.
+        assert!(hf.find_tensor_info("layers.0.self_attn.q_proj.weight").is_none());
+        assert!(hf.find_tensor_info("layers.0.ffn.experts.1.w1.weight").is_none());
+
+        // And the stored data bytes match what we wrote.
+        let (_, data) = hf
+            .tensor_data(&matched_name)
+            .expect("tensor data readable back");
+        assert_eq!(data, &direct[..], "round-tripped data must equal direct encode");
     }
 }

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -1,0 +1,94 @@
+//! SP4: selective re-quant overlay builder. See
+//! docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md §3.
+//!
+//! `quantize_to_format` — tier-name → existing `quantize_*` encoder dispatch.
+//! (The arch-aware `reap_override_for` resolver is added in the next task.)
+
+use crate::{
+    gen_fwht_signs, quantize_hfq4g256, quantize_hfq6g256, quantize_mq2g256_lloyd,
+    quantize_mq3g256_lloyd, quantize_mq4g256, quantize_mq4g256_lloyd, quantize_mq6g256,
+    quantize_q8f16, HfqTensor, QuantType,
+};
+
+/// Quantize one tensor's f32 data to the named tier, returning the HFQ tensor.
+/// Covers the self-calibrating tiers usable in an overlay without an imatrix.
+/// `shape` is the row-major tensor shape (e.g. `[rows, cols]`).
+///
+/// The FWHT-rotated tiers (mq*/lloyd) use the canonical sign seeds 42 / 1042 —
+/// the same seeds the monolithic quantize loop uses (`main.rs` `gen_fwht_signs(42|1042, 256)`),
+/// so the bytes produced here are byte-identical to `--format <tier>`.
+pub fn quantize_to_format(
+    name: &str,
+    fmt: &str,
+    f32_data: &[f32],
+    shape: &[usize],
+) -> Result<HfqTensor, String> {
+    let shape_u32: Vec<u32> = shape.iter().map(|&s| s as u32).collect();
+    // Canonical FWHT sign tables (only built for the rotated tiers).
+    let signs = || (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
+    let (qt, gs, data) = match fmt {
+        "q8" | "q8f16" => (QuantType::Q8F16, 0u32, quantize_q8f16(f32_data)),
+        "hfq4" | "hfq4g256" => (QuantType::HFQ4G256, 256, quantize_hfq4g256(f32_data)),
+        "hfq6" | "hfq6g256" => (QuantType::HFQ6G256, 256, quantize_hfq6g256(f32_data)),
+        "mq4" | "mq4g256" => {
+            let (s1, s2) = signs();
+            (QuantType::MQ4G256, 256, quantize_mq4g256(f32_data, &s1, &s2))
+        }
+        "mq6" | "mq6g256" => {
+            let (s1, s2) = signs();
+            (QuantType::MQ6G256, 256, quantize_mq6g256(f32_data, &s1, &s2))
+        }
+        "mq2lloyd" | "mq2g256lloyd" => {
+            let (s1, s2) = signs();
+            (QuantType::MQ2G256Lloyd, 256, quantize_mq2g256_lloyd(f32_data, &s1, &s2))
+        }
+        "mq3lloyd" | "mq3g256lloyd" => {
+            let (s1, s2) = signs();
+            (QuantType::MQ3G256Lloyd, 256, quantize_mq3g256_lloyd(f32_data, &s1, &s2))
+        }
+        "mq4lloyd" | "mq4g256lloyd" => {
+            let (s1, s2) = signs();
+            (QuantType::MQ4G256Lloyd, 256, quantize_mq4g256_lloyd(f32_data, &s1, &s2))
+        }
+        other => return Err(format!("reap: unsupported overlay tier '{other}' for {name}")),
+    };
+    Ok(HfqTensor {
+        name: name.to_string(),
+        quant_type: qt,
+        shape: shape_u32,
+        group_size: gs,
+        data,
+        spilled_len: 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_underlying_encoder_byte_for_byte() {
+        // 512 f32 (two 256-groups) of varied values.
+        let f32: Vec<f32> = (0..512).map(|i| ((i as f32) * 0.013).sin()).collect();
+        let direct = quantize_hfq4g256(&f32);
+        let t = quantize_to_format("x", "hfq4g256", &f32, &[2, 256]).unwrap();
+        assert_eq!(t.data, direct, "overlay encode must equal direct encode");
+        assert_eq!(t.shape, vec![2u32, 256]);
+        assert_eq!(t.quant_type, QuantType::HFQ4G256);
+    }
+
+    #[test]
+    fn mq4_matches_with_canonical_signs() {
+        let f32: Vec<f32> = (0..256).map(|i| (i as f32) * 0.5 - 64.0).collect();
+        let (s1, s2) = (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
+        let direct = quantize_mq4g256(&f32, &s1, &s2);
+        let t = quantize_to_format("x", "mq4", &f32, &[1, 256]).unwrap();
+        assert_eq!(t.data, direct);
+    }
+
+    #[test]
+    fn rejects_unknown_tier() {
+        let err = quantize_to_format("x", "bogus", &[0.0; 256], &[1, 256]).unwrap_err();
+        assert!(err.contains("unsupported overlay tier 'bogus'"), "got: {err}");
+    }
+}

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -324,6 +324,13 @@ mod integ {
     use crate::{quantize_hfq4g256, write_hfq};
     use hipfire_reap::plan::ReapPlan;
     use hipfire_runtime::hfq::HfqFile;
+    use std::sync::Mutex;
+
+    // `HfqFile::open` READS the process-global `HIPFIRE_REAP_PLAN` env var on
+    // every call. The end-to-end test below sets it before `open`, so it must
+    // serialize against any other test in this module that calls `open` (none
+    // today, but keep the guard to mirror SP3 T2's hipfire-runtime test).
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     fn plan_layer0_expert0_hfq4(dir: &std::path::Path) -> ReapPlan {
         std::fs::write(
@@ -398,5 +405,81 @@ mod integ {
             .tensor_data(&matched_name)
             .expect("tensor data readable back");
         assert_eq!(data, &direct[..], "round-tripped data must equal direct encode");
+    }
+
+    /// SP3 Task 3: full SP4-overlay → SP3-load round trip on REAL HFQ
+    /// containers. Build a base (expert + attention tensors, both Q8F16),
+    /// build an overlay that re-quantizes ONLY the expert tensor to HFQ4G256,
+    /// point `HIPFIRE_REAP_PLAN` at the overlay dir, then `HfqFile::open` the
+    /// base and assert: overlay attached, expert resolves to the overlay's
+    /// HFQ4G256 bytes, attention falls through to base Q8F16.
+    #[test]
+    fn sp4_overlay_to_sp3_load_end_to_end() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+        let exp_name = "layers.0.ffn.experts.0.w1.weight";
+        let attn_name = "layers.0.self_attn.q_proj.weight";
+        // [2, 256] = 512 f32 (multiple of the 256 group for the HFQ4G256 tier).
+        let shape = [2usize, 256];
+        let exp_f32: Vec<f32> = (0..2 * 256).map(|i| ((i as f32) * 0.019).sin() * 5.0).collect();
+        let attn_f32: Vec<f32> = (0..2 * 256).map(|i| ((i as f32) * 0.011).cos() * 2.0).collect();
+
+        // --- (1) base model: both tensors → Q8F16, arch 9, written to base.hfq.
+        let base_dir = tempfile::tempdir().unwrap();
+        let base_path = base_dir.path().join("base.hfq");
+        let exp_q8 = quantize_to_format(exp_name, "q8", &exp_f32, &shape).unwrap();
+        let attn_q8 = quantize_to_format(attn_name, "q8", &attn_f32, &shape).unwrap();
+        assert_eq!(exp_q8.quant_type, QuantType::Q8F16);
+        write_hfq(&base_path, 9, "{}", &[exp_q8, attn_q8], None).unwrap();
+
+        // --- (2) overlay: re-quantize ONLY the expert tensor → HFQ4G256.
+        let plan_dir = tempfile::tempdir().unwrap();
+        let overlay_path = plan_dir.path().join("overlay.hfq");
+        let exp_overlay = quantize_to_format(exp_name, "hfq4g256", &exp_f32, &shape).unwrap();
+        assert_eq!(exp_overlay.quant_type, QuantType::HFQ4G256);
+        write_hfq(&overlay_path, 9, "{}", &[exp_overlay], None).unwrap();
+
+        // The byte-exact reference the overlay must serve for the expert tensor.
+        let direct_hfq4 = quantize_to_format(exp_name, "hfq4g256", &exp_f32, &shape)
+            .unwrap()
+            .data;
+
+        // --- (3) point HIPFIRE_REAP_PLAN at the overlay dir, then open the base.
+        // Capture everything we need while the guard is held; remove the env var
+        // immediately after `open` (before any assert can unwind) so a failure
+        // can't leak the var to a concurrent `open`.
+        std::env::set_var("HIPFIRE_REAP_PLAN", plan_dir.path());
+        let f = HfqFile::open(&base_path).unwrap();
+        std::env::remove_var("HIPFIRE_REAP_PLAN");
+
+        // Overlay auto-attached (arch_id 9 matches; expert name is a base subset).
+        assert!(f.has_overlay(), "overlay.hfq should auto-attach from HIPFIRE_REAP_PLAN");
+
+        // Expert tensor resolves to the OVERLAY (HFQ4G256), and its bytes equal
+        // a direct hfq4g256 encode of the same f32.
+        let exp_info = f
+            .find_tensor_info(exp_name)
+            .expect("expert tensor resolvable");
+        assert_eq!(
+            exp_info.quant_type,
+            QuantType::HFQ4G256 as u8,
+            "expert tensor must resolve to the overlay tier"
+        );
+        let (exp_info2, exp_bytes) = f.tensor_data_vec(exp_name).expect("expert bytes");
+        assert_eq!(exp_info2.quant_type, QuantType::HFQ4G256 as u8);
+        assert_eq!(
+            exp_bytes, direct_hfq4,
+            "expert overlay bytes must equal a direct hfq4g256 encode"
+        );
+
+        // Attention tensor falls through to BASE (Q8F16).
+        let attn_info = f
+            .find_tensor_info(attn_name)
+            .expect("attention tensor resolvable from base");
+        assert_eq!(
+            attn_info.quant_type,
+            QuantType::Q8F16 as u8,
+            "attention tensor must fall through to base Q8F16"
+        );
     }
 }

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -1,14 +1,16 @@
 //! SP4: selective re-quant overlay builder. See
 //! docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md §3.
 //!
-//! `quantize_to_format` — tier-name → existing `quantize_*` encoder dispatch.
-//! (The arch-aware `reap_override_for` resolver is added in the next task.)
+//! Two pure-ish units shared by the overlay (and, later, bake) flow:
+//!   * `quantize_to_format` — tier-name → existing `quantize_*` encoder dispatch.
+//!   * `reap_override_for`   — arch-aware tensor-name → override-tier resolver.
 
 use crate::{
     gen_fwht_signs, quantize_hfq4g256, quantize_hfq6g256, quantize_mq2g256_lloyd,
     quantize_mq3g256_lloyd, quantize_mq4g256, quantize_mq4g256_lloyd, quantize_mq6g256,
     quantize_q8f16, HfqTensor, QuantType,
 };
+use hipfire_reap::plan::{QuantOverride, ReapPlan, Role};
 
 /// Quantize one tensor's f32 data to the named tier, returning the HFQ tensor.
 /// Covers the self-calibrating tiers usable in an overlay without an imatrix.
@@ -62,6 +64,82 @@ pub fn quantize_to_format(
     })
 }
 
+/// Detected arch family for tensor-name matching (the quantizer already knows
+/// the arch_id; pass the matching variant in).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ReapArch {
+    Deepseek4,
+    Qwen35,
+    Lfm2Moe,
+    Minimax,
+}
+
+/// Resolve a tensor name to its override tier under `plan`, or None.
+/// Matches by (layer, role, [expert]) using the arch's tensor naming.
+pub fn reap_override_for<'a>(name: &str, arch: ReapArch, plan: &'a ReapPlan) -> Option<&'a str> {
+    for ov in &plan.quant_overrides {
+        if tensor_matches(name, arch, ov) {
+            return Some(ov.tier.as_str());
+        }
+    }
+    None
+}
+
+fn tensor_matches(name: &str, arch: ReapArch, ov: &QuantOverride) -> bool {
+    // Layer gate: the name must reference `ov.layer`. All four arches embed the
+    // layer index as `.layers.{L}.` or `layers.{L}.`.
+    let layer_tok = format!("layers.{}.", ov.layer);
+    if !name.contains(&layer_tok) {
+        return false;
+    }
+    match ov.role {
+        Role::RoutedExperts => {
+            let (seg, w_ok): (&str, fn(&str) -> bool) = match arch {
+                ReapArch::Deepseek4 => (
+                    ".ffn.experts.",
+                    |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
+                ),
+                ReapArch::Qwen35 => (
+                    ".mlp.experts.",
+                    |n| n.ends_with(".gate_up_proj.weight") || n.ends_with(".down_proj.weight"),
+                ),
+                ReapArch::Lfm2Moe => (
+                    ".feed_forward.experts.",
+                    |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
+                ),
+                ReapArch::Minimax => (
+                    ".block_sparse_moe.experts.",
+                    |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight"),
+                ),
+            };
+            if !name.contains(seg) || !w_ok(name) {
+                return false;
+            }
+            if ov.experts.is_empty() {
+                return true; // whole role at this layer
+            }
+            // expert index: the token right after `seg`. ds4 layout (verified
+            // against main.rs:5843 — `layers.L.ffn.experts.E.{w1,w2,w3}.weight`)
+            // makes the first dotted token after `seg` the expert index.
+            let after = &name[name.find(seg).unwrap() + seg.len()..];
+            let eidx: u32 = match after.split('.').next().and_then(|s| s.parse().ok()) {
+                Some(e) => e,
+                None => return false,
+            };
+            ov.experts.contains(&eidx)
+        }
+        Role::Attention => {
+            name.contains(".self_attn.") || name.contains(".attn.") || name.contains(".attention.")
+        }
+        Role::Router => {
+            name.contains(".gate.weight") || name.contains(".router") || name.contains(".gate.tid2eid")
+        }
+        Role::SharedExpert => name.contains(".shared_expert") || name.contains(".shared_experts"),
+        Role::LmHead => name.contains("lm_head") || name.contains("output.weight"),
+        Role::Embed => name.contains("embed_tokens") || name.contains("tok_embeddings"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,5 +168,73 @@ mod tests {
     fn rejects_unknown_tier() {
         let err = quantize_to_format("x", "bogus", &[0.0; 256], &[1, 256]).unwrap_err();
         assert!(err.contains("unsupported overlay tier 'bogus'"), "got: {err}");
+    }
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+
+    fn plan_with(json: &str) -> ReapPlan {
+        // write to a tempdir & load_unchecked
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("reap_plan.json"), json).unwrap();
+        ReapPlan::load_unchecked(d.path().to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn ds4_specific_experts() {
+        let p = plan_with(
+            r#"{"original_experts":256,"num_layers":43,
+            "quant_overrides":[{"layer":20,"role":"routed_experts","experts":[7],"tier":"mq3lloyd"}]}"#,
+        );
+        assert_eq!(
+            reap_override_for("layers.20.ffn.experts.7.w1.weight", ReapArch::Deepseek4, &p),
+            Some("mq3lloyd")
+        );
+        assert_eq!(
+            reap_override_for("layers.20.ffn.experts.8.w1.weight", ReapArch::Deepseek4, &p),
+            None
+        ); // wrong expert
+        assert_eq!(
+            reap_override_for("layers.21.ffn.experts.7.w1.weight", ReapArch::Deepseek4, &p),
+            None
+        ); // wrong layer
+    }
+
+    #[test]
+    fn qwen35_whole_role() {
+        let p = plan_with(
+            r#"{"original_experts":128,"num_layers":48,
+            "quant_overrides":[{"layer":5,"role":"routed_experts","tier":"hfq6"}]}"#,
+        );
+        assert_eq!(
+            reap_override_for("model.layers.5.mlp.experts.99.gate_up_proj.weight", ReapArch::Qwen35, &p),
+            Some("hfq6")
+        );
+        assert_eq!(
+            reap_override_for("model.layers.5.mlp.experts.99.down_proj.weight", ReapArch::Qwen35, &p),
+            Some("hfq6")
+        );
+        assert_eq!(
+            reap_override_for("model.layers.5.self_attn.q_proj.weight", ReapArch::Qwen35, &p),
+            None
+        );
+    }
+
+    #[test]
+    fn attention_role() {
+        let p = plan_with(
+            r#"{"original_experts":256,"num_layers":43,
+            "quant_overrides":[{"layer":41,"role":"attention","tier":"q8"}]}"#,
+        );
+        assert_eq!(
+            reap_override_for("model.layers.41.self_attn.q_proj.weight", ReapArch::Qwen35, &p),
+            Some("q8")
+        );
+        assert_eq!(
+            reap_override_for("model.layers.40.self_attn.q_proj.weight", ReapArch::Qwen35, &p),
+            None
+        );
     }
 }

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -127,6 +127,32 @@ pub fn build_overlay(
     Ok(out)
 }
 
+/// Bake driver: quantize EVERY tensor, applying the plan's per-tensor override
+/// tier where one matches and falling back to `base_fmt` otherwise.
+///
+/// `tensors` yields `(name, shape, f32_data)` for the model's tensors. Unlike
+/// `build_overlay` (subset only), bake emits the whole model. Pruning is Task 2
+/// — this version emits every tensor handed to it.
+///
+/// `main.rs`'s bake path inlines the override hook into the existing whole-model
+/// quantize loop (so non-overridden tensors keep their arch-specific default
+/// quant); this standalone helper is exercised by the in-module bake tests,
+/// hence the allow.
+#[allow(dead_code)]
+pub fn bake_tensors(
+    arch: ReapArch,
+    plan: &ReapPlan,
+    base_fmt: &str,
+    tensors: impl Iterator<Item = (String, Vec<usize>, Vec<f32>)>,
+) -> Result<Vec<HfqTensor>, String> {
+    let mut out = Vec::new();
+    for (name, shape, f32) in tensors {
+        let fmt = reap_override_for(&name, arch, plan).unwrap_or(base_fmt);
+        out.push(quantize_to_format(&name, fmt, &f32, &shape)?);
+    }
+    Ok(out)
+}
+
 /// Resolve a tensor name to its override tier under `plan`, or None.
 /// Matches by (layer, role, [expert]) using the arch's tensor naming.
 pub fn reap_override_for<'a>(name: &str, arch: ReapArch, plan: &'a ReapPlan) -> Option<&'a str> {
@@ -308,6 +334,54 @@ mod resolve_tests {
             reap_override_for("model.layers.40.self_attn.q_proj.weight", ReapArch::Qwen35, &p),
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod bake_tests {
+    use super::*;
+
+    fn plan_with(json: &str) -> ReapPlan {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("reap_plan.json"), json).unwrap();
+        ReapPlan::load_unchecked(d.path().to_str().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn no_override_bakes_all_at_base_fmt() {
+        // Empty quant_overrides → every tensor falls back to base_fmt (q8).
+        let p = plan_with(
+            r#"{"original_experts":128,"num_layers":48,"quant_overrides":[]}"#,
+        );
+        let data = vec![0.3f32; 256];
+        let tensors = vec![(
+            "layers.0.self_attn.q_proj.weight".to_string(),
+            vec![1usize, 256],
+            data.clone(),
+        )];
+        let out = bake_tensors(ReapArch::Qwen35, &p, "q8", tensors.into_iter()).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].quant_type, QuantType::Q8F16);
+        // Bytes equal a direct q8 of the same data (anchor: no-override bake == normal quantize).
+        let direct = quantize_to_format("x", "q8", &data, &[1, 256]).unwrap();
+        assert_eq!(out[0].data, direct.data);
+    }
+
+    #[test]
+    fn override_wins_over_base_fmt() {
+        // Layer-0 attention override → hfq6, beating the q8 base_fmt.
+        let p = plan_with(
+            r#"{"original_experts":128,"num_layers":48,
+            "quant_overrides":[{"layer":0,"role":"attention","tier":"hfq6"}]}"#,
+        );
+        let tensors = vec![(
+            "layers.0.self_attn.q_proj.weight".to_string(),
+            vec![2usize, 256],
+            vec![0.1f32; 512],
+        )];
+        let out = bake_tensors(ReapArch::Qwen35, &p, "q8", tensors.into_iter()).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].quant_type, QuantType::HFQ6G256); // override, not base q8
     }
 }
 

--- a/crates/hipfire-quantize/src/reap_overlay.rs
+++ b/crates/hipfire-quantize/src/reap_overlay.rs
@@ -29,7 +29,7 @@ pub fn quantize_to_format(
     // Canonical FWHT sign tables (only built for the rotated tiers).
     let signs = || (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
     let (qt, gs, data) = match fmt {
-        "q8" | "q8f16" => (QuantType::Q8F16, 0u32, quantize_q8f16(f32_data)),
+        "q8" | "q8f16" => (QuantType::Q8F16, 32u32, quantize_q8f16(f32_data)),
         "hfq4" | "hfq4g256" => (QuantType::HFQ4G256, 256, quantize_hfq4g256(f32_data)),
         "hfq6" | "hfq6g256" => (QuantType::HFQ6G256, 256, quantize_hfq6g256(f32_data)),
         "mq4" | "mq4g256" => {
@@ -66,6 +66,7 @@ pub fn quantize_to_format(
 
 /// Detected arch family for tensor-name matching (the quantizer already knows
 /// the arch_id; pass the matching variant in).
+#[allow(dead_code)] // Lfm2Moe / Minimax constructed by Task 4 (CLI arch detection)
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ReapArch {
     Deepseek4,
@@ -165,6 +166,15 @@ mod tests {
     }
 
     #[test]
+    fn mq3lloyd_matches_with_canonical_signs() {
+        let f32: Vec<f32> = (0..256).map(|i| ((i as f32) * 0.21).cos() * 7.0).collect();
+        let (s1, s2) = (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
+        let direct = quantize_mq3g256_lloyd(&f32, &s1, &s2);
+        let t = quantize_to_format("x", "mq3lloyd", &f32, &[1, 256]).unwrap();
+        assert_eq!(t.data, direct);
+    }
+
+    #[test]
     fn rejects_unknown_tier() {
         let err = quantize_to_format("x", "bogus", &[0.0; 256], &[1, 256]).unwrap_err();
         assert!(err.contains("unsupported overlay tier 'bogus'"), "got: {err}");
@@ -220,6 +230,16 @@ mod resolve_tests {
             reap_override_for("model.layers.5.self_attn.q_proj.weight", ReapArch::Qwen35, &p),
             None
         );
+    }
+
+    #[test]
+    fn layer_token_no_false_positive_2_vs_20() {
+        let p = plan_with(r#"{"original_experts":256,"num_layers":43,
+            "quant_overrides":[{"layer":2,"role":"routed_experts","experts":[0],"tier":"q8"}]}"#);
+        // layer-20 tensor must NOT match a layer-2 override
+        assert_eq!(reap_override_for("layers.20.ffn.experts.0.w1.weight", ReapArch::Deepseek4, &p), None);
+        // layer-2 does match
+        assert_eq!(reap_override_for("layers.2.ffn.experts.0.w1.weight", ReapArch::Deepseek4, &p), Some("q8"));
     }
 
     #[test]

--- a/crates/hipfire-reap/Cargo.toml
+++ b/crates/hipfire-reap/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hipfire-reap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+rdna-compute = { path = "../rdna-compute" }
+serde_json = { version = "1", features = ["preserve_order"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/hipfire-reap/Cargo.toml
+++ b/crates/hipfire-reap/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [dependencies]
 hipfire-runtime = { path = "../hipfire-runtime" }
-rdna-compute = { path = "../rdna-compute" }
 serde_json = { version = "1", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/crates/hipfire-reap/src/gather.rs
+++ b/crates/hipfire-reap/src/gather.rs
@@ -1,0 +1,57 @@
+/// Gather kept rows from a row-major tensor's raw bytes. `shape[0]` is the
+/// row count (e.g. experts); every row must be `bytes.len()/shape[0]` bytes.
+/// Returns `(new_shape, gathered_bytes)`. Exact for row-independent quant.
+pub fn gather_rows(shape: &[usize], bytes: &[u8], keep: &[u32]) -> Result<(Vec<usize>, Vec<u8>), String> {
+    let orig_rows = *shape.first().unwrap_or(&0);
+    if orig_rows == 0 || bytes.len() % orig_rows != 0 {
+        return Err(format!(
+            "reap: row-gather: {orig_rows} rows don't divide {} bytes",
+            bytes.len()
+        ));
+    }
+    let rowstride = bytes.len() / orig_rows;
+    let mut out = Vec::with_capacity(rowstride * keep.len());
+    for &oe in keep {
+        let oe = oe as usize;
+        if oe >= orig_rows {
+            return Err(format!("reap: row-gather keep idx {oe} >= rows {orig_rows}"));
+        }
+        out.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
+    }
+    let mut new_shape = shape.to_vec();
+    new_shape[0] = keep.len();
+    Ok((new_shape, out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gathers_subset_in_order() {
+        // 4 rows × 3 bytes
+        let bytes: Vec<u8> = vec![0,0,0, 1,1,1, 2,2,2, 3,3,3];
+        let (shape, out) = gather_rows(&[4, 3], &bytes, &[2, 0, 3]).unwrap();
+        assert_eq!(shape, vec![3, 3]);
+        assert_eq!(out, vec![2,2,2, 0,0,0, 3,3,3]);
+    }
+
+    #[test]
+    fn identity_keep_is_byte_identical() {
+        let bytes: Vec<u8> = (0..24).collect();
+        let (_, out) = gather_rows(&[4, 6], &bytes, &[0, 1, 2, 3]).unwrap();
+        assert_eq!(out, bytes);
+    }
+
+    #[test]
+    fn errors_on_indivisible_rows() {
+        let err = gather_rows(&[3, 2], &[0, 1, 2, 3, 4], &[0]).unwrap_err();
+        assert!(err.contains("don't divide"), "got: {err}");
+    }
+
+    #[test]
+    fn errors_on_out_of_range_keep() {
+        let err = gather_rows(&[2, 2], &[0, 1, 2, 3], &[5]).unwrap_err();
+        assert!(err.contains("keep idx 5 >= rows 2"), "got: {err}");
+    }
+}

--- a/crates/hipfire-reap/src/hook.rs
+++ b/crates/hipfire-reap/src/hook.rs
@@ -1,0 +1,14 @@
+use crate::plan::ReapPlan;
+
+/// Arch-specific REAP extras. Default impls are no-ops so arches that need
+/// nothing (qwen35, lfm2moe, minimax) don't implement anything.
+pub trait ReapArchHook {
+    /// Path to an arch sidecar file inside the plan dir, if the arch uses one.
+    fn sidecar_path(&self, plan: &ReapPlan, name: &str) -> std::path::PathBuf {
+        plan.dir.join(name)
+    }
+    /// Whether this layer's auxiliary head (e.g. ds4 MTP) is skipped under reap.
+    fn skip_aux_head(&self, _plan: &ReapPlan, _layer: usize) -> bool {
+        false
+    }
+}

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -2,7 +2,9 @@
 //! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
 
 pub mod gather;
+pub mod hook;
 pub mod plan;
 pub mod source;
 
+pub use hook::ReapArchHook;
 pub use source::{ExpertPlan, TensorSource};

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -1,0 +1,2 @@
+//! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
+//! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -1,2 +1,4 @@
 //! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
 //! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+
+pub mod plan;

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -7,4 +7,4 @@ pub mod plan;
 pub mod source;
 
 pub use hook::ReapArchHook;
-pub use source::{ExpertPlan, TensorSource};
+pub use source::ExpertPlan;

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -1,4 +1,5 @@
 //! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
 //! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
 
+pub mod gather;
 pub mod plan;

--- a/crates/hipfire-reap/src/lib.rs
+++ b/crates/hipfire-reap/src/lib.rs
@@ -3,3 +3,6 @@
 
 pub mod gather;
 pub mod plan;
+pub mod source;
+
+pub use source::{ExpertPlan, TensorSource};

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -62,12 +62,10 @@ impl ReapPlan {
         num_layers_expected: usize,
         orig_experts_expected: usize,
     ) -> Result<Self, String> {
-        let path = Path::new(dir).join("reap_plan.json");
-        let txt = std::fs::read_to_string(&path)
-            .map_err(|e| format!("reap: read {path:?}: {e}"))?;
-        let v: serde_json::Value =
-            serde_json::from_str(&txt).map_err(|e| format!("reap: parse {path:?}: {e}"))?;
+        let v = Self::read_plan_value(dir)?;
 
+        // Cross-check the json's counts against the model's BEFORE parsing the
+        // body, so a count mismatch is reported as the primary error.
         let original_experts = v["original_experts"]
             .as_u64()
             .unwrap_or(orig_experts_expected as u64) as usize;
@@ -83,12 +81,52 @@ impl ReapPlan {
             ));
         }
 
+        // `parse_value` defaults absent counts to 0; restore the model-derived
+        // counts so a plan that omits them still validates its keep/overrides
+        // against the model's dimensions (matching the pre-refactor behavior).
+        let mut v = v;
+        if v["original_experts"].as_u64().is_none() {
+            v["original_experts"] = serde_json::json!(orig_experts_expected);
+        }
+        if v["num_layers"].as_u64().is_none() {
+            v["num_layers"] = serde_json::json!(num_layers_expected);
+        }
+        Self::parse_value(&v, dir)
+    }
+
+    /// Load `<dir>/reap_plan.json` WITHOUT validating against the model's
+    /// layer/expert counts. The counts (`num_layers`/`original_experts`) are
+    /// taken from the json itself. Used by the quantizer, which reads the plan
+    /// before it knows the model's counts. All per-override and per-keep
+    /// validations (non-integer experts, experts-on-non-routed-role,
+    /// index-vs-original bounds, layer-count consistency) are still enforced.
+    pub fn load_unchecked(dir: &str) -> Result<Self, String> {
+        let v = Self::read_plan_value(dir)?;
+        Self::parse_value(&v, dir)
+    }
+
+    /// Read & json-parse `<dir>/reap_plan.json`.
+    fn read_plan_value(dir: &str) -> Result<serde_json::Value, String> {
+        let path = Path::new(dir).join("reap_plan.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: read {path:?}: {e}"))?;
+        serde_json::from_str(&txt).map_err(|e| format!("reap: parse {path:?}: {e}"))
+    }
+
+    /// Parse a `reap_plan.json` value into a `ReapPlan`, taking `num_layers`
+    /// and `original_experts` FROM the json. Shared by `load` (which adds the
+    /// `== expected` cross-checks first) and `load_unchecked`. Defaults to 0
+    /// when a count is absent.
+    fn parse_value(v: &serde_json::Value, dir: &str) -> Result<Self, String> {
+        let original_experts = v["original_experts"].as_u64().unwrap_or(0) as usize;
+        let num_layers = v["num_layers"].as_u64().unwrap_or(0) as usize;
+
         let keep = match v["keep"]["per_layer"].as_array() {
             None => None,
             Some(arr) => {
-                if arr.len() != num_layers_expected {
+                if arr.len() != num_layers {
                     return Err(format!(
-                        "reap: keep.per_layer has {} layers, model has {num_layers_expected}",
+                        "reap: keep.per_layer has {} layers, model has {num_layers}",
                         arr.len()
                     ));
                 }
@@ -130,9 +168,9 @@ impl ReapPlan {
                     .as_u64()
                     .ok_or_else(|| format!("reap: quant_override[{i}] missing layer"))?
                     as usize;
-                if layer >= num_layers_expected {
+                if layer >= num_layers {
                     return Err(format!(
-                        "reap: quant_override[{i}] layer {layer} >= num_layers {num_layers_expected}"
+                        "reap: quant_override[{i}] layer {layer} >= num_layers {num_layers}"
                     ));
                 }
                 let role = Role::parse(
@@ -165,7 +203,7 @@ impl ReapPlan {
 
         Ok(ReapPlan {
             model_arch: v["model_arch"].as_str().map(|s| s.to_string()),
-            num_layers: num_layers_expected,
+            num_layers,
             original_experts,
             keep,
             quant_overrides,
@@ -348,6 +386,21 @@ mod tests {
         );
         let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
         assert!(err.contains("not an integer"), "got: {err}");
+    }
+
+    #[test]
+    fn load_unchecked_parses_without_model_counts() {
+        let d = write_plan(
+            r#"{"original_experts":256,"num_layers":43,
+                "quant_overrides":[{"layer":20,"role":"routed_experts","experts":[7,12],"tier":"mq3lloyd"},
+                                   {"layer":41,"role":"attention","tier":"q8"}]}"#,
+        );
+        let p = ReapPlan::load_unchecked(d.path().to_str().unwrap()).unwrap();
+        assert_eq!(p.original_experts, 256);
+        assert_eq!(p.num_layers, 43);
+        assert_eq!(p.quant_overrides.len(), 2);
+        assert_eq!(p.quant_overrides[0].tier, "mq3lloyd");
+        assert_eq!(p.quant_overrides[0].experts, vec![7, 12]);
     }
 
     #[test]

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -47,6 +47,7 @@ pub struct ReapPlan {
 }
 
 impl ReapPlan {
+    /// Returns 0 if keep is Some with an empty outer vec (cannot arise from load()).
     pub fn kept_per_layer(&self) -> usize {
         match &self.keep {
             Some(k) => k.first().map(|r| r.len()).unwrap_or(0),
@@ -137,10 +138,18 @@ impl ReapPlan {
                 let role = Role::parse(
                     o["role"].as_str().ok_or_else(|| format!("reap: quant_override[{i}] missing role"))?,
                 )?;
-                let experts: Vec<u32> = o["experts"]
-                    .as_array()
-                    .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect())
-                    .unwrap_or_default();
+                let experts: Vec<u32> = if let Some(a) = o["experts"].as_array() {
+                    a.iter().enumerate().map(|(j, x)| {
+                        let n = x.as_u64()
+                            .ok_or_else(|| format!("reap: quant_override[{i}] experts[{j}] not an integer"))? as u32;
+                        if n as usize >= original_experts {
+                            return Err(format!("reap: quant_override[{i}] expert {n} >= original_experts {original_experts}"));
+                        }
+                        Ok(n)
+                    }).collect::<Result<Vec<_>, String>>()?
+                } else {
+                    Vec::new()
+                };
                 if !experts.is_empty() && role != Role::RoutedExperts {
                     return Err(format!(
                         "reap: quant_override[{i}] lists experts but role is not routed_experts"
@@ -223,5 +232,25 @@ mod tests {
         let d = write_plan(r#"{"original_experts":4,"num_layers":3,"keep":{"per_layer":[[0,1]]}}"#);
         let err = ReapPlan::load(d.path().to_str().unwrap(), 3, 4).unwrap_err();
         assert!(err.contains("keep.per_layer has 1 layers"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_non_integer_override_expert() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"routed_experts","experts":[1,"bad"],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("not an integer"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_out_of_range_override_expert() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"routed_experts","experts":[9],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains(">= original_experts 4"), "got: {err}");
     }
 }

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -1,0 +1,227 @@
+use std::path::{Path, PathBuf};
+
+/// One selective-requant edit (applied in SP2+; parsed & validated now).
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuantOverride {
+    pub layer: usize,
+    pub role: Role,
+    /// Only meaningful for `Role::RoutedExperts`; empty ⇒ whole role at this layer.
+    pub experts: Vec<u32>,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    RoutedExperts,
+    SharedExpert,
+    Attention,
+    Router,
+    LmHead,
+    Embed,
+}
+
+impl Role {
+    pub fn parse(s: &str) -> Result<Role, String> {
+        Ok(match s {
+            "routed_experts" => Role::RoutedExperts,
+            "shared_expert" => Role::SharedExpert,
+            "attention" => Role::Attention,
+            "router" => Role::Router,
+            "lm_head" => Role::LmHead,
+            "embed" => Role::Embed,
+            other => return Err(format!("reap: unknown role '{other}'")),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReapPlan {
+    pub model_arch: Option<String>,
+    pub num_layers: usize,
+    pub original_experts: usize,
+    /// `keep[l][slot]` = original expert index in compact slot `slot`.
+    /// `None` ⇒ no pruning (keep all `original_experts`).
+    pub keep: Option<Vec<Vec<u32>>>,
+    pub quant_overrides: Vec<QuantOverride>,
+    pub dir: PathBuf,
+}
+
+impl ReapPlan {
+    pub fn kept_per_layer(&self) -> usize {
+        match &self.keep {
+            Some(k) => k.first().map(|r| r.len()).unwrap_or(0),
+            None => self.original_experts,
+        }
+    }
+
+    /// Load `<dir>/reap_plan.json`, validating against the model's layer/expert
+    /// counts (passed BEFORE any n_routed_experts override).
+    pub fn load(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = Path::new(dir).join("reap_plan.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: read {path:?}: {e}"))?;
+        let v: serde_json::Value =
+            serde_json::from_str(&txt).map_err(|e| format!("reap: parse {path:?}: {e}"))?;
+
+        let original_experts = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if original_experts != orig_experts_expected {
+            return Err(format!(
+                "reap: original_experts {original_experts} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let num_layers = v["num_layers"].as_u64().unwrap_or(num_layers_expected as u64) as usize;
+        if num_layers != num_layers_expected {
+            return Err(format!(
+                "reap: num_layers {num_layers} != model num_hidden_layers {num_layers_expected}"
+            ));
+        }
+
+        let keep = match v["keep"]["per_layer"].as_array() {
+            None => None,
+            Some(arr) => {
+                if arr.len() != num_layers_expected {
+                    return Err(format!(
+                        "reap: keep.per_layer has {} layers, model has {num_layers_expected}",
+                        arr.len()
+                    ));
+                }
+                let kept = arr.first().and_then(|r| r.as_array()).map(|r| r.len()).unwrap_or(0);
+                let mut out = Vec::with_capacity(arr.len());
+                for (l, row) in arr.iter().enumerate() {
+                    let r = row
+                        .as_array()
+                        .ok_or_else(|| format!("reap: keep layer {l} not an array"))?;
+                    if r.len() != kept {
+                        return Err(format!(
+                            "reap: keep layer {l} has {} entries, expected {kept}",
+                            r.len()
+                        ));
+                    }
+                    let mut v32 = Vec::with_capacity(kept);
+                    for x in r {
+                        let idx = x
+                            .as_u64()
+                            .ok_or_else(|| format!("reap: keep layer {l} non-integer index"))?
+                            as u32;
+                        if idx as usize >= original_experts {
+                            return Err(format!(
+                                "reap: keep layer {l} index {idx} >= original_experts {original_experts}"
+                            ));
+                        }
+                        v32.push(idx);
+                    }
+                    out.push(v32);
+                }
+                Some(out)
+            }
+        };
+
+        let mut quant_overrides = Vec::new();
+        if let Some(arr) = v["quant_overrides"].as_array() {
+            for (i, o) in arr.iter().enumerate() {
+                let layer = o["layer"]
+                    .as_u64()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing layer"))?
+                    as usize;
+                if layer >= num_layers_expected {
+                    return Err(format!(
+                        "reap: quant_override[{i}] layer {layer} >= num_layers {num_layers_expected}"
+                    ));
+                }
+                let role = Role::parse(
+                    o["role"].as_str().ok_or_else(|| format!("reap: quant_override[{i}] missing role"))?,
+                )?;
+                let experts: Vec<u32> = o["experts"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect())
+                    .unwrap_or_default();
+                if !experts.is_empty() && role != Role::RoutedExperts {
+                    return Err(format!(
+                        "reap: quant_override[{i}] lists experts but role is not routed_experts"
+                    ));
+                }
+                let tier = o["tier"]
+                    .as_str()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing tier"))?
+                    .to_string();
+                quant_overrides.push(QuantOverride { layer, role, experts, tier });
+            }
+        }
+
+        Ok(ReapPlan {
+            model_arch: v["model_arch"].as_str().map(|s| s.to_string()),
+            num_layers: num_layers_expected,
+            original_experts,
+            keep,
+            quant_overrides,
+            dir: PathBuf::from(dir),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_plan(json: &str) -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(d.path().join("reap_plan.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        d
+    }
+
+    #[test]
+    fn keep_all_when_keep_absent() {
+        let d = write_plan(r#"{"original_experts":8,"num_layers":2}"#);
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 8).unwrap();
+        assert!(p.keep.is_none());
+        assert_eq!(p.kept_per_layer(), 8);
+    }
+
+    #[test]
+    fn parses_keep_and_overrides() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":2,
+                "keep":{"per_layer":[[0,2,3],[1,2,3]]},
+                "quant_overrides":[{"layer":1,"role":"routed_experts","experts":[2],"tier":"mq3lloyd"}]}"#,
+        );
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 4).unwrap();
+        assert_eq!(p.kept_per_layer(), 3);
+        assert_eq!(p.keep.as_ref().unwrap()[0], vec![0, 2, 3]);
+        assert_eq!(p.quant_overrides.len(), 1);
+        assert_eq!(p.quant_overrides[0].tier, "mq3lloyd");
+    }
+
+    #[test]
+    fn rejects_out_of_range_index() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,"keep":{"per_layer":[[0,9]]}}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("index 9 >= original_experts 4"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_experts_on_non_routed_role() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"attention","experts":[1],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("not routed_experts"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_layer_count_mismatch() {
+        let d = write_plan(r#"{"original_experts":4,"num_layers":3,"keep":{"per_layer":[[0,1]]}}"#);
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 3, 4).unwrap_err();
+        assert!(err.contains("keep.per_layer has 1 layers"), "got: {err}");
+    }
+}

--- a/crates/hipfire-reap/src/plan.rs
+++ b/crates/hipfire-reap/src/plan.rs
@@ -172,6 +172,95 @@ impl ReapPlan {
             dir: PathBuf::from(dir),
         })
     }
+
+    /// Load `<dir>/reap_plan.json` if present, else fall back to a legacy
+    /// `<dir>/keep_by_layer.json` (keep-only; no overrides). Lets old
+    /// deepseek4 sidecars keep working through the generic loader.
+    pub fn load_any(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        if Path::new(dir).join("reap_plan.json").exists() {
+            return Self::load(dir, num_layers_expected, orig_experts_expected);
+        }
+        Self::load_legacy_keepmap(dir, num_layers_expected, orig_experts_expected)
+    }
+
+    /// Load the legacy `<dir>/keep_by_layer.json` schema (top-level
+    /// `kept_per_layer:u64`, optional `original_experts:u64`, and
+    /// `keep: [[u32; kept]; num_layers]`) and produce a keep-only
+    /// `ReapPlan`. Validation mirrors the old `ReapKeepMap::load`: the
+    /// `original_experts` must match the model, layer count must match,
+    /// each row length must equal `kept_per_layer`, and every index must
+    /// be `< original_experts`.
+    pub fn load_legacy_keepmap(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = Path::new(dir).join("keep_by_layer.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: legacy keep-map read {path:?}: {e}"))?;
+        let v: serde_json::Value = serde_json::from_str(&txt)
+            .map_err(|e| format!("reap: legacy keep-map parse {path:?}: {e}"))?;
+
+        let kept = v["kept_per_layer"]
+            .as_u64()
+            .ok_or("reap: legacy keep-map missing kept_per_layer")? as usize;
+        let original_experts = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if original_experts != orig_experts_expected {
+            return Err(format!(
+                "reap: legacy keep-map original_experts {original_experts} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let keep_arr = v["keep"]
+            .as_array()
+            .ok_or("reap: legacy keep-map missing `keep` array")?;
+        if keep_arr.len() != num_layers_expected {
+            return Err(format!(
+                "reap: legacy keep-map has {} layers, model has {num_layers_expected}",
+                keep_arr.len()
+            ));
+        }
+        let mut keep = Vec::with_capacity(keep_arr.len());
+        for (l, row) in keep_arr.iter().enumerate() {
+            let r = row
+                .as_array()
+                .ok_or_else(|| format!("reap: legacy keep layer {l} not an array"))?;
+            if r.len() != kept {
+                return Err(format!(
+                    "reap: legacy keep layer {l} has {} entries, expected {kept}",
+                    r.len()
+                ));
+            }
+            let mut v32 = Vec::with_capacity(kept);
+            for x in r {
+                let idx = x
+                    .as_u64()
+                    .ok_or_else(|| format!("reap: legacy keep layer {l} non-integer index"))?
+                    as u32;
+                if idx as usize >= original_experts {
+                    return Err(format!(
+                        "reap: legacy keep layer {l} index {idx} >= original_experts {original_experts}"
+                    ));
+                }
+                v32.push(idx);
+            }
+            keep.push(v32);
+        }
+
+        Ok(ReapPlan {
+            model_arch: None,
+            num_layers: num_layers_expected,
+            original_experts,
+            keep: Some(keep),
+            quant_overrides: Vec::new(),
+            dir: PathBuf::from(dir),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -184,6 +273,23 @@ mod tests {
         let mut f = std::fs::File::create(d.path().join("reap_plan.json")).unwrap();
         f.write_all(json.as_bytes()).unwrap();
         d
+    }
+
+    fn write_legacy(json: &str) -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(d.path().join("keep_by_layer.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        d
+    }
+
+    #[test]
+    fn loads_legacy_keepmap() {
+        let d = write_legacy(
+            r#"{"kept_per_layer":2,"original_experts":4,"keep":[[0,3],[1,2]]}"#,
+        );
+        let p = ReapPlan::load_any(d.path().to_str().unwrap(), 2, 4).unwrap();
+        assert_eq!(p.kept_per_layer(), 2);
+        assert_eq!(p.keep.as_ref().unwrap()[0], vec![0, 3]);
     }
 
     #[test]

--- a/crates/hipfire-reap/src/source.rs
+++ b/crates/hipfire-reap/src/source.rs
@@ -37,6 +37,7 @@ impl<'a> ExpertPlan<'a> {
         self.keep
     }
     /// Original expert index for a compact slot (identity when no keep map).
+    /// Panics if slot >= n_slots(full); callers must iterate 0..n_slots(full).
     pub fn src(&self, slot: usize) -> usize {
         self.keep.map(|k| k[slot] as usize).unwrap_or(slot)
     }

--- a/crates/hipfire-reap/src/source.rs
+++ b/crates/hipfire-reap/src/source.rs
@@ -1,30 +1,4 @@
 use crate::plan::ReapPlan;
-use hipfire_runtime::hfq::{HfqFile, HfqTensorInfo};
-
-/// Overlay-then-base tensor resolver. SP1: overlay is always None (base only);
-/// SP3 adds the overlay HfqFile and prefers it when it holds `name`.
-pub struct TensorSource<'a> {
-    pub base: &'a HfqFile,
-    pub overlay: Option<&'a HfqFile>,
-}
-
-impl<'a> TensorSource<'a> {
-    pub fn new(base: &'a HfqFile) -> Self {
-        TensorSource { base, overlay: None }
-    }
-
-    /// Resolve a tensor by name: overlay first (SP3), else base.
-    /// Returns `(&HfqTensorInfo, Vec<u8>)` using `tensor_data_vec` for
-    /// owned bytes (avoids RefCell borrow and works on all platforms).
-    pub fn tensor(&self, name: &str) -> Option<(&'a HfqTensorInfo, Vec<u8>)> {
-        if let Some(ov) = self.overlay {
-            if let Some(hit) = ov.tensor_data_vec(name) {
-                return Some(hit);
-            }
-        }
-        self.base.tensor_data_vec(name)
-    }
-}
 
 /// Per-(layer, role) plan slice the arch loader consumes at its expert loop.
 pub struct ExpertPlan<'a> {

--- a/crates/hipfire-reap/src/source.rs
+++ b/crates/hipfire-reap/src/source.rs
@@ -1,0 +1,75 @@
+use crate::plan::ReapPlan;
+use hipfire_runtime::hfq::{HfqFile, HfqTensorInfo};
+
+/// Overlay-then-base tensor resolver. SP1: overlay is always None (base only);
+/// SP3 adds the overlay HfqFile and prefers it when it holds `name`.
+pub struct TensorSource<'a> {
+    pub base: &'a HfqFile,
+    pub overlay: Option<&'a HfqFile>,
+}
+
+impl<'a> TensorSource<'a> {
+    pub fn new(base: &'a HfqFile) -> Self {
+        TensorSource { base, overlay: None }
+    }
+
+    /// Resolve a tensor by name: overlay first (SP3), else base.
+    /// Returns `(&HfqTensorInfo, Vec<u8>)` using `tensor_data_vec` for
+    /// owned bytes (avoids RefCell borrow and works on all platforms).
+    pub fn tensor(&self, name: &str) -> Option<(&'a HfqTensorInfo, Vec<u8>)> {
+        if let Some(ov) = self.overlay {
+            if let Some(hit) = ov.tensor_data_vec(name) {
+                return Some(hit);
+            }
+        }
+        self.base.tensor_data_vec(name)
+    }
+}
+
+/// Per-(layer, role) plan slice the arch loader consumes at its expert loop.
+pub struct ExpertPlan<'a> {
+    /// `keep[slot]` = original expert index for compact slot. `None` ⇒ identity.
+    keep: Option<&'a [u32]>,
+}
+
+impl<'a> ExpertPlan<'a> {
+    pub fn keep(&self) -> Option<&'a [u32]> {
+        self.keep
+    }
+    /// Original expert index for a compact slot (identity when no keep map).
+    pub fn src(&self, slot: usize) -> usize {
+        self.keep.map(|k| k[slot] as usize).unwrap_or(slot)
+    }
+    /// Number of compact expert slots for this layer.
+    pub fn n_slots(&self, full: usize) -> usize {
+        self.keep.map(|k| k.len()).unwrap_or(full)
+    }
+}
+
+impl ReapPlan {
+    /// Build the per-layer expert plan (routed experts). `None`-keep ⇒ identity.
+    pub fn expert_plan(&self, layer: usize) -> ExpertPlan<'_> {
+        ExpertPlan {
+            keep: self.keep.as_ref().map(|k| k[layer].as_slice()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // ExpertPlan::src/n_slots are pure; test them without an HfqFile.
+    #[test]
+    fn identity_src_when_no_keep() {
+        let ep = ExpertPlan { keep: None };
+        assert_eq!(ep.src(5), 5);
+        assert_eq!(ep.n_slots(8), 8);
+    }
+    #[test]
+    fn remaps_src_with_keep() {
+        let k = vec![3u32, 1, 0];
+        let ep = ExpertPlan { keep: Some(&k) };
+        assert_eq!(ep.src(0), 3);
+        assert_eq!(ep.n_slots(8), 3);
+    }
+}

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -101,6 +101,8 @@ hipfire-arch-deepseek4 = { path = "../hipfire-arch-deepseek4" }
 hipfire-arch-dots-ocr = { path = "../hipfire-arch-dots-ocr" }
 hipfire-detect = { path = "../hipfire-detect" }
 hipfire-atlas = { path = "../hipfire-atlas" }
+# In-test minimal HFQ writer (overlay resolution tests in src/hfq.rs).
+tempfile = "3"
 
 # Each example below carries `required-features` listing the cargo
 # features its `use hipfire_arch_*` imports depend on. This documents

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -62,11 +62,35 @@ pub struct HfqFile {
     /// can't be evicted while the mapping exists (FADV_DONTNEED is ignored
     /// for mmap'd regions per Linux kernel docs).
     pread_buf: std::cell::RefCell<Vec<u8>>,
+    /// Optional overlay HFQ whose tensors shadow this file's by name (the
+    /// REAP load-time splice, SP3). When `Some`, every tensor read method
+    /// consults the overlay first and falls back to the base. When `None`
+    /// (the common case), every read path is byte-identical to pre-overlay
+    /// behavior — each overlay check is gated on `self.overlay.is_some()`.
+    overlay: Option<Box<HfqFile>>,
 }
 
 impl HfqFile {
     pub fn open(path: &Path) -> std::io::Result<Self> {
         Self::open_at_offset(path, 0)
+    }
+
+    /// Attach an overlay whose tensors shadow this file's by name. Used by the
+    /// REAP load-time splice (SP3). Errors if arch_id differs (wrong model).
+    pub fn attach_overlay(&mut self, overlay: HfqFile) -> Result<(), String> {
+        if overlay.arch_id != self.arch_id {
+            return Err(format!(
+                "reap overlay: arch_id {} != base arch_id {}",
+                overlay.arch_id, self.arch_id
+            ));
+        }
+        self.overlay = Some(Box::new(overlay));
+        Ok(())
+    }
+
+    /// True when an overlay is attached (its tensors shadow the base).
+    pub fn has_overlay(&self) -> bool {
+        self.overlay.is_some()
     }
 
     /// Open an HFQM container that lives inside a larger file, starting at
@@ -202,6 +226,7 @@ impl HfqFile {
             path: path.to_path_buf(),
             mmap: Some(mmap), arch_id, metadata_json, tensors, tensor_map,
             pread_buf: std::cell::RefCell::new(Vec::new()),
+            overlay: None,
         })
     }
 
@@ -304,11 +329,29 @@ impl HfqFile {
     /// without copying its data. The weight pager calls this at load time to
     /// register byte ranges without forcing eager VRAM allocation.
     pub fn find_tensor_info(&self, name: &str) -> Option<&HfqTensorInfo> {
+        // Overlay-first resolution (SP3): an attached overlay shadows the base
+        // by name. Gated on `is_some()` so the no-overlay path is unchanged.
+        if self.overlay.is_some() {
+            if let Some(ov) = &self.overlay {
+                if let Some(info) = ov.find_tensor_info(name) {
+                    return Some(info);
+                }
+            }
+        }
         let idx = self.resolve_idx(name)?;
         Some(&self.tensors[idx])
     }
 
     pub fn tensor_data(&self, name: &str) -> Option<(&HfqTensorInfo, &[u8])> {
+        // Overlay-first resolution (SP3): if the overlay has this tensor,
+        // return its data; otherwise fall through to the base.
+        if self.overlay.is_some() {
+            if let Some(ov) = &self.overlay {
+                if ov.find_tensor_info(name).is_some() {
+                    return ov.tensor_data(name);
+                }
+            }
+        }
         let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
         debug_assert!(
@@ -329,6 +372,15 @@ impl HfqFile {
     #[cfg(unix)]
     pub fn tensor_data_pread(&self, name: &str) -> Option<(&HfqTensorInfo, std::cell::Ref<'_, Vec<u8>>)> {
         use std::os::unix::io::AsRawFd;
+        // Overlay-first resolution (SP3): the overlay reads from its own fd /
+        // pread_buf, so the returned guard borrows the overlay, not the base.
+        if self.overlay.is_some() {
+            if let Some(ov) = &self.overlay {
+                if ov.find_tensor_info(name).is_some() {
+                    return ov.tensor_data_pread(name);
+                }
+            }
+        }
         let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
         let fd = self._file.as_raw_fd();
@@ -357,6 +409,16 @@ impl HfqFile {
     /// Non-unix fallback: just delegates to mmap-based tensor_data.
     #[cfg(not(unix))]
     pub fn tensor_data_pread(&self, name: &str) -> Option<(&HfqTensorInfo, &[u8])> {
+        // Overlay-first resolution (SP3). `tensor_data` already consults the
+        // overlay, so delegating preserves it; the explicit guard keeps this
+        // symmetric with the unix path.
+        if self.overlay.is_some() {
+            if let Some(ov) = &self.overlay {
+                if ov.find_tensor_info(name).is_some() {
+                    return ov.tensor_data_pread(name);
+                }
+            }
+        }
         self.tensor_data(name)
     }
 
@@ -366,6 +428,15 @@ impl HfqFile {
     ///
     /// Returns owned Vec<u8> to avoid lifetime issues with the pread RefCell.
     pub fn tensor_data_vec(&self, name: &str) -> Option<(&HfqTensorInfo, Vec<u8>)> {
+        // Overlay-first resolution (SP3): the returned info reference borrows
+        // the overlay (which lives as long as `&self`), and the Vec is owned.
+        if self.overlay.is_some() {
+            if let Some(ov) = &self.overlay {
+                if ov.find_tensor_info(name).is_some() {
+                    return ov.tensor_data_vec(name);
+                }
+            }
+        }
         let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
 
@@ -479,6 +550,23 @@ impl crate::model_source::ModelSource for HfqFile {
     }
 
     fn tensor_names(&self) -> Vec<&str> {
+        // Overlay-first resolution (SP3): the union of base ∪ overlay names,
+        // deduped. Deterministic order = base index order, then any
+        // overlay-only names sorted, so callers that sort get a stable result.
+        if let Some(ov) = &self.overlay {
+            let mut names: Vec<&str> = self.tensors.iter().map(|t| t.name.as_str()).collect();
+            let base: std::collections::HashSet<&str> = names.iter().copied().collect();
+            let mut extra: Vec<&str> = ov
+                .tensors
+                .iter()
+                .map(|t| t.name.as_str())
+                .filter(|n| !base.contains(n))
+                .collect();
+            extra.sort();
+            extra.dedup();
+            names.extend(extra);
+            return names;
+        }
         self.tensors.iter().map(|t| t.name.as_str()).collect()
     }
 
@@ -1203,4 +1291,114 @@ pub fn load_weights_paroquant_llama(
     }
 
     Ok(LlamaWeights { token_embd, embd_format: embd_fmt, output_norm, output, layers })
+}
+
+// ─── Overlay resolution tests (SP3) ─────────────────────────────────────────
+
+#[cfg(test)]
+mod overlay_tests {
+    use super::*;
+    use crate::model_source::ModelSource; // for `tensor_names`
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    /// Minimal HFQ writer mirroring `hipfire-quantize`'s `write_hfq`
+    /// (`crates/hipfire-quantize/src/main.rs:3398`) byte-for-byte for the
+    /// layout `HfqFile::open` parses:
+    ///   - 32B header: magic "HFQM", u32 version, u32 arch_id, u32 n_tensors,
+    ///     u64 metadata_offset, u64 data_offset.
+    ///   - metadata JSON (we emit `{}`; the parser scans matching braces to
+    ///     find its end, so it must be valid balanced JSON).
+    ///   - index: u32 n; per tensor: u16 name_len, name bytes, u8 quant_type,
+    ///     u8 n_dims, n_dims×u32 shape, u32 group_size, u64 data_size.
+    ///   - zero padding so the data region starts 4096-aligned.
+    ///   - tensor data, concatenated in index order (offsets are derived at
+    ///     read time cumulatively from `data_offset`).
+    fn write_min_hfq(path: &Path, arch_id: u32, tensors: &[(&str, u8, &[u32], &[u8])]) {
+        let metadata = b"{}"; // balanced JSON; brace-scan parser stops at the close brace
+        let header_size: u64 = 32;
+        let metadata_offset = header_size;
+        let index_offset = metadata_offset + metadata.len() as u64;
+
+        let mut index = Vec::new();
+        index.extend_from_slice(&(tensors.len() as u32).to_le_bytes());
+        for (name, qt, shape, data) in tensors {
+            let nb = name.as_bytes();
+            index.extend_from_slice(&(nb.len() as u16).to_le_bytes());
+            index.extend_from_slice(nb);
+            index.push(*qt);
+            index.push(shape.len() as u8);
+            for &d in *shape {
+                index.extend_from_slice(&d.to_le_bytes());
+            }
+            index.extend_from_slice(&0u32.to_le_bytes()); // group_size
+            index.extend_from_slice(&(data.len() as u64).to_le_bytes());
+        }
+
+        let data_start_unaligned = index_offset + index.len() as u64;
+        let data_offset = (data_start_unaligned + 4095) & !4095;
+
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(b"HFQM").unwrap();
+        f.write_all(&1u32.to_le_bytes()).unwrap(); // version
+        f.write_all(&arch_id.to_le_bytes()).unwrap();
+        f.write_all(&(tensors.len() as u32).to_le_bytes()).unwrap();
+        f.write_all(&metadata_offset.to_le_bytes()).unwrap();
+        f.write_all(&data_offset.to_le_bytes()).unwrap();
+        f.write_all(metadata).unwrap();
+        f.write_all(&index).unwrap();
+        let pad = (data_offset - data_start_unaligned) as usize;
+        f.write_all(&vec![0u8; pad]).unwrap();
+        for (_, _, _, data) in tensors {
+            f.write_all(data).unwrap();
+        }
+        f.flush().unwrap();
+    }
+
+    // Env vars are process-global. `HfqFile::open` READS `HIPFIRE_REAP_PLAN`
+    // on every call, so EVERY test here that calls `open` must serialize on
+    // this mutex — otherwise the env-attach test's `set_var` leaks into a
+    // concurrent `open` in another test and attaches the wrong overlay.
+    // Hold the lock for the whole test body so env stays consistent across
+    // every `open` within it.
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn overlay_tensor_shadows_base() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("base.hfq");
+        let ov = dir.path().join("overlay.hfq");
+        // base has tensorA (qt=3) + tensorB (qt=3); overlay re-quantizes A to qt=8.
+        write_min_hfq(&base, 9, &[("A", 3, &[2, 4], &vec![1u8; 2 * 4]), ("B", 3, &[2, 4], &vec![2u8; 2 * 4])]);
+        write_min_hfq(&ov, 9, &[("A", 8, &[2, 4], &vec![9u8; 2 * 4])]);
+        let mut f = HfqFile::open(&base).unwrap();
+        f.attach_overlay(HfqFile::open(&ov).unwrap()).unwrap();
+        // A resolves to overlay (qt 8, bytes 9); B falls through to base (qt 3, bytes 2).
+        let (ia, da) = f.tensor_data_vec("A").unwrap();
+        assert_eq!(ia.quant_type, 8);
+        assert!(da.iter().all(|&b| b == 9));
+        let (ib, db) = f.tensor_data_vec("B").unwrap();
+        assert_eq!(ib.quant_type, 3);
+        assert!(db.iter().all(|&b| b == 2));
+        assert_eq!(f.find_tensor_info("A").unwrap().quant_type, 8);
+        // tensor_names is the union (base ∪ overlay), no dup.
+        let mut names = f.tensor_names();
+        names.sort();
+        assert_eq!(names, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn overlay_arch_mismatch_rejected() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("b.hfq");
+        let ov = dir.path().join("o.hfq");
+        write_min_hfq(&base, 9, &[("A", 3, &[1, 4], &vec![0u8; 4])]);
+        write_min_hfq(&ov, 6, &[("A", 3, &[1, 4], &vec![0u8; 4])]);
+        let mut f = HfqFile::open(&base).unwrap();
+        let err = f.attach_overlay(HfqFile::open(&ov).unwrap()).unwrap_err();
+        assert!(err.contains("arch_id 6 != base arch_id 9"), "got: {err}");
+    }
+
 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -72,7 +72,32 @@ pub struct HfqFile {
 
 impl HfqFile {
     pub fn open(path: &Path) -> std::io::Result<Self> {
-        Self::open_at_offset(path, 0)
+        let mut f = Self::open_at_offset(path, 0)?;
+        // REAP load-time overlay splice (SP3): when HIPFIRE_REAP_PLAN points
+        // at a dir containing `overlay.hfq`, attach it so its re-quantized
+        // tensors shadow the base by name. Opened via `open_at_offset` (NOT
+        // `open`) so the overlay does NOT recursively env-attach. A mismatched
+        // arch_id is logged and we proceed base-only — the safe default for
+        // unrelated model opens that happen to share the env var.
+        if let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") {
+            let ov_path = std::path::Path::new(&dir).join("overlay.hfq");
+            if ov_path.exists() {
+                match Self::open_at_offset(&ov_path, 0)
+                    .map_err(|e| e.to_string())
+                    .and_then(|ov| {
+                        let n = ov.tensors.len();
+                        f.attach_overlay(ov).map(|_| n)
+                    }) {
+                    Ok(n) => eprintln!(
+                        "reap: overlay ACTIVE — {n} tensor(s) from {ov_path:?} shadow the base"
+                    ),
+                    Err(e) => eprintln!(
+                        "reap: WARNING overlay at {ov_path:?} not attached: {e}"
+                    ),
+                }
+            }
+        }
+        Ok(f)
     }
 
     /// Attach an overlay whose tensors shadow this file's by name. Used by the
@@ -1401,4 +1426,21 @@ mod overlay_tests {
         assert!(err.contains("arch_id 6 != base arch_id 9"), "got: {err}");
     }
 
+    #[test]
+    fn open_auto_attaches_overlay_from_env() {
+        // Env mutation is process-global; lock so this serializes with any
+        // other env-mutating test in this module.
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("base.hfq");
+        write_min_hfq(&base, 9, &[("A", 3, &[1, 4], &vec![1u8; 4])]);
+        // overlay.hfq lives in the plan dir.
+        let plan = tempfile::tempdir().unwrap();
+        write_min_hfq(&plan.path().join("overlay.hfq"), 9, &[("A", 8, &[1, 4], &vec![7u8; 4])]);
+        std::env::set_var("HIPFIRE_REAP_PLAN", plan.path());
+        let f = HfqFile::open(&base).unwrap();
+        std::env::remove_var("HIPFIRE_REAP_PLAN");
+        assert!(f.has_overlay());
+        assert_eq!(f.find_tensor_info("A").unwrap().quant_type, 8); // overlay won
+    }
 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -109,6 +109,19 @@ impl HfqFile {
                 overlay.arch_id, self.arch_id
             ));
         }
+        // A pure-shadow overlay only RE-quantizes existing tensors; it must not
+        // introduce names absent from the base. This catches an overlay built for a
+        // DIFFERENT model that happens to share arch_id (silent-wrong-weights guard).
+        // Called BEFORE self.overlay is set, so find_tensor_info searches only the
+        // base — correct.
+        for ti in &overlay.tensors {
+            if self.find_tensor_info(&ti.name).is_none() {
+                return Err(format!(
+                    "reap overlay: tensor '{}' not present in base — overlay likely built for a different model",
+                    ti.name
+                ));
+            }
+        }
         self.overlay = Some(Box::new(overlay));
         Ok(())
     }
@@ -1442,5 +1455,20 @@ mod overlay_tests {
         std::env::remove_var("HIPFIRE_REAP_PLAN");
         assert!(f.has_overlay());
         assert_eq!(f.find_tensor_info("A").unwrap().quant_type, 8); // overlay won
+    }
+
+    #[test]
+    fn overlay_with_foreign_tensor_rejected() {
+        let _g = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("HIPFIRE_REAP_PLAN");
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("b.hfq");
+        let ov = dir.path().join("o.hfq");
+        write_min_hfq(&base, 9, &[("A", 3, &[1, 4], &vec![0u8; 4])]);
+        // same arch_id 9, but overlay has a tensor "Z" the base lacks
+        write_min_hfq(&ov, 9, &[("A", 8, &[1, 4], &vec![1u8; 4]), ("Z", 8, &[1, 4], &vec![1u8; 4])]);
+        let mut f = HfqFile::open(&base).unwrap();
+        let err = f.attach_overlay(HfqFile::open(&ov).unwrap()).unwrap_err();
+        assert!(err.contains("'Z' not present in base"), "got: {err}");
     }
 }

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
@@ -1,0 +1,808 @@
+# Generic MoE REAP — Sub-project 1: Generic Keep-Map Loader — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift the DeepSeek-V4-specific REAP keep-map loader into a model-agnostic `hipfire-reap` crate and wire it into all 4 MoE arches present on the base (`deepseek4`, `qwen35`, `lfm2moe`, `minimax`), preserving the byte-identical default-off / keep-all-identity guarantee.
+
+**Architecture:** A new `hipfire-reap` crate owns plan parsing (`ReapPlan`), an overlay-then-base tensor resolver (`TensorSource`), an exact byte row-gather (`gather_rows`), and a per-(layer,role) `ExpertPlan` the arch loaders consume at their existing expert-enumeration seam. Arch-specific oddities (deepseek4 `tid2eid`/MTP) stay in the arch crate behind a `ReapArchHook`. Quant-override/overlay *application* and mixed dispatch are SP2–SP4; this plan ships pruning + the overlay-aware resolver plumbing only (tier table is parsed and threaded, but every tier resolves to the base dtype until SP2).
+
+**Tech Stack:** Rust, `serde_json`, the in-repo `hipfire-runtime` (`HfqFile`, `Gpu`, `DType`, `GpuTensor`). Tests via `cargo test -p hipfire-reap` and arch-level identity NLL checks via existing `examples/deepseek4_perplexity.rs`.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` (§1, §4 SP1 gates).
+
+**Scope note:** `cohere2moe` is in-flight on `nw_cohere2moe_support` and not on this base; it gets the identical Task-9-style wiring once merged. SP2 (mixed dispatch), SP3 (overlay application), SP4 (bake) get their own plans authored after this lands.
+
+---
+
+### Task 1: Scaffold the `hipfire-reap` crate
+
+**Files:**
+- Create: `crates/hipfire-reap/Cargo.toml`
+- Create: `crates/hipfire-reap/src/lib.rs`
+- Modify: `Cargo.toml` (workspace `members`)
+
+- [ ] **Step 1: Create the crate manifest**
+
+`crates/hipfire-reap/Cargo.toml`:
+```toml
+[package]
+name = "hipfire-reap"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hipfire-runtime = { path = "../hipfire-runtime" }
+rdna_compute = { path = "../../rdna_compute" }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
+```
+(Verify the exact `rdna_compute` relative path and `serde_json`/`tempfile` versions against a sibling crate's `Cargo.toml`, e.g. `crates/hipfire-arch-deepseek4/Cargo.toml`; match whatever the workspace already pins.)
+
+- [ ] **Step 2: Create a placeholder lib so the crate compiles**
+
+`crates/hipfire-reap/src/lib.rs`:
+```rust
+//! Model-agnostic REAP: selective expert pruning + (SP2+) selective re-quant
+//! overlay for MoE models. See docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+```
+
+- [ ] **Step 3: Register the crate in the workspace**
+
+In the root `Cargo.toml` `[workspace] members = [...]` list, add `"crates/hipfire-reap"` (alphabetically near the other `crates/hipfire-*` entries). Confirm the list style (some workspaces glob `crates/*`; if so, no edit needed — check first).
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `cargo build -p hipfire-reap`
+Expected: compiles clean (an unused-crate warning is fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-reap/Cargo.toml crates/hipfire-reap/src/lib.rs Cargo.toml
+git commit -m "feat(reap): scaffold hipfire-reap crate"
+```
+
+---
+
+### Task 2: `ReapPlan` — parse & validate `reap_plan.json`
+
+This generalizes `ReapKeepMap::load` (currently `crates/hipfire-arch-deepseek4/src/deepseek4.rs:256-328`) — same validation, but model-agnostic and extended with the optional `quant_overrides` manifest. Pruning is optional (`keep` may be absent ⇒ keep-all).
+
+**Files:**
+- Create: `crates/hipfire-reap/src/plan.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs` (add `pub mod plan;`)
+- Test: inline `#[cfg(test)]` in `plan.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `pub mod plan;` to `lib.rs`, then create `crates/hipfire-reap/src/plan.rs`:
+```rust
+use std::path::{Path, PathBuf};
+
+/// One selective-requant edit (applied in SP2+; parsed & validated now).
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuantOverride {
+    pub layer: usize,
+    pub role: Role,
+    /// Only meaningful for `Role::RoutedExperts`; empty ⇒ whole role at this layer.
+    pub experts: Vec<u32>,
+    pub tier: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    RoutedExperts,
+    SharedExpert,
+    Attention,
+    Router,
+    LmHead,
+    Embed,
+}
+
+impl Role {
+    pub fn parse(s: &str) -> Result<Role, String> {
+        Ok(match s {
+            "routed_experts" => Role::RoutedExperts,
+            "shared_expert" => Role::SharedExpert,
+            "attention" => Role::Attention,
+            "router" => Role::Router,
+            "lm_head" => Role::LmHead,
+            "embed" => Role::Embed,
+            other => return Err(format!("reap: unknown role '{other}'")),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReapPlan {
+    pub model_arch: Option<String>,
+    pub num_layers: usize,
+    pub original_experts: usize,
+    /// `keep[l][slot]` = original expert index in compact slot `slot`.
+    /// `None` ⇒ no pruning (keep all `original_experts`).
+    pub keep: Option<Vec<Vec<u32>>>,
+    pub quant_overrides: Vec<QuantOverride>,
+    pub dir: PathBuf,
+}
+
+impl ReapPlan {
+    pub fn kept_per_layer(&self) -> usize {
+        match &self.keep {
+            Some(k) => k.first().map(|r| r.len()).unwrap_or(0),
+            None => self.original_experts,
+        }
+    }
+
+    /// Load `<dir>/reap_plan.json`, validating against the model's layer/expert
+    /// counts (passed BEFORE any n_routed_experts override).
+    pub fn load(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        let path = Path::new(dir).join("reap_plan.json");
+        let txt = std::fs::read_to_string(&path)
+            .map_err(|e| format!("reap: read {path:?}: {e}"))?;
+        let v: serde_json::Value =
+            serde_json::from_str(&txt).map_err(|e| format!("reap: parse {path:?}: {e}"))?;
+
+        let original_experts = v["original_experts"]
+            .as_u64()
+            .unwrap_or(orig_experts_expected as u64) as usize;
+        if original_experts != orig_experts_expected {
+            return Err(format!(
+                "reap: original_experts {original_experts} != model n_routed_experts {orig_experts_expected}"
+            ));
+        }
+        let num_layers = v["num_layers"].as_u64().unwrap_or(num_layers_expected as u64) as usize;
+        if num_layers != num_layers_expected {
+            return Err(format!(
+                "reap: num_layers {num_layers} != model num_hidden_layers {num_layers_expected}"
+            ));
+        }
+
+        let keep = match v["keep"]["per_layer"].as_array() {
+            None => None,
+            Some(arr) => {
+                if arr.len() != num_layers_expected {
+                    return Err(format!(
+                        "reap: keep.per_layer has {} layers, model has {num_layers_expected}",
+                        arr.len()
+                    ));
+                }
+                let kept = arr.first().and_then(|r| r.as_array()).map(|r| r.len()).unwrap_or(0);
+                let mut out = Vec::with_capacity(arr.len());
+                for (l, row) in arr.iter().enumerate() {
+                    let r = row
+                        .as_array()
+                        .ok_or_else(|| format!("reap: keep layer {l} not an array"))?;
+                    if r.len() != kept {
+                        return Err(format!(
+                            "reap: keep layer {l} has {} entries, expected {kept}",
+                            r.len()
+                        ));
+                    }
+                    let mut v32 = Vec::with_capacity(kept);
+                    for x in r {
+                        let idx = x
+                            .as_u64()
+                            .ok_or_else(|| format!("reap: keep layer {l} non-integer index"))?
+                            as u32;
+                        if idx as usize >= original_experts {
+                            return Err(format!(
+                                "reap: keep layer {l} index {idx} >= original_experts {original_experts}"
+                            ));
+                        }
+                        v32.push(idx);
+                    }
+                    out.push(v32);
+                }
+                Some(out)
+            }
+        };
+
+        let mut quant_overrides = Vec::new();
+        if let Some(arr) = v["quant_overrides"].as_array() {
+            for (i, o) in arr.iter().enumerate() {
+                let layer = o["layer"]
+                    .as_u64()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing layer"))?
+                    as usize;
+                if layer >= num_layers_expected {
+                    return Err(format!(
+                        "reap: quant_override[{i}] layer {layer} >= num_layers {num_layers_expected}"
+                    ));
+                }
+                let role = Role::parse(
+                    o["role"].as_str().ok_or_else(|| format!("reap: quant_override[{i}] missing role"))?,
+                )?;
+                let experts: Vec<u32> = o["experts"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect())
+                    .unwrap_or_default();
+                if !experts.is_empty() && role != Role::RoutedExperts {
+                    return Err(format!(
+                        "reap: quant_override[{i}] lists experts but role is not routed_experts"
+                    ));
+                }
+                let tier = o["tier"]
+                    .as_str()
+                    .ok_or_else(|| format!("reap: quant_override[{i}] missing tier"))?
+                    .to_string();
+                quant_overrides.push(QuantOverride { layer, role, experts, tier });
+            }
+        }
+
+        Ok(ReapPlan {
+            model_arch: v["model_arch"].as_str().map(|s| s.to_string()),
+            num_layers: num_layers_expected,
+            original_experts,
+            keep,
+            quant_overrides,
+            dir: PathBuf::from(dir),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_plan(json: &str) -> tempfile::TempDir {
+        let d = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(d.path().join("reap_plan.json")).unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        d
+    }
+
+    #[test]
+    fn keep_all_when_keep_absent() {
+        let d = write_plan(r#"{"original_experts":8,"num_layers":2}"#);
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 8).unwrap();
+        assert!(p.keep.is_none());
+        assert_eq!(p.kept_per_layer(), 8);
+    }
+
+    #[test]
+    fn parses_keep_and_overrides() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":2,
+                "keep":{"per_layer":[[0,2,3],[1,2,3]]},
+                "quant_overrides":[{"layer":1,"role":"routed_experts","experts":[2],"tier":"mq3lloyd"}]}"#,
+        );
+        let p = ReapPlan::load(d.path().to_str().unwrap(), 2, 4).unwrap();
+        assert_eq!(p.kept_per_layer(), 3);
+        assert_eq!(p.keep.as_ref().unwrap()[0], vec![0, 2, 3]);
+        assert_eq!(p.quant_overrides.len(), 1);
+        assert_eq!(p.quant_overrides[0].tier, "mq3lloyd");
+    }
+
+    #[test]
+    fn rejects_out_of_range_index() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,"keep":{"per_layer":[[0,9]]}}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("index 9 >= original_experts 4"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_experts_on_non_routed_role() {
+        let d = write_plan(
+            r#"{"original_experts":4,"num_layers":1,
+                "quant_overrides":[{"layer":0,"role":"attention","experts":[1],"tier":"q8"}]}"#,
+        );
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 1, 4).unwrap_err();
+        assert!(err.contains("not routed_experts"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_layer_count_mismatch() {
+        let d = write_plan(r#"{"original_experts":4,"num_layers":3,"keep":{"per_layer":[[0,1]]}}"#);
+        let err = ReapPlan::load(d.path().to_str().unwrap(), 3, 4).unwrap_err();
+        assert!(err.contains("keep.per_layer has 1 layers"), "got: {err}");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile-first)**
+
+Run: `cargo test -p hipfire-reap plan::`
+Expected: passes once written — but first confirm `tempfile` is a dev-dep (Task 1). If it doesn't compile, fix the manifest, not the test.
+
+- [ ] **Step 3: (impl already inline above) Run tests to verify they pass**
+
+Run: `cargo test -p hipfire-reap plan::`
+Expected: 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/hipfire-reap/src/plan.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): ReapPlan json parse + validation"
+```
+
+---
+
+### Task 3: `gather_rows` — exact byte row-gather
+
+Generalizes `upload_quant_or_f16_keep`'s gather math (`crates/hipfire-arch-deepseek4/src/arch.rs:384-424`) into a pure, GPU-free function returning gathered bytes + new shape. Exact for row-independent quant (F16/Q8/MQ*-G256); rows that don't divide the byte length are a hard error.
+
+**Files:**
+- Create: `crates/hipfire-reap/src/gather.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs` (`pub mod gather;`)
+
+- [ ] **Step 1: Write the failing tests**
+
+`crates/hipfire-reap/src/gather.rs`:
+```rust
+/// Gather kept rows from a row-major tensor's raw bytes. `shape[0]` is the
+/// row count (e.g. experts); every row must be `bytes.len()/shape[0]` bytes.
+/// Returns `(new_shape, gathered_bytes)`. Exact for row-independent quant.
+pub fn gather_rows(shape: &[usize], bytes: &[u8], keep: &[u32]) -> Result<(Vec<usize>, Vec<u8>), String> {
+    let orig_rows = *shape.first().unwrap_or(&0);
+    if orig_rows == 0 || bytes.len() % orig_rows != 0 {
+        return Err(format!(
+            "reap: row-gather: {orig_rows} rows don't divide {} bytes",
+            bytes.len()
+        ));
+    }
+    let rowstride = bytes.len() / orig_rows;
+    let mut out = Vec::with_capacity(rowstride * keep.len());
+    for &oe in keep {
+        let oe = oe as usize;
+        if oe >= orig_rows {
+            return Err(format!("reap: row-gather keep idx {oe} >= rows {orig_rows}"));
+        }
+        out.extend_from_slice(&bytes[oe * rowstride..(oe + 1) * rowstride]);
+    }
+    let mut new_shape = shape.to_vec();
+    new_shape[0] = keep.len();
+    Ok((new_shape, out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gathers_subset_in_order() {
+        // 4 rows × 3 bytes
+        let bytes: Vec<u8> = vec![0,0,0, 1,1,1, 2,2,2, 3,3,3];
+        let (shape, out) = gather_rows(&[4, 3], &bytes, &[2, 0, 3]).unwrap();
+        assert_eq!(shape, vec![3, 3]);
+        assert_eq!(out, vec![2,2,2, 0,0,0, 3,3,3]);
+    }
+
+    #[test]
+    fn identity_keep_is_byte_identical() {
+        let bytes: Vec<u8> = (0..24).collect();
+        let (_, out) = gather_rows(&[4, 6], &bytes, &[0, 1, 2, 3]).unwrap();
+        assert_eq!(out, bytes);
+    }
+
+    #[test]
+    fn errors_on_indivisible_rows() {
+        let err = gather_rows(&[3, 2], &[0, 1, 2, 3, 4], &[0]).unwrap_err();
+        assert!(err.contains("don't divide"), "got: {err}");
+    }
+
+    #[test]
+    fn errors_on_out_of_range_keep() {
+        let err = gather_rows(&[2, 2], &[0, 1, 2, 3], &[5]).unwrap_err();
+        assert!(err.contains("keep idx 5 >= rows 2"), "got: {err}");
+    }
+}
+```
+Add `pub mod gather;` to `lib.rs`.
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo test -p hipfire-reap gather::`
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/gather.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): exact byte row-gather primitive"
+```
+
+---
+
+### Task 4: `TensorSource` + `ExpertPlan` — the loader-facing API
+
+`TensorSource` wraps a base `&HfqFile` (overlay handle is `None` in SP1; the field exists so SP3 slots in without changing call sites). `ExpertPlan` is what an arch asks for per (layer, role): the optional keep slice and a tier resolver (always base dtype in SP1).
+
+**Files:**
+- Create: `crates/hipfire-reap/src/source.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs` (`pub mod source;`, re-exports)
+
+- [ ] **Step 1: Write the source module + a unit test for the keep accessor**
+
+`crates/hipfire-reap/src/source.rs`:
+```rust
+use crate::plan::ReapPlan;
+use hipfire_runtime::hfq::HfqFile; // adjust path to wherever HfqFile is exported
+
+/// Overlay-then-base tensor resolver. SP1: overlay is always None (base only);
+/// SP3 adds the overlay HfqFile and prefers it when it holds `name`.
+pub struct TensorSource<'a> {
+    pub base: &'a HfqFile,
+    pub overlay: Option<&'a HfqFile>,
+}
+
+impl<'a> TensorSource<'a> {
+    pub fn new(base: &'a HfqFile) -> Self {
+        TensorSource { base, overlay: None }
+    }
+
+    /// Resolve a tensor by name: overlay first (SP3), else base.
+    pub fn tensor(&self, name: &str) -> Option<(hipfire_runtime::hfq::TensorInfo, Vec<u8>)> {
+        if let Some(ov) = self.overlay {
+            if let Some(hit) = ov.tensor_data_pread(name) {
+                return Some(hit);
+            }
+        }
+        self.base.tensor_data_pread(name)
+    }
+}
+
+/// Per-(layer, role) plan slice the arch loader consumes at its expert loop.
+pub struct ExpertPlan<'a> {
+    /// `keep[slot]` = original expert index for compact slot. `None` ⇒ identity.
+    keep: Option<&'a [u32]>,
+}
+
+impl<'a> ExpertPlan<'a> {
+    pub fn keep(&self) -> Option<&'a [u32]> {
+        self.keep
+    }
+    /// Original expert index for a compact slot (identity when no keep map).
+    pub fn src(&self, slot: usize) -> usize {
+        self.keep.map(|k| k[slot] as usize).unwrap_or(slot)
+    }
+    /// Number of compact expert slots for this layer.
+    pub fn n_slots(&self, full: usize) -> usize {
+        self.keep.map(|k| k.len()).unwrap_or(full)
+    }
+}
+
+impl ReapPlan {
+    /// Build the per-layer expert plan (routed experts). `None`-keep ⇒ identity.
+    pub fn expert_plan(&self, layer: usize) -> ExpertPlan<'_> {
+        ExpertPlan {
+            keep: self.keep.as_ref().map(|k| k[layer].as_slice()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // ExpertPlan::src/n_slots are pure; test them without an HfqFile.
+    #[test]
+    fn identity_src_when_no_keep() {
+        let ep = ExpertPlan { keep: None };
+        assert_eq!(ep.src(5), 5);
+        assert_eq!(ep.n_slots(8), 8);
+    }
+    #[test]
+    fn remaps_src_with_keep() {
+        let k = vec![3u32, 1, 0];
+        let ep = ExpertPlan { keep: Some(&k) };
+        assert_eq!(ep.src(0), 3);
+        assert_eq!(ep.n_slots(8), 3);
+    }
+}
+```
+**Before running:** confirm the real module paths for `HfqFile`, `TensorInfo`, and `tensor_data_pread`'s return type by grepping the deepseek4 loader (it calls `hfq.tensor_data_pread(&name)` returning `Option<(info, bytes)>`). Fix the `use` and the `tensor()` signature to match the actual types (the return is likely `(&TensorInfo, Vec<u8>)` or owned — match it; the test only exercises the pure `ExpertPlan` methods, so it compiles regardless of the exact HfqFile signature once the `use` resolves).
+
+Add `pub mod source;` and `pub use source::{ExpertPlan, TensorSource};` to `lib.rs`.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p hipfire-reap source::`
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/source.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): TensorSource + ExpertPlan loader API"
+```
+
+---
+
+### Task 5: `ReapArchHook` trait for arch-specific extras
+
+Lets the arch crate inject its own sidecar handling (deepseek4 `tid2eid` remap, MTP-skip) without `hipfire-reap` knowing about it.
+
+**Files:**
+- Create: `crates/hipfire-reap/src/hook.rs`
+- Modify: `crates/hipfire-reap/src/lib.rs`
+
+- [ ] **Step 1: Define the trait**
+
+`crates/hipfire-reap/src/hook.rs`:
+```rust
+use crate::plan::ReapPlan;
+
+/// Arch-specific REAP extras. Default impls are no-ops so arches that need
+/// nothing (qwen35, lfm2moe, minimax) don't implement anything.
+pub trait ReapArchHook {
+    /// Path to an arch sidecar file inside the plan dir, if the arch uses one.
+    fn sidecar_path(&self, plan: &ReapPlan, name: &str) -> std::path::PathBuf {
+        plan.dir.join(name)
+    }
+    /// Whether this layer's auxiliary head (e.g. ds4 MTP) is skipped under reap.
+    fn skip_aux_head(&self, _plan: &ReapPlan, _layer: usize) -> bool {
+        false
+    }
+}
+```
+Add `pub mod hook;` and `pub use hook::ReapArchHook;` to `lib.rs`.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cargo build -p hipfire-reap`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/hook.rs crates/hipfire-reap/src/lib.rs
+git commit -m "feat(reap): ReapArchHook trait for arch-specific extras"
+```
+
+---
+
+### Task 6: Re-point deepseek4 onto `hipfire-reap` (the lift)
+
+Replace the in-crate `ReapKeepMap` + `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` path with `ReapPlan`/`HIPFIRE_REAP_PLAN`, keeping the old env var as a back-compat alias that loads a `keep`-only plan. The existing `upload_quant_or_f16_keep`/`upload_global_f16_as_f32_keep` GPU helpers stay (they wrap `gather_rows`'s math + an upload); we only swap their byte-gather core to call `hipfire_reap::gather::gather_rows` so there is one source of truth.
+
+**Files:**
+- Modify: `crates/hipfire-arch-deepseek4/Cargo.toml` (add `hipfire-reap` dep)
+- Modify: `crates/hipfire-arch-deepseek4/src/deepseek4.rs:100-236` (env hook, field type) and `:242-328` (delete `ReapKeepMap`)
+- Modify: `crates/hipfire-arch-deepseek4/src/arch.rs:384-424` (gather core → `gather_rows`)
+
+- [ ] **Step 1: Add the dependency**
+
+In `crates/hipfire-arch-deepseek4/Cargo.toml` `[dependencies]`, add:
+```toml
+hipfire-reap = { path = "../hipfire-reap" }
+```
+
+- [ ] **Step 2: Swap the env hook (deepseek4.rs ~229-236)**
+
+Replace the block that reads `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` and builds `ReapKeepMap` with one that prefers `HIPFIRE_REAP_PLAN` and falls back to the old var:
+```rust
+// REAP plan: emulate a pruned expert pool by partial-load. New generic env
+// HIPFIRE_REAP_PLAN=<dir> (reap_plan.json); legacy HIPFIRE_DEEPSEEK4_REAP_KEEPMAP
+// (keep_by_layer.json) still honored as a keep-only alias.
+let reap_dir = std::env::var("HIPFIRE_REAP_PLAN")
+    .ok()
+    .or_else(|| std::env::var("HIPFIRE_DEEPSEEK4_REAP_KEEPMAP").ok());
+if let Some(dir) = reap_dir {
+    let plan = hipfire_reap::plan::ReapPlan::load_any(
+        &dir,
+        config.num_hidden_layers,
+        config.n_routed_experts,
+    )?;
+    eprintln!(
+        "deepseek4: REAP plan ACTIVE — keeping {} of {} routed experts/layer; dir {dir}",
+        plan.kept_per_layer(),
+        config.n_routed_experts
+    );
+    config.n_routed_experts = plan.kept_per_layer();
+    config.reap_keep = Some(std::sync::Arc::new(plan));
+}
+```
+Change the `reap_keep` field type (deepseek4.rs ~109) from `Option<Arc<ReapKeepMap>>` to `Option<Arc<hipfire_reap::plan::ReapPlan>>`. Update all readers of `.reap_keep` (the arch.rs upload sites and the `tid2eid_path` caller) to use `plan.keep` / the `ExpertPlan` accessors and the `ReapArchHook` for `tid2eid_path` (move `tid2eid_path` onto a small ds4 `ReapArchHook` impl).
+
+- [ ] **Step 3: Add `ReapPlan::load_any` (keep-only-alias loader)**
+
+In `crates/hipfire-reap/src/plan.rs`, add a helper that accepts either `reap_plan.json` or a legacy `keep_by_layer.json` in the dir:
+```rust
+impl ReapPlan {
+    /// Load `reap_plan.json` if present, else a legacy `keep_by_layer.json`
+    /// (keep-only; no overrides). Lets old ds4 sidecars keep working.
+    pub fn load_any(
+        dir: &str,
+        num_layers_expected: usize,
+        orig_experts_expected: usize,
+    ) -> Result<Self, String> {
+        if Path::new(dir).join("reap_plan.json").exists() {
+            return Self::load(dir, num_layers_expected, orig_experts_expected);
+        }
+        Self::load_legacy_keepmap(dir, num_layers_expected, orig_experts_expected)
+    }
+}
+```
+Add `load_legacy_keepmap` that reads `keep_by_layer.json` (the old schema: `kept_per_layer`, `original_experts`, `keep`) and produces a `ReapPlan` with `keep: Some(...)`, `quant_overrides: vec![]`. Reuse the existing validation logic. Add a unit test mirroring an existing legacy sidecar shape.
+
+- [ ] **Step 4: Swap the gather core in arch.rs (~404-412)**
+
+Inside `upload_quant_or_f16_keep`, replace the manual `rowstride`/loop with:
+```rust
+let shape_usize: Vec<usize> = info.shape.iter().map(|&s| s as usize).collect();
+let (new_shape, sub) = hipfire_reap::gather::gather_rows(&shape_usize, &bytes, keep)?;
+```
+then upload `sub`/`new_shape` as before, preserving the `info.quant_type` → `t.dtype` mapping. Do the analogous swap is NOT needed for `upload_global_f16_as_f32_keep` (it decodes f16→f32 element-wise; leave it, or refactor to call `gather_rows` then decode — optional, keep behavior identical).
+
+- [ ] **Step 5: Build + run the ds4 identity check**
+
+Run: `cargo build -p hipfire-arch-deepseek4 && cargo test -p hipfire-reap`
+Then the identity NLL gate (the existing keep-all-256 sidecar): rebuild the ds4 perplexity example and confirm a keep-all `reap_plan.json` reproduces the no-plan baseline NLL to 10 decimals (use the existing `scripts/reap/build_keepall_sidecar.py`, regenerated to emit `reap_plan.json`, or point `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` at the legacy sidecar to exercise `load_legacy_keepmap`).
+Expected: identical NLL — the lift is behavior-preserving.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hipfire-arch-deepseek4 crates/hipfire-reap
+git commit -m "refactor(ds4): lift REAP onto hipfire-reap; HIPFIRE_REAP_PLAN + legacy alias"
+```
+
+---
+
+### Task 7: Wire `qwen35` (buffer arch)
+
+Buffer arch: experts are individual `ExpertWeights { gate_up, down }` (`crates/hipfire-arch-qwen35/src/qwen35.rs:4331-4346`). Pruning = iterate compact slots and load only kept experts by remapped name; router logits get a `gather_rows` on the per-expert rows.
+
+**Files:**
+- Modify: `crates/hipfire-arch-qwen35/Cargo.toml` (add `hipfire-reap`)
+- Modify: `crates/hipfire-arch-qwen35/src/qwen35.rs` (MoE loader ~4320-4380, config/env hook, router load)
+
+- [ ] **Step 1: Add dependency + thread the plan**
+
+Add `hipfire-reap = { path = "../hipfire-reap" }`. Locate where qwen35 reads its config/builds weights; add the same `HIPFIRE_REAP_PLAN` env read as ds4 (Task 6 Step 2), storing `Option<Arc<ReapPlan>>` on the config/weights struct, and override the routed-expert count (`n_routed_experts`/equivalent) to `plan.kept_per_layer()` when active.
+
+- [ ] **Step 2: Write the failing identity test**
+
+Add an arch-level test (or reuse the qwen35 perplexity/eval example) asserting a keep-all plan reproduces baseline logits for a small qwen35-MoE fixture. If no tiny fixture exists, gate this as a manual NLL check documented in the task and add a `#[test]` that at least exercises the loader path with a keep-all plan on a toy-sized config (skip if no fixture; note it).
+
+- [ ] **Step 3: Implement the loop change**
+
+Replace the expert loop (`for x in 0..n_exp`) with compact-slot iteration:
+```rust
+let plan = config.reap_keep.as_ref();
+let ep = plan.map(|p| p.expert_plan(layer_idx));
+let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
+for slot in 0..n_slots {
+    let x = ep.as_ref().map(|e| e.src(slot)).unwrap_or(slot);
+    let gate_up = load_weight_tensor(hfq, gpu, &format!("{p}.mlp.experts.{x}.gate_up_proj.weight"), 2 * mi, config.dim)?;
+    let down = load_weight_tensor(hfq, gpu, &format!("{p}.mlp.experts.{x}.down_proj.weight"), config.dim, mi)?;
+    experts.push(ExpertWeights { gate_up, down });
+}
+```
+For the **router** (`{p}.mlp.gate.weight` or equivalent, `[n_exp, dim]`): when `ep` has a keep, read its bytes, `gather_rows(&[n_exp, dim_stride], &bytes, keep)`, and upload the gathered subset so the router emits logits only for kept experts. (Find the exact router tensor name in the qwen35 loader and match its existing upload.)
+
+- [ ] **Step 4: Build + identity check**
+
+Run: `cargo build -p hipfire-arch-qwen35`, then the keep-all NLL check.
+Expected: baseline reproduced.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-arch-qwen35
+git commit -m "feat(qwen35): generic REAP keep-map loader wiring"
+```
+
+---
+
+### Task 8: Wire `lfm2moe` (buffer arch, fused-at-load gate_up)
+
+Same buffer-arch pattern as qwen35, but gate_up is fused from `w1`/`w3` at load (`crates/hipfire-arch-lfm2moe/src/lfm2moe.rs:345-454`) and per-layer AWQ scales hang off `experts[0]`.
+
+**Files:**
+- Modify: `crates/hipfire-arch-lfm2moe/Cargo.toml` (add `hipfire-reap`)
+- Modify: `crates/hipfire-arch-lfm2moe/src/lfm2moe.rs:345-454` + config/env hook
+
+- [ ] **Step 1: Add dependency + env hook + count override** (as Task 7 Step 1).
+
+- [ ] **Step 2: Convert the expert loop to compact slots**
+
+In the `MoeFfnWeights::load` expert loop, replace `e` with `slot`/`src` exactly as Task 7 Step 3, applying `src` to the `{prefix}.feed_forward.experts.{src}.{w1,w3,w2}.weight` names. Keep the w1‖w3 fuse unchanged (it operates per expert). **AWQ caveat:** the shared per-layer AWQ scale read from `experts[0]` must read from `experts[src(0)]`'s scale tensor — confirm the AWQ scale is layer-shared (same for all experts) or per-expert; if per-expert, gather it under keep. Document which, in the commit.
+
+- [ ] **Step 3: Router gather** as Task 7 Step 3 (find lfm2moe's router/gate tensor).
+
+- [ ] **Step 4: Build + identity check**
+
+Run: `cargo build -p hipfire-arch-lfm2moe`, then keep-all NLL check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-arch-lfm2moe
+git commit -m "feat(lfm2moe): generic REAP keep-map loader wiring"
+```
+
+---
+
+### Task 9: Wire `minimax` (blob arch, like deepseek4)
+
+Blob arch: all experts packed into single `gu_combined`/`dn_combined` blobs with a stride pointer table (`crates/hipfire-arch-minimax/src/minimax.rs:280-517`). Pruning = pack only kept experts' bytes via `src(slot)`, mirroring ds4's `upload_layer_routed_experts` change.
+
+**Files:**
+- Modify: `crates/hipfire-arch-minimax/Cargo.toml` (add `hipfire-reap`)
+- Modify: `crates/hipfire-arch-minimax/src/minimax.rs:280-517` + config/env hook
+
+- [ ] **Step 1: Add dependency + env hook + count override** (as Task 7 Step 1). MiniMax already has EP-shard logic; assert reap and EP-shard are mutually exclusive (mirror ds4 arch.rs's guard: error if both a keep plan and a shard config are present).
+
+- [ ] **Step 2: Pack only kept experts**
+
+In the blob-build loops (the `for e in 0..n_exp` that `extend_from_slice` w1/w3/w2 bytes), iterate compact slots and read `experts.{src(slot)}`:
+```rust
+let ep = config.reap_keep.as_ref().map(|p| p.expert_plan(layer_idx));
+let n_slots = ep.as_ref().map(|e| e.n_slots(n_exp)).unwrap_or(n_exp);
+for slot in 0..n_slots {
+    let e = ep.as_ref().map(|x| x.src(slot)).unwrap_or(slot);
+    // ... read experts.{e}.w1/w3/w2, extend into gu_combined/dn_combined ...
+}
+```
+The stride pointer table is then built over `n_slots` compact entries (unchanged math). **EP-shard:** since reap and EP-shard are mutually exclusive (Step 1), the non-owned-zero path is untouched when reap is active.
+
+- [ ] **Step 3: Router gather** (minimax router/gate `[n_exp, dim]`) as Task 7 Step 3.
+
+- [ ] **Step 4: Build + identity check**
+
+Run: `cargo build -p hipfire-arch-minimax`, then keep-all NLL check.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-arch-minimax
+git commit -m "feat(minimax): generic REAP keep-map loader wiring"
+```
+
+---
+
+### Task 10: Cross-arch regression gate + end-to-end smoke
+
+**Files:**
+- Create: `crates/hipfire-reap/tests/identity_gate.md` (documented manual gate runner) or extend `scripts/reap/`
+- Modify: `scripts/reap/build_keepall_sidecar.py` → emit `reap_plan.json` (generic)
+
+- [ ] **Step 1: Generalize the keep-all sidecar builder**
+
+Update `scripts/reap/build_keepall_sidecar.py` to write a generic `reap_plan.json` with `keep.per_layer = [[0..N-1]] * num_layers` for a given (num_layers, n_experts), arch-agnostic.
+
+- [ ] **Step 2: Run the identity gate on every wired arch**
+
+For each of ds4, qwen35, lfm2moe, minimax with an available MoE checkpoint: load with `HIPFIRE_REAP_PLAN=<keepall dir>` and confirm logits/NLL match the no-plan baseline to 10 decimals. Record results in `scripts/reap/README.md`.
+Expected: all 4 reproduce baseline (the machinery is an exact no-op under keep-all).
+
+- [ ] **Step 3: ds4 end-to-end smoke**
+
+Reproduce the known K144 result through the new generic path: full-256 PPL ≈ 7.56 vs pruned-144 ≈ 17.73 on wikitext2 ctx=1024 (existing `scripts/reap/run_ppl_kld.sh`, regenerated keep-map as `reap_plan.json`).
+Expected: matches the pre-lift numbers — no regression.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/reap crates/hipfire-reap/tests
+git commit -m "test(reap): cross-arch keep-all identity gate + ds4 K144 smoke"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§1, §4-SP1):**
+- `hipfire-reap` crate + `ReapPlan`/`TensorSource`/`gather_rows`/`ExpertPlan`/`ReapArchHook` → Tasks 1–5. ✓
+- Overlay-then-base resolver present but overlay=None until SP3 → `TensorSource.overlay` field, Task 4. ✓
+- Blob-arch per-tier sub-blob packing → **deferred to SP2** (this plan packs kept experts into the *existing single* blob; multi-tier sub-blobs need the dtype table from SP2). Noted in Architecture. ✓ (pruning-only is correct for SP1.)
+- All 4 base arches wired → Tasks 6–9; cohere2moe on-merge noted. ✓
+- Byte-identical / keep-all identity gate → Tasks 6 Step 5, 10. ✓
+- `gather_rows` exactness + `ReapPlan` validation unit tests → Tasks 2, 3. ✓
+- Legacy env alias → Task 6 Step 3. ✓
+
+**Placeholder scan:** Tasks 7–9 Step 2 reference "find the exact router tensor name" / "if no fixture exists" — these are genuine per-arch lookups the implementer must do at the seam; each gives the file:line and the transform pattern with concrete code, not hand-waving. Acceptable (the unknown is a tensor *name* in a known file, not missing logic).
+
+**Type consistency:** `ReapPlan` (fields `keep: Option<Vec<Vec<u32>>>`, `quant_overrides`, `dir`), `ExpertPlan::{src,n_slots,keep}`, `gather_rows(shape,bytes,keep)->(Vec<usize>,Vec<u8>)`, `TensorSource::{new,tensor,overlay}`, `ReapArchHook` — names used consistently across Tasks 4–10. `config.reap_keep: Option<Arc<ReapPlan>>` used identically in Tasks 6–9. ✓
+
+**Known follow-ups (SP2+):** mixed-tier sub-blob packing, `per_expert_quant` dtype table, overlay application (`TensorSource.overlay = Some(...)`), bake. Each gets its own plan.

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp1-loader.md
@@ -10,6 +10,13 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` (§1, §4 SP1 gates).
 
+> ⛔ **GPU EMBARGO (2026-06-11):** the GPU is in use by separate cohere work. Do **NOT** run any
+> step that loads a model on the GPU: no `examples/daemon`, no perplexity/NLL/PPL/KLD runs, no
+> `cargo run`, and no `cargo test` on the arch crates (they may init the GPU). Allowed: editing
+> code, `cargo build -p <crate>` (compile only — kernels JIT at runtime, not build time), and
+> `cargo test -p hipfire-reap` (pure-CPU unit tests). Steps marked **[GPU — DEFERRED]** must be
+> left unchecked with a note; implement the code they verify, but do not execute them.
+
 **Scope note:** `cohere2moe` is in-flight on `nw_cohere2moe_support` and not on this base; it gets the identical Task-9-style wiring once merged. SP2 (mixed dispatch), SP3 (overlay application), SP4 (bake) get their own plans authored after this lands.
 
 ---
@@ -633,11 +640,15 @@ let (new_shape, sub) = hipfire_reap::gather::gather_rows(&shape_usize, &bytes, k
 ```
 then upload `sub`/`new_shape` as before, preserving the `info.quant_type` → `t.dtype` mapping. Do the analogous swap is NOT needed for `upload_global_f16_as_f32_keep` (it decodes f16→f32 element-wise; leave it, or refactor to call `gather_rows` then decode — optional, keep behavior identical).
 
-- [ ] **Step 5: Build + run the ds4 identity check**
+- [ ] **Step 5a: Build + CPU tests (run now)**
 
 Run: `cargo build -p hipfire-arch-deepseek4 && cargo test -p hipfire-reap`
-Then the identity NLL gate (the existing keep-all-256 sidecar): rebuild the ds4 perplexity example and confirm a keep-all `reap_plan.json` reproduces the no-plan baseline NLL to 10 decimals (use the existing `scripts/reap/build_keepall_sidecar.py`, regenerated to emit `reap_plan.json`, or point `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` at the legacy sidecar to exercise `load_legacy_keepmap`).
-Expected: identical NLL — the lift is behavior-preserving.
+Expected: compiles; `hipfire-reap` unit tests (incl. the new `load_legacy_keepmap` test) pass.
+
+- [ ] **Step 5b: [GPU — DEFERRED] ds4 identity NLL gate**
+
+The identity NLL gate (existing keep-all-256 sidecar): confirm a keep-all `reap_plan.json` reproduces the no-plan baseline NLL to 10 decimals (use `scripts/reap/build_keepall_sidecar.py` regenerated to emit `reap_plan.json`, or point `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP` at the legacy sidecar to exercise `load_legacy_keepmap`).
+**Do NOT run under the GPU embargo** — leave unchecked; note "deferred: GPU in use". The lift must be behavior-preserving; this is the gate to run once the GPU frees.
 
 - [ ] **Step 6: Commit**
 
@@ -680,10 +691,10 @@ for slot in 0..n_slots {
 ```
 For the **router** (`{p}.mlp.gate.weight` or equivalent, `[n_exp, dim]`): when `ep` has a keep, read its bytes, `gather_rows(&[n_exp, dim_stride], &bytes, keep)`, and upload the gathered subset so the router emits logits only for kept experts. (Find the exact router tensor name in the qwen35 loader and match its existing upload.)
 
-- [ ] **Step 4: Build + identity check**
+- [ ] **Step 4: Build (run now) + [GPU — DEFERRED] identity check**
 
-Run: `cargo build -p hipfire-arch-qwen35`, then the keep-all NLL check.
-Expected: baseline reproduced.
+Run: `cargo build -p hipfire-arch-qwen35` (compile only).
+The keep-all NLL check is **[GPU — DEFERRED]** under the embargo — leave unchecked, note "deferred: GPU in use".
 
 - [ ] **Step 5: Commit**
 
@@ -710,9 +721,10 @@ In the `MoeFfnWeights::load` expert loop, replace `e` with `slot`/`src` exactly 
 
 - [ ] **Step 3: Router gather** as Task 7 Step 3 (find lfm2moe's router/gate tensor).
 
-- [ ] **Step 4: Build + identity check**
+- [ ] **Step 4: Build (run now) + [GPU — DEFERRED] identity check**
 
-Run: `cargo build -p hipfire-arch-lfm2moe`, then keep-all NLL check.
+Run: `cargo build -p hipfire-arch-lfm2moe` (compile only).
+Keep-all NLL check is **[GPU — DEFERRED]** — leave unchecked, note "deferred: GPU in use".
 
 - [ ] **Step 5: Commit**
 
@@ -748,9 +760,10 @@ The stride pointer table is then built over `n_slots` compact entries (unchanged
 
 - [ ] **Step 3: Router gather** (minimax router/gate `[n_exp, dim]`) as Task 7 Step 3.
 
-- [ ] **Step 4: Build + identity check**
+- [ ] **Step 4: Build (run now) + [GPU — DEFERRED] identity check**
 
-Run: `cargo build -p hipfire-arch-minimax`, then keep-all NLL check.
+Run: `cargo build -p hipfire-arch-minimax` (compile only).
+Keep-all NLL check is **[GPU — DEFERRED]** — leave unchecked, note "deferred: GPU in use".
 
 - [ ] **Step 5: Commit**
 
@@ -771,21 +784,22 @@ git commit -m "feat(minimax): generic REAP keep-map loader wiring"
 
 Update `scripts/reap/build_keepall_sidecar.py` to write a generic `reap_plan.json` with `keep.per_layer = [[0..N-1]] * num_layers` for a given (num_layers, n_experts), arch-agnostic.
 
-- [ ] **Step 2: Run the identity gate on every wired arch**
+- [ ] **Step 2: [GPU — DEFERRED] Run the identity gate on every wired arch**
 
 For each of ds4, qwen35, lfm2moe, minimax with an available MoE checkpoint: load with `HIPFIRE_REAP_PLAN=<keepall dir>` and confirm logits/NLL match the no-plan baseline to 10 decimals. Record results in `scripts/reap/README.md`.
-Expected: all 4 reproduce baseline (the machinery is an exact no-op under keep-all).
+**Do NOT run under the GPU embargo** — leave unchecked, note "deferred: GPU in use". Expected (when run): all 4 reproduce baseline (exact no-op under keep-all).
 
-- [ ] **Step 3: ds4 end-to-end smoke**
+- [ ] **Step 3: [GPU — DEFERRED] ds4 end-to-end smoke**
 
 Reproduce the known K144 result through the new generic path: full-256 PPL ≈ 7.56 vs pruned-144 ≈ 17.73 on wikitext2 ctx=1024 (existing `scripts/reap/run_ppl_kld.sh`, regenerated keep-map as `reap_plan.json`).
-Expected: matches the pre-lift numbers — no regression.
+**Do NOT run under the GPU embargo** — leave unchecked, note "deferred: GPU in use". Expected (when run): matches pre-lift numbers — no regression.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Commit the (Python/script) changes**
 
+Step 1 (CPU, the `build_keepall_sidecar.py` generalization) is runnable now; Steps 2–3 are deferred. Commit what's done:
 ```bash
 git add scripts/reap crates/hipfire-reap/tests
-git commit -m "test(reap): cross-arch keep-all identity gate + ds4 K144 smoke"
+git commit -m "test(reap): generalize keep-all sidecar builder; cross-arch identity gate (GPU-deferred)"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp3-overlay-load.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp3-overlay-load.md
@@ -1,0 +1,238 @@
+# Generic MoE REAP — SP3: Load-Time Overlay Splice — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a `<HIPFIRE_REAP_PLAN>/overlay.hfq` (built by SP4a) take effect at load: when present, `HfqFile` tensor reads resolve overlay-then-base, so re-quantized tensors splice over the base model transparently — no arch changes.
+
+**Architecture:** Add an optional `overlay: Option<Box<HfqFile>>` to `HfqFile` (`hipfire-runtime`). Its read methods (`find_tensor_info`/`tensor_data`/`tensor_data_pread`/`tensor_data_vec`/`tensor_names`) check the overlay first, fall back to base. `HfqFile::open` auto-attaches `<dir>/overlay.hfq` when `HIPFIRE_REAP_PLAN=<dir>` is set and the overlay's `arch_id` matches the base — so every consumer (config + weight loading, all 4 arches, the keep-map gather) gets overlay resolution with ZERO call-site changes, and an overridden tensor's new `quant_type` flows naturally to dispatch.
+
+**Tech Stack:** Rust, `hipfire-runtime` (`HfqFile`), `hipfire-quantize` (`write_hfq` — for integration tests only). No GPU.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` §1 (loader resolution rule), §3.
+
+> **Mostly CPU-verifiable.** The overlay-first resolution + env-attach are CPU-unit/integration-testable here. What's GPU-DEFERRED: serving a model whose overlay mixes tiers *within one layer* (needs SP2). A **per-layer-uniform** overlay (a whole layer's experts at a new tier) flows its dtype to `MoeDtypes` and serves through existing dispatch — verify that end-to-end once the GPU frees.
+
+**Relationship to SP1's `TensorSource`:** SP1 added a `TensorSource { base, overlay }` wrapper (overlay always None) as an SP3 seam. This plan implements the overlay at the **`HfqFile` level instead** (lower-touch — no per-arch read rewiring). `TensorSource` becomes vestigial; Task 4 removes it to avoid two overlay mechanisms.
+
+---
+
+### Task 1: `HfqFile` overlay field + overlay-first reads
+
+**Files:**
+- Modify: `crates/hipfire-runtime/src/hfq.rs` (struct `:42`, `open_at_offset` `:82`, read methods `:306`–`~485`)
+- Test: inline `#[cfg(test)]` in `hfq.rs` (with a minimal in-test HFQ writer)
+
+- [ ] **Step 1: Add the field**
+
+In `pub struct HfqFile` (`:42`), add: `overlay: Option<Box<HfqFile>>,`. In `open_at_offset` (`:82`), initialize `overlay: None` in the constructed `Self { ... }`. Add an accessor + attach:
+```rust
+impl HfqFile {
+    /// Attach an overlay whose tensors shadow this file's by name. Used by the
+    /// REAP load-time splice (SP3). Errors if arch_id differs (wrong model).
+    pub fn attach_overlay(&mut self, overlay: HfqFile) -> Result<(), String> {
+        if overlay.arch_id != self.arch_id {
+            return Err(format!(
+                "reap overlay: arch_id {} != base arch_id {}", overlay.arch_id, self.arch_id));
+        }
+        self.overlay = Some(Box::new(overlay));
+        Ok(())
+    }
+    pub fn has_overlay(&self) -> bool { self.overlay.is_some() }
+}
+```
+
+- [ ] **Step 2: Write the failing resolution tests (with an in-test HFQ writer)**
+
+Add to `hfq.rs` `#[cfg(test)]`. First a minimal writer (the format is: 32B header `HFQM`/version/arch_id/n_tensors/metadata_offset/data_offset, then metadata JSON, then index `[u32 n, per-tensor: u16 name_len, name, u8 quant_type, u8 n_dims, n_dims×u32 shape, u32 group_size, u64 data_size]`, then 4096-aligned data). Write a helper `fn write_min_hfq(path, arch_id, &[(name, quant_type, shape, data)])` that emits a valid container (mirror the real `write_hfq` layout — read `hipfire-quantize`'s `write_hfq` at `main.rs:3398` for the exact byte order; data region 4096-aligned). Then:
+```rust
+#[test]
+fn overlay_tensor_shadows_base() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("base.hfq");
+    let ov = dir.path().join("overlay.hfq");
+    // base has tensorA (qt=3) + tensorB (qt=3); overlay re-quantizes tensorA to qt=8.
+    write_min_hfq(&base, 9, &[("A", 3, &[2,4], &vec![1u8;  2*4]), ("B", 3, &[2,4], &vec![2u8; 2*4])]);
+    write_min_hfq(&ov,   9, &[("A", 8, &[2,4], &vec![9u8;  2*4])]);
+    let mut f = HfqFile::open(&base).unwrap();
+    f.attach_overlay(HfqFile::open(&ov).unwrap()).unwrap();
+    // A resolves to overlay (qt 8, bytes 9); B falls through to base (qt 3, bytes 2).
+    let (ia, da) = f.tensor_data_vec("A").unwrap();
+    assert_eq!(ia.quant_type, 8); assert!(da.iter().all(|&b| b == 9));
+    let (ib, db) = f.tensor_data_vec("B").unwrap();
+    assert_eq!(ib.quant_type, 3); assert!(db.iter().all(|&b| b == 2));
+    assert_eq!(f.find_tensor_info("A").unwrap().quant_type, 8);
+    // tensor_names is the union (base ∪ overlay), no dup.
+    let mut names = f.tensor_names(); names.sort();
+    assert_eq!(names, vec!["A".to_string(), "B".to_string()]);
+}
+#[test]
+fn overlay_arch_mismatch_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("b.hfq"); let ov = dir.path().join("o.hfq");
+    write_min_hfq(&base, 9, &[("A", 3, &[1,4], &vec![0u8;4])]);
+    write_min_hfq(&ov,   6, &[("A", 3, &[1,4], &vec![0u8;4])]);
+    let mut f = HfqFile::open(&base).unwrap();
+    let err = f.attach_overlay(HfqFile::open(&ov).unwrap()).unwrap_err();
+    assert!(err.contains("arch_id 6 != base arch_id 9"), "got: {err}");
+}
+```
+Add `tempfile` to `crates/hipfire-runtime` `[dev-dependencies]` if absent.
+
+- [ ] **Step 3: Run to confirm fail**
+
+Run: `cargo test -p hipfire-runtime overlay_` → FAIL (overlay not consulted yet).
+
+- [ ] **Step 4: Implement overlay-first resolution**
+
+In each read method, add an overlay check at the TOP that returns the overlay's result when the overlay has the name:
+- `find_tensor_info` (`:306`): `if let Some(ov) = &self.overlay { if let Some(i) = ov.find_tensor_info(name) { return Some(i); } }`
+- `tensor_data` (`:311`): same guard, return `ov.tensor_data(name)` if `ov.find_tensor_info(name).is_some()`.
+- BOTH `tensor_data_pread` (`:330` unix, `:359` non-unix): same guard → `ov.tensor_data_pread(name)`.
+- `tensor_data_vec` (`:368`): same guard → `ov.tensor_data_vec(name)`.
+- `tensor_names` (`~:481`): return the UNION of base names + overlay names, deduped (base name list with any overlay-only names appended). Keep deterministic order (base order, then overlay-only sorted) so the test's sort is stable.
+Guard each with `self.overlay.is_some()` so the no-overlay path is byte-identical to today (zero overhead).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p hipfire-runtime overlay_` → both pass. Then `cargo test -p hipfire-runtime` → no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hipfire-runtime/src/hfq.rs crates/hipfire-runtime/Cargo.toml
+git commit -m "feat(reap): HfqFile overlay — overlay-then-base tensor resolution"
+```
+
+---
+
+### Task 2: Auto-attach the overlay from `HIPFIRE_REAP_PLAN` in `open()`
+
+**Files:**
+- Modify: `crates/hipfire-runtime/src/hfq.rs` (`open` `:68`)
+- Test: inline
+
+- [ ] **Step 1: Write the failing env-attach test**
+
+```rust
+#[test]
+fn open_auto_attaches_overlay_from_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("base.hfq");
+    write_min_hfq(&base, 9, &[("A", 3, &[1,4], &vec![1u8;4])]);
+    // overlay.hfq lives in the plan dir
+    let plan = tempfile::tempdir().unwrap();
+    write_min_hfq(&plan.path().join("overlay.hfq"), 9, &[("A", 8, &[1,4], &vec![7u8;4])]);
+    // Env-scoped: set, open, assert, unset. (Serialize env tests via a mutex if needed.)
+    std::env::set_var("HIPFIRE_REAP_PLAN", plan.path());
+    let f = HfqFile::open(&base).unwrap();
+    std::env::remove_var("HIPFIRE_REAP_PLAN");
+    assert!(f.has_overlay());
+    assert_eq!(f.find_tensor_info("A").unwrap().quant_type, 8); // overlay won
+}
+```
+(Env mutation in tests is process-global; if `hipfire-runtime` has other env-reading tests, guard with a shared `static MUTEX` or run this test alone. Note it in the test.)
+
+- [ ] **Step 2: Run to confirm fail**
+
+Run: `cargo test -p hipfire-runtime open_auto_attaches` → FAIL (no auto-attach).
+
+- [ ] **Step 3: Implement auto-attach in `open`**
+
+`open` currently just calls `open_at_offset(path, 0)`. Change it to, after the base opens, check the env and attach (only for the canonical `open`, NOT `open_at_offset`, so embedded-container opens are unaffected):
+```rust
+pub fn open(path: &Path) -> std::io::Result<Self> {
+    let mut f = Self::open_at_offset(path, 0)?;
+    if let Ok(dir) = std::env::var("HIPFIRE_REAP_PLAN") {
+        let ov_path = std::path::Path::new(&dir).join("overlay.hfq");
+        if ov_path.exists() {
+            match Self::open_at_offset(&ov_path, 0).map_err(|e| e.to_string())
+                .and_then(|ov| { let n = ov.tensors.len(); f.attach_overlay(ov).map(|_| n) }) {
+                Ok(n) => eprintln!("reap: overlay ACTIVE — {n} tensor(s) from {ov_path:?} shadow the base"),
+                Err(e) => eprintln!("reap: WARNING overlay at {ov_path:?} not attached: {e}"),
+            }
+        }
+    }
+    Ok(f)
+}
+```
+(Use `open_at_offset` for the overlay so it does NOT recursively env-attach. `attach_overlay` enforces the arch_id match — a mismatch logs a warning and proceeds base-only, which is the safe default for unrelated model opens.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p hipfire-runtime open_auto_attaches` → pass. `cargo test -p hipfire-runtime` → green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-runtime/src/hfq.rs
+git commit -m "feat(reap): HfqFile::open auto-attaches HIPFIRE_REAP_PLAN/overlay.hfq (arch-guarded)"
+```
+
+---
+
+### Task 3: End-to-end integration test (real overlay via SP4)
+
+**Files:**
+- Create: `crates/hipfire-quantize/src/reap_overlay.rs` test addition OR `crates/hipfire-quantize` in-module test (binary crate — no `tests/` lib access; mirror SP4 Task 4's in-module `integ` location)
+
+- [ ] **Step 1: Write the test**
+
+Using the real `write_hfq` (in `hipfire-quantize`) and `HfqFile`:
+1. Write a `base.hfq` with two tensors (`layers.0.ffn.experts.0.w1.weight` qt Q8F16, and `layers.0.self_attn.q_proj.weight` qt Q8F16) to a tempdir.
+2. Build an `overlay.hfq` re-quantizing the expert tensor to HFQ4G256 via `build_overlay` (or `quantize_to_format` directly) + `write_hfq`, placed in a `plan-dir`.
+3. Set `HIPFIRE_REAP_PLAN=<plan-dir>`, `HfqFile::open(base)`, assert: the expert tensor resolves to the overlay (quant_type HFQ4G256, overlay bytes) and the attention tensor falls through to base (Q8F16). Unset env.
+This proves the SP4-overlay → SP3-load round trip on real containers.
+
+- [ ] **Step 2: Run**
+
+Run: `cargo test -p hipfire-quantize reap_overlay` → all pass incl. the new round-trip.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-quantize/src/reap_overlay.rs
+git commit -m "test(reap): SP4-overlay -> SP3-load end-to-end (real containers, CPU)"
+```
+
+---
+
+### Task 4: Remove the now-redundant `TensorSource`; docs
+
+`TensorSource` (SP1, `crates/hipfire-reap/src/source.rs`) was a placeholder for SP3; the overlay now lives in `HfqFile`. Keeping both is two mechanisms for one job.
+
+**Files:**
+- Modify: `crates/hipfire-reap/src/source.rs`, `lib.rs`
+- Modify: `scripts/reap/README.md`
+
+- [ ] **Step 1: Remove `TensorSource`, keep `ExpertPlan`**
+
+`source.rs` holds both `TensorSource` and `ExpertPlan` (+ `ReapPlan::expert_plan`). `ExpertPlan` IS used by the arches (SP1); keep it. Delete only `TensorSource` (and its `tensor()`/`overlay` field) and its `pub use` in `lib.rs`. Grep to confirm `TensorSource` has no other users (it should have none — it was inert). Run `cargo test -p hipfire-reap` → still green (ExpertPlan tests unaffected).
+
+- [ ] **Step 2: Document SP3 in README**
+
+In the "Selective re-quant (overlay)" section (added by SP4), update the "Consuming the overlay" note: SP3 is now DONE — `HIPFIRE_REAP_PLAN=<dir>` with an `overlay.hfq` present makes `HfqFile` resolve overlay-then-base automatically (no arch changes); a per-layer-uniform overlay serves via existing dispatch, intra-layer-mixed still needs SP2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/hipfire-reap/src/source.rs crates/hipfire-reap/src/lib.rs scripts/reap/README.md
+git commit -m "refactor(reap): drop vestigial TensorSource (overlay now in HfqFile); SP3 docs"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§1 resolution rule, §3 overlay consumption):**
+- Overlay-then-base tensor resolution → Task 1 (all 5 read methods). ✓
+- Activated by `HIPFIRE_REAP_PLAN`/`overlay.hfq` → Task 2 (env auto-attach, arch-guarded). ✓
+- Zero arch changes (transparent) → achieved by putting it in `HfqFile` (all arches read through it). ✓
+- Overridden tensor's new quant_type reaches dispatch → Task 1 (`find_tensor_info`/`tensor_data*` return overlay `HfqTensorInfo` with its quant_type). ✓
+- End-to-end with a real SP4 overlay → Task 3. ✓
+- Intra-layer-mixed serving → **GPU-deferred to SP2** (noted). ✓
+
+**Placeholder scan:** Task 1 Step 2 asks the implementer to mirror `write_hfq`'s byte layout for a minimal test writer — concrete (the format is fully specified + the real writer is at a given file:line), not hand-waving. No TBDs.
+
+**Type consistency:** `HfqFile.overlay: Option<Box<HfqFile>>`, `attach_overlay(&mut self, HfqFile) -> Result<(),String>`, `has_overlay()`, read methods unchanged signatures (overlay checked internally). `HfqTensorInfo.quant_type` (u8) used consistently. `write_min_hfq` test helper consistent across Task 1/2 tests.
+
+**Known follow-ups:** SP2 (intra-layer-mixed dispatch) makes per-expert overlays serveable; the per-layer-uniform overlay serve path is GPU-owed to verify; SP4b bake.

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp4-overlay-quant.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp4-overlay-quant.md
@@ -1,0 +1,388 @@
+# Generic MoE REAP — SP4 (part a): Selective Re-Quant Overlay Builder — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `hipfire reap quant` to the (CPU-only) quantizer: re-quantize ONLY the tensors named by a reap plan's `quant_overrides` — read from the original fp16/bf16 safetensors — into a small `overlay.hfq`, so a quant config can be iterated without re-quantizing the whole model.
+
+**Architecture:** Thread a `hipfire_reap::plan::ReapPlan` into `hipfire-quantize`. Two new pure-ish units: `quantize_to_format(fmt, &[f32], shape) -> HfqTensor` (an encoder-dispatch over the existing self-calibrating `quantize_*` fns) and `reap_override_for(name, &plan) -> Option<&str>` (arch-aware role+layer+expert → target tier). A new `--reap-overlay <plan-dir> --reap-out <overlay.hfq>` mode filters the existing tensor loop to overridden tensors only and writes a subset `.hfq` via the existing `write_hfq()`. The full quantize loop is untouched in default mode.
+
+**Tech Stack:** Rust, `hipfire-quantize` (CPU; reads safetensors, writes HFQ), `hipfire-reap` (ReapPlan), `hipfire-runtime` (HfqFile reader for tests). No GPU.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` §3 (`reap quant`), §1 (`reap_plan.json` schema).
+
+> **CPU-verifiable.** Unlike SP1's loader (GPU-gated), this whole plan is CPU-runnable: byte-equivalence of `quantize_to_format` vs the underlying `quantize_*` fns, name resolution unit tests, and a real overlay-build smoke comparing overlay bytes to a full-quant of the same tensor. Run everything.
+
+**Scope note:** This is the **overlay builder** (the iterate loop). `reap bake` (whole-model quantize with overrides + expert pruning/renumber → standalone `.hfq`) is **SP4b**, a separate plan — it overlaps SP1's prune logic and is lower priority. Serving an overlay that mixes tiers *within a layer* additionally needs **SP2** (GPU mixed dispatch); per-layer-uniform overlays serve through existing dispatch once **SP3** (load-time splice) lands. This plan only builds correct overlay bytes; consuming them is SP3.
+
+---
+
+## Pre-read (grounding the implementer)
+
+The quantizer is `crates/hipfire-quantize/src/main.rs` (~6k lines, CPU). Key facts (verify, don't trust):
+- It ALWAYS reads original safetensors (fp16/bf16) via `SafetensorsFile` (`main.rs:88`, `tensor_data()` `:117`, `to_f32()` `:235`). FP8 ds4 weights pair `.weight`+`.scale` (`tensor_to_f32_with_optional_fp8_scale`, called ~`:5683`).
+- Per-tensor encoders are free fns taking f32: `quantize_q8f16(&[f32])` (`:700`), `quantize_mq4g256(&[f32],&signs1,&signs2)` (`:819`), `quantize_mq6g256` (`:862`), `quantize_hfq4g256(&[f32])` (`:957`), `quantize_hfq3g256` (`:2710`), `quantize_mq2g256_lloyd(&[f32],&s1,&s2)` (`:2398`). FWHT signs are deterministic: `gen_fwht_signs(seed, 256)` (`:5685` uses seeds 42 / 1042). Lloyd codebooks are LOCAL per 256-group (self-calibrating; no imatrix needed for the plain variants).
+- The quantize loop is `for (name, file_idx) in &all_tensors {` (`:5628`); each branch computes f32, calls a `quantize_*`, pushes `HfqTensor { name, quant_type, shape, group_size, data, spilled_len }`, `continue`s. Final `write_hfq(...)` (`:3398`) writes the whole `hfq_tensors: Vec<HfqTensor>` and accepts an ARBITRARY subset (no full-model assumption).
+- `QuantType` enum + the qt byte codes are in the writer/`hfq.rs` (e.g. Q8F16=3, HFQ4G256=6, MQ4G256=13, MQ2G256Lloyd=19). `HfqTensor` struct is defined in `main.rs` (grep `struct HfqTensor`).
+- `ReapPlan` (from `hipfire-reap`) exposes `quant_overrides: Vec<QuantOverride>` where `QuantOverride { layer: usize, role: Role, experts: Vec<u32>, tier: String }`, `Role ∈ {RoutedExperts, SharedExpert, Attention, Router, LmHead, Embed}`. Load via `ReapPlan::load_any(dir, num_layers, orig_experts)` — but the quantizer may not know `num_layers`/`orig_experts` up front; see Task 3 for loading without the model's counts (use a lenient loader).
+
+---
+
+### Task 1: Add `hipfire-reap` dep + a lenient plan loader for the quantizer
+
+The quantizer reads the plan BEFORE it knows the model's layer/expert counts (those come from the safetensors). Add a `ReapPlan::load_unchecked(dir)` that parses without cross-validating against model counts (validation of indices vs the actual model happens when tensors are matched).
+
+**Files:**
+- Modify: `crates/hipfire-quantize/Cargo.toml`
+- Modify: `crates/hipfire-reap/src/plan.rs` (add `load_unchecked`)
+- Test: inline in `plan.rs`
+
+- [ ] **Step 1: Add the dep**
+
+In `crates/hipfire-quantize/Cargo.toml` `[dependencies]`: `hipfire-reap = { path = "../hipfire-reap" }`. Verify it builds: `cargo build -p hipfire-quantize` (may be slow; that's fine).
+
+- [ ] **Step 2: Write the failing test for `load_unchecked`**
+
+In `crates/hipfire-reap/src/plan.rs` `#[cfg(test)]`:
+```rust
+#[test]
+fn load_unchecked_parses_without_model_counts() {
+    let d = write_plan(
+        r#"{"original_experts":256,"num_layers":43,
+            "quant_overrides":[{"layer":20,"role":"routed_experts","experts":[7,12],"tier":"mq3lloyd"},
+                               {"layer":41,"role":"attention","tier":"q8"}]}"#,
+    );
+    let p = ReapPlan::load_unchecked(d.path().to_str().unwrap()).unwrap();
+    assert_eq!(p.original_experts, 256);
+    assert_eq!(p.num_layers, 43);
+    assert_eq!(p.quant_overrides.len(), 2);
+    assert_eq!(p.quant_overrides[0].tier, "mq3lloyd");
+    assert_eq!(p.quant_overrides[0].experts, vec![7, 12]);
+}
+```
+(`write_plan` already exists in this module's tests.)
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `cargo test -p hipfire-reap load_unchecked` → FAIL (`load_unchecked` not found).
+
+- [ ] **Step 4: Implement `load_unchecked`**
+
+In `crates/hipfire-reap/src/plan.rs`, add a method that reads `reap_plan.json`, parses `original_experts`/`num_layers`/`keep`/`quant_overrides` using the SAME field-parsing as `load`, but takes the model counts FROM the json (not from caller args) and skips the `!= expected` cross-checks. Factor the shared field-parsing so `load` and `load_unchecked` don't duplicate (extract a private `fn parse_value(v: &serde_json::Value, dir: &str) -> Result<Self, String>` that both call; `load` then additionally asserts `original_experts == orig_experts_expected` and `num_layers == num_layers_expected`). Keep the per-override validations (non-integer experts → Err, experts-on-non-routed-role → Err). Expert-index-vs-original bounds: keep the existing check against the plan's own `original_experts`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p hipfire-reap` → all prior tests + `load_unchecked_parses_without_model_counts` pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hipfire-reap/src/plan.rs crates/hipfire-quantize/Cargo.toml
+git commit -m "feat(reap): ReapPlan::load_unchecked for the quantizer; quantize dep"
+```
+
+---
+
+### Task 2: `quantize_to_format` — reusable per-tensor encoder dispatch
+
+A single fn mapping a tier name → the right existing `quantize_*` call, returning an `HfqTensor`. This is the DRY core both overlay and (later) bake reuse.
+
+**Files:**
+- Create: `crates/hipfire-quantize/src/reap_overlay.rs`
+- Modify: `crates/hipfire-quantize/src/main.rs` (add `mod reap_overlay;`, make the needed `quantize_*` fns + `HfqTensor`/`QuantType` reachable — `pub(crate)` if not already)
+- Test: inline `#[cfg(test)]` in `reap_overlay.rs`
+
+- [ ] **Step 1: Write the failing byte-equivalence test**
+
+`crates/hipfire-quantize/src/reap_overlay.rs`:
+```rust
+//! SP4: selective re-quant overlay builder. See
+//! docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md §3.
+use crate::{HfqTensor, QuantType, quantize_q8f16, quantize_hfq4g256, quantize_hfq6g256,
+            quantize_mq4g256, quantize_mq6g256, gen_fwht_signs};
+// NOTE: adjust the import list / paths to the ACTUAL symbol names + visibility in main.rs.
+// If a `quantize_hfq6g256` free fn doesn't exist, find the real HFQ6 encoder and use it.
+
+/// Quantize one tensor's f32 data to the named tier, returning the HFQ tensor.
+/// Covers the self-calibrating tiers usable in an overlay without an imatrix.
+/// `shape` is the row-major tensor shape (e.g. `[rows, cols]`).
+pub fn quantize_to_format(
+    name: &str,
+    fmt: &str,
+    f32_data: &[f32],
+    shape: &[usize],
+) -> Result<HfqTensor, String> {
+    let shape_u32: Vec<u32> = shape.iter().map(|&s| s as u32).collect();
+    let (qt, gs, data) = match fmt {
+        "q8" | "q8f16" => (QuantType::Q8F16, 0u32, quantize_q8f16(f32_data)),
+        "hfq4" | "hfq4g256" => (QuantType::HFQ4G256, 256, quantize_hfq4g256(f32_data)),
+        "hfq6" | "hfq6g256" => (QuantType::HFQ6G256, 256, quantize_hfq6g256(f32_data)),
+        "mq4" | "mq4g256" => {
+            let (s1, s2) = (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
+            (QuantType::MQ4G256, 256, quantize_mq4g256(f32_data, &s1, &s2))
+        }
+        "mq6" | "mq6g256" => {
+            let (s1, s2) = (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
+            (QuantType::MQ6G256, 256, quantize_mq6g256(f32_data, &s1, &s2))
+        }
+        other => return Err(format!("reap: unsupported overlay tier '{other}' for {name}")),
+    };
+    Ok(HfqTensor { name: name.to_string(), quant_type: qt, shape: shape_u32,
+                   group_size: gs, data, spilled_len: 0 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn matches_underlying_encoder_byte_for_byte() {
+        // 512 f32 (two 256-groups) of varied values.
+        let f32: Vec<f32> = (0..512).map(|i| ((i as f32) * 0.013).sin()).collect();
+        let direct = quantize_hfq4g256(&f32);
+        let t = quantize_to_format("x", "hfq4g256", &f32, &[2, 256]).unwrap();
+        assert_eq!(t.data, direct, "overlay encode must equal direct encode");
+        assert_eq!(t.shape, vec![2u32, 256]);
+        assert_eq!(t.quant_type, QuantType::HFQ4G256);
+    }
+    #[test]
+    fn mq4_matches_with_canonical_signs() {
+        let f32: Vec<f32> = (0..256).map(|i| (i as f32) * 0.5 - 64.0).collect();
+        let (s1, s2) = (gen_fwht_signs(42, 256), gen_fwht_signs(1042, 256));
+        let direct = quantize_mq4g256(&f32, &s1, &s2);
+        let t = quantize_to_format("x", "mq4", &f32, &[1, 256]).unwrap();
+        assert_eq!(t.data, direct);
+    }
+    #[test]
+    fn rejects_unknown_tier() {
+        let err = quantize_to_format("x", "bogus", &[0.0; 256], &[1, 256]).unwrap_err();
+        assert!(err.contains("unsupported overlay tier 'bogus'"), "got: {err}");
+    }
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p hipfire-quantize reap_overlay::` → FAIL (module/symbols missing).
+
+- [ ] **Step 3: Wire visibility + module**
+
+Add `mod reap_overlay;` to `main.rs`. The `quantize_*` fns + `gen_fwht_signs` + `HfqTensor` + `QuantType` are currently private to `main.rs`; mark each one this file imports as `pub(crate)`. Find the REAL names: grep `fn quantize_` and `enum QuantType` / `struct HfqTensor`. If `quantize_hfq6g256` doesn't exist as a free fn (HFQ6 may be produced via a different code path), either add a thin free fn wrapping the real HFQ6 encoder or map `"hfq6"` to whatever the real entry point is — match the byte output the full quantizer would produce for `--format hfq6`. Add the Lloyd tiers (`mq2lloyd`/`mq3lloyd`/`mq4lloyd`) by mapping to the real `quantize_mq*g256_lloyd` fns (signs seeds 42/1042 as the loop uses); if an mq3-lloyd encoder needs args you can't supply context-free, add it to the match with the correct call and extend the tests.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p hipfire-quantize reap_overlay::` → 3 tests pass (byte-equivalence proves the overlay encode is identical to the full quantizer's encode).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/hipfire-quantize/src/reap_overlay.rs crates/hipfire-quantize/src/main.rs
+git commit -m "feat(reap): quantize_to_format encoder-dispatch for overlay (byte-equiv tested)"
+```
+
+---
+
+### Task 3: `reap_override_for` — arch-aware tensor → target-tier resolver
+
+Given a tensor name + the plan, return the override tier (or None). Encapsulates the per-arch role+layer+expert → tensor-name matching.
+
+**Files:**
+- Modify: `crates/hipfire-quantize/src/reap_overlay.rs`
+- Test: inline
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `reap_overlay.rs`:
+```rust
+use hipfire_reap::plan::{ReapPlan, Role};
+
+/// Detected arch family for tensor-name matching (the quantizer already knows
+/// the arch_id; pass the matching variant in).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ReapArch { Deepseek4, Qwen35, Lfm2Moe, Minimax }
+
+/// Resolve a tensor name to its override tier under `plan`, or None.
+/// Matches by (layer, role, [expert]) using the arch's tensor naming.
+pub fn reap_override_for<'a>(name: &str, arch: ReapArch, plan: &'a ReapPlan) -> Option<&'a str> {
+    for ov in &plan.quant_overrides {
+        if tensor_matches(name, arch, ov) {
+            return Some(ov.tier.as_str());
+        }
+    }
+    None
+}
+
+fn tensor_matches(name: &str, arch: ReapArch, ov: &hipfire_reap::plan::QuantOverride) -> bool {
+    // Layer gate: the name must reference `ov.layer`. All four arches embed the
+    // layer index as `.layers.{L}.` or `layers.{L}.`.
+    let layer_tok_a = format!("layers.{}.", ov.layer);
+    if !name.contains(&layer_tok_a) { return false; }
+    match ov.role {
+        Role::RoutedExperts => {
+            let (seg, w_ok): (&str, fn(&str) -> bool) = match arch {
+                ReapArch::Deepseek4 => (".ffn.experts.", |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight")),
+                ReapArch::Qwen35    => (".mlp.experts.", |n| n.ends_with(".gate_up_proj.weight") || n.ends_with(".down_proj.weight")),
+                ReapArch::Lfm2Moe   => (".feed_forward.experts.", |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight")),
+                ReapArch::Minimax   => (".block_sparse_moe.experts.", |n| n.ends_with(".w1.weight") || n.ends_with(".w2.weight") || n.ends_with(".w3.weight")),
+            };
+            if !name.contains(seg) || !w_ok(name) { return false; }
+            if ov.experts.is_empty() { return true; } // whole role at this layer
+            // expert index: the token right after `seg`
+            let after = &name[name.find(seg).unwrap() + seg.len()..];
+            let eidx: u32 = match after.split('.').next().and_then(|s| s.parse().ok()) {
+                Some(e) => e, None => return false,
+            };
+            ov.experts.contains(&eidx)
+        }
+        Role::Attention => name.contains(".self_attn.") || name.contains(".attn.") || name.contains(".attention."),
+        Role::Router => name.contains(".gate.weight") || name.contains(".router") || name.contains(".gate.tid2eid"),
+        Role::SharedExpert => name.contains(".shared_expert") || name.contains(".shared_experts"),
+        Role::LmHead => name.contains("lm_head") || name.contains("output.weight"),
+        Role::Embed => name.contains("embed_tokens") || name.contains("tok_embeddings"),
+    }
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+    fn plan_with(json: &str) -> ReapPlan {
+        // write to a tempdir & load_unchecked
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("reap_plan.json"), json).unwrap();
+        ReapPlan::load_unchecked(d.path().to_str().unwrap()).unwrap()
+    }
+    #[test]
+    fn ds4_specific_experts() {
+        let p = plan_with(r#"{"original_experts":256,"num_layers":43,
+            "quant_overrides":[{"layer":20,"role":"routed_experts","experts":[7],"tier":"mq3lloyd"}]}"#);
+        assert_eq!(reap_override_for("layers.20.ffn.experts.7.w1.weight", ReapArch::Deepseek4, &p), Some("mq3lloyd"));
+        assert_eq!(reap_override_for("layers.20.ffn.experts.8.w1.weight", ReapArch::Deepseek4, &p), None); // wrong expert
+        assert_eq!(reap_override_for("layers.21.ffn.experts.7.w1.weight", ReapArch::Deepseek4, &p), None); // wrong layer
+    }
+    #[test]
+    fn qwen35_whole_role() {
+        let p = plan_with(r#"{"original_experts":128,"num_layers":48,
+            "quant_overrides":[{"layer":5,"role":"routed_experts","tier":"hfq6"}]}"#);
+        assert_eq!(reap_override_for("model.layers.5.mlp.experts.99.gate_up_proj.weight", ReapArch::Qwen35, &p), Some("hfq6"));
+        assert_eq!(reap_override_for("model.layers.5.mlp.experts.99.down_proj.weight", ReapArch::Qwen35, &p), Some("hfq6"));
+        assert_eq!(reap_override_for("model.layers.5.self_attn.q_proj.weight", ReapArch::Qwen35, &p), None);
+    }
+    #[test]
+    fn attention_role() {
+        let p = plan_with(r#"{"original_experts":256,"num_layers":43,
+            "quant_overrides":[{"layer":41,"role":"attention","tier":"q8"}]}"#);
+        assert_eq!(reap_override_for("model.layers.41.self_attn.q_proj.weight", ReapArch::Qwen35, &p), Some("q8"));
+        assert_eq!(reap_override_for("model.layers.40.self_attn.q_proj.weight", ReapArch::Qwen35, &p), None);
+    }
+}
+```
+Add `tempfile` to `crates/hipfire-quantize` `[dev-dependencies]` if not present.
+
+- [ ] **Step 2: Run to confirm fail, then it should pass once compiled**
+
+Run: `cargo test -p hipfire-quantize reap_overlay` → the `resolve_tests` pass. If `Role`/`QuantOverride` field names differ, fix imports to the real `hipfire-reap` API.
+
+- [ ] **Step 3: Verify the ds4 expert-index parse against real names**
+
+The ds4 expert token-after-`seg` parse assumes `...experts.{E}.w1.weight`. Confirm against a real ds4 tensor name (grep the quantizer's ds4 branch ~`:5848`). Adjust `split('.').next()` if the real layout differs (e.g. an extra segment).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/hipfire-quantize/src/reap_overlay.rs crates/hipfire-quantize/Cargo.toml
+git commit -m "feat(reap): reap_override_for arch-aware tensor->tier resolver"
+```
+
+---
+
+### Task 4: `--reap-overlay` CLI mode — emit the subset overlay.hfq
+
+Wire it into the quantizer: a new mode that, instead of the full quantize, loops the model tensors, quantizes ONLY the overridden ones via `quantize_to_format`, and writes `overlay.hfq`.
+
+**Files:**
+- Modify: `crates/hipfire-quantize/src/main.rs` (arg parse + the mode branch)
+- Modify: `crates/hipfire-quantize/src/reap_overlay.rs` (a `build_overlay` driver if cleaner)
+- Test: an integration-style test (see Step 4) + manual smoke
+
+- [ ] **Step 1: Add the CLI args**
+
+In the arg parsing (near `--format` at `main.rs:4715`), add `--reap-overlay <plan-dir>` and `--reap-out <overlay.hfq path>` and `--reap-arch <deepseek4|qwen35|lfm2moe|minimax>` (or detect from arch_id already resolved). When `--reap-overlay` is set, the quantizer enters overlay mode (skip the normal whole-model write).
+
+- [ ] **Step 2: Implement the overlay loop**
+
+Add a function (in `reap_overlay.rs`) the main flow calls when overlay mode is active:
+```rust
+pub fn build_overlay(
+    arch: ReapArch,
+    plan: &ReapPlan,
+    // an iterator yielding (name, shape, f32_data) for the model's tensors —
+    // the caller (main.rs) provides this from the already-open SafetensorsFile(s),
+    // reusing tensor_to_f32_with_optional_fp8_scale for each tensor it decides to emit.
+    tensors: impl Iterator<Item = (String, Vec<usize>, Vec<f32>)>,
+) -> Result<Vec<HfqTensor>, String> {
+    let mut out = Vec::new();
+    for (name, shape, f32) in tensors {
+        if let Some(fmt) = reap_override_for(&name, arch, plan) {
+            out.push(quantize_to_format(&name, fmt, &f32, &shape)?);
+        }
+    }
+    Ok(out)
+}
+```
+In `main.rs`, the overlay branch iterates `all_tensors`, and for each tensor checks `reap_override_for(name, arch, &plan).is_some()` BEFORE doing the expensive f32 decode — only decode+quantize the matched ones (the whole point: skip the rest). Reuse `tensor_to_f32_with_optional_fp8_scale`. Collect into `hfq_tensors`, then call the existing `write_hfq(&reap_out_path, &hfq_tensors, ...)` (match `write_hfq`'s real signature — it also writes metadata; for an overlay, pass minimal/empty metadata or copy the base's arch_id, whichever `write_hfq` requires — read its signature).
+
+- [ ] **Step 3: Guard: error if no overrides matched**
+
+If `hfq_tensors` is empty after the loop, return an error: `"reap overlay: no tensors matched the plan's quant_overrides (check arch/layer/expert names)"`. A silent empty overlay is a footgun.
+
+- [ ] **Step 4: Integration test (CPU) — overlay bytes == full-quant bytes for the same tensor**
+
+Add a test under `crates/hipfire-quantize/tests/reap_overlay_integ.rs` that:
+1. Builds a tiny synthetic safetensors file in a tempdir with ~3 named tensors matching a known arch (e.g. `layers.0.ffn.experts.0.w1.weight` shape `[4,256]` fp16, plus a non-matching `layers.0.self_attn.q_proj.weight`).
+2. Writes a `reap_plan.json` overriding `layer 0 routed_experts expert 0 → hfq4g256`.
+3. Runs `build_overlay` over the tensors and asserts: (a) exactly the 1 matched tensor is emitted, (b) its bytes equal `quantize_hfq4g256(f32_of_that_tensor)` directly, (c) reading the written `overlay.hfq` back via `hipfire_runtime::hfq::HfqFile` yields that tensor by name with the right quant_type.
+If constructing a synthetic safetensors is heavy, test `build_overlay` directly with a hand-built tensor iterator (skip the file round-trip for the loop logic; still round-trip `write_hfq`→`HfqFile` for the container).
+
+- [ ] **Step 5: Run + manual smoke**
+
+Run: `cargo test -p hipfire-quantize reap_overlay` (unit + integ). Then a real smoke if a model is handy (CPU): `cargo run --release -p hipfire-quantize -- --reap-overlay <plan-dir> --reap-arch deepseek4 --reap-out /tmp/overlay.hfq <model-dir>` and confirm it writes only the overridden tensors (inspect with `HfqFile::tensor_names()`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/hipfire-quantize/src/main.rs crates/hipfire-quantize/src/reap_overlay.rs crates/hipfire-quantize/tests/reap_overlay_integ.rs
+git commit -m "feat(reap): --reap-overlay mode emits subset overlay.hfq (CPU, byte-verified)"
+```
+
+---
+
+### Task 5: Docs
+
+**Files:**
+- Modify: `scripts/reap/README.md`
+
+- [ ] **Step 1: Document the overlay workflow**
+
+Add a "Selective re-quant (overlay)" section: the `--reap-overlay` invocation, that it reads the ORIGINAL safetensors (so up-quant recovers precision), the supported tiers (`q8`, `hfq4/6`, `mq4/6`, lloyd variants), that the overlay is consumed at load by SP3 (`HIPFIRE_REAP_PLAN` with an `overlay.hfq` in the dir), and that per-expert-within-a-layer overlays need SP2 to serve (per-layer-uniform serve via existing dispatch).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/reap/README.md
+git commit -m "docs(reap): selective re-quant overlay workflow"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§3 `reap quant`):**
+- Re-quantize only targeted tensors from original safetensors → Task 4 (`build_overlay` decodes/quantizes only matched). ✓
+- Write small `overlay.hfq` keyed by original tensor names → Task 4 (`write_hfq` subset). ✓
+- Reuse existing per-format encoders → Task 2 (`quantize_to_format` dispatches to `quantize_*`). ✓
+- Per-expert + whole-role targeting → Task 3 (`reap_override_for`, `experts` empty = whole role). ✓
+- `reap bake` → **explicitly deferred to SP4b** (noted up front). ✓ (gap is intentional, documented)
+
+**Placeholder scan:** Tasks 2/3 say "find the REAL symbol names / adjust to actual API" — these are genuine grep-and-match steps against a known file (`main.rs`), with concrete fallbacks given, not hand-waving. The encoder set in `quantize_to_format` is concrete; lloyd-tier wiring is the one spot needing the implementer to locate the real `quantize_mq3g256_lloyd` entry (flagged with a fallback). Acceptable.
+
+**Type consistency:** `quantize_to_format(name, fmt, &[f32], &[usize]) -> Result<HfqTensor>`, `reap_override_for(name, ReapArch, &ReapPlan) -> Option<&str>`, `ReapArch` enum, `build_overlay(...) -> Vec<HfqTensor>`, `ReapPlan::load_unchecked` — names consistent across Tasks 1–4. `HfqTensor` field names (`name/quant_type/shape/group_size/data/spilled_len`) taken from the real `:5691` push — implementer must confirm.
+
+**Known follow-ups:** SP4b (bake + prune/renumber); imatrix-weighted lloyd tiers in overlays (pass `--imatrix` through); SP3 makes overlays loadable; SP2 makes intra-layer-mixed overlays serveable.

--- a/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp4b-bake.md
+++ b/docs/superpowers/plans/2026-06-11-generic-moe-reap-sp4b-bake.md
@@ -1,0 +1,209 @@
+# Generic MoE REAP — SP4b: Bake to Standalone .hfq — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `hipfire reap bake`: a full-model quantize from the original safetensors that applies a reap plan's `quant_overrides` per-tensor AND (optionally) prunes/renumbers experts per the plan's keep-map, producing a standalone `.hfq` that serves through the normal load path with NO env var — the "freeze once happy" step.
+
+**Architecture:** Reuse the existing whole-model quantize loop in `hipfire-quantize`. Two additive hooks: (1) an **override hook** at the top of the per-tensor loop body — if `reap_override_for(name)` returns a tier, quantize via `quantize_to_format` (SP4a) and skip the arch's default branch; otherwise fall through to the normal quantize. (2) a **prune hook** — for routed-expert tensors, skip experts not in `keep[L]` and rename kept experts to compact slots; gather router/per-expert-bias rows to the kept set. The expert count in the output metadata is reduced to the kept count. Unlike SP4a's overlay (subset only), bake emits the WHOLE model.
+
+**Tech Stack:** Rust, `hipfire-quantize` (CPU), `hipfire-reap` (`ReapPlan`, `reap_override_for`, `quantize_to_format`, `gather_rows`). No GPU.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md` §3 (`reap bake`).
+
+> **CPU-verifiable.** Anchor test: a bake with NO overrides + NO keep (keep-all) must be **byte-identical** to the normal `--format <base>` quantize of the same model (bake is a pure superset hook). Override and prune are verified by targeted tests. Serving a baked model whose experts mix tiers within a layer still needs SP2 to run on GPU; a uniform-tier or per-layer-tier baked model serves through existing dispatch.
+
+**Scope notes:**
+- **ds4 hash-layer `tid2eid` remap under prune is DEFERRED** (a follow-up): pruning a deepseek4 model's hash layers (0–2) requires rewriting `tid2eid` to the compact expert space (the logic exists in `scripts/reap/build_reap_keepmap.py`). This plan prunes score-layer experts + non-ds4 arches correctly; a ds4 bake with `keep` errors out on hash layers with a clear "tid2eid remap not yet supported in bake — use load-time keep-map" message rather than producing a wrong model. Override-bake (no prune) works for ds4.
+- Imatrix-weighted lloyd override tiers: `quantize_to_format` covers the self-calibrating tiers; an override to an imatrix-calibrated tier is out of scope (overlay/bake both use the self-calibrating encoders).
+
+---
+
+### Task 1: `--reap-bake` mode + per-tensor override application (no prune yet)
+
+**Files:**
+- Modify: `crates/hipfire-quantize/src/main.rs` (arg parse near `--reap-overlay`; override hook in the loop at `:5628`)
+- Modify: `crates/hipfire-quantize/src/reap_overlay.rs` (rename module concept is fine; add a `bake`-mode flag or reuse helpers)
+- Test: in-module test in `reap_overlay.rs`
+
+- [ ] **Step 1: Add the CLI arg**
+
+Near the `--reap-overlay` parsing, add `--reap-bake <plan-dir>` (mutually exclusive with `--reap-overlay`; error if both). When set, the normal quantize runs to completion BUT with the override hook active and the output written to the normal `--format` output path (or a `--reap-out` path if you reuse that arg). Arch detection reuses `ReapArch::from_arch_id`/`from_flag` (SP4a).
+
+- [ ] **Step 2: Write the failing tests**
+
+In `reap_overlay.rs` tests, add a unit test for the override-decision helper (pure): the bake override hook should, for a tensor matching the plan, return the override tier, and for a non-matching tensor return None (so it flows to normal quantize). This is exactly `reap_override_for` (already tested), so the NEW test is the bake-loop behavior. Since the loop is in `main.rs` (binary, hard to unit-test directly), add an in-module integration test that drives a small `bake_tensors` helper:
+```rust
+/// Apply bake to a stream of (name, shape, f32) tensors: overridden tensors are
+/// quantized to their tier; non-overridden tensors are quantized to `base_fmt`.
+/// (Pruning is Task 2 — this version emits every tensor.)
+pub fn bake_tensors(
+    arch: ReapArch, plan: &ReapPlan, base_fmt: &str,
+    tensors: impl Iterator<Item = (String, Vec<usize>, Vec<f32>)>,
+) -> Result<Vec<HfqTensor>, String> {
+    let mut out = Vec::new();
+    for (name, shape, f32) in tensors {
+        let fmt = reap_override_for(&name, arch, plan).unwrap_or(base_fmt);
+        out.push(quantize_to_format(&name, fmt, &f32, &shape)?);
+    }
+    Ok(out)
+}
+#[cfg(test)]
+mod bake_tests {
+    use super::*;
+    #[test]
+    fn no_override_bakes_all_at_base_fmt() {
+        let p = /* plan_with empty quant_overrides */;
+        let tensors = vec![("layers.0.self_attn.q_proj.weight".into(), vec![1,256], vec![0.3f32;256])];
+        let out = bake_tensors(ReapArch::Qwen35, &p, "q8", tensors.into_iter()).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].quant_type, QuantType::Q8F16);
+        // == direct q8 of the same data
+        assert_eq!(out[0].data, quantize_to_format("x","q8",&vec![0.3f32;256],&[1,256]).unwrap().data);
+    }
+    #[test]
+    fn override_wins_over_base_fmt() {
+        let p = /* plan_with override: layer 0 attention -> hfq6 */;
+        let tensors = vec![("layers.0.self_attn.q_proj.weight".into(), vec![2,256], vec![0.1f32;512])];
+        let out = bake_tensors(ReapArch::Qwen35, &p, "q8", tensors.into_iter()).unwrap();
+        assert_eq!(out[0].quant_type, QuantType::HFQ6G256); // override, not base q8
+    }
+}
+```
+(Use the real `plan_with` helper / `ReapPlan::load_unchecked` from a tempdir as the SP4a tests do. Match `QuantType` variant names.)
+
+- [ ] **Step 3: Run to confirm fail → implement `bake_tensors` → pass**
+
+Run: `cargo test -p hipfire-quantize reap_overlay` → the bake tests pass.
+
+- [ ] **Step 4: Wire the override hook into the real main.rs loop**
+
+At the TOP of the `for (name, file_idx) in &all_tensors` loop body (`:5628`), after the skip filters but BEFORE the arch-specific branches, add (only when bake mode is active):
+```rust
+if let Some(plan) = &reap_bake_plan {
+    if let Some(fmt) = reap_overlay::reap_override_for(name, reap_arch, plan) {
+        let (meta, raw) = st_files[*file_idx].tensor_data(name).unwrap();
+        let f32 = tensor_to_f32_with_optional_fp8_scale(name, raw, meta, &fp8_scale_for, &st_files);
+        let shape: Vec<usize> = meta.shape.iter().map(|&s| s as usize).collect();
+        hfq_tensors.push(reap_overlay::quantize_to_format(name, fmt, &f32, &shape)?);
+        st_files[*file_idx].drop_tensor_pages(name);
+        continue; // skip the normal arch branch for this overridden tensor
+    }
+}
+```
+Non-overridden tensors fall through to the unchanged normal quantize. The final `write_hfq` writes the whole model to the output path. **Default mode (no `--reap-bake`) is untouched** (the hook is behind `if let Some(plan) = &reap_bake_plan`).
+
+- [ ] **Step 5: Anchor test — no-override bake == normal quantize**
+
+Add an in-module integration test: write a tiny synthetic safetensors (or drive the loop's tensor source) for ~2 tensors; run the bake path with an EMPTY-overrides plan and `base_fmt = q8`; assert the resulting `hfq_tensors` bytes equal the normal `--format q8` quantize of the same tensors. (If driving the real main loop in a test is impractical, assert via `bake_tensors` with empty overrides == direct `quantize_to_format(base_fmt)` for each — which the `no_override_bakes_all_at_base_fmt` test already covers at the helper level; note the main-loop hook is exercised by the manual smoke in Step 6.)
+
+- [ ] **Step 6: Manual smoke (CPU, if a model is handy)**
+
+`cargo run --release -p hipfire-quantize -- --reap-bake <plan-dir> --reap-arch qwen35 --format q8 --reap-out /tmp/baked.hfq <model-dir>`; open `/tmp/baked.hfq` with `HfqFile`, confirm the overridden tensors carry the override quant_type and the rest are q8. Note in report whether a model was available.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/hipfire-quantize/src/main.rs crates/hipfire-quantize/src/reap_overlay.rs
+git commit -m "feat(reap): --reap-bake applies quant_overrides over a full quantize (CPU)"
+```
+
+---
+
+### Task 2: Expert pruning + renumber in bake
+
+**Files:**
+- Modify: `crates/hipfire-quantize/src/reap_overlay.rs` (a name-rewrite + keep helper)
+- Modify: `crates/hipfire-quantize/src/main.rs` (prune hook in the loop; reduce expert count in output metadata)
+- Test: in-module
+
+- [ ] **Step 1: Write the failing tests for the prune/rename helper**
+
+```rust
+/// For a routed-expert tensor under an active keep, decide: drop it, or emit it
+/// renamed to its compact slot. Returns None to drop, Some(new_name) to keep.
+/// `keep_l` is keep[layer] (original expert indices in compact-slot order).
+pub fn bake_expert_rename(name: &str, arch: ReapArch, layer: usize, keep_l: &[u32]) -> Option<String> {
+    // parse the expert index E from `name` (arch seg, as reap_override_for does);
+    // if E in keep_l at position `slot`, return name with E replaced by `slot`;
+    // else None (drop).
+}
+#[cfg(test)]
+mod prune_tests {
+    use super::*;
+    #[test]
+    fn renames_kept_expert_to_compact_slot() {
+        // keep[0] = [0,2,3]; original expert 2 -> compact slot 1
+        let n = "layers.0.ffn.experts.2.w1.weight";
+        assert_eq!(bake_expert_rename(n, ReapArch::Deepseek4, 0, &[0,2,3]),
+                   Some("layers.0.ffn.experts.1.w1.weight".to_string()));
+    }
+    #[test]
+    fn drops_pruned_expert() {
+        let n = "layers.0.ffn.experts.5.w1.weight";
+        assert_eq!(bake_expert_rename(n, ReapArch::Deepseek4, 0, &[0,2,3]), None);
+    }
+}
+```
+
+- [ ] **Step 2: Implement `bake_expert_rename`**
+
+Reuse the arch expert-segment + index parse from `reap_override_for`/`tensor_matches` (factor the "extract expert index from name for arch" into a shared `fn expert_index_of(name, arch) -> Option<u32>` so both use it — DRY). Compute `slot = keep_l.iter().position(|&e| e == E)`; if Some, rebuild the name replacing the `E` token with `slot`; if None, return None.
+
+- [ ] **Step 3: Wire the prune hook into the loop**
+
+In the bake branch of the main loop, BEFORE the override hook, for routed-expert tensors when `plan.keep` is Some: determine the tensor's layer (parse `layers.{L}.`) and call `bake_expert_rename`. If None → `continue` (drop; `drop_tensor_pages`). If `Some(new_name)` → use `new_name` as the output `HfqTensor.name` (the override/normal quantize still reads the ORIGINAL tensor bytes, but writes under the compact name). **ds4 hash-layer guard:** if `arch == Deepseek4` and the layer is a hash layer (0,1,2) and `plan.keep` is Some, return a hard error ("tid2eid remap not supported in bake — see scope note") rather than emitting a wrong hash layer.
+
+- [ ] **Step 4: Router + per-expert-bias gather under prune**
+
+For the router/gate weight (`[n_exp, dim]`) and any per-expert bias (`[n_exp]`) at a layer with an active keep: gather the kept rows via `hipfire_reap::gather::gather_rows(&shape, &raw_or_f32_bytes, keep_l)` before quantizing, so the baked router emits logits only for kept experts (mirror the loader's gather, but at quantize time). Quantize the gathered tensor normally. Add a test that the gathered router has `keep_l.len()` rows.
+
+- [ ] **Step 5: Reduce expert count in output metadata**
+
+The output `.hfq` metadata JSON carries the model config (incl. `n_routed_experts`/`num_experts`). Under an active keep, patch that field to `kept_per_layer` in the metadata before `write_hfq`, so the baked model loads with the compact expert count (no env var, no keep-map needed at load). Find where `metadata_json` is built and apply the patch (string/JSON edit of the experts field). Add a test asserting the patched metadata has the reduced count.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p hipfire-quantize reap_overlay` → all prune tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/hipfire-quantize/src/main.rs crates/hipfire-quantize/src/reap_overlay.rs
+git commit -m "feat(reap): bake prunes+renumbers kept experts, gathers router/bias, patches expert count"
+```
+
+---
+
+### Task 3: Docs
+
+**Files:**
+- Modify: `scripts/reap/README.md`
+
+- [ ] **Step 1: Document bake**
+
+Add a "Bake (freeze) — SP4b" subsection under the overlay section: `hipfire-quantize --reap-bake <plan-dir> --format <base> --reap-out final.hfq <safetensors-dir>` produces a standalone `.hfq` that serves with NO env var — `quant_overrides` applied per-tensor, kept experts pruned+renumbered, expert count patched into metadata. Note the ds4-hash-`tid2eid` prune limitation (use load-time keep-map for pruned ds4 hash layers) and that intra-layer-mixed-tier baked models need SP2 to serve.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/reap/README.md
+git commit -m "docs(reap): bake-to-standalone workflow (SP4b)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§3 `reap bake`):**
+- Full-model quantize with per-tensor overrides → Task 1 (override hook). ✓
+- Pruned experts dropped + renumbered to compact slots → Task 2 (`bake_expert_rename` + loop hook). ✓
+- Router/bias gathered to kept set → Task 2 Step 4. ✓
+- Standalone servable .hfq (expert count in metadata) → Task 2 Step 5. ✓
+- Arch sidecars folded in → **ds4 tid2eid prune DEFERRED** (hard-error guard, scope note). ✓ (documented gap)
+- Anchor: no-override+keep-all bake == normal quantize → Task 1 Step 5 (+ helper test). ✓
+
+**Placeholder scan:** Task 1 Step 2 / Task 2 Step 1 test bodies use `/* plan_with ... */` placeholders for plan construction — the implementer fills these with the real `ReapPlan::load_unchecked(tempdir)` pattern already established in SP4a's tests (concrete, same module). Acceptable (references an existing, working helper). No TBDs in logic.
+
+**Type consistency:** `bake_tensors(ReapArch, &ReapPlan, base_fmt, iterator) -> Result<Vec<HfqTensor>>`, `bake_expert_rename(name, ReapArch, layer, &[u32]) -> Option<String>`, `expert_index_of(name, ReapArch) -> Option<u32>` (shared with `reap_override_for`), reuse `quantize_to_format`/`reap_override_for`/`gather_rows`. Consistent with SP4a symbols.
+
+**Known follow-ups:** ds4 hash-layer `tid2eid` remap in bake; imatrix-calibrated override tiers; GPU serve-verify of baked uniform-tier models; SP2 for intra-layer-mixed serve.

--- a/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+++ b/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
@@ -1,0 +1,232 @@
+# Generic MoE REAP — selective expert pruning + selective re-quant
+
+**Date:** 2026-06-11
+**Branch:** `nw_generic_moe_reap` (worktree `~/repos/hipfire-reap`, based off `nw_reap162b_keepmap` @ `43ed446d`)
+**Author:** Nick Woolmer
+
+## Problem
+
+The existing REAP loader (`43ed446d`, branch `nw_reap162b_keepmap`) is **DeepSeek-V4-specific**.
+It lets us emulate a REAP-pruned checkpoint (e.g. 0xSero 162B, 256→144 experts) by
+partial-loading the kept experts from an existing full mq2-lloyd quant — no re-quant —
+via an env-gated keep-map sidecar (`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP`). It validated cleanly
+(keep-all identity reproduces baseline NLL to 10 decimals) and produced the K144 finding
+(full PPL 7.56 vs pruned 17.73).
+
+We want two generalizations:
+
+1. **Generic across all MoE archs.** Any user should be able to selectively reap any MoE
+   model — `deepseek4`, `qwen35`, `cohere2moe`, `lfm2moe`, `minimax` — not just ds4.
+2. **Lightweight selective re-quant.** Selectively up- or down-quant specific layers/experts
+   *without* re-quantizing the whole model, to iterate and fine-tune a quant config cheaply.
+
+## Prior art (reuse, don't duplicate)
+
+- **Existing ds4 REAP loader** (`43ed446d`): `ReapKeepMap` + `from_hfq` env hook in `deepseek4.rs`;
+  per-expert byte row-gather `upload_quant_or_f16_keep` + hash `tid2eid` remap in `arch.rs`;
+  `examples/deepseek4_perplexity.rs` + `scripts/reap/`. This is the foundation we lift.
+- **Mixed-precision K-map** (`docs/superpowers/specs/2026-05-08-mixed-quant-kmap-design.md`,
+  implemented in `hipfire-quantize/src/main.rs`: `enum QuantLevel`, `kmap_resolve_mode`,
+  `Promote6`). This is the *build-time, heuristic* mixed-precision path (tensor role/layer/MoE →
+  level → one new `.hfq`). Our `quant_overrides` is the *explicit, manual* counterpart, and
+  `reap bake` reuses the quantizer's per-format encoders + K-map machinery rather than
+  reimplementing quant math. **Distinction:** K-map promotes by *tensor role* (lm_head, router,
+  edge layers) where tensors are already separately dispatched; our novel runtime work is mixing
+  tiers *among routed experts within a single layer's expert pool*, which needs new dispatch.
+
+## Non-goals
+
+- New mixed-type MoE GEMV kernels (we bucket existing single-tier kernels instead).
+- Prefill grouped-GEMM support for mixed-tier layers (decode/scoring is the target; see §2 scope honesty).
+- Combining REAP with EP (expert-parallel) sharding — kept mutually exclusive, as today.
+
+## Artifacts & contract
+
+Two artifacts per experiment, plus an activation env var.
+
+### A. `reap_plan.json` — metadata/contract (no weight bytes)
+
+```jsonc
+{
+  "version": 1,
+  "model_arch": "deepseek4",        // optional; validated against detected arch
+  "original_experts": 256,          // base per-layer routed count; validated pre-override
+  "num_layers": 43,
+
+  "keep": {                         // OPTIONAL — omit ⇒ no pruning (keep all)
+    "per_layer": [[0,1,5, /* … */ ], /* … */ ]   // kept ORIGINAL indices, compact-slot order
+  },
+
+  "quant_overrides": [              // OPTIONAL — manifest of re-quantized tensors
+    { "layer": 20, "role": "routed_experts", "experts": [7,12], "tier": "mq3lloyd" },
+    { "layer": 41, "role": "attention",                          "tier": "q8"       }
+  ],
+
+  "arch": { "deepseek4": { "tid2eid_layers": [0,1,2] } }  // arch-specific extras
+}
+```
+
+- `role` ∈ `routed_experts | shared_expert | attention | router | lm_head | embed`.
+- `experts` is valid only for `role: routed_experts` (absent ⇒ whole role at that layer).
+- `tier` is a quant-format name the quantizer understands (`q8`, `f16`, `mq2lloyd`,
+  `mq3lloyd`, `mq4lloyd`, `hfq4g256`, `hfq6g256`, …).
+
+### B. `overlay.hfq` — small HFQ sidecar with only the re-quantized tensors
+
+Keyed by the **same tensor names** as the base file (`{prefix}.ffn.experts.7.w1.weight`, …).
+Built by `hipfire reap quant`. Cheap because only targeted tensors are re-quantized.
+
+### Loader resolution rule (the heart of it)
+
+When fetching tensor `N`: check `overlay.hfq` first, else base `.hfq`; then apply keep-gather.
+Dispatch reads each expert's effective tier from the plan to bucket kernels. This reuses the
+existing tensor-by-name HFQ lookup, so all 5 arches get overlay support at the same seam they
+already load from.
+
+### Activation
+
+`HIPFIRE_REAP_PLAN=<dir>` (dir holds `reap_plan.json` + optional `overlay.hfq` + arch sidecars),
+generalizing today's `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP`. Default-off ⇒ untouched base load.
+The old env var is kept as a thin alias (parses into a `keep`-only plan) for back-compat with
+existing ds4 sidecars.
+
+## Decomposition (4 sub-projects, dependency order)
+
+1. **Generic reap keep-map loader** — `hipfire-reap` crate + `ExpertLoaderHook` seam across all
+   5 arches. Independent; extends existing code.
+2. **Mixed-quant dispatch** — `MoeDtypes` per-expert tier vectors + bucketed dispatch. Prereq for
+   per-expert/mixed quant at runtime.
+3. **Load-time quant overlay** — `overlay.hfq` spliced over base at load (fast iterate loop).
+   Depends on 2.
+4. **Offline bake** — quantizer writes a standalone `.hfq` from plan + overlay. Depends on 1+3
+   plan format.
+
+---
+
+## §1 — `hipfire-reap` crate & loader seam (sub-project 1)
+
+**New crate `hipfire-reap`** (deps: `hipfire-runtime` for `HfqFile`/`Gpu`/`DType`; depended on by
+each arch crate). Owns all model-agnostic logic so arch crates stay thin.
+
+- **`ReapPlan`** — parse + validate `reap_plan.json`. Generalizes the ds4 `ReapKeepMap`
+  validation (layer count, `original_experts`, in-range indices, role/expert misuse). Resolves
+  the optional `overlay.hfq` handle.
+- **`TensorSource`** — overlay-then-base resolution: `fn tensor(name) -> (info, bytes)`. Replaces
+  raw `hfq.tensor_data_pread(name)` in arch loaders.
+- **`gather_rows(info, bytes, keep) -> (info', bytes')`** — generalized, arch-free version of ds4
+  `upload_quant_or_f16_keep`. Exact byte gather for row-independent quant (F16/Q8/MQ*-G256);
+  errors on row-coupled formats. Used for router gate/bias and any expert-pruned role.
+- **`ExpertPlan { keep: Option<&[u32]>, tier_of_slot: impl Fn(usize) -> DType }`** per (layer,
+  role) — what the arch loader asks `hipfire-reap` for.
+- **`ReapArchHook`** — callback the plan invokes for arch-specific bits (ds4 `tid2eid` remap +
+  MTP-skip). Only ds4 implements it; `hipfire-reap` never learns about it.
+
+**The seam in each arch** is the existing expert-enumeration loop
+(`for e in 0..n_exp { … pread(experts.{e}…) … }`). It becomes: iterate compact slots, resolve
+`src = keep[slot]`, fetch via `TensorSource`, group the upload **by tier**:
+
+- **Blob-packing arches (deepseek4 `arch.rs:163-333`, minimax `minimax.rs:280-517`):** build
+  **one sub-blob per quant tier present in the layer** instead of one blob/layer. Each expert's
+  pointer-table slot points into its tier's sub-blob (pointer table is already per-expert → no
+  kernel change). Uniform-tier layer ⇒ one sub-blob ⇒ byte-identical to today.
+- **Buffer arches (qwen35 `qwen35.rs:4331-4435`, cohere2moe `cohere2moe.rs:188-237`, lfm2moe
+  `lfm2moe.rs:345-454`):** already one `WeightTensor` (+ `gpu_dtype`) per expert → mixed tiers
+  naturally representable; only change is recording the per-expert tier for dispatch.
+
+**Byte-identical guarantee:** no plan ⇒ original path unchanged. Keep-all + no overrides ⇒ gather
+is identity and single-tier sub-blob equals today's blob. The identity-sidecar test becomes the
+cross-arch regression gate.
+
+**Files touched:** new `crates/hipfire-reap/`; `arch.rs`/`*.rs` expert loops in all 5 arch crates;
+`deepseek4.rs` env hook → delegate to `hipfire-reap` + register `ReapArchHook`.
+
+---
+
+## §2 — Mixed-quant dispatch (sub-project 2)
+
+Today `MoeDtypes` (`hipfire-dispatch/src/families/moe.rs:41-50`) carries one `routed_gate_up`/
+`routed_down` `DType` sampled from `expert[0]`; `pipeline/mod.rs:207-435` branches monolithically.
+
+- **Extend `MoeDtypes`** with `per_expert_gate_up: Option<Vec<DType>>` and
+  `per_expert_down: Option<Vec<DType>>`. `None` ⇒ today's uniform path, untouched. `Some(v)` ⇒
+  mixed path. Arch `MoeDtypes` builder fills these from the `ExpertPlan` tier table only when the
+  layer is actually mixed.
+- **`MoeResolution::resolve`** gains `mixed: bool`. Set ⇒ **bucketed path**: group the layer's
+  top-k selected experts by tier; for each tier call the existing single-tier
+  `gemv_*_moe_*_indexed` kernel over that tier's sub-blob + remapped compact indices, accumulating
+  into the same output. 2-3 tiers ⇒ 2-3 launches/layer; uniform layers never enter this path.
+- **Index remapping:** each bucket gets a compact index list (selected experts of that tier) +
+  the tier sub-blob pointer table from §1 — the kernel sees the contiguous-stride layout it
+  already expects. **No kernel signature changes.**
+- **Both decode sites covered:** generic `run_moe_decode` (`pipeline/mod.rs:207`) *and* ds4
+  `run_moe_decode_bias_aware` (`pipeline/mod.rs:604`) / `ffn_hash_routed`
+  (`deepseek4/forward.rs:3505`). The memory flags these as two separate dispatch sites (the
+  all-NaN gotcha) — the bucketing helper lives in `hipfire-dispatch`; both call it.
+
+**Scope honesty:** this targets decode/scoring (PPL/KLD, serve-decode). Prefill grouped-GEMM
+kernels stay single-tier per layer; a mixed layer falls back to per-tier grouped calls, or if a
+tier lacks a prefill kernel (e.g. mq3) that layer is **decode-only** — matching the current mq3
+"score-not-serve" limitation. Spec calls this out; no silent degradation.
+
+---
+
+## §3 — Quant tooling: overlays & bake (sub-projects 3 & 4)
+
+**`hipfire reap quant`** (build an overlay): reads the base `.hfq`; for each `quant_overrides`
+entry re-quantizes only the targeted tensors to `tier`, writing them into `overlay.hfq` under
+their original names. Reuses existing per-format encoders + the K-map `kmap_resolve_mode` path in
+`hipfire-quantize/src/main.rs` — no new quant math. Re-quanting "layer 20 experts 7,12" is
+seconds, not full-model hours. This is the fast iterate loop.
+
+- Per-expert `routed_experts` with `experts: [...]` ⇒ only those experts' `w1/w3/w2` (or
+  `gate_up_proj/down_proj`) rows are re-quantized; the loader tier table marks those slots so §1
+  packs them into the right tier sub-blob and §2 buckets them.
+- Whole-role overrides (attention/router/lm_head/embed) replace the single tensor wholesale.
+
+**`hipfire reap bake`** (freeze to standalone `.hfq`): consumes the same `reap_plan.json` +
+`overlay.hfq` and writes an ordinary servable `.hfq`:
+- pruned experts dropped, kept experts renumbered to compact slots (byte row-gather → disk);
+- overlay tensors written in place of base counterparts;
+- arch sidecars (ds4 `tid2eid`) folded into file metadata so the baked model needs no plan/env at
+  load.
+
+Result loads through the normal path, no env var. Overlay = iterate; bake = freeze once happy.
+Both consume one plan, so what you tuned is exactly what you bake.
+
+---
+
+## §4 — Testing & validation
+
+Per-sub-project gates, anchored on the **identity invariant** (keep-all + no overrides reproduces
+baseline NLL to 10 decimals).
+
+- **SP1 (generic loader):** identity-sidecar test → **cross-arch regression gate**: each of the 5
+  MoE arches must reproduce its no-plan baseline logits (bit-for-bit, or NLL to 10 decimals) under
+  a keep-all plan. Unit tests on `ReapPlan` validation (bad layer counts, out-of-range indices,
+  role/expert misuse) and `gather_rows` exactness (gathered subset == direct per-row reads, for
+  F16/Q8/MQ*-G256).
+- **SP2 (mixed dispatch):** **bucketing-equivalence test** — a layer whose experts are all one
+  tier, routed through the *mixed* path, must match the uniform path exactly (bucketing is a no-op
+  decomposition before any real mixing). Run on both `run_moe_decode` and ds4 bias-aware/hash
+  paths.
+- **SP3 (overlay):** overlay re-quantizing a tensor **to the tier it already is** must reproduce
+  base load (plumbing exact when re-quant is a no-op). Then a real down-quant (one layer mq2→mq3)
+  shows the expected small, *localized* NLL shift via the generalized `scripts/reap` PPL/KLD
+  harness.
+- **SP4 (bake):** baked model must produce **identical logits to the same plan applied via overlay
+  at load** (bake == freeze the overlay path). Baked file loads with no env var and serves through
+  the normal path.
+
+**End-to-end smoke:** reproduce the existing 162B K144 result (full 7.56 vs pruned 17.73 PPL)
+through the new *generic* ds4 path — confirms no regression from the lift.
+
+Each gate is a written assertion before the code (TDD-friendly).
+
+## Open questions / risks
+
+- **`gather_rows` on row-coupled quant:** must hard-error (not silently corrupt) for any format
+  whose rows aren't self-contained. Enumerate which current formats are row-independent up front.
+- **Tier sub-blob count blow-up:** pathological plans (many tiers/layer) multiply sub-blobs +
+  launches. Cap/ warn beyond N tiers per layer.
+- **K-map ↔ overrides precedence:** if a baked model is produced with both `--kmap` and a reap
+  plan, define precedence (proposed: explicit `quant_overrides` win over heuristic `kmap_resolve`).

--- a/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
+++ b/docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md
@@ -16,7 +16,10 @@ via an env-gated keep-map sidecar (`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP`). It validat
 We want two generalizations:
 
 1. **Generic across all MoE archs.** Any user should be able to selectively reap any MoE
-   model — `deepseek4`, `qwen35`, `cohere2moe`, `lfm2moe`, `minimax` — not just ds4.
+   model — not just ds4. Target archs present on the integration base are `deepseek4`,
+   `qwen35`, `lfm2moe`, `minimax`. **`cohere2moe` is currently in-flight on branch
+   `nw_cohere2moe_support` and not yet on master** — it gets the *identical* one-call
+   `ExpertLoaderHook` wiring once it merges; we do not build on that moving branch here.
 2. **Lightweight selective re-quant.** Selectively up- or down-quant specific layers/experts
    *without* re-quantizing the whole model, to iterate and fine-tune a quant config cheaply.
 

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -30,6 +30,33 @@ exact byte ops — no dequant. REAP and EP-sharding are mutually exclusive.
 > all `hipfire-reap` CPU unit tests pass; the 10-decimal NLL gate must be run once
 > the GPU frees. See the SP1 plan's GPU-embargo note.
 
+## Selective re-quant (overlay) — SP4
+
+Iterate a quant config WITHOUT re-quantizing the whole model. The quantizer
+(`hipfire-quantize`, CPU-only) re-quantizes ONLY the tensors named by a reap plan's
+`quant_overrides`, reading the **original fp16/bf16 safetensors** (so *up*-quanting
+recovers precision — it does not dequant the lossy base), and writes a small
+`overlay.hfq` keyed by the same tensor names:
+
+```bash
+hipfire-quantize --reap-overlay <plan-dir> --reap-arch <deepseek4|qwen35|lfm2moe|minimax> \
+                 --reap-out <plan-dir>/overlay.hfq  <original-safetensors-model-dir>
+#   plan-dir holds reap_plan.json with e.g.
+#   "quant_overrides":[{"layer":20,"role":"routed_experts","experts":[7,12],"tier":"mq3lloyd"},
+#                      {"layer":41,"role":"attention","tier":"q8"}]
+```
+
+Supported `tier`s: `q8`, `hfq4`/`hfq6`, `mq4`/`mq6`, and the Lloyd variants
+`mq2lloyd`/`mq3lloyd`/`mq4lloyd` (each byte-identical to what `--format <tier>` would
+emit for that tensor; verified by unit tests). `--reap-arch` is auto-detected from the
+model's arch_id when omitted (minimax must be passed explicitly).
+
+**Consuming the overlay:** the load-time splice (`HIPFIRE_REAP_PLAN=<plan-dir>` with an
+`overlay.hfq` present) is **SP3** (loader prefers overlay tensors over the base). An
+overlay that mixes tiers among experts *within one layer* additionally needs **SP2**
+(GPU bucketed dispatch) to serve; per-layer-uniform overrides serve through existing
+dispatch. The standalone-`.hfq` **bake** is **SP4b** (a follow-on plan).
+
 ## Workflow
 
 ```bash

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -1,0 +1,55 @@
+# REAP keep-map test harness (DeepSeek V4)
+
+Evaluate a **REAP-pruned** DeepSeek-V4 variant (e.g. 0xSero `DeepSeek-V4-Flash-162B`,
+256→144 routed experts) **without re-quantizing** — by partial-loading the kept
+experts out of an existing full quant (`deepseek-v4-flash.mq2lloyd`).
+
+A REAP prune is a *pure expert selection*: the kept experts (and the router rows
+for them) are byte-identical to the full model; only the hash-router `tid2eid`
+tables (layers 0–2) are remapped. So the loader can keep only `keep[l]` experts
+per layer, packed into compact slots `0..kept`, and reproduce the pruned model
+exactly from the full quant.
+
+## Loader hook
+
+`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` activates the keep-map in the ds4 loader
+(`crates/hipfire-arch-deepseek4/src/{deepseek4.rs,arch.rs}`). Default-off ⇒ the
+load path is byte-identical (validated: a keep-all-256 identity sidecar
+reproduces the full baseline NLL to 10 decimals). When active: `n_routed_experts`
+→ kept count; expert blob loads `experts.{keep[l][slot]}`; Q8 gate + F16 bias rows
+are gathered to `keep[l]`; hash `tid2eid` is read from the sidecar. All exact byte
+ops — no dequant.
+
+## Workflow
+
+```bash
+# 1. Build the keep-map sidecar from the pruned repo's reap_plan.json + safetensors
+python3 scripts/reap/build_reap_keepmap.py
+#    -> /data/hipfire-models/reap_keepmap_162B_k144/{keep_by_layer.json, tid2eid_l{0,1,2}.i32}
+
+# 2. (optional) Identity sidecar to validate the machinery is an exact no-op
+python3 scripts/reap/build_keepall_sidecar.py
+#    HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=/data/hipfire-models/reap_keepall_256 ... must == full PPL
+
+# 3. Build the PPL harness
+cargo build --release -p hipfire-arch-deepseek4 --example deepseek4_perplexity
+
+# 4. Run full-vs-pruned PPL + KLD
+scripts/reap/run_ppl_kld.sh 1024 8
+```
+
+`deepseek4_perplexity <model> <corpus> [--ctx N] [--warmup N] [--offset N] [--dump-logits PATH]`
+computes NLL/PPL via `decode_step`; `--dump-logits` writes per-position full-vocab
+logits (`DS4PPL01` format) for `kld_compare.py` (stdlib-only — this box's numpy is
+broken). Set the keep-map env var to score the pruned variant; unset for the full
+baseline.
+
+## Result (0xSero 162B, K144, mq2-lloyd, wikitext2, ctx=1024)
+
+| | full-256 | pruned-144 |
+|---|---|---|
+| PPL | 7.56 | 17.73 |
+| NLL/tok | 2.023 | 2.875 |
+
+KL(full‖pruned) = 1.14 nats, KL(pruned‖full) = 1.64, top-1 agreement = 57.6%.
+The K144 checkpoint is heavily degraded (experimental, partial calibration).

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -1,8 +1,13 @@
-# REAP keep-map test harness (DeepSeek V4)
+# REAP keep-map test harness (generic MoE)
 
-Evaluate a **REAP-pruned** DeepSeek-V4 variant (e.g. 0xSero `DeepSeek-V4-Flash-162B`,
+Evaluate a **REAP-pruned** MoE variant (e.g. 0xSero `DeepSeek-V4-Flash-162B`,
 256→144 routed experts) **without re-quantizing** — by partial-loading the kept
 experts out of an existing full quant (`deepseek-v4-flash.mq2lloyd`).
+
+The keep-map loader is now **arch-generic** (crate `hipfire-reap`), wired into
+`deepseek4`, `qwen35`, `lfm2moe`, `minimax`. Activate on any of them with
+`HIPFIRE_REAP_PLAN=<dir>` (a `reap_plan.json`). `cohere2moe` gets the same wiring
+once it merges to master. See `docs/superpowers/specs/2026-06-11-generic-moe-reap-design.md`.
 
 A REAP prune is a *pure expert selection*: the kept experts (and the router rows
 for them) are byte-identical to the full model; only the hash-router `tid2eid`
@@ -12,13 +17,18 @@ exactly from the full quant.
 
 ## Loader hook
 
-`HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` activates the keep-map in the ds4 loader
-(`crates/hipfire-arch-deepseek4/src/{deepseek4.rs,arch.rs}`). Default-off ⇒ the
-load path is byte-identical (validated: a keep-all-256 identity sidecar
-reproduces the full baseline NLL to 10 decimals). When active: `n_routed_experts`
-→ kept count; expert blob loads `experts.{keep[l][slot]}`; Q8 gate + F16 bias rows
-are gathered to `keep[l]`; hash `tid2eid` is read from the sidecar. All exact byte
-ops — no dequant.
+`HIPFIRE_REAP_PLAN=<dir>` activates the generic keep-map (any wired MoE arch); for
+ds4, the legacy `HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=<dir>` still works as an alias
+(loads a keep-only plan from `keep_by_layer.json`). Default-off ⇒ the load path is
+byte-identical. When active: routed-expert count → kept count; each kept expert is
+loaded/packed from `experts.{keep[l][slot]}`; router/gate (+ per-expert bias, ds4
+hash `tid2eid`) rows are gathered to `keep[l]` via the shared `gather_rows`. All
+exact byte ops — no dequant. REAP and EP-sharding are mutually exclusive.
+
+> ⚠️ The cross-arch **keep-all identity gate** and the ds4 **K144 PPL/KLD smoke**
+> below are **GPU-deferred** (the box's GPU is in use). The loader code compiles and
+> all `hipfire-reap` CPU unit tests pass; the 10-decimal NLL gate must be run once
+> the GPU frees. See the SP1 plan's GPU-embargo note.
 
 ## Workflow
 
@@ -27,9 +37,13 @@ ops — no dequant.
 python3 scripts/reap/build_reap_keepmap.py
 #    -> /data/hipfire-models/reap_keepmap_162B_k144/{keep_by_layer.json, tid2eid_l{0,1,2}.i32}
 
-# 2. (optional) Identity sidecar to validate the machinery is an exact no-op
-python3 scripts/reap/build_keepall_sidecar.py
-#    HIPFIRE_DEEPSEEK4_REAP_KEEPMAP=/data/hipfire-models/reap_keepall_256 ... must == full PPL
+# 2. (optional) Keep-all identity plan to validate the machinery is an exact no-op.
+#    Generic (any arch): emits reap_plan.json for HIPFIRE_REAP_PLAN.
+python3 scripts/reap/build_keepall_sidecar.py --num-layers <L> --num-experts <E> \
+        --arch <name> --out /data/hipfire-models/reap_keepall_<E>
+#    ds4 convenience (also emits tid2eid + legacy keep_by_layer.json):
+python3 scripts/reap/build_keepall_sidecar.py --ds4
+#    Then HIPFIRE_REAP_PLAN=<out> must reproduce that arch's no-plan baseline NLL.
 
 # 3. Build the PPL harness
 cargo build --release -p hipfire-arch-deepseek4 --example deepseek4_perplexity

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -58,8 +58,30 @@ auto-attach is guarded: the overlay's `arch_id` must match the base, and every o
 tensor name must be a subset of the base's (a foreign tensor rejects the overlay, so a
 mismatched plan can't corrupt a load). A per-layer-uniform overlay serves through the
 existing dispatch unchanged; an overlay that mixes tiers among experts *within one
-layer* still needs **SP2** (GPU bucketed dispatch) to serve. The standalone-`.hfq`
-**bake** is **SP4b** (a follow-on plan).
+layer* still needs **SP2** (GPU bucketed dispatch) to serve.
+
+## Bake (freeze) — SP4b DONE
+
+Once a quant config is tuned, bake it into a standalone `.hfq` that serves with NO env
+var. Bake runs a full-model quantize from the original safetensors, applies the plan's
+`quant_overrides` per-tensor, and (if the plan has a `keep` map) prunes + renumbers kept
+experts to compact slots, gathers router/per-expert-bias rows to the kept set, and
+patches the routed-expert count into the output metadata:
+
+```bash
+hipfire-quantize --reap-bake <plan-dir> --reap-arch <arch> --format <base-tier> \
+                 --reap-out final.hfq  <original-safetensors-model-dir>
+# final.hfq loads through the normal path — no HIPFIRE_REAP_PLAN needed.
+```
+
+Anchor invariant: a bake with no `quant_overrides` and no `keep` is byte-identical to a
+plain `--format <base-tier>` quantize. **Limitations:** (1) deepseek4 **hash layers 0–2**
+under a `keep` map require a `tid2eid` remap that bake does not yet do — it hard-errors;
+use the **load-time keep-map** (`HIPFIRE_REAP_PLAN`) for pruned ds4 hash layers, or bake
+overrides only (no prune) for ds4. (2) The metadata expert-count patch writes one global
+field from `keep[0]`, so a *non-uniform-per-layer* keep count isn't fully reflected in
+metadata (per-tensor pruning is still per-layer correct). (3) A baked model that mixes
+tiers among experts *within one layer* needs **SP2** to serve.
 
 ## Workflow
 

--- a/scripts/reap/README.md
+++ b/scripts/reap/README.md
@@ -51,11 +51,15 @@ Supported `tier`s: `q8`, `hfq4`/`hfq6`, `mq4`/`mq6`, and the Lloyd variants
 emit for that tensor; verified by unit tests). `--reap-arch` is auto-detected from the
 model's arch_id when omitted (minimax must be passed explicitly).
 
-**Consuming the overlay:** the load-time splice (`HIPFIRE_REAP_PLAN=<plan-dir>` with an
-`overlay.hfq` present) is **SP3** (loader prefers overlay tensors over the base). An
-overlay that mixes tiers among experts *within one layer* additionally needs **SP2**
-(GPU bucketed dispatch) to serve; per-layer-uniform overrides serve through existing
-dispatch. The standalone-`.hfq` **bake** is **SP4b** (a follow-on plan).
+**Consuming the overlay — SP3 DONE:** the load-time splice is implemented. Set
+`HIPFIRE_REAP_PLAN=<plan-dir>` with an `overlay.hfq` present in that dir, and
+`HfqFile` resolves overlay-then-base automatically — no arch changes required. The
+auto-attach is guarded: the overlay's `arch_id` must match the base, and every overlay
+tensor name must be a subset of the base's (a foreign tensor rejects the overlay, so a
+mismatched plan can't corrupt a load). A per-layer-uniform overlay serves through the
+existing dispatch unchanged; an overlay that mixes tiers among experts *within one
+layer* still needs **SP2** (GPU bucketed dispatch) to serve. The standalone-`.hfq`
+**bake** is **SP4b** (a follow-on plan).
 
 ## Workflow
 

--- a/scripts/reap/build_keepall_sidecar.py
+++ b/scripts/reap/build_keepall_sidecar.py
@@ -1,17 +1,31 @@
 #!/usr/bin/env python3
-# Identity sidecar: keep ALL 256 experts (no pruning), ORIGINAL tid2eid.
-# If the keep-map machinery is correct, running with this must reproduce the
-# full-256 (no-keep-map) PPL exactly — isolates machinery bugs from REAP cost.
-import struct, json, os
+# Keep-ALL identity plan: keep every expert (no pruning). If the generic REAP
+# machinery is correct, loading any MoE arch with HIPFIRE_REAP_PLAN=<out> must
+# reproduce that arch's no-plan baseline NLL to ~10 decimals — isolating
+# machinery bugs from REAP pruning cost. Arch-agnostic.
+#
+# Usage:
+#   build_keepall_sidecar.py --num-layers N --num-experts E --out DIR [--arch NAME]
+#   # ds4 convenience (also emits hash-layer tid2eid sidecars + legacy
+#   # keep_by_layer.json so the HIPFIRE_DEEPSEEK4_REAP_KEEPMAP alias path is
+#   # exercised too):
+#   build_keepall_sidecar.py --ds4 [--out DIR]
+#
+# Emits <out>/reap_plan.json (new generic schema). In --ds4 mode also emits
+# tid2eid_l{L}.i32 (identity, original) and the legacy keep_by_layer.json.
+import argparse, json, os, struct
 
 HUB = "/home/nick/.cache/huggingface/hub"
-OUT = "/data/hipfire-models/reap_keepall_256"
+
+
 def snap(m):
     base = os.path.join(HUB, m, "snapshots")
     return os.path.join(base, sorted(os.listdir(base))[0])
-ORIG = snap("models--deepseek-ai--DeepSeek-V4-Flash")
+
 
 _hc = {}
+
+
 def header_for(root, shard):
     k = (root, shard)
     if k not in _hc:
@@ -19,29 +33,86 @@ def header_for(root, shard):
             n = struct.unpack("<Q", f.read(8))[0]
             _hc[k] = (json.loads(f.read(n)), 8 + n)
     return _hc[k]
+
+
 def read_tensor(root, wm, name):
-    shard = wm[name]; hdr, base = header_for(root, shard); meta = hdr[name]
+    shard = wm[name]
+    hdr, base = header_for(root, shard)
+    meta = hdr[name]
     s, e = meta["data_offsets"]
     with open(os.path.join(root, shard), "rb") as f:
-        f.seek(base + s); return meta["dtype"], meta["shape"], f.read(e - s)
+        f.seek(base + s)
+        return meta["dtype"], meta["shape"], f.read(e - s)
 
-wm = json.load(open(os.path.join(ORIG, "model.safetensors.index.json")))["weight_map"]
-ORIG_EXP, NLAY, HASH = 256, 43, [0, 1, 2]
-os.makedirs(OUT, exist_ok=True)
-keep = [list(range(ORIG_EXP)) for _ in range(NLAY)]
-json.dump({"kept_per_layer": ORIG_EXP, "num_layers": NLAY, "num_hash_layers": len(HASH),
-           "original_experts": ORIG_EXP, "keep": keep},
-          open(os.path.join(OUT, "keep_by_layer.json"), "w"))
 
-DT = {"I64": (8, "<q"), "I32": (4, "<i"), "U32": (4, "<I")}
-for L in HASH:
-    dt, shape, data = read_tensor(ORIG, wm, f"layers.{L}.ffn.gate.tid2eid")
-    esz, fmt = DT[dt]
-    n = 1
-    for s in shape: n *= s
-    vals = [struct.unpack_from(fmt, data, i*esz)[0] for i in range(n)]
-    assert 0 <= min(vals) and max(vals) < ORIG_EXP, f"L{L} range {min(vals)}..{max(vals)}"
-    with open(os.path.join(OUT, f"tid2eid_l{L}.i32"), "wb") as f:
-        f.write(b"".join(struct.pack("<i", v) for v in vals))
-    print(f"  L{L}: orig tid2eid {dt}{shape} range [{min(vals)},{max(vals)}] -> i32 OK")
-print(f"keep-all sidecar written to {OUT}")
+def write_plan(out, arch, num_layers, num_experts):
+    """Write the generic keep-all reap_plan.json (ReapPlan::load schema)."""
+    os.makedirs(out, exist_ok=True)
+    keep = [list(range(num_experts)) for _ in range(num_layers)]
+    plan = {
+        "version": 1,
+        "original_experts": num_experts,
+        "num_layers": num_layers,
+        "keep": {"per_layer": keep},
+    }
+    if arch:
+        plan["model_arch"] = arch
+    with open(os.path.join(out, "reap_plan.json"), "w") as f:
+        json.dump(plan, f)
+    print(f"keep-all reap_plan.json ({num_layers}L x {num_experts}E"
+          f"{', arch=' + arch if arch else ''}) -> {out}")
+
+
+def write_ds4_extras(out, orig_snapshot, num_layers, num_experts, hash_layers):
+    """ds4-only: identity tid2eid sidecars + legacy keep_by_layer.json."""
+    wm = json.load(open(os.path.join(orig_snapshot, "model.safetensors.index.json")))["weight_map"]
+    # Legacy alias schema (load_legacy_keepmap / HIPFIRE_DEEPSEEK4_REAP_KEEPMAP).
+    keep = [list(range(num_experts)) for _ in range(num_layers)]
+    json.dump(
+        {"kept_per_layer": num_experts, "num_layers": num_layers,
+         "num_hash_layers": len(hash_layers), "original_experts": num_experts, "keep": keep},
+        open(os.path.join(out, "keep_by_layer.json"), "w"),
+    )
+    DT = {"I64": (8, "<q"), "I32": (4, "<i"), "U32": (4, "<I")}
+    for L in hash_layers:
+        dt, shape, data = read_tensor(orig_snapshot, wm, f"layers.{L}.ffn.gate.tid2eid")
+        esz, fmt = DT[dt]
+        n = 1
+        for s in shape:
+            n *= s
+        vals = [struct.unpack_from(fmt, data, i * esz)[0] for i in range(n)]
+        assert 0 <= min(vals) and max(vals) < num_experts, f"L{L} range {min(vals)}..{max(vals)}"
+        with open(os.path.join(out, f"tid2eid_l{L}.i32"), "wb") as f:
+            f.write(b"".join(struct.pack("<i", v) for v in vals))
+        print(f"  L{L}: orig tid2eid {dt}{shape} range [{min(vals)},{max(vals)}] -> i32 OK")
+    print(f"ds4 legacy keep_by_layer.json + tid2eid sidecars -> {out}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Build a keep-all identity REAP plan.")
+    ap.add_argument("--num-layers", type=int, help="number of MoE layers")
+    ap.add_argument("--num-experts", type=int, help="routed experts per layer (original count)")
+    ap.add_argument("--arch", default=None, help="optional model_arch tag for the plan")
+    ap.add_argument("--out", default=None, help="output dir for the plan")
+    ap.add_argument("--ds4", action="store_true",
+                    help="DeepSeek-V4-Flash convenience: 43L x 256E + tid2eid + legacy sidecar")
+    ap.add_argument("--ds4-model", default="models--deepseek-ai--DeepSeek-V4-Flash",
+                    help="HF hub dir name for the ds4 original (for tid2eid)")
+    ap.add_argument("--hash-layers", default="0,1,2", help="ds4 hash layer indices (comma-sep)")
+    args = ap.parse_args()
+
+    if args.ds4:
+        num_layers = args.num_layers or 43
+        num_experts = args.num_experts or 256
+        out = args.out or "/data/hipfire-models/reap_keepall_256"
+        hash_layers = [int(x) for x in args.hash_layers.split(",") if x != ""]
+        write_plan(out, "deepseek4", num_layers, num_experts)
+        write_ds4_extras(out, snap(args.ds4_model), num_layers, num_experts, hash_layers)
+    else:
+        if args.num_layers is None or args.num_experts is None or args.out is None:
+            ap.error("--num-layers, --num-experts and --out are required (or use --ds4)")
+        write_plan(args.out, args.arch, args.num_layers, args.num_experts)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reap/build_keepall_sidecar.py
+++ b/scripts/reap/build_keepall_sidecar.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Identity sidecar: keep ALL 256 experts (no pruning), ORIGINAL tid2eid.
+# If the keep-map machinery is correct, running with this must reproduce the
+# full-256 (no-keep-map) PPL exactly — isolates machinery bugs from REAP cost.
+import struct, json, os
+
+HUB = "/home/nick/.cache/huggingface/hub"
+OUT = "/data/hipfire-models/reap_keepall_256"
+def snap(m):
+    base = os.path.join(HUB, m, "snapshots")
+    return os.path.join(base, sorted(os.listdir(base))[0])
+ORIG = snap("models--deepseek-ai--DeepSeek-V4-Flash")
+
+_hc = {}
+def header_for(root, shard):
+    k = (root, shard)
+    if k not in _hc:
+        with open(os.path.join(root, shard), "rb") as f:
+            n = struct.unpack("<Q", f.read(8))[0]
+            _hc[k] = (json.loads(f.read(n)), 8 + n)
+    return _hc[k]
+def read_tensor(root, wm, name):
+    shard = wm[name]; hdr, base = header_for(root, shard); meta = hdr[name]
+    s, e = meta["data_offsets"]
+    with open(os.path.join(root, shard), "rb") as f:
+        f.seek(base + s); return meta["dtype"], meta["shape"], f.read(e - s)
+
+wm = json.load(open(os.path.join(ORIG, "model.safetensors.index.json")))["weight_map"]
+ORIG_EXP, NLAY, HASH = 256, 43, [0, 1, 2]
+os.makedirs(OUT, exist_ok=True)
+keep = [list(range(ORIG_EXP)) for _ in range(NLAY)]
+json.dump({"kept_per_layer": ORIG_EXP, "num_layers": NLAY, "num_hash_layers": len(HASH),
+           "original_experts": ORIG_EXP, "keep": keep},
+          open(os.path.join(OUT, "keep_by_layer.json"), "w"))
+
+DT = {"I64": (8, "<q"), "I32": (4, "<i"), "U32": (4, "<I")}
+for L in HASH:
+    dt, shape, data = read_tensor(ORIG, wm, f"layers.{L}.ffn.gate.tid2eid")
+    esz, fmt = DT[dt]
+    n = 1
+    for s in shape: n *= s
+    vals = [struct.unpack_from(fmt, data, i*esz)[0] for i in range(n)]
+    assert 0 <= min(vals) and max(vals) < ORIG_EXP, f"L{L} range {min(vals)}..{max(vals)}"
+    with open(os.path.join(OUT, f"tid2eid_l{L}.i32"), "wb") as f:
+        f.write(b"".join(struct.pack("<i", v) for v in vals))
+    print(f"  L{L}: orig tid2eid {dt}{shape} range [{min(vals)},{max(vals)}] -> i32 OK")
+print(f"keep-all sidecar written to {OUT}")

--- a/scripts/reap/build_reap_keepmap.py
+++ b/scripts/reap/build_reap_keepmap.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Build the REAP keep-map sidecar for the keep-map-aware ds4 loader.
+# Output:
+#   $OUT/keep_by_layer.json   - {kept_per_layer, num_layers, num_hash_layers, original_experts, keep:[[...]]}
+#   $OUT/tid2eid_l{0,1,2}.i32 - sero's remapped hash tables, raw LE int32, shape [129280,6]
+#   $OUT/MANIFEST.txt         - provenance
+import json, struct, os, sys
+
+HUB = "/home/nick/.cache/huggingface/hub"
+OUT = "/data/hipfire-models/reap_keepmap_162B_k144"
+def snap(m):
+    base = os.path.join(HUB, m, "snapshots")
+    return os.path.join(base, sorted(os.listdir(base))[0])
+SERO = snap("models--0xSero--DeepSeek-V4-Flash-162B")
+
+# ---- dependency-free safetensors reader ----
+_hc = {}
+def header_for(root, shard):
+    key = (root, shard)
+    if key not in _hc:
+        with open(os.path.join(root, shard), "rb") as f:
+            n = struct.unpack("<Q", f.read(8))[0]
+            hdr = json.loads(f.read(n))
+        _hc[key] = (hdr, 8 + n)
+    return _hc[key]
+def read_tensor(root, wm, name):
+    if name not in wm:
+        return None
+    shard = wm[name]
+    hdr, base = header_for(root, shard)
+    meta = hdr[name]
+    s, e = meta["data_offsets"]
+    with open(os.path.join(root, shard), "rb") as f:
+        f.seek(base + s); data = f.read(e - s)
+    return meta["dtype"], meta["shape"], data
+
+wm = json.load(open(os.path.join(SERO, "model.safetensors.index.json")))["weight_map"]
+plan = json.load(open(os.path.join(SERO, "reap_plan.json")))
+keep = plan["keep_maps"]["keep_by_layer"]
+kept = plan["kept_experts_per_layer"]          # 144
+orig = plan["original_experts_per_layer"]      # 256
+hashL = plan["hash_routed_layers"]             # [0,1,2]
+nlay = len(keep)                               # 43
+
+# ---- validate keep map ----
+keep_list = []
+for L in range(nlay):
+    k = keep[str(L)]
+    assert len(k) == kept, f"layer {L}: {len(k)} != {kept}"
+    assert len(set(k)) == kept, f"layer {L}: duplicates"
+    assert min(k) >= 0 and max(k) < orig, f"layer {L}: idx out of range"
+    keep_list.append(k)
+print(f"keep map OK: {nlay} layers x {kept} kept (of {orig}); hash layers {hashL}")
+
+os.makedirs(OUT, exist_ok=True)
+with open(os.path.join(OUT, "keep_by_layer.json"), "w") as f:
+    json.dump({"kept_per_layer": kept, "num_layers": nlay,
+               "num_hash_layers": len(hashL), "original_experts": orig,
+               "keep": keep_list}, f)
+
+# ---- tid2eid for hash layers, from sero (already remapped, 0..kept-1 space) ----
+DT = {"I64": (8, "<q"), "I32": (4, "<i"), "I16": (2, "<h"), "U32": (4, "<I")}
+for L in hashL:
+    t = read_tensor(SERO, wm, f"layers.{L}.ffn.gate.tid2eid")
+    assert t is not None, f"layer {L}: sero missing tid2eid"
+    dt, shape, data = t
+    assert dt in DT, f"layer {L}: unexpected tid2eid dtype {dt}"
+    esz, fmt = DT[dt]
+    n = 1
+    for s in shape: n *= s
+    assert len(data) == n * esz, f"layer {L}: size mismatch"
+    vals = struct.unpack("<" + fmt[1] * n, data) if False else [struct.unpack_from(fmt, data, i*esz)[0] for i in range(n)]
+    vmin, vmax = min(vals), max(vals)
+    assert vmin >= 0 and vmax < kept, f"layer {L}: tid2eid range [{vmin},{vmax}] not in [0,{kept-1}] (NOT slot space!)"
+    out = b"".join(struct.pack("<i", v) for v in vals)
+    with open(os.path.join(OUT, f"tid2eid_l{L}.i32"), "wb") as f:
+        f.write(out)
+    print(f"  layer {L}: tid2eid {dt}{shape} range [{vmin},{vmax}] -> {len(out)}B i32  OK (slot space)")
+
+with open(os.path.join(OUT, "MANIFEST.txt"), "w") as f:
+    f.write(f"source: {SERO}\nbase: {plan['base_model_id']}\n"
+            f"target: {plan['target_label']}\nkept_per_layer: {kept}\n"
+            f"num_layers: {nlay}\nhash_layers: {hashL}\n")
+print(f"\nsidecar written to {OUT}")
+for fn in sorted(os.listdir(OUT)):
+    print(f"  {fn}  ({os.path.getsize(os.path.join(OUT, fn))}B)")

--- a/scripts/reap/kld_compare.py
+++ b/scripts/reap/kld_compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# stdlib-only KLD comparator for two DS4PPL01 logit dumps (no numpy).
+#   usage: kld_stdlib.py <full.logits> <pruned.logits>
+# A = full (reference P), B = pruned (Q).
+import struct, sys, math
+from array import array
+
+def open_dump(p):
+    f = open(p, "rb")
+    assert f.read(8) == b"DS4PPL01", f"{p}: bad magic"
+    vocab = struct.unpack("<I", f.read(4))[0]
+    n = struct.unpack("<I", f.read(4))[0]
+    return f, vocab, n
+
+A, B = sys.argv[1], sys.argv[2]
+fa, va, na = open_dump(A)
+fb, vb, nb = open_dump(B)
+assert va == vb and na == nb, f"mismatch vocab {va}/{vb} n {na}/{nb}"
+V = va
+exp, log, fsum = math.exp, math.log, math.fsum
+
+skl_pq = skl_qp = 0.0
+top1 = 0
+for i in range(na):
+    pa, ta = struct.unpack("<II", fa.read(8))
+    xP = array("f"); xP.frombytes(fa.read(V * 4))
+    pb, tb = struct.unpack("<II", fb.read(8))
+    xQ = array("f"); xQ.frombytes(fb.read(V * 4))
+    assert pa == pb and ta == tb, f"misalign at {i}: pos {pa}/{pb} tgt {ta}/{tb}"
+
+    mP = max(xP); mQ = max(xQ)          # C-level
+    eP = [exp(v - mP) for v in xP]
+    eQ = [exp(v - mQ) for v in xQ]
+    sP = fsum(eP); sQ = fsum(eQ)
+    lseP = mP + log(sP); lseQ = mQ + log(sQ)
+    # KL(P||Q) = (lseQ-lseP) + sum_i P_i (xP_i - xQ_i);  P_i = eP_i / sP
+    accp = fsum(ep * (xp - xq) for ep, xp, xq in zip(eP, xP, xQ))
+    accq = fsum(eq * (xq - xp) for eq, xp, xq in zip(eQ, xP, xQ))
+    skl_pq += (lseQ - lseP) + accp / sP
+    skl_qp += (lseP - lseQ) + accq / sQ
+    if xP.index(mP) == xQ.index(mQ):
+        top1 += 1
+    if (i + 1) % 128 == 0:
+        sys.stderr.write(f"  {i+1}/{na} KL(f||p)={skl_pq/(i+1):.4f}\n")
+
+print(f"positions:               {na}")
+print(f"mean KL(full || pruned): {skl_pq/na:.6f} nats")
+print(f"mean KL(pruned || full): {skl_qp/na:.6f} nats")
+print(f"top-1 argmax agreement:  {top1}/{na} = {100*top1/na:.2f}%")

--- a/scripts/reap/run_ppl_kld.sh
+++ b/scripts/reap/run_ppl_kld.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Full vs REAP-pruned ds4 PPL + KLD comparison (same corpus/offset/ctx/warmup).
+#   usage: scripts/reap/run_ppl_kld.sh [CTX=1024] [WARMUP=8]
+# Requires: target/release/examples/deepseek4_perplexity built, and the keep-map
+# sidecar at $KEEPMAP (see build_reap_keepmap.py). Edit MODEL/CORPUS/KEEPMAP for
+# your box.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+CTX="${1:-1024}"; WARMUP="${2:-8}"
+MODEL="${MODEL:-/data/hipfire-models/deepseek-v4-flash.mq2lloyd}"
+CORPUS="${CORPUS:-benchmarks/quality-baselines/slice/wikitext2-1024s-2048ctx.txt}"
+KEEPMAP="${KEEPMAP:-/data/hipfire-models/reap_keepmap_162B_k144}"
+BIN=./target/release/examples/deepseek4_perplexity
+OUT="${OUT:-/data/hipfire-models/reap_ppl_kld_ctx${CTX}}"
+mkdir -p "$OUT"
+FILT='pre-compiled blob|recompiling'
+
+echo "===== FULL-256 (keep-map OFF) ctx=$CTX ====="
+"$BIN" "$MODEL" "$CORPUS" --ctx "$CTX" --warmup "$WARMUP" \
+    --dump-logits "$OUT/full.logits" 2>&1 | grep -vE "$FILT" | tee "$OUT/full.log"
+
+echo "===== PRUNED-144 (keep-map ON) ctx=$CTX ====="
+HIPFIRE_DEEPSEEK4_REAP_KEEPMAP="$KEEPMAP" "$BIN" "$MODEL" "$CORPUS" --ctx "$CTX" --warmup "$WARMUP" \
+    --dump-logits "$OUT/pruned.logits" 2>&1 | grep -vE "$FILT" | tee "$OUT/pruned.log"
+
+echo "===== KLD (full vs pruned) ====="
+python3 scripts/reap/kld_compare.py "$OUT/full.logits" "$OUT/pruned.logits" | tee "$OUT/kld.txt"
+
+echo "===== SUMMARY (ctx=$CTX) ====="
+fp=$(grep '^PPL:' "$OUT/full.log" | awk '{print $2}')
+pp=$(grep '^PPL:' "$OUT/pruned.log" | awk '{print $2}')
+echo "full-256 PPL=$fp   pruned-144 PPL=$pp"
+# Free the large logit dumps once KLD is computed (keep logs + kld.txt).
+rm -f "$OUT/full.logits" "$OUT/pruned.logits"
+echo "(logit dumps removed; logs + kld.txt kept in $OUT)"


### PR DESCRIPTION
## Summary

The **selective re-quant** half of generic MoE REAP: up/down-quant specific layers/experts **without re-quantizing the whole model**, to iterate a quant config and then freeze it. All CPU-verifiable and verified (the quantizer is CPU-only).

Stacks on **#442** (SP1, the generic keep-map loader) — this PR's *new* content is SP4a + SP3 + SP4b. (Bundled to `master` like #442; the underlying SP1 + reap-162b commits ride along until #442 merges.)

## What's in it

- **SP4a — overlay builder** (`hipfire-quantize --reap-overlay`): re-quantizes ONLY the tensors named by a reap plan's `quant_overrides`, reading the **original fp16/bf16 safetensors** (so up-quant recovers precision), into a small `overlay.hfq`. New `reap_overlay.rs`: `quantize_to_format` (8 tiers — q8/hfq4/hfq6/mq4/mq6/mq2-4 lloyd — each **byte-identical** to `--format <tier>`), `reap_override_for` (arch-aware resolver), `ReapPlan::load_unchecked`.
- **SP3 — load-time splice**: `HfqFile` gains an optional overlay; reads resolve **overlay-then-base**; `HfqFile::open` auto-attaches `<HIPFIRE_REAP_PLAN>/overlay.hfq`, guarded by `arch_id` match **and** overlay-names ⊆ base (rejects a wrong-model overlay). **Zero arch changes** (all arches read through `HfqFile`). The vestigial SP1 `TensorSource` is removed.
- **SP4b — bake** (`--reap-bake`): full-model quantize that applies `quant_overrides` per-tensor and (with a `keep` map) prunes+renumbers kept experts to compact slots, gathers router/per-expert-bias rows, and patches the expert count into metadata → a standalone `.hfq` that serves with no env var.

## Verification (all CPU)

- `hipfire-reap`, `hipfire-runtime`, `hipfire-quantize` test suites green; `reap_overlay` 26 tests incl. byte-equivalence, overlay→load round-trip on real containers, prune/gather/metadata-patch.
- **Anchor invariants:** overlay encode == full-quant encode (byte-for-byte); no-override+no-keep bake == plain `--format` quantize; qwen35 3D-stacked split-loop verified identity under no-keep (no quantization regression).

## Owed / follow-ups

- **GPU-deferred (owed):** SP1's keep-all identity NLL gate + ds4 K144 smoke (GPU was in use). And **serving** a per-layer-uniform overlay/bake (CPU build verified; GPU serve unverified).
- **SP2** (mixed-tier GPU dispatch, for per-expert tiers *within one layer*) is a separate follow-on branch — not in this PR.
- ds4 hash-layer `tid2eid` remap in bake (hard-errors today); imatrix-calibrated override tiers.
- **Note:** commit `3dac6c01` contains a few foreign `main.rs` hunks from an unrelated MQ4-Lloyd workstream that surfaced uncommitted in the worktree (preserved on `wip/mq4lloyd-rescue`); additive/harmless, flagged for awareness.

## Test plan

- [ ] `cargo test -p hipfire-reap -p hipfire-runtime -p hipfire-quantize` (CPU) — green
- [ ] Build an overlay, load with `HIPFIRE_REAP_PLAN`, confirm overridden tensors carry the new tier (GPU serve)
- [ ] Bake a small qwen35/lfm2 model end-to-end; confirm it loads + serves with no env var (GPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)