### PR TITLE
fix(rccl): mark all_reduce_sum_f32 unsafe (clippy not_unsafe_ptr_arg_deref)

### DIFF
--- a/crates/hip-bridge/examples/rccl_smoke.rs
+++ b/crates/hip-bridge/examples/rccl_smoke.rs
@@ -75,13 +75,16 @@ fn main() {
         for _ in 0..warmup {
             rccl.group_start().expect("group_start");
             for r in 0..n_ranks {
-                rccl.all_reduce_sum_f32(
-                    r,
-                    send_bufs[r].as_ptr() as *const f32,
-                    recv_bufs[r].as_ptr() as *mut f32,
-                    count,
-                    streams[r].raw_ptr(),
-                )
+                // SAFETY: device buffers of `count` f32 with a live per-rank stream.
+                unsafe {
+                    rccl.all_reduce_sum_f32(
+                        r,
+                        send_bufs[r].as_ptr() as *const f32,
+                        recv_bufs[r].as_ptr() as *mut f32,
+                        count,
+                        streams[r].raw_ptr(),
+                    )
+                }
                 .expect("all_reduce warm");
             }
             rccl.group_end().expect("group_end");
@@ -97,13 +100,16 @@ fn main() {
             let t = Instant::now();
             rccl.group_start().expect("group_start");
             for r in 0..n_ranks {
-                rccl.all_reduce_sum_f32(
-                    r,
-                    send_bufs[r].as_ptr() as *const f32,
-                    recv_bufs[r].as_ptr() as *mut f32,
-                    count,
-                    streams[r].raw_ptr(),
-                )
+                // SAFETY: device buffers of `count` f32 with a live per-rank stream.
+                unsafe {
+                    rccl.all_reduce_sum_f32(
+                        r,
+                        send_bufs[r].as_ptr() as *const f32,
+                        recv_bufs[r].as_ptr() as *mut f32,
+                        count,
+                        streams[r].raw_ptr(),
+                    )
+                }
                 .expect("all_reduce");
             }
             rccl.group_end().expect("group_end");

--- a/crates/hip-bridge/src/rccl.rs
+++ b/crates/hip-bridge/src/rccl.rs
@@ -102,11 +102,7 @@ impl RcclComms {
     /// `ncclCommInitAll`. Each comm[i] binds to `device_ids[i]`.
     pub fn init_all(device_ids: &[i32]) -> RcclResult<Self> {
         let lib = unsafe {
-            let candidates = [
-                "librccl.so",
-                "librccl.so.1",
-                "librccl.so.1.0",
-            ];
+            let candidates = ["librccl.so", "librccl.so.1", "librccl.so.1.0"];
             let mut loaded = None;
             for name in &candidates {
                 if let Ok(l) = Library::new(name) {
@@ -133,14 +129,39 @@ impl RcclComms {
             }};
         }
 
-        let (fn_comm_init_all, fn_comm_destroy, fn_all_reduce, fn_group_start, fn_group_end, fn_get_error_string, fn_get_version) = unsafe {
+        let (
+            fn_comm_init_all,
+            fn_comm_destroy,
+            fn_all_reduce,
+            fn_group_start,
+            fn_group_end,
+            fn_get_error_string,
+            fn_get_version,
+        ) = unsafe {
             (
-                load_sym!("ncclCommInitAll", unsafe extern "C" fn(*mut NcclComm, c_int, *const c_int) -> u32),
+                load_sym!(
+                    "ncclCommInitAll",
+                    unsafe extern "C" fn(*mut NcclComm, c_int, *const c_int) -> u32
+                ),
                 load_sym!("ncclCommDestroy", unsafe extern "C" fn(NcclComm) -> u32),
-                load_sym!("ncclAllReduce", unsafe extern "C" fn(*const c_void, *mut c_void, usize, u32, u32, NcclComm, *mut c_void) -> u32),
+                load_sym!(
+                    "ncclAllReduce",
+                    unsafe extern "C" fn(
+                        *const c_void,
+                        *mut c_void,
+                        usize,
+                        u32,
+                        u32,
+                        NcclComm,
+                        *mut c_void,
+                    ) -> u32
+                ),
                 load_sym!("ncclGroupStart", unsafe extern "C" fn() -> u32),
                 load_sym!("ncclGroupEnd", unsafe extern "C" fn() -> u32),
-                load_sym!("ncclGetErrorString", unsafe extern "C" fn(u32) -> *const c_char),
+                load_sym!(
+                    "ncclGetErrorString",
+                    unsafe extern "C" fn(u32) -> *const c_char
+                ),
                 load_sym!("ncclGetVersion", unsafe extern "C" fn(*mut c_int) -> u32),
             )
         };
@@ -290,7 +311,13 @@ impl RcclComms {
 
     /// Typed convenience for f32 sum — the load-bearing TP all-reduce
     /// shape (residual stream summation across ranks).
-    pub fn all_reduce_sum_f32(
+    ///
+    /// # Safety
+    /// Caller asserts `sendbuff`/`recvbuff` point to `count` valid f32
+    /// elements of device memory associated with `rank`, and that `stream`
+    /// is a live stream on that device. See `all_reduce` for the rest of the
+    /// safety contract.
+    pub unsafe fn all_reduce_sum_f32(
         &self,
         rank: usize,
         sendbuff: *const f32,
@@ -298,17 +325,15 @@ impl RcclComms {
         count: usize,
         stream: *mut c_void,
     ) -> RcclResult<()> {
-        unsafe {
-            self.all_reduce(
-                rank,
-                sendbuff as *const c_void,
-                recvbuff as *mut c_void,
-                count,
-                RcclDataType::Float32,
-                RcclRedOp::Sum,
-                stream,
-            )
-        }
+        self.all_reduce(
+            rank,
+            sendbuff as *const c_void,
+            recvbuff as *mut c_void,
+            count,
+            RcclDataType::Float32,
+            RcclRedOp::Sum,
+            stream,
+        )
     }
 
     /// Typed convenience for fp16 sum (residual stream in mixed-precision).

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -21,10 +21,10 @@
 //! 3. Pass the multi-GPU coherence gate.
 
 use hip_bridge::{
-    DeviceBuffer, Event, HipError, HipResult, RcclComms,
-    HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED, HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
+    DeviceBuffer, Event, HipError, HipResult, RcclComms, HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED,
+    HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
 };
-use rdna_compute::{Gpu, GpuTensor, DType};
+use rdna_compute::{DType, Gpu, GpuTensor};
 
 /// Stream-event handoff returned by `Gpus::boundary_copy`. When the src
 /// device has an active stream, `completion` holds a HIP event recorded
@@ -119,10 +119,16 @@ impl Gpus {
     pub fn init_layers(per_device: &[usize]) -> HipResult<Self> {
         let n_devices = per_device.len();
         if n_devices == 0 {
-            return Err(HipError::new(0, "init_layers: per_device must be non-empty"));
+            return Err(HipError::new(
+                0,
+                "init_layers: per_device must be non-empty",
+            ));
         }
         if per_device.contains(&0) {
-            return Err(HipError::new(0, "init_layers: each device must own ≥1 layer"));
+            return Err(HipError::new(
+                0,
+                "init_layers: each device must own ≥1 layer",
+            ));
         }
         let n_layers: usize = per_device.iter().sum();
         let device_ids = resolve_device_ids(n_devices)?;
@@ -254,7 +260,10 @@ impl Gpus {
                     all_ok = false;
                     continue;
                 }
-                match self.devices[i].hip.enable_peer_access(self.devices[j].device_id) {
+                match self.devices[i]
+                    .hip
+                    .enable_peer_access(self.devices[j].device_id)
+                {
                     Ok(()) => {}
                     // ffi.rs already converts 704 → Ok(()); this arm is
                     // belt-and-suspenders against ROCm versions where the
@@ -325,12 +334,15 @@ impl Gpus {
         let dst_dev_id = self.devices[dst_dev].device_id;
         match src_gpu.active_stream.as_ref() {
             Some(stream) => {
-                src_gpu.hip.memcpy_peer_async(
-                    dst, dst_dev_id, src, src_dev_id, n_bytes, stream,
-                )?;
+                src_gpu
+                    .hip
+                    .memcpy_peer_async(dst, dst_dev_id, src, src_dev_id, n_bytes, stream)?;
                 let event = src_gpu.hip.event_create()?;
                 match src_gpu.hip.event_record(&event, Some(stream)) {
-                    Ok(()) => Ok(BoundaryEvent { dst_dev, completion: Some(event) }),
+                    Ok(()) => Ok(BoundaryEvent {
+                        dst_dev,
+                        completion: Some(event),
+                    }),
                     Err(e) => {
                         let _ = src_gpu.hip.event_destroy(event);
                         Err(e)
@@ -342,8 +354,13 @@ impl Gpus {
                 // lands. No event needed — recording into the HIP null
                 // stream is fragile across ROCm versions; skip it and
                 // signal "already done" via completion: None.
-                src_gpu.hip.memcpy_peer(dst, dst_dev_id, src, src_dev_id, n_bytes)?;
-                Ok(BoundaryEvent { dst_dev, completion: None })
+                src_gpu
+                    .hip
+                    .memcpy_peer(dst, dst_dev_id, src, src_dev_id, n_bytes)?;
+                Ok(BoundaryEvent {
+                    dst_dev,
+                    completion: None,
+                })
             }
         }
     }
@@ -380,11 +397,7 @@ impl Gpus {
         wait_result.and(destroy_result)
     }
 
-    fn from_parts(
-        devices: Vec<Gpu>,
-        per_device: Vec<usize>,
-        n_layers: usize,
-    ) -> HipResult<Self> {
+    fn from_parts(devices: Vec<Gpu>, per_device: Vec<usize>, n_layers: usize) -> HipResult<Self> {
         debug_assert_eq!(per_device.iter().sum::<usize>(), n_layers);
         debug_assert_eq!(per_device.len(), devices.len());
         let n_devices = devices.len();
@@ -464,11 +477,7 @@ impl Gpus {
     /// immediately; the buffers are valid only after a subsequent
     /// `stream_synchronize` (or a downstream dispatch that's already
     /// ordered behind the same stream).
-    pub fn all_reduce_sum_f32(
-        &mut self,
-        buffers: &[&DeviceBuffer],
-        count: usize,
-    ) -> HipResult<()> {
+    pub fn all_reduce_sum_f32(&mut self, buffers: &[&DeviceBuffer], count: usize) -> HipResult<()> {
         if buffers.len() != self.devices.len() {
             return Err(HipError::new(
                 0,
@@ -509,13 +518,17 @@ impl Gpus {
                     ),
                 )
             })?;
-            rccl.all_reduce_sum_f32(
-                r,
-                buf.as_ptr() as *const f32,
-                buf.as_ptr() as *mut f32,
-                count,
-                stream.raw_ptr(),
-            )
+            // SAFETY: `buf` is a live device buffer of `count` f32 on device
+            // `r`, and `stream` is that device's active stream.
+            unsafe {
+                rccl.all_reduce_sum_f32(
+                    r,
+                    buf.as_ptr() as *const f32,
+                    buf.as_ptr() as *mut f32,
+                    count,
+                    stream.raw_ptr(),
+                )
+            }
             .map_err(|e| HipError::new(0, &format!("ncclAllReduce rank={r}: {e}")))?;
         }
         rccl.group_end()
@@ -536,7 +549,10 @@ impl Gpus {
         }
         // Free the old (too-small) set on its owning devices before regrowing.
         if !self.peer_ar_tmp.is_empty() {
-            for (r, row) in std::mem::take(&mut self.peer_ar_tmp).into_iter().enumerate() {
+            for (r, row) in std::mem::take(&mut self.peer_ar_tmp)
+                .into_iter()
+                .enumerate()
+            {
                 let _ = self.devices[r].bind_thread();
                 for buf in row {
                     let _ = self.devices[r].hip.free(buf);
@@ -581,7 +597,10 @@ impl Gpus {
         if buffers.len() != n {
             return Err(HipError::new(
                 0,
-                &format!("all_reduce_sum_f32_peer: buffers.len()={} != n_devices={n}", buffers.len()),
+                &format!(
+                    "all_reduce_sum_f32_peer: buffers.len()={} != n_devices={n}",
+                    buffers.len()
+                ),
             ));
         }
         if n == 1 {
@@ -598,7 +617,8 @@ impl Gpus {
                 if j == r {
                     continue;
                 }
-                let evt = self.boundary_copy(j, r, buffers[j], &self.peer_ar_tmp[r][slot], bytes)?;
+                let evt =
+                    self.boundary_copy(j, r, buffers[j], &self.peer_ar_tmp[r][slot], bytes)?;
                 evts.push(evt);
                 slot += 1;
             }
@@ -711,7 +731,8 @@ fn preflight_vram_with_opts(devices: &[Gpu], check_vram_delta: bool) -> HipResul
     let max_free = *frees.iter().max().unwrap();
     let min_free = *frees.iter().min().unwrap();
     let delta_gb = (max_free - min_free) as f64 / 1e9;
-    let tol_gb = crate::config::get().uniform_vram_tolerance_gb
+    let tol_gb = crate::config::get()
+        .uniform_vram_tolerance_gb
         .map(|t| t as f64)
         .unwrap_or(DEFAULT_VRAM_TOLERANCE_GB);
     if delta_gb > tol_gb {


### PR DESCRIPTION
## Problem

CI's clippy job (`cargo clippy --workspace --all-targets --locked`) hard-fails (exit 101) on a single deny-by-default lint, independent of any feature branch:

```
error: this public function might dereference a raw pointer but is not marked `unsafe`
   --> crates/hip-bridge/src/rccl.rs:309:17
   = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default
```

`Rccl::all_reduce_sum_f32` took raw `*const f32`/`*mut f32` pointers but was exposed as a safe `pub fn`. This is what turns the clippy check red on PRs that didn't touch any Rust (e.g. #451, bash-only).

## Fix

Mark `all_reduce_sum_f32` as `unsafe` with a `# Safety` doc — consistent with its already-`unsafe` sibling `all_reduce_sum_f16` directly below it — and wrap the three call sites in `unsafe {}`:

- `crates/hipfire-runtime/src/multi_gpu.rs` — PP all-reduce
- `crates/hip-bridge/examples/rccl_smoke.rs` — warm + timed loops

The remaining clippy output (`type_complexity`, `manual_c_str_literals`) are warnings that do not fail the build, so they're left untouched.

## Verification

`cargo clippy --workspace --all-targets --locked` runs clean locally after the change. No behavior change — purely an FFI safety annotation; no kernel/forward/dispatch logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)