### PR TITLE
fix(spec): skip DFlash verify-graph for Q8 KV at long context (was failing decode)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -2478,7 +2478,25 @@ fn verify_dflash_block_inner(
         }
     }
     let tree_ok_for_graph = !tree_verify_present || tree_graph_enabled;
+    // The captured single-chunk verify forward refuses Q8 (non-asym) KV once
+    // physical_cap exceeds the LDS-resident context limit: its long-context flash
+    // path would `hip.malloc` + `memcpy_htod` inside the captured region (illegal
+    // under stream capture, and it bakes max_ctx_len = physical_cap into the LDS
+    // scalar regardless of the actual decode length), so it returns an error every
+    // cycle — see `forward_prefill_batch_single_chunk_captured` in qwen35.rs. The
+    // caller used to propagate that error and fail the whole decode. Detect the
+    // exact unsupported combination here and SKIP the graph path so verify falls
+    // through to the uncaptured forward (which handles long-context Q8 fine). Asym
+    // KV and physical_cap within the limit stay capture-safe and keep the
+    // verify-graph speedup on every arch. Keep this threshold in sync with
+    // LDS_CTX_LIMIT in qwen35.rs.
+    const VERIFY_GRAPH_Q8_CTX_LIMIT: usize = 15000;
+    let kv = &target.kv_cache;
+    let captured_forward_supports_kv = !(kv.quant_q8
+        && !(kv.quant_asym2 || kv.quant_asym3 || kv.quant_asym4)
+        && kv.physical_cap > VERIFY_GRAPH_Q8_CTX_LIMIT);
     let verify_graph_ok = std::env::var("HIPFIRE_VERIFY_GRAPH").ok().as_deref() != Some("0")
+        && captured_forward_supports_kv
         && tree_ok_for_graph
         && matches!(
             target.weights.embd_format,


### PR DESCRIPTION
## Problem

DFlash speculative decode produces **0 tokens / FAIL** for any model with **Q8 KV at large `physical_cap`** (e.g. `qwen3.6-27b.mq4`, `physical_cap` 131072) when `dflash_mode=on`. Prefill works; AR decode works.

## Root cause (not a deadlock, not arch-specific)

The captured single-chunk verify forward (`forward_prefill_batch_single_chunk_captured`, `qwen35.rs:5985`) **refuses Q8 (non-asym) KV once `physical_cap > 15000`** (`LDS_CTX_LIMIT`): under stream capture it bakes `max_ctx_len = physical_cap` into the LDS scalar, which it treats as routing to a per-position long-context fallback that would `hip.malloc` + `memcpy_htod` inside the captured region. It returns an error — and `verify_dflash_block_inner` **propagated that error and failed the whole decode** instead of falling back to the working non-graph forward.

The guard is arch-independent, so this fails on RDNA4/gfx12 and gfx1100 too — it surfaces wherever a model runs Q8 KV with a large `physical_cap`.

Instrumented trace on gfx1151 (every verify cycle):
```
batch_result err=Some("forward_prefill_batch_single_chunk_captured: Q8 KV with
physical_cap 131072 > 15000 hits the per-position long-context fallback, which
issues hip.malloc + memcpy_htod inside the captured region...")
```

## Fix

Gate `verify_graph_ok` on the **same condition the captured forward checks** (`Q8 && !asym && physical_cap > 15000`), so the unsupported combination cleanly skips the graph path and falls through to the uncaptured forward (which handles long-context Q8 fine). Asym2/3/4 KV and `physical_cap` within the limit stay capture-safe and keep the verify-graph speedup where it's supported.

This supersedes the arch-based (RDNA3.5) gate from the first push of this branch — the root cause is the KV / `physical_cap` combination, not the GPU.

## Verification (gfx1151, qwen3.6-27b mq4 + matching dflash draft, Q8 KV, physical_cap 131072, dflash on)

| | Decode |
|---|---|
| before | every cycle errors → **0 tok/s, FAIL** |
| **after** | **16.6 tok/s**, draft loaded, no error ✅ |
| AR baseline (dflash off) | 13.4 tok/s |

The dflash speculative uplift (13.4 → ~16 tok/s) comes from the non-graph forward, which the fallback uses — so this fix loses no speed.

## Why not make verify-graph actually capture this config? (measured, not assumed)

I checked whether the guard could just be lifted to let Q8 long-context capture. Bypassing it, capture **succeeds** (warmup → "captured for B=16 with 1154 blobs", no error) — the "hipMalloc under capture" rationale is more conservative than the current batched path needs. **But it buys nothing on this hardware:** steady-state replay measured **15.8 tok/s vs 15.7 tok/s** non-graph — statistically identical. The verify-graph's launch-coalescing win is a discrete-GPU effect; on Strix Halo's unified-memory iGPU it washes out. So the skip-gate is the right fix rather than a deeper "make capture work" change, which would add capture overhead + 1154 cached blobs for no speedup. (A maintainer with dGPU context may still want to relax the `qwen35.rs:5985` guard for arches where verify-graph does pay off — orthogonal to this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
