### PR TITLE
docs: de-leak + de-stale CLAUDE.md and AGENTS.md (contributor-generic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ __pycache__/
 .claude/
 # Personal CLI instructions
 cli/CLAUDE.md
+CLAUDE.local.md
 .pr_body_0_1_7_alpha.md
 .bench_0_1_7_alpha/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,20 +133,19 @@ or vendoring this repository.
 
 ---
 
-# Testing playbook (v0.1.9-alpha)
+# Testing playbook
 
 **Audience:** agents (or humans) running smoke / perf / correctness
-tests on hipfire v0.1.9-alpha — particularly the production-ready MQ3
-sub-4-bit Magnum Quant family, the DFlash MQ3 cross-quant matrix, and
-the existing DFlash draft pull / prompt-shape adaptation paths
-inherited from v0.1.8.
+tests on hipfire — particularly the MQ3 sub-4-bit Magnum Quant family,
+the DFlash MQ3 cross-quant matrix, and the DFlash draft pull /
+prompt-shape adaptation paths.
 
 **Companion docs:** [`CLAUDE.md`](CLAUDE.md) holds project-wide rules
 (non-negotiable hard rules, e.g. coherence-gate is the canonical gate).
-This file holds the *testing playbook* — how to verify v0.1.9-alpha
+This file holds the *testing playbook* — how to verify the engine
 works, what to measure, what counts as pass/fail.
 
-**v0.1.9-alpha default behavior to be aware of:**
+**Default behavior to be aware of:**
 - **MQ3 is production on gfx11** (`gfx1100/1101/1102/1150/1151`) and
   gfx12 (`gfx1200/1201`). On gfx10 / gfx906 / gfx94x, MQ3 weights still
   load and run via per-token GEMV fallback — correct, just slower
@@ -155,9 +154,9 @@ works, what to measure, what counts as pass/fail.
 - **MQ2 is refused by default.** The quantizer requires
   `--format mq2 --i-know-this-is-broken` to opt in. Severe quality
   cliff confirmed; Lloyd-Max MQ2/MQ3 (qt=19/20) is the path forward.
-- **`dflash_mode=off` default carries over from v0.1.8.** Any test
-  exercising DFlash still needs `hipfire config set dflash_mode auto`
-  or `HIPFIRE_DFLASH_DRAFT=<path>` first.
+- **`dflash_mode=off` is the default.** Any test exercising DFlash
+  still needs `hipfire config set dflash_mode auto` or
+  `HIPFIRE_DFLASH_DRAFT=<path>` first.
 
 ---
 
@@ -264,95 +263,57 @@ cargo build --release --features deltanet \
 
 ---
 
-## 2 · What v0.1.9-alpha added (test surface)
+## 2 · Test surface (quant formats, DFlash, prompt-shape)
 
-### A. MQ3 production (sub-4-bit Magnum Quant)
+### A. MQ3 (sub-4-bit Magnum Quant)
 
-The headline of v0.1.9-alpha. MQ3 = FWHT-rotated 3-bit weight format,
-104 B/group (3.25 bpw vs MQ4's 4 bpw at 136 B/group). Three new things
-are now wired:
+MQ3 = FWHT-rotated 3-bit weight format, 104 B/group (3.25 bpw vs MQ4's
+4 bpw at 136 B/group). What's wired:
 
-- **K4-unrolled GEMV decode + fused residual** on gfx1100. Decode
-  matches MQ4 within 2% (9B 141 tok/s vs MQ4's 128.7).
-- **WMMA prefill family** (`gemm_qkvza/qkv/gate_up/residual hfq3`)
-  closing the 17× prefill gap that gated ship. Arch-gated to gfx11
-  wave32 WMMA. gfx12 K4 variant ships in the same release.
-- **DFlash cross-quant matrix.** MQ3↔MQ3, MQ3↔MQ4, MQ4↔MQ3 all valid
-  for dense models. MoE/A3B + MQ3 still refused at daemon load.
+- **K4-unrolled GEMV decode + fused residual** on gfx1100 — decode matches
+  MQ4 within ~2% (9B ~141 vs MQ4 ~129 tok/s).
+- **WMMA prefill family** (`gemm_qkvza/qkv/gate_up/residual hfq3`), arch-gated
+  to gfx11 wave32 WMMA; gfx12 ships a K4 variant.
+- **DFlash cross-quant matrix** — MQ3↔MQ3, MQ3↔MQ4, MQ4↔MQ3 all valid for
+  dense models. MoE/A3B + MQ3 is refused at daemon load.
 
-Sweep harness for MQ3 quality + perf:
-```bash
-./scripts/mq3-mq2-sweep.sh   # 4-prompt × 5-model bench, md5-stamped
-```
+Sweep harness (quality + perf, md5-stamped): `./scripts/mq3-mq2-sweep.sh`.
 
-### B. Cache-invalidation lifecycle
+### B. Cache invalidation on model swap
 
-`Gpu::unload_model` now drains `mmq_screen_cache` + `fp16_shadow_cache`
-and tears down captured hipGraphs (verify, replay, AR forward). Three
-Codex stop-time follow-ups, all pointer-keyed cache silent-corruption
-class. Smoke test: rapid `hipfire serve` model swap loop should NOT
-emit garbage on the new model's first decode.
+`Gpu::unload_model` drains `mmq_screen_cache` + `fp16_shadow_cache` and tears
+down captured hipGraphs (verify, replay, AR forward) — a pointer-keyed
+silent-corruption class. **Smoke test:** a rapid `hipfire serve` model-swap
+loop must NOT emit garbage on the new model's first decode.
 
-### C. Defensive `parseToolCalls` (#111 stopgap)
+### C. Prompt-shape adaptation (default ON)
 
-Three known MQ4 attractor malformations are repaired before the
-OpenAI shape returns: spec form, flat form, XML-tag corruption.
-Token-attractor root cause (calibration retrain) deferred. Smoke
-test: tool-calling prompt against `qwen3.5-9b.mq4` should never
-return raw `<tool_call>` text in `message.content`.
-
-### D. Inherited from v0.1.8 (still load-bearing)
-
-- **Phase 1: prompt-shape adaptation — DEFAULT ON (2026-04-26)**
-
-Engine-side `\n{3,}` → `\n\n` collapse before tokenize, eliminating the
-rare BPE token 1358 (`\n\n\n`) in favor of HOT token 271 (`\n\n`) on
-Qwen3.5/3.6 vocab.
-
-**Default ON since 2026-04-26** — empirical 199 tok/s on 27B-3.5 LRU
-DFlash (vs 159 with opt-out). The original v0.1.8-alpha ship had this
-opt-in; it was promoted to default after the 2026-04-26 perf-regression
-recovery confirmed +24% τ with zero correctness cost (commit 9a2c667).
-
-To **opt out** (rare — only when raw `\n{3,}` whitespace is semantically
-load-bearing):
+Engine-side `\n{3,}` → `\n\n` collapse before tokenize (drops the rare BPE
+token 1358 `\n\n\n` for the HOT token 271 `\n\n` on Qwen3.5/3.6 vocab).
+**Default ON** — worth +14–27% tok/s on PEP-8-style code prompts containing
+`\n{3,}`, zero effect otherwise, zero correctness cost. Opt out only when raw
+`\n{3,}` whitespace is semantically load-bearing:
 
 - Env: `HIPFIRE_NORMALIZE_PROMPT=0`
 - TUI: `hipfire config set prompt_normalize false`
 - Per-model: `hipfire config qwen3.5:27b set prompt_normalize false`
 
-**Expected lift over OPT-OUT baseline:** +14% to +27% tok/s on PEP-8-style
-code prompts that contain `\n{3,}` patterns. Zero effect on prompts
-without those patterns.
-
 **Verify:** see §3 prompt-shape A/B test.
 
-### B. Token heat diagnostic
+### D. Token-heat diagnostic
 
-`HIPFIRE_PROMPT_TOKEN_HEAT=1` triggers `Tokenizer::dump_prompt_heat()`
-at every encode site. Output goes to stderr (pretty) or stdout (JSON
-when `HIPFIRE_PROMPT_HEAT_JSON=1`).
+`HIPFIRE_PROMPT_TOKEN_HEAT=1` triggers `Tokenizer::dump_prompt_heat()` at every
+encode site (stderr pretty, or stdout JSON with `HIPFIRE_PROMPT_HEAT_JSON=1`).
+Standalone: `./target/release/examples/encode_prompt MODEL.hfq PROMPT.txt --heat`.
 
-Standalone tool: `./target/release/examples/encode_prompt MODEL.hfq
-PROMPT.txt --heat`.
+### E. DFlash draft endpoints (HuggingFace)
 
-### C. EOT-stop fix
-
-Daemon, run, and dflash_spec_demo now stop on `<|endoftext|>` token,
-not just `<|im_end|>`. The Fibonacci-attractor loop in raw-text DFlash
-is killed.
-
-### D. DFlash drafts on HuggingFace
-
-Three new HF endpoints (uploaded 2026-04-25, schuttdev account):
 - `schuttdev/hipfire-qwen3.5-9b/qwen35-9b-dflash-mq4.hfq`
 - `schuttdev/hipfire-qwen3.5-27b/qwen35-27b-dflash-mq4.hfq`
-- `schuttdev/hipfire-qwen3.6-27b/qwen36-27b-dflash-mq4.hfq`
+- `schuttdev/hipfire-qwen3.6-27b/qwen36-27b-dflash-mq4.hfq` (+ the 3.6 27B
+  target `schuttdev/hipfire-qwen3.6-27b/qwen3.6-27b.mq4`)
 
-Plus the 3.6 27B target itself: `schuttdev/hipfire-qwen3.6-27b/qwen3.6-27b.mq4`.
-
-Pullable via `hipfire pull qwen3.{5,6}:{9b,27b}-draft` and
-`hipfire pull qwen3.6:27b`.
+Pullable via `hipfire pull qwen3.{5,6}:{9b,27b}-draft` and `hipfire pull qwen3.6:27b`.
 
 ---
 
@@ -393,7 +354,7 @@ The `def add(x, y)` prompt is the canonical peak case (we beat 207
 tok/s here, vs. Lucebox's RTX 3090 demo peak):
 
 ```bash
-PROMPT=$(python3 -c "import json; print([json.loads(l) for l in open('/home/kaden/.hipfire/datasets/HumanEval.jsonl')][53]['prompt'])")
+PROMPT=$(python3 -c "import json; print([json.loads(l) for l in open('~/.hipfire/datasets/HumanEval.jsonl')][53]['prompt'])")
 HIPFIRE_NORMALIZE_PROMPT=1 ./target/release/examples/dflash_spec_demo \
   --target ~/.hipfire/models/qwen3.5-27b.mq4 \
   --draft ~/.hipfire/models/qwen35-27b-dflash-mq4.hfq \
@@ -507,8 +468,8 @@ For dataclass benches:
 
 ### Pinned Hugging Face bench fixture
 
-For hiptrx dense Qwen3.6-27B AWQ MTP/DFlash perf work, do not identify
-the canonical trunk by local filename. Local filenames drift and lookalike
+For dense Qwen3.6-27B AWQ MTP/DFlash perf work, do not identify the
+canonical trunk by local filename. Local filenames drift and lookalike
 AWQ/MQ4 files are not comparable.
 
 The canonical trunk is whichever local artifact byte-matches the current
@@ -531,14 +492,14 @@ should be discarded.
 
 ### Pinned A3B MoE DFlash fixtures
 
-For hiptrx Qwen3.6-35B-A3B MoE DFlash perf/profiling work, use the
+For Qwen3.6-35B-A3B MoE DFlash perf/profiling work, use the
 following command shape and do not substitute other prompts unless the
 user explicitly updates this fixture section:
 
 ```bash
 ./target/release/examples/dflash_spec_demo \
-  --target /home/kaden/.hipfire/models/qwen3.6-35b-a3b.mq4-awq-mi300x \
-  --draft /home/kaden/.hipfire/models/qwen36-35b-a3b-dflash-mq4.hfq \
+  --target ~/.hipfire/models/qwen3.6-35b-a3b.mq4-awq-mi300x \
+  --draft ~/.hipfire/models/qwen36-35b-a3b-dflash-mq4.hfq \
   --prompt-file <allowed-prompt> \
   --max 256 --temp 0.0 --no-chatml --kv-mode q8 --ctx 4096 \
   --block-size 6 --no-adaptive-b
@@ -623,7 +584,7 @@ If you want to actively contribute findings, these are open:
    τ? Run `encode_prompt --heat` on a wide variety of prompts and look
    for patterns.
 2. **Path C training**: a target-aligned custom DFlash draft. Recipe at
-   `../dflash-fe/RECIPE_RedHat_DFlash_MI300X.md`.
+   an out-of-repo recipe (ask the maintainer).
 3. **Path D engineering**: stale-context overlap pipelining — the only
    structural lever still on the table for 27B-3.5 code beyond +8.2%.
 4. **DDTree gfx1100 fix**: linearization-slot RoPE phase delta skew
@@ -633,9 +594,5 @@ If you want to actively contribute findings, these are open:
 
 ---
 
-*Last updated: 2026-05-02 (v0.1.9-alpha — MQ3 production-ready: K4
-decode, WMMA prefill family, DFlash cross-quant matrix, gfx12 port,
-cache-invalidation lifecycle, defensive parseToolCalls (#111 stopgap),
-gfx906 + gfx1152 arch gating, speed-gate DPM warmup). When this doc
-gets stale (more than 1-2 releases behind HEAD), update it as part of
-the release PR.*
+*Last updated: 2026-06-22. When this doc gets stale (more than 1-2
+releases behind HEAD), update it as part of the release PR.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,204 +1,92 @@
-# HipFire: RDNA GPU Unlock & Rust-Native Inference Engine
+# hipfire: Rust-Native Inference Engine for AMD RDNA GPUs
 
 ## Mission
 
-Build a Rust-native ML inference (and eventually training) engine for AMD RDNA GPUs,
-starting with the RX 5700 XT (gfx1010/RDNA1) on this machine (k9lin). The end goal is
-a portable method that works across ANY RDNA generation (RDNA1→RDNA4), not just this card.
+hipfire is a Rust-native ML inference engine (eventually training) for AMD RDNA
+GPUs, built on a single HIP/ROCm-direct compute backend — no Python in the hot
+path, no Vulkan/cross-vendor layer. It runs natively across RDNA generations
+(RDNA1 gfx1010 → RDNA4 gfx1201) without lying about the hardware identity (no
+`HSA_OVERRIDE_GFX_VERSION`). The project merges three efforts into one pipeline:
 
-This project combines three efforts into one pipeline:
-1. **autorocm** — Map and unlock ROCm on consumer RDNA hardware
-2. **autokernel** — Optimize HIP/compute kernels for the specific hardware
-3. **hipfire** — Rust-native inference engine (no Python in the hot path)
+1. **autorocm** — map and unlock ROCm on consumer RDNA hardware
+2. **autokernel** — optimize HIP/compute kernels per architecture
+3. **hipfire** — the Rust-native inference engine itself
 
-## Reference Projects (READ THESE FIRST)
+## Architecture
 
-Before writing any code or dispatching any agents, study these two projects deeply.
-They define the methodology and architectural patterns we're following:
+The crate stack layers bottom-up. User-facing entry is a Bun/TypeScript CLI
+(`cli/index.ts`) that posts to — or spawns — the inference daemon
+(`crates/hipfire-runtime/examples/daemon.rs`, a JSON-lines stdio server).
+Kernels are HIP source under `kernels/src/`, compiled at runtime via `hipcc`
+and cached as `.hsaco` per GPU arch.
 
-### 1. Karpathy's autoresearch
-- https://github.com/karpathy/autoresearch
-- Key pattern: `program.md` (strategy) → agent modifies single file → fixed eval → keep/discard → repeat
-- We adapt this for hardware/driver exploration, not model training
-- The "fixed eval" equivalent is our tiered ROCm validation harness (see harness.sh)
+- **hip-bridge / hsa-bridge** — safe Rust FFI to the AMD HIP / HSA runtimes via
+  `dlopen` (no link-time ROCm dependency).
+- **rdna-compute** — kernel dispatch, hipGraph capture, JIT loader, arch-feature
+  predicates.
+- **hipfire-dispatch** — unified per-kernel-family dispatch; picks the kernel by
+  quant format × arch capability × feature flags resolved at init.
+- **hipfire-runtime** — inference orchestrator: KV cache, sampler, token loop,
+  HFQ loader, tokenizer, and the daemon. Top of the compute DAG.
+- **hipfire-quantize** — CPU-side encoder (safetensors/GGUF → `.hfq`/`.mq4`/…);
+  builds without a GPU.
+- **hipfire-detect** — GPU-independent observability: attractor / special-token /
+  n-gram / tool-call detectors (used by the gates and `coherence_probe`).
+- **hipfire-arch-\*** — one crate per model family's forward pass, keyed by
+  `arch_id` (see `docs/architecture-ids.md`): llama (0/1), qwen35 (5 dense / 6
+  MoE-A3B, also hosts DFlash spec-decode), qwen2 (7), dots-ocr (8), deepseek4 (9,
+  multi-GPU EP), minimax (10), lfm2moe (11), cohere2moe (12). `toy` (0xFF) is the
+  new-port template; the daemon refuses to dispatch it.
+- Support crates: hipfire-loader, hipfire-atlas (perf corpus), hipfire-reap (MoE
+  expert pruning), hipfire-tui (chat/settings TUI), redline (experimental
+  direct-KMD compute, not wired into serving).
 
-### 2. ncdrone/rustane
-- https://github.com/ncdrone/rustane
-- Key pattern: Rust-native FFI to private/undocumented hardware APIs via dlopen
-- Their `ane-bridge` crate talks to Apple's Neural Engine through reverse-engineered private APIs
-- We do the same thing but targeting AMD's ROCm/HIP/HSA runtime stack
-- Study their architecture: ane-bridge (FFI layer) → metal-decode (GPU shaders) → engine (orchestrator)
-- Our equivalent: hip-bridge (FFI layer) → rdna-compute (shader dispatch) → engine (orchestrator)
-
-### 3. Also reference
-- Mesa radeonsi/radv source — open AMD GPU driver, has gfx1010 support paths
-- amdgpu kernel driver source — KMD ioctl surface, PM4 command buffer format
-- ROCm source (especially the HSA runtime) — find the artificial gating checks
-
-## Hardware Context
-
-**Origin target (RDNA1 unlock):** AMD RX 5700 XT (Navi 10, **gfx1010**, RDNA1,
-8GB GDDR6) — the card this project was started to unlock. AMD officially refuses
-ROCm support for RDNA1; consumer RDNA cards are artificially gated. The
-`HSA_OVERRIDE_GFX_VERSION=10.3.0` hack (treat gfx1010 as gfx1030) is unreliable,
-version-dependent, and segfaults — per Rule 5 it is NOT a permanent solution.
-The 5700 XT now lives on the **hipx** box (HIP device 0, ~7GB), not k9lin.
-
-**Current dev + validation fleet (RDNA1 → RDNA4, all native — no GFX override):**
-- **k9lin** (primary dev/perf host, local) — **gfx1100 / RX 7900 XTX, 24GB,
-  RDNA3** (Navi 31, `1002:744c`). The canonical perf box: the
-  perf-benchmarking methodology (±1–3% band, Δ≥5% investigate) is calibrated to
-  this card. Fits quantized 9B/27B/A3B; not full MiniMax-class.
-- **hipx** (ssh) — **gfx1151 / Strix Halo, RDNA3.5, ~96GB** carveout (HIP
-  device 1, pin `HIP_VISIBLE_DEVICES=1`) for big models + WMMA; plus the
-  **gfx1010 / RDNA1** 5700 XT (device 0, ~7GB).
-- **hiptrx** (ssh) — **4× AMD Radeon AI PRO R9700 / gfx1201, RDNA4, 32 GiB
-  each** (rocm-smi reports 34,208,743,424 B ≈ 34.2 GB; ~128 GiB aggregate) on a
-  Threadripper 9970X. RDNA4 coverage + multi-GPU pipeline-parallel.
-
-Cross-arch validation (e.g. #397's mandated gfx1100 RDNA3 + gfx1201 RDNA4
-gates, RDNA4 non-optional) maps natively: RDNA1 = hipx/gfx1010, RDNA3 =
-k9lin/gfx1100, RDNA3.5 = hipx/gfx1151, RDNA4 = hiptrx/gfx1201. Per-box
-`gpu-lock.sh` → genuine cross-box parallel validation.
-
-## Orchestration Model
-
-You (Claude Code Opus) are the orchestrator. You make all architectural decisions.
-You dispatch Sonnet subagents via the Task tool for parallel work.
-You synthesize their findings and decide what to test and in what order.
-
-**Reasoning budget:** You are running at max reasoning effort. Think hard at every
-phase transition. The subagents are cheaper — dispatch them liberally for scoped tasks.
-
-**Experiment tracking:** Git-commit every meaningful state change. Every approach tested
-gets a commit with structured results. Failed approaches are just as valuable as
-successful ones — document WHY they failed so the search space narrows.
+## Building, testing & gates
 
 ```
-git init (if not already)
-git add -A && git commit -m "phase N: description of what changed and result"
+# Workspace build — no GPU/ROCm needed (HIP is dlopen'd at runtime); CI-required:
+cargo build --release --workspace --all-targets --locked
+# The inference daemon:
+cargo build --release --example daemon --features deltanet -p hipfire-runtime
+# No-GPU local check (cargo check + lib tests + pytest + bun typecheck):
+./scripts/no-gpu-ci.sh
+# Wire the pre-commit hook once per clone (sets core.hooksPath=.githooks):
+./scripts/install-hooks.sh
 ```
 
-## Phases
+CI (`.github/workflows/ci.yml`) runs `build` + `test --lib` (both required) plus
+advisory `fmt`/`clippy` on every PR/push to `master` or `integration/**`; a daily
+workflow refreshes `registry/v1.json`. There is no GPU CI runner yet — the
+**GPU-bound correctness/perf gates run locally** (the pre-commit hook fires the
+relevant ones when staged files match the kernel/serve/spec/pp hotspot globs).
+The gate suite is documented in the sections below; `scripts/gates.sh` is the
+unified wrapper. Conventions: don't `--no-verify`; don't bare `cargo fmt` (use
+`scripts/fmt-changed.sh`); don't hand-edit `registry/v1.json` (it's generated by
+`scripts/registry_gen.py` from the curated `cli/registry.json`).
 
-### Phase 0: Setup (~10 min)
+## Reference architecture lineage
 
-1. Configure Serena plugin for this Rust project (you have the Serena plugin — figure out its init sequence for a new Rust workspace)
-2. Verify Rust toolchain: `rustup default stable`, confirm 1.75.0+
-3. Verify hardware visibility:
-   - `lspci | grep -i amd` — confirm 5700 XT visible
-   - `ls /dev/dri/` — confirm render nodes exist
-   - `dmesg | grep -i amdgpu` — confirm kernel driver loaded
-   - `cat /sys/class/drm/card*/device/vendor` — confirm AMD vendor ID
-4. Check what's already installed: `dpkg -l | grep -i rocm`, `which hipcc`, `pip list | grep torch`
-5. Initialize git repo, commit initial scaffold
-6. Run `./harness.sh` to get baseline (expect most tiers to fail — that's the point)
-7. Document starting state in `findings/phase0-baseline.md`
+hipfire follows two patterns: ncdrone/rustane's Rust-native `dlopen` FFI to a
+private hardware runtime (their `ane-bridge` → our `hip-bridge`/`hsa-bridge`),
+and Karpathy's autoresearch single-file-experiment + fixed-eval loop (here the
+"fixed eval" is the coherence/perf gate suite). Mesa radeonsi/RADV, the amdgpu
+KMD ioctl surface, and the ROCm HSA runtime remain useful references for
+kernel/driver work.
 
-### Phase 1: Mapping (~2-4 hrs)
+## Orchestration & experiment tracking
 
-Dispatch 16 Sonnet subagents in parallel. Each agent gets a focused probe task.
-They write structured findings to `findings/phase1-*.md`.
+Heavy or parallelizable work is dispatched to subagents; the orchestrator
+synthesizes findings and decides what to test in what order. **Git-commit every
+meaningful state change** — every approach tested, including failed ones, gets a
+commit with structured results. The history IS the research; document WHY a thing
+failed so the search space narrows.
 
-**Hardware probing agents (4):**
-- Agent 1: Full hardware inventory — PCIe topology, IOMMU groups, power states, clock ranges, firmware versions. Dump everything from sysfs.
-- Agent 2: KMD ioctl surface mapping — what ioctls does amdgpu expose? Which ones relate to compute dispatch? Read `/usr/include/drm/amdgpu_drm.h` or equivalent headers.
-- Agent 3: Memory architecture — VRAM layout, GTT size, visible VRAM, doorbell pages. Map the memory hierarchy from sysfs + drm info ioctls.
-- Agent 4: Current driver state — which amdgpu module params are loaded? What firmware blobs are present? What's in `/lib/firmware/amdgpu/navi10*`?
+## Project history
 
-**ROCm compatibility agents (4):**
-- Agent 5: ROCm version matrix — search online for every reported gfx1010 + ROCm version combination. Structure as: ROCm version → result (works/partial/fails) → failure mode → source URL.
-- Agent 6: HSA runtime gating analysis — if ROCm source is available locally or online, find the exact checks that reject gfx1010. Is it a GFX ID allowlist? A feature capability check? Where in the code?
-- Agent 7: HIP compilation path for gfx1010 — can hipcc target gfx1010 directly? What flags are needed? Does it need the GFX override or can it be told explicitly? Search ROCm issues and forums.
-- Agent 8: rocBLAS/MIOpen gfx1010 status — these libraries ship precompiled kernels per GFX ID. Are gfx1010 kernels included in any version? If not, can they be compiled from source targeting gfx1010?
-
-**Mesa/open-source path agents (3):**
-- Agent 9: radeonsi OpenCL — does Mesa's rusticl or clover provide OpenCL on gfx1010? This could be an alternative compute path.
-- Agent 10: Mesa's register headers for gfx10 — find `sid.h`, `gfx10_format_table.h`, etc. Map the compute-relevant registers (COMPUTE_DISPATCH_INITIATOR, shader resource descriptors, etc.)
-- Agent 11: Compare gfx1010 vs gfx1030 ISA differences — what RDNA2 instructions are actually missing from RDNA1? This determines whether the HSA override hack is fundamentally sound or just lucky.
-
-**Rust ecosystem agents (3):**
-- Agent 12: Survey existing Rust AMD GPU crates — hip-rs, ocl (OpenCL), any direct amdgpu bindings. What's the state of the art?
-- Agent 13: Study rustane's ane-bridge FFI pattern — how they dlopen private frameworks, wrap unsafe calls in safe Rust. Document the pattern for adaptation to HIP/HSA.
-- Agent 14: Research candle-rs AMD support — candle has some ROCm support. What's the status? Could we build on it rather than from scratch?
-
-**Note:** Vulkan/wgpu/RADV is explicitly **out of scope** as of 2026-04-25 (issue #44 closed). hipfire ships a single HIP/ROCm-direct backend; cross-vendor compute is not a goal.
-
-**After all agents complete:** Synthesize findings into `findings/phase1-synthesis.md`.
-Identify the actual blocking points (not folklore). Rank the viable paths forward.
-
-### Phase 2: Theory & Competing Approaches (~1-2 hrs)
-
-Based on Phase 1 synthesis, dispatch a SECOND wave of research agents.
-These agents each advocate for a DIFFERENT approach. You want competition, not consensus.
-
-Expected approach categories (adjust based on Phase 1 findings):
-
-- **Approach A: Patch ROCm** — Find and bypass the gfx1010 gating. Compile ROCm components from source targeting gfx1010. Most direct path if feasible.
-- **Approach B: Rust FFI to HIP/HSA directly** — Skip the ROCm userspace stack. dlopen libhsa-runtime64.so and libamdhip64.so directly, replicate the dispatch path in Rust. Like rustane does for ANE.
-- **Approach D: Direct KMD dispatch** — Bypass all userspace. Talk to /dev/dri/renderD128 via amdgpu ioctls. Build command buffers (PM4 packets) in Rust. Maximum control, maximum effort.
-
-**Note:** Vulkan-based approaches (former Approach C "compute baseline" and Approach E "hybrid") are out of scope as of 2026-04-25. We do not ship a second backend; cross-vendor compute is not a goal of this project.
-
-Each approach gets a dedicated agent that writes a structured proposal to `approaches/approach-X.md`:
-- Prerequisites and dependencies
-- Estimated implementation effort
-- Risk assessment (what could go wrong)
-- Performance ceiling (theoretical max throughput)
-- Portability to other RDNA generations
-- Concrete first step to validate feasibility
-
-**After all proposals:** You (Opus) rank them. Write `approaches/ranking.md` with your reasoning.
-Pick the top 2-3 for Phase 3 validation.
-
-### Phase 3: E2E Validation (~4-6 hrs)
-
-Test approaches IN ORDER of your ranking. For each approach:
-
-1. Implement the minimum viable version
-2. Run `./harness.sh` — record which tiers pass
-3. If it reaches Tier 4+ (actual compute works), keep going
-4. If it fails below Tier 2, document why and move to next approach
-5. Git commit results regardless
-
-The harness tiers (see harness.sh for implementation):
-- Tier 0: Does amdgpu kernel module load cleanly?
-- Tier 1: Does the userspace runtime see the card?
-- Tier 2: Can the compute runtime initialize?
-- Tier 3: Can we allocate GPU memory and copy data?
-- Tier 4: Can a simple compute kernel execute and return correct results?
-- Tier 5: Can a matmul kernel run correctly?
-- Tier 6: Performance — bandwidth and FLOPS relative to theoretical peak
-
-**Key decision point:** After testing all ranked approaches, which path has the best
-Tier reached + portability + Rust-native potential? That's your Phase 4 foundation.
-
-Write decision to `experiments/phase3-decision.md`.
-
-### Phase 4: Build the Engine (remaining time)
-
-Using the validated approach from Phase 3, start building the actual Rust inference engine.
-
-Target architecture (adapt based on what works):
-```
-hipfire/
-├── crates/
-│   ├── hip-bridge/      # (or kmd-bridge — whichever HIP path won)
-│   │   └── src/lib.rs   # Safe Rust FFI to AMD compute runtime
-│   ├── rdna-compute/    # Compute shader dispatch, kernel management
-│   │   └── src/lib.rs   # Kernel compilation, buffer management, dispatch
-│   └── engine/          # Inference orchestrator
-│       └── src/lib.rs   # Model loading, tensor ops, inference loop
-├── kernels/             # HIP compute shaders
-│   ├── gemv.hip
-│   ├── rmsnorm.hip
-│   └── rope.hip
-└── Cargo.toml
-```
-
-**Minimum Phase 4 deliverable:** Load a small model (e.g., TinyLlama 1.1B Q4),
-run a single forward pass on the 5700 XT, get correct output tokens.
-Performance doesn't matter yet — correctness first.
+Phases 0–4 (ROCm-unlock recon → approach bake-off → E2E validation → first
+forward pass) bootstrapped the engine and are complete. For that archaeology see
+`git log` and the `findings/` / `approaches/` history; day-to-day work now lives
+in `crates/` and the gate suite below — there is no setup phase to re-run.
 
 ## Perf benchmarking (kernel perf changes)
 
@@ -502,18 +390,32 @@ hook in your own local `.claude/settings.json` that sources `scripts/gpu-lock.sh
 
 ## Rules
 
-1. **No Python in the inference hot path.** Python is allowed for tooling, benchmarks, comparison baselines. Never in the actual engine.
-2. **Git commit everything.** Every experiment, every finding, every failed approach. The history IS the research.
-3. **Document failures explicitly.** "Approach B failed because HSA_RUNTIME returns error code 0x1013 when initializing on gfx1010 without override" is more valuable than "it didn't work."
-4. **Portability matters.** Every decision should consider: will this work on RDNA2? RDNA3? RDNA4? If it's 5700XT-only it's a hack, not a solution.
-5. **No HSA_OVERRIDE_GFX_VERSION as a permanent solution.** It's acceptable as a temporary test during Phase 3, but the final engine must not depend on lying about the hardware identity.
-6. **When blocked, search.** You have internet access. Use it aggressively — GitHub issues, AMD docs, Mesa source, phoronix forums, reddit r/ROCm, Tom's Hardware.
-7. **No Vulkan / wgpu / cross-vendor compute backend.** Out of scope as of 2026-04-25 (issue #44 closed). hipfire ships a single HIP/ROCm-direct backend; cross-vendor coverage is not a goal of this project. If Phase 3 yields nothing, pivot to a different HIP-side approach (KMD direct, ROCm patch, HSA FFI), not to Vulkan.
+1. **No Python in the inference hot path.** Python is fine for tooling,
+   benchmarks, and comparison baselines — never in the engine itself.
+2. **Git commit everything.** Every experiment, finding, and failed approach.
+   The history IS the research.
+3. **Document failures explicitly.** "Approach B failed because HSA_RUNTIME
+   returns 0x1013 on init without override" beats "it didn't work."
+4. **Portability matters.** Every decision should consider RDNA2/3/4. If it only
+   works on one GPU arch, it's a hack, not a solution.
+5. **No `HSA_OVERRIDE_GFX_VERSION` as a permanent solution.** Acceptable only as
+   a throwaway local test; the engine must never depend on lying about the
+   hardware identity.
+6. **When blocked, search.** Use the internet aggressively — GitHub issues, AMD
+   docs, Mesa source, forums.
+7. **No Vulkan / wgpu / cross-vendor backend.** Out of scope (issue #44, closed
+   2026-04-25). hipfire ships a single HIP/ROCm-direct backend; if a compute path
+   stalls, pivot to another HIP-side approach (KMD-direct, ROCm patch, HSA FFI),
+   not Vulkan.
 
-## Success Criteria
+## Local / personal config
 
-- [ ] RX 5700 XT running compute workloads through a Rust-native path (no Python)
-- [ ] At least one inference-relevant kernel (matmul/GEMV) executing correctly
-- [ ] Documented method that generalizes to other RDNA generations
-- [ ] All findings, approaches, and experiments committed to git with structured documentation
-- [ ] Clear `NEXT-STEPS.md` for what to build next after this overnight session
+Machine-specific context — your GPU fleet, ssh hosts, device pins, local paths —
+does NOT belong in this committed file (it confuses contributors). Keep it in a
+personal file that Claude Code auto-loads but git ignores. Recommended:
+`~/.claude/hipfire-fleet.md` (loads in every checkout/worktree, pulled in by the
+import below). A per-repo `CLAUDE.local.md` is also gitignored + auto-loaded, but
+only in the single worktree it sits in. The import below is a no-op for anyone
+who doesn't have the file.
+
+@~/.claude/hipfire-fleet.md


### PR DESCRIPTION
The committed instruction files carried personal GPU-fleet specifics (`k9lin`/`hipx`/`hiptrx`, ssh hosts, `HIP_VISIBLE_DEVICES` pins, absolute `/home/kaden` paths) that confused contributors. This de-leaks + de-stales both, keeping all load-bearing content.

**Fleet migration (split mechanism).** The fleet moves to a personal `~/.claude/hipfire-fleet.md` (auto-loaded by Claude Code, loads in every worktree, physically can't leak), pulled into `CLAUDE.md` via a graceful `@~/.claude/hipfire-fleet.md` import (a no-op for anyone without the file). `CLAUDE.local.md` added to `.gitignore` for the per-checkout pattern.

**CLAUDE.md** (520 → 421): cut genesis Phases 0–4 + Success Criteria + Hardware Context; condense Reference Projects + Orchestration; **add** an Architecture (crate + `arch_id` map) and a Building/testing/gates section; generalize Mission + Rules (no more 5700XT/Phase refs). The 8 methodology/gate sections (perf-benchmarking, coherence gates, prompt-τ, GPU-lock, …) are **byte-identical**.

**AGENTS.md** (641 → 599): the provenance Notice is kept **verbatim**; genericize 4 leaked `/home` paths + 2 `hiptrx` refs; de-stale the `v0.1.9-alpha`/`v0.1.8` version pins (→ "current"), prune the `#111`-stopgap + EOT-fix changelog subsections, refresh the footer date. Methodology + flag tables unchanged.

No git-history rewrite (HEAD-forward only). The fleet file is local-only and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)