### PR TITLE
fix(gpu-lock): flock-based stale-proof GPU mutex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,11 +456,22 @@ no committed hook that auto-acquires the lock. (`.claude/settings.json` is not t
 the repo; if you want `cargo` commands to auto-acquire/release, wire a PreToolUse/PostToolUse
 hook in your own local `.claude/settings.json` that sources `scripts/gpu-lock.sh`.)
 
-- Lock file: `/tmp/hipfire-gpu.lock`
-- Contains a human-readable status like `model-ingestion agent is using the gpu`
-- Agents poll every 5s (configurable via `GPU_POLL_INTERVAL`) when the GPU is busy
+- Lock file: `/tmp/hipfire-gpu.lock` (override with `HIPFIRE_GPU_LOCKFILE`)
+- Backed by `flock(1)` held on an open fd, so the **kernel auto-releases the
+  lock when the holder dies for any reason** (kill -9, crash, OOM, terminal
+  close). Stale locks are structurally impossible — **never `rm` the lockfile**
+  (unlinking an flock'd file lets a second acquirer lock a fresh inode → two
+  holders). If validation seems "stuck on a stale lock", it isn't stale: a live
+  holder is genuinely using the GPU — check `gpu_status`.
+- Records `agent pid=… host=… acquired=…` in the file for diagnostics
+- While a live holder is busy, waiters print status every 5s
+  (`GPU_POLL_INTERVAL`) and give up after `GPU_LOCK_TIMEOUT` (default 1800s;
+  `0` = wait forever), exiting non-zero instead of hanging indefinitely
+- `gpu_acquire` is reentrant within a process tree (`HIPFIRE_GPU_LOCK_OWNER`),
+  so nested gates (e.g. `pp-gate` under `speed-gate`) don't self-deadlock
 - Manual usage: `source scripts/gpu-lock.sh && gpu_acquire "<branch>" && gpu_release`
 - Check status: `source scripts/gpu-lock.sh && gpu_status`
+- Regression test (no GPU): `bash scripts/test-gpu-lock.sh`
 
 ## Rules
 

--- a/docs/skills/serve-restart/SKILL.md
+++ b/docs/skills/serve-restart/SKILL.md
@@ -19,8 +19,10 @@ scripts/serve-restart.sh [port] [-- <extra hipfire serve args>]
 Default port 11435. Env honored: `HIPFIRE_MODELS_DIR`, `HIPFIRE_VERIFY_GRAPH`.
 
 It: kills `cli/index.ts serve` + `examples/daemon`, `fuser -k <port>/tcp`,
-removes `~/.hipfire/{daemon,serve}.pid` + `/tmp/hipfire-gpu.lock`, waits
-the port free, relaunches detached, tails to `warm-up complete`.
+removes `~/.hipfire/{daemon,serve}.pid`, waits the port free, relaunches
+detached, tails to `warm-up complete`. (It no longer touches
+`/tmp/hipfire-gpu.lock` — that is an flock'd file the kernel auto-releases
+on holder death; deleting it would break GPU mutual exclusion.)
 
 ## Just kill, don't restart
 

--- a/docs/skills/serve-restart/SKILL.md
+++ b/docs/skills/serve-restart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: serve-restart
-description: Cleanly stop, free the port, and restart `hipfire serve`. Use when serve "Failed to start (port in use)", a stale daemon holds VRAM, an os-error-2/JSON-parse pre-warm crash left a zombie singleton, or you just want a guaranteed-fresh daemon. Kills both bun CLI serve and the spawned target/release/examples/daemon, reaps stale ~/.hipfire/daemon.pid + serve.pid + GPU lock, fuser-frees the port, then relaunches.
+description: Cleanly stop, free the port, and restart `hipfire serve`. Use when serve "Failed to start (port in use)", a stale daemon holds VRAM, an os-error-2/JSON-parse pre-warm crash left a zombie singleton, or you just want a guaranteed-fresh daemon. Kills both bun CLI serve and the spawned target/release/examples/daemon, reaps stale ~/.hipfire/daemon.pid + serve.pid, fuser-frees the port, then relaunches.
 ---
 
 # Cleanly restart hipfire serve

--- a/scripts/gpu-lock.sh
+++ b/scripts/gpu-lock.sh
@@ -5,45 +5,105 @@
 # hipfire — see LICENSE and NOTICE in the project root.
 
 # gpu-lock.sh — GPU mutex for multi-agent coordination
-# Source this in both agent sessions: source gpu-lock.sh
-# Then use: gpu_acquire "model-ingestion" && { run tests; gpu_release; }
+# Source this in an agent session:  source scripts/gpu-lock.sh
+# Then:  gpu_acquire "model-ingestion" && { run tests; gpu_release; }
+#
+# Backed by flock(1): the lock is held on an open file descriptor, so the
+# Linux kernel releases it automatically when the holding process dies for
+# ANY reason — kill -9, crash, OOM, agent cancellation, terminal close.
+# Stale locks are therefore structurally impossible: there is nothing to
+# clean up by hand.
+#
+# IMPORTANT: never `rm` the lockfile. Unlinking a file that a holder has
+# flock'd lets the next acquirer create a *different* inode and lock that
+# too — yielding two simultaneous holders. The file is a permanent fixture;
+# recovery happens in the kernel, not by deleting the file.
 
-LOCKFILE="/tmp/hipfire-gpu.lock"
-POLL_INTERVAL="${GPU_POLL_INTERVAL:-5}"
+LOCKFILE="${HIPFIRE_GPU_LOCKFILE:-/tmp/hipfire-gpu.lock}"
+POLL_INTERVAL="${GPU_POLL_INTERVAL:-5}"          # cadence of "busy" messages (s)
+GPU_LOCK_TIMEOUT="${GPU_LOCK_TIMEOUT:-1800}"     # hard cap (s); 0 = wait forever
+GPU_LOCK_FD=""                                   # set by gpu_acquire (auto-alloc)
 
 gpu_acquire() {
     local agent_name="${1:?usage: gpu_acquire <agent-name>}"
 
-    while true; do
-        # Atomic lock attempt: create file only if it doesn't exist
-        if (set -o noclobber; echo "${agent_name} agent is using the gpu" > "$LOCKFILE") 2>/dev/null; then
-            echo "[gpu-lock] acquired by ${agent_name}"
-            return 0
-        fi
+    if ! command -v flock >/dev/null 2>&1; then
+        echo "[gpu-lock] FATAL: flock(1) not found — refusing to run unlocked" >&2
+        return 3
+    fi
 
-        # Lock held by someone else — report and wait
+    # Reentrancy: an ancestor in this process tree already holds the lock.
+    # Recognise it and no-op so nested gates (e.g. pp-gate) don't deadlock on
+    # their own parent's reservation.
+    if [ -n "${HIPFIRE_GPU_LOCK_OWNER:-}" ]; then
+        echo "[gpu-lock] reentrant: already held by ancestor pid=${HIPFIRE_GPU_LOCK_OWNER}"
+        return 0
+    fi
+
+    # Open (create if missing) WITHOUT truncating, so we don't clobber a live
+    # holder's metadata while we wait. Bash auto-allocates a free fd into
+    # GPU_LOCK_FD; it persists in this shell until gpu_release closes it.
+    exec {GPU_LOCK_FD}<>"$LOCKFILE"
+
+    local waited=0
+    until flock -w "$POLL_INTERVAL" "$GPU_LOCK_FD"; do
+        waited=$(( waited + POLL_INTERVAL ))
         local holder
-        holder=$(cat "$LOCKFILE" 2>/dev/null || echo "unknown")
-        echo "[gpu-lock] busy: ${holder} — retrying in ${POLL_INTERVAL}s"
-        sleep "$POLL_INTERVAL"
+        holder=$(cat "$LOCKFILE" 2>/dev/null || echo unknown)
+        if [ "$GPU_LOCK_TIMEOUT" -gt 0 ] && [ "$waited" -ge "$GPU_LOCK_TIMEOUT" ]; then
+            echo "[gpu-lock] TIMEOUT after ${waited}s; holder still alive: ${holder}" >&2
+            exec {GPU_LOCK_FD}>&-
+            GPU_LOCK_FD=""
+            return 2
+        fi
+        echo "[gpu-lock] busy: ${holder} — waited ${waited}s, still waiting…"
     done
+
+    # We hold it. Record metadata (truncate + write via a separate redirect;
+    # this does not disturb the flock held on $GPU_LOCK_FD).
+    printf '%s pid=%s host=%s acquired=%s\n' \
+        "$agent_name" "$$" "$(hostname)" "$(date -Is 2>/dev/null || date)" > "$LOCKFILE"
+    export HIPFIRE_GPU_LOCK_OWNER="$$"
+    echo "[gpu-lock] acquired by ${agent_name}"
+    return 0
 }
 
 gpu_release() {
-    if [ -f "$LOCKFILE" ]; then
-        local holder
-        holder=$(cat "$LOCKFILE" 2>/dev/null)
-        rm -f "$LOCKFILE"
-        echo "[gpu-lock] released (was: ${holder})"
-    else
+    # Only the process that actually acquired may release. A child that merely
+    # inherited HIPFIRE_GPU_LOCK_OWNER from an ancestor must not release it.
+    if [ -z "${HIPFIRE_GPU_LOCK_OWNER:-}" ]; then
         echo "[gpu-lock] no lock held"
+        return 0
     fi
+    if [ "$HIPFIRE_GPU_LOCK_OWNER" != "$$" ]; then
+        return 0   # reentrant child — the ancestor owns it, leave it be
+    fi
+
+    if [ -n "${GPU_LOCK_FD:-}" ]; then
+        flock -u "$GPU_LOCK_FD" 2>/dev/null
+        exec {GPU_LOCK_FD}>&- 2>/dev/null
+        GPU_LOCK_FD=""
+    fi
+    unset HIPFIRE_GPU_LOCK_OWNER
+    # NB: never rm "$LOCKFILE" — see header.
+    echo "[gpu-lock] released"
 }
 
 gpu_status() {
-    if [ -f "$LOCKFILE" ]; then
-        cat "$LOCKFILE"
-    else
+    if [ ! -e "$LOCKFILE" ]; then
         echo "gpu is free"
+        return 0
+    fi
+    # Probe with a non-blocking flock on a scratch fd. If we can take it,
+    # nobody is holding it — any leftover file content is cosmetic/stale.
+    local probe_fd
+    exec {probe_fd}<>"$LOCKFILE"
+    if flock -n "$probe_fd"; then
+        flock -u "$probe_fd"
+        exec {probe_fd}>&-
+        echo "gpu is free"
+    else
+        exec {probe_fd}>&-
+        echo "gpu BUSY: $(cat "$LOCKFILE" 2>/dev/null)"
     fi
 }

--- a/scripts/gpu-lock.sh
+++ b/scripts/gpu-lock.sh
@@ -21,6 +21,7 @@
 
 LOCKFILE="${HIPFIRE_GPU_LOCKFILE:-/tmp/hipfire-gpu.lock}"
 POLL_INTERVAL="${GPU_POLL_INTERVAL:-5}"          # cadence of "busy" messages (s)
+(( POLL_INTERVAL < 1 )) && POLL_INTERVAL=1        # 0 would make flock -w non-blocking → spin
 GPU_LOCK_TIMEOUT="${GPU_LOCK_TIMEOUT:-1800}"     # hard cap (s); 0 = wait forever
 GPU_LOCK_FD=""                                   # set by gpu_acquire (auto-alloc)
 

--- a/scripts/pp-gate.sh
+++ b/scripts/pp-gate.sh
@@ -492,11 +492,10 @@ if [ "$rebuild" -eq 1 ]; then
 fi
 
 # ── GPU lock ─────────────────────────────────────────────────────────────
-# Only acquire if no caller has already taken it. Otherwise we'd
-# deadlock on the parent's lock — gpu_acquire polls indefinitely and
-# doesn't recognize a parent agent's reservation. Detection: lockfile
-# present at script start.
-if [ -r "$LOCK_SCRIPT" ] && [ ! -f /tmp/hipfire-gpu.lock ]; then
+# gpu_acquire is reentrant: if a parent gate already holds the lock it
+# no-ops (HIPFIRE_GPU_LOCK_OWNER), and gpu_release in this child won't
+# release the ancestor's lock. So acquire unconditionally.
+if [ -r "$LOCK_SCRIPT" ]; then
     # shellcheck disable=SC1090
     . "$LOCK_SCRIPT"
     gpu_acquire "pp-gate" || { echo "could not acquire GPU lock" >&2; exit 2; }

--- a/scripts/serve-restart.sh
+++ b/scripts/serve-restart.sh
@@ -12,7 +12,10 @@ echo "[serve-restart] killing serve/daemon, freeing :$PORT"
 for pat in "cli/index.ts serve" "examples/daemon" "bun.*serve"; do
   for p in $(pgrep -f "$pat"); do kill -9 "$p" 2>/dev/null; done; done
 fuser -k "$PORT/tcp" 2>/dev/null
-rm -f ~/.hipfire/daemon.pid ~/.hipfire/serve.pid /tmp/hipfire-gpu.lock
+rm -f ~/.hipfire/daemon.pid ~/.hipfire/serve.pid
+# NB: do NOT rm /tmp/hipfire-gpu.lock — it is an flock'd file; unlinking it
+# breaks mutual exclusion (a new acquirer would lock a fresh inode). The
+# kernel auto-releases the flock when the holder dies, so no cleanup needed.
 for i in $(seq 1 10); do ss -ltn 2>/dev/null | grep -q ":$PORT " || break; sleep 1; done
 ss -ltn 2>/dev/null | grep -q ":$PORT " && { echo "[serve-restart] WARN port still busy"; exit 1; }
 echo "[serve-restart] clean"; rocm-smi --showmeminfo vram 2>/dev/null | grep Used | head

--- a/scripts/test-gpu-lock.sh
+++ b/scripts/test-gpu-lock.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+
+# test-gpu-lock.sh — regression test for scripts/gpu-lock.sh (no GPU required).
+# Covers the failure modes that motivated the flock rewrite:
+#   1. stale self-heal   — a kill -9'd holder must NOT block the next acquirer
+#   2. busy -> timeout   — a live holder makes the waiter exit non-zero, not hang
+#   3. reentrancy        — a nested gate no-ops and never releases the ancestor's lock
+#   4. no-rm invariant   — release leaves the file in place; status reports free
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+LOCKSH="$PWD/scripts/gpu-lock.sh"
+
+# Isolated lockfile so we never touch a real agent's /tmp/hipfire-gpu.lock.
+export HIPFIRE_GPU_LOCKFILE="/tmp/test-gpu-lock.$$"
+trap 'rm -f "$HIPFIRE_GPU_LOCKFILE"' EXIT
+
+pass=0 fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# ── 1. stale self-heal ────────────────────────────────────────────────────
+echo "[1] stale self-heal (kill -9 holder, next acquire must succeed fast)"
+# setsid → own process group so kill -9 takes the holder AND any children
+# (otherwise an inherited fd in a child would keep the flock alive).
+setsid bash -c "source '$LOCKSH'; gpu_acquire holder1 >/dev/null; sleep 60" &
+holder_pid=$!
+sleep 1
+kill -9 -"$holder_pid" 2>/dev/null || kill -9 "$holder_pid" 2>/dev/null
+sleep 1
+if timeout 8 bash -c "source '$LOCKSH'; GPU_LOCK_TIMEOUT=5 gpu_acquire holder2 >/dev/null 2>&1; gpu_release >/dev/null 2>&1"; then
+    ok "acquired immediately after holder was killed"
+else
+    bad "second acquire hung/failed — stale lock not self-healed"
+fi
+
+# ── 2. busy -> timeout ────────────────────────────────────────────────────
+echo "[2] genuine busy holder -> waiter times out with non-zero exit"
+setsid bash -c "source '$LOCKSH'; gpu_acquire busy1 >/dev/null; sleep 60" &
+busy_pid=$!
+sleep 1
+timeout 12 bash -c "source '$LOCKSH'; GPU_LOCK_TIMEOUT=2 GPU_POLL_INTERVAL=1 gpu_acquire waiter >/dev/null 2>&1"
+rc=$?
+kill -9 -"$busy_pid" 2>/dev/null || kill -9 "$busy_pid" 2>/dev/null
+if [ "$rc" -eq 2 ]; then
+    ok "waiter returned 2 (timeout) instead of hanging"
+else
+    bad "waiter returned $rc (expected 2)"
+fi
+sleep 1
+
+# ── 3. reentrancy ─────────────────────────────────────────────────────────
+echo "[3] reentrant nested acquire no-ops; child release leaves ancestor lock held"
+reentrancy_check() {
+    source "$LOCKSH"
+    gpu_acquire parent >/dev/null || { echo "OUTER_ACQUIRE_FAILED"; return; }
+    # child inherits exported HIPFIRE_GPU_LOCK_OWNER → must no-op + not release
+    bash -c "source '$LOCKSH'; gpu_acquire child >/dev/null; rc=\$?; gpu_release >/dev/null; echo CHILD_RC=\$rc"
+    echo "STATUS_AFTER_CHILD=$(gpu_status)"
+    gpu_release >/dev/null
+    echo "STATUS_AFTER_PARENT=$(gpu_status)"
+}
+out="$(reentrancy_check)"
+echo "$out" | sed 's/^/    /'
+if echo "$out" | grep -q "CHILD_RC=0" \
+   && echo "$out" | grep -q "STATUS_AFTER_CHILD=gpu BUSY" \
+   && echo "$out" | grep -q "STATUS_AFTER_PARENT=gpu is free"; then
+    ok "child reentrant no-op; ancestor stayed locked; parent released cleanly"
+else
+    bad "reentrancy semantics wrong"
+fi
+
+# ── 4. no-rm invariant ────────────────────────────────────────────────────
+echo "[4] release does not delete the lockfile; status reports free"
+bash -c "source '$LOCKSH'; gpu_acquire t4 >/dev/null; gpu_release >/dev/null"
+if [ -e "$HIPFIRE_GPU_LOCKFILE" ]; then
+    st="$(bash -c "source '$LOCKSH'; gpu_status")"
+    [ "$st" = "gpu is free" ] && ok "file persists, status='gpu is free'" \
+        || bad "file persists but status='$st'"
+else
+    bad "lockfile was deleted on release (breaks flock mutual exclusion)"
+fi
+
+echo
+echo "===== $pass passed, $fail failed ====="
+[ "$fail" -eq 0 ]

--- a/scripts/test-gpu-lock.sh
+++ b/scripts/test-gpu-lock.sh
@@ -23,13 +23,26 @@ pass=0 fail=0
 ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
 bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
 
+# Wait (up to ~5s) for a holder to actually acquire — gpu_acquire writes the
+# agent name into the lockfile only AFTER flock succeeds, so this confirms the
+# lock is genuinely held before we try to race/kill it. Avoids a vacuous pass
+# on a loaded runner where a fixed sleep fires before acquisition.
+await_held() {
+    local name="$1" i
+    for i in $(seq 1 50); do
+        grep -q "$name" "$HIPFIRE_GPU_LOCKFILE" 2>/dev/null && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
 # ── 1. stale self-heal ────────────────────────────────────────────────────
 echo "[1] stale self-heal (kill -9 holder, next acquire must succeed fast)"
 # setsid → own process group so kill -9 takes the holder AND any children
 # (otherwise an inherited fd in a child would keep the flock alive).
 setsid bash -c "source '$LOCKSH'; gpu_acquire holder1 >/dev/null; sleep 60" &
 holder_pid=$!
-sleep 1
+await_held holder1 || bad "holder1 never acquired (test setup race)"
 kill -9 -"$holder_pid" 2>/dev/null || kill -9 "$holder_pid" 2>/dev/null
 sleep 1
 if timeout 8 bash -c "source '$LOCKSH'; GPU_LOCK_TIMEOUT=5 gpu_acquire holder2 >/dev/null 2>&1; gpu_release >/dev/null 2>&1"; then
@@ -42,7 +55,7 @@ fi
 echo "[2] genuine busy holder -> waiter times out with non-zero exit"
 setsid bash -c "source '$LOCKSH'; gpu_acquire busy1 >/dev/null; sleep 60" &
 busy_pid=$!
-sleep 1
+await_held busy1 || bad "busy1 never acquired (test setup race)"
 timeout 12 bash -c "source '$LOCKSH'; GPU_LOCK_TIMEOUT=2 GPU_POLL_INTERVAL=1 gpu_acquire waiter >/dev/null 2>&1"
 rc=$?
 kill -9 -"$busy_pid" 2>/dev/null || kill -9 "$busy_pid" 2>/dev/null


### PR DESCRIPTION
## Problem

Validation gates and benches repeatedly hung waiting on a **stale** `/tmp/hipfire-gpu.lock`. Root cause in `scripts/gpu-lock.sh`: the lock was just a file holding a human-readable string, with **no owner identity and no liveness signal**, and `gpu_acquire` polled **forever** with zero staleness detection. Whenever a holder died without running `gpu_release` — `kill -9`, agent cancellation, crash, OOM, terminal close (none of which reliably fire the `trap … EXIT` the gates rely on) — the file persisted and every waiter blocked indefinitely.

Two existing workarounds confirmed the pain and were themselves buggy:
- `serve-restart.sh` blindly `rm -f /tmp/hipfire-gpu.lock`.
- `pp-gate.sh` skipped locking entirely when the file merely *existed* — unable to tell "my parent holds it" from "a rival agent holds it", so a stale file made it silently run **unlocked**.

## Fix: flock-backed mutex (stale-proof by construction)

`flock(1)` is now held on an open fd, so the **kernel releases the lock automatically the instant the holder dies, for any reason**. Staleness becomes structurally impossible — no PID-reuse race, no manual recovery. PID/host/timestamp are still written into the file for `gpu_status`/diagnostics.

- **Bounded wait** — a genuinely-busy *live* holder makes waiters give up after `GPU_LOCK_TIMEOUT` (default 1800s, `0` = forever) and exit non-zero, instead of hanging.
- **Reentrant** (`HIPFIRE_GPU_LOCK_OWNER`) — nested gates (e.g. `pp-gate` under `speed-gate`) no longer self-deadlock, and a child never releases its parent's lock. Also fixes `pp-gate.sh`'s silent-unlocked-run bug.
- **Never deletes the lockfile** — unlinking an flock'd file lets a second acquirer lock a fresh inode (two holders). Dropped the dangerous `rm` from `serve-restart.sh`.
- `HIPFIRE_GPU_LOCKFILE` env override (lets the test avoid touching the real lock).

The public API (`gpu_acquire`/`gpu_release`/`gpu_status`) is unchanged, so all 8 gate scripts (coherence, coherence-dflash, coherence-deepseek4-mtp, agentic, agentic-jinja-tools, pflash, pp, speed) and the bench/probe scripts that already source `gpu-lock.sh` pick up the new behavior with **no changes**.

## Files
- `scripts/gpu-lock.sh` — rewritten (flock + reentrancy + timeout + lockfile override)
- `scripts/serve-restart.sh` — dropped the lockfile `rm`
- `scripts/pp-gate.sh` — unconditional acquire (reentrancy handles nesting)
- `scripts/test-gpu-lock.sh` — **new** no-GPU regression test
- `CLAUDE.md`, `docs/skills/serve-restart/SKILL.md` — doc updates

## Verification

`bash scripts/test-gpu-lock.sh` (no GPU required) — all 4 pass:

```
PASS: acquired immediately after holder was killed      (stale self-heal — the bug)
PASS: waiter returned 2 (timeout) instead of hanging
PASS: child reentrant no-op; ancestor stayed locked
PASS: file persists, status='gpu is free'               (no-rm invariant)
```

Real-environment smoke on the actual `/tmp/hipfire-gpu.lock` (gfx1151): cross-process `gpu_status` reports BUSY with metadata while held; a `kill -9`'d holder's lock auto-heals so a fresh acquire succeeds immediately. `bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)