### PR TITLE
chore(fmt): add fmt-changed helper + pre-commit rustfmt gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,6 +40,26 @@ set -e
 # List files staged for this commit.
 CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
 
+# ── rustfmt-changed gate (every commit, GPU-free, ~instant) ─────────────
+# Mirror CI's changed-file rustfmt check (scripts/ci-rustfmt-changed.sh) on
+# the staged Rust files. The repo carries historical format debt so we only
+# check files in THIS commit, not the workspace. Fix with:
+#   scripts/fmt-changed.sh
+# Bypass (e.g. mid-rebase) with: SKIP_FMT_CHECK=1 git commit ...
+if [[ -z "${SKIP_FMT_CHECK:-}" ]]; then
+    mapfile -t fmt_files < <(echo "$CHANGED" | grep -E '\.rs$' || true)
+    if [[ "${#fmt_files[@]}" -gt 0 ]]; then
+        if ! rustfmt --edition 2021 --check --config skip_children=true "${fmt_files[@]}"; then
+            echo "" >&2
+            echo "✗ rustfmt: staged Rust file(s) are not formatted (CI's changed-file gate will flag this)." >&2
+            echo "  Fix:    scripts/fmt-changed.sh && git add -u" >&2
+            echo "  Bypass: SKIP_FMT_CHECK=1 git commit ..." >&2
+            echo "  Do NOT run 'cargo fmt' — it reformats the whole workspace's format debt." >&2
+            exit 1
+        fi
+    fi
+fi
+
 # Hotspots that can affect forward-pass output or speed.
 #
 # Updated for post-0.1.20 modular topology (PR 7+):

--- a/scripts/fmt-changed.sh
+++ b/scripts/fmt-changed.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Format ONLY the Rust files this branch touches, matching CI's rules.
+#
+# Why this exists: the repo carries historical rustfmt debt (most files are
+# not formatted), so CI only checks CHANGED files — see
+# scripts/ci-rustfmt-changed.sh. Running bare `cargo fmt` rewrites the whole
+# workspace's debt (100+ files) and buries your actual change. DO NOT run
+# `cargo fmt` here. Run this instead — it formats only what you changed, with
+# the same flags CI checks (`--edition 2021 --config skip_children=true`).
+#
+# Files considered = union of:
+#   - committed changes vs the base ref (default origin/master; override BASE_REF)
+#   - staged changes
+#   - unstaged working-tree changes
+#
+# Usage:
+#   scripts/fmt-changed.sh                 # format files changed vs origin/master
+#   BASE_REF=origin/integration/foo scripts/fmt-changed.sh
+
+base_ref="${BASE_REF:-origin/master}"
+
+# Best-effort: make sure the base ref exists locally so the diff range works.
+if ! git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+  remote="${base_ref%%/*}"
+  branch="${base_ref#*/}"
+  git fetch --no-tags "${remote}" "${branch}:refs/remotes/${base_ref}" >/dev/null 2>&1 || true
+fi
+
+collect() {
+  if git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+    git diff --name-only --diff-filter=ACMRT "${base_ref}...HEAD" -- '*.rs'
+  fi
+  git diff --name-only --diff-filter=ACMRT -- '*.rs'          # unstaged
+  git diff --cached --name-only --diff-filter=ACMRT -- '*.rs' # staged
+}
+
+mapfile -t files < <(collect | sort -u)
+
+if [[ "${#files[@]}" -eq 0 ]]; then
+  echo "No changed Rust files to format."
+  exit 0
+fi
+
+printf 'rustfmt-formatting %d changed Rust file(s):\n' "${#files[@]}"
+printf '  %s\n' "${files[@]}"
+rustfmt --edition 2021 --config skip_children=true "${files[@]}"
+echo "Done. Review the diff (it may include pre-existing format debt in files you touched — that is what CI's changed-file gate checks)."


### PR DESCRIPTION
## Motivation

CI enforces rustfmt on **changed files only** (`scripts/ci-rustfmt-changed.sh`), because the repo carries deliberate historical workspace-wide format debt (`ci.yml:14`). That setup has a local footgun:

- Running bare **`cargo fmt`** reformats 100+ debt-carrying files and buries your actual change (one wrong `cargo fmt -p <crate>` rewrote 166 files).
- Meanwhile CI checks each *whole* changed file, so any file you touch must be fully rustfmt-clean — easy to miss locally since nothing checks it before push.

There was no local equivalent of the CI rule, and the pre-commit hook did no formatting at all.

## Changes

- **`scripts/fmt-changed.sh`** — formats only the Rust files changed vs the base ref (plus staged/unstaged), using CI's exact flags (`--edition 2021 --config skip_children=true`). The drop-in replacement for `cargo fmt` in this repo.
- **`.githooks/pre-commit`** — a fast, GPU-free rustfmt-changed **check** on staged Rust files, run on every commit before the heavy path-gated gates. Fails early with the fix command. Bypass with `SKIP_FMT_CHECK=1`.

## Notes

- The hook check only activates for clones that opt into the repo hooks (`git config core.hooksPath .githooks`, per CLAUDE.md).
- Tested end-to-end: a misformatted staged file trips the gate; `scripts/fmt-changed.sh` fixes it; re-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)